### PR TITLE
influxdb_user: Don't grant admin privilege in check mode

### DIFF
--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -235,10 +235,12 @@ def main():
 
             try:
                 if admin and not user['admin']:
-                    client.grant_admin_privileges(user_name)
+                    if not module.check_mode:
+                        client.grant_admin_privileges(user_name)
                     changed = True
                 elif not admin and user['admin']:
-                    client.revoke_admin_privileges(user_name)
+                    if not module.check_mode:
+                        client.revoke_admin_privileges(user_name)
                     changed = True
             except influx.exceptions.InfluxDBClientError as e:
                 module.fail_json(msg=to_native(e))


### PR DESCRIPTION
##### SUMMARY

influxdb_user module don't change the admin flag for existing
user

Fixes: ansible/ansible#68139

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/database/influxdb/influxdb_user.py
