### PR TITLE
Fix remaining failing plugin unit tests

### DIFF
--- a/tests/unit/plugins/cache/test_memcached.py
+++ b/tests/unit/plugins/cache/test_memcached.py
@@ -32,4 +32,4 @@ def test_memcached_cachemodule():
 
 
 def test_memcached_cachemodule_with_loader():
-    assert isinstance(cache_loader.get('memcached'), MemcachedCache)
+    assert isinstance(cache_loader.get('community.general.memcached'), MemcachedCache)

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -33,4 +33,4 @@ def test_redis_cachemodule():
 
 def test_redis_cachemodule_with_loader():
     # The _uri option is required for the redis plugin
-    assert isinstance(cache_loader.get('redis', **{'_uri': '127.0.0.1:6379:1'}), RedisCache)
+    assert isinstance(cache_loader.get('community.general.redis', **{'_uri': '127.0.0.1:6379:1'}), RedisCache)

--- a/tests/unit/plugins/lookup/test_avi.py
+++ b/tests/unit/plugins/lookup/test_avi.py
@@ -65,7 +65,7 @@ def super_switcher(scope="function", autouse=True):
 
 
 def test_lookup_multiple_obj(dummy_credentials):
-    avi_lookup = lookup_loader.get('avi')
+    avi_lookup = lookup_loader.get('community.general.avi')
     avi_mock = MagicMock()
     avi_mock.return_value.get.return_value.json.return_value = data["mock_multiple_obj"]
     with patch.object(avi, 'ApiSession', avi_mock):
@@ -75,7 +75,7 @@ def test_lookup_multiple_obj(dummy_credentials):
 
 
 def test_lookup_single_obj(dummy_credentials):
-    avi_lookup = lookup_loader.get('avi')
+    avi_lookup = lookup_loader.get('community.general.avi')
     avi_mock = MagicMock()
     avi_mock.return_value.get_object_by_name.return_value = data["mock_single_obj"]
     with patch.object(avi, 'ApiSession', avi_mock):
@@ -85,7 +85,7 @@ def test_lookup_single_obj(dummy_credentials):
 
 
 def test_invalid_lookup(dummy_credentials):
-    avi_lookup = lookup_loader.get('avi')
+    avi_lookup = lookup_loader.get('community.general.avi')
     avi_mock = MagicMock()
     with pytest.raises(AnsibleError):
         with patch.object(avi, 'ApiSession', avi_mock):


### PR DESCRIPTION
##### SUMMARY
Tests need to be adjusted to handle FQCN to loader, and not short name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/unit/plugins/cache/test_memcached.py
tests/unit/plugins/cache/test_redis.py
tests/unit/plugins/lookup/test_avi.py
