### PR TITLE
Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated

### DIFF
--- a/changelogs/fragments/229_lvol_percentage_fix.yml
+++ b/changelogs/fragments/229_lvol_percentage_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated.

--- a/changelogs/fragments/229_lvol_percentage_fix.yml
+++ b/changelogs/fragments/229_lvol_percentage_fix.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated.
+ - lvol - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated.

--- a/changelogs/fragments/229_lvol_percentage_fix.yml
+++ b/changelogs/fragments/229_lvol_percentage_fix.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - lvol - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated.
+ - lvol - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated (https://github.com/ansible-collections/community.general/pull/229).

--- a/changelogs/fragments/229_lvol_percentage_fix.yml
+++ b/changelogs/fragments/229_lvol_percentage_fix.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - lvol - Fix idempotent issue when using lvol with %VG or %PVS size options and VG is fully allocated (https://github.com/ansible-collections/community.general/pull/229).
+ - lvol - fix idempotency issue when using lvol with ``%VG`` or ``%PVS`` size options and VG is fully allocated (https://github.com/ansible-collections/community.general/pull/229).

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -468,6 +468,10 @@ def main():
                 size_requested = size_percent * this_vg['size'] / 100
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
+
+            # Round down to the next lowest whole physical extent
+            size_requested -= (size_requested % this_vg['ext_size'])
+
             if '+' in size:
                 size_requested += this_lv['size']
             if this_lv['size'] < size_requested:


### PR DESCRIPTION
##### SUMMARY
Changed the behavior when using %VG or %PVS to make the size_requested an even modulus with the VGs physical extents by rounding down.  This makes the usage of %VG or %PVS idempotent when the calculated size_requested does not end on a physical extent boundary and the VG is fully allocated.

Fixes #290.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol

##### ADDITIONAL INFORMATION

The VG looks like this:

> vgs --noheadings --nosuffix -o vg_name,size,free,vg_extent_size --units 'm' --separator ';' mysql_vg
>
> mysql_vg;3060.00;0;4.00

Based on the logic of the module the size requested looks like this:

> size_requested = size_percent * this_vg['size'] / 100
> 2295.0 = 25 * 3060.00 / 100
>

When divided by the extent size we can see it is not whole number:
> size_requested / 4 = 573.75

This is not an issue unless the VG is fully allocated.  When that is the case you get the following error:

> fatal: [mysql]: FAILED! => {"changed": false, "msg": "Logical Volume var_lib_mysql2 could not be extended. Not enough free space left (1.0m required / 0.0m available)"}

Example playbook:
```
    tasks:
    - lvol:
        vg: 'mysql_vg'
        lv: 'var_lib_mysql2'
        size: '25%VG'
        shrink: no
        state: 'present'
```