### PR TITLE
filesystem.py: fix xfs growfs

### DIFF
--- a/changelogs/fragments/33979-xfs_growfs.yml
+++ b/changelogs/fragments/33979-xfs_growfs.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- filesystem: resizefs of xfs filesystems is fixed. Filesystem needs to be mounted.
+- "filesystem - resizefs of xfs filesystems is fixed. Filesystem needs to be mounted."

--- a/changelogs/fragments/33979-xfs_growfs.yml
+++ b/changelogs/fragments/33979-xfs_growfs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- filesystem: resizefs of xfs filesystems is fixed. Filesystem needs to be mounted.

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -100,6 +100,20 @@ class Device(object):
         else:
             self.module.fail_json(changed=False, msg="Target device not supported: %s" % self)
 
+    def get_mountpoint(self):
+        """Return (first) mountpoint of device. Returns None when not mounted."""
+        cmd_findmnt = self.module.get_bin_path("findmnt", required=True)
+
+        # find mountpoint
+        rc, mountpoint, _ = self.module.run_command([cmd_findmnt, "--mtab", "--noheadings", "--output",
+                                                    "TARGET", "--source", self.path], check_rc=False)
+        if rc != 0:
+            mountpoint = None
+        else:
+            mountpoint = mountpoint.split('\n')[0]
+
+        return mountpoint
+
     def __str__(self):
         return self.path
 
@@ -191,7 +205,13 @@ class XFS(Filesystem):
 
     def get_fs_size(self, dev):
         cmd = self.module.get_bin_path('xfs_growfs', required=True)
-        _, size, _ = self.module.run_command([cmd, '-n', str(dev)], check_rc=True, environ_update=self.LANG_ENV)
+        mountpoint = dev.get_mountpoint()
+
+        if not mountpoint:
+            # xfs filesystem needs to be mounted
+            self.module.fail_json(msg="%s needs to be mounted for xfs operations" % dev)
+
+        _, size, _ = self.module.run_command([cmd, '-n', str(mountpoint)], check_rc=True, environ_update=self.LANG_ENV)
         for line in size.splitlines():
             col = line.split('=')
             if col[0].strip() == 'data':
@@ -202,6 +222,16 @@ class XFS(Filesystem):
                 block_size = int(col[2].split()[0])
                 block_count = int(col[3].split(',')[0])
                 return block_size * block_count
+
+    def grow_cmd(self, dev):
+        mountpoint = dev.get_mountpoint()
+        if not mountpoint:
+            # xfs filesystem needs to be mounted
+            self.module.fail_json(msg="%s needs to be mounted for xfs operations" % dev)
+
+        cmd = self.module.get_bin_path(self.GROW, required=True)
+
+        return [cmd, str(mountpoint)]
 
 
 class Reiserfs(Filesystem):


### PR DESCRIPTION
##### SUMMARY
reopening of https://github.com/ansible/ansible/pull/55646
<!--- Describe the change below, including rationale and design decisions -->
xfs needs to be mounted to be expanted.

Add function to get mountpoint of filesystem.

* Fail if xfs filesystem is not mounted

xfs growfs needs to be executed on a mountpoint. That will be enforced
now by xfsprogs-4.12.
https://bugzilla.redhat.com/show_bug.cgi?id=1477192
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/33979

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filesystem.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
before:
```
server1| FAILED! => {
    "changed": false,
    "cmd": "/usr/sbin/xfs_growfs -n /dev/vg00/work.tmp",
    "msg": "xfs_growfs: /dev/vg00/work.tmp is not a mounted XFS filesystem",
    "rc": 1,
    "stderr": "xfs_growfs: /dev/vg00/work.tmp is not a mounted XFS filesystem\n",
    "stderr_lines": [
        "xfs_growfs: /dev/vg00/work.tmp is not a mounted XFS filesystem"
    ],
    "stdout": "",
    "stdout_lines": []
}
```

after:
```
server1| SUCCESS => {
    "changed": false,
    "msg": "XFS filesystem is using the whole device /dev/vg00/work.tmp"
}
```
or (when mounted)

```
server1| SUCCESS => {
    "changed": true,
    "msg": "meta-data=/dev/mapper/vg00-work.tmp isize=512    agcount=4, agsize=32768 blks\n         =                       sectsz=512   attr=2, projid32bit=1\n         =                       crc=1        finobt=1 spinodes=0 rmapbt=0\n         =                       reflink=0\ndata     =                       bsize=4096   blocks=131072, imaxpct=25\n         =                       sunit=0      swidth=0 blks\nnaming   =version 2              bsize=4096   ascii-ci=0 ftype=1\nlog      =internal               bsize=4096   blocks=855, version=2\n         =                       sectsz=512   sunit=0 blks, lazy-count=1\nrealtime =none                   extsz=4096   blocks=0, rtextents=0\ndata blocks changed from 131072 to 134144\n"
}
```
or (when not mounted)
```

server1| FAILED! => {
    "changed": false,
    "msg": "/dev/vg00/work.tmp needs to be mounted for xfs operations"
}
```


