### PR TITLE
rhn_channel: Add validate_certs parameter

### DIFF
--- a/changelogs/fragments/68374_rhn_channel.yml
+++ b/changelogs/fragments/68374_rhn_channel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add validate_certs in rhn_channel module (https://github.com/ansible/ansible/issues/68374).


### PR DESCRIPTION
##### SUMMARY

Provide parameter to override HTTPS verification.

Fixes: ansible/ansible#68374

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/68374_rhn_channel.yml
plugins/modules/packaging/os/rhn_channel.py
