### PR TITLE
postgres: make interfaces of exec_sql clearer

### DIFF
--- a/plugins/modules/database/postgresql/postgresql_copy.py
+++ b/plugins/modules/database/postgresql/postgresql_copy.py
@@ -253,7 +253,7 @@ class PgCopyData(object):
             if self.changed:
                 self.executed_queries.append(' '.join(query_fragments))
         else:
-            if exec_sql(self, ' '.join(query_fragments), ddl=True):
+            if exec_sql(self, ' '.join(query_fragments), return_bool=True):
                 self.changed = True
 
     def copy_to(self):
@@ -288,7 +288,7 @@ class PgCopyData(object):
             if self.changed:
                 self.executed_queries.append(' '.join(query_fragments))
         else:
-            if exec_sql(self, ' '.join(query_fragments), ddl=True):
+            if exec_sql(self, ' '.join(query_fragments), return_bool=True):
                 self.changed = True
 
     def __transform_options(self):

--- a/plugins/modules/database/postgresql/postgresql_idx.py
+++ b/plugins/modules/database/postgresql/postgresql_idx.py
@@ -411,7 +411,7 @@ class Index(object):
 
         self.executed_query = query
 
-        if exec_sql(self, query, ddl=True, add_to_executed=False):
+        if exec_sql(self, query, return_bool=True, add_to_executed=False):
             return True
 
         return False
@@ -447,7 +447,7 @@ class Index(object):
 
         self.executed_query = query
 
-        if exec_sql(self, query, ddl=True, add_to_executed=False):
+        if exec_sql(self, query, return_bool=True, add_to_executed=False):
             return True
 
         return False

--- a/plugins/modules/database/postgresql/postgresql_owner.py
+++ b/plugins/modules/database/postgresql/postgresql_owner.py
@@ -231,7 +231,7 @@ class PgOwnership(object):
         query.append('TO %s' % pg_quote_identifier(self.role, 'role'))
         query = ' '.join(query)
 
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def set_owner(self, obj_type, obj_name):
         """Change owner of a database object.
@@ -325,49 +325,49 @@ class PgOwnership(object):
         """Set the database owner."""
         query = "ALTER DATABASE %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'database'),
                                                    pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_func_owner(self):
         """Set the function owner."""
         query = "ALTER FUNCTION %s OWNER TO %s" % (self.obj_name,
                                                    pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_seq_owner(self):
         """Set the sequence owner."""
         query = "ALTER SEQUENCE %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'table'),
                                                    pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_schema_owner(self):
         """Set the schema owner."""
         query = "ALTER SCHEMA %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'schema'),
                                                  pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_table_owner(self):
         """Set the table owner."""
         query = "ALTER TABLE %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'table'),
                                                 pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_tablespace_owner(self):
         """Set the tablespace owner."""
         query = "ALTER TABLESPACE %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'database'),
                                                      pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_view_owner(self):
         """Set the view owner."""
         query = "ALTER VIEW %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'table'),
                                                pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __set_mat_view_owner(self):
         """Set the materialized view owner."""
         query = "ALTER MATERIALIZED VIEW %s OWNER TO %s" % (pg_quote_identifier(self.obj_name, 'table'),
                                                             pg_quote_identifier(self.role, 'role'))
-        self.changed = exec_sql(self, query, ddl=True)
+        self.changed = exec_sql(self, query, return_bool=True)
 
     def __role_exists(self, role):
         """Return True if role exists, otherwise return False."""

--- a/plugins/modules/database/postgresql/postgresql_publication.py
+++ b/plugins/modules/database/postgresql/postgresql_publication.py
@@ -562,7 +562,7 @@ class PgPublication():
             self.executed_queries.append(query)
             return True
         else:
-            return exec_sql(self, query, ddl=True)
+            return exec_sql(self, query, return_bool=True)
 
 
 # ===========================================

--- a/plugins/modules/database/postgresql/postgresql_sequence.py
+++ b/plugins/modules/database/postgresql/postgresql_sequence.py
@@ -419,7 +419,7 @@ class Sequence(object):
         if self.module.params.get('cycle'):
             query.append('CYCLE')
 
-        return exec_sql(self, ' '.join(query), ddl=True)
+        return exec_sql(self, ' '.join(query), return_bool=True)
 
     def drop(self):
         """Implements DROP SEQUENCE command behavior."""
@@ -429,7 +429,7 @@ class Sequence(object):
         if self.module.params.get('cascade'):
             query.append('CASCADE')
 
-        return exec_sql(self, ' '.join(query), ddl=True)
+        return exec_sql(self, ' '.join(query), return_bool=True)
 
     def rename(self):
         """Implements ALTER SEQUENCE RENAME TO command behavior."""
@@ -437,7 +437,7 @@ class Sequence(object):
         query.append(self.__add_schema())
         query.append('RENAME TO %s' % pg_quote_identifier(self.module.params['rename_to'], 'sequence'))
 
-        return exec_sql(self, ' '.join(query), ddl=True)
+        return exec_sql(self, ' '.join(query), return_bool=True)
 
     def set_owner(self):
         """Implements ALTER SEQUENCE OWNER TO command behavior."""
@@ -445,7 +445,7 @@ class Sequence(object):
         query.append(self.__add_schema())
         query.append('OWNER TO %s' % pg_quote_identifier(self.module.params['owner'], 'role'))
 
-        return exec_sql(self, ' '.join(query), ddl=True)
+        return exec_sql(self, ' '.join(query), return_bool=True)
 
     def set_schema(self):
         """Implements ALTER SEQUENCE SET SCHEMA command behavior."""
@@ -453,7 +453,7 @@ class Sequence(object):
         query.append(self.__add_schema())
         query.append('SET SCHEMA %s' % pg_quote_identifier(self.module.params['newschema'], 'schema'))
 
-        return exec_sql(self, ' '.join(query), ddl=True)
+        return exec_sql(self, ' '.join(query), return_bool=True)
 
     def __add_schema(self):
         return '.'.join([pg_quote_identifier(self.schema, 'schema'),

--- a/plugins/modules/database/postgresql/postgresql_slot.py
+++ b/plugins/modules/database/postgresql/postgresql_slot.py
@@ -192,19 +192,19 @@ class PgSlot(object):
 
             self.changed = exec_sql(self, query,
                                     query_params={'name': self.name, 'i_reserve': immediately_reserve},
-                                    ddl=True)
+                                    return_bool=True)
 
         elif kind == 'logical':
             query = "SELECT pg_create_logical_replication_slot(%(name)s, %(o_plugin)s)"
             self.changed = exec_sql(self, query,
-                                    query_params={'name': self.name, 'o_plugin': output_plugin}, ddl=True)
+                                    query_params={'name': self.name, 'o_plugin': output_plugin}, return_bool=True)
 
     def drop(self):
         if not self.exists:
             return False
 
         query = "SELECT pg_drop_replication_slot(%(name)s)"
-        self.changed = exec_sql(self, query, query_params={'name': self.name}, ddl=True)
+        self.changed = exec_sql(self, query, query_params={'name': self.name}, return_bool=True)
 
     def __slot_exists(self):
         query = "SELECT slot_type FROM pg_replication_slots WHERE slot_name = %(name)s"

--- a/plugins/modules/database/postgresql/postgresql_subscription.py
+++ b/plugins/modules/database/postgresql/postgresql_subscription.py
@@ -562,7 +562,7 @@ class PgSubscription():
             self.executed_queries.append(query)
             return True
         else:
-            return exec_sql(self, query, ddl=True)
+            return exec_sql(self, query, return_bool=True)
 
 
 # ===========================================

--- a/plugins/modules/database/postgresql/postgresql_table.py
+++ b/plugins/modules/database/postgresql/postgresql_table.py
@@ -367,7 +367,7 @@ class Table(object):
         if tblspace:
             query += " TABLESPACE %s" % pg_quote_identifier(tblspace, 'database')
 
-        if exec_sql(self, query, ddl=True):
+        if exec_sql(self, query, return_bool=True):
             changed = True
 
         if owner:
@@ -414,7 +414,7 @@ class Table(object):
         if tblspace:
             query += " TABLESPACE %s" % pg_quote_identifier(tblspace, 'database')
 
-        if exec_sql(self, query, ddl=True):
+        if exec_sql(self, query, return_bool=True):
             changed = True
 
         if owner:
@@ -424,17 +424,17 @@ class Table(object):
 
     def truncate(self):
         query = "TRUNCATE TABLE %s" % pg_quote_identifier(self.name, 'table')
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def rename(self, newname):
         query = "ALTER TABLE %s RENAME TO %s" % (pg_quote_identifier(self.name, 'table'),
                                                  pg_quote_identifier(newname, 'table'))
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def set_owner(self, username):
         query = "ALTER TABLE %s OWNER TO %s" % (pg_quote_identifier(self.name, 'table'),
                                                 pg_quote_identifier(username, 'role'))
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def drop(self, cascade=False):
         if not self.exists:
@@ -443,16 +443,16 @@ class Table(object):
         query = "DROP TABLE %s" % pg_quote_identifier(self.name, 'table')
         if cascade:
             query += " CASCADE"
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def set_tblspace(self, tblspace):
         query = "ALTER TABLE %s SET TABLESPACE %s" % (pg_quote_identifier(self.name, 'table'),
                                                       pg_quote_identifier(tblspace, 'database'))
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def set_stor_params(self, params):
         query = "ALTER TABLE %s SET (%s)" % (pg_quote_identifier(self.name, 'table'), params)
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
 
 # ===========================================

--- a/plugins/modules/database/postgresql/postgresql_tablespace.py
+++ b/plugins/modules/database/postgresql/postgresql_tablespace.py
@@ -287,14 +287,14 @@ class PgTablespace(object):
             location (str) -- tablespace directory path in the FS
         """
         query = ("CREATE TABLESPACE %s LOCATION '%s'" % (pg_quote_identifier(self.name, 'database'), location))
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def drop(self):
         """Drop tablespace.
 
         Return True if success, otherwise, return False.
         """
-        return exec_sql(self, "DROP TABLESPACE %s" % pg_quote_identifier(self.name, 'database'), ddl=True)
+        return exec_sql(self, "DROP TABLESPACE %s" % pg_quote_identifier(self.name, 'database'), return_bool=True)
 
     def set_owner(self, new_owner):
         """Set tablespace owner.
@@ -308,7 +308,7 @@ class PgTablespace(object):
             return False
 
         query = "ALTER TABLESPACE %s OWNER TO %s" % (pg_quote_identifier(self.name, 'database'), new_owner)
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def rename(self, newname):
         """Rename tablespace.
@@ -320,7 +320,7 @@ class PgTablespace(object):
         """
         query = "ALTER TABLESPACE %s RENAME TO %s" % (pg_quote_identifier(self.name, 'database'), newname)
         self.new_name = newname
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def set_settings(self, new_settings):
         """Set tablespace settings (options).
@@ -358,7 +358,7 @@ class PgTablespace(object):
             setting (str) -- string in format "setting_name = 'setting_value'"
         """
         query = "ALTER TABLESPACE %s RESET (%s)" % (pg_quote_identifier(self.name, 'database'), setting)
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
     def __set_setting(self, setting):
         """Set tablespace setting.
@@ -369,7 +369,7 @@ class PgTablespace(object):
             setting (str) -- string in format "setting_name = 'setting_value'"
         """
         query = "ALTER TABLESPACE %s SET (%s)" % (pg_quote_identifier(self.name, 'database'), setting)
-        return exec_sql(self, query, ddl=True)
+        return exec_sql(self, query, return_bool=True)
 
 
 # ===========================================


### PR DESCRIPTION
(cherry picked from commit fb6583a15c1f7fd8e48f4f3ef214ed4e74c3d8c6)

##### SUMMARY
postgres: make interfaces of postgres.exec_sql clearer
This function was introduced by me.
Now, despite this typical for DDL queries, i'm convinced that it will make the function's interface clearer.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```plugins/module_utils/postgres.py```
```plugins/modules/database/postgresql/postgresql_copy.py```
```plugins/modules/database/postgresql/postgresql_idx.py```
```plugins/modules/database/postgresql/postgresql_owner.py```
```plugins/modules/database/postgresql/postgresql_table.py```
```plugins/modules/database/postgresql/postgresql_sequence.py```
```plugins/modules/database/postgresql/postgresql_slot.py```
```plugins/modules/database/postgresql/postgresql_tablespace```
```plugins/modules/database/postgresql/postgresql_publication```
```plugins/modules/database/postgresql/postgresql_subscription```

