### PR TITLE
Update docker connection plugin

### DIFF
--- a/changelogs/fragments/80-update_docker_connection_plugin.yml
+++ b/changelogs/fragments/80-update_docker_connection_plugin.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - docker connection plugin - do not prefix remote path if running on Windows containers.

--- a/changelogs/fragments/80-update_docker_connection_plugin.yml
+++ b/changelogs/fragments/80-update_docker_connection_plugin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker connection plugin - do not prefix remote path if running on Windows containers.

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -334,7 +334,7 @@ class Connection(ConnectionBase):
 
         if getattr(self._shell, "_IS_WINDOWS", False):
             import ntpath
-            actual_out_path = os.path.join(out_dir, ntpath.basename(in_path))
+            actual_out_path = ntpath.join(out_dir, ntpath.basename(in_path))
         else:
             actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
 

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -274,9 +274,13 @@ class Connection(ConnectionBase):
 
             Can revisit using $HOME instead if it's a problem
         '''
-        if not remote_path.startswith(os.path.sep):
-            remote_path = os.path.join(os.path.sep, remote_path)
-        return os.path.normpath(remote_path)
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            import ntpath
+            return ntpath.normpath(remote_path)
+        else:
+            if not remote_path.startswith(os.path.sep):
+                remote_path = os.path.join(os.path.sep, remote_path)
+            return os.path.normpath(remote_path)
 
     def put_file(self, in_path, out_path):
         """ Transfer a file from local to docker container """
@@ -328,7 +332,11 @@ class Connection(ConnectionBase):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.communicate()
 
-        actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            import ntpath
+            actual_out_path = os.path.join(out_dir, ntpath.basename(in_path))
+        else:
+            actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
 
         if p.returncode != 0:
             # Older docker doesn't have native support for fetching files command `cp`


### PR DESCRIPTION
##### SUMMARY
Duplicate of https://github.com/ansible/ansible/pull/68012 . Hoping to merge here and then backport to ansible stable-2.9.

https://github.com/ansible/ansible/pull/67832 fixes the need to run powershell modules on windows containers via docker connection. However, while running win_copy on windows containers, destination path is prefixed, which doesn't work in the case of windows. The changes in this PR take care of bypassing that while running the role on windows containers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Docker connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
