### PR TITLE
Fix command line construction in the puppet module

### DIFF
--- a/changelogs/fragments/114-puppet-commandline-construction.yml
+++ b/changelogs/fragments/114-puppet-commandline-construction.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "puppet - fix command line construction for check mode and ``manifest:``"

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -289,7 +289,7 @@ def main():
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         else:
-            cmd += shlex_quote(p['manifest'])
+            cmd += " %s" % shlex_quote(p['manifest'])
         if p['summarize']:
             cmd += " --summarize"
         if p['debug']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -255,16 +255,16 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
-        if p['use_srv_records'] is not None:
-            if not p['use_srv_records']:
-                cmd += " --no-use_srv_records"
-            else:
-                cmd += " --use_srv_records"
         elif 'noop' in p:
             if p['noop']:
                 cmd += " --noop"
             else:
                 cmd += " --no-noop"
+        if p['use_srv_records'] is not None:
+            if not p['use_srv_records']:
+                cmd += " --no-use_srv_records"
+            else:
+                cmd += " --use_srv_records"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':


### PR DESCRIPTION
##### SUMMARY
Fix command line construction in the `puppet` module related to check mode and using manifests directly

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
puppet

##### ADDITIONAL INFORMATION
Commit 69ead0ba7864b1e7367eb9755b51d30ecc0da0d2 in the ansible/ansible
repository introduced another if-statement in the middle of a if/elif pair,
which causes the elif to execute together with the original if
which created '--noop --no-noop' commands.

Another issue I noticed while fixing that was that if I apply an manifest directly, it tries to execute `--noop/path/manifest.pp` which fails.

**Test case 1**
```
---
- hosts: localhost
  tasks:
  - puppet:
```

Executed with:
```
ansible-playbook --check /test.yaml
```

Before change:
```
/usr/bin/puppet agent --onetime --no-daemonize --no-usecacheonfailure --no-splay --detailed-exitcodes --verbose --color 0 --noop --no-noop
```

After change:
```
/usr/bin/puppet agent --onetime --no-daemonize --no-usecacheonfailure --no-splay --detailed-exitcodes --verbose --color 0 --noop
```

**Test case 2**
```
---
- hosts: localhost
  tasks:
  - puppet:
      manifest: /test.pp
```

Executed with:
```
ansible-playbook --check /test.yaml
```

Before change (causes an error):
```
/usr/bin/puppet apply --detailed-exitcodes  --noop/test.pp
```

After change:
```
/usr/bin/puppet apply --detailed-exitcodes --noop  /test.pp
```

Tested with ansible 2.9.6