### PR TITLE
Fix module._name comparisons to also consider FQCNs

### DIFF
--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -385,7 +385,7 @@ def main():
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'ali_instance_facts':
+    if module._name in ('ali_instance_facts', 'community.general.ali_instance_facts'):
         module.deprecate("The 'ali_instance_facts' module has been renamed to 'ali_instance_info'", version='2.13')
 
     if HAS_FOOTMARK is False:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_account_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_account_info.py
@@ -75,7 +75,7 @@ def core(module):
 def main():
     argument_spec = DigitalOceanHelper.digital_ocean_argument_spec()
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_account_facts':
+    if module._name in ('digital_ocean_account_facts', 'community.general.digital_ocean_account_facts'):
         module.deprecate("The 'digital_ocean_account_facts' module has been renamed to 'digital_ocean_account_info'", version='2.13')
     try:
         core(module)

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_certificate_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_certificate_info.py
@@ -106,7 +106,7 @@ def main():
         certificate_id=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_certificate_facts':
+    if module._name in ('digital_ocean_certificate_facts', 'community.general.digital_ocean_certificate_facts'):
         module.deprecate("The 'digital_ocean_certificate_facts' module has been renamed to 'digital_ocean_certificate_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_domain_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_domain_info.py
@@ -131,7 +131,7 @@ def main():
         domain_name=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_domain_facts':
+    if module._name in ('digital_ocean_domain_facts', 'community.general.digital_ocean_domain_facts'):
         module.deprecate("The 'digital_ocean_domain_facts' module has been renamed to 'digital_ocean_domain_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_firewall_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_firewall_info.py
@@ -124,7 +124,7 @@ def main():
         name=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_firewall_facts':
+    if module._name in ('digital_ocean_firewall_facts', 'community.general.digital_ocean_firewall_facts'):
         module.deprecate("The 'digital_ocean_firewall_facts' module has been renamed to 'digital_ocean_firewall_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_floating_ip_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_floating_ip_info.py
@@ -111,7 +111,7 @@ def main():
     module = AnsibleModule(
         argument_spec=DigitalOceanHelper.digital_ocean_argument_spec()
     )
-    if module._name == 'digital_ocean_floating_ip_facts':
+    if module._name in ('digital_ocean_floating_ip_facts', 'community.general.digital_ocean_floating_ip_facts'):
         module.deprecate("The 'digital_ocean_floating_ip_facts' module has been renamed to 'digital_ocean_floating_ip_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_image_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_image_info.py
@@ -141,7 +141,7 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_image_facts':
+    if module._name in ('digital_ocean_image_facts', 'community.general.digital_ocean_image_facts'):
         module.deprecate("The 'digital_ocean_image_facts' module has been renamed to 'digital_ocean_image_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_load_balancer_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_load_balancer_info.py
@@ -108,7 +108,7 @@ def main():
         load_balancer_id=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_load_balancer_facts':
+    if module._name in ('digital_ocean_load_balancer_facts', 'community.general.digital_ocean_load_balancer_facts'):
         module.deprecate("The 'digital_ocean_load_balancer_facts' module has been renamed to 'digital_ocean_load_balancer_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_region_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_region_info.py
@@ -108,7 +108,7 @@ def core(module):
 def main():
     argument_spec = DigitalOceanHelper.digital_ocean_argument_spec()
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_region_facts':
+    if module._name in ('digital_ocean_region_facts', 'community.general.digital_ocean_region_facts'):
         module.deprecate("The 'digital_ocean_region_facts' module has been renamed to 'digital_ocean_region_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_size_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_size_info.py
@@ -106,7 +106,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
     )
-    if module._name == 'digital_ocean_size_facts':
+    if module._name in ('digital_ocean_size_facts', 'community.general.digital_ocean_size_facts'):
         module.deprecate("The 'digital_ocean_size_facts' module has been renamed to 'digital_ocean_size_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_snapshot_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_snapshot_info.py
@@ -153,7 +153,7 @@ def main():
             ['snapshot_type', 'by_id', ['snapshot_id']],
         ],
     )
-    if module._name == 'digital_ocean_snapshot_facts':
+    if module._name in ('digital_ocean_snapshot_facts', 'community.general.digital_ocean_snapshot_facts'):
         module.deprecate("The 'digital_ocean_snapshot_facts' module has been renamed to 'digital_ocean_snapshot_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
@@ -108,7 +108,7 @@ def main():
         tag_name=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_tag_facts':
+    if module._name in ('digital_ocean_tag_facts', 'community.general.digital_ocean_tag_facts'):
         module.deprecate("The 'digital_ocean_tag_facts' module has been renamed to 'digital_ocean_tag_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_volume_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_volume_info.py
@@ -133,7 +133,7 @@ def main():
         region_name=dict(type='str', required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'digital_ocean_volume_facts':
+    if module._name in ('digital_ocean_volume_facts', 'community.general.digital_ocean_volume_facts'):
         module.deprecate("The 'digital_ocean_volume_facts' module has been renamed to 'digital_ocean_volume_info'", version='2.13')
 
     try:

--- a/plugins/modules/cloud/docker/docker_compose.py
+++ b/plugins/modules/cloud/docker/docker_compose.py
@@ -1140,7 +1140,7 @@ def main():
         supports_check_mode=True,
         min_docker_api_version='1.20',
     )
-    if client.module._name == 'docker_service':
+    if client.module._name in ('docker_service', 'community.general.docker_service'):
         client.module.deprecate("The 'docker_service' module has been renamed to 'docker_compose'.", version='2.12')
 
     try:

--- a/plugins/modules/cloud/docker/docker_image_info.py
+++ b/plugins/modules/cloud/docker/docker_image_info.py
@@ -253,7 +253,7 @@ def main():
         supports_check_mode=True,
         min_docker_api_version='1.20',
     )
-    if client.module._name == 'docker_image_facts':
+    if client.module._name in ('docker_image_facts', 'community.general.docker_image_facts'):
         client.module.deprecate("The 'docker_image_facts' module has been renamed to 'docker_image_info'", version='2.12')
 
     try:

--- a/plugins/modules/cloud/google/gcpubsub_info.py
+++ b/plugins/modules/cloud/google/gcpubsub_info.py
@@ -108,7 +108,7 @@ def main():
         service_account_email=dict(),
         credentials_file=dict(),
         project_id=dict(), ),)
-    if module._name == 'gcpubsub_facts':
+    if module._name in ('gcpubsub_facts', 'community.general.gcpubsub_facts'):
         module.deprecate("The 'gcpubsub_facts' module has been renamed to 'gcpubsub_info'", version='2.13')
 
     if not HAS_PYTHON26:

--- a/plugins/modules/cloud/memset/memset_memstore_info.py
+++ b/plugins/modules/cloud/memset/memset_memstore_info.py
@@ -155,7 +155,7 @@ def main():
         ),
         supports_check_mode=False
     )
-    if module._name == 'memset_memstore_facts':
+    if module._name in ('memset_memstore_facts', 'community.general.memset_memstore_facts'):
         module.deprecate("The 'memset_memstore_facts' module has been renamed to 'memset_memstore_info'", version='2.13')
 
     # populate the dict with the user-provided vars.

--- a/plugins/modules/cloud/memset/memset_server_info.py
+++ b/plugins/modules/cloud/memset/memset_server_info.py
@@ -280,7 +280,7 @@ def main():
         ),
         supports_check_mode=False
     )
-    if module._name == 'memset_server_facts':
+    if module._name in ('memset_server_facts', 'community.general.memset_server_facts'):
         module.deprecate("The 'memset_server_facts' module has been renamed to 'memset_server_info'", version='2.13')
 
     # populate the dict with the user-provided vars.

--- a/plugins/modules/cloud/opennebula/one_image_info.py
+++ b/plugins/modules/cloud/opennebula/one_image_info.py
@@ -259,7 +259,7 @@ def main():
     module = AnsibleModule(argument_spec=fields,
                            mutually_exclusive=[['ids', 'name']],
                            supports_check_mode=True)
-    if module._name == 'one_image_facts':
+    if module._name in ('one_image_facts', 'community.general.one_image_facts'):
         module.deprecate("The 'one_image_facts' module has been renamed to 'one_image_info'", version='2.13')
 
     if not HAS_PYONE:

--- a/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -125,7 +125,7 @@ def main():
         vm=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_affinity_label_facts'
+    is_old_facts = module._name in ('ovirt_affinity_label_facts', 'community.general.ovirt_affinity_label_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_affinity_label_facts' module has been renamed to 'ovirt_affinity_label_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_api_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_api_facts.py
@@ -72,7 +72,7 @@ from ansible_collections.ovirt.ovirt.plugins.module_utils.ovirt import (
 def main():
     argument_spec = ovirt_info_full_argument_spec()
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_api_facts'
+    is_old_facts = module._name in ('ovirt_api_facts', 'community.general.ovirt_api_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_api_facts' module has been renamed to 'ovirt_api_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -93,7 +93,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_cluster_facts'
+    is_old_facts = module._name in ('ovirt_cluster_facts', 'community.general.ovirt_cluster_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_cluster_facts' module has been renamed to 'ovirt_cluster_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -76,7 +76,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_datacenter_facts'
+    is_old_facts = module._name in ('ovirt_datacenter_facts', 'community.general.ovirt_datacenter_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_datacenter_facts' module has been renamed to 'ovirt_datacenter_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
@@ -92,7 +92,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_disk_facts'
+    is_old_facts = module._name in ('ovirt_disk_facts', 'community.general.ovirt_disk_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_disk_facts' module has been renamed to 'ovirt_disk_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_event_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_event_facts.py
@@ -131,7 +131,7 @@ def main():
         wait=dict(default=True, type='bool', required=False)
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_event_facts'
+    is_old_facts = module._name in ('ovirt_event_facts', 'community.general.ovirt_event_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_event_facts' module has been renamed to 'ovirt_event_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -124,7 +124,7 @@ def main():
         ),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_external_provider_facts'
+    is_old_facts = module._name in ('ovirt_external_provider_facts', 'community.general.ovirt_external_provider_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_external_provider_facts' module has been renamed to 'ovirt_external_provider_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_group_facts.py
@@ -91,7 +91,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_group_facts'
+    is_old_facts = module._name in ('ovirt_group_facts', 'community.general.ovirt_group_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_group_facts' module has been renamed to 'ovirt_group_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_host_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_facts.py
@@ -109,7 +109,7 @@ def main():
         cluster_version=dict(default=None, type='str'),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_host_facts'
+    is_old_facts = module._name in ('ovirt_host_facts', 'community.general.ovirt_host_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_host_facts' module has been renamed to 'ovirt_host_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
@@ -132,7 +132,7 @@ def main():
         fcp=dict(default=None, type='dict'),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_host_storage_facts'
+    is_old_facts = module._name in ('ovirt_host_storage_facts', 'community.general.ovirt_host_storage_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_host_storage_facts' module has been renamed to 'ovirt_host_storage_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_network_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_network_facts.py
@@ -93,7 +93,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_network_facts'
+    is_old_facts = module._name in ('ovirt_network_facts', 'community.general.ovirt_network_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_network_facts' module has been renamed to 'ovirt_network_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
@@ -98,7 +98,7 @@ def main():
         name=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_nic_facts'
+    is_old_facts = module._name in ('ovirt_nic_facts', 'community.general.ovirt_nic_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_nic_facts' module has been renamed to 'ovirt_nic_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
@@ -135,7 +135,7 @@ def main():
         namespace=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_permission_facts'
+    is_old_facts = module._name in ('ovirt_permission_facts', 'community.general.ovirt_permission_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_permission_facts' module has been renamed to 'ovirt_permission_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
@@ -98,7 +98,7 @@ def main():
         name=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_quota_facts'
+    is_old_facts = module._name in ('ovirt_quota_facts', 'community.general.ovirt_quota_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_quota_facts' module has been renamed to 'ovirt_quota_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
@@ -98,7 +98,7 @@ def main():
         name=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_scheduling_policy_facts'
+    is_old_facts = module._name in ('ovirt_scheduling_policy_facts', 'community.general.ovirt_scheduling_policy_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_scheduling_policy_facts' module has been renamed to 'ovirt_scheduling_policy_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
@@ -88,7 +88,7 @@ def main():
         snapshot_id=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_snapshot_facts'
+    is_old_facts = module._name in ('ovirt_snapshot_facts', 'community.general.ovirt_snapshot_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_snapshot_facts' module has been renamed to 'ovirt_snapshot_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
@@ -93,7 +93,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_storage_domain_facts'
+    is_old_facts = module._name in ('ovirt_storage_domain_facts', 'community.general.ovirt_storage_domain_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_storage_domain_facts' module has been renamed to 'ovirt_storage_domain_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
@@ -103,7 +103,7 @@ def main():
         unregistered=dict(default=False, type='bool'),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_storage_template_facts'
+    is_old_facts = module._name in ('ovirt_storage_template_facts', 'community.general.ovirt_storage_template_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_storage_template_facts' module has been renamed to 'ovirt_storage_template_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
@@ -103,7 +103,7 @@ def main():
         unregistered=dict(default=False, type='bool'),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_storage_vm_facts'
+    is_old_facts = module._name in ('ovirt_storage_vm_facts', 'community.general.ovirt_storage_vm_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_storage_vm_facts' module has been renamed to 'ovirt_storage_vm_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
@@ -114,7 +114,7 @@ def main():
         vm=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_tag_facts'
+    is_old_facts = module._name in ('ovirt_tag_facts', 'community.general.ovirt_tag_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_tag_facts' module has been renamed to 'ovirt_tag_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_template_facts.py
@@ -93,7 +93,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_template_facts'
+    is_old_facts = module._name in ('ovirt_template_facts', 'community.general.ovirt_template_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_template_facts' module has been renamed to 'ovirt_template_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_user_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_user_facts.py
@@ -91,7 +91,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_user_facts'
+    is_old_facts = module._name in ('ovirt_user_facts', 'community.general.ovirt_user_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_user_facts' module has been renamed to 'ovirt_user_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
@@ -124,7 +124,7 @@ def main():
         max=dict(default=None, type='int'),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_vm_facts'
+    is_old_facts = module._name in ('ovirt_vm_facts', 'community.general.ovirt_vm_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_vm_facts' module has been renamed to 'ovirt_vm_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
@@ -91,7 +91,7 @@ def main():
         pattern=dict(default='', required=False),
     )
     module = AnsibleModule(argument_spec)
-    is_old_facts = module._name == 'ovirt_vmpool_facts'
+    is_old_facts = module._name in ('ovirt_vmpool_facts', 'community.general.ovirt_vmpool_facts')
     if is_old_facts:
         module.deprecate("The 'ovirt_vmpool_facts' module has been renamed to 'ovirt_vmpool_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/smartos/smartos_image_info.py
+++ b/plugins/modules/cloud/smartos/smartos_image_info.py
@@ -104,7 +104,7 @@ def main():
         ),
         supports_check_mode=False,
     )
-    is_old_facts = module._name == 'smartos_image_facts'
+    is_old_facts = module._name in ('smartos_image_facts', 'community.general.smartos_image_facts')
     if is_old_facts:
         module.deprecate("The 'smartos_image_facts' module has been renamed to 'smartos_image_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/cloud/xenserver/xenserver_guest_info.py
+++ b/plugins/modules/cloud/xenserver/xenserver_guest_info.py
@@ -209,7 +209,7 @@ def main():
                            ],
                            )
 
-    if module._name == 'xenserver_guest_facts':
+    if module._name in ('xenserver_guest_facts', 'community.general.xenserver_guest_facts'):
         module.deprecate("The 'xenserver_guest_facts' module has been renamed to 'xenserver_guest_info'", version='2.13')
 
     result = {'failed': False, 'changed': False}

--- a/plugins/modules/database/vertica/vertica_info.py
+++ b/plugins/modules/database/vertica/vertica_info.py
@@ -233,7 +233,7 @@ def main():
             login_user=dict(default='dbadmin'),
             login_password=dict(default=None, no_log=True),
         ), supports_check_mode=True)
-    is_old_facts = module._name == 'vertica_facts'
+    is_old_facts = module._name in ('vertica_facts', 'community.general.vertica_facts')
     if is_old_facts:
         module.deprecate("The 'vertica_facts' module has been renamed to 'vertica_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/identity/onepassword_info.py
+++ b/plugins/modules/identity/onepassword_info.py
@@ -383,7 +383,7 @@ def main():
 
     results = {'onepassword': OnePasswordInfo().run()}
 
-    if module._name == 'onepassword_facts':
+    if module._name in ('onepassword_facts', 'community.general.onepassword_facts'):
         module.deprecate("The 'onepassword_facts' module has been renamed to 'onepassword_info'. "
                          "When called with the new name it no longer returns 'ansible_facts'", version='2.13')
         module.exit_json(changed=False, ansible_facts=results)

--- a/plugins/modules/remote_management/hpilo/hpilo_info.py
+++ b/plugins/modules/remote_management/hpilo/hpilo_info.py
@@ -164,7 +164,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    is_old_facts = module._name == 'hpilo_facts'
+    is_old_facts = module._name in ('hpilo_facts', 'community.general.hpilo_facts')
     if is_old_facts:
         module.deprecate("The 'hpilo_facts' module has been renamed to 'hpilo_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/intersight/intersight_info.py
+++ b/plugins/modules/remote_management/intersight/intersight_info.py
@@ -105,7 +105,7 @@ def main():
         argument_spec,
         supports_check_mode=True,
     )
-    if module._name == 'intersight_facts':
+    if module._name in ('intersight_facts', 'community.general.intersight_facts'):
         module.deprecate("The 'intersight_facts' module has been renamed to 'intersight_info'", version='2.13')
 
     intersight = IntersightModule(module)

--- a/plugins/modules/remote_management/oneview/oneview_datacenter_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_datacenter_info.py
@@ -118,7 +118,7 @@ class DatacenterInfoModule(OneViewModuleBase):
 
     def __init__(self):
         super(DatacenterInfoModule, self).__init__(additional_arg_spec=self.argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_datacenter_facts'
+        self.is_old_facts = self.module._name in ('oneview_datacenter_facts', 'community.general.oneview_datacenter_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_datacenter_facts' module has been renamed to 'oneview_datacenter_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
@@ -161,7 +161,7 @@ class EnclosureInfoModule(OneViewModuleBase):
 
     def __init__(self):
         super(EnclosureInfoModule, self).__init__(additional_arg_spec=self.argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_enclosure_facts'
+        self.is_old_facts = self.module._name in ('oneview_enclosure_facts', 'community.general.oneview_enclosure_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_enclosure_facts' module has been renamed to 'oneview_enclosure_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py
@@ -116,7 +116,7 @@ class EthernetNetworkInfoModule(OneViewModuleBase):
 
     def __init__(self):
         super(EthernetNetworkInfoModule, self).__init__(additional_arg_spec=self.argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_ethernet_network_facts'
+        self.is_old_facts = self.module._name in ('oneview_ethernet_network_facts', 'community.general.oneview_ethernet_network_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_ethernet_network_facts' module has been renamed to 'oneview_ethernet_network_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_fc_network_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_fc_network_info.py
@@ -87,7 +87,7 @@ class FcNetworkInfoModule(OneViewModuleBase):
         )
 
         super(FcNetworkInfoModule, self).__init__(additional_arg_spec=argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_fc_network_facts'
+        self.is_old_facts = self.module._name in ('oneview_fc_network_facts', 'community.general.oneview_fc_network_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_fc_network_facts' module has been renamed to 'oneview_fc_network_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_fcoe_network_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_fcoe_network_info.py
@@ -86,7 +86,7 @@ class FcoeNetworkInfoModule(OneViewModuleBase):
         )
 
         super(FcoeNetworkInfoModule, self).__init__(additional_arg_spec=argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_fcoe_network_facts'
+        self.is_old_facts = self.module._name in ('oneview_fcoe_network_facts', 'community.general.oneview_fcoe_network_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_fcoe_network_facts' module has been renamed to 'oneview_fcoe_network_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_logical_interconnect_group_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_logical_interconnect_group_info.py
@@ -100,7 +100,7 @@ class LogicalInterconnectGroupInfoModule(OneViewModuleBase):
         )
 
         super(LogicalInterconnectGroupInfoModule, self).__init__(additional_arg_spec=argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_logical_interconnect_group_facts'
+        self.is_old_facts = self.module._name in ('oneview_logical_interconnect_group_facts', 'community.general.oneview_logical_interconnect_group_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_logical_interconnect_group_facts' module has been renamed to 'oneview_logical_interconnect_group_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_network_set_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_network_set_info.py
@@ -137,7 +137,7 @@ class NetworkSetInfoModule(OneViewModuleBase):
 
     def __init__(self):
         super(NetworkSetInfoModule, self).__init__(additional_arg_spec=self.argument_spec)
-        self.is_old_facts = self.module._name == 'oneview_network_set_facts'
+        self.is_old_facts = self.module._name in ('oneview_network_set_facts', 'community.general.oneview_network_set_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_network_set_facts' module has been renamed to 'oneview_network_set_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/oneview/oneview_san_manager_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_san_manager_info.py
@@ -94,7 +94,7 @@ class SanManagerInfoModule(OneViewModuleBase):
     def __init__(self):
         super(SanManagerInfoModule, self).__init__(additional_arg_spec=self.argument_spec)
         self.resource_client = self.oneview_client.san_managers
-        self.is_old_facts = self.module._name == 'oneview_san_manager_facts'
+        self.is_old_facts = self.module._name in ('oneview_san_manager_facts', 'community.general.oneview_san_manager_facts')
         if self.is_old_facts:
             self.module.deprecate("The 'oneview_san_manager_facts' module has been renamed to 'oneview_san_manager_info', "
                                   "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/redfish/idrac_redfish_info.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_info.py
@@ -183,7 +183,7 @@ def main():
         ),
         supports_check_mode=False
     )
-    is_old_facts = module._name == 'idrac_redfish_facts'
+    is_old_facts = module._name in ('idrac_redfish_facts', 'community.general.idrac_redfish_facts')
     if is_old_facts:
         module.deprecate("The 'idrac_redfish_facts' module has been renamed to 'idrac_redfish_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/remote_management/redfish/redfish_info.py
+++ b/plugins/modules/remote_management/redfish/redfish_info.py
@@ -309,7 +309,7 @@ def main():
         ),
         supports_check_mode=False
     )
-    is_old_facts = module._name == 'redfish_facts'
+    is_old_facts = module._name in ('redfish_facts', 'community.general.redfish_facts')
     if is_old_facts:
         module.deprecate("The 'redfish_facts' module has been renamed to 'redfish_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/source_control/github/github_webhook_info.py
+++ b/plugins/modules/source_control/github/github_webhook_info.py
@@ -126,7 +126,7 @@ def main():
         mutually_exclusive=(('password', 'token'), ),
         required_one_of=(("password", "token"), ),
         supports_check_mode=True)
-    if module._name == 'github_webhook_facts':
+    if module._name in ('github_webhook_facts', 'community.general.github_webhook_facts'):
         module.deprecate("The 'github_webhook_facts' module has been renamed to 'github_webhook_info'", version='2.13')
 
     if not HAS_GITHUB:

--- a/plugins/modules/storage/glusterfs/gluster_heal_info.py
+++ b/plugins/modules/storage/glusterfs/gluster_heal_info.py
@@ -165,7 +165,7 @@ def main():
             status_filter=dict(type='str', default='self-heal', choices=['self-heal', 'rebalance']),
         ),
     )
-    is_old_facts = module._name == 'gluster_heal_facts'
+    is_old_facts = module._name in ('gluster_heal_facts', 'community.general.gluster_heal_facts')
     if is_old_facts:
         module.deprecate("The 'gluster_heal_facts' module has been renamed to 'gluster_heal_info', "
                          "and the renamed one no longer returns ansible_facts", version='2.13')

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -116,7 +116,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    if module._name == 'python_requirements_facts':
+    if module._name in ('python_requirements_facts', 'community.general.python_requirements_facts'):
         module.deprecate("The 'python_requirements_facts' module has been renamed to 'python_requirements_info'", version='2.13')
     if not HAS_DISTUTILS:
         module.fail_json(

--- a/plugins/modules/web_infrastructure/jenkins_job_info.py
+++ b/plugins/modules/web_infrastructure/jenkins_job_info.py
@@ -236,7 +236,7 @@ def main():
         ],
         supports_check_mode=True,
     )
-    if module._name == 'jenkins_job_facts':
+    if module._name in ('jenkins_job_facts', 'community.general.jenkins_job_facts'):
         module.deprecate("The 'jenkins_job_facts' module has been renamed to 'jenkins_job_info'", version='2.13')
 
     test_dependencies(module)


### PR DESCRIPTION
##### SUMMARY
`module._name` contains the name used in the task, i.e. it can also have the `community.general.` prefix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ali_instance_info
digital_ocean_account_info
digital_ocean_certificate_info
digital_ocean_domain_info
digital_ocean_firewall_info
digital_ocean_floating_ip_info
digital_ocean_image_info
digital_ocean_load_balancer_info
digital_ocean_region_info
digital_ocean_size_info
digital_ocean_snapshot_info
digital_ocean_tag_info
digital_ocean_volume_info
docker_compose
docker_image_info
gcpubsub_info
memset_memstore_info
memset_server_info
one_image_info
ovirt_affinity_label_facts
ovirt_api_facts
ovirt_cluster_facts
ovirt_datacenter_facts
ovirt_disk_facts
ovirt_event_facts
ovirt_external_provider_facts
ovirt_group_facts
ovirt_host_facts
ovirt_host_storage_facts
ovirt_network_facts
ovirt_nic_facts
ovirt_permission_facts
ovirt_quota_facts
ovirt_scheduling_policy_facts
ovirt_snapshot_facts
ovirt_storage_domain_facts
ovirt_storage_template_facts
ovirt_storage_vm_facts
ovirt_tag_facts
ovirt_template_facts
ovirt_user_facts
ovirt_vm_facts
ovirt_vmpool_facts
smartos_image_info
xenserver_guest_info
vertica_info
onepassword_info
hpilo_info
intersight_info
oneview_datacenter_info
oneview_enclosure_info
oneview_ethernet_network_info
oneview_fc_network_info
oneview_fcoe_network_info
oneview_logical_interconnect_group_info
oneview_network_set_info
oneview_san_manager_info
idrac_redfish_info
redfish_info
github_webhook_info
gluster_heal_info
python_requirements_info
jenkins_job_info
