### PR TITLE
Fix imports and installing dependencies in CI, part 1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ tags: null
 #dependencies:
 #  netapp.ontap: '>=0.1.0'
 #  community.kubernetes: '>=0.1.0'
-#  ovirt.ovirt: '>=0.1.0'
+#  ovirt.ovirt_collection: '>=0.1.0'
 #  ansible.netcommon: '>=0.1.0'
 #  cisco.mso: '>=0.1.0'
 #  ansible.posix: '>=0.1.0'

--- a/plugins/module_utils/kubevirt.py
+++ b/plugins/module_utils/kubevirt.py
@@ -9,8 +9,8 @@ from distutils.version import Version
 
 from ansible.module_utils.common import dict_transformations
 from ansible.module_utils.common._collections_compat import Sequence
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import list_dict_str
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.raw import KubernetesRawModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import list_dict_str
+from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
 
 import copy
 import re

--- a/plugins/module_utils/network/f5/iworkflow.py
+++ b/plugins/module_utils/network/f5/iworkflow.py
@@ -20,8 +20,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5BaseClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
 
 
 class F5Client(F5BaseClient):

--- a/plugins/module_utils/network/f5/urls.py
+++ b/plugins/module_utils/network/f5/urls.py
@@ -12,7 +12,7 @@ import re
 try:
     from library.module_utils.network.f5.common import F5ModuleError
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
 
 _CLEAN_HEADER_REGEX_BYTE = re.compile(b'^\\S[^\\r\\n]*$|^$')
 _CLEAN_HEADER_REGEX_STR = re.compile(r'^\S[^\r\n]*$|^$')

--- a/plugins/modules/cloud/kubevirt/kubevirt_cdi_upload.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_cdi_upload.py
@@ -83,8 +83,8 @@ import traceback
 
 from collections import defaultdict
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.raw import KubernetesRawModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
 
 # 3rd party imports
 try:

--- a/plugins/modules/cloud/kubevirt/kubevirt_preset.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_preset.py
@@ -92,7 +92,7 @@ import copy
 import traceback
 
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.general.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/cloud/kubevirt/kubevirt_pvc.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_pvc.py
@@ -254,8 +254,8 @@ import traceback
 
 from collections import defaultdict
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.raw import KubernetesRawModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.raw import KubernetesRawModule
 from ansible_collections.community.general.plugins.module_utils.kubevirt import virtdict, KubeVirtRawModule
 
 

--- a/plugins/modules/cloud/kubevirt/kubevirt_rs.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_rs.py
@@ -111,7 +111,7 @@ import copy
 import traceback
 
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.general.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/cloud/kubevirt/kubevirt_template.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_template.py
@@ -205,7 +205,7 @@ kubevirt_template:
 import copy
 import traceback
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
 
 from ansible_collections.community.general.plugins.module_utils.kubevirt import (
     virtdict,

--- a/plugins/modules/cloud/kubevirt/kubevirt_vm.py
+++ b/plugins/modules/cloud/kubevirt/kubevirt_vm.py
@@ -249,7 +249,7 @@ kubevirt_vm:
 import copy
 import traceback
 
-from ansible_collections.community.kubernetes.plugins.module_utils.k8s.common import AUTH_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC
 from ansible_collections.community.general.plugins.module_utils.kubevirt import (
     virtdict,
     KubeVirtRawModule,

--- a/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -109,7 +109,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -55,7 +55,7 @@ options:
       description:
         - "Name of the host, which affinity labels should be listed."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_api_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_api_facts.py
@@ -32,7 +32,7 @@ notes:
        which contains a information about oVirt/RHV API. You need to register the result with
        the I(register) keyword to use it."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_api_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_api_facts.py
@@ -61,7 +61,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -51,7 +51,7 @@ options:
         - "For example to search cluster X from datacenter Y use following pattern:
            name=X and datacenter=Y"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -80,7 +80,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -63,7 +63,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -35,7 +35,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search datacenter I(X) use following pattern: I(name=X)"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
@@ -51,7 +51,7 @@ options:
         - "For example to search Disk X from storage Y use following pattern:
            name=X and storage.name=Y"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
@@ -79,7 +79,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_event_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_event_facts.py
@@ -74,7 +74,7 @@ options:
         default: true
         type: bool
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_event_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_event_facts.py
@@ -112,7 +112,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -92,7 +92,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -54,7 +54,7 @@ options:
         description:
             - "Name of the external provider, can be used as glob expression."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_group_facts.py
@@ -50,7 +50,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search group X use following pattern: name=X"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_group_facts.py
@@ -78,7 +78,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_host_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_facts.py
@@ -83,7 +83,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_host_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_facts.py
@@ -47,7 +47,7 @@ options:
       type: str
 
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
@@ -62,7 +62,7 @@ options:
                 description:
                   - "LUN id."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
@@ -98,7 +98,7 @@ except ImportError:
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_network_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_network_facts.py
@@ -80,7 +80,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_network_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_network_facts.py
@@ -50,7 +50,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search network starting with string vlan1 use: name=vlan1*"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
@@ -83,7 +83,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
@@ -53,7 +53,7 @@ options:
         description:
             - "Name of the NIC, can be used as glob expression."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
@@ -95,7 +95,7 @@ except ImportError:
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_link_name,

--- a/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
@@ -61,7 +61,7 @@ options:
             - "Namespace of the authorization provider, where user/group resides."
         required: false
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
@@ -83,7 +83,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
@@ -53,7 +53,7 @@ options:
         description:
             - "Name of the quota, can be used as glob expression."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
@@ -53,7 +53,7 @@ options:
         description:
             - "Name of the scheduling policy, can be used as glob expression."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
@@ -84,7 +84,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
@@ -72,7 +72,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
@@ -41,7 +41,7 @@ options:
         description:
             - "Id of the snapshot we want to retrieve information about."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
@@ -80,7 +80,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
@@ -51,7 +51,7 @@ options:
         - "For example to search storage domain X from datacenter Y use following pattern:
            name=X and datacenter=Y"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
@@ -87,7 +87,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
@@ -58,7 +58,7 @@ options:
         description:
             - "The storage domain name where the templates should be listed."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
@@ -87,7 +87,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
@@ -58,7 +58,7 @@ options:
         description:
             - "The storage domain name where the virtual machines should be listed."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
@@ -98,7 +98,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
@@ -55,7 +55,7 @@ options:
       description:
         - "Name of the host, which tags should be listed."
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_template_facts.py
@@ -51,7 +51,7 @@ options:
         - "For example to search template X from datacenter Y use following pattern:
            name=X and datacenter=Y"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_template_facts.py
@@ -80,7 +80,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_user_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_user_facts.py
@@ -78,7 +78,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_user_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_user_facts.py
@@ -50,7 +50,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search user X use following pattern: name=X"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
@@ -70,7 +70,7 @@ options:
            effect when the virtual machine is restarted. By default the value is set by engine."
       type: bool
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
@@ -107,7 +107,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
@@ -50,7 +50,7 @@ options:
         - "Search term which is accepted by oVirt/RHV search backend."
         - "For example to search vmpool X: name=X"
 extends_documentation_fragment:
-- ovirt.ovirt.ovirt_info
+- ovirt.ovirt_collection.ovirt_info
 
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
@@ -78,7 +78,7 @@ import traceback
 
 from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
+from ansible_collections.ovirt.ovirt_collection.plugins.module_utils.ovirt import (
     check_sdk,
     create_connection,
     get_dict_of_struct,

--- a/plugins/modules/network/aci/aci_interface_policy_fc.py
+++ b/plugins/modules/network/aci/aci_interface_policy_fc.py
@@ -174,7 +174,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 
 def main():

--- a/plugins/modules/network/aci/aci_interface_policy_fc.py
+++ b/plugins/modules/network/aci/aci_interface_policy_fc.py
@@ -46,7 +46,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/aci_interface_policy_l2.py
+++ b/plugins/modules/network/aci/aci_interface_policy_l2.py
@@ -184,7 +184,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 # Mapping dicts are used to normalize the proposed data to what the APIC expects, which will keep diffs accurate
 QINQ_MAPPING = dict(

--- a/plugins/modules/network/aci/aci_interface_policy_l2.py
+++ b/plugins/modules/network/aci/aci_interface_policy_l2.py
@@ -57,7 +57,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/aci_interface_policy_lldp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_lldp.py
@@ -179,7 +179,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 
 def main():

--- a/plugins/modules/network/aci/aci_interface_policy_lldp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_lldp.py
@@ -50,7 +50,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/aci_interface_policy_mcp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_mcp.py
@@ -173,7 +173,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 
 def main():

--- a/plugins/modules/network/aci/aci_interface_policy_mcp.py
+++ b/plugins/modules/network/aci/aci_interface_policy_mcp.py
@@ -45,7 +45,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_channel.py
@@ -223,7 +223,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 
 def main():

--- a/plugins/modules/network/aci/aci_interface_policy_port_channel.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_channel.py
@@ -94,7 +94,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/aci_interface_policy_port_security.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_security.py
@@ -181,7 +181,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
 
 def main():

--- a/plugins/modules/network/aci/aci_interface_policy_port_security.py
+++ b/plugins/modules/network/aci/aci_interface_policy_port_security.py
@@ -52,7 +52,7 @@ options:
     - The alias for the current object. This relates to the nameAlias field in ACI.
     type: str
 extends_documentation_fragment:
-- cisco.aci.aci
+- cisco.aci.modules
 
 seealso:
 - name: APIC Management Information Model reference

--- a/plugins/modules/network/aci/mso_schema_template_external_epg_contract.py
+++ b/plugins/modules/network/aci/mso_schema_template_external_epg_contract.py
@@ -132,7 +132,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.network.aci.mso import MSOModule, mso_argument_spec, mso_contractref_spec, issubset
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_contractref_spec, issubset
 
 
 def main():

--- a/plugins/modules/network/aci/mso_schema_template_external_epg_contract.py
+++ b/plugins/modules/network/aci/mso_schema_template_external_epg_contract.py
@@ -70,7 +70,7 @@ seealso:
 - module: cisco.mso.mso_schema_template_externalepg
 - module: cisco.mso.mso_schema_template_contract_filter
 extends_documentation_fragment:
-- cisco.mso.mso
+- cisco.mso.modules
 
 '''
 

--- a/plugins/modules/network/aci/mso_schema_template_external_epg_subnet.py
+++ b/plugins/modules/network/aci/mso_schema_template_external_epg_subnet.py
@@ -57,7 +57,7 @@ options:
 notes:
 - Due to restrictions of the MSO REST API concurrent modifications to EPG subnets can be dangerous and corrupt data.
 extends_documentation_fragment:
-- cisco.mso.mso
+- cisco.mso.modules
 
 '''
 

--- a/plugins/modules/network/aci/mso_schema_template_external_epg_subnet.py
+++ b/plugins/modules/network/aci/mso_schema_template_external_epg_subnet.py
@@ -115,7 +115,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.mso.plugins.module_utils.network.aci.mso import MSOModule, mso_argument_spec, mso_reference_spec, mso_subnet_spec
+from ansible_collections.cisco.mso.plugins.module_utils.mso import MSOModule, mso_argument_spec, mso_reference_spec, mso_subnet_spec
 
 
 def main():

--- a/plugins/modules/network/check_point/checkpoint_access_rule.py
+++ b/plugins/modules/network/check_point/checkpoint_access_rule.py
@@ -119,7 +119,7 @@ checkpoint_access_rules:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.check_point.mgmt.plugins.module_utils.network.checkpoint.checkpoint import checkpoint_argument_spec, publish, install_policy
+from ansible_collections.check_point.mgmt.plugins.module_utils.checkpoint import checkpoint_argument_spec, publish, install_policy
 
 
 def get_access_rule(module, connection):

--- a/plugins/modules/network/check_point/checkpoint_host.py
+++ b/plugins/modules/network/check_point/checkpoint_host.py
@@ -93,7 +93,7 @@ checkpoint_hosts:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.check_point.mgmt.plugins.module_utils.network.checkpoint.checkpoint import checkpoint_argument_spec, publish, install_policy
+from ansible_collections.check_point.mgmt.plugins.module_utils.checkpoint import checkpoint_argument_spec, publish, install_policy
 
 
 def get_host(module, connection):

--- a/plugins/modules/network/check_point/cp_publish.py
+++ b/plugins/modules/network/check_point/cp_publish.py
@@ -56,7 +56,7 @@ cp_publish:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.check_point.mgmt.plugins.module_utils.network.checkpoint.checkpoint import checkpoint_argument_spec_for_commands, api_command
+from ansible_collections.check_point.mgmt.plugins.module_utils.checkpoint import checkpoint_argument_spec_for_commands, api_command
 
 
 def main():

--- a/plugins/modules/network/eric_eccli/eric_eccli_command.py
+++ b/plugins/modules/network/eric_eccli/eric_eccli_command.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: eric_eccli_command
 author: Ericsson IPOS OAM team (@itercheng)
@@ -34,7 +34,7 @@ options:
         the number of retries has expired. If a command sent to the
         device requires answering a prompt, it is possible to pass
         a dict containing I(command), I(answer) and I(prompt).
-        Common answers are 'y' or "\r" (carriage return, must be
+        Common answers are 'y' or "\\r" (carriage return, must be
         double quotes). See examples.
     type: list
     required: true
@@ -80,7 +80,7 @@ notes:
   - For more information on using Ansible to manage Ericsson devices see the Ericsson documents.
   - "Starting with Ansible 2.5 we recommend using C(connection: network_cli)."
   - For more information please see the L(ERIC_ECCLI Platform Options guide,../network/user_guide/platform_eric_eccli.html).
-'''
+"""
 
 EXAMPLES = r"""
 tasks:

--- a/plugins/modules/network/f5/bigip_asm_policy.py
+++ b/plugins/modules/network/f5/bigip_asm_policy.py
@@ -248,14 +248,14 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import upload_file
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import tmos_version
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import module_provisioned
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import upload_file
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_device_info.py
+++ b/plugins/modules/network/f5/bigip_device_info.py
@@ -7004,16 +7004,16 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.urls import parseStats
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import flatten_boolean
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import modules_provisioned
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import tmos_version
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import modules_provisioned
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
     from ansible_collections.community.general.plugins.module_utils.network.f5.urls import parseStats
 
 

--- a/plugins/modules/network/f5/bigip_device_traffic_group.py
+++ b/plugins/modules/network/f5/bigip_device_traffic_group.py
@@ -203,13 +203,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.common import flatten_boolean
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import flatten_boolean
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_facts.py
+++ b/plugins/modules/network/f5/bigip_facts.py
@@ -104,8 +104,8 @@ try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
     from ansible_collections.community.general.plugins.module_utils.network.f5.legacy import bigip_api, bigsuds_found
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5BaseClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
 
 try:
     from suds import MethodNotFound, WebFault

--- a/plugins/modules/network/f5/bigip_firewall_address_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_address_list.py
@@ -178,16 +178,16 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.ipaddress import is_valid_ip_interface
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import transform_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_address
     from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_interface
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.ipaddress import is_valid_ip_interface
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip_interface
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_firewall_port_list.py
+++ b/plugins/modules/network/f5/bigip_firewall_port_list.py
@@ -185,13 +185,13 @@ try:
     from library.module_utils.network.f5.common import transform_name
     from library.module_utils.network.f5.icontrol import module_provisioned
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import transform_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import module_provisioned
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import module_provisioned
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigip_gtm_facts.py
+++ b/plugins/modules/network/f5/bigip_gtm_facts.py
@@ -194,16 +194,16 @@ except ImportError:
 try:
     from library.module_utils.network.f5.common import F5BaseClient
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5BaseClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5BaseClient
 
 try:
     from library.module_utils.network.f5.common import F5ModuleError
     from library.module_utils.network.f5.common import AnsibleF5Parameters
     from library.module_utils.network.f5.common import f5_argument_spec
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
 
 
 class F5Client(F5BaseClient):

--- a/plugins/modules/network/f5/bigip_lx_package.py
+++ b/plugins/modules/network/f5/bigip_lx_package.py
@@ -105,12 +105,12 @@ try:
     from library.module_utils.network.f5.icontrol import tmos_version
     from library.module_utils.network.f5.icontrol import upload_file
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigip import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import tmos_version
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.icontrol import upload_file
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigip import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import tmos_version
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.icontrol import upload_file
 
 
 class Parameters(AnsibleF5Parameters):

--- a/plugins/modules/network/f5/bigiq_device_info.py
+++ b/plugins/modules/network/f5/bigiq_device_info.py
@@ -836,14 +836,14 @@ try:
     from library.module_utils.network.f5.ipaddress import is_valid_ip
     from library.module_utils.network.f5.common import transform_name
 except ImportError:
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.bigiq import F5RestClient
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import F5ModuleError
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import AnsibleF5Parameters
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import f5_argument_spec
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import fq_name
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import flatten_boolean
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.ipaddress import is_valid_ip
-    from ansible_collections.f5networks.f5_modules.plugins.module_utils.network.f5.common import transform_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.bigiq import F5RestClient
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import F5ModuleError
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import AnsibleF5Parameters
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import f5_argument_spec
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import fq_name
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import flatten_boolean
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.ipaddress import is_valid_ip
+    from ansible_collections.f5networks.f5_modules.plugins.module_utils.common import transform_name
 
 
 def parseStats(entry):

--- a/plugins/modules/network/fortimanager/fmgr_device.py
+++ b/plugins/modules/network/fortimanager/fmgr_device.py
@@ -119,12 +119,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def discover_device(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_device_config.py
+++ b/plugins/modules/network/fortimanager/fmgr_device_config.py
@@ -107,12 +107,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
 
 
 def update_device_hostname(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_device_group.py
+++ b/plugins/modules/network/fortimanager/fmgr_device_group.py
@@ -126,12 +126,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def get_groups(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_device_provision_template.py
+++ b/plugins/modules/network/fortimanager/fmgr_device_provision_template.py
@@ -587,12 +587,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def get_devprof(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwobj_address.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwobj_address.py
@@ -274,11 +274,11 @@ api_result:
 import re
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def fmgr_fwobj_ipv4(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwobj_ippool.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwobj_ippool.py
@@ -285,13 +285,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_fwobj_ippool6.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwobj_ippool6.py
@@ -126,13 +126,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 def fmgr_fwobj_ippool6_modify(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwobj_service.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwobj_service.py
@@ -292,12 +292,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 def fmgr_fwobj_service_custom(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwobj_vip.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwobj_vip.py
@@ -1757,14 +1757,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 def fmgr_firewall_vip_modify(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwpol_ipv4.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwpol_ipv4.py
@@ -970,14 +970,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 def fmgr_firewall_policy_modify(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_fwpol_package.py
+++ b/plugins/modules/network/fortimanager/fmgr_fwpol_package.py
@@ -216,12 +216,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
 
 
 def fmgr_fwpol_package(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_ha.py
+++ b/plugins/modules/network/fortimanager/fmgr_ha.py
@@ -137,12 +137,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def fmgr_set_ha_mode(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_provisioning.py
+++ b/plugins/modules/network/fortimanager/fmgr_provisioning.py
@@ -145,7 +145,7 @@ api_result:
 """
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import AnsibleFortiManager
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import AnsibleFortiManager
 
 # check for pyFMG lib
 try:

--- a/plugins/modules/network/fortimanager/fmgr_query.py
+++ b/plugins/modules/network/fortimanager/fmgr_query.py
@@ -140,12 +140,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def fmgr_get_custom(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_script.py
+++ b/plugins/modules/network/fortimanager/fmgr_script.py
@@ -119,12 +119,12 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
 def set_script(fmgr, paramgram):

--- a/plugins/modules/network/fortimanager/fmgr_secprof_appctrl.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_appctrl.py
@@ -348,13 +348,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 ###############
 # START METHODS

--- a/plugins/modules/network/fortimanager/fmgr_secprof_av.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_av.py
@@ -977,13 +977,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 ###############
 # START METHODS

--- a/plugins/modules/network/fortimanager/fmgr_secprof_dns.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_dns.py
@@ -208,14 +208,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_ips.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_ips.py
@@ -436,13 +436,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_profile_group.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_profile_group.py
@@ -167,14 +167,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_proxy.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_proxy.py
@@ -209,13 +209,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_spam.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_spam.py
@@ -417,13 +417,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 ###############
 # START METHODS

--- a/plugins/modules/network/fortimanager/fmgr_secprof_ssl_ssh.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_ssl_ssh.py
@@ -696,14 +696,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 ###############
 # START METHODS

--- a/plugins/modules/network/fortimanager/fmgr_secprof_voip.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_voip.py
@@ -888,13 +888,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_waf.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_waf.py
@@ -1051,14 +1051,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_wanopt.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_wanopt.py
@@ -490,13 +490,13 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 ###############

--- a/plugins/modules/network/fortimanager/fmgr_secprof_web.py
+++ b/plugins/modules/network/fortimanager/fmgr_secprof_web.py
@@ -783,14 +783,14 @@ api_result:
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.fortimanager import FortiManagerHandler
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGBaseException
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRCommon
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FMGRMethods
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import DEFAULT_RESULT_OBJ
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import prepare_dict
-from ansible_collections.fortinet.fortios.plugins.module_utils.network.fortimanager.common import scrub_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.fortimanager import FortiManagerHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGBaseException
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRCommon
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FMGRMethods
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import DEFAULT_RESULT_OBJ
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import prepare_dict
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import scrub_dict
 
 
 def fmgr_webfilter_profile_modify(fmgr, paramgram):

--- a/plugins/modules/network/icx/icx_command.py
+++ b/plugins/modules/network/icx/icx_command.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: icx_command
 author: "Ruckus Wireless (@Commscope)"
@@ -34,7 +34,7 @@ options:
         device requires answering a prompt, checkall and newline if
         multiple prompts, it is possible to pass
         a dict containing I(command), I(answer), I(prompt), I(check_all)
-        and I(newline).Common answers are 'y' or "\r" (carriage return,
+        and I(newline).Common answers are 'y' or "\\r" (carriage return,
         must be double quotes). See examples.
     type: list
     required: true
@@ -74,7 +74,7 @@ options:
         trying the command again.
     type: int
     default: 1
-'''
+"""
 
 EXAMPLES = """
 tasks:

--- a/plugins/modules/network/voss/voss_command.py
+++ b/plugins/modules/network/voss/voss_command.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: voss_command
 author: "Lindsay Hill (@LindsayHill)"
@@ -48,7 +48,7 @@ options:
         until the condition is satisfied or the number of retries has
         expired. If a command sent to the device requires answering a
         prompt, it is possible to pass a dict containing I(command),
-        I(answer) and I(prompt). Common answers are 'y' or "\r"
+        I(answer) and I(prompt). Common answers are 'y' or "\\r"
         (carriage return, must be double quotes). See examples.
     required: true
   wait_for:
@@ -82,7 +82,7 @@ options:
         conditions, the interval indicates how long to wait before
         trying the command again.
     default: 1
-'''
+"""
 
 EXAMPLES = r"""
 tasks:

--- a/plugins/modules/remote_management/intersight/intersight_info.py
+++ b/plugins/modules/remote_management/intersight/intersight_info.py
@@ -72,7 +72,7 @@ intersight_servers:
       sample: 5978bea36ad4b000018d63dc
 '''
 
-from ansible_collections.cisco.intersight.plugins.module_utils.remote_management.intersight import IntersightModule, intersight_argument_spec
+from ansible_collections.cisco.intersight.plugins.module_utils.intersight import IntersightModule, intersight_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/storage/netapp/na_cdot_aggregate.py
+++ b/plugins/modules/storage/netapp/na_cdot_aggregate.py
@@ -18,7 +18,7 @@ module: na_cdot_aggregate
 
 short_description: Manage NetApp cDOT aggregates.
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_license.py
+++ b/plugins/modules/storage/netapp/na_cdot_license.py
@@ -18,7 +18,7 @@ module: na_cdot_license
 
 short_description: Manage NetApp cDOT protocol and feature licenses
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_lun.py
+++ b/plugins/modules/storage/netapp/na_cdot_lun.py
@@ -18,7 +18,7 @@ module: na_cdot_lun
 
 short_description: Manage  NetApp cDOT luns
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_qtree.py
+++ b/plugins/modules/storage/netapp/na_cdot_qtree.py
@@ -18,7 +18,7 @@ module: na_cdot_qtree
 
 short_description: Manage qtrees
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_svm.py
+++ b/plugins/modules/storage/netapp/na_cdot_svm.py
@@ -18,7 +18,7 @@ module: na_cdot_svm
 
 short_description: Manage NetApp cDOT svm
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_user.py
+++ b/plugins/modules/storage/netapp/na_cdot_user.py
@@ -18,7 +18,7 @@ module: na_cdot_user
 
 short_description: useradmin configuration and management
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_user_role.py
+++ b/plugins/modules/storage/netapp/na_cdot_user_role.py
@@ -18,7 +18,7 @@ module: na_cdot_user_role
 
 short_description: useradmin configuration and management
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/plugins/modules/storage/netapp/na_cdot_volume.py
+++ b/plugins/modules/storage/netapp/na_cdot_volume.py
@@ -18,7 +18,7 @@ module: na_cdot_volume
 
 short_description: Manage NetApp cDOT volumes
 extends_documentation_fragment:
-- netapp.ontap.netapp.ontap
+- netapp.ontap.netapp.na_ontap
 
 author: Sumit Kumar (@timuster) <sumit4@netapp.com>
 

--- a/tests/unit/modules/system/interfaces_file/interfaces_file/test_interfaces_file.py
+++ b/tests/unit/modules/system/interfaces_file/interfaces_file/test_interfaces_file.py
@@ -156,7 +156,7 @@ class TestInterfacesFileModule(unittest.TestCase):
                 fail_json_iterations = []
                 for i, options in enumerate(options_list):
                     try:
-                        _, lines = interfaces_file.setInterfaceOption(module, lines, options['iface'], options['option'], options['value'], options['state'])
+                        dummy, lines = interfaces_file.setInterfaceOption(module, lines, options['iface'], options['option'], options['value'], options['state'])
                     except AnsibleFailJson as e:
                         fail_json_iterations.append("[%d] fail_json message: %s\noptions:\n%s" %
                                                     (i, str(e), json.dumps(options, sort_keys=True, indent=4, separators=(',', ': '))))
@@ -188,8 +188,8 @@ class TestInterfacesFileModule(unittest.TestCase):
                         fail_json_iterations = []
                         options['state'] = state
                         try:
-                            _, lines = interfaces_file.setInterfaceOption(module, lines,
-                                                                          options['iface'], options['option'], options['value'], options['state'])
+                            dummy, lines = interfaces_file.setInterfaceOption(module, lines,
+                                                                              options['iface'], options['option'], options['value'], options['state'])
                         except AnsibleFailJson as e:
                             fail_json_iterations.append("fail_json message: %s\noptions:\n%s" %
                                                         (str(e), json.dumps(options, sort_keys=True, indent=4, separators=(',', ': '))))
@@ -312,8 +312,8 @@ class TestInterfacesFileModule(unittest.TestCase):
                     options = options_list[0]
                     fail_json_iterations = []
                     try:
-                        _, lines = interfaces_file.setInterfaceOption(module, lines, options['iface'], options['option'],
-                                                                      options['value'], options['state'], options['address_family'])
+                        dummy, lines = interfaces_file.setInterfaceOption(module, lines, options['iface'], options['option'],
+                                                                          options['value'], options['state'], options['address_family'])
                     except AnsibleFailJson as e:
                         fail_json_iterations.append("fail_json message: %s\noptions:\n%s" %
                                                     (str(e), json.dumps(options, sort_keys=True, indent=4, separators=(',', ': '))))

--- a/tests/unit/modules/system/interfaces_file/interfaces_file/test_interfaces_file.py
+++ b/tests/unit/modules/system/interfaces_file/interfaces_file/test_interfaces_file.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+__metaclass__ = type
+
 from ansible_collections.ansible.posix.tests.unit.compat import unittest
 from ansible_collections.community.general.plugins.modules import interfaces_file
 from shutil import copyfile, move

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -42,6 +42,7 @@ cd "${TEST_DIR}"
 ansible-galaxy -vvv collection install ansible.posix
 ansible-galaxy -vvv collection install community.crypto
 ansible-galaxy -vvv collection install ansible.netcommon
+ansible-galaxy -vvv collection install ovirt.ovirt_collection
 
 # unit tests
 ansible-galaxy -vvv collection install community.kubernetes

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -48,6 +48,7 @@ ansible-galaxy -vvv collection install ovirt.ovirt_collection
 ansible-galaxy -vvv collection install community.kubernetes
 ansible-galaxy -vvv collection install netbox.netbox
 ansible-galaxy -vvv collection install netapp.ontap
+ansible-galaxy -vvv collection install cisco.mso
 ansible-galaxy -vvv collection install cisco.meraki
 ansible-galaxy -vvv collection install fortinet.fortios
 ansible-galaxy -vvv collection install junipernetworks.junos

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -56,6 +56,7 @@ ansible-galaxy -vvv collection install cisco.aci
 ansible-galaxy -vvv collection install google.cloud
 ansible-galaxy -vvv collection install community.kubernetes
 ansible-galaxy -vvv collection install f5networks.f5_modules
+ansible-galaxy -vvv collection install check_point.mgmt
 
 # Needed until https://github.com/ansible/ansible/issues/68415 is fixed:
 chmod -R a+rX "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -50,6 +50,7 @@ ansible-galaxy -vvv collection install netbox.netbox
 ansible-galaxy -vvv collection install netapp.ontap
 ansible-galaxy -vvv collection install cisco.mso
 ansible-galaxy -vvv collection install cisco.meraki
+ansible-galaxy -vvv collection install cisco.intersight
 ansible-galaxy -vvv collection install fortinet.fortios
 ansible-galaxy -vvv collection install junipernetworks.junos
 ansible-galaxy -vvv collection install cisco.aci


### PR DESCRIPTION
##### SUMMARY
Makes most of the `import` test problems go away. The only problems left are:
 1) The f5networks.f5_modules collection seems to be broken, its module_utils files import stuff which is no longer in ansible/ansible.
 2) A lot of (all?) storage/netapp/* modules try to import something which does (no longer?) exist in https://github.com/ansible-collections/netapp/tree/master/ansible_collections/netapp/ontap/plugins/module_utils

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lots of files
