### PR TITLE
supervisorctl tests: shorten path to .sock file to make OSX happy.

### DIFF
--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group2
 skip/python3
 skip/aix
-disabled #fixme

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -1,4 +1,9 @@
 - block:
+  - tempfile:
+      state: directory
+      suffix: supervisorctl-tests
+    register: supervisord_sock_path
+
   - command: 'echo {{ output_dir }}'
     register: echo
   - set_fact:
@@ -36,3 +41,7 @@
         - 'uninstall_{{ ansible_distribution }}.yml' # CentOS
         - 'uninstall_{{ ansible_os_family }}.yml'    # RedHat
         - 'uninstall_{{ ansible_system }}.yml'       # Linux
+
+  - file:
+      path: '{{ supervisord_sock_path.path }}'
+      state: absent

--- a/tests/integration/targets/supervisorctl/tasks/test_stop.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_stop.yml
@@ -3,7 +3,7 @@
     name: 'pys:py1'
     state: stopped
     # test with 'server_url' parameter
-    server_url: 'unix://{{ remote_dir }}/supervisord.sock'
+    server_url: 'unix://{{ supervisord_sock_path.path }}/supervisord.sock'
   register: result
   when: credentials.username == ''
 
@@ -12,7 +12,7 @@
     name: 'pys:py1'
     state: stopped
     # test with unix socket
-    server_url: 'unix://{{ remote_dir }}/supervisord.sock'
+    server_url: 'unix://{{ supervisord_sock_path.path }}/supervisord.sock'
     username: '{{ credentials.username }}'
     password: '{{ credentials.password }}'
   register: result_with_auth
@@ -37,7 +37,7 @@
     name: pys:py1
     state: stopped
     # test with 'server_url' parameter
-    server_url: 'unix://{{ remote_dir }}/supervisord.sock'
+    server_url: 'unix://{{ supervisord_sock_path.path }}/supervisord.sock'
   register: result
   when: credentials.username == ''
 
@@ -46,7 +46,7 @@
     name: pys:py1
     state: stopped
     # test with unix socket
-    server_url: 'unix://{{ remote_dir }}/supervisord.sock'
+    server_url: 'unix://{{ supervisord_sock_path.path }}/supervisord.sock'
     username: '{{ credentials.username }}'
     password: '{{ credentials.password }}'
   register: result_with_auth

--- a/tests/integration/targets/supervisorctl/templates/supervisord.conf
+++ b/tests/integration/targets/supervisorctl/templates/supervisord.conf
@@ -22,7 +22,7 @@ redirect_stderr=yes
 programs=py1,py2
 
 [unix_http_server]
-file={{ remote_dir }}/supervisord.sock
+file={{ supervisord_sock_path.path }}/supervisord.sock
 {% if credentials.username is defined and credentials.username|default(false, boolean=true) %}
 username = {{ credentials.username }}
 password = {{ credentials.password }}
@@ -36,7 +36,7 @@ password = {{ credentials.password }}
 {% endif %}
 
 [supervisorctl]
-serverurl=unix://{{ remote_dir }}/supervisord.sock
+serverurl=unix://{{ supervisord_sock_path.path }}/supervisord.sock
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
##### SUMMARY
Fix problem with supervisorctl tests on OSX: the .sock filename seems to be "too long" (for OSX). ([CI run where it breaks](https://app.shippable.com/github/ansible-collections/community.general/runs/239/36/tests)) This is probably caused by the output dir to be longer since it includes `ansible_collections.community.general` and stuff.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
supervisorctl
