### PR TITLE
mysql_user: add resource_limits parameter

### DIFF
--- a/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
+++ b/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_user - add the `resource_limit` parameter (https://github.com/ansible-collections/community.general/issues/133).

--- a/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
+++ b/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- mysql_user - add the `resource_limit` parameter (https://github.com/ansible-collections/community.general/issues/133).
+- mysql_user - add the resource_limit parameter (https://github.com/ansible-collections/community.general/issues/133).

--- a/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
+++ b/changelogs/fragments/142-mysql_user_add_resource_limit_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- mysql_user - add the resource_limit parameter (https://github.com/ansible-collections/community.general/issues/133).
+- mysql_user - add the resource_limits parameter (https://github.com/ansible-collections/community.general/issues/133).

--- a/tests/integration/targets/mysql_user/aliases
+++ b/tests/integration/targets/mysql_user/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/aix
 skip/osx
 skip/freebsd
-skip/suse

--- a/tests/integration/targets/mysql_user/aliases
+++ b/tests/integration/targets/mysql_user/aliases
@@ -3,4 +3,4 @@ shippable/posix/group1
 skip/aix
 skip/osx
 skip/freebsd
-skip/opensuse
+skip/suse

--- a/tests/integration/targets/mysql_user/aliases
+++ b/tests/integration/targets/mysql_user/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/aix
 skip/osx
 skip/freebsd
+skip/opensuse

--- a/tests/integration/targets/mysql_user/tasks/main.yml
+++ b/tests/integration/targets/mysql_user/tasks/main.yml
@@ -21,6 +21,8 @@
 #
 - include: create_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
 
+- include: resource_limits.yml
+
 - include: assert_user.yml user_name={{user_name_1}}
 
 - include: remove_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}

--- a/tests/integration/targets/mysql_user/tasks/resource_limits.yml
+++ b/tests/integration/targets/mysql_user/tasks/resource_limits.yml
@@ -1,0 +1,112 @@
+# test code for resource_limits parameter
+
+- block:
+
+  - name: Drop mysql user {{ user_name_1 }} if exists
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      state: absent
+      login_unix_socket: '{{ mysql_socket }}'
+
+  - name: Create mysql user {{ user_name_1 }} with resource limits in check_mode
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      password: '{{ user_password_1 }}'
+      state: present
+      login_unix_socket: '{{ mysql_socket }}'
+      resource_limits:
+        MAX_QUERIES_PER_HOUR: 10
+        MAX_CONNECTIONS_PER_HOUR: 5
+    check_mode: yes
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: Create mysql user {{ user_name_1 }} with resource limits in actual mode
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      password: '{{ user_password_1 }}'
+      state: present
+      login_unix_socket: '{{ mysql_socket }}'
+      resource_limits:
+        MAX_QUERIES_PER_HOUR: 10
+        MAX_CONNECTIONS_PER_HOUR: 5
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: Check
+    mysql_query:
+      query: >
+        SELECT User FROM mysql.user WHERE User = '{{ user_name_1 }}' AND Host = 'localhost'
+        AND max_questions = 10 AND max_connections = 5
+      login_unix_socket: '{{ mysql_socket }}'
+    register: result
+
+  - assert:
+      that:
+      - result.rowcount[0] == 1
+
+  - name: Try to set the same limits again in check mode
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      password: '{{ user_password_1 }}'
+      state: present
+      login_unix_socket: '{{ mysql_socket }}'
+      resource_limits:
+        MAX_QUERIES_PER_HOUR: 10
+        MAX_CONNECTIONS_PER_HOUR: 5
+    check_mode: yes
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: Try to set the same limits again in actual mode
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      password: '{{ user_password_1 }}'
+      state: present
+      login_unix_socket: '{{ mysql_socket }}'
+      resource_limits:
+        MAX_QUERIES_PER_HOUR: 10
+        MAX_CONNECTIONS_PER_HOUR: 5
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: Change limits
+    mysql_user:
+      name: '{{ user_name_1 }}'
+      password: '{{ user_password_1 }}'
+      state: present
+      login_unix_socket: '{{ mysql_socket }}'
+      resource_limits:
+        MAX_QUERIES_PER_HOUR: 5
+        MAX_CONNECTIONS_PER_HOUR: 5
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: Check
+    mysql_query:
+      query: >
+        SELECT User FROM mysql.user WHERE User = '{{ user_name_1 }}' AND Host = 'localhost'
+        AND max_questions = 5 AND max_connections = 5
+      login_unix_socket: '{{ mysql_socket }}'
+    register: result
+
+  - assert:
+      that:
+      - result.rowcount[0] == 1
+
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18') or (ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '8')


### PR DESCRIPTION
##### SUMMARY
mysql_user: add resource_limits parameter

Fixes: https://github.com/ansible-collections/community.general/issues/133

```
  resource_limits:
    description:
      - Limit the user for certain server resources. Provided since MySQL 5.6 / MariaDB 10.2.
      - "Available options are C(MAX_QUERIES_PER_HOUR: num), C(MAX_UPDATES_PER_HOUR: num),
        C(MAX_CONNECTIONS_PER_HOUR: num), C(MAX_USER_CONNECTIONS: num)."
      - Used when I(state=present), ignored otherwise.
    type: dict
```

##### EXAMPLE
```
- name: Limit bob's resources to 10 queries per hour and 5 connections per hour
  mysql_user:
    name: bob
    resource_limits:
      MAX_QUERIES_PER_HOUR: 10
      MAX_CONNECTIONS_PER_HOUR: 5
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/mysql/mysql_user.py```
