### PR TITLE
Fix CI and jenkins_plugin module

### DIFF
--- a/changelogs/fragments/202-jenkins_plugin-fix-import.yml
+++ b/changelogs/fragments/202-jenkins_plugin-fix-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- jenkins_plugin - make compatible to Ansible 2.10 by fixing import.

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -266,7 +266,8 @@ from ansible.module_utils.basic import AnsibleModule, to_bytes
 from ansible.module_utils.six.moves import http_cookiejar as cookiejar
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, url_argument_spec
-from ansible.module_utils._text import to_native, text_type, binary_type
+from ansible.module_utils.six import text_type, binary_type
+from ansible.module_utils._text import to_native
 import base64
 import hashlib
 import json


### PR DESCRIPTION
##### SUMMARY
The `jenkins_plugin` module imported `text_type` and `binary_type` from `ansible.module_utils._text`, which in turn imported them from `ansible.module_utils.six`. ansible/ansible#68965 removed them from `_text`, hence the module broke and CI also failed for unrelated modules/plugins.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/jenkins_plugin.py
