### PR TITLE
Fix example since lookup/query is not filter

### DIFF
--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -20,7 +20,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: Example of the change in the description
-  debug: msg="{{ [1,2,3]|lookup('cartesian', [a, b])}}"
+  debug: msg="{{ lookup('cartesian', [1,2,3], [a, b])}}"
 
 - name: loops over the cartesian product of the supplied lists
   debug: msg="{{item}}"


### PR DESCRIPTION
##### SUMMARY
`lookup`/`query` plugin can't be used as filter with `template error while templating string: no filter named 'lookup'`.

See ansible/ansible#68478

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lookup

##### ADDITIONAL INFORMATION