### PR TITLE
add description and hookscript parameters to proxmox LXC container

### DIFF
--- a/changelogs/fragments/245-proxmox.yml
+++ b/changelogs/fragments/245-proxmox.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - add the ``description`` and ``hookscript`` parameter (https://github.com/ansible-collections/community.general/pull/245).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -142,7 +142,7 @@ options:
   hookscript:
     description:
       - Script that will be executed during various steps in the containers lifetime.
-    type: ?
+    type: str
 
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -162,6 +162,19 @@ EXAMPLES = r'''
     hostname: example.org
     ostemplate: 'local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
 
+- name: Create new container with hookscript and description
+  proxmox:
+    vmid: 100
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    password: 123456
+    hostname: example.org
+    ostemplate: 'local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
+    hookscript: 'local:snippets/vm_hook.sh'
+    description: created with ansible
+
 - name: Create new container automatically selecting the next available vmid.
   proxmox:
     node: 'uk-mc02'

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -538,9 +538,9 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
-                            unprivileged=int(module.params['unprivileged'],
+                            unprivileged=int(module.params['unprivileged']),
                             description=module.params['description'],
-                            hookscript=module.params['hookscript']))
+                            hookscript=module.params['hookscript'])
 
             module.exit_json(changed=True, msg="deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
         except Exception as e:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -140,7 +140,8 @@ options:
       - This is saved as comment inside the configuration file.
   hookscript:
     description:
-      - Script that will be exectued during various steps in the containers lifetime.
+      - Script that will be executed during various steps in the containers lifetime.
+    type: ?
 
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -134,6 +134,13 @@ options:
       - Indicate if the container should be unprivileged
     type: bool
     default: 'no'
+  description:
+    description:
+      - Specify the description for the container. Only used on the configuration web interface.
+      - This is saved as comment inside the configuration file.
+  hookscript:
+    description:
+      - Script that will be exectued during various steps in the containers lifetime.
 
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
@@ -448,7 +455,9 @@ def main():
             force=dict(type='bool', default='no'),
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
             pubkey=dict(type='str', default=None),
-            unprivileged=dict(type='bool', default='no')
+            unprivileged=dict(type='bool', default='no'),
+            description=dict(type='str'),
+            hookscript=dict(type='str'),
         )
     )
 
@@ -529,7 +538,9 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
-                            unprivileged=int(module.params['unprivileged']))
+                            unprivileged=int(module.params['unprivileged'],
+                            description=module.params['description'],
+                            hookscript=module.params['hookscript']))
 
             module.exit_json(changed=True, msg="deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
         except Exception as e:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -137,7 +137,8 @@ options:
   description:
     description:
       - Specify the description for the container. Only used on the configuration web interface.
-      - This is saved as comment inside the configuration file.
+      - This is saved as a comment inside the configuration file.
+    type: str
   hookscript:
     description:
       - Script that will be executed during various steps in the containers lifetime.


### PR DESCRIPTION
##### SUMMARY
adding missing options for the Proxmox LXC container.
 - hookscript
 - description

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox

##### ADDITIONAL INFORMATION
no big change only added 2 new parameters.
example:
```
- proxmox:
    vmid: 100
    node: uk-mc02
    api_user: root@pam
    api_password: 1q2w3e
    api_host: node1
    password: 123456
    hostname: example.org
    ostemplate: 'local:vztmpl/debian-10.0-standard_10.0-1_amd64.tar.gz'
    hookscript: 'local:snippets/vm_hook.sh'
    description: created with ansible
```
