### PR TITLE
Update sesu.py: use defined prompt

### DIFF
--- a/changelogs/fragments/227-sesu-use-defined-prompt.yaml
+++ b/changelogs/fragments/227-sesu-use-defined-prompt.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sesu - make use of the prompt specified in the code

--- a/plugins/become/sesu.py
+++ b/plugins/become/sesu.py
@@ -75,7 +75,7 @@ class BecomeModule(BecomeBase):
 
     name = 'community.general.sesu'
 
-    _prompt = 'Please enter your password:'
+    prompt = 'Please enter your password:'
     fail = missing = ('Sorry, try again with sesu.',)
 
     def build_become_command(self, cmd, shell):


### PR DESCRIPTION
##### SUMMARY

Make `sesu` become method use the defined prompt.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
plugins/become/sesu.py

##### ADDITIONAL INFORMATION
The `BecomeBase` expects the prompt in the `prompt` variable.