### PR TITLE
edgeos: Always exit configure mode

### DIFF
--- a/plugins/module_utils/network/edgeos/edgeos.py
+++ b/plugins/module_utils/network/edgeos/edgeos.py
@@ -122,11 +122,10 @@ def load_config(module, commands, commit=False, comment=None):
         except ConnectionError:
             connection.discard_changes()
             module.fail_json(msg='commit failed: %s' % out)
-
-    if not commit:
-        connection.discard_changes()
     else:
-        connection.get('exit')
+        connection.discard_changes()
+
+    connection.get('exit')
 
     if diff:
         return diff


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, the configure mode was kept active when not committing the changes.
This made later invocations of `show configuration commands` invalid (because
that command must be executed outside of configure mode) which caused all later
edgeos_config module invocations in check_mode to erroneously return a changed
state.

I have tested that the behavior in check_mode is fixed and unchanged (working) without check_mode.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes ansible/ansible#68350

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
edgeos