### PR TITLE
parted: Allow passing negative numbers to specify partition boundary relative to disk end

### DIFF
--- a/changelogs/fragments/parted_negative_numbers.yml
+++ b/changelogs/fragments/parted_negative_numbers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - "parted - accept negative numbers in ``part_start`` and ``part_end``"

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -625,6 +625,10 @@ def main():
         if current_device['generic'].get('table', None) != label:
             script += "mklabel %s " % label
 
+        # parted <= 3.2.153 bug: optional filesystem parameter is mandatory for negative part_start
+        if fs_type is None and part_start.startswith('-'):
+            fs_type = 'ext2'
+
         # Create partition if required
         if part_type and not part_exists(current_parts, 'num', number):
             script += "mkpart %s %s%s %s " % (

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -190,6 +190,7 @@ EXAMPLES = r'''
     device: /dev/sdb
     number: 3
     state: present
+    fs_type: ext3
     part_start: -1GiB
 
 # Example on how to read info and reuse it in subsequent task

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -68,15 +68,17 @@ options:
   part_start:
     description:
     - Where the partition will start as offset from the beginning of the disk,
-      that is, the "distance" from the start of the disk.
+      that is, the "distance" from the start of the disk. Negative numbers
+      specify distance from the end of the disk.
     - The distance can be specified with all the units supported by parted
       (except compat) and it is case sensitive, e.g. C(10GiB), C(15%).
     type: str
     default: 0%
-  part_end :
+  part_end:
     description:
     - Where the partition will end as offset from the beginning of the disk,
-      that is, the "distance" from the start of the disk.
+      that is, the "distance" from the start of the disk. Negative numbers
+      specify distance from the end of the disk.
     - The distance can be specified with all the units supported by parted
       (except compat) and it is case sensitive, e.g. C(10GiB), C(15%).
     type: str
@@ -178,6 +180,13 @@ EXAMPLES = r'''
     state: present
     part_start: 1GiB
 
+- name: Create a new primary partition with a size of 1GiB at disk's end
+  parted:
+    device: /dev/sdb
+    number: 3
+    state: present
+    part_start: -1GiB
+
 # Example on how to read info and reuse it in subsequent task
 - name: Read device information (always use unit when probing)
   parted: device=/dev/sdb unit=MiB
@@ -206,9 +215,9 @@ parted_units = units_si + units_iec + ['s', '%', 'cyl', 'chs', 'compact']
 
 def parse_unit(size_str, unit=''):
     """
-    Parses a string containing a size of information
+    Parses a string containing a size or boundary information
     """
-    matches = re.search(r'^([\d.]+)([\w%]+)?$', size_str)
+    matches = re.search(r'^(-?[\d.]+)([\w%]+)?$', size_str)
     if matches is None:
         # "<cylinder>,<head>,<sector>" format
         matches = re.search(r'^(\d+),(\d+),(\d+)$', size_str)

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -180,6 +180,7 @@ class TestParted(ModuleTestCase):
             'device': '/dev/sdb',
             'number': 4,
             'state': 'present',
+            'fs_type': 'ext2',
             'part_start': '-1GiB',
         })
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -175,6 +175,16 @@ class TestParted(ModuleTestCase):
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):
             self.execute_module(changed=True, script='unit KiB mkpart primary 0% 1GiB')
 
+    def test_create_new_partition_minus_1G(self):
+        set_module_args({
+            'device': '/dev/sdb',
+            'number': 4,
+            'state': 'present',
+            'part_start': '-1GiB',
+        })
+        with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext2 -1GiB 100%')
+
     def test_remove_partition_number_1(self):
         set_module_args({
             'device': '/dev/sdb',


### PR DESCRIPTION
##### SUMMARY
Allow passing negative numbers to specify partition boundary relative to disk end
Fixes: https://github.com/ansible/ansible/issues/43369

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION
