### PR TITLE
postgresql_user: add trust_input parameter

### DIFF
--- a/changelogs/fragments/116-postgresql_user_add_trust_input_parameter.yml
+++ b/changelogs/fragments/116-postgresql_user_add_trust_input_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_user - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/116).

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -29,6 +29,21 @@
 import re
 
 
+# Input patterns for is_input_dangerous function:
+#
+# 1. '"' in string and '--' in string or
+# "'" in string and '--' in string
+PATTERN_1 = re.compile(r'(\'|\").*--')
+
+# 2. union \ intersect \ except + select
+PATTERN_2 = re.compile(r'(union|UNION|intersect|INTERSECT|'
+                       r'except|EXCEPT).*(select|SELECT)')
+
+# 3. ';' and any KEY_WORDS
+PATTERN_3 = re.compile(r';.*(select|SELECT|update|UPDATE|insert|INSERT|'
+                       r'delete|DELETE|drop|DROP|truncate|TRUNCATE|alter|ALTER)')
+
+
 class SQLParseError(Exception):
     pass
 
@@ -155,25 +170,13 @@ def is_input_dangerous(string):
     if not string:
         return False
 
-    # 1. '"' in string and '--' in string or
-    # "'" in string and '--' in string
-    pattern1 = re.compile(r'(\'|\").*--')
-
-    if re.search(pattern1, string):
+    if re.search(PATTERN_1, string):
         return True
 
-    # 2. union \ intersect \ except + select
-    pattern2 = re.compile(r'(union|UNION|intersect|INTERSECT|'
-                          r'except|EXCEPT).*(select|SELECT)')
-
-    if re.search(pattern2, string):
+    if re.search(PATTERN_2, string):
         return True
 
-    # 3. ';' and any KEY_WORDS
-    pattern3 = re.compile(r';.*(select|SELECT|update|UPDATE|insert|INSERT|'
-                          r'delete|DELETE|drop|DROP|truncate|TRUNCATE|alter|ALTER)')
-
-    if re.search(pattern3, string):
+    if re.search(PATTERN_3, string):
         return True
 
     return False

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -179,7 +179,7 @@ def is_input_dangerous(string):
     return False
 
 
-def check_input(module, **args):
+def check_input(module, *args):
     """Wrapper for is_input_dangerous function."""
     needs_to_check = args
 

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -36,8 +36,7 @@ import re
 PATTERN_1 = re.compile(r'(\'|\").*--')
 
 # 2. union \ intersect \ except + select
-PATTERN_2 = re.compile(r'(union|UNION|intersect|INTERSECT|'
-                       r'except|EXCEPT).*(select|SELECT)')
+PATTERN_2 = re.compile(r'(UNION|INTERSECT|EXCEPT).*SELECT', re.IGNORECASE)
 
 # 3. ';' and any KEY_WORDS
 PATTERN_3 = re.compile(r';.*(SELECT|UPDATE|INSERT|DELETE|DROP|TRUNCATE|ALTER)', re.IGNORECASE)
@@ -169,11 +168,11 @@ def is_input_dangerous(string):
     if not string:
         return False
 
-    return (
-        re.search(PATTERN_1, string)
-        or re.search(PATTERN_2, string)
-        or re.search(PATTERN_3, string)
-    )
+    for pattern in (PATTERN_1, PATTERN_2, PATTERN_3):
+        if re.search(pattern, string):
+            return True
+
+    return False
 
 
 def check_input(module, *args):

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -177,3 +177,29 @@ def is_input_dangerous(string):
         return True
 
     return False
+
+
+def check_input(module, **args):
+    """Wrapper for is_input_dangerous function."""
+    needs_to_check = args
+
+    dangerous_elements = []
+
+    for elem in needs_to_check:
+        if isinstance(elem, str):
+            if is_input_dangerous(elem):
+                dangerous_elements.append(elem)
+
+        elif isinstance(elem, list):
+            for e in elem:
+                if is_input_dangerous(e):
+                    dangerous_elements.append(e)
+
+        else:
+            elem = str(elem)
+            if is_input_dangerous(elem):
+                dangerous_elements.append(elem)
+
+    if dangerous_elements:
+        module.fail_json(msg="Passed input '%s' is "
+                             "potentially dangerous" % ', '.join(dangerous_elements))

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -40,8 +40,7 @@ PATTERN_2 = re.compile(r'(union|UNION|intersect|INTERSECT|'
                        r'except|EXCEPT).*(select|SELECT)')
 
 # 3. ';' and any KEY_WORDS
-PATTERN_3 = re.compile(r';.*(select|SELECT|update|UPDATE|insert|INSERT|'
-                       r'delete|DELETE|drop|DROP|truncate|TRUNCATE|alter|ALTER)')
+PATTERN_3 = re.compile(r';.*(SELECT|UPDATE|INSERT|DELETE|DROP|TRUNCATE|ALTER)', re.IGNORECASE)
 
 
 class SQLParseError(Exception):

--- a/plugins/module_utils/database.py
+++ b/plugins/module_utils/database.py
@@ -169,16 +169,11 @@ def is_input_dangerous(string):
     if not string:
         return False
 
-    if re.search(PATTERN_1, string):
-        return True
-
-    if re.search(PATTERN_2, string):
-        return True
-
-    if re.search(PATTERN_3, string):
-        return True
-
-    return False
+    return (
+        re.search(PATTERN_1, string)
+        or re.search(PATTERN_2, string)
+        or re.search(PATTERN_3, string)
+    )
 
 
 def check_input(module, *args):

--- a/plugins/modules/database/postgresql/postgresql_user.py
+++ b/plugins/modules/database/postgresql/postgresql_user.py
@@ -147,6 +147,11 @@ options:
     description:
     - Add a comment on the user (equal to the COMMENT ON ROLE statement result).
     type: str
+  trust_input:
+    description:
+    - If C(no), check whether values of some parameters are potentially dangerous.
+    type: bool
+    default: yes
 notes:
 - The module creates a user (role) with login privilege by default.
   Use NOLOGIN role_attr_flags to change this behaviour.
@@ -252,7 +257,11 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.database import pg_quote_identifier, SQLParseError
+from ansible_collections.community.general.plugins.module_utils.database import (
+    pg_quote_identifier,
+    SQLParseError,
+    check_input,
+)
 from ansible_collections.community.general.plugins.module_utils.postgres import (
     connect_to_db,
     get_conn_params,
@@ -812,6 +821,7 @@ def main():
         session_role=dict(type='str'),
         groups=dict(type='list', elements='str'),
         comment=dict(type='str', default=None),
+        trust_input=dict(type='bool', default=True),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -837,6 +847,12 @@ def main():
     if groups:
         groups = [e.strip() for e in groups]
     comment = module.params["comment"]
+
+    trust_input = module.params['trust_input']
+    if not trust_input:
+        # Check input for potentially dangerous elements:
+        check_input(module, user, password, privs, expires,
+                    role_attr_flags, groups, comment)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params)

--- a/tests/integration/targets/postgresql_user/defaults/main.yml
+++ b/tests/integration/targets/postgresql_user/defaults/main.yml
@@ -1,3 +1,4 @@
 db_name: 'ansible_db'
 db_user1: 'ansible_db_user1'
 db_user2: 'ansible_db_user2'
+dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -742,7 +742,6 @@
   - assert:
       that:
       - result is changed
-      - result.queries == ['CREATE USER "{{ dangerous_name }}"']
 
   always:
   #

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -717,6 +717,33 @@
       that:
       - result.rowcount == 2
 
+  ########################
+  # Test trust_input param
+
+  - name: Create role with potentially dangerous name, don't trust
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ dangerous_name }}'
+      trust_input: no
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg == 'Passed input \'{{ dangerous_name }}\' is potentially dangerous'
+
+  - name: Create role with potentially dangerous name, trust
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ dangerous_name }}'
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ['CREATE USER "{{ dangerous_name }}"']
+
   always:
   #
   # Clean up
@@ -739,3 +766,4 @@
     - '{{ test_user2 }}'
     - '{{ test_group1 }}'
     - '{{ test_group2 }}'
+    - '{{ dangerous_name }}'

--- a/tests/unit/plugins/module_utils/test_database.py
+++ b/tests/unit/plugins/module_utils/test_database.py
@@ -79,14 +79,32 @@ INVALID_QUOTES = ((test[0], test[1], INVALID[test]) for test in sorted(INVALID))
 
 IS_STRINGS_DANGEROUS = (
     (u'', False),
+    (u' ', False),
     (u'alternative database', False),
     (u'backup of TRUNCATED table', False),
     (u'bob.dropper', False),
     (u'd\'artagnan', False),
+    (u'user_with_select_update_truncate_right', False),
     (u';DROP DATABASE fluffy_pets_photos', True),
+    (u';drop DATABASE fluffy_pets_photos', True),
     (u'; TRUNCATE TABLE his_valuable_table', True),
+    (u'; truncate TABLE his_valuable_table', True),
     (u'\'--', True),
+    (u'"--', True),
     (u'\' union select username, password from admin_credentials', True),
+    (u'\' UNION SELECT username, password from admin_credentials', True),
+    (u'\' intersect select', True),
+    (u'\' INTERSECT select', True),
+    (u'\' except select', True),
+    (u'\' EXCEPT select', True),
+    (u';ALTER TABLE prices', True),
+    (u';alter table prices', True),
+    (u"; UPDATE products SET price = '0'", True),
+    (u";update products SET price = '0'", True),
+    (u"; DELETE FROM products", True),
+    (u"; delete FROM products", True),
+    (u"; SELECT * FROM products", True),
+    (u" ; select * from products", True),
 )
 
 


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible-collections/community.general/issues/106

The PR:
1. implements checks for potentially dangerous output (like SQL injections)
2. intreduces ```trust_input``` parameter to postgresql_user module (not to break current pipelines it's set as ```yes```)

If it's approved by community and merged:
1. it'll be intruduced to postgresql_privs, postgresql_membership and other modules where needed.
2. we'll continue to solve https://github.com/ansible/ansible/issues/66422 and other stuff to be able to use names containing dots.

**Note: it has unit tests, but would be really great if anybody who's experienced in re-module regexp looks at this to recheck.**

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/module_utils/database.py```
```plugins/modules/database/postgresql/postgresql_user.py```
