### PR TITLE
Remove version_added from return values and docs fragments

### DIFF
--- a/plugins/doc_fragments/rackspace.py
+++ b/plugins/doc_fragments/rackspace.py
@@ -63,7 +63,6 @@ options:
     description:
       - The URI of the authentication service.
     default: https://identity.api.rackspacecloud.com/v2.0/
-    version_added: '1.5'
   credentials:
     description:
       - File to find the Rackspace credentials in. Ignored if I(api_key) and
@@ -73,12 +72,10 @@ options:
     description:
       - Environment as configured in I(~/.pyrax.cfg),
         see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration).
-    version_added: '1.5'
   identity_type:
     description:
       - Authentication mechanism to use, such as rackspace or keystone.
     default: rackspace
-    version_added: '1.5'
   region:
     description:
       - Region to create an instance in.
@@ -86,18 +83,15 @@ options:
   tenant_id:
     description:
       - The tenant ID used for authentication.
-    version_added: '1.5'
   tenant_name:
     description:
       - The tenant name used for authentication.
-    version_added: '1.5'
   username:
     description:
       - Rackspace username, overrides I(credentials).
   validate_certs:
     description:
       - Whether or not to require SSL validation of API endpoints.
-    version_added: '1.5'
     type: bool
     aliases: [ verify_ssl ]
 requirements:

--- a/plugins/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/plugins/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -158,7 +158,6 @@ region:
   returned: success when state == present
   type: dict
   sample: {'slug': 'lpg'}
-  version_added: '2.10'
 state:
   description: The current status of the floating IP.
   returned: success

--- a/plugins/modules/cloud/cloudscale/cloudscale_server.py
+++ b/plugins/modules/cloud/cloudscale/cloudscale_server.py
@@ -225,7 +225,6 @@ zone:
   returned: success when not state == absent
   type: dict
   sample: { 'slug': 'lpg1' }
-  version_added: '2.10'
 volumes:
   description: List of volumes attached to the server
   returned: success when not state == absent
@@ -258,13 +257,11 @@ server_groups:
   returned: success when not state == absent
   type: list
   sample: [ {"href": "https://api.cloudscale.ch/v1/server-groups/...", "uuid": "...", "name": "db-group"} ]
-  version_added: '2.8'
 tags:
   description: Tags assosiated with the volume.
   returned: success
   type: dict
   sample: { 'project': 'my project' }
-  version_added: '2.9'
 '''
 
 from datetime import datetime, timedelta

--- a/plugins/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/plugins/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -106,7 +106,6 @@ zone:
   returned: success
   type: dict
   sample: { 'slug': 'rma1' }
-  version_added: '2.10'
 servers:
   description: A list of servers that are part of the server group.
   returned: if available
@@ -122,7 +121,6 @@ tags:
   returned: success
   type: dict
   sample: { 'project': 'my project' }
-  version_added: '2.9'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/plugins/modules/cloud/cloudscale/cloudscale_volume.py
@@ -151,7 +151,6 @@ zone:
   returned: state == present
   type: dict
   sample: {'slug': 'lpg1'}
-  version_added: '2.10'
 server_uuids:
   description: The UUIDs of the servers this volume is attached to.
   returned: state == present
@@ -167,7 +166,6 @@ tags:
   returned: state == present
   type: dict
   sample: { 'project': 'my project' }
-  version_added: '2.9'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudstack/cs_firewall.py
+++ b/plugins/modules/cloud/cloudstack/cs_firewall.py
@@ -181,7 +181,6 @@ cidrs:
   returned: success
   type: list
   sample: [ '0.0.0.0/0' ]
-  version_added: '2.5'
 protocol:
   description: Protocol of the rule.
   returned: success

--- a/plugins/modules/cloud/cloudstack/cs_instance.py
+++ b/plugins/modules/cloud/cloudstack/cs_instance.py
@@ -341,7 +341,6 @@ default_ip6:
   returned: if available
   type: str
   sample: 2a04:c43:c00:a07:4b4:beff:fe00:74
-  version_added: '2.6'
 public_ip:
   description: Public IP address with instance via static NAT rule.
   returned: if available
@@ -362,7 +361,6 @@ template_display_text:
   returned: success
   type: str
   sample: Linux Debian 9 64-bit 200G Disk (2017-10-08-622866)
-  version_added: '2.6'
 service_offering:
   description: Name of the service offering the instance has.
   returned: success
@@ -403,7 +401,6 @@ host:
   returned: success and instance is running
   type: str
   sample: host-01.example.com
-  version_added: '2.6'
 instance_name:
   description: Internal name of the instance (ROOT admin only).
   returned: success

--- a/plugins/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/plugins/modules/cloud/cloudstack/cs_instance_facts.py
@@ -178,7 +178,6 @@ host:
   returned: success and instance is running
   type: str
   sample: host01.example.com
-  version_added: '2.6'
 instance_name:
   description: Internal name of the instance (ROOT admin only).
   returned: success
@@ -193,7 +192,6 @@ nic:
   description: List of dictionaries of the instance nics.
   returned: success
   type: complex
-  version_added: '2.8'
   contains:
     broadcasturi:
       description: The broadcast uri of the nic.

--- a/plugins/modules/cloud/cloudstack/cs_instance_info.py
+++ b/plugins/modules/cloud/cloudstack/cs_instance_info.py
@@ -187,7 +187,6 @@ instances:
       returned: success and instance is running
       type: str
       sample: host01.example.com
-      version_added: '2.6'
     instance_name:
       description: Internal name of the instance (ROOT admin only).
       returned: success
@@ -202,7 +201,6 @@ instances:
       description: List of dictionaries of the instance nics.
       returned: success
       type: complex
-      version_added: '2.8'
       contains:
         broadcasturi:
           description: The broadcast uri of the nic.

--- a/plugins/modules/cloud/cloudstack/cs_ip_address.py
+++ b/plugins/modules/cloud/cloudstack/cs_ip_address.py
@@ -150,7 +150,6 @@ tags:
   returned: success
   type: dict
   sample: '[ { "key": "myCustomID", "value": "5510c31a-416e-11e8-9013-02000a6b00bf" } ]'
-  version_added: '2.6'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudstack/cs_iso.py
+++ b/plugins/modules/cloud/cloudstack/cs_iso.py
@@ -182,31 +182,26 @@ is_public:
   returned: success
   type: bool
   sample: true
-  version_added: '2.4'
 bootable:
   description: True if the ISO is bootable.
   returned: success
   type: bool
   sample: true
-  version_added: '2.4'
 is_featured:
   description: True if the ISO is featured.
   returned: success
   type: bool
   sample: true
-  version_added: '2.4'
 format:
   description: Format of the ISO.
   returned: success
   type: str
   sample: ISO
-  version_added: '2.4'
 os_type:
   description: Typo of the OS.
   returned: success
   type: str
   sample: CentOS 6.5 (64-bit)
-  version_added: '2.4'
 checksum:
   description: MD5 checksum of the ISO.
   returned: success
@@ -222,7 +217,6 @@ cross_zones:
   returned: success
   type: bool
   sample: false
-  version_added: '2.4'
 domain:
   description: Domain the ISO is related to.
   returned: success
@@ -243,7 +237,6 @@ tags:
   returned: success
   type: dict
   sample: '[ { "key": "foo", "value": "bar" } ]'
-  version_added: '2.4'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudstack/cs_network.py
+++ b/plugins/modules/cloud/cloudstack/cs_network.py
@@ -287,13 +287,11 @@ acl:
   returned: success
   type: str
   sample: My ACL
-  version_added: '2.5'
 acl_id:
   description: ID of the access control list for the VPC network tier.
   returned: success
   type: str
   sample: dfafcd55-0510-4b8c-b6c5-b8cedb4cfd88
-  version_added: '2.5'
 broadcast_domain_type:
   description: Broadcast domain type of the network.
   returned: success
@@ -334,25 +332,21 @@ network_offering_display_text:
   returned: success
   type: str
   sample: Offering for Isolated Vpc networks with Source Nat service enabled
-  version_added: '2.5'
 network_offering_conserve_mode:
   description: Whether the network offering has IP conserve mode enabled or not.
   returned: success
   type: bool
   sample: false
-  version_added: '2.5'
 network_offering_availability:
   description: The availability of the network offering the network is created from
   returned: success
   type: str
   sample: Optional
-  version_added: '2.5'
 is_system:
   description: Whether the network is system related or not.
   returned: success
   type: bool
   sample: false
-  version_added: '2.5'
 vpc:
   description: Name of the VPC.
   returned: if available

--- a/plugins/modules/cloud/cloudstack/cs_network_acl_rule.py
+++ b/plugins/modules/cloud/cloudstack/cs_network_acl_rule.py
@@ -179,7 +179,6 @@ cidrs:
   returned: success
   type: list
   sample: [ 0.0.0.0/0 ]
-  version_added: '2.9'
 rule_position:
   description: Position of the network ACL rule.
   returned: success

--- a/plugins/modules/cloud/cloudstack/cs_network_offering.py
+++ b/plugins/modules/cloud/cloudstack/cs_network_offering.py
@@ -215,7 +215,6 @@ for_vpc:
   returned: success
   type: bool
   sample: false
-  version_added: '2.8'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudstack/cs_service_offering.py
+++ b/plugins/modules/cloud/cloudstack/cs_service_offering.py
@@ -382,7 +382,6 @@ is_customized:
   returned: success
   type: bool
   sample: false
-  version_added: '2.8'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/cloudstack/cs_volume.py
+++ b/plugins/modules/cloud/cloudstack/cs_volume.py
@@ -264,7 +264,6 @@ url:
   returned: success when I(state=extracted)
   type: str
   sample: http://1.12.3.4/userdata/387e2c7c-7c42-4ecc-b4ed-84e8367a1965.vhd
-  version_added: '2.8'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/cloud/vultr/_vultr_account_facts.py
+++ b/plugins/modules/cloud/vultr/_vultr_account_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_account_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_account_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_account_info.py
+++ b/plugins/modules/cloud/vultr/vultr_account_info.py
@@ -60,7 +60,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_block_storage.py
+++ b/plugins/modules/cloud/vultr/vultr_block_storage.py
@@ -84,7 +84,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_block_storage_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_block_storage_facts.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_block_storage_info.py
+++ b/plugins/modules/cloud/vultr/vultr_block_storage_info.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_dns_domain.py
+++ b/plugins/modules/cloud/vultr/vultr_dns_domain.py
@@ -80,7 +80,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_dns_domain_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_dns_domain_facts.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_dns_domain_info.py
+++ b/plugins/modules/cloud/vultr/vultr_dns_domain_info.py
@@ -60,7 +60,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_dns_record.py
+++ b/plugins/modules/cloud/vultr/vultr_dns_record.py
@@ -150,7 +150,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_firewall_group.py
+++ b/plugins/modules/cloud/vultr/vultr_firewall_group.py
@@ -74,7 +74,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_firewall_group_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_firewall_group_facts.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_firewall_group_info.py
+++ b/plugins/modules/cloud/vultr/vultr_firewall_group_info.py
@@ -60,7 +60,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_firewall_rule.py
+++ b/plugins/modules/cloud/vultr/vultr_firewall_rule.py
@@ -122,7 +122,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_network.py
+++ b/plugins/modules/cloud/vultr/vultr_network.py
@@ -82,7 +82,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_network_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_network_facts.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_network_info.py
+++ b/plugins/modules/cloud/vultr/vultr_network_info.py
@@ -60,7 +60,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_os_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_os_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_os_info.py
+++ b/plugins/modules/cloud/vultr/vultr_os_info.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_plan_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_plan_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_plan_info.py
+++ b/plugins/modules/cloud/vultr/vultr_plan_info.py
@@ -61,7 +61,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_region_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_region_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_region_info.py
+++ b/plugins/modules/cloud/vultr/vultr_region_info.py
@@ -61,7 +61,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_server.py
+++ b/plugins/modules/cloud/vultr/vultr_server.py
@@ -189,7 +189,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_server_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_server_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_server_info.py
+++ b/plugins/modules/cloud/vultr/vultr_server_info.py
@@ -61,7 +61,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_ssh_key.py
+++ b/plugins/modules/cloud/vultr/vultr_ssh_key.py
@@ -79,7 +79,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_ssh_key_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_ssh_key_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_ssh_key_info.py
+++ b/plugins/modules/cloud/vultr/vultr_ssh_key_info.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_startup_script.py
+++ b/plugins/modules/cloud/vultr/vultr_startup_script.py
@@ -92,7 +92,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_startup_script_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_startup_script_facts.py
@@ -64,7 +64,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_startup_script_info.py
+++ b/plugins/modules/cloud/vultr/vultr_startup_script_info.py
@@ -61,7 +61,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_user.py
+++ b/plugins/modules/cloud/vultr/vultr_user.py
@@ -119,7 +119,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_user_facts.py
+++ b/plugins/modules/cloud/vultr/vultr_user_facts.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/cloud/vultr/vultr_user_info.py
+++ b/plugins/modules/cloud/vultr/vultr_user_info.py
@@ -63,7 +63,6 @@ vultr_api:
       returned: success
       type: int
       sample: 12
-      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/plugins/modules/database/mysql/mysql_db.py
+++ b/plugins/modules/database/mysql/mysql_db.py
@@ -251,13 +251,11 @@ db_list:
   returned: always
   type: list
   sample: ["foo", "bar"]
-  version_added: '2.9'
 executed_commands:
   description: List of commands which tried to run.
   returned: if executed
   type: list
   sample: ["CREATE DATABASE acme"]
-  version_added: '2.10'
 '''
 
 import os

--- a/plugins/modules/database/mysql/mysql_info.py
+++ b/plugins/modules/database/mysql/mysql_info.py
@@ -167,7 +167,6 @@ global_status:
   type: dict
   sample:
   - { "Innodb_buffer_pool_read_requests": 123, "Innodb_buffer_pool_reads": 32 }
-  version_added: "2.10"
 users:
   description: Users information.
   returned: if not excluded by filter

--- a/plugins/modules/database/mysql/mysql_replication.py
+++ b/plugins/modules/database/mysql/mysql_replication.py
@@ -231,7 +231,6 @@ queries:
   returned: always
   type: list
   sample: ["CHANGE MASTER TO MASTER_HOST='master2.example.com',MASTER_PORT=3306"]
-  version_added: '2.10'
 '''
 
 import os

--- a/plugins/modules/database/mysql/mysql_variables.py
+++ b/plugins/modules/database/mysql/mysql_variables.py
@@ -76,7 +76,6 @@ queries:
   returned: if executed
   type: list
   sample: ["SET GLOBAL `read_only` = 1"]
-  version_added: '2.10'
 '''
 
 import os

--- a/plugins/modules/database/postgresql/postgresql_db.py
+++ b/plugins/modules/database/postgresql/postgresql_db.py
@@ -190,7 +190,6 @@ executed_commands:
   returned: always
   type: list
   sample: ["CREATE DATABASE acme"]
-  version_added: '2.10'
 '''
 
 

--- a/plugins/modules/database/postgresql/postgresql_info.py
+++ b/plugins/modules/database/postgresql/postgresql_info.py
@@ -243,7 +243,6 @@ databases:
           - Content depends on PostgreSQL server version.
           returned: if configured
           type: dict
-          version_added: "2.10"
           sample: { "pub1": { "ownername": "postgres", "puballtables": true, "pubinsert": true, "pubupdate": true } }
         subscriptions:
           description:
@@ -252,7 +251,6 @@ databases:
           - Content depends on PostgreSQL server version.
           returned: if configured
           type: dict
-          version_added: "2.10"
           sample:
           - { "my_subscription": {"ownername": "postgres", "subenabled": true, "subpublications": ["first_publication"] } }
 repl_slots:

--- a/plugins/modules/database/postgresql/postgresql_lang.py
+++ b/plugins/modules/database/postgresql/postgresql_lang.py
@@ -173,7 +173,6 @@ queries:
   returned: always
   type: list
   sample: ['CREATE LANGUAGE "acme"']
-  version_added: '2.8'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/database/postgresql/postgresql_privs.py
+++ b/plugins/modules/database/postgresql/postgresql_privs.py
@@ -403,7 +403,6 @@ queries:
   returned: always
   type: list
   sample: ['REVOKE GRANT OPTION FOR INSERT ON TABLE "books" FROM "reader";']
-  version_added: '2.8'
 '''
 
 import traceback

--- a/plugins/modules/database/postgresql/postgresql_user.py
+++ b/plugins/modules/database/postgresql/postgresql_user.py
@@ -235,7 +235,6 @@ queries:
   returned: always
   type: list
   sample: ['CREATE USER "alice"', 'GRANT CONNECT ON DATABASE "acme" TO "alice"']
-  version_added: '2.8'
 '''
 
 import itertools

--- a/plugins/modules/system/mksysb.py
+++ b/plugins/modules/system/mksysb.py
@@ -93,12 +93,10 @@ changed:
   description: Return changed for mksysb actions as true or false.
   returned: always
   type: bool
-  version_added: 2.5
 msg:
   description: Return message regarding the action.
   returned: always
   type: str
-  version_added: 2.5
 '''
 
 

--- a/plugins/modules/system/pamd.py
+++ b/plugins/modules/system/pamd.py
@@ -228,13 +228,11 @@ change_count:
     type: int
     sample: 1
     returned: success
-    version_added: 2.4
 new_rule:
     description: The changes to the rule.  This was available in Ansible 2.4 and Ansible 2.5.  It was removed in Ansible 2.6.
     type: str
     sample: None      None None sha512 shadow try_first_pass use_authtok
     returned: success
-    version_added: 2.4
 updated_rule_(n):
     description: The rule(s) that was/were changed.  This is only available in
       Ansible 2.4 and was removed in Ansible 2.5.
@@ -243,7 +241,6 @@ updated_rule_(n):
     - password      sufficient  pam_unix.so sha512 shadow try_first_pass
       use_authtok
     returned: success
-    version_added: 2.4
 action:
     description:
     - "That action that was taken and is one of: update_rule,
@@ -252,7 +249,6 @@ action:
     returned: always
     type: str
     sample: "update_rule"
-    version_added: 2.4
 dest:
     description:
     - "Path to pam.d service that was changed.  This is only available in
@@ -265,7 +261,6 @@ backupdest:
     - "The file name of the backup file, if created."
     returned: success
     type: str
-    version_added: 2.6
 ...
 '''
 

--- a/scripts/inventory/openshift.py
+++ b/scripts/inventory/openshift.py
@@ -24,7 +24,6 @@ short_description: Openshift gears external inventory script
 description:
   - Generates inventory of Openshift gears using the REST interface
   - this permit to reuse playbook to setup an Openshift gear
-version_added: None
 author: Michael Scherer
 '''
 


### PR DESCRIPTION
##### SUMMARY
These were left during migration, as opposed to `version_added` for options and plugins themselves.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules
