### PR TITLE
Add Thycotic DevOps Secrets Vault lookup plugin

### DIFF
--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Adam Migus <adam@migus.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# python 3 headers, required if submitting to Ansible
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2020, Adam Migus <adam@migus.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# python 3 headers, required if submitting to Ansible
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
@@ -10,15 +9,16 @@ DOCUMENTATION = r"""
 lookup: dsv
 author: Adam Migus (adam@migus.org)
 short_description: Get secrets from Thycotic DevOps Secrets Vault
+version_added: 1.0.0
 description:
     - Uses the Thycotic DevOps Secrets Vault Python SDK to get Secrets from a
-       DSV `tenant` using a `client_id` and `client_secret`.
+      DSV I(tenant) using a I(client_id) and I(client_secret).
 requirements:
     - python-dsv-sdk - https://pypi.org/project/python-dsv-sdk/
 options:
     _terms:
         description: The path to the secret, e.g. C(/staging/servers/web1).
-        required: True
+        required: true
     tenant:
         description: The first format parameter in the default I(url_template).
         env:

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -26,7 +26,7 @@ options:
         ini:
             - section: dsv_lookup
               key: tenant
-        required: True
+        required: true
     tld:
         default: com
         description: The top-level domain of the tenant; the second format
@@ -36,7 +36,7 @@ options:
         ini:
             - section: dsv_lookup
               key: tld
-        required: False
+        required: false
     client_id:
         description: The client_id with which to request the Access Grant.
         env:
@@ -44,7 +44,7 @@ options:
         ini:
             - section: dsv_lookup
               key: client_id
-        required: True
+        required: true
     client_secret:
         description: The client secret associated with the specific I(client_id).
         env:
@@ -52,7 +52,7 @@ options:
         ini:
             - section: dsv_lookup
               key: client_secret
-        required: True
+        required: true
     url_template:
         default: https://{}.secretsvaultcloud.{}/v1
         description: The path to prepend to the base URL to form a valid REST
@@ -62,7 +62,7 @@ options:
         ini:
             - section: dsv_lookup
               key: url_template
-        required: False
+        required: false
 """
 
 RETURN = r"""

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -70,7 +70,7 @@ _list:
 EXAMPLES = r"""
 - hosts: localhost
   vars:
-      secret: "{{ lookup('dsv', '/test/secret') }}"
+      secret: "{{ lookup('community.general.dsv', '/test/secret') }}"
   tasks:
       - debug: msg="the password is {{ secret["data"]["password"] }}"
 """

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -97,19 +97,24 @@ display = Display()
 
 
 class LookupModule(LookupBase):
+    @staticmethod
+    def Client(vault_parameters):
+        return SecretsVault(**vault_parameters)
+
     def run(self, terms, variables, **kwargs):
         if sdk_is_missing:
             raise AnsibleError("python-dsv-sdk must be installed to use this plugin")
 
         self.set_options(var_options=variables, direct=kwargs)
 
-        vault_parameters = {
-            "tenant": self.get_option("tenant"),
-            "client_id": self.get_option("client_id"),
-            "client_secret": self.get_option("client_secret"),
-            "url_template": self.get_option("url_template"),
-        }
-        vault = SecretsVault(**vault_parameters)
+        vault = LookupModule.Client(
+            **{
+                "tenant": self.get_option("tenant"),
+                "client_id": self.get_option("client_id"),
+                "client_secret": self.get_option("client_secret"),
+                "url_template": self.get_option("url_template"),
+            }
+        )
         result = []
 
         for term in terms:

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -78,13 +78,15 @@ EXAMPLES = r"""
 
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
+sdk_is_missing = False
+
 try:
     from thycotic.secrets.vault import (
         SecretsVault,
         SecretsVaultError,
     )
 except ImportError:
-    raise AnsibleError("python-dsv-sdk must be installed to use this plugin")
+    sdk_is_missing = True
 
 from ansible.utils.display import Display
 from ansible.plugins.lookup import LookupBase
@@ -95,6 +97,9 @@ display = Display()
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
+        if sdk_is_missing:
+            raise AnsibleError("python-dsv-sdk must be installed to use this plugin")
+
         self.set_options(var_options=variables, direct=kwargs)
 
         vault_parameters = {

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -120,5 +120,4 @@ class LookupModule(LookupBase):
                 raise AnsibleError(
                     "DevOps Secrets Vault lookup failure: %s" % error.message
                 )
-        display.debug(u"dsv_lookup result: %s" % result)
         return result

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -72,7 +72,8 @@ EXAMPLES = r"""
   vars:
       secret: "{{ lookup('community.general.dsv', '/test/secret') }}"
   tasks:
-      - debug: msg="the password is {{ secret["data"]["password"] }}"
+      - debug:
+          msg: 'the password is {{ secret["data"]["password"] }}'
 """
 
 from ansible.errors import AnsibleError, AnsibleOptionsError

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -1,0 +1,123 @@
+# python 3 headers, required if submitting to Ansible
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+lookup: dsv
+author: Adam Migus (adam@migus.org)
+short_description: Get secrets from Thycotic DevOps Secrets Vault
+description:
+    - Uses the Thycotic DevOps Secrets Vault Python SDK to get Secrets from a
+       DSV `tenant` using a `client_id` and `client_secret`.
+requirements:
+    - python-dsv-sdk - https://pypi.org/project/python-dsv-sdk/
+options:
+    _terms:
+        description: the path to the secret e.g. /staging/servers/web1
+        required: True
+    tenant:
+        description: the first format parameter in the default `url_template`
+        env:
+            - name: DSV_TENANT
+        ini:
+            - section: dsv_lookup
+              key: tenant
+        required: True
+    tld:
+        default: com
+        description: the top-level domain of the tenant; the second format
+            parameter in the default `url_template`
+        env:
+            - name: DSV_TLD
+        ini:
+            - section: dsv_lookup
+              key: tld
+        required: False
+    client_id:
+        description: the client_id with which to request the Access Grant
+        env:
+            - name: DSV_CLIENT_ID
+        ini:
+            - section: dsv_lookup
+              key: client_id
+        required: True
+    client_secret:
+        description: the client_secret associated with the specific client_id
+        env:
+            - name: DSV_CLIENT_SECRET
+        ini:
+            - section: dsv_lookup
+              key: client_secret
+        required: True
+    url_template:
+        default: https://{}.secretsvaultcloud.{}/v1
+        description: the path to append to the base URL to form a valid REST
+            API request
+        env:
+            - name: DSV_URL_TEMPLATE
+        ini:
+            - section: dsv_lookup
+              key: url_template
+        required: False"""
+
+RETURN = r"""
+_list:
+    description:
+        - One or more JSON responses to `GET /secrets/{path}`
+        - See https://dsv.thycotic.com/api/index.html#operation/getSecret"""
+
+EXAMPLES = r"""
+- hosts: localhost
+  vars:
+      secret: "{{ lookup('dsv', '/test/secret') }}"
+  tasks:
+      - debug: msg="the password is {{ secret["data"]["password"] }}"
+"""
+
+from ansible.errors import AnsibleError, AnsibleOptionsError
+
+try:
+    from thycotic.secrets.vault import (
+        SecretsVault,
+        SecretsVaultError,
+    )
+except ImportError:
+    raise AnsibleError("python-dsv-sdk must be installed to use this plugin")
+
+from ansible.utils.display import Display
+from ansible.plugins.lookup import LookupBase
+
+
+display = Display()
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        vault_parameters = {
+            "tenant": self.get_option("tenant"),
+            "client_id": self.get_option("client_id"),
+            "client_secret": self.get_option("client_secret"),
+            "url_template": self.get_option("url_template"),
+        }
+        vault = SecretsVault(**vault_parameters)
+        result = []
+
+        for term in terms:
+            display.debug("dsv_lookup term: %s" % term)
+            try:
+                path = term.lstrip("[/:]")
+
+                if path == "":
+                    raise AnsibleOptionsError("Invalid secret path: %s" % term)
+
+                display.vvv(u"DevOps Secrets Vault GET /secrets/%s" % path)
+                result.append(vault.get_secret_json(path))
+            except SecretsVaultError as error:
+                raise AnsibleError(
+                    "DevOps Secrets Vault lookup failure: %s" % error.message
+                )
+        display.debug(u"dsv_lookup result: %s" % result)
+        return result

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -1,4 +1,3 @@
-# python 3 headers, required if submitting to Ansible
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
@@ -14,10 +13,10 @@ requirements:
     - python-dsv-sdk - https://pypi.org/project/python-dsv-sdk/
 options:
     _terms:
-        description: the path to the secret e.g. /staging/servers/web1
+        description: The path to the secret, e.g. C(/staging/servers/web1).
         required: True
     tenant:
-        description: the first format parameter in the default `url_template`
+        description: The first format parameter in the default I(url_template).
         env:
             - name: DSV_TENANT
         ini:
@@ -26,8 +25,8 @@ options:
         required: True
     tld:
         default: com
-        description: the top-level domain of the tenant; the second format
-            parameter in the default `url_template`
+        description: The top-level domain of the tenant; the second format
+            parameter in the default I(url_template).
         env:
             - name: DSV_TLD
         ini:
@@ -35,7 +34,7 @@ options:
               key: tld
         required: False
     client_id:
-        description: the client_id with which to request the Access Grant
+        description: The client_id with which to request the Access Grant.
         env:
             - name: DSV_CLIENT_ID
         ini:
@@ -43,7 +42,7 @@ options:
               key: client_id
         required: True
     client_secret:
-        description: the client_secret associated with the specific client_id
+        description: The client secret associated with the specific I(client_id).
         env:
             - name: DSV_CLIENT_SECRET
         ini:
@@ -52,20 +51,22 @@ options:
         required: True
     url_template:
         default: https://{}.secretsvaultcloud.{}/v1
-        description: the path to append to the base URL to form a valid REST
-            API request
+        description: The path to prepend to the base URL to form a valid REST
+            API request.
         env:
             - name: DSV_URL_TEMPLATE
         ini:
             - section: dsv_lookup
               key: url_template
-        required: False"""
+        required: False
+"""
 
 RETURN = r"""
 _list:
     description:
-        - One or more JSON responses to `GET /secrets/{path}`
-        - See https://dsv.thycotic.com/api/index.html#operation/getSecret"""
+        - One or more JSON responses to C(GET /secrets/{path}).
+        - See U(https://dsv.thycotic.com/api/index.html#operation/getSecret).
+"""
 
 EXAMPLES = r"""
 - hosts: localhost

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -1,20 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2020, Adam Migus <adam@migus.org>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2020, Adam Migus <adam@migus.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -31,7 +31,7 @@ from ansible.plugins.loader import lookup_loader
 
 
 class MockSecretsVault(MagicMock):
-    RESPONSE = '{"foo":"bar"}'
+    RESPONSE = '{"foo": "bar"}'
 
     def get_secret_json(self, path):
         return self.RESPONSE

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat.unittest import TestCase
+from ansible_collections.community.general.tests.unit.compat.mock import (
+    patch,
+    MagicMock,
+)
+from ansible_collections.community.general.plugins.lookup import dsv
+from ansible.plugins.loader import lookup_loader
+
+
+class MockSecretsVault(MagicMock):
+    RESPONSE = '{"foo":"bar"}'
+
+    def get_secret_json(self, path):
+        return self.RESPONSE
+
+
+class TestLookupModule(TestCase):
+    def setUp(self):
+        dsv.sdk_is_missing = False
+        self.lookup = lookup_loader.get("community.general.dsv")
+
+    @patch(
+        "ansible_collections.community.general.plugins.lookup.dsv.LookupModule.Client",
+        MockSecretsVault(),
+    )
+    def test_get_secret_json(self):
+        self.assertListEqual(
+            [MockSecretsVault.RESPONSE],
+            self.lookup.run(
+                ["/dummy"],
+                [],
+                **{"tenant": "dummy", "client_id": "dummy", "client_secret": "dummy",}
+            ),
+        )

--- a/tests/unit/plugins/lookup/test_dsv.py
+++ b/tests/unit/plugins/lookup/test_dsv.py
@@ -52,6 +52,6 @@ class TestLookupModule(TestCase):
             self.lookup.run(
                 ["/dummy"],
                 [],
-                **{"tenant": "dummy", "client_id": "dummy", "client_secret": "dummy",}
+                **{"tenant": "dummy", "client_id": "dummy", "client_secret": "dummy", }
             ),
         )


### PR DESCRIPTION
##### SUMMARY
Add a lookup plug-in capable of retrieving Secrets from Thycotic's DevOps Secrets Vault. The plug-in uses python-dsv-sdk which is available here: https://pypi.org/project/python-dsv-sdk/

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
dsv

##### ADDITIONAL INFORMATION
- This is a re-submission of a closed PR with the changes suggested in that PR.
- The cyclomatic complexity of this plug-in is 5 and the SDK on which it's based is 3.  As such, I've opted not to include a pytest.  If future versions have increased complexity, I will add tests at that point.