### PR TITLE
New module: git_commit

### DIFF
--- a/plugins/modules/git_commit.py
+++ b/plugins/modules/git_commit.py
@@ -1,0 +1,1 @@
+./source_control/git/git_commit.py

--- a/plugins/modules/source_control/git/git_commit.py
+++ b/plugins/modules/source_control/git/git_commit.py
@@ -1,0 +1,243 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Federico Olivieri (lvrfrc87@gmail.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: git_commit
+author:
+    - "Federico Olivieri (@Federico87)"
+version_added: "2.10"
+short_description: Perform git add and git commit operations.
+description:
+    - Manage C(git add) and C(git commit) on a local git.
+options:
+    path:
+        description:
+            - Folder path where C(.git/) is located.
+        required: true
+        type: path
+    comment:
+        description:
+            - Git commit comment. Same as C(git commit -m).
+        type: str
+        required: true
+    add:
+        description:
+            - List of files under C(path) to be staged. Same as C(git add .).
+              File globs not accepted, such as C(./*) or C(*).
+        type: list
+        elements: str
+    empty_commit:
+        description:
+            - Drive module behaviour in case nothing to commit.
+              If C(allow) empty commit is allowed, same as C(--allow-empty).
+              Do not commit if C(skip). Fail job if C(fail).
+        choices: ['allow', 'fail', 'skip']
+        type: str
+        default: 'fail'
+requirements:
+    - git>=2.10.0 (the command line tool)
+'''
+
+EXAMPLES = '''
+- name: Add and commit two files.
+  community.general.git_commit:
+    path: /Users/federicoolivieri/git/git_test_module
+    comment: My amazing backup
+    add: ['test.txt', 'txt.test']
+    empty_commit: fail
+
+- name: Empty commit.
+  community.general.git_commit:
+    path: /Users/federicoolivieri/git/git_test_module
+    comment: My amazing empty commit
+    empty_commit: allow
+    add: ['.']
+
+- name: Skip if nothing to commit.
+  community.general.git_commit:
+    path: /Users/federicoolivieri/git/git_test_module
+    comment: Skip my amazing empty commit
+    empty_commit: skyp
+    add: ['.']
+'''
+
+RETURN = '''
+output:
+    description: list of git cli command stdout
+    type: list
+    returned: always
+    sample: [
+        "[master 99830f4] Remove [ test.txt, tax.txt ]\n 4 files changed, 26 insertions(+)..."
+    ]
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
+
+display = Display()
+
+
+def git_add(module):
+
+    add = module.params.get('add')
+    path = module.params.get('path')
+
+    if not add:
+        add = ["."]
+    # "git add do_not_exist" -> rc: 128
+    # "git add i_exist"      -> rc: 0
+    # "git add ."            -> rc: 0
+    add_cmds = [
+        'git',
+        'add',
+    ]
+    for item in add:
+        add_cmds.insert(len(add_cmds), item)
+
+    rc, _output, error = module.run_command(add_cmds, cwd=path)
+
+    if rc == 128:
+        module.fail_json(msg=error)
+
+    if rc == 0:
+        # no output returned when rc = 0
+        return
+
+
+def git_commit(module):
+
+    def git_commit_run(cmd, path):
+
+        rc, output, error = module.run_command(cmd, cwd=path)
+
+        if rc == 1:
+            module.fail_json(msg=error)
+        if rc == 0:
+            return output
+
+    result = dict(changed=False)
+    empty_commit = module.params.get('empty_commit')
+    comment = module.params.get('comment')
+    path = module.params.get('path')
+    cmd_porcelain = ['git', 'commit', '--porcelain']
+
+    # rc is always 1 for "git commit --porcelain"
+    _rc, output, error = module.run_command(cmd_porcelain, cwd=path)
+
+    if error:
+        module.fail_json(msg=error)
+
+    # do not allow empty commit with empty_commit=fail
+    if empty_commit == 'fail' and not output:
+        module.fail_json(msg='No empty commit allowed with empty_commit=fail')
+
+    # add and commit if output and empty_commit=fail
+    if empty_commit == 'fail' and output:
+
+        git_add(module)
+
+        commit_cmds = [
+            'git',
+            'commit',
+            '-m',
+            '"{0}"'.format(comment),
+        ]
+
+        output = git_commit_run(commit_cmds, path)
+
+        if output:
+            result.update(
+                git_commit=output,
+                changed=True
+            )
+
+            return result
+
+    # if empty_commit=allow skip git_add()
+    if empty_commit == 'allow' and not output:
+        commit_cmds = [
+            'git',
+            'commit',
+            '--allow-empty',
+            '-m',
+            '"{0}"'.format(comment),
+        ]
+
+        output = git_commit_run(commit_cmds, path)
+
+        if output:
+            result.update(
+                git_commit=output,
+                changed=True
+            )
+
+            return result
+
+    # if empty_commit=allow and pending stages, issue a warning and carry-on
+    if empty_commit == 'allow' and output:
+        display.warning(msg='You are going to run an empty commit but you have pending changes: {0}'.format(output))
+
+        commit_cmds = [
+            'git',
+            'commit',
+            '--allow-empty',
+            '-m',
+            '"{0}"'.format(comment),
+        ]
+
+        output = git_commit_run(commit_cmds, path)
+
+        if output:
+            result.update(
+                git_commit=output,
+                changed=True
+            )
+
+            return result
+
+    # return if empty_commit=skip and nothing to commit
+    if empty_commit == 'skip' and not output:
+
+        result.update(changed=False)
+
+        return result
+
+    # if empty_commit=skip and pending stages, issue a warning and return
+    if empty_commit == 'skip' and output:
+        display.warning('You are going to skip commit but you have pending changes: {0}'.format(output))
+
+        result.update(changed=False)
+
+        return result
+
+
+def main():
+
+    argument_spec = dict(
+        path=dict(required=True, type="path"),
+        comment=dict(required=True),
+        add=dict(type='list', elements='str'),
+        empty_commit=dict(choices=["allow", "fail", "skip"], default='fail')
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    result = dict()
+    result.update(git_commit(module))
+    if result:
+        module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/source_control/git/git_commit.py
+++ b/plugins/modules/source_control/git/git_commit.py
@@ -99,6 +99,7 @@ def git_add(module):
         'git',
         'add',
         '--',
+        '--',
     ]
 
     add_cmds.extend(add)

--- a/plugins/modules/source_control/git/git_commit.py
+++ b/plugins/modules/source_control/git/git_commit.py
@@ -13,7 +13,6 @@ DOCUMENTATION = '''
 module: git_commit
 author:
     - "Federico Olivieri (@Federico87)"
-version_added: "2.10"
 short_description: Perform git add and git commit operations.
 description:
     - Manage C(git add) and C(git commit) on a local git.
@@ -65,7 +64,7 @@ EXAMPLES = '''
   community.general.git_commit:
     path: /Users/federicoolivieri/git/git_test_module
     comment: Skip my amazing empty commit
-    empty_commit: skyp
+    empty_commit: skip
     add: ['.']
 '''
 
@@ -99,13 +98,14 @@ def git_add(module):
     add_cmds = [
         'git',
         'add',
+        '--',
     ]
-    for item in add:
-        add_cmds.insert(len(add_cmds), item)
+
+    add_cmds.extend(add)
 
     rc, _output, error = module.run_command(add_cmds, cwd=path)
 
-    if rc == 128:
+    if rc != 0:
         module.fail_json(msg=error)
 
     if rc == 0:
@@ -119,7 +119,7 @@ def git_commit(module):
 
         rc, output, error = module.run_command(cmd, cwd=path)
 
-        if rc == 1:
+        if rc != 0:
             module.fail_json(msg=error)
         if rc == 0:
             return output
@@ -149,7 +149,7 @@ def git_commit(module):
             'git',
             'commit',
             '-m',
-            '"{0}"'.format(comment),
+            comment,
         ]
 
         output = git_commit_run(commit_cmds, path)

--- a/tests/integration/targets/git_commit/aliases
+++ b/tests/integration/targets/git_commit/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group4
+skip/aix

--- a/tests/integration/targets/git_commit/meta/main.yml
+++ b/tests/integration/targets/git_commit/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_pkg_mgr

--- a/tests/integration/targets/git_commit/tasks/local.yml
+++ b/tests/integration/targets/git_commit/tasks/local.yml
@@ -1,0 +1,104 @@
+- name: LOCAL | empty_commit == 'fail' and not output
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: I am an empty commit.
+    empty_commit: fail
+  ignore_errors: yes
+- debug: var=result
+- assert: { that: "result.changed == false" }
+
+- name: FILE | set first random file name.
+  set_fact:
+    file1: "{{ lookup('pipe','date +%s%N') }}.txt"
+
+- name: FILE | Create file1
+  file:
+    path: "{{ playbook_dir }}/test_directory/repo/{{ file1 }}"
+    state: touch
+
+- name: LOCAL | empty_commit == 'fail' and output
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Add {{ file1 }}"
+    add: [ "{{ file1 }}" ]
+    empty_commit: fail
+- debug: var=result
+- assert: { that: "result.changed == true" }
+
+- name: FILE | set first random file name.
+  set_fact:
+    file2: "{{ lookup('pipe','date +%s%N') }}.txt"
+
+- name: FILE | Create file2
+  file:
+    path: "{{ playbook_dir }}/test_directory/repo/{{ file2 }}"
+    state: touch
+
+- name: LOCAL | test add=["."]
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Add all the thinghs"
+    empty_commit: fail
+- debug: var=result
+- assert: { that: "result.changed == true" }
+
+- name: LOCAL | empty_commit == 'allow' and not output
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Nothing to add, allow-empty"
+    add: [ "." ]
+    empty_commit: allow
+- debug: var=result
+- assert: { that: "result.changed == true" }
+
+- name: FILE | set first random file name.
+  set_fact:
+    file3: "{{ lookup('pipe','date +%s%N') }}.txt"
+
+- name: FILE | Create file3
+  file:
+    path: "{{ playbook_dir }}/test_directory/repo/{{ file3 }}"
+    state: touch
+
+- name: LOCAL | empty_commit == 'allow' and output - warning
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Drop a warning"
+    add: [ "{{ file3 }}" ]
+    empty_commit: allow
+- debug: var=result
+- assert: { that: "result.changed == true" }
+
+- name: LOCAL | empty_commit == 'skip' and not output
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Drop a warning"
+    add: [ "." ]
+    empty_commit: skip
+- debug: var=result
+- assert: { that: "result.changed == false" }
+
+- name: FILE | set first random file name.
+  set_fact:
+    file4: "{{ lookup('pipe','date +%s%N') }}.txt"
+
+- name: FILE | Create file4
+  file:
+    path: "{{ playbook_dir }}/test_directory/repo/{{ file4 }}"
+    state: touch
+
+- name: LOCAL | empty_commit == 'skip' and output - warning
+  register: result
+  git_commit:
+    path: "{{ playbook_dir }}/test_directory/repo"
+    comment: "Drop a warning"
+    add: [ "{{ file4 }}" ]
+    empty_commit: skip
+- debug: var=result
+- assert: { that: "result.changed == false" }

--- a/tests/integration/targets/git_commit/tasks/main.yml
+++ b/tests/integration/targets/git_commit/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: setup.yml
+- include_tasks: local.yml

--- a/tests/integration/targets/git_commit/tasks/setup.yml
+++ b/tests/integration/targets/git_commit/tasks/setup.yml
@@ -1,0 +1,34 @@
+- name: SETUP | update git to the latest.
+  package:
+    name: git
+    state: latest
+  when: ansible_distribution != "MacOSX"
+
+- name: SETUP | check git version.
+  shell: git --version | grep 'git version' | sed 's/git version //'
+  register: git_version
+
+- name: SETUP | edit git version variable.
+  set_fact:
+    git_int: "{{  git_version | replace('.', '') }}"
+
+- name: SETUP | end play if git is not >=2.19.
+  meta: end_play
+  when: git_int.stdout | int < 2100
+
+- name: SETUP | create test directory.
+  file: 
+    path: "{{ playbook_dir }}/test_directory" 
+    state: directory
+
+- name: SETUP | set git local.
+  shell: "{{ item }}"
+  loop:
+    - "git -C {{ playbook_dir }}/test_directory init --bare repo.git"
+    - "git -C {{ playbook_dir }}/test_directory clone repo.git -l"
+
+- name: SETUP | set git global user.email if not already set.
+  shell: git -C {{ playbook_dir }}/test_directory/repo config --global user.email "noreply@example.com"
+  
+- name: SETUP | set git global user.name if not already set.
+  shell: git -C {{ playbook_dir }}/test_directory/repo config --global user.name  "Ansible Test Runner"


### PR DESCRIPTION
##### SUMMARY
As discussed in https://github.com/ansible-collections/community.general/pull/57.
PR for `git_commit` module.

```
- name: Add and commit two files.
  community.general.git_commit:
    path: /Users/federicoolivieri/git/git_test_module
    comment: My amazing backup
    add: ['test.txt', 'txt.test']
    empty_commit: fail

- name: Empty commit.
  community.general.git_commit:
    path: /Users/federicoolivieri/git/git_test_module
    comment: My amazing empty commit
    empty_commit: allow
    add: ['.']

- name: Skip if nothing to commit.
  community.general.git_commit:
    path: /Users/federicoolivieri/git/git_test_module
    comment: Skip my amazing empty commit
    empty_commit: skip
    add: ['.']
``` 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
`git_commit`
