### PR TITLE
gitlab_user: add support to block / unblock user

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -15,10 +15,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: gitlab_user
-short_description: Creates/updates/deletes GitLab Users
+short_description: Creates/updates/deletes/blocks/unblocks GitLab Users
 description:
   - When the user does not exist in GitLab, it will be created.
   - When the user does exists and state=absent, the user will be deleted.
+  - When the user does exists and state=blocked, the user will be blocked.
   - When changes are made to user, the user will be updated.
 notes:
   - From Ansible 2.10 and onwards, name, email and password are optional while deleting the user.
@@ -85,11 +86,11 @@ options:
     choices: ["guest", "reporter", "developer", "master", "maintainer", "owner"]
   state:
     description:
-      - create or delete group.
-      - Possible values are present and absent.
+      - create, delete or block a user.
+      - Possible values are present, absent, blocked, and unblocked.
     default: present
     type: str
-    choices: ["present", "absent"]
+    choices: ["present", "absent", "blocked", "unblocked"]
   confirm:
     description:
       - Require confirmation.
@@ -132,6 +133,24 @@ EXAMPLES = '''
     state: present
     group: super_group/mon_group
     access_level: owner
+  delegate_to: localhost
+
+- name: "Block GitLab User"
+  gitlab_user:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ access_token }}"
+    validate_certs: False
+    username: myusername
+    state: blocked
+  delegate_to: localhost
+
+- name: "Unblock GitLab User"
+  gitlab_user:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ access_token }}"
+    validate_certs: False
+    username: myusername
+    state: unblocked
   delegate_to: localhost
 '''
 
@@ -383,6 +402,13 @@ class GitLabUser(object):
             return True
         return False
 
+    '''
+    @param username Username of the user
+    '''
+    def isActive(self, username):
+        user = self.findUser(username)
+        return user.attributes['state'] == 'active'
+
     def deleteUser(self):
         if self._module.check_mode:
             return True
@@ -391,13 +417,29 @@ class GitLabUser(object):
 
         return user.delete()
 
+    def blockUser(self):
+        if self._module.check_mode:
+            return True
+
+        user = self.userObject
+
+        return user.block()
+
+    def unblockUser(self):
+        if self._module.check_mode:
+            return True
+
+        user = self.userObject
+
+        return user.unblock()
+
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
         name=dict(type='str'),
-        state=dict(type='str', default="present", choices=["absent", "present"]),
+        state=dict(type='str', default="present", choices=["absent", "present", "blocked", "unblocked"]),
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True),
         email=dict(type='str'),
@@ -448,6 +490,7 @@ def main():
 
     gitlab_user = GitLabUser(module, gitlab_instance)
     user_exists = gitlab_user.existsUser(user_username)
+    user_is_active = gitlab_user.isActive(user_username)
 
     if state == 'absent':
         if user_exists:
@@ -455,6 +498,20 @@ def main():
             module.exit_json(changed=True, msg="Successfully deleted user %s" % user_username)
         else:
             module.exit_json(changed=False, msg="User deleted or does not exists")
+
+    if state == 'blocked':
+        if user_exists and user_is_active:
+            gitlab_user.blockUser()
+            module.exit_json(changed=True, msg="Successfully blocked user %s" % user_username)
+        else:
+            module.exit_json(changed=False, msg="User already blocked or does not exists")
+
+    if state == 'unblocked':
+        if user_exists and not user_is_active:
+            gitlab_user.unblockUser()
+            module.exit_json(changed=True, msg="Successfully unblocked user %s" % user_username)
+        else:
+            module.exit_json(changed=False, msg="User is not blocked or does not exists")
 
     if state == 'present':
         if gitlab_user.createOrUpdateUser(user_username, {


### PR DESCRIPTION
##### SUMMARY

Adds support to gitlab_user to block/unblock the account of a given user (#187)

Fixes #187
Fixes https://github.com/ansible/ansible/issues/61754
Fixes https://github.com/ansible/ansible/pull/61864
Fixes https://github.com/ansible/ansible/pull/66273

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

gitlab_user

##### ADDITIONAL INFORMATION

It is currently not possible to specify state=blocked or state=unblocked to block/unblock the user's account in GitLab.
Previously, the only possible options were to create or delete the account.
