### PR TITLE
Fix false positive for MySQL user module

### DIFF
--- a/plugins/modules/database/mysql/mysql_user.py
+++ b/plugins/modules/database/mysql/mysql_user.py
@@ -694,7 +694,7 @@ def main():
             priv=dict(type='raw'),
             append_privs=dict(type='bool', default=False),
             check_implicit_admin=dict(type='bool', default=False),
-            update_password=dict(type='str', default='always', choices=['always', 'on_create']),
+            update_password=dict(type='str', default='always', choices=['always', 'on_create'], no_log=False),
             connect_timeout=dict(type='int', default=30),
             config_file=dict(type='path', default='~/.my.cnf'),
             sql_log_bin=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This stops a false positive warnings that the `update_password` param
doesn't have the `no_log` set.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Similar to the issue in #17.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module mysql_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Related to https://github.com/ansible/ansible/pull/68118