### PR TITLE
postgresql_info: fix invalid 'sample' value

### DIFF
--- a/plugins/modules/database/postgresql/postgresql_info.py
+++ b/plugins/modules/database/postgresql/postgresql_info.py
@@ -291,7 +291,7 @@ replications:
   returned: if pg_stat_replication view existent
   type: dict
   sample:
-  - { 76580: { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
+  - { "76580": { "app_name": "standby1", "backend_start": "2019-02-03 00:14:33.908593+03",
     "client_addr": "10.10.10.2", "client_hostname": "", "state": "streaming", "usename": "postgres" } }
   contains:
     usename:


### PR DESCRIPTION
##### SUMMARY
The `sample` value contains a dictionary with a non-string key. That's not a valid JSON value and cannot be returned by the module.

Found with ansible/ansible#69287.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
postgresql_info
