### PR TITLE
Temporarily disable zypper_repository tests

### DIFF
--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -4,3 +4,4 @@ skip/aix
 skip/freebsd
 skip/osx
 skip/rhel
+disabled #fixme


### PR DESCRIPTION
##### SUMMARY
The tests currently fail reliably:

- https://app.shippable.com/github/ansible-collections/community.general/runs/359/23/tests https://app.shippable.com/github/ansible-collections/community.general/runs/359/24/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/358/23/tests https://app.shippable.com/github/ansible-collections/community.general/runs/358/24/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/357/23/tests https://app.shippable.com/github/ansible-collections/community.general/runs/357/24/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/356/31/tests https://app.shippable.com/github/ansible-collections/community.general/runs/356/32/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/354/31/tests https://app.shippable.com/github/ansible-collections/community.general/runs/354/32/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/353/31/tests https://app.shippable.com/github/ansible-collections/community.general/runs/353/32/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/352/31/tests https://app.shippable.com/github/ansible-collections/community.general/runs/352/32/tests
- https://app.shippable.com/github/ansible-collections/community.general/runs/351/31/tests https://app.shippable.com/github/ansible-collections/community.general/runs/351/32/tests

(before that they worked)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository
