### PR TITLE
Fix retry on shippable setup

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -29,8 +29,10 @@ python -V
 function retry
 {
     for repetition in 1 2 3; do
+        set +e
         "$@"
         result=$?
+        set -e
         if [ ${result} == 0 ]; then
             return ${result}
         fi


### PR DESCRIPTION
##### SUMMARY
`set -e` was still active, thus retry doesn't work (see f.ex. https://app.shippable.com/github/ansible-collections/community.general/runs/211/3/console).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/utils/shippable/shippable.sh
