### PR TITLE
Fix the behavior of ipa modules in case IPA_HOST is empty

### DIFF
--- a/changelogs/fragments/241-fix-ipa-modules-when-ipa_host-empty.yml
+++ b/changelogs/fragments/241-fix-ipa-modules-when-ipa_host-empty.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa modules - fix error when IPA_HOST is empty and fallback on DNS

--- a/changelogs/fragments/241-fix-ipa-modules-when-ipa_host-empty.yml
+++ b/changelogs/fragments/241-fix-ipa-modules-when-ipa_host-empty.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa modules - fix error when IPA_HOST is empty and fallback on DNS
+  - ipa modules - fix error when IPA_HOST is empty and fallback on DNS (https://github.com/ansible-collections/community.general/pull/241)

--- a/plugins/module_utils/ipa.py
+++ b/plugins/module_utils/ipa.py
@@ -43,7 +43,9 @@ from ansible.module_utils.basic import env_fallback, AnsibleFallbackNotFound
 def _env_then_dns_fallback(*args, **kwargs):
     ''' Load value from environment or DNS in that order'''
     try:
-        return env_fallback(*args, **kwargs)
+        result = env_fallback(*args, **kwargs)
+        if result == '':
+            raise AnsibleFallbackNotFound
     except AnsibleFallbackNotFound:
         # If no host was given, we try to guess it from IPA.
         # The ipa-ca entry is a standard entry that IPA will have set for


### PR DESCRIPTION
##### SUMMARY

Fix the behavior of ipa modules in case IPA_HOST is empty

The expected behavior, when the env is empty, is to
fallback on DNS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa

##### ADDITIONAL INFORMATION

Without this fix, if IPA_HOST is empty,
there are different errors, depending on urllib version,
which additionally confuses the user. Example errors:
 * `host_find: Request failed: <urlopen error no host given>`
 * `Failed to connect to None at port 443: [Errno 111]
   Connection refused", "status": -1, "url":
   "https:///ipa/session/json`

```paste below

2020-04-26 16:27:13 | fatal: [undercloud]: FAILED! => changed=false 
2020-04-26 16:27:13 |   msg: 'host_find: Request failed: <urlopen error no host given>'

fatal: [localhost]: FAILED! => {"changed": false,
   "msg": "Failed to connect to None at port 443: [Errno 111] Connection refused",
   "status": -1,
   "url": "https:///ipa/session/json"}

```
