### PR TITLE
Fix warning message in dense callback plugin

### DIFF
--- a/changelogs/fragments/83-dense-callback-warning.yml
+++ b/changelogs/fragments/83-dense-callback-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dense callback - fix plugin access to its configuration variables and remove a warning message (https://github.com/ansible/ansible/issues/64628).

--- a/plugins/callback/dense.py
+++ b/plugins/callback/dense.py
@@ -144,7 +144,7 @@ colors = dict(
 states = ('skipped', 'ok', 'changed', 'failed', 'unreachable')
 
 
-class CallbackModule_dense(CallbackModule_default):
+class CallbackModule(CallbackModule_default):
 
     '''
     This is the dense callback interface, where screen estate is still valued.
@@ -497,5 +497,3 @@ class CallbackModule_dense(CallbackModule_default):
 # When using -vv or higher, simply do the default action
 if display.verbosity >= 2 or not HAS_OD:
     CallbackModule = CallbackModule_default
-else:
-    CallbackModule = CallbackModule_dense


### PR DESCRIPTION
##### SUMMARY
Migrated from ansible/ansible#65377
Fixes ansible/ansible#64628

Removes a warning message that is displayed every time dense callback plugin is used.
This should also make dense callback plugin effectively take its configuration variables into account.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/callback/dense

##### ADDITIONAL INFORMATION
Warning message mentioned in ansible/ansible#64628 is:
```
[WARNING]: Failure using method (v2_runner_on_start) in callback plugin
(<ansible.plugins.callback.dense.CallbackModule_dense object at 0x1105c6890>): 'show_per_host_start'
```

Absence of `v2_runner_on_start()` in callback `dense` is not an issue here because method inherited from callback `default` should work.

The true problem is that plugin class is named `CallbackModule_dense` instead of `CallbackModule`.
Therefore `get_plugin_class()` returns `'callback_dense'` instead of `'callback'`:
https://github.com/ansible/ansible/blob/0407af936a093c9e3c9feb098bf21e13f69abd7e/lib/ansible/plugins/__init__.py#L40-L44

And therefore  `set_options()` fails to retrieve all plugin configuration variables used by this plugin (including the one required by `v2_runner_on_start()`, leading to this warning message):
https://github.com/ansible/ansible/blob/0407af936a093c9e3c9feb098bf21e13f69abd7e/lib/ansible/plugins/callback/__init__.py#L99

Renaming class to `CallbackModule` as proposed in this PR does remove the warning message.