### PR TITLE
Fix docker_swarm, docker_machine and gitlab_runners inventory plugins

### DIFF
--- a/plugins/inventory/docker_machine.py
+++ b/plugins/inventory/docker_machine.py
@@ -248,7 +248,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         """Return the possibility of a file being consumable by this plugin."""
         return (
             super(InventoryModule, self).verify_file(path) and
-            path.endswith((self.NAME + '.yaml', self.NAME + '.yml')))
+            path.endswith(('docker_machine.yaml', 'docker_machine.yml')))
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path, cache)

--- a/plugins/inventory/docker_swarm.py
+++ b/plugins/inventory/docker_swarm.py
@@ -244,7 +244,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         """Return the possibly of a file being consumable by this plugin."""
         return (
             super(InventoryModule, self).verify_file(path) and
-            path.endswith((self.NAME + '.yaml', self.NAME + '.yml')))
+            path.endswith(('docker_swarm.yaml', 'docker_swarm.yml')))
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_DOCKER:

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -120,7 +120,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         """Return the possibly of a file being consumable by this plugin."""
         return (
             super(InventoryModule, self).verify_file(path) and
-            path.endswith((self.NAME + ".yaml", self.NAME + ".yml")))
+            path.endswith(("gitlab_runners.yaml", "gitlab_runners.yml")))
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_GITLAB:


### PR DESCRIPTION
##### SUMMARY
Their `verify` method uses `self.NAME`, which now includes `community.general.`.

Somewhat related problem as #50.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm inventory plugin
docker_machine inventory plugin
gitlab_runners inventory plugin
