### PR TITLE
cloudflare_dns: fix KeyError

### DIFF
--- a/changelogs/fragments/243-cloudflare_dns_fix_keyerror.yml
+++ b/changelogs/fragments/243-cloudflare_dns_fix_keyerror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudflare_dns - fix KeyError 'success' (https://github.com/ansible-collections/community.general/issues/236).

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -496,11 +496,11 @@ class CloudflareAPI(object):
         if result is None:
             self.module.fail_json(msg=error_msg)
 
-        if not result.get('success'):
-            if not 'success' in result:
-                error_msg += "; Unexpected error details: {0}".format(result.get('error'))
-                self.module.fail_json(msg=error_msg)
-                
+        if 'success' not in result:
+            error_msg += "; Unexpected error details: {0}".format(result.get('error'))
+            self.module.fail_json(msg=error_msg)
+
+        if not result['success']:
             error_msg += "; Error details: "
             for error in result['errors']:
                 error_msg += "code: {0}, error: {1}; ".format(error['code'], error['message'])

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -496,7 +496,11 @@ class CloudflareAPI(object):
         if result is None:
             self.module.fail_json(msg=error_msg)
 
-        if not result['success']:
+        if not result.get('success'):
+            if not 'success' in result:
+                error_msg += "; Unexpected error details: {0}".format(result.get('error'))
+                self.module.fail_json(msg=error_msg)
+                
             error_msg += "; Error details: "
             for error in result['errors']:
                 error_msg += "code: {0}, error: {1}; ".format(error['code'], error['message'])


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/236

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ADDITIONAL INFORMATION
Fix errors of the type `KeyError: 'success'` to show a more meaningful message, like:

`API user does not have permission; Status: 401; Method: DELETE: Call: /zones/a8222778e37a0276468013d671b39e15/dns_records/b8051d66e565436cd6f24fbd34621f52; Error details: You cannot use this API for domains with a .cf, .ga, .gq, .ml, or .tk TLD (top-level domain). To configure the DNS settings for this domain, use the Cloudflare Dashboard.`
