### PR TITLE
Add changelog fragments for this collection from ansible/ansible

### DIFF
--- a/changelogs/fragments/36876-github-deploy-key-fix-pagination.yaml
+++ b/changelogs/fragments/36876-github-deploy-key-fix-pagination.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "github_deploy_key - added support for pagination"

--- a/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
+++ b/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_publish - Fix to ensure the module works correctly for pika v1.0.0 and later. (https://github.com/ansible/ansible/pull/61960)

--- a/changelogs/fragments/58812-support_absolute_paths_additionally.yml
+++ b/changelogs/fragments/58812-support_absolute_paths_additionally.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - terraform - adding support for absolute paths additionally to the relative path within project_path (https://github.com/ansible/ansible/issues/58578)

--- a/changelogs/fragments/59522-renamed-module-tls-client-auth-params-to-avoid-overlaping-with-fetch_url.yaml
+++ b/changelogs/fragments/59522-renamed-module-tls-client-auth-params-to-avoid-overlaping-with-fetch_url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pulp_repo - the ``client_cert`` and ``client_key`` options were used for both requests to the Pulp instance and for the repo to sync with, resulting in errors when they were used. Use the new options ``feed_client_cert`` and ``feed_client_key`` for client certificates that should only be used for repo synchronisation, and not for communication with the Pulp instance. (https://github.com/ansible/ansible/issues/59513)

--- a/changelogs/fragments/59765-cron-cronvar-use-get-bin-path.yaml
+++ b/changelogs/fragments/59765-cron-cronvar-use-get-bin-path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cronvar - use get_bin_path utility to locate the default crontab executable instead of the hardcoded /usr/bin/crontab. (https://github.com/ansible/ansible/pull/59765)

--- a/changelogs/fragments/59877-fix-keyerror-in-redfish-getlogs.yaml
+++ b/changelogs/fragments/59877-fix-keyerror-in-redfish-getlogs.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_facts - fix KeyError exceptions in GetLogs (https://github.com/ansible/ansible/issues/59797)

--- a/changelogs/fragments/59927-fix-redfish-power-reset-type-mapping.yaml
+++ b/changelogs/fragments/59927-fix-redfish-power-reset-type-mapping.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - fix power ResetType mapping logic (https://github.com/ansible/ansible/issues/59804)

--- a/changelogs/fragments/60201-idrac-redfish-config-attributes-support.yml
+++ b/changelogs/fragments/60201-idrac-redfish-config-attributes-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - idrac_redfish_config - Support for multiple manager attributes configuration

--- a/changelogs/fragments/60961-docker_compose-fix-deprecation-warning.yml
+++ b/changelogs/fragments/60961-docker_compose-fix-deprecation-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_compose - fix issue where docker deprecation warning results in ansible erroneously reporting a failure"

--- a/changelogs/fragments/61562-nagios-start.yaml
+++ b/changelogs/fragments/61562-nagios-start.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - nagios module - a start parameter has been added, allowing the time a
+    Nagios outage starts to be set. It defaults to the current time if not
+    provided, preserving the previous behavior and ensuring compatibility with
+    existing playbooks.

--- a/changelogs/fragments/61655-fix-digital-ocean-droplet-create.yaml
+++ b/changelogs/fragments/61655-fix-digital-ocean-droplet-create.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - Fix creation of DigitalOcean droplets using digital_ocean_droplet module (https://github.com/ansible/ansible/pull/61655)

--- a/changelogs/fragments/61740-docker_container-port-range-parsing.yml
+++ b/changelogs/fragments/61740-docker_container-port-range-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - improve error behavior when parsing port ranges fails."

--- a/changelogs/fragments/61921-gitlab_user.yml
+++ b/changelogs/fragments/61921-gitlab_user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- While deleting gitlab user, name, email and password is no longer required ini gitlab_user module (https://github.com/ansible/ansible/issues/61921).

--- a/changelogs/fragments/61961-pacman_remove_recurse_option.yaml
+++ b/changelogs/fragments/61961-pacman_remove_recurse_option.yaml
@@ -1,0 +1,2 @@
+removed_features:
+  - pacman - Removed deprecated ``recurse`` option, use ``extra_args=--recursive`` instead

--- a/changelogs/fragments/62329-nsupdate-lookup-internal-zones.yaml
+++ b/changelogs/fragments/62329-nsupdate-lookup-internal-zones.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Fix zone name lookup of internal/private zones (https://github.com/ansible/ansible/issues/62052)

--- a/changelogs/fragments/62348-yarn-no_version_install_fix.yml
+++ b/changelogs/fragments/62348-yarn-no_version_install_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - yarn - handle no version when installing module by name (https://github.com/ansible/ansible/issues/55097)

--- a/changelogs/fragments/62617-fix-redfish-enable-account-if-enabled-prop-missing.yaml
+++ b/changelogs/fragments/62617-fix-redfish-enable-account-if-enabled-prop-missing.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - fix EnableAccount if Enabled property is not present in Account resource (https://github.com/ansible/ansible/issues/59822)

--- a/changelogs/fragments/62621-docker_login-fix-60381.yaml
+++ b/changelogs/fragments/62621-docker_login-fix-60381.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - correct broken fix for https://github.com/ansible/ansible/pull/60381 which crashes for Python 3."

--- a/changelogs/fragments/62648-mysql_replication_add_master_use_gtid_param.yml
+++ b/changelogs/fragments/62648-mysql_replication_add_master_use_gtid_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``master_use_gtid`` parameter (https://github.com/ansible/ansible/pull/62648).

--- a/changelogs/fragments/62928-docker_container-ip-address-idempotency.yml
+++ b/changelogs/fragments/62928-docker_container-ip-address-idempotency.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "docker_container - fix idempotency for IP addresses for networks. The old implementation checked the effective
+   IP addresses assigned by the Docker daemon, and not the specified ones. This causes idempotency issues for
+   containers which are not running, since they have no effective IP addresses assigned."

--- a/changelogs/fragments/62971-docker_container-image-finding.yml
+++ b/changelogs/fragments/62971-docker_container-image-finding.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - make sure that when image is missing, check mode indicates a change (image will be pulled)."

--- a/changelogs/fragments/62999-postgresql_lang_add_owner_parameter.yml
+++ b/changelogs/fragments/62999-postgresql_lang_add_owner_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_lang - add ``owner`` parameter (https://github.com/ansible/ansible/pull/62999).

--- a/changelogs/fragments/63036-mysql_replication_add_return_value.yml
+++ b/changelogs/fragments/63036-mysql_replication_add_return_value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``queries`` return value (https://github.com/ansible/ansible/pull/63036).

--- a/changelogs/fragments/63130-mysql_replication_add_master_delay_parameter.yml
+++ b/changelogs/fragments/63130-mysql_replication_add_master_delay_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``master_delay`` parameter (https://github.com/ansible/ansible/issues/51326).

--- a/changelogs/fragments/63174-nsupdate-tsig-all-the-queries.yaml
+++ b/changelogs/fragments/63174-nsupdate-tsig-all-the-queries.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nsupdate - Use provided TSIG key to not only sign update queries but also lookup queries

--- a/changelogs/fragments/63189-mysql_info-global-status.yml
+++ b/changelogs/fragments/63189-mysql_info-global-status.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_info - add ``global_status`` filter parameter option and return (https://github.com/ansible/ansible/pull/63189).

--- a/changelogs/fragments/63229-mysql_replication_add_connection_name_parameter.yml
+++ b/changelogs/fragments/63229-mysql_replication_add_connection_name_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``connection_name`` parameter (https://github.com/ansible/ansible/issues/46243).

--- a/changelogs/fragments/63271-mysql_replication_add_channel_parameter.yml
+++ b/changelogs/fragments/63271-mysql_replication_add_channel_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``channel`` parameter (https://github.com/ansible/ansible/issues/29311).

--- a/changelogs/fragments/63321-mysql_replication_add_resetmaster_to_mode.yml
+++ b/changelogs/fragments/63321-mysql_replication_add_resetmaster_to_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add support of ``resetmaster`` choice to ``mode`` parameter (https://github.com/ansible/ansible/issues/42870).

--- a/changelogs/fragments/63345-docker_image-deprecation-warnings.yml
+++ b/changelogs/fragments/63345-docker_image-deprecation-warnings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_image - make sure that deprecated options also emit proper deprecation warnings next to warnings which indicate how to replace them."

--- a/changelogs/fragments/63371-mysql_info_add_exclude_fields_parameter.yml
+++ b/changelogs/fragments/63371-mysql_info_add_exclude_fields_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_info - add ``exclude_fields`` parameter (https://github.com/ansible/ansible/issues/63319).

--- a/changelogs/fragments/63408-nsupdate-dont-fix-none-txt-value.yaml
+++ b/changelogs/fragments/63408-nsupdate-dont-fix-none-txt-value.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Do not try fixing non-existing TXT values (https://github.com/ansible/ansible/issues/63364)

--- a/changelogs/fragments/63418-docker_node_info-errors.yml
+++ b/changelogs/fragments/63418-docker_node_info-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_node_info - improve error handling when service inspection fails, for example because node name being ambiguous
+   (https://github.com/ansible/ansible/issues/63353, PR https://github.com/ansible/ansible/pull/63418)."

--- a/changelogs/fragments/63419-docker_container-defaults.yml
+++ b/changelogs/fragments/63419-docker_container-defaults.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- "docker_container - add new ``container_default_behavior`` option (PR https://github.com/ansible/ansible/pull/63419)."
+deprecated_features:
+- "docker_container - the default of ``container_default_behavior`` will change from ``compatibility`` to ``no_defaults`` in Ansible 2.14. Set the option to an explicit value to avoid a deprecation warning."

--- a/changelogs/fragments/63420-docker_container-trust_image_content.yml
+++ b/changelogs/fragments/63420-docker_container-trust_image_content.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- "docker_container - the ``trust_image_content`` option is now deprecated and will be removed in Ansible 2.14. It has never been used by the module."

--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - docker_stack - Added ``stdout``, ``stderr``, and ``rc`` to return values.
+
+deprecated_features:
+  - docker_stack - Return values ``out`` and ``err`` have been deprecated and will be removed in Ansible 2.14. Use ``stdout`` and ``stderr`` instead.

--- a/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
+++ b/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - '**security issue** - Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs (CVE-2019-14864)'

--- a/changelogs/fragments/63546-mysql_replication_allow_to_pass_empty_values.yml
+++ b/changelogs/fragments/63546-mysql_replication_allow_to_pass_empty_values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_replication - allow to pass empty values to parameters (https://github.com/ansible/ansible/issues/23976).

--- a/changelogs/fragments/63547-mysql_variables_add_mode_param.yml
+++ b/changelogs/fragments/63547-mysql_variables_add_mode_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_variables - add ``mode`` parameter (https://github.com/ansible/ansible/issues/60119).

--- a/changelogs/fragments/63555-postgresql_privs_typy_obj_types.yaml
+++ b/changelogs/fragments/63555-postgresql_privs_typy_obj_types.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_privs - add support for TYPE as object types in postgresql_privs module (https://github.com/ansible/ansible/issues/62432).

--- a/changelogs/fragments/63565-postgresql_user_allow_user_name_with_dots.yml
+++ b/changelogs/fragments/63565-postgresql_user_allow_user_name_with_dots.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_user - allow to pass user name which contains dots (https://github.com/ansible/ansible/issues/63204).

--- a/changelogs/fragments/63621-gitlab_user-fix-sshkey-and-user.yml
+++ b/changelogs/fragments/63621-gitlab_user-fix-sshkey-and-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "gitlab_user - Fix adding ssh key to new/changed user and adding group membership for new/changed user"

--- a/changelogs/fragments/63629-postgresql_db_pgc_support.yaml
+++ b/changelogs/fragments/63629-postgresql_db_pgc_support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_db - add support for .pgc file format for dump and restores.

--- a/changelogs/fragments/63887-docker_swarm_service-sort-lists-when-checking-changes.yml
+++ b/changelogs/fragments/63887-docker_swarm_service-sort-lists-when-checking-changes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_swarm_service - Sort lists when checking for changes."

--- a/changelogs/fragments/63903-ufw.yaml
+++ b/changelogs/fragments/63903-ufw.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ufw - accept ``interface_in`` and ``interface_out`` as parameters.

--- a/changelogs/fragments/63969-zabbix_action_argsfix.yml
+++ b/changelogs/fragments/63969-zabbix_action_argsfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_action - arguments ``event_source`` and ``esc_period`` no longer required when ``state=absent``

--- a/changelogs/fragments/63990-replace-deprecated-basic-functions.yml
+++ b/changelogs/fragments/63990-replace-deprecated-basic-functions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - replace use of deprecated functions from ``ansible.module_utils.basic``.

--- a/changelogs/fragments/64007-postgresql_db_allow_user_name_with_dots.yml
+++ b/changelogs/fragments/64007-postgresql_db_allow_user_name_with_dots.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_db - allow to pass users names which contain dots (https://github.com/ansible/ansible/issues/63204).

--- a/changelogs/fragments/64032-zabbix_template_fix_return_XML_as_a_string_even_python3.yml
+++ b/changelogs/fragments/64032-zabbix_template_fix_return_XML_as_a_string_even_python3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix to return XML as a string even for python3 (https://github.com/ansible/ansible/pull/64032).

--- a/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
+++ b/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - make sure current_pass_hash is a string before using it in comparison (https://github.com/ansible/ansible/issues/60567).

--- a/changelogs/fragments/64288-fix-hashi-vault-kv-v2.yaml
+++ b/changelogs/fragments/64288-fix-hashi-vault-kv-v2.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "hashi_vault - Fix KV v2 lookup to always return latest version"

--- a/changelogs/fragments/64371-postgresql_privs-always-reports-as-changed-when-using-default_privs.yml
+++ b/changelogs/fragments/64371-postgresql_privs-always-reports-as-changed-when-using-default_privs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs.py - fix reports as changed behavior of module when using ``type=default_privs`` (https://github.com/ansible/ansible/issues/64371).

--- a/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
+++ b/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - Use ``with`` statement when accessing files, to prevent that invalid JSON output is produced."

--- a/changelogs/fragments/64582-postgresql_publication_fix_typo_in_module_warn.yml
+++ b/changelogs/fragments/64582-postgresql_publication_fix_typo_in_module_warn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_publication - fix typo in module.warn method name (https://github.com/ansible/ansible/issues/64582).

--- a/changelogs/fragments/64583-postgresql_subscription_fix_typo_in_module_warn.yml
+++ b/changelogs/fragments/64583-postgresql_subscription_fix_typo_in_module_warn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_subscription - fix typo in module.warn method name (https://github.com/ansible/ansible/pull/64583).

--- a/changelogs/fragments/64585-mysql_dont_mask_mysql_connect_errors_from_modules.yml
+++ b/changelogs/fragments/64585-mysql_dont_mask_mysql_connect_errors_from_modules.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql - dont mask ``mysql_connect`` function errors from modules (https://github.com/ansible/ansible/issues/64560).

--- a/changelogs/fragments/64635-docker_container-network_mode.yml
+++ b/changelogs/fragments/64635-docker_container-network_mode.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- "docker_container - the default value for ``network_mode`` will change in Ansible 2.14, provided at least one network is specified and ``networks_cli_compatible`` is ``true``. See porting guide, module documentation or deprecation warning for more details."

--- a/changelogs/fragments/64637-docker_swarm_service-tmpfs-source.yml
+++ b/changelogs/fragments/64637-docker_swarm_service-tmpfs-source.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - ``source`` must no longer be specified for ``tmpfs`` mounts."

--- a/changelogs/fragments/64661-postgres_py_add_query_params_arg.yml
+++ b/changelogs/fragments/64661-postgres_py_add_query_params_arg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- postgres.py - add a new keyword argument ``query_params`` (https://github.com/ansible/ansible/pull/64661).
+- postgresql_idx.py - use the ``query_params`` arg of exec_sql function (https://github.com/ansible/ansible/pull/64661).

--- a/changelogs/fragments/64683-docker_container-cpus.yml
+++ b/changelogs/fragments/64683-docker_container-cpus.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - add ``cpus`` option (https://github.com/ansible/ansible/issues/34320)."

--- a/changelogs/fragments/64797-fix-error-deleting-redfish-acct.yaml
+++ b/changelogs/fragments/64797-fix-error-deleting-redfish-acct.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - redfish_command - fix error when deleting a disabled Redfish account (https://github.com/ansible/ansible/issues/64684)

--- a/changelogs/fragments/64989-gitlab-handle-lib-new-version.yml
+++ b/changelogs/fragments/64989-gitlab-handle-lib-new-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix GitLab modules authentication by handling `python-gitlab` library version >= 1.13.0 (https://github.com/ansible/ansible/issues/64770)

--- a/changelogs/fragments/64994-postgresql_ext_use_query_params.yml
+++ b/changelogs/fragments/64994-postgresql_ext_use_query_params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_ext - use query parameters with cursor object (https://github.com/ansible/ansible/pull/64994).

--- a/changelogs/fragments/65018-docker-none-errors.yml
+++ b/changelogs/fragments/65018-docker-none-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_container - fix network idempotence comparison error."
+- "docker_network - fix idempotence comparison error."

--- a/changelogs/fragments/65044-fix-terraform-no-workspace.yaml
+++ b/changelogs/fragments/65044-fix-terraform-no-workspace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- terraform module - fixes usage for providers not supporting workspaces

--- a/changelogs/fragments/65093-postgresql_lang_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65093-postgresql_lang_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_lang - use query params with cursor.execute (https://github.com/ansible/ansible/pull/65093).

--- a/changelogs/fragments/65164-postgres_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65164-postgres_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgres - use query params with cursor.execute in module_utils.postgres.PgMembership class (https://github.com/ansible/ansible/pull/65164).

--- a/changelogs/fragments/65223-postgresql_db-exception-added.yml
+++ b/changelogs/fragments/65223-postgresql_db-exception-added.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_db - Removed exception for 'LibraryError' (https://github.com/ansible/ansible/issues/65223).

--- a/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
+++ b/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacman - Fix pacman output parsing on localized environment. (https://github.com/ansible/ansible/issues/65237)

--- a/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
+++ b/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - fixed inventory_mode key error, which occurs with Zabbix 4.4.1 or more (https://github.com/ansible/ansible/issues/65304).

--- a/changelogs/fragments/65310-postgresql_owner_use_query_params.yml
+++ b/changelogs/fragments/65310-postgresql_owner_use_query_params.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_owner - use query_params with cursor object (https://github.com/ansible/ansible/pull/65310).

--- a/changelogs/fragments/65372-misc-context-manager.yml
+++ b/changelogs/fragments/65372-misc-context-manager.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - spacewalk inventory - improve file handling by using a context manager.
+  - intersight_rest_api, intersight_info - improve file handling by using a context manager.
+  - one_vm - improve file handling by using a context manager.
+  - postgresql_query - improve file handling by using a context manager.

--- a/changelogs/fragments/65387-homebrew_check_mode_option.yml
+++ b/changelogs/fragments/65387-homebrew_check_mode_option.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - fix Homebrew module's some functions ignored check_mode option (https://github.com/ansible/ansible/pull/65387).

--- a/changelogs/fragments/65404-postgresql_publication_user_query_params_with_cursor.yml
+++ b/changelogs/fragments/65404-postgresql_publication_user_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_publication - use query params arg with cursor object (https://github.com/ansible/ansible/issues/65404).

--- a/changelogs/fragments/65498-mysql_db_add_executed_commands_return_val.yml
+++ b/changelogs/fragments/65498-mysql_db_add_executed_commands_return_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``executed_commands`` returned value (https://github.com/ansible/ansible/pull/65498).

--- a/changelogs/fragments/65542-postgresql_db_add_executed_commands_return_val.yml
+++ b/changelogs/fragments/65542-postgresql_db_add_executed_commands_return_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_db - add the ``executed_commands`` returned value (https://github.com/ansible/ansible/pull/65542).

--- a/changelogs/fragments/65547-mysql_db_add_force_param.yml
+++ b/changelogs/fragments/65547-mysql_db_add_force_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``force`` parameter (https://github.com/ansible/ansible/pull/65547).

--- a/changelogs/fragments/65609-docker-context-manager.yml
+++ b/changelogs/fragments/65609-docker-context-manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_image - improve file handling when loading images from disk.

--- a/changelogs/fragments/65632-docker-argspec-fixup.yml
+++ b/changelogs/fragments/65632-docker-argspec-fixup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_image - fix validation of build options."
+- "docker_login - fix error handling when ``username`` or ``password`` is not specified when ``state`` is ``present``."

--- a/changelogs/fragments/65679-postgresql_schema_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65679-postgresql_schema_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_schema - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65679).

--- a/changelogs/fragments/65750-pacman.yml
+++ b/changelogs/fragments/65750-pacman.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pacman - fix module crash with ``IndexError: list index out of range`` (https://github.com/ansible/ansible/issues/63077)"

--- a/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
+++ b/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_info - add ``return_empty_dbs`` parameter to list empty databases (https://github.com/ansible/ansible/issues/65727).

--- a/changelogs/fragments/65787-postgresql_sequence_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65787-postgresql_sequence_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_sequence - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65787).

--- a/changelogs/fragments/65789-mysql_user_add_plugin_authentication_parameters.yml
+++ b/changelogs/fragments/65789-mysql_user_add_plugin_authentication_parameters.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- mysql_user - add ``plugin`` parameter (https://github.com/ansible/ansible/pull/44267).
+- mysql_user - add ``plugin_hash_string`` parameter (https://github.com/ansible/ansible/pull/44267).
+- mysql_user - add ``plugin_auth_string`` parameter (https://github.com/ansible/ansible/pull/44267).

--- a/changelogs/fragments/65791-postgresql_modules_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65791-postgresql_modules_use_query_params_with_cursor.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- postgresql_set - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).
+- postgresql_slot - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).
+- postgresql_subscription - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).

--- a/changelogs/fragments/65839-docker_network-idempotence.yml
+++ b/changelogs/fragments/65839-docker_network-idempotence.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_network - fix idempotency for multiple IPAM configs of the same IP version (https://github.com/ansible/ansible/issues/65815)."
+- "docker_network - validate IPAM config subnet CIDR notation on module setup and not during idempotence checking."

--- a/changelogs/fragments/65854-docker_container-wait-for-removal.yml
+++ b/changelogs/fragments/65854-docker_container-wait-for-removal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - wait for removal of container if docker API returns early (https://github.com/ansible/ansible/issues/65811)."

--- a/changelogs/fragments/65862-postgresql_modules_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65862-postgresql_modules_use_query_params_with_cursor.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- postgresql_table - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65862).
+- postgresql_tablespace - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65862).
+- postgresql_user - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65862).

--- a/changelogs/fragments/65894-redfish-bios-attributes.yaml
+++ b/changelogs/fragments/65894-redfish-bios-attributes.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- redfish_config - New ``bios_attributes`` option to allow setting multiple BIOS attributes in one command.
+deprecated_features:
+- redfish_config - Deprecate ``bios_attribute_name`` and ``bios_attribute_value`` in favor of new `bios_attributes`` option.

--- a/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
+++ b/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix sorting lists with None elements for python3 (https://github.com/ansible/ansible/issues/65761).

--- a/changelogs/fragments/65993-restart-docker_container-on-restart-policy-updates.yaml
+++ b/changelogs/fragments/65993-restart-docker_container-on-restart-policy-updates.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_container.py - update a containers restart_policy without restarting the container (https://github.com/ansible/ansible/issues/65993)

--- a/changelogs/fragments/66026-zabbix_host_info.yml
+++ b/changelogs/fragments/66026-zabbix_host_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_host_info - ``host_name`` based search results now include host groups.

--- a/changelogs/fragments/66048-mysql_add_master_data_parameter.yml
+++ b/changelogs/fragments/66048-mysql_add_master_data_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add ``master_data`` parameter (https://github.com/ansible/ansible/pull/66048).

--- a/changelogs/fragments/66060-redfish-new-resource-id-option.yaml
+++ b/changelogs/fragments/66060-redfish-new-resource-id-option.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- redfish_config, redfish_command - Add ``resource_id`` option to specify which System, Manager, or Chassis resource to modify.
+deprecated_features:
+- redfish_config, redfish_command - Behavior to modify the first System, Mananger, or Chassis resource when multiple are present is deprecated. Use the new ``resource_id`` option to specify target resource to modify.

--- a/changelogs/fragments/66144-docker_container-removal-timeout.yml
+++ b/changelogs/fragments/66144-docker_container-removal-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - allow to configure timeout when the module waits for a container's removal."

--- a/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
+++ b/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fix task always reporting as changed when using ``healthcheck.start_period``."

--- a/changelogs/fragments/66157-postgresql-create-unique-indexes.yml
+++ b/changelogs/fragments/66157-postgresql-create-unique-indexes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - database - add support to unique indexes in postgresql_idx

--- a/changelogs/fragments/66247-zabbix_proxy-address-field.yaml
+++ b/changelogs/fragments/66247-zabbix_proxy-address-field.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_proxy - added option proxy_address for comma-delimited list of IP/CIDR addresses or DNS names to accept active proxy requests from

--- a/changelogs/fragments/66252-mysql_replication_fail_on_error.yml
+++ b/changelogs/fragments/66252-mysql_replication_fail_on_error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``fail_on_error`` parameter (https://github.com/ansible/ansible/pull/66252).

--- a/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
+++ b/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cyberarkpassword - fix invalid attribute access (https://github.com/ansible/ansible/issues/66268)

--- a/changelogs/fragments/66322-moved_line_causing_terraform_output_suppression.yml
+++ b/changelogs/fragments/66322-moved_line_causing_terraform_output_suppression.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - terraform - reset out and err before plan creation (https://github.com/ansible/ansible/issues/64369)

--- a/changelogs/fragments/66331-postgresql_query_fix_unable_to_handle_non_ascii_chars_when_python3.yml
+++ b/changelogs/fragments/66331-postgresql_query_fix_unable_to_handle_non_ascii_chars_when_python3.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- postgresql_query - the module doesn't support non-ASCII characters in SQL files with Python3 (https://github.com/ansible/ansible/issues/65367).
+minor_changes:
+- postgresql_query - add the ``encoding`` parameter (https://github.com/ansible/ansible/issues/65367).

--- a/changelogs/fragments/66357-support-changing-fetch_url-settings-for-rundeck-modules.yaml
+++ b/changelogs/fragments/66357-support-changing-fetch_url-settings-for-rundeck-modules.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- rundeck modules - added new options ``client_cert``, ``client_key``, ``force``, ``force_basic_auth``, ``http_agent``, ``url_password``, ``url_username``, ``use_proxy``, ``validate_certs`` to allow changing fetch_url parameters.

--- a/changelogs/fragments/66382-docker_container-port-range.yml
+++ b/changelogs/fragments/66382-docker_container-port-range.yml
@@ -1,0 +1,3 @@
+minor_changes:
+ - "docker_container - support for port ranges was adjusted to be more compatible to the ``docker`` command line utility:
+    a one-port container range combined with a multiple-port host range will no longer result in only the first host port be used, but the whole range being passed to Docker so that a free port in that range will be used."

--- a/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
+++ b/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pamd - Bugfix for attribute error when removing the first or last line"

--- a/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
+++ b/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
@@ -1,0 +1,6 @@
+---
+
+bugfixes:
+  - zabbix_template - fixed error when providing empty ``link_templates`` to the module (see https://github.com/ansible/ansible/issues/66417)
+  - zabbix_template - fixed invalid (non-importable) output provided by exporting XML (see https://github.com/ansible/ansible/issues/66466)
+  

--- a/changelogs/fragments/66599-docker-healthcheck.yml
+++ b/changelogs/fragments/66599-docker-healthcheck.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_container - passing ``test: [NONE]`` now actually disables the image's healthcheck, as documented."
+- "docker_swarm_service - passing ``test: [NONE]`` now actually disables the image's healthcheck, as documented."

--- a/changelogs/fragments/66600-docker_container-volumes.yml
+++ b/changelogs/fragments/66600-docker_container-volumes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_container - only passes anonymous volumes to docker daemon as ``Volumes``. This increases compatibility with the ``docker`` CLI program. Note that if you specify ``volumes: strict`` in ``comparisons``, this could cause existing containers created with docker_container from Ansible 2.9 or earlier to restart."

--- a/changelogs/fragments/66688-mysql_db_add_skip_lock_tables_option.yml
+++ b/changelogs/fragments/66688-mysql_db_add_skip_lock_tables_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add ``skip_lock_tables`` option (https://github.com/ansible/ansible/pull/66688).

--- a/changelogs/fragments/66711-postgresql_user_add_comment_parameter.yml
+++ b/changelogs/fragments/66711-postgresql_user_add_comment_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_user - add the comment parameter (https://github.com/ansible/ansible/pull/66711).

--- a/changelogs/fragments/66717-postgresql_db_add_dump_extra_args_param.yml
+++ b/changelogs/fragments/66717-postgresql_db_add_dump_extra_args_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_db - add ``dump_extra_args`` parameter (https://github.com/ansible/ansible/pull/66717).

--- a/changelogs/fragments/66747-zabbix_template-newupdaterule-deletemissinglinkedtemplate.yml
+++ b/changelogs/fragments/66747-zabbix_template-newupdaterule-deletemissinglinkedtemplate.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_template - adding new update rule templateLinkage.deleteMissing for newer zabbix versions (https://github.com/ansible/ansible/pull/66747).
+  

--- a/changelogs/fragments/66777-zabbix_host_tags_macros_support.yml
+++ b/changelogs/fragments/66777-zabbix_host_tags_macros_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- zabbix_host - now supports configuring user macros and host tags on the managed host (see https://github.com/ansible/ansible/pull/66777)

--- a/changelogs/fragments/66792-vultr-improve-plan.yml
+++ b/changelogs/fragments/66792-vultr-improve-plan.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vultr_server_info, vultr_server - Improved handling of discontinued plans (https://github.com/ansible/ansible/issues/66707).

--- a/changelogs/fragments/66801-mysql_user_priv_can_be_dict.yml
+++ b/changelogs/fragments/66801-mysql_user_priv_can_be_dict.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_user - ``priv`` parameter can be string or dictionary (https://github.com/ansible/ansible/issues/57533).

--- a/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
+++ b/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_variable - fix the module doesn't support variables name with dot (https://github.com/ansible/ansible/issues/54239).

--- a/changelogs/fragments/66807-redhat_subscription-no-default-quantity.yaml
+++ b/changelogs/fragments/66807-redhat_subscription-no-default-quantity.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - do not set the default quantity to ``1`` when no quantity is provided (https://github.com/ansible/ansible/issues/66478)

--- a/changelogs/fragments/66837-zabbix-proxy-interface.yml
+++ b/changelogs/fragments/66837-zabbix-proxy-interface.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_proxy - ``interface`` sub-options ``type`` and ``main`` are now deprecated and will be removed in Ansible 2.14. Also, the values passed to ``interface`` are now checked for correct types and unexpected keys.

--- a/changelogs/fragments/66841-zabbix_action-allowstrfor-esc_period.yml
+++ b/changelogs/fragments/66841-zabbix_action-allowstrfor-esc_period.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_action - allow str values for ``esc_period`` options (https://github.com/ansible/ansible/pull/66841).

--- a/changelogs/fragments/66914-purefa_user_string.yaml
+++ b/changelogs/fragments/66914-purefa_user_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - pure - fix incorrect user_string setting in module_utils file (https://github.com/ansible/ansible/pull/66914)

--- a/changelogs/fragments/66929-pmrun-quote-entire-success-command-string.yml
+++ b/changelogs/fragments/66929-pmrun-quote-entire-success-command-string.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pmrun plugin - The success_command string was no longer quoted. This caused unusual use-cases like ``become_flags=su - root -c`` to fail.

--- a/changelogs/fragments/66957-scaleway-jsonify-only-for-json-requests.yml
+++ b/changelogs/fragments/66957-scaleway-jsonify-only-for-json-requests.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'scaleway: use jsonify unmarshaller only for application/json requests to avoid breaking the multiline configuration with requests in text/plain (https://github.com/ansible/ansible/issues/65036)'

--- a/changelogs/fragments/66974-mysql_user_doesnt_support_privs_with_underscore.yml
+++ b/changelogs/fragments/66974-mysql_user_doesnt_support_privs_with_underscore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix support privileges with underscore (https://github.com/ansible/ansible/issues/66974).

--- a/changelogs/fragments/67046-postgresql_modules_make_params_required.yml
+++ b/changelogs/fragments/67046-postgresql_modules_make_params_required.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- postgresql_membership - make the ``groups`` and ``target_roles`` parameters required (https://github.com/ansible/ansible/pull/67046).
+- postgresql_slot - make the ``name`` parameter required (https://github.com/ansible/ansible/pull/67046).
+- postgresql_tablespace - make the ``tablespace`` parameter required (https://github.com/ansible/ansible/pull/67046).

--- a/changelogs/fragments/67302-zabbix_template_info-add-omit_date-field.yml
+++ b/changelogs/fragments/67302-zabbix_template_info-add-omit_date-field.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_template - add new option omit_date to remove date from exported/dumped template (https://github.com/ansible/ansible/pull/67302)
+  - zabbix_template_info - add new option omit_date to remove date from exported/dumped template (https://github.com/ansible/ansible/pull/67302)

--- a/changelogs/fragments/67337-fix-proxysql-mysql-cursor.yaml
+++ b/changelogs/fragments/67337-fix-proxysql-mysql-cursor.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxysql - fixed mysql dictcursor

--- a/changelogs/fragments/67353-docker_login-permissions.yml
+++ b/changelogs/fragments/67353-docker_login-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - make sure that ``~/.docker/config.json`` is created with permissions ``0600``."

--- a/changelogs/fragments/67418-postgresql_set_converts_value_to_uppercase.yml
+++ b/changelogs/fragments/67418-postgresql_set_converts_value_to_uppercase.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - fix converting value to uppercase (https://github.com/ansible/ansible/issues/67377).

--- a/changelogs/fragments/67437-vultr-fix-retry-max-delay-param.yml
+++ b/changelogs/fragments/67437-vultr-fix-retry-max-delay-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vultr - Fixed the issue retry max delay param was ignored.

--- a/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
+++ b/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_project_variable - implement masked and protected attributes

--- a/changelogs/fragments/67464-postgresql_info_add_collecting_subscription_info.yml
+++ b/changelogs/fragments/67464-postgresql_info_add_collecting_subscription_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add collection info about replication subscriptions (https://github.com/ansible/ansible/pull/67464).

--- a/changelogs/fragments/67614-postgresql_info_add_collecting_publication_info.yml
+++ b/changelogs/fragments/67614-postgresql_info_add_collecting_publication_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add collecting info about logical replication publications in databases (https://github.com/ansible/ansible/pull/67614).

--- a/changelogs/fragments/67655-scaleway_compute-get-image-instead-loop-on-list.yml
+++ b/changelogs/fragments/67655-scaleway_compute-get-image-instead-loop-on-list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'scaleway_compute(check_image_id): use get image instead loop on first page of images results'

--- a/changelogs/fragments/67693-zabbix_mediatype.yml
+++ b/changelogs/fragments/67693-zabbix_mediatype.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_mediatype - Fixed to support zabbix 4.4 or more and python3 (https://github.com/ansible/ansible/pull/67693)

--- a/changelogs/fragments/67747-mysql_db_add_dump_extra_args_param.yml
+++ b/changelogs/fragments/67747-mysql_db_add_dump_extra_args_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``dump_extra_args`` parameter (https://github.com/ansible/ansible/pull/67747).

--- a/changelogs/fragments/67767-mysql_db_fix_bug_introduced_by_56721.yml
+++ b/changelogs/fragments/67767-mysql_db_fix_bug_introduced_by_56721.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_db - fix bug in the ``db_import`` function introduced by https://github.com/ansible/ansible/pull/56721 (https://github.com/ansible/ansible/issues/65351).

--- a/changelogs/fragments/67832-run_powershell_modules_on_windows_containers.yml
+++ b/changelogs/fragments/67832-run_powershell_modules_on_windows_containers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker connection plugin - run Powershell modules on Windows containers.

--- a/changelogs/fragments/atomic_image_absent.yml
+++ b/changelogs/fragments/atomic_image_absent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Run command in absent state in atomic_image module.

--- a/changelogs/fragments/become-pass-precedence.yaml
+++ b/changelogs/fragments/become-pass-precedence.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- become - Fix various plugins that still used play_context to get the become password instead of through the plugin - https://github.com/ansible/ansible/issues/62367
+- runas - Fix the ``runas`` ``become_pass`` variable fallback from ``ansible_runas_runas`` to ``ansible_runas_pass``

--- a/changelogs/fragments/clc_aa_policy-remove-unused-wait-parameter.yaml
+++ b/changelogs/fragments/clc_aa_policy-remove-unused-wait-parameter.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "clc_aa_policy - The ``wait`` option had no effect and will be removed in Ansible 2.14"

--- a/changelogs/fragments/cron-only-get-bin-path-once.yaml
+++ b/changelogs/fragments/cron-only-get-bin-path-once.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cronvar - only run ``get_bin_path()`` once

--- a/changelogs/fragments/cronvar-correct-binary-name.yaml
+++ b/changelogs/fragments/cronvar-correct-binary-name.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cronvar - use correct binary name (https://github.com/ansible/ansible/issues/63274)

--- a/changelogs/fragments/firewalld-version-0_7_0.yml
+++ b/changelogs/fragments/firewalld-version-0_7_0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - firewalld - enable the firewalld module to function offline with firewalld version 0.7.0 and newer (https://github.com/ansible/ansible/issues/63254)

--- a/changelogs/fragments/fix_zabbix_host_visible_name.yml
+++ b/changelogs/fragments/fix_zabbix_host_visible_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - zabbix_host - was not possible to update a host where visible_name was not set in zabbix

--- a/changelogs/fragments/gitlab_project_variable.yml
+++ b/changelogs/fragments/gitlab_project_variable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Redact GitLab Project variables which might include sensetive information such as password, api_keys and other project related details.

--- a/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
+++ b/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq lookup plugin - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.

--- a/changelogs/fragments/lxd_container_url.yaml
+++ b/changelogs/fragments/lxd_container_url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes the url handling in lxd_container module that url cannot be specified in lxd environment created by snap.

--- a/changelogs/fragments/lxd_profile_url.yaml
+++ b/changelogs/fragments/lxd_profile_url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes the url handling in lxd_profile module that url cannot be specified in lxd environment created by snap.

--- a/changelogs/fragments/mqtt-ssl-protocols.yml
+++ b/changelogs/fragments/mqtt-ssl-protocols.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix SSL protocol references in the ``mqtt`` module to prevent failures on Python 2.6.

--- a/changelogs/fragments/ovirt-dont-ignore-instance_cpus-parameter.yaml
+++ b/changelogs/fragments/ovirt-dont-ignore-instance_cpus-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ovirt - don't ignore ``instance_cpus`` parameter

--- a/changelogs/fragments/postgresol_privs-fix-status-sorting.yaml
+++ b/changelogs/fragments/postgresol_privs-fix-status-sorting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - sort results before comparing so that the values are compared and not the result of ``.sort()`` (https://github.com/ansible/ansible/pull/65125)

--- a/changelogs/fragments/proxmox-6-version-detection.yaml
+++ b/changelogs/fragments/proxmox-6-version-detection.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "proxmox - fix version detection of proxmox 6 and up (Fixes https://github.com/ansible/ansible/issues/59164)"

--- a/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
+++ b/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_publish - Support for connecting with SSL certificates.

--- a/changelogs/fragments/remove-2.9-deprecations.yml
+++ b/changelogs/fragments/remove-2.9-deprecations.yml
@@ -1,0 +1,2 @@
+removed_features:
+- "core - remove support for ``check_invalid_arguments`` in ``UTMModule``."

--- a/changelogs/fragments/solaris_zone_name_fix.yml
+++ b/changelogs/fragments/solaris_zone_name_fix.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- "**SECURITY** - CVE-2019-14904 - solaris_zone module accepts zone name and performs actions related to that.
+   However, there is no user input validation done while performing actions. A malicious user could provide a
+   crafted zone name which allows executing commands into the server manipulating the module behaviour. Adding
+   user input validation as per Solaris Zone documentation fixes this issue."

--- a/changelogs/fragments/syslogger-disable-check-mode.yaml
+++ b/changelogs/fragments/syslogger-disable-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - syslogger callback plugin - remove check mode support since it did nothing anyway

--- a/changelogs/fragments/xml-deprecated-functions.yml
+++ b/changelogs/fragments/xml-deprecated-functions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix the ``xml`` module to use ``list(elem)`` instead of ``elem.getchildren()`` since it is being removed in Python 3.9

--- a/changelogs/fragments/zabbix-hostmacro.yml
+++ b/changelogs/fragments/zabbix-hostmacro.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_hostmacro - ``macro_value`` is no longer required when ``state=absent``
+  - zabbix_hostmacro - ``macro_name`` now accepts macros in zabbix native format as well (e.g. ``{$MACRO}``)

--- a/changelogs/fragments/zabbix_user-mediatype-error.yml
+++ b/changelogs/fragments/zabbix_user-mediatype-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_user - Fixed an issue where module failed with zabbix 4.4 or above (see https://github.com/ansible/ansible/pull/67475)


### PR DESCRIPTION
##### SUMMARY
Add changelog fragments from ansible/ansible which belong to community.general. Based on the data in ansible/ansible#68498 and related PRs (see my links at the bottom + list of additional fragments) with some automatic and then manual postprocessing. Some fragments were edited to remove parts which did not ended up in this collection. I did leave some overly generic changelog fragments away (like "improved various module docs").

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
