### PR TITLE
homebrew: Add info about changed packages

### DIFF
--- a/changelogs/fragments/59376-homebrew_fix.yml
+++ b/changelogs/fragments/59376-homebrew_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add information about changed packages in homebrew returned facts (https://github.com/ansible/ansible/issues/59376).


### PR DESCRIPTION
##### SUMMARY

homebrew now returns details about changed and unchanged packages
after performing the operations.

Fixes: ansible/ansible#59376

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/homebrew.py
