### PR TITLE
postgresql_membership: add trust_input parameter

### DIFF
--- a/changelogs/fragments/158-postgresql_membership_add_trust_input_parameter.yml
+++ b/changelogs/fragments/158-postgresql_membership_add_trust_input_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_membership - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/158).

--- a/plugins/modules/database/postgresql/postgresql_membership.py
+++ b/plugins/modules/database/postgresql/postgresql_membership.py
@@ -181,10 +181,11 @@ def main():
     target_roles = module.params['target_roles']
     fail_on_role = module.params['fail_on_role']
     state = module.params['state']
+    session_role = module.params['session_role']
     trust_input = module.params['trust_input']
     if not trust_input:
         # Check input for potentially dangerous elements:
-        check_input(module, groups, target_roles)
+        check_input(module, groups, target_roles, session_role)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, autocommit=False)

--- a/tests/integration/targets/postgresql_membership/defaults/main.yml
+++ b/tests/integration/targets/postgresql_membership/defaults/main.yml
@@ -3,3 +3,4 @@ test_group2: group2
 test_group3: group.with.dots
 test_user1: user1
 test_user2: user.with.dots
+dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'

--- a/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
@@ -345,3 +345,46 @@
     that:
     - result is changed
     - result.queries == ["GRANT \"{{ test_group3 }}\" TO \"{{ test_user1 }}\""]
+
+#############################
+# Check trust_input parameter
+
+- name: postgresql_membership - try to use dangerous input, don't trust
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_membership:
+    login_user: "{{ pg_user }}"
+    db: postgres
+    group:
+    - "{{ test_group3}}"
+    - "{{ dangerous_name }}"
+    user: "{{ test_user1 }}"
+    state: present
+    trust_input: no
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is failed
+    - result.msg == 'Passed input \'{{ dangerous_name }}\' is potentially dangerous'
+
+- name: postgresql_membership - try to use dangerous input, trust explicitly
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_membership:
+    login_user: "{{ pg_user }}"
+    db: postgres
+    group:
+    - "{{ test_group3}}"
+    - "{{ dangerous_name }}"
+    user: "{{ test_user1 }}"
+    state: present
+    trust_input: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is failed
+    - result.msg == 'Role {{ dangerous_name }} does not exist'


### PR DESCRIPTION
##### SUMMARY
postgresql_membership: add trust_input parameter
continuing to introduce https://github.com/ansible-collections/community.general/pull/116

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_membership.py```
