### PR TITLE
jira: Fix incompatible pathname2url import (#204)

### DIFF
--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -286,7 +286,9 @@ EXAMPLES = """
 import base64
 import json
 import sys
-import urllib
+
+from ansible.module_utils.six.moves.urllib.request import pathname2url
+
 from ansible.module_utils._text import to_text, to_bytes
 
 from ansible.module_utils.basic import AnsibleModule
@@ -401,10 +403,10 @@ def fetch(restbase, user, passwd, params):
 
 
 def search(restbase, user, passwd, params):
-    url = restbase + '/search?jql=' + urllib.request.pathname2url(params['jql'])
+    url = restbase + '/search?jql=' + pathname2url(params['jql'])
     if params['fields']:
         fields = params['fields'].keys()
-        url = url + '&fields=' + '&fields='.join([urllib.request.pathname2url(f) for f in fields])
+        url = url + '&fields=' + '&fields='.join([pathname2url(f) for f in fields])
     if params['maxresults']:
         url = url + '&maxResults=' + str(params['maxresults'])
     ret = get(url, user, passwd, params['timeout'])


### PR DESCRIPTION
##### SUMMARY
Fixes #204.

The call to pathname2url was broken in Python 2. Fix it by importing from module_utils.six instead of importing urllib and calling it from there.

The code being fixed is pretty new, see https://github.com/ansible-collections/community.general/pull/22 where it was added. So I don't think this bug is in a released version yet. For that reason maybe there's no need for a changelog, but let me know if you think otherwise.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jira

##### ADDITIONAL INFORMATION
See more details in #204. I've tested this locally with Python 3 and Python 2 and it works well for me.
