### PR TITLE
New merge lists plugin from a given key

### DIFF
--- a/plugins/lookup/mergelist.py
+++ b/plugins/lookup/mergelist.py
@@ -1,0 +1,75 @@
+# (c) 2020, Jose Angel Munoz <josea.munoz(at)gmail.com>
+# (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    lookup: mergelist
+    author: Jose Angel Munoz <josea.munoz@gmail.com>
+    short_description: merges lists from a given array key
+    description:
+      - This lookup returns the contents of two or more merged lists using a common key.
+    options:
+      _terms:
+        description: list(s) to merge
+        required: True
+    notes:
+      - if key is not defined, "name" will be the default
+      - use query if you want to return a list when a single value is given.
+'''
+
+EXAMPLES = """
+  - name: Merges list1 and list2 with 'name' as key
+    debug:
+      msg: "{{ query('community.general.mergelist', list1, list2) }}"
+    vars:
+      list1:
+        - name: myname01
+          param01: myparam01
+        - name: myname02
+          param01: myparam02
+      list2:
+        - name: myname01
+          param01: myparam03
+        - name: myname02
+          param02: myparam04
+        - name: myname03
+          param03: myparam03
+
+  - name: Merges list1 and list2 with 'id' as key
+    debug:
+      msg: "{{ query('community.general.mergelist', list1, list2, key='id') }}"
+"""
+
+RETURN = """
+  _list:
+    description:
+      - medged list with key and value
+"""
+
+from collections import defaultdict
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+
+        array = defaultdict(dict)
+        arraykey = "name"
+
+        for items in terms:
+
+            if isinstance(items, str):
+                arraykey = items
+
+            elif isinstance(items, list):
+                for item in items:
+                    try:
+                        array[item[arraykey]].update(item)
+                    except KeyError as exception:
+                        raise AnsibleError("Key not found: %s" % exception)
+            ret = list(array.values())
+
+        return ret

--- a/plugins/lookup/mergelist.py
+++ b/plugins/lookup/mergelist.py
@@ -7,13 +7,16 @@ __metaclass__ = type
 DOCUMENTATION = '''
     lookup: mergelist
     author: Jose Angel Munoz <josea.munoz@gmail.com>
-    short_description: merges lists from a given array key
+    short_description: Merges lists of dictionaries by a given key
     description:
-      - This lookup returns the contents of two or more merged lists using a common key.
+      - This lookup returns the contents of two or more merged lists of dictionaries using a common key.
     options:
       _terms:
-        description: list(s) to merge
+        description: List(s) to merge.
         required: True
+      key:
+        description: Common key used to merge.
+        required: False
     notes:
       - if key is not defined, "name" will be the default
       - use query if you want to return a list when a single value is given.
@@ -40,12 +43,45 @@ EXAMPLES = """
   - name: Merges list1 and list2 with 'id' as key
     debug:
       msg: "{{ query('community.general.mergelist', list1, list2, key='id') }}"
+    vars:
+      list1:
+        - id: myname01
+          param01: myparam01
+        - id: myname02
+          param01: myparam02
+      list2:
+        - id: myname01
+          param01: myparam03
+        - id: myname02
+          param02: myparam04
+        - id: myname03
+          param03: myparam03
+
+  - name: Merges list1, list2 and list3 with 'id' as key
+    debug:
+      msg: "{{ query('community.general.mergelist', list1, list2, list3, key='id') }}"
+    vars:
+      list1:
+        - id: myname01
+          param01: myparam01
+        - id: myname02
+          param01: myparam02
+      list2:
+        - id: myname01
+          param01: myparam03
+        - id: myname02
+          param02: myparam04
+        - id: myname03
+          param03: myparam03
+      list3:
+        - id: myname01
+          param03: myparam05
 """
 
 RETURN = """
   _list:
     description:
-      - medged list with key and value
+      - Medged list of dictionaries.
 """
 
 from collections import defaultdict
@@ -54,22 +90,17 @@ from ansible.errors import AnsibleError
 
 
 class LookupModule(LookupBase):
-    def run(self, terms, variables=None, **kwargs):
+    def run(self, terms, variables=None, key='name', **kwargs):
 
         array = defaultdict(dict)
-        arraykey = "name"
 
-        for items in terms:
-
-            if isinstance(items, str):
-                arraykey = items
-
-            elif isinstance(items, list):
-                for item in items:
-                    try:
-                        array[item[arraykey]].update(item)
-                    except KeyError as exception:
-                        raise AnsibleError("Key not found: %s" % exception)
-            ret = list(array.values())
-
-        return ret
+        for term in terms:
+            for item in term:
+                try:
+                    array[item[key]].update(item)
+                except KeyError as keyexception:
+                    raise AnsibleError("Key not found: %s" % keyexception)
+                except TypeError as errorexception:
+                    raise AnsibleError("Incorrect formatting: %s" %
+                                       errorexception)
+        return list(array.values())

--- a/tests/integration/targets/lookup_mergelist/aliases
+++ b/tests/integration/targets/lookup_mergelist/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group2
+skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_mergelist/aliases
+++ b/tests/integration/targets/lookup_mergelist/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group2
+shippable/posix/group3
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_mergelist/aliases
+++ b/tests/integration/targets/lookup_mergelist/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group3
+shippable/posix/group4
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_mergelist/tasks/main.yml
+++ b/tests/integration/targets/lookup_mergelist/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# lookup_mergelist integration tests
+# 2020, Jose Angel Munoz <josea.munoz@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Merges list1 and list2 with 'name' as key
+  set_fact:
+    mergedlists: "{{ lookup('community.general.mergelist', list1, list2) | sort(attribute='name') }}"
+  vars:
+    list1:
+      - name: myname01
+        param01: myparam01
+      - name: myname02
+        param01: myparam02
+    list2:
+      - name: myname01
+        param01: myparam03
+      - name: myname02
+        param02: myparam04
+      - name: myname03
+        param03: myparam03
+
+- name: Checks mergelist values
+  assert:
+    msg: unexpected mergelist values
+    that:
+      - mergedlists is iterable
+      - mergedlists | length() == 3
+      - mergedlists[0].name == "myname01"
+      - mergedlists[1].name == "myname02"
+      - mergedlists[2].name == "myname03"
+      - mergedlists[0].param01 == "myparam03"
+      - mergedlists[1].param01 == "myparam02"
+      - mergedlists[1].param02 == "myparam04"
+      - mergedlists[2].param03 == "myparam03"

--- a/tests/integration/targets/lookup_mergelist/tasks/main.yml
+++ b/tests/integration/targets/lookup_mergelist/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Merges list1 and list2 with 'name' as key
   set_fact:
-    mergedlists: "{{ lookup('community.general.mergelist', list1, list2) | sort(attribute='name') }}"
+    mergedlistbasic: "{{ lookup('community.general.mergelist', list1, list2) | sort(attribute='name') }}"
   vars:
     list1:
       - name: myname01
@@ -24,12 +24,85 @@
   assert:
     msg: unexpected mergelist values
     that:
-      - mergedlists is iterable
-      - mergedlists | length() == 3
-      - mergedlists[0].name == "myname01"
-      - mergedlists[1].name == "myname02"
-      - mergedlists[2].name == "myname03"
-      - mergedlists[0].param01 == "myparam03"
-      - mergedlists[1].param01 == "myparam02"
-      - mergedlists[1].param02 == "myparam04"
-      - mergedlists[2].param03 == "myparam03"
+      - mergedlistbasic is iterable
+      - mergedlistbasic | length() == 3
+      - mergedlistbasic[0].name == "myname01"
+      - mergedlistbasic[1].name == "myname02"
+      - mergedlistbasic[2].name == "myname03"
+      - mergedlistbasic[0].param01 == "myparam03"
+      - mergedlistbasic[1].param01 == "myparam02"
+      - mergedlistbasic[1].param02 == "myparam04"
+      - mergedlistbasic[2].param03 == "myparam03"
+
+- name: Merges list1 and list2 with 'id' as key
+  set_fact:
+    mergedlistkey: "{{ lookup('community.general.mergelist', list1, list2, key='id') | sort(attribute='id') }}"
+  vars:
+    list1:
+      - id: myname01
+        param01: myparam01
+      - id: myname02
+        param01: myparam02
+    list2:
+      - id: myname01
+        param01: myparam03
+      - id: myname02
+        param02: myparam04
+      - id: myname03
+        param03: myparam03
+
+- name: Checks mergelist values
+  assert:
+    msg: unexpected mergelist values
+    that:
+      - mergedlistkey is iterable
+      - mergedlistkey | length() == 3
+      - mergedlistkey[0].id == "myname01"
+      - mergedlistkey[1].id == "myname02"
+      - mergedlistkey[2].id == "myname03"
+      - mergedlistkey[0].param01 == "myparam03"
+      - mergedlistkey[1].param01 == "myparam02"
+      - mergedlistkey[1].param02 == "myparam04"
+      - mergedlistkey[2].param03 == "myparam03"
+
+- name: Merges list1, list2 and list3 with 'id' as key
+  set_fact:
+    mergedlistmulti: "{{ lookup('community.general.mergelist', list1, list2, list3, key='id') | sort(attribute='id') }}"
+  vars:
+    list1:
+      - id: myname01
+        param01: myparam01
+      - id: myname02
+        param01: myparam02
+    list2:
+      - id: myname01
+        param01: myparam03
+      - id: myname02
+        param02: myparam04
+      - id: myname03
+        param03: myparam03
+    list3:
+      - id: myname01
+        param01: myparam03
+        param03: myparam08
+      - id: myname02
+        param02: myparam04
+      - id: myname04
+        param03: myparam03
+
+- name: Checks mergelist values
+  assert:
+    msg: unexpected mergelist values
+    that:
+      - mergedlistmulti is iterable
+      - mergedlistmulti | length() == 4
+      - mergedlistmulti[0].id == "myname01"
+      - mergedlistmulti[1].id == "myname02"
+      - mergedlistmulti[2].id == "myname03"
+      - mergedlistmulti[3].id == "myname04"
+      - mergedlistmulti[0].param01 == "myparam03"
+      - mergedlistmulti[0].param03 == "myparam08"
+      - mergedlistmulti[1].param01 == "myparam02"
+      - mergedlistmulti[1].param02 == "myparam04"
+      - mergedlistmulti[2].param03 == "myparam03"
+      - mergedlistmulti[3].param03 == "myparam03"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #249 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mergelist

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When creating complex and long structures there are ways to merge or replace one to one dictionaries starting from their head. There is no a simple way to merge small fragments of different dictionaries from a given master key.

For instance: A keyvault ACL in Azure can be unreadable. To keep a consistency and merge new configurations and don't break the existing ones, something like this can be performed:

```yaml
q('mergelist',
       _keyvaultinfo.keyvaults[0].access_policies | default([]),
        keyvault_objectid.keyvaultsp | default([]) ) |
          json_query('[*].{
            tenant_id: tenant_id, 
            object_id: object_id,
            certificates: permissions.certificates,
            keys: permissions.keys,
            secrets: permissions.secrets
            }', 
           key='object_id')
```
Something like this without this plugin is not easily achievable.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Given two lists like:

```yaml
list1:
  - name: myname01
    param01: myparam01
  - name: myname02
    param01: myparam02

list2:
  - name: myname01
    param01: myparam03
  - name: myname02
    param02: myparam04
  - name: myname03
    param03: myparam03
```

When doing:

```yaml
"{{ query('mergelist', 'name', list1, list2) }}"
```

The results will be:

```yaml
  - name: myname01
    param01: myparam03
  - name: myname02
    param01: myparam02
    param02: myparam04
  - name: myname03
    param03: myparam03
```
