### PR TITLE
Reenable consul test, fix issues with a hack

### DIFF
--- a/tests/integration/targets/consul/aliases
+++ b/tests/integration/targets/consul/aliases
@@ -1,4 +1,3 @@
 shippable/posix/group2
 destructive
 skip/aix
-disabled #fixme

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -47,6 +47,16 @@ pip --version
 pip list --disable-pip-version-check
 retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
+# START: HACK
+if [ "${script}" == "osx" ]; then
+    # Make sure that the latest versions of pyOpenSSL and cryptography will be installed on macOS before
+    # ansible-playbook is started. This is necessary until https://github.com/ansible/ansible/issues/68701
+    # has been fixed.
+    sed -i -e 's/cryptography.*/cryptography >= 2.9.2/g' /root/venv/lib/python2.7/site-packages/ansible_test/_data/requirements/integration.txt
+    echo 'pyOpenSSL >= 19.1.0' >> /root/venv/lib/python2.7/site-packages/ansible_test/_data/requirements/integration.txt
+fi
+# END: HACK
+
 export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
 SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
 TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/general"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -64,7 +64,7 @@ mkdir -p "${TEST_DIR}"
 cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
 cd "${TEST_DIR}"
 
-# STAR: HACK install dependencies
+# START: HACK install dependencies
 retry ansible-galaxy -vvv collection install ansible.netcommon
 retry ansible-galaxy -vvv collection install ansible.posix
 # https://github.com/CiscoDevNet/ansible-intersight/issues/9


### PR DESCRIPTION
##### SUMMARY
Use the same hack as in ansible-collections/community.crypto#36 to avoid the always unstable macOS result when `setup_openssl` is used. This allows to re-enable the consul tests.

The hack can be removed once ansible/ansible#68701 has been fixed.

Closes #117.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul
CI
