### PR TITLE
Fix become plugins

### DIFF
--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -111,13 +111,13 @@ class BecomeModule(BecomeBase):
 
         self.prompt = True
 
-        become_exe = self.get_option('become_exe') or 'doas'
+        become_exe = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
+        flags = self.get_option('become_flags')
         if not self.get_option('become_pass') and '-n' not in flags:
             flags += ' -n'
 
-        user = self.get_option('become_user') or ''
+        user = self.get_option('become_user')
         if user:
             user = '-u %s' % (user)
 

--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -111,7 +111,14 @@ class BecomeModule(BecomeBase):
 
         self.prompt = True
 
-        become_exe = self.get_option('become_exe') or self.name
+        become_exe = self.get_option('become_exe')
+        if not become_exe or become_exe == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            become_exe = 'doas'
 
         flags = self.get_option('become_flags') or ''
         if not self.get_option('become_pass') and '-n' not in flags:

--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -111,14 +111,7 @@ class BecomeModule(BecomeBase):
 
         self.prompt = True
 
-        become_exe = self.get_option('become_exe')
-        if not become_exe or become_exe == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            become_exe = 'doas'
+        become_exe = self.get_option('become_exe') or 'doas'
 
         flags = self.get_option('become_flags') or ''
         if not self.get_option('become_pass') and '-n' not in flags:

--- a/plugins/become/dzdo.py
+++ b/plugins/become/dzdo.py
@@ -82,14 +82,14 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        becomecmd = self.get_option('become_exe') or 'dzdo'
+        becomecmd = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
+        flags = self.get_option('become_flags')
         if self.get_option('become_pass'):
             self.prompt = '[dzdo via ansible, key=%s] password:' % self._id
             flags = '%s -p "%s"' % (flags.replace('-n', ''), self.prompt)
 
-        user = self.get_option('become_user') or ''
+        user = self.get_option('become_user')
         if user:
             user = '-u %s' % (user)
 

--- a/plugins/become/dzdo.py
+++ b/plugins/become/dzdo.py
@@ -82,14 +82,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        becomecmd = self.get_option('become_exe')
-        if not becomecmd or becomecmd == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            becomecmd = 'dzdo'
+        becomecmd = self.get_option('become_exe') or 'dzdo'
 
         flags = self.get_option('become_flags') or ''
         if self.get_option('become_pass'):

--- a/plugins/become/dzdo.py
+++ b/plugins/become/dzdo.py
@@ -82,7 +82,14 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        becomecmd = self.get_option('become_exe') or self.name
+        becomecmd = self.get_option('become_exe')
+        if not becomecmd or becomecmd == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            becomecmd = 'dzdo'
 
         flags = self.get_option('become_flags') or ''
         if self.get_option('become_pass'):

--- a/plugins/become/ksu.py
+++ b/plugins/become/ksu.py
@@ -13,6 +13,7 @@ DOCUMENTATION = '''
     options:
         become_user:
             description: User you 'become' to execute the task
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_user
@@ -113,8 +114,8 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe') or 'ksu'
+        exe = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
-        user = self.get_option('become_user') or ''
+        flags = self.get_option('become_flags')
+        user = self.get_option('become_user')
         return '%s %s %s -e %s ' % (exe, user, flags, self._build_success_command(cmd, shell))

--- a/plugins/become/ksu.py
+++ b/plugins/become/ksu.py
@@ -113,14 +113,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe')
-        if not exe or exe == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            exe = 'ksu'
+        exe = self.get_option('become_exe') or 'ksu'
 
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''

--- a/plugins/become/ksu.py
+++ b/plugins/become/ksu.py
@@ -113,7 +113,15 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe') or self.name
+        exe = self.get_option('become_exe')
+        if not exe or exe == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            exe = 'ksu'
+
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
         return '%s %s %s -e %s ' % (exe, user, flags, self._build_success_command(cmd, shell))

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -13,6 +13,7 @@ DOCUMENTATION = '''
     options:
         become_user:
             description: User you 'become' to execute the task
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_user
@@ -80,8 +81,8 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or 'machinectl'
+        become = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
-        user = self.get_option('become_user') or ''
+        flags = self.get_option('become_flags')
+        user = self.get_option('become_user')
         return '%s -q shell %s %s@ %s' % (become, flags, user, cmd)

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -80,14 +80,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe')
-        if not become or become == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            become = 'machinectl'
+        become = self.get_option('become_exe') or 'machinectl'
 
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -80,7 +80,15 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or self.name
+        become = self.get_option('become_exe')
+        if not become or become == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            become = 'machinectl'
+
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
         return '%s -q shell %s %s@ %s' % (become, flags, user, cmd)

--- a/plugins/become/pbrun.py
+++ b/plugins/become/pbrun.py
@@ -41,6 +41,7 @@ DOCUMENTATION = '''
               - name: ANSIBLE_PBRUN_EXE
         become_flags:
             description: Options to pass to pbrun
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_flags
@@ -93,10 +94,10 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become_exe = self.get_option('become_exe') or 'pbrun'
+        become_exe = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
-        user = self.get_option('become_user') or ''
+        flags = self.get_option('become_flags')
+        user = self.get_option('become_user')
         if user:
             user = '-u %s' % (user)
         noexe = not self.get_option('wrap_exe')

--- a/plugins/become/pbrun.py
+++ b/plugins/become/pbrun.py
@@ -93,7 +93,15 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become_exe = self.get_option('become_exe') or self.name
+        become_exe = self.get_option('become_exe')
+        if not become_exe or become_exe == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            become_exe = 'pbrun'
+
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
         if user:

--- a/plugins/become/pbrun.py
+++ b/plugins/become/pbrun.py
@@ -93,14 +93,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become_exe = self.get_option('become_exe')
-        if not become_exe or become_exe == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            become_exe = 'pbrun'
+        become_exe = self.get_option('become_exe') or 'pbrun'
 
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -97,7 +97,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe') or 'pfexec'
+        exe = self.get_option('become_exe')
 
         flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -97,7 +97,15 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe') or self.name
+        exe = self.get_option('become_exe')
+        if not exe or exe == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            exe = 'pfexec'
+
         flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')
         return '%s %s "%s"' % (exe, flags, self._build_success_command(cmd, shell, noexe=noexe))

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -97,14 +97,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe = self.get_option('become_exe')
-        if not exe or exe == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            exe = 'pfexec'
+        exe = self.get_option('become_exe') or 'pfexec'
 
         flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')

--- a/plugins/become/pmrun.py
+++ b/plugins/become/pmrun.py
@@ -27,6 +27,7 @@ DOCUMENTATION = '''
               - name: ANSIBLE_PMRUN_EXE
         become_flags:
             description: Options to pass to pmrun
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_flags
@@ -70,7 +71,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or 'pmrun'
+        become = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
+        flags = self.get_option('become_flags')
         return '%s %s %s' % (become, flags, shlex_quote(self._build_success_command(cmd, shell)))

--- a/plugins/become/pmrun.py
+++ b/plugins/become/pmrun.py
@@ -70,14 +70,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe')
-        if not become or become == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            become = 'pmrun'
+        become = self.get_option('become_exe') or 'pmrun'
 
         flags = self.get_option('become_flags') or ''
         return '%s %s %s' % (become, flags, shlex_quote(self._build_success_command(cmd, shell)))

--- a/plugins/become/pmrun.py
+++ b/plugins/become/pmrun.py
@@ -70,6 +70,14 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or self.name
+        become = self.get_option('become_exe')
+        if not become or become == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            become = 'pmrun'
+
         flags = self.get_option('become_flags') or ''
         return '%s %s %s' % (become, flags, shlex_quote(self._build_success_command(cmd, shell)))

--- a/plugins/become/sesu.py
+++ b/plugins/become/sesu.py
@@ -13,6 +13,7 @@ DOCUMENTATION = '''
     options:
         become_user:
             description: User you 'become' to execute the task
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_user
@@ -83,8 +84,8 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or 'sesu'
+        become = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags') or ''
-        user = self.get_option('become_user') or ''
+        flags = self.get_option('become_flags')
+        user = self.get_option('become_user')
         return '%s %s %s -c %s' % (become, flags, user, self._build_success_command(cmd, shell))

--- a/plugins/become/sesu.py
+++ b/plugins/become/sesu.py
@@ -83,7 +83,15 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe') or self.name
+        become = self.get_option('become_exe')
+        if not become or become == self.name:
+            # HACK! Ansible's playbook/play_context.py initializes the become_exe
+            # with the become method's name if it is not explicitly specified.
+            # Since in the community.general collection that name is prefixed with
+            # `community.general.`, we have to check for that default and replace
+            # it with the "short name" of the become plugin.
+            become = 'sesu'
+
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
         return '%s %s %s -c %s' % (become, flags, user, self._build_success_command(cmd, shell))

--- a/plugins/become/sesu.py
+++ b/plugins/become/sesu.py
@@ -83,14 +83,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self.get_option('become_exe')
-        if not become or become == self.name:
-            # HACK! Ansible's playbook/play_context.py initializes the become_exe
-            # with the become method's name if it is not explicitly specified.
-            # Since in the community.general collection that name is prefixed with
-            # `community.general.`, we have to check for that default and replace
-            # it with the "short name" of the become plugin.
-            become = 'sesu'
+        become = self.get_option('become_exe') or 'sesu'
 
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''

--- a/tests/unit/plugins/become/helper.py
+++ b/tests/unit/plugins/become/helper.py
@@ -13,29 +13,7 @@ from ansible.plugins.loader import become_loader, get_shell_plugin
 
 def call_become_plugin(play_context, cmd, executable=None):
     """Helper function to call become plugin simiarly on how Ansible itself handles this."""
-    if not cmd or not play_context.become:
-        return cmd
-
-    plugin = become_loader.get(play_context.become_method)
-    if not plugin:
-        raise AnsibleError("Privilege escalation method not found: %s" % play_context.become_method)
-
-    play_context.set_become_plugin(plugin)
-
-    options = {
-        'become_exe': play_context.become_exe,
-        'become_flags': play_context.become_flags,
-        'become_user': play_context.become_user,
-        'become_pass': play_context.become_pass,
-    }
-    task_keys = {}
-    for k, v in options.items():
-        if v is not None:
-            task_keys[k] = v
-    plugin.set_options(task_keys=options, var_options={})
-
-    if not executable:
-        executable = play_context.executable
-
+    plugin = become_loader.get(play_context['become_method'])
+    plugin.set_options(task_keys=play_context, var_options={})
     shell = get_shell_plugin(executable=executable)
     return plugin.build_become_command(cmd, shell)

--- a/tests/unit/plugins/become/helper.py
+++ b/tests/unit/plugins/become/helper.py
@@ -13,6 +13,9 @@ from ansible.plugins.loader import become_loader, get_shell_plugin
 
 def call_become_plugin(play_context, cmd, executable=None):
     """Helper function to call become plugin simiarly on how Ansible itself handles this."""
+    if not cmd or not play_context.become:
+        return cmd
+
     plugin = become_loader.get(play_context.become_method)
     if not plugin:
         raise AnsibleError("Privilege escalation method not found: %s" % play_context.become_method)

--- a/tests/unit/plugins/become/helper.py
+++ b/tests/unit/plugins/become/helper.py
@@ -11,9 +11,9 @@ from ansible.errors import AnsibleError
 from ansible.plugins.loader import become_loader, get_shell_plugin
 
 
-def call_become_plugin(play_context, cmd, executable=None):
+def call_become_plugin(task, var_options, cmd, executable=None):
     """Helper function to call become plugin simiarly on how Ansible itself handles this."""
-    plugin = become_loader.get(play_context['become_method'])
-    plugin.set_options(task_keys=play_context, var_options={})
+    plugin = become_loader.get(task['become_method'])
+    plugin.set_options(task_keys=task, var_options=var_options)
     shell = get_shell_plugin(executable=executable)
     return plugin.build_become_command(cmd, shell)

--- a/tests/unit/plugins/become/helper.py
+++ b/tests/unit/plugins/become/helper.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.loader import get_shell_plugin
+
+
+def make_become_cmd(play_context, cmd, executable=None):
+    """ helper function to create privilege escalation commands """
+    if not cmd or not play_context.become:
+        return cmd
+
+    become_method = play_context.become_method
+
+    # load/call become plugins here
+    plugin = play_context._become_plugin
+
+    if plugin:
+        options = {
+            'become_exe': play_context.become_exe or '',
+            'become_flags': play_context.become_flags or '',
+            'become_user': play_context.become_user,
+            'become_pass': play_context.become_pass
+        }
+        plugin.set_options(direct=options)
+
+        if not executable:
+            executable = play_context.executable
+
+        shell = get_shell_plugin(executable=executable)
+        cmd = plugin.build_become_command(cmd, shell)
+        # for backwards compat:
+        if play_context.become_pass:
+            play_context.prompt = plugin.prompt
+    else:
+        raise AnsibleError("Privilege escalation method not found: %s" % become_method)
+
+    return cmd

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
 
 from .helper import call_become_plugin
 
@@ -18,23 +17,20 @@ from .helper import call_become_plugin
 def test_doas(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     doas_exe = 'doas'
     doas_flags = '-n'
 
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_method = 'community.general.doas'
-    play_context.become_flags = doas_flags
+    play_context = {
+        'become_user': 'foo',
+        'become_method': 'community.general.doas',
+        'become_flags': doas_flags,
+    }
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,
+    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context['become_user'], default_exe, success,
                                                               default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -51,13 +51,13 @@ def test_doas_varoptions(mocker, parser, reset_cli_args):
     task = {
         'become_user': 'foo',
         'become_method': 'community.general.doas',
-        'become_flags': doas_flags,
+        'become_flags': 'xxx',
     }
     var_options = {
-        'become_user': 'bar',
-        'become_flags': '',
+        'ansible_become_user': 'bar',
+        'ansible_become_flags': doas_flags,
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, task['become_user'], default_exe, success,
+    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, var_options['ansible_become_user'], default_exe, success,
                                                               default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -35,3 +35,29 @@ def test_doas(mocker, parser, reset_cli_args):
     print(cmd)
     assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, task['become_user'], default_exe, success,
                                                               default_cmd), cmd) is not None)
+
+
+def test_doas_varoptions(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    doas_exe = 'doas'
+    doas_flags = '-n'
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    task = {
+        'become_user': 'foo',
+        'become_method': 'community.general.doas',
+        'become_flags': doas_flags,
+    }
+    var_options = {
+        'become_user': 'bar',
+        'become_flags': '',
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, task['become_user'], default_exe, success,
+                                                              default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -11,9 +11,8 @@ import re
 
 from ansible import context
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
 
-from .helper import make_become_cmd
+from .helper import call_become_plugin
 
 
 def test_doas(mocker, parser, reset_cli_args):
@@ -26,16 +25,16 @@ def test_doas(mocker, parser, reset_cli_args):
     doas_exe = 'doas'
     doas_flags = '-n'
 
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('community.general.doas'))
     play_context.become_method = 'community.general.doas'
     play_context.become_flags = doas_flags
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,
                                                               default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -25,12 +25,13 @@ def test_doas(mocker, parser, reset_cli_args):
 
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context = {
+    task = {
         'become_user': 'foo',
         'become_method': 'community.general.doas',
         'become_flags': doas_flags,
     }
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    var_options = {}
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context['become_user'], default_exe, success,
+    assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, task['become_user'], default_exe, success,
                                                               default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -13,6 +13,8 @@ from ansible import context
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import become_loader
 
+from .helper import make_become_cmd
+
 
 def test_doas(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
@@ -24,7 +26,7 @@ def test_doas(mocker, parser, reset_cli_args):
     doas_exe = 'doas'
     doas_flags = '-n'
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
@@ -34,6 +36,6 @@ def test_doas(mocker, parser, reset_cli_args):
     play_context.set_become_plugin(become_loader.get('community.general.doas'))
     play_context.become_method = 'community.general.doas'
     play_context.become_flags = doas_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,
                                                               default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_doas.py
+++ b/tests/unit/plugins/become/test_doas.py
@@ -31,8 +31,8 @@ def test_doas(mocker, parser, reset_cli_args):
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('doas'))
-    play_context.become_method = 'doas'
+    play_context.set_become_plugin(become_loader.get('community.general.doas'))
+    play_context.become_method = 'community.general.doas'
     play_context.become_flags = doas_flags
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert (re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (doas_exe, doas_flags, play_context.become_user, default_exe, success,

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
 
 from .helper import call_become_plugin
 
@@ -18,28 +17,25 @@ from .helper import call_become_plugin
 def test_dzdo(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     dzdo_exe = 'dzdo'
     dzdo_flags = ''
 
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_method = 'community.general.dzdo'
-    play_context.become_flags = dzdo_flags
+    play_context = {
+        'become_user': 'foo',
+        'become_method': 'community.general.dzdo',
+        'become_flags': dzdo_flags,
+    }
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
+    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context['become_user'], default_exe,
                                                              success, default_cmd), cmd) is not None
-    play_context.become_pass = 'testpass'
+    play_context['become_pass'] = 'testpass'
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
-                                                                   play_context.become_user, default_exe, success, default_cmd), cmd) is not None
+                                                                   play_context['become_user'], default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -11,9 +11,8 @@ import re
 
 from ansible import context
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
 
-from .helper import make_become_cmd
+from .helper import call_become_plugin
 
 
 def test_dzdo(mocker, parser, reset_cli_args):
@@ -26,21 +25,21 @@ def test_dzdo(mocker, parser, reset_cli_args):
     dzdo_exe = 'dzdo'
     dzdo_flags = ''
 
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
     play_context.become_method = 'community.general.dzdo'
     play_context.become_flags = dzdo_flags
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
                                                              success, default_cmd), cmd) is not None
     play_context.become_pass = 'testpass'
-    play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
                                                                    play_context.become_user, default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -56,18 +56,18 @@ def test_dzdo_varoptions(mocker, parser, reset_cli_args):
     task = {
         'become_user': 'foo',
         'become_method': 'community.general.dzdo',
-        'become_flags': dzdo_flags,
+        'become_flags': 'xxx',
     }
     var_options = {
-        'become_user': 'bar',
-        'become_flags': '',
+        'ansible_become_user': 'bar',
+        'ansible_become_flags': dzdo_flags,
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, '', task['become_user'], default_exe,
+    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, var_options['ansible_become_user'], default_exe,
                                                              success, default_cmd), cmd) is not None
-    task['become_pass'] = 'testpass'
+    var_options['ansible_become_pass'] = 'testpass'
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, '', r'\"\[dzdo via ansible, key=.+?\] password:\"',
-                                                                   task['become_user'], default_exe, success, default_cmd), cmd) is not None
+    assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
+                                                                   var_options['ansible_become_user'], default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -25,17 +25,18 @@ def test_dzdo(mocker, parser, reset_cli_args):
 
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context = {
+    task = {
         'become_user': 'foo',
         'become_method': 'community.general.dzdo',
         'become_flags': dzdo_flags,
     }
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    var_options = {}
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context['become_user'], default_exe,
+    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, task['become_user'], default_exe,
                                                              success, default_cmd), cmd) is not None
-    play_context['become_pass'] = 'testpass'
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    task['become_pass'] = 'testpass'
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
-                                                                   play_context['become_user'], default_exe, success, default_cmd), cmd) is not None
+                                                                   task['become_user'], default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -40,3 +40,34 @@ def test_dzdo(mocker, parser, reset_cli_args):
     print(cmd)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
                                                                    task['become_user'], default_exe, success, default_cmd), cmd) is not None
+
+
+def test_dzdo_varoptions(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    dzdo_exe = 'dzdo'
+    dzdo_flags = ''
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    task = {
+        'become_user': 'foo',
+        'become_method': 'community.general.dzdo',
+        'become_flags': dzdo_flags,
+    }
+    var_options = {
+        'become_user': 'bar',
+        'become_flags': '',
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, '', task['become_user'], default_exe,
+                                                             success, default_cmd), cmd) is not None
+    task['become_pass'] = 'testpass'
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, '', r'\"\[dzdo via ansible, key=.+?\] password:\"',
+                                                                   task['become_user'], default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -13,6 +13,8 @@ from ansible import context
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import become_loader
 
+from .helper import make_become_cmd
+
 
 def test_dzdo(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
@@ -24,7 +26,7 @@ def test_dzdo(mocker, parser, reset_cli_args):
     dzdo_exe = 'dzdo'
     dzdo_flags = ''
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
@@ -34,11 +36,11 @@ def test_dzdo(mocker, parser, reset_cli_args):
     play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
     play_context.become_method = 'community.general.dzdo'
     play_context.become_flags = dzdo_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
                                                              success, default_cmd), cmd) is not None
     play_context.become_pass = 'testpass'
     play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
                                                                    play_context.become_user, default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_dzdo.py
+++ b/tests/unit/plugins/become/test_dzdo.py
@@ -31,14 +31,14 @@ def test_dzdo(mocker, parser, reset_cli_args):
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('dzdo'))
-    play_context.become_method = 'dzdo'
+    play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
+    play_context.become_method = 'community.general.dzdo'
     play_context.become_flags = dzdo_flags
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, play_context.become_user, default_exe,
                                                              success, default_cmd), cmd) is not None
     play_context.become_pass = 'testpass'
-    play_context.set_become_plugin(become_loader.get('dzdo'))
+    play_context.set_become_plugin(become_loader.get('community.general.dzdo'))
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -p %s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, dzdo_flags, r'\"\[dzdo via ansible, key=.+?\] password:\"',
                                                                    play_context.become_user, default_exe, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
 
 from .helper import call_become_plugin
 
@@ -18,23 +17,20 @@ from .helper import call_become_plugin
 def test_ksu(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     ksu_exe = 'ksu'
     ksu_flags = ''
 
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_method = 'community.general.ksu'
-    play_context.become_flags = ksu_flags
+    play_context = {
+        'become_user': 'foo',
+        'become_method': 'community.general.ksu',
+        'become_flags': ksu_flags,
+    }
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,
+    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context['become_user'], ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -11,9 +11,8 @@ import re
 
 from ansible import context
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
 
-from .helper import make_become_cmd
+from .helper import call_become_plugin
 
 
 def test_ksu(mocker, parser, reset_cli_args):
@@ -26,16 +25,16 @@ def test_ksu(mocker, parser, reset_cli_args):
     ksu_exe = 'ksu'
     ksu_flags = ''
 
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('community.general.ksu'))
     play_context.become_method = 'community.general.ksu'
     play_context.become_flags = ksu_flags
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -35,3 +35,29 @@ def test_ksu(mocker, parser, reset_cli_args):
     print(cmd)
     assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, task['become_user'], ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)
+
+
+def test_ksu_varoptions(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    ksu_exe = 'ksu'
+    ksu_flags = ''
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    task = {
+        'become_user': 'foo',
+        'become_method': 'community.general.ksu',
+        'become_flags': ksu_flags,
+    }
+    var_options = {
+        'become_user': 'bar',
+        'become_flags': '',
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, task['become_user'], '',
+                                                              default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -25,12 +25,13 @@ def test_ksu(mocker, parser, reset_cli_args):
 
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context = {
+    task = {
         'become_user': 'foo',
         'become_method': 'community.general.ksu',
         'become_flags': ksu_flags,
     }
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    var_options = {}
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context['become_user'], ksu_flags,
+    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, task['become_user'], ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -51,13 +51,13 @@ def test_ksu_varoptions(mocker, parser, reset_cli_args):
     task = {
         'become_user': 'foo',
         'become_method': 'community.general.ksu',
-        'become_flags': ksu_flags,
+        'become_flags': 'xxx',
     }
     var_options = {
-        'become_user': 'bar',
-        'become_flags': '',
+        'ansible_become_user': 'bar',
+        'ansible_become_flags': ksu_flags,
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, task['become_user'], '',
+    assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, var_options['ansible_become_user'], ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -13,6 +13,8 @@ from ansible import context
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import become_loader
 
+from .helper import make_become_cmd
+
 
 def test_ksu(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
@@ -24,7 +26,7 @@ def test_ksu(mocker, parser, reset_cli_args):
     ksu_exe = 'ksu'
     ksu_flags = ''
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
@@ -34,6 +36,6 @@ def test_ksu(mocker, parser, reset_cli_args):
     play_context.set_become_plugin(become_loader.get('community.general.ksu'))
     play_context.become_method = 'community.general.ksu'
     play_context.become_flags = ksu_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,
                                                               default_exe, success, default_cmd), cmd) is not None)

--- a/tests/unit/plugins/become/test_ksu.py
+++ b/tests/unit/plugins/become/test_ksu.py
@@ -31,8 +31,8 @@ def test_ksu(mocker, parser, reset_cli_args):
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('ksu'))
-    play_context.become_method = 'ksu'
+    play_context.set_become_plugin(become_loader.get('community.general.ksu'))
+    play_context.become_method = 'community.general.ksu'
     play_context.become_flags = ksu_flags
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert (re.match("""%s %s %s -e %s -c 'echo %s; %s'""" % (ksu_exe, play_context.become_user, ksu_flags,

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -51,13 +51,13 @@ def test_pbrun_var_varoptions(mocker, parser, reset_cli_args):
     task = {
         'become_user': 'foo',
         'become_method': 'community.general.pbrun',
-        'become_flags': pbrun_flags,
+        'become_flags': 'xxx',
     }
     var_options = {
-        'become_user': 'bar',
-        'become_flags': '',
+        'ansible_become_user': 'bar',
+        'ansible_become_flags': pbrun_flags,
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, '', task['become_user'],
+    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, var_options['ansible_become_user'],
                                                        success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
 
 from .helper import call_become_plugin
 
@@ -18,23 +17,20 @@ from .helper import call_become_plugin
 def test_pbrun(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     pbrun_exe = 'pbrun'
     pbrun_flags = ''
 
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_method = 'community.general.pbrun'
-    play_context.become_flags = pbrun_flags
+    play_context = {
+        'become_user': 'foo',
+        'become_method': 'community.general.pbrun',
+        'become_flags': pbrun_flags,
+    }
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,
+    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context['become_user'],
                                                        success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -25,12 +25,13 @@ def test_pbrun(mocker, parser, reset_cli_args):
 
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context = {
+    task = {
         'become_user': 'foo',
         'become_method': 'community.general.pbrun',
         'become_flags': pbrun_flags,
     }
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    var_options = {}
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context['become_user'],
+    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, task['become_user'],
                                                        success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -11,9 +11,8 @@ import re
 
 from ansible import context
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
 
-from .helper import make_become_cmd
+from .helper import call_become_plugin
 
 
 def test_pbrun(mocker, parser, reset_cli_args):
@@ -26,16 +25,16 @@ def test_pbrun(mocker, parser, reset_cli_args):
     pbrun_exe = 'pbrun'
     pbrun_flags = ''
 
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('community.general.pbrun'))
     play_context.become_method = 'community.general.pbrun'
     play_context.become_flags = pbrun_flags
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,
                                                        success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -35,3 +35,29 @@ def test_pbrun(mocker, parser, reset_cli_args):
     print(cmd)
     assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, task['become_user'],
                                                        success, default_cmd), cmd) is not None
+
+
+def test_pbrun_var_varoptions(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    pbrun_exe = 'pbrun'
+    pbrun_flags = ''
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    task = {
+        'become_user': 'foo',
+        'become_method': 'community.general.pbrun',
+        'become_flags': pbrun_flags,
+    }
+    var_options = {
+        'become_user': 'bar',
+        'become_flags': '',
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, '', task['become_user'],
+                                                       success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -13,6 +13,8 @@ from ansible import context
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import become_loader
 
+from .helper import make_become_cmd
+
 
 def test_pbrun(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
@@ -24,7 +26,7 @@ def test_pbrun(mocker, parser, reset_cli_args):
     pbrun_exe = 'pbrun'
     pbrun_flags = ''
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
@@ -34,6 +36,6 @@ def test_pbrun(mocker, parser, reset_cli_args):
     play_context.set_become_plugin(become_loader.get('community.general.pbrun'))
     play_context.become_method = 'community.general.pbrun'
     play_context.become_flags = pbrun_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,
                                                        success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pbrun.py
+++ b/tests/unit/plugins/become/test_pbrun.py
@@ -31,8 +31,8 @@ def test_pbrun(mocker, parser, reset_cli_args):
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('pbrun'))
-    play_context.become_method = 'pbrun'
+    play_context.set_become_plugin(become_loader.get('community.general.pbrun'))
+    play_context.become_method = 'community.general.pbrun'
     play_context.become_flags = pbrun_flags
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert re.match("""%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user,

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -34,3 +34,28 @@ def test_pfexec(mocker, parser, reset_cli_args):
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+
+
+def test_pfexec_varoptions(mocker, parser, reset_cli_args):
+    options = parser.parse_args([])
+    context._init_global_context(options)
+
+    default_cmd = "/bin/foo"
+    default_exe = "/bin/bash"
+    pfexec_exe = 'pfexec'
+    pfexec_flags = ''
+
+    success = 'BECOME-SUCCESS-.+?'
+
+    task = {
+        'become_user': 'foo',
+        'become_method': 'community.general.pfexec',
+        'become_flags': pfexec_flags,
+    }
+    var_options = {
+        'become_user': 'bar',
+        'become_flags': '',
+    }
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
+    print(cmd)
+    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, '', success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -50,12 +50,12 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     task = {
         'become_user': 'foo',
         'become_method': 'community.general.pfexec',
-        'become_flags': pfexec_flags,
+        'become_flags': 'xxx',
     }
     var_options = {
-        'become_user': 'bar',
-        'become_flags': '',
+        'ansible_become_user': 'bar',
+        'ansible_become_flags': pfexec_flags,
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, '', success, default_cmd), cmd) is not None
+    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -11,9 +11,8 @@ import re
 
 from ansible import context
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
 
-from .helper import make_become_cmd
+from .helper import call_become_plugin
 
 
 def test_pfexec(mocker, parser, reset_cli_args):
@@ -26,15 +25,15 @@ def test_pfexec(mocker, parser, reset_cli_args):
     pfexec_exe = 'pfexec'
     pfexec_flags = ''
 
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('community.general.pfexec'))
     play_context.become_method = 'community.general.pfexec'
     play_context.become_flags = pfexec_flags
-    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
+    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    print(cmd)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
 
 from .helper import call_become_plugin
 
@@ -18,22 +17,19 @@ from .helper import call_become_plugin
 def test_pfexec(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
     default_cmd = "/bin/foo"
     default_exe = "/bin/bash"
     pfexec_exe = 'pfexec'
     pfexec_flags = ''
 
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
-
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_method = 'community.general.pfexec'
-    play_context.become_flags = pfexec_flags
+    play_context = {
+        'become_user': 'foo',
+        'become_method': 'community.general.pfexec',
+        'become_flags': pfexec_flags,
+    }
     cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -25,11 +25,12 @@ def test_pfexec(mocker, parser, reset_cli_args):
 
     success = 'BECOME-SUCCESS-.+?'
 
-    play_context = {
+    task = {
         'become_user': 'foo',
         'become_method': 'community.general.pfexec',
         'become_flags': pfexec_flags,
     }
-    cmd = call_become_plugin(play_context, cmd=default_cmd, executable=default_exe)
+    var_options = {}
+    cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -13,6 +13,8 @@ from ansible import context
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import become_loader
 
+from .helper import make_become_cmd
+
 
 def test_pfexec(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
@@ -24,7 +26,7 @@ def test_pfexec(mocker, parser, reset_cli_args):
     pfexec_exe = 'pfexec'
     pfexec_flags = ''
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert cmd == default_cmd
 
     success = 'BECOME-SUCCESS-.+?'
@@ -34,5 +36,5 @@ def test_pfexec(mocker, parser, reset_cli_args):
     play_context.set_become_plugin(become_loader.get('community.general.pfexec'))
     play_context.become_method = 'community.general.pfexec'
     play_context.become_flags = pfexec_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    cmd = make_become_cmd(play_context, cmd=default_cmd, executable=default_exe)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -31,8 +31,8 @@ def test_pfexec(mocker, parser, reset_cli_args):
 
     play_context.become = True
     play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('pfexec'))
-    play_context.become_method = 'pfexec'
+    play_context.set_become_plugin(become_loader.get('community.general.pfexec'))
+    play_context.become_method = 'community.general.pfexec'
     play_context.become_flags = pfexec_flags
     cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
     assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None


### PR DESCRIPTION
##### SUMMARY
Currently all become plugins in community.general are broken (if `become_exe` is not explicitly specified by the user), since https://github.com/ansible/ansible/blob/01638e0ea222b115909bfd73677b97be92744ff2/lib/ansible/playbook/play_context.py#L358 explicitly uses the `become_name` as a default value, which for become plugins in community.general is prefixed with `community.general.`.

This fix is a hack. If we want this collection to work with current versions of 2.9, we need to keep it, otherwise we can get rid of it once ansible/ansible is fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/become/
