### PR TITLE
Pear - Add prompt parameter on pear module that allows to specify one or more prompts

### DIFF
--- a/changelogs/fragments/29253-pear_add_prompts_parameter.yml
+++ b/changelogs/fragments/29253-pear_add_prompts_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- added prompts parameter to allow users to specify expected prompt that could hang Ansible execution while using pear
+- pear - added ``prompts`` parameter to allow users to specify expected prompt that could hang Ansible execution

--- a/changelogs/fragments/29253-pear_add_prompts_parameter.yml
+++ b/changelogs/fragments/29253-pear_add_prompts_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- added prompts parameter to allow users to specify expected prompt that could hang Ansible execution while using pear

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -71,8 +71,8 @@ EXAMPLES = r'''
     prompts:
         - (.*)Enable internal debugging in APCu \[no\]
 
-# Install pecl package with expected prompt and an answer
-- pear:
+- name: Install pecl package with expected prompt and an answer
+  pear:
     name: pecl/apcu
     state: present
     prompts:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -44,7 +44,7 @@ options:
             - Prompts will be processed in the same order as the packages list
             - You can optionnally specify an answer to any question in the list
             - If no answer is provided, the list item will only contain the regular expression.
-            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value eg: C(my_regular_expression: 'an_answer')"
+            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value C(my_regular_expression: 'an_answer')"
             - You can provide a list containing items with or without answer
             - A prompt list can be shorter or longer than the packages list but will issue a warning
             - If you want to specify that a package will not need prompts in the middle of a list,  C(null)

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -73,7 +73,7 @@ EXAMPLES = r'''
 
 - name: Install multiple pear/pecl packages at once with prompts.
   # Prompts will be processed on the same order as the packages order
-# If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+  # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
   # If there is more packages than prompts, additionnal prompts will be ignored
   pear:
     name: pecl/gnupg, pecl/apcu

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -75,7 +75,7 @@ EXAMPLES = r'''
   # Prompts will be processed on the same order as the packages order
 # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
 # If there is more packages than prompts, additionnal prompts will be ignored
-- pear:
+  pear:
     name: pecl/gnupg, pecl/apcu
     state: present
     prompts:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -71,7 +71,8 @@ EXAMPLES = r'''
     prompts:
         - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
-# Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order
+- name: Install multiple pear/pecl packages at once with prompts.
+  # Prompts will be processed on the same order as the packages order
 # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
 # If there is more packages than prompts, additionnal prompts will be ignored
 - pear:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -36,12 +36,12 @@ options:
         default: "present"
         choices: ["present", "absent", "latest"]
     executable:
-      description:
-        - Path to the pear executable
+        description:
+            - Path to the pear executable
     prompts: 
         description:
             - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
-      version_added: "2.10"
+        version_added: "2.10"
 '''
 
 EXAMPLES = r'''
@@ -59,21 +59,21 @@ EXAMPLES = r'''
 - pear:
     name: pecl/apcu
     state: present
-    prompt: 
+    prompts: 
         - (.*)Enable internal debugging in APCu \[no\]
 
 # Install pecl package with expected prompt and an answer
 - pear:
     name: pecl/apcu
     state: present
-    prompt:
+    prompts:
         - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 # Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected. If there is more prompts than packages, additionnal prompts will be ignored
 - pear:
     name: pecl/gnupg, pecl/apcu
     state: present
-    prompt:
+    prompts:
       - I am a test prompt cause gnupg doesnt asks anything
       - (.*)Enable internal debugging in APCu \[no\]: "yes"
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -202,6 +202,7 @@ def remove_packages(module, packages):
 def install_packages(module, state, packages, prompts):
     install_c = 0
     has_prompt = bool(prompts)
+    default_stdin = "\n"
 
     if has_prompt:
         nb_prompts = len(prompts)
@@ -219,7 +220,6 @@ def install_packages(module, state, packages, prompts):
 
         # Preparing prompts answer according to item type
         tmp_prompts = []
-        default_prompt_answer = "\n"
         for _item in prompts:
             # If the current item is a dict then we expect it's key to be the prompt regex and it's value to be the answer
             # We also expect here that the dict only has ONE key and the first key will be taken
@@ -229,9 +229,9 @@ def install_packages(module, state, packages, prompts):
 
                 tmp_prompts.append((key, answer))
             elif not _item:
-                tmp_prompts.append((None, None))
+                tmp_prompts.append((None, default_stdin))
             else:
-                tmp_prompts.append((_item, default_prompt_answer))
+                tmp_prompts.append((_item, default_stdin))
         prompts = tmp_prompts
     for i, package in enumerate(packages):
         # if the package is installed and state == present
@@ -246,12 +246,15 @@ def install_packages(module, state, packages, prompts):
         if state == 'latest':
             command = 'upgrade'
 
-        current_prompt_regex = (None, None)
         if has_prompt and i < len(prompts):
-            current_prompt_regex = prompts[i]
+            prompt_regex = prompts[i][0]
+            data = prompts[i][1]
+        else:
+            prompt_regex = None
+            data = default_stdin
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1], binary_data=True)
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=prompt_regex, data=data, binary_data=True)
         if rc != 0:
             module.fail_json(msg="failed to install %s: %s" % (package, to_text(stdout + stderr)))
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -40,7 +40,7 @@ options:
             - Path to the pear executable
     prompts:
         description:
-            - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
+            - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
         version_added: "2.10"
 '''
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -265,7 +265,8 @@ def main():
             name=dict(aliases=['pkg'], required=True),
             state=dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
             executable=dict(default=None, required=False, type='path'),
-            prompts=dict(default=None, required=False, type='list', elements='raw')),
+            prompts=dict(default=None, required=False, type='list', elements='raw'),
+        ),
         supports_check_mode=True)
 
     p = module.params

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -74,7 +74,7 @@ EXAMPLES = r'''
 - name: Install multiple pear/pecl packages at once with prompts.
   # Prompts will be processed on the same order as the packages order
 # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
-# If there is more packages than prompts, additionnal prompts will be ignored
+  # If there is more packages than prompts, additionnal prompts will be ignored
   pear:
     name: pecl/gnupg, pecl/apcu
     state: present

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -57,7 +57,7 @@ EXAMPLES = r'''
     name: pecl/json_post
     state: present
 
-# Install pecl package with expected prompt
+- name: Install pecl package with expected prompt
 - pear:
     name: pecl/apcu
     state: present

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -227,7 +227,7 @@ def install_packages(module, state, packages, prompts):
             command = 'upgrade'
 
         current_prompt_regex = (None, None)
-        if has_prompt and (len(prompts) > 0 and i < len(prompts)):
+        if has_prompt and i < len(prompts):
             current_prompt_regex = prompts[i]
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -41,6 +41,8 @@ options:
     prompts:
         description:
             - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
+        type: list
+        elements: raw
         version_added: "2.10"
 '''
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -206,8 +206,7 @@ def install_packages(module, state, packages, prompts):
             # We also expect here that the dict only has ONE key and the first key will be taken
             if isinstance(_item, dict):
                 key = list(_item.keys())[0]
-                answer = _item[key] if _item[key] else default_prompt_answer
-                answer += "\n"
+                answer = _item[key] + "\n"
 
                 tmp_prompts.append((key, answer))
             else:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -60,14 +60,14 @@ EXAMPLES = '''
     name: pecl/apcu
     state: present
     prompt: 
-        - (.*)Enable internal debugging in APCu \[no\]
+        - (.*)Enable internal debugging in APCu \\[no\\]
 
 # Install pecl package with expected prompt and an answer
 - pear:
     name: pecl/apcu
     state: present
     prompt:
-        - (.*)Enable internal debugging in APCu \[no\]: "yes"
+        - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
 
 # Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected. If there is more prompts than packages, additionnal prompts will be ignored
 - pear:
@@ -75,7 +75,7 @@ EXAMPLES = '''
     state: present
     prompt:
       - I am a test prompt cause gnupg doesnt asks anything
-      - (.*)Enable internal debugging in APCu \[no\]: "yes"
+      - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
 
 # Upgrade package
 - pear:
@@ -184,14 +184,13 @@ def install_packages(module, state, packages, prompts):
         nb_prompts = len(prompts)
         nb_packages = len(packages)
 
-        if nb_prompts > 0 and ( nb_prompts != nb_packages ):
+        if nb_prompts > 0 and (nb_prompts != nb_packages):
             if nb_prompts > nb_packages:
                 diff = nb_prompts - nb_packages
                 msg = "%s packages to install but %s prompts to expect. %s prompts will be ignored" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             else:
                 diff = nb_packages - nb_prompts
                 msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
-            
             module.warn(msg)
 
         # Preparing prompts answer according to item type
@@ -208,9 +207,7 @@ def install_packages(module, state, packages, prompts):
                 tmp_prompts.append((key, answer))
             else:
                 tmp_prompts.append((_item, default_prompt_answer))
-
-        prompts = tmp_prompts                     
-            
+        prompts = tmp_prompts 
     for i, package in enumerate(packages):
         # if the package is installed and state == present
         # or state == latest and is up-to-date then skip
@@ -227,8 +224,6 @@ def install_packages(module, state, packages, prompts):
         current_prompt_regex = (None, None)
         if has_prompt and (len(prompts) > 0 and i < len(prompts)):
             current_prompt_regex = prompts[i]
-
-            print(current_prompt_regex)
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1])

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -38,7 +38,7 @@ options:
     executable:
         description:
             - Path to the pear executable
-    prompts: 
+    prompts:
         description:
             - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
         version_added: "2.10"
@@ -59,7 +59,7 @@ EXAMPLES = r'''
 - pear:
     name: pecl/apcu
     state: present
-    prompts: 
+    prompts:
         - (.*)Enable internal debugging in APCu \[no\]
 
 # Install pecl package with expected prompt and an answer
@@ -69,7 +69,9 @@ EXAMPLES = r'''
     prompts:
         - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
-# Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected. If there is more prompts than packages, additionnal prompts will be ignored
+# Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order
+# If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+# If there is more packages than prompts, additionnal prompts will be ignored
 - pear:
     name: pecl/gnupg, pecl/apcu
     state: present
@@ -190,7 +192,8 @@ def install_packages(module, state, packages, prompts):
                 msg = "%s packages to install but %s prompts to expect. %s prompts will be ignored" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             else:
                 diff = nb_packages - nb_prompts
-                msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
+                msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" \
+                    % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             module.warn(msg)
 
         # Preparing prompts answer according to item type
@@ -207,7 +210,7 @@ def install_packages(module, state, packages, prompts):
                 tmp_prompts.append((key, answer))
             else:
                 tmp_prompts.append((_item, default_prompt_answer))
-        prompts = tmp_prompts 
+        prompts = tmp_prompts
     for i, package in enumerate(packages):
         # if the package is installed and state == present
         # or state == latest and is up-to-date then skip

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -58,7 +58,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Install pecl package with expected prompt
-- pear:
+  pear:
     name: pecl/apcu
     state: present
     prompts:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -40,7 +40,7 @@ options:
             - Path to the pear executable
     prompts:
         description:
-            - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
+            - List of regular expressions which can be used to detect prompts during pear package installation with an optional string to answer the expected regex.
         type: list
         elements: raw
         version_added: "2.10"

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -40,7 +40,14 @@ options:
             - Path to the pear executable
     prompts:
         description:
-            - List of regular expressions which can be used to detect prompts during pear package installation with an optional string to answer the expected regex.
+            - List of regular expressions that can be used to detect prompts during pear package installation to answer the expected question.
+            - Prompts will be processed in the same order as the packages list
+            - You can optionnally specify an answer to any question in the list
+            - If no answer is provided, the list item will only contain the regular expression.
+            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value eg: C(my_regular_expression: 'an_answer')"
+            - You can provide a list containing items with or without answer
+            - A prompt list can be shorter or longer than the packages list but will issue a warning
+            - If you want to specify that a package will not need prompts in the middle of a list,  C(null)
         type: list
         elements: raw
         version_added: "2.10"
@@ -79,7 +86,18 @@ EXAMPLES = r'''
     name: pecl/gnupg, pecl/apcu
     state: present
     prompts:
-      - I am a test prompt cause gnupg doesnt asks anything
+      - I am a test prompt because gnupg doesnt asks anything
+      - (.*)Enable internal debugging in APCu \[no\]: "yes"
+
+- name: Install multiple pear/pecl packages at once skipping the first prompt
+  # Prompts will be processed on the same order as the packages order
+  # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+  # If there is more packages than prompts, additionnal prompts will be ignored
+  pear:
+    name: pecl/gnupg, pecl/apcu
+    state: present
+    prompts:
+      - null
       - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 # Upgrade package
@@ -210,6 +228,8 @@ def install_packages(module, state, packages, prompts):
                 answer = _item[key] + "\n"
 
                 tmp_prompts.append((key, answer))
+            elif not _item:
+                tmp_prompts.append((None, None))
             else:
                 tmp_prompts.append((_item, default_prompt_answer))
         prompts = tmp_prompts
@@ -231,7 +251,7 @@ def install_packages(module, state, packages, prompts):
             current_prompt_regex = prompts[i]
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1])
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1], binary_data=True)
         if rc != 0:
             module.fail_json(msg="failed to install %s: %s" % (package, to_text(stdout + stderr)))
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -264,7 +264,7 @@ def main():
             name=dict(aliases=['pkg'], required=True),
             state=dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
             executable=dict(default=None, required=False, type='path'),
-            prompts=dict(default=None, required=False, type='list')),
+            prompts=dict(default=None, required=False, type='list', elements='raw')),
         supports_check_mode=True)
 
     p = module.params

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -44,7 +44,7 @@ options:
       version_added: "2.10"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Install pear package
 - pear:
     name: Net_URL2
@@ -60,14 +60,14 @@ EXAMPLES = '''
     name: pecl/apcu
     state: present
     prompt: 
-        - (.*)Enable internal debugging in APCu \\[no\\]
+        - (.*)Enable internal debugging in APCu \[no\]
 
 # Install pecl package with expected prompt and an answer
 - pear:
     name: pecl/apcu
     state: present
     prompt:
-        - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
+        - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 # Install multiple pear/pecl packages at once with prompts. Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected. If there is more prompts than packages, additionnal prompts will be ignored
 - pear:
@@ -75,7 +75,7 @@ EXAMPLES = '''
     state: present
     prompt:
       - I am a test prompt cause gnupg doesnt asks anything
-      - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
+      - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 # Upgrade package
 - pear:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -182,7 +182,7 @@ def remove_packages(module, packages):
 
 def install_packages(module, state, packages, prompts):
     install_c = 0
-    has_prompt = True if prompts else False
+    has_prompt = bool(prompts)
 
     if has_prompt:
         nb_prompts = len(prompts)


### PR DESCRIPTION
##### SUMMARY
Add a new parameter to pear module allowing user to pass one or more regex and (optionnally) their answer for each package that will be installed.
Depending on what package we want to install, pear can ask for some information or just typing a character.
This hangs Ansible execution and the added parameter is used to detect these questions and answer them with a newline character by default or a user specified string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pear

##### ADDITIONAL INFORMATION
This fixes an issue created on [](https://github.com/ansible/ansible) repo 2 and half years ago : [](https://github.com/ansible/ansible/issues/29253)

Exemple playbook:

The example below have a prompt specified but no answer. Thus, the module will input newline caracter "\n" by default 
```
pear:
  name: pecl/apcu
  state: installed
  prompts:
    - "(.*)Enable internal debugging in APCu \[no\]"
```

The example below is the same except we specify a user answer.
```
pear:
  name: pecl/apcu
  state: installed
  prompts:
    - "(.*)Enable internal debugging in APCu \[no\]": "yes"
```