### PR TITLE
mysql_info: added spaces to CI tests

### DIFF
--- a/tests/integration/targets/mysql_info/tasks/main.yml
+++ b/tests/integration/targets/mysql_info/tasks/main.yml
@@ -1,3 +1,12 @@
+# Test code for mysql_info module
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+###################
+# Prepare for tests
+#
+
+# Create role for tests
 - name: mysql_info -  create mysql user {{ user_name }}
   mysql_user:
     name: '{{ user_name }}'
@@ -6,18 +15,24 @@
     priv: '*.*:ALL'
     login_unix_socket: '{{ mysql_socket }}'
 
+# Create default MySQL config file with credentials
 - name: mysql_info - create default config file
   template:
     src: my.cnf.j2
     dest: /root/.my.cnf
     mode: '0400'
 
+# Create non-default MySQL config file with credentials
 - name: mysql_info - create non-default config file
   template:
     src: my.cnf.j2
     dest: /root/non-default_my.cnf
     mode: '0400'
 
+###############
+# Do tests
+
+# Access by default cred file
 - name: mysql_info - collect default cred file
   mysql_info:
     login_user: '{{ user_name }}'
@@ -33,6 +48,7 @@
     - result.engines != {}
     - result.users != {}
 
+# Access by non-default cred file
 - name: mysql_info - check non-default cred file
   mysql_info:
     login_user: '{{ user_name }}'
@@ -44,6 +60,7 @@
     - result.changed == false
     - result.version != {}
 
+# Remove cred files
 - name: mysql_info - remove cred files
   file:
     path: '{{ item }}'
@@ -52,6 +69,7 @@
   - /root/.my.cnf
   - /root/non-default_my.cnf
 
+# Access with password
 - name: mysql_info - check access with password
   mysql_info:
     login_user: '{{ user_name }}'
@@ -63,6 +81,7 @@
     - result.changed == false
     - result.version != {}
 
+# Test excluding
 - name: Collect all info except settings and users
   mysql_info:
     login_user: '{{ user_name }}'
@@ -80,6 +99,7 @@
     - result.settings is not defined
     - result.users is not defined
 
+# Test including
 - name: Collect info only about version and databases
   mysql_info:
     login_user: '{{ user_name }}'
@@ -99,6 +119,7 @@
     - result.global_status is not defined
     - result.users is not defined
 
+# Test exclude_fields
 - name: Collect info about databases excluding their sizes
   mysql_info:
     login_user: '{{ user_name }}'

--- a/tests/integration/targets/mysql_info/tasks/main.yml
+++ b/tests/integration/targets/mysql_info/tasks/main.yml
@@ -5,20 +5,24 @@
     state: present
     priv: '*.*:ALL'
     login_unix_socket: '{{ mysql_socket }}'
+
 - name: mysql_info - create default config file
   template:
     src: my.cnf.j2
     dest: /root/.my.cnf
     mode: '0400'
+
 - name: mysql_info - create non-default config file
   template:
     src: my.cnf.j2
     dest: /root/non-default_my.cnf
     mode: '0400'
+
 - name: mysql_info - collect default cred file
   mysql_info:
     login_user: '{{ user_name }}'
   register: result
+
 - assert:
     that:
     - result.changed == false
@@ -28,15 +32,18 @@
     - result.databases != {}
     - result.engines != {}
     - result.users != {}
+
 - name: mysql_info - check non-default cred file
   mysql_info:
     login_user: '{{ user_name }}'
     config_file: /root/non-default_my.cnf
   register: result
+
 - assert:
     that:
     - result.changed == false
     - result.version != {}
+
 - name: mysql_info - remove cred files
   file:
     path: '{{ item }}'
@@ -44,21 +51,25 @@
   with_items:
   - /root/.my.cnf
   - /root/non-default_my.cnf
+
 - name: mysql_info - check access with password
   mysql_info:
     login_user: '{{ user_name }}'
     login_password: '{{ user_pass }}'
   register: result
+
 - assert:
     that:
     - result.changed == false
     - result.version != {}
+
 - name: Collect all info except settings and users
   mysql_info:
     login_user: '{{ user_name }}'
     login_password: '{{ user_pass }}'
     filter: '!settings,!users'
   register: result
+
 - assert:
     that:
     - result.changed == false
@@ -68,6 +79,7 @@
     - result.engines != {}
     - result.settings is not defined
     - result.users is not defined
+
 - name: Collect info only about version and databases
   mysql_info:
     login_user: '{{ user_name }}'
@@ -76,6 +88,7 @@
     - version
     - databases
   register: result
+
 - assert:
     that:
     - result.changed == false
@@ -85,6 +98,7 @@
     - result.settings is not defined
     - result.global_status is not defined
     - result.users is not defined
+
 - name: Collect info about databases excluding their sizes
   mysql_info:
     login_user: '{{ user_name }}'
@@ -95,16 +109,19 @@
     - db_size
     - unsupported
   register: result
+
 - assert:
     that:
     - result.changed == false
     - result.databases != {}
     - result.databases.mysql == {}
+
 - name: Create empty database acme
   mysql_db:
     login_user: '{{ user_name }}'
     login_password: '{{ user_pass }}'
     name: acme
+
 - name: Collect info about databases
   mysql_info:
     login_user: '{{ user_name }}'
@@ -113,11 +130,13 @@
     - databases
     return_empty_dbs: true
   register: result
+
 - assert:
     that:
     - result.changed == false
     - result.databases.acme.size == 0
     - result.databases.mysql != {}
+
 - name: Collect info about databases excluding their sizes
   mysql_info:
     login_user: '{{ user_name }}'
@@ -128,11 +147,13 @@
     - db_size
     return_empty_dbs: true
   register: result
+
 - assert:
     that:
     - result.changed == false
     - result.databases.acme == {}
     - result.databases.mysql == {}
+
 - name: Remove acme database
   mysql_db:
     login_user: '{{ user_name }}'

--- a/tests/integration/targets/mysql_info/tasks/main.yml
+++ b/tests/integration/targets/mysql_info/tasks/main.yml
@@ -119,7 +119,9 @@
     - result.global_status is not defined
     - result.users is not defined
 
-# Test exclude_fields
+# Test exclude_fields: db_size
+# 'unsupported' element is passed to check that an unsupported value
+# won't break anything (will be ignored regarding to the module's documentation).
 - name: Collect info about databases excluding their sizes
   mysql_info:
     login_user: '{{ user_name }}'
@@ -137,6 +139,9 @@
     - result.databases != {}
     - result.databases.mysql == {}
 
+########################################################
+# Issue #65727, empty databases must be in returned dict
+#
 - name: Create empty database acme
   mysql_db:
     login_user: '{{ user_name }}'
@@ -152,6 +157,7 @@
     return_empty_dbs: true
   register: result
 
+# Check acme is in returned dict
 - assert:
     that:
     - result.changed == false
@@ -169,6 +175,7 @@
     return_empty_dbs: true
   register: result
 
+# Check acme is in returned dict
 - assert:
     that:
     - result.changed == false


### PR DESCRIPTION
##### SUMMARY
mysql_info: added spaces and comments to CI tests

they disappeared since the migration to community.general

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```tests/integration/targets/mysql_info/tasks/main.yml```
