### PR TITLE
galaxy.yml - Do not add anymore dependencies

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,6 +8,7 @@ description: null
 license: GPL-3.0-or-later
 license_file: COPYING
 tags: null
+# NOTE: No more dependencies can be added to this list
 #dependencies:
 #  netapp.ontap: '>=0.1.0'
 #  community.kubernetes: '>=0.1.0'


### PR DESCRIPTION
##### SUMMARY
We really don't want any more run-time dependencies adding to `community.general`, so lets document that

I will go through remove as many of these as we can.

