### PR TITLE
ip_netns: fix module name in example

### DIFF
--- a/plugins/modules/net_tools/ip_netns.py
+++ b/plugins/modules/net_tools/ip_netns.py
@@ -48,6 +48,7 @@ EXAMPLES = '''
   ip_netns:
     name: mario
     state: present
+
 - name: Delete a namespace named luigi
   ip_netns:
     name: luigi

--- a/plugins/modules/net_tools/ip_netns.py
+++ b/plugins/modules/net_tools/ip_netns.py
@@ -44,7 +44,6 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a namespace named mario
 - name: Create a namespace named mario
   ip_netns:
     name: mario

--- a/plugins/modules/net_tools/ip_netns.py
+++ b/plugins/modules/net_tools/ip_netns.py
@@ -46,11 +46,11 @@ options:
 EXAMPLES = '''
 # Create a namespace named mario
 - name: Create a namespace named mario
-  namespace:
+  ip_netns:
     name: mario
     state: present
 - name: Delete a namespace named luigi
-  namespace:
+  ip_netns:
     name: luigi
     state: absent
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Was referenced as 'namespace' while it should have been 'ip_netns'.

Closes: #203
Signed-off-by: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ip_netns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
