### PR TITLE
Remove rabbitmq-related changelog fragments

### DIFF
--- a/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
+++ b/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - rabbitmq_publish - Fix to ensure the module works correctly for pika v1.0.0 and later. (https://github.com/ansible/ansible/pull/61960)

--- a/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
+++ b/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - rabbitmq lookup plugin - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.

--- a/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
+++ b/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - rabbitmq_publish - Support for connecting with SSL certificates.


### PR DESCRIPTION
##### SUMMARY
When adding changelog fragments from ansible/ansible in #156, I forgot to exclude the rabbitmq fragments - the rabbitmq content has been removed from community.general in #13.

This PR removes these changelog fragments.

CC @odyssey4me since you might be interested in them :)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog