### PR TITLE
Add the Thycotic Secret Server lookup plugin.

### DIFF
--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -62,7 +62,8 @@ RETURN = r"""
 _list:
     description:
         - The JSON responses to C(GET /secrets/{id}).
-        - See https://updates.thycotic.net/secretserver/restapiguide/TokenAuth/#operation--secrets--id--get>"""
+        - See U(https://updates.thycotic.net/secretserver/restapiguide/TokenAuth/#operation--secrets--id--get).
+"""
 
 EXAMPLES = r"""
 - hosts: localhost
@@ -119,5 +120,4 @@ class LookupModule(LookupBase):
                 raise AnsibleOptionsError("Secret ID must be an integer")
             except SecretServerError as error:
                 raise AnsibleError("Secret Server lookup failure: %s" % error.message)
-        display.debug(u"tss_lookup result: %s" % result)
         return result

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -9,17 +9,17 @@ author: Adam Migus (adam@migus.org)
 short_description: Get secrets from Thycotic Secret Server
 description:
     - Uses the Thycotic Secret Server Python SDK to get Secrets from Secret
-      Server using token authentication with `username` and `password` on
-      the REST API at `base_url`.
+      Server using token authentication with I(username) and I(password) on
+      the REST API at I(base_url).
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 options:
     _terms:
-        description: the integer ID of the secret
+        description: The integer ID of the secret.
         required: True
         type: integer
     base_url:
-        description: the base URL of the server e.g. https://localhost/SecretServer
+        description: The base URL of the server, e.g. C(https://localhost/SecretServer).
         env:
             - name: TSS_BASE_URL
         ini:
@@ -27,7 +27,7 @@ options:
               key: base_url
         required: True
     username:
-        description: the username with which to request the OAuth2 Access Grant
+        description: The username with which to request the OAuth2 Access Grant.
         env:
             - name: TSS_USERNAME
         ini:
@@ -35,7 +35,7 @@ options:
               key: username
         required: True
     password:
-        description: the password associated with the supplied username
+        description: The password associated with the supplied username.
         env:
             - name: TSS_PASSWORD
         ini:
@@ -44,23 +44,24 @@ options:
         required: True
     api_path_uri:
         default: /api/v1
-        description: the path to append to the base URL to form a valid REST
-            API request
+        description: The path to append to the base URL to form a valid REST
+            API request.
         env:
             - name: TSS_API_PATH_URI
         required: False
     token_path_uri:
         default: /oauth2/token
-        description: the path to append to the base URL to form a valid OAuth2
-            Access Grant request
+        description: The path to append to the base URL to form a valid OAuth2
+            Access Grant request.
         env:
             - name: TSS_TOKEN_PATH_URI
-        required: False"""
+        required: False
+"""
 
 RETURN = r"""
 _list:
     description:
-        - The JSON responses to `GET /secrets/{id}`
+        - The JSON responses to C(GET /secrets/{id}).
         - See https://updates.thycotic.net/secretserver/restapiguide/TokenAuth/#operation--secrets--id--get>"""
 
 EXAMPLES = r"""

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -9,6 +9,7 @@ DOCUMENTATION = r"""
 lookup: tss
 author: Adam Migus (adam@migus.org)
 short_description: Get secrets from Thycotic Secret Server
+version_added: 1.0.0
 description:
     - Uses the Thycotic Secret Server Python SDK to get Secrets from Secret
       Server using token authentication with I(username) and I(password) on
@@ -18,8 +19,8 @@ requirements:
 options:
     _terms:
         description: The integer ID of the secret.
-        required: True
-        type: integer
+        required: true
+        type: int
     base_url:
         description: The base URL of the server, e.g. C(https://localhost/SecretServer).
         env:
@@ -27,7 +28,7 @@ options:
         ini:
             - section: tss_lookup
               key: base_url
-        required: True
+        required: true
     username:
         description: The username with which to request the OAuth2 Access Grant.
         env:
@@ -35,7 +36,7 @@ options:
         ini:
             - section: tss_lookup
               key: username
-        required: True
+        required: true
     password:
         description: The password associated with the supplied username.
         env:
@@ -43,21 +44,21 @@ options:
         ini:
             - section: tss_lookup
               key: password
-        required: True
+        required: true
     api_path_uri:
         default: /api/v1
         description: The path to append to the base URL to form a valid REST
             API request.
         env:
             - name: TSS_API_PATH_URI
-        required: False
+        required: false
     token_path_uri:
         default: /oauth2/token
         description: The path to append to the base URL to form a valid OAuth2
             Access Grant request.
         env:
             - name: TSS_TOKEN_PATH_URI
-        required: False
+        required: false
 """
 
 RETURN = r"""

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Adam Migus <adam@migus.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # python 3 headers, required if submitting to Ansible
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2020, Adam Migus <adam@migus.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# python 3 headers, required if submitting to Ansible
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -1,0 +1,117 @@
+# python 3 headers, required if submitting to Ansible
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+lookup: tss
+author: Adam Migus (adam@migus.org)
+short_description: Get secrets from Thycotic Secret Server
+description:
+    - Uses the Thycotic Secret Server Python SDK to get Secrets from Secret
+      Server using token authentication with `username` and `password` on
+      the REST API at `base_url`.
+requirements:
+    - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
+options:
+    _terms:
+        description: the integer ID of the secret
+        required: True
+        type: integer
+    base_url:
+        description: the base URL of the server e.g. https://localhost/SecretServer
+        env:
+            - name: TSS_BASE_URL
+        ini:
+            - section: tss_lookup
+              key: base_url
+        required: True
+    username:
+        description: the username with which to request the OAuth2 Access Grant
+        env:
+            - name: TSS_USERNAME
+        ini:
+            - section: tss_lookup
+              key: username
+        required: True
+    password:
+        description: the password associated with the supplied username
+        env:
+            - name: TSS_PASSWORD
+        ini:
+            - section: tss_lookup
+              key: password
+        required: True
+    api_path_uri:
+        default: /api/v1
+        description: the path to append to the base URL to form a valid REST
+            API request
+        env:
+            - name: TSS_API_PATH_URI
+        required: False
+    token_path_uri:
+        default: /oauth2/token
+        description: the path to append to the base URL to form a valid OAuth2
+            Access Grant request
+        env:
+            - name: TSS_TOKEN_PATH_URI
+        required: False"""
+
+RETURN = r"""
+_list:
+    description:
+        - The JSON responses to `GET /secrets/{id}`
+        - See https://updates.thycotic.net/secretserver/restapiguide/TokenAuth/#operation--secrets--id--get>"""
+
+EXAMPLES = r"""
+- hosts: localhost
+  vars:
+      secret: "{{ lookup('tss', 1) }}"
+  tasks:
+      - debug: msg="the password is {{ (secret['items'] | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
+"""
+
+from ansible.errors import AnsibleError, AnsibleOptionsError
+
+try:
+    from thycotic.secrets.server import (
+        SecretServer,
+        SecretServerAccessError,
+        SecretServerError,
+    )
+except ImportError:
+    raise AnsibleError("python-tss-sdk must be installed to use this plugin")
+
+from ansible.utils.display import Display
+from ansible.plugins.lookup import LookupBase
+
+
+display = Display()
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        server_parameters = {
+            "base_url": self.get_option("base_url"),
+            "username": self.get_option("username"),
+            "password": self.get_option("password"),
+            "api_path_uri": self.get_option("api_path_uri"),
+            "token_path_uri": self.get_option("token_path_uri"),
+        }
+        secret_server = SecretServer(**server_parameters)
+        result = []
+
+        for term in terms:
+            display.debug("tss_lookup term: %s" % term)
+            try:
+                id = int(term)
+                display.vvv(u"Secret Server lookup of Secret with ID %d" % id)
+                result.append(secret_server.get_secret_json(id))
+            except ValueError:
+                raise AnsibleOptionsError("Secret ID must be an integer")
+            except SecretServerError as error:
+                raise AnsibleError("Secret Server lookup failure: %s" % error.message)
+        display.debug(u"tss_lookup result: %s" % result)
+        return result

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -73,6 +73,8 @@ EXAMPLES = r"""
 
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
+sdk_is_missing = False
+
 try:
     from thycotic.secrets.server import (
         SecretServer,
@@ -80,7 +82,7 @@ try:
         SecretServerError,
     )
 except ImportError:
-    raise AnsibleError("python-tss-sdk must be installed to use this plugin")
+    sdk_is_missing = True
 
 from ansible.utils.display import Display
 from ansible.plugins.lookup import LookupBase
@@ -91,6 +93,9 @@ display = Display()
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
+        if sdk_is_missing:
+            raise AnsibleError("python-tss-sdk must be installed to use this plugin")
+
         self.set_options(var_options=variables, direct=kwargs)
 
         server_parameters = {

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -66,7 +66,7 @@ _list:
 EXAMPLES = r"""
 - hosts: localhost
   vars:
-      secret: "{{ lookup('tss', 1) }}"
+      secret: "{{ lookup('community.general.tss', 1) }}"
   tasks:
       - debug: msg="the password is {{ (secret['items'] | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
 """

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -94,20 +94,25 @@ display = Display()
 
 
 class LookupModule(LookupBase):
+    @staticmethod
+    def Client(server_parameters):
+        return SecretServer(**server_parameters)
+
     def run(self, terms, variables, **kwargs):
         if sdk_is_missing:
             raise AnsibleError("python-tss-sdk must be installed to use this plugin")
 
         self.set_options(var_options=variables, direct=kwargs)
 
-        server_parameters = {
-            "base_url": self.get_option("base_url"),
-            "username": self.get_option("username"),
-            "password": self.get_option("password"),
-            "api_path_uri": self.get_option("api_path_uri"),
-            "token_path_uri": self.get_option("token_path_uri"),
-        }
-        secret_server = SecretServer(**server_parameters)
+        secret_server = LookupModule.Client(
+            {
+                "base_url": self.get_option("base_url"),
+                "username": self.get_option("username"),
+                "password": self.get_option("password"),
+                "api_path_uri": self.get_option("api_path_uri"),
+                "token_path_uri": self.get_option("token_path_uri"),
+            }
+        )
         result = []
 
         for term in terms:

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -1,20 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2020, Adam Migus <adam@migus.org>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Make coding more python3-ish
 from __future__ import absolute_import, division, print_function

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2020, Adam Migus <adam@migus.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat.unittest import TestCase
+from ansible_collections.community.general.tests.unit.compat.mock import (
+    patch,
+    MagicMock,
+)
+from ansible_collections.community.general.plugins.lookup import tss
+from ansible.plugins.loader import lookup_loader
+
+
+class MockSecretServer(MagicMock):
+    RESPONSE = '{"foo":"bar"}'
+
+    def get_secret_json(self, path):
+        return self.RESPONSE
+
+
+class TestLookupModule(TestCase):
+    def setUp(self):
+        tss.sdk_is_missing = False
+        self.lookup = lookup_loader.get("community.general.tss")
+
+    @patch(
+        "ansible_collections.community.general.plugins.lookup.tss.LookupModule.Client",
+        MockSecretServer(),
+    )
+    def test_get_secret_json(self):
+        self.assertListEqual(
+            [MockSecretServer.RESPONSE],
+            self.lookup.run(
+                [1],
+                [],
+                **{"base_url": "dummy", "username": "dummy", "password": "dummy",}
+            ),
+        )

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -52,6 +52,6 @@ class TestLookupModule(TestCase):
             self.lookup.run(
                 [1],
                 [],
-                **{"base_url": "dummy", "username": "dummy", "password": "dummy",}
+                **{"base_url": "dummy", "username": "dummy", "password": "dummy", }
             ),
         )

--- a/tests/unit/plugins/lookup/test_tss.py
+++ b/tests/unit/plugins/lookup/test_tss.py
@@ -31,7 +31,7 @@ from ansible.plugins.loader import lookup_loader
 
 
 class MockSecretServer(MagicMock):
-    RESPONSE = '{"foo":"bar"}'
+    RESPONSE = '{"foo": "bar"}'
 
     def get_secret_json(self, path):
         return self.RESPONSE


### PR DESCRIPTION
##### SUMMARY
Add a lookup plug-in capable of retrieving Secrets from Thycotic's Secret Server. The plug-in uses python-tss-sdk which is available here: https://pypi.org/project/python-tss-sdk/

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
tss

##### ADDITIONAL INFORMATION
The cyclomatic complexity of this plug-in is 5 and the SDK on which it's based is 3. As such, I've opted not to include a pytest. If future versions have increased complexity, I will add tests at that point.
