### PR TITLE
parted: consider current partition state even in check_mode

### DIFF
--- a/changelogs/fragments/183-parted_check_mode.yml
+++ b/changelogs/fragments/183-parted_check_mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'parted: consider current partition state even in check mode'

--- a/changelogs/fragments/183-parted_check_mode.yml
+++ b/changelogs/fragments/183-parted_check_mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - 'parted: consider current partition state even in check mode'
+  - parted - consider current partition state even in check mode (https://github.com/ansible-collections/community.general/issues/183).

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -637,11 +637,13 @@ def main():
             changed = True
             script = ""
 
-            current_parts = get_device_info(device, unit)['partitions']
+            if not module.check_mode:
+                current_parts = get_device_info(device, unit)['partitions']
 
         if part_exists(current_parts, 'num', number) or module.check_mode:
-            partition = {'flags': []}      # Empty structure for the check-mode
-            if not module.check_mode:
+            if changed and module.check_mode:
+                partition = {'flags': []}   # Empty structure for the check-mode
+            else:
                 partition = [p for p in current_parts if p['num'] == number][0]
 
             # Assign name to the partition

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -88,6 +88,28 @@ parted_dict2 = {
     "partitions": []
 }
 
+# fake some_flag exists
+parted_dict3 = {
+    "generic": {
+        "dev": "/dev/sdb",
+        "size": 286061.0,
+        "unit": "mb",
+        "table": "msdos",
+        "model": "ATA TOSHIBA THNSFJ25",
+        "logical_block": 512,
+        "physical_block": 512
+    },
+    "partitions": [{
+        "num": 1,
+        "begin": 1.05,
+        "end": 106.0,
+        "size": 105.0,
+        "fstype": "fat32",
+        "name": '',
+        "flags": ["some_flag"],
+        "unit": "mb"
+    }]
+}
 
 class TestParted(ModuleTestCase):
     def setUp(self):
@@ -239,3 +261,29 @@ class TestParted(ModuleTestCase):
         })
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict2):
             self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
+
+    def test_check_mode_unchanged(self):
+        # Test that get_device_info result is checked in check mode too
+        # No change on partition 1
+        set_module_args({
+            'device': '/dev/sdb',
+            'number': 1,
+            'state': 'present',
+            'flags': ['some_flag'],
+            '_ansible_check_mode': True,
+        })
+        with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict3):
+            self.execute_module(changed=False)
+
+    def test_check_mode_changed(self):
+        # Test that get_device_info result is checked in check mode too
+        # Flag change on partition 1
+        set_module_args({
+            'device': '/dev/sdb',
+            'number': 1,
+            'state': 'present',
+            'flags': ['other_flag'],
+            '_ansible_check_mode': True,
+        })
+        with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict3):
+            self.execute_module(changed=True)

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -111,6 +111,7 @@ parted_dict3 = {
     }]
 }
 
+
 class TestParted(ModuleTestCase):
     def setUp(self):
         super(TestParted, self).setUp()


### PR DESCRIPTION
##### SUMMARY
Fixed check_mode to consider current partition state when label and partition was already created.

Fixes: #183 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION
