### PR TITLE
[splunk] Add an option to not fail when the certificate is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub Actions CI/CD build status — Collection test suite](https://github.com/ansible-collection-migration/community.general/workflows/Collection%20test%20suite/badge.svg?branch=master)](https://github.com/ansible-collection-migration/community.general/actions?query=workflow%3A%22Collection%20test%20suite%22)
+[![Run Status](https://api.shippable.com/projects/5e664a167c32620006c9fa50/badge?branch=master)](https://app.shippable.com/github/ansible-collections/community.general/dashboard) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
 
 Ansible Collection: community.general
 =================================================

--- a/changelogs/fragments/237-splunk-add-option-to-not-validate-cert.yaml
+++ b/changelogs/fragments/237-splunk-add-option-to-not-validate-cert.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - splunk - Add an option to allow not to validate certificate from HEC (https://github.com/ansible-collections/community.general/pull/237).

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -49,6 +49,11 @@ DOCUMENTATION = '''
         description: Whether to validate certificates for connections to HEC.  Do not set to
                      C(false) except when you are sure that nobody can intercept the connection
                      between this plugin and HEC, as setting it to C(false) enables man-in-the-middle attacks!
+        env:
+          - name: SPLUNK_VALIDATE_CERTS
+        ini:
+          - section: callback_splunk
+            key: validate_certs
         type: bool
         default: true
         version_added: '2.10'


### PR DESCRIPTION
Add an boolean option `validate_certs` to not validate the certificate of the HTTP Event Collector.

I'm not a developer so I'm trying to mimic the existing code.
The feature is not working yet because `get_option('valid_certificates')` always returns `None`, I don't know why.
I'm not sure either adding a new parameter to function `send_event` is good.

Thanks for giving me so advices and coding guidance.

##### SUMMARY
Add an option to not fail when the HEC certificate is not valid.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
splunk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
```