### PR TITLE
postgresql_membership: remove unused import of exec_sql function

### DIFF
--- a/changelogs/fragments/178-postgresql_membership_remove_unused_import.yml
+++ b/changelogs/fragments/178-postgresql_membership_remove_unused_import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_membership - remove unused import of exec_sql function (https://github.com/ansible-collections/community.general/pull/178).

--- a/plugins/modules/database/postgresql/postgresql_membership.py
+++ b/plugins/modules/database/postgresql/postgresql_membership.py
@@ -143,7 +143,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.postgres import (
     connect_to_db,
-    exec_sql,
     get_conn_params,
     PgMembership,
     postgres_common_argument_spec,


### PR DESCRIPTION
##### SUMMARY
postgresql_membership: remove unused import of exec_sql function

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_membership.py```
