### PR TITLE
Fix false positive warnings for PostgreSQL User

### DIFF
--- a/plugins/modules/database/postgresql/postgresql_user.py
+++ b/plugins/modules/database/postgresql/postgresql_user.py
@@ -806,7 +806,7 @@ def main():
         fail_on_user=dict(type='bool', default='yes', aliases=['fail_on_role']),
         role_attr_flags=dict(type='str', default=''),
         encrypted=dict(type='bool', default='yes'),
-        no_password_changes=dict(type='bool', default='no'),
+        no_password_changes=dict(type='bool', default='no', no_log=False),
         expires=dict(type='str', default=None),
         conn_limit=dict(type='int', default=None),
         session_role=dict(type='str'),


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This stops a the false positive warnings that the `no_password_changes`
doesn't have the `no_log` set.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/68106
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module postgresql_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Related to https://github.com/ansible/ansible/pull/68116

