### PR TITLE
apt_rpm: support installing a list of packages (Fixes #143)

### DIFF
--- a/changelogs/fragments/apt_rpm_typefix.yml
+++ b/changelogs/fragments/apt_rpm_typefix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - Fix package type from str to list to fix package->apt_rpm invoking with list of packages
+  - apt_rpm - Fix ``package`` type from ``str`` to ``list`` to fix invoking with list of packages

--- a/changelogs/fragments/apt_rpm_typefix.yml
+++ b/changelogs/fragments/apt_rpm_typefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix package type from str to list to fix package->apt_rpm invoking with list of packages

--- a/changelogs/fragments/apt_rpm_typefix.yml
+++ b/changelogs/fragments/apt_rpm_typefix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - apt_rpm - Fix ``package`` type from ``str`` to ``list`` to fix invoking with list of packages
+  - apt_rpm - fix ``package`` type from ``str`` to ``list`` to fix invoking with list of packages (https://github.com/ansible-collections/community.general/issues/143).

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -146,7 +146,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='installed', choices=['absent', 'installed', 'present', 'removed']),
             update_cache=dict(type='bool', default=False, aliases=['update-cache']),
-            package=dict(type='str', required=True, aliases=['name', 'pkg']),
+            package=dict(type='list', required=True, aliases=['name', 'pkg']),
         ),
     )
 

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -146,7 +146,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='installed', choices=['absent', 'installed', 'present', 'removed']),
             update_cache=dict(type='bool', default=False, aliases=['update-cache']),
-            package=dict(type='list', required=True, aliases=['name', 'pkg']),
+            package=dict(type='list', elements='str', required=True, aliases=['name', 'pkg']),
         ),
     )
 

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -158,7 +158,7 @@ def main():
     if p['update_cache']:
         update_package_db(module)
 
-    packages = p['package'].split(',')
+    packages = p['package']
 
     if p['state'] in ['installed', 'present']:
         install_packages(module, packages)

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -19,7 +19,7 @@ description:
 options:
   pkg:
     description:
-      - name of package to install, upgrade or remove.
+      - list of packages to install, upgrade or remove.
     required: true
   state:
     description:

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -17,10 +17,13 @@ short_description: apt_rpm package manager
 description:
   - Manages packages with I(apt-rpm). Both low-level (I(rpm)) and high-level (I(apt-get)) package manager binaries required.
 options:
-  pkg:
+  package:
     description:
       - list of packages to install, upgrade or remove.
     required: true
+    aliases: [ name, pkg ]
+    type: list
+    elements: str
   state:
     description:
       - Indicates the desired package state.
@@ -39,6 +42,13 @@ EXAMPLES = '''
 - name: Install package foo
   apt_rpm:
     pkg: foo
+    state: present
+
+- name: Install packages foo and bar
+  apt_rpm:
+    pkg:
+      - foo
+      - bar
     state: present
 
 - name: Remove package foo


### PR DESCRIPTION
##### SUMMARY
apt_rpm does not support install packages provided as list, only as comma delimited string. So package module does not work with apt_rpm

Fixes #143 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt_rpm
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```


edits by Gundalow: Update summary and title