### PR TITLE
fix "TypeError: Object of type map is not JSON serializable"

### DIFF
--- a/changelogs/fragments/223-manageiq_provider-fix-serialization.yml
+++ b/changelogs/fragments/223-manageiq_provider-fix-serialization.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- manageiq_provider - fix serialization error when running on python3 environment.

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -571,7 +571,7 @@ def delete_nulls(h):
         a hash without nulls
     """
     if isinstance(h, list):
-        return [delete_nulls(i) for i in h if i is not None]
+        return [delete_nulls(i) for i in h]
     if isinstance(h, dict):
         return dict((k, delete_nulls(v)) for k, v in h.items() if v is not None)
 

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -573,7 +573,7 @@ def delete_nulls(h):
     if isinstance(h, list):
         return map(delete_nulls, h)
     if isinstance(h, dict):
-        return dict((k, delete_nulls(v)) for k, v in h.items() if v is not None)
+        return dict((k, v) for k, v in h.items() if v is not None)
 
     return h
 

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -571,7 +571,7 @@ def delete_nulls(h):
         a hash without nulls
     """
     if isinstance(h, list):
-        return [delete_nulls(i) for i in h if i]
+        return [delete_nulls(i) for i in h if i is not None]
     if isinstance(h, dict):
         return dict((k, delete_nulls(v)) for k, v in h.items() if v is not None)
 

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -571,9 +571,9 @@ def delete_nulls(h):
         a hash without nulls
     """
     if isinstance(h, list):
-        return map(delete_nulls, h)
+        return [delete_nulls(i) for i in h if i]
     if isinstance(h, dict):
-        return dict((k, v) for k, v in h.items() if v is not None)
+        return dict((k, delete_nulls(v)) for k, v in h.items() if v is not None)
 
     return h
 


### PR DESCRIPTION
… running module on Python 3 Environment

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
delete_nulls function was changed in manageiq_provider.py to fix Serialization Error ocurring on a python 3 environment.
Fix was tested with:
- python 3.7.3
- python 2.7.16

Fixes #222 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
manageiq_provider

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
This pull request is supposed to ensure compatibility with python2 and python3 for module manageiq_provider
```
