### PR TITLE
passwordstore: Honor equal sign in userpass

### DIFF
--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -15,10 +15,10 @@ DOCUMENTATION = '''
         It also retrieves YAML style keys stored as multilines in the passwordfile.
     options:
       _terms:
-        description: query key
+        description: query key.
         required: True
       passwordstore:
-        description: location of the password store
+        description: location of the password store.
         default: '~/.password-store'
       directory:
         description: The directory of the password store.
@@ -42,7 +42,7 @@ DOCUMENTATION = '''
       userpass:
         description: Specify a password to save, instead of a generated one.
       length:
-        description: The length of the generated password
+        description: The length of the generated password.
         type: integer
         default: 16
       backup:
@@ -50,7 +50,7 @@ DOCUMENTATION = '''
         type: bool
         default: 'no'
       nosymbols:
-        description: use alphanumeric characters
+        description: use alphanumeric characters.
         type: bool
         default: 'no'
 '''
@@ -153,7 +153,7 @@ class LookupModule(LookupBase):
             # next parse the optional parameters in keyvalue pairs
             try:
                 for param in params[1:]:
-                    name, value = param.split('=')
+                    name, value = param.split('=', 1)
                     if name not in self.paramvals:
                         raise AnsibleAssertionError('%s not in paramvals' % name)
                     self.paramvals[name] = value

--- a/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -47,3 +47,16 @@
   assert:
     that:
       - readpass == newpass
+
+- name: Create a password with equal sign
+  set_fact:
+    newpass: "{{ lookup('passwordstore', 'test-pass-equal userpass=SimpleSample= create=yes') }}"
+
+- name: Fetch a password with equal sign
+  set_fact:
+    readpass: "{{ lookup('passwordstore', 'test-pass-equal') }}"
+
+- name: Verify password
+  assert:
+    that:
+      - readpass == newpass


### PR DESCRIPTION
##### SUMMARY

passwordstore lookup plugin now can handle equal sign in user input

Fixes: ansible/ansible#68265

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup/passwordstore.py
tests/integration/targets/lookup_passwordstore/tasks/tests.yml
