### PR TITLE
lxc_container: fix the type of the 'container_config' parameter

### DIFF
--- a/changelogs/fragments/216-fix-lxc-container-container_config-parameter.yaml
+++ b/changelogs/fragments/216-fix-lxc-container-container_config-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lxc_container - fix the type of the container_config parameter

--- a/changelogs/fragments/216-fix-lxc-container-container_config-parameter.yaml
+++ b/changelogs/fragments/216-fix-lxc-container-container_config-parameter.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - lxc_container - fix the type of the container_config parameter
+  - lxc_container - fix the type of the ``container_config`` parameter. It is now processed as a list and not a string (https://github.com/ansible-collections/community.general/pull/216).

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -148,6 +148,8 @@ options:
     container_config:
         description:
           - list of 'key=value' options to use when configuring a container.
+        type: list
+        elements: str
 requirements:
   - 'lxc >= 1.0 # OS package'
   - 'python >= 2.6 # OS Package'

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -1693,7 +1693,8 @@ def main():
                 type='str'
             ),
             container_config=dict(
-                type='list'
+                type='list',
+                elements='str'
             ),
             container_log=dict(
                 type='bool',

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -706,14 +706,7 @@ class LxcContainerManagement(object):
         with open(container_config_file, 'rb') as f:
             container_config = to_text(f.read(), errors='surrogate_or_strict').splitlines(True)
 
-        # Note used ast literal_eval because AnsibleModule does not provide for
-        # adequate dictionary parsing.
-        # Issue: https://github.com/ansible/ansible/issues/7679
-        # TODO(cloudnull) adjust import when issue has been resolved.
-        import ast
-        options_dict = ast.literal_eval(_container_config)
-        parsed_options = [i.split('=', 1) for i in options_dict]
-
+        parsed_options = [i.split('=', 1) for i in _container_config]
         config_change = False
         for key, value in parsed_options:
             key = key.strip()
@@ -1700,7 +1693,7 @@ def main():
                 type='str'
             ),
             container_config=dict(
-                type='str'
+                type='list'
             ),
             container_log=dict(
                 type='bool',


### PR DESCRIPTION
##### SUMMARY
Fix the parameter type of `container_config`.

The documentation of the module states that `container_config` is a list but the type specified in the module code is `str` which generate an annoying warning when `container_config` is used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc_container