### PR TITLE
Return correct values when running yarn in check mode

### DIFF
--- a/changelogs/fragments/153-yarn_fix_checkmode-ec61975fc65df7f0.yaml
+++ b/changelogs/fragments/153-yarn_fix_checkmode-ec61975fc65df7f0.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- yarn - Return correct values when running yarn in check mode (https://github.com/ansible-collections/community.general/pull/153).

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -222,7 +222,7 @@ class Yarn(object):
             rc, out, err = self.module.run_command(cmd, check_rc=check_rc, cwd=cwd)
             return out, err
 
-        return None, None
+        return(None, None)
 
     def list(self):
         cmd = ['list', '--depth=0', '--json']

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -222,7 +222,7 @@ class Yarn(object):
             rc, out, err = self.module.run_command(cmd, check_rc=check_rc, cwd=cwd)
             return out, err
 
-        return ''
+        return None, None
 
     def list(self):
         cmd = ['list', '--depth=0', '--json']

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -69,6 +69,24 @@
         that:
           - not (yarn_install is changed)
 
+    - name: 'Install all packages in check mode.'
+      yarn:
+        path: '{{ output_dir }}'
+        executable: '{{ yarn_bin_path }}/yarn'
+        state: present
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      check_mode: true
+      register: yarn_install_check
+
+    - name: verify test yarn global installation in check mode
+      assert:
+        that:
+          - yarn_install_check.err is defined
+          - yarn_install_check.out is defined
+          - yarn_install_check.err is none
+          - yarn_install_check.out is none
+
     - name: 'Install package with explicit version (older version of package)'
       yarn:
         path: '{{ output_dir }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #152 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`yarn` module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When running check mode on yarn module, it returns an empty string by default when it expects two values for err and out. For instance:

```py
out, err = yarn.install()
```
Currently the return is like:
```py
return ''
```
and should be at least:
```py
return(None, None)
```
From my point of view, this module needs to be have some checks for idempotency and dry-runs, but for now this will fix the issue. If you think it is interesting refactoring it, let me know and I can work on it.

<!--- Paste verbatim command output below, e.g. before and after your change -->
After the change
```json
changed: [localhost] => {
    "changed": true,
    "err": null,
    "invocation": {
        "module_args": {
            "executable": null,
            "global": true,
            "ignore_scripts": false,
            "name": "now",
            "path": null,
            "production": false,
            "registry": null,
            "state": "present",
            "version": null
        }
    },
    "out": null
}
```
