### PR TITLE
redfish_config: fix support for boolean BIOS attributes

### DIFF
--- a/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_config - fix support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -57,7 +57,7 @@ options:
     description:
       - value of BIOS attr to update (deprecated - use bios_attributes instead)
     default: 'null'
-    type: str
+    type: raw
   bios_attributes:
     required: false
     description:
@@ -230,7 +230,7 @@ def main():
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
-            bios_attribute_value=dict(default='null'),
+            bios_attribute_value=dict(default='null', type='raw'),
             bios_attributes=dict(type='dict', default={}),
             timeout=dict(type='int', default=10),
             boot_order=dict(type='list', elements='str', default=[]),


### PR DESCRIPTION
Currently the redfish_config module will convert boolean bios_attribute_value
settings to strings (type str). This will cause BMCs expecting booleans to
error out.

This PR will change the default type of bios_attribute_value to 'raw' in order
to support strings and booleans.

Fixes ansible/ansible#68251

##### SUMMARY
Note that this is a copy/pasta of ansible/ansible#68382. 

This fixes the behavior in Ansible 2.10 (also present in Ansible 2.9 and Ansible 2.8) that converts boolean based BIOS values to strings.

Note that I opened another PR against `stable-2.9` initially: ansible/ansible#68254

I can close this out and open a separate backport request to fix this bug in `stable-2.9` and `stable-2.8`. The backport request will require a slight tweak to redfish_utils.py to fix this bug because ansible/ansible#62764 was only added in devel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_config

##### ADDITIONAL INFORMATION

