### PR TITLE
Revert "Don't run CI on Master (#73)"

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -123,7 +123,6 @@ branches:
   except:
     - "*-patch-*"
     - "revert-*-*"
-    - "master"
 
 build:
   ci:


### PR DESCRIPTION
This reverts commit f2418d343db7ad6a490b4d78bd9dbeec9ab5ab67.

##### SUMMARY
Looks like we have no CI anymore right now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
