### PR TITLE
adding ipv6 support to nios_next_ip

### DIFF
--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -89,7 +89,7 @@ class LookupModule(LookupBase):
             raise AnsibleError('missing argument in the form of A.B.C.D/E')
 
         provider = kwargs.pop('provider', {})
-        wapi = WapiLookup(provider) 
+        wapi = WapiLookup(provider)
         if type(ipaddress.ip_network(network)) == ipaddress.IPv6Network:
             network_obj = wapi.get_object('ipv6network', {'network': network})
         else:

--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -79,6 +79,7 @@ from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleError
 import ipaddress
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
@@ -88,8 +89,7 @@ class LookupModule(LookupBase):
             raise AnsibleError('missing argument in the form of A.B.C.D/E')
 
         provider = kwargs.pop('provider', {})
-        wapi = WapiLookup(provider)
-        
+        wapi = WapiLookup(provider) 
         if type(ipaddress.ip_network(network)) == ipaddress.IPv6Network:
             network_obj = wapi.get_object('ipv6network', {'network': network})
         else:


### PR DESCRIPTION
##### SUMMARY
Current module only works with ipv4. I am adding patch to support ipv6 as well.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nios_next_ip

##### ADDITIONAL INFORMATION
Before my changes:
PLAY [localhost] ***************************************************************************************************************************************************************************************************

TASK [Find next available IP in Infoblox when host does not exist and IP is not defined] ***************************************************************************************************************************
No handlers could be found for logger "infoblox_client.connector"
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'nios_next_ip'. Error was a <class 'ansible.errors.AnsibleError'>, original message: unable to find network object 2620:52:2:1111::/64"}

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


After my changes:
TASK [Find next available IP in Infoblox when host does not exist and IP is not defined] ***************************************************************************************************************************
ok: [localhost]

TASK [debug] *******************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "2620:52:2:1111::1"
}


```
