### PR TITLE
adding list support to dconf

### DIFF
--- a/plugins/modules/system/dconf.py
+++ b/plugins/modules/system/dconf.py
@@ -278,16 +278,16 @@ class DconfPreference(object):
 
         return value
 
-    def list(self, key):
+    def list_sub_dirs(self, key):
         """
-        List the sub-keys and sub-dirs of a dir.
+        List the sub-dirs of a dir.
 
         If an error occurs, a call will be made to AnsibleModule.fail_json.
 
         :param key: A directory path which the sub-dirs should be return. Should be a full path, starting and ending with '/'.
         :type key: str
 
-        :returns: list -- List the sub-keys and sub-dirs of a dir. If the value does not have sub-dirs, returns None.
+        :returns: list -- List the sub-dirs of a dir. If the value does not have sub-dirs, returns None.
         """
 
         command = ["dconf", "list", key]
@@ -300,9 +300,8 @@ class DconfPreference(object):
         if out == '':
             values = None
         else:
-            values = out.split('\n')
+            values = out.rstrip('\n').split('\n')
         return values
-
 
     def write(self, key, value):
         """
@@ -381,7 +380,7 @@ def main():
     # Setup the Ansible module
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(default='present', choices=['present', 'absent', 'read', 'list']),
+            state=dict(default='present', choices=['present', 'absent', 'read', 'list_sub_dirs']),
             key=dict(required=True, type='str'),
             value=dict(required=False, default=None, type='str'),
         ),
@@ -402,8 +401,8 @@ def main():
     if module.params['state'] == 'read':
         value = dconf.read(module.params['key'])
         module.exit_json(changed=False, value=value)
-    elif module.params['state'] == 'list':
-        values = dconf.list(module.params['key'])
+    elif module.params['state'] == 'list_sub_dirs':
+        values = dconf.list_sub_dirs(module.params['key'])
         module.exit_json(changed=False, values=values)
     elif module.params['state'] == 'present':
         changed = dconf.write(module.params['key'], module.params['value'])

--- a/plugins/modules/system/dconf.py
+++ b/plugins/modules/system/dconf.py
@@ -64,7 +64,7 @@ options:
     default: present
     choices:
       - read
-      - list
+      - list_sub_dirs
       - present
       - absent
     description:
@@ -123,7 +123,7 @@ EXAMPLES = """
 - name: List GNOME Terminal profiles
   dconf:
     key: "/org/gnome/terminal/legacy/profiles:/"
-    state: list
+    state: list_sub_dirs
   register: terminal_profiles
 """
 


### PR DESCRIPTION
##### SUMMARY
The current module only returns a value key. I am adding the patch to support list sub-dirs as well.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dconf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: Read terminal profile
  dconf:
    key: "/org/gnome/terminal/legacy/profiles:/"
    state: list
  register: terminal_profiles

- debug:
    msg: "{{ terminal_profiles['values'][0] }}"

TASK [desktop : Read terminal profile] *****************************************************************************************************
ok: [localhost]

TASK [desktop : debug] *********************************************************************************************************************
ok: [localhost] => {
    "msg": ":b1dcc9dd-5262-4d8d-a863-c897e6d979b9/"
}
```
