### PR TITLE
Fixed flatpak module to accept a list of names to install/uninstall

### DIFF
--- a/changelogs/fragments/267-flatpak-install-list.yaml
+++ b/changelogs/fragments/267-flatpak-install-list.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- flatpak - allow installing a list of packages (https://github.com/ansible/ansible/issues/41996).

--- a/plugins/modules/packaging/os/flatpak.py
+++ b/plugins/modules/packaging/os/flatpak.py
@@ -59,7 +59,8 @@ options:
     default: system
   name:
     description:
-    - The name of the flatpak to manage.
+    - The name of the flatpak to manage. To operate on several packages this
+      can accept a list of packages.
     - When used with I(state=present), I(name) can be specified as an C(http(s)) URL to a
       C(flatpakref) file or the unique reverse DNS name that identifies a flatpak.
     - When supplying a reverse DNS name, you can use the I(remote) option to specify on what remote
@@ -70,7 +71,8 @@ options:
       installed flatpak based on the name of the flatpakref to remove it. However, there is no
       guarantee that the names of the flatpakref file and the reverse DNS name of the installed
       flatpak do match.
-    type: str
+    type: list
+    elements: str
     required: true
   remote:
     description:
@@ -111,9 +113,24 @@ EXAMPLES = r'''
     state: present
     remote: gnome
 
+- name: Install multiple packages
+  flatpak:
+    name:
+      - org.gimp.GIMP
+      - org.inkscape.Inkscape
+      - org.mozilla.firefox
+
 - name: Remove the gedit flatpak
   flatpak:
     name: org.gnome.gedit
+    state: absent
+
+- name: Remove multiple packages
+  flatpak:
+    name:
+      - org.gimp.GIMP
+      - org.inkscape.Inkscape
+      - org.mozilla.firefox
     state: absent
 '''
 
@@ -151,34 +168,53 @@ from ansible.module_utils.basic import AnsibleModule
 OUTDATED_FLATPAK_VERSION_ERROR_MESSAGE = "Unknown option --columns=application"
 
 
-def install_flat(module, binary, remote, name, method):
+def install_flat(module, binary, remote, names, method):
     """Add a new flatpak."""
     global result
-    if name.startswith('http://') or name.startswith('https://'):
-        command = [binary, "install", "--{0}".format(method), "-y", name]
-    else:
-        command = [binary, "install", "--{0}".format(method), "-y", remote, name]
-    _flatpak_command(module, module.check_mode, command)
+    uri_names = []
+    id_names = []
+    for name in names:
+        if name.startswith('http://') or name.startswith('https://'):
+            uri_names.append(name)
+        else:
+            id_names.append(name)
+    if uri_names:
+        command = [binary, "install", "--{0}".format(method), "-y"]
+        command.extend(uri_names)
+        _flatpak_command(module, module.check_mode, command)
+    if id_names:
+        command = [binary, "install", "--{0}".format(method), "-y", remote]
+        command.extend(id_names)
+        _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
 
-def uninstall_flat(module, binary, name, method):
+def uninstall_flat(module, binary, names, method):
     """Remove an existing flatpak."""
     global result
-    installed_flat_name = _match_installed_flat_name(module, binary, name, method)
-    command = [binary, "uninstall", "--{0}".format(method), "-y", name]
+    installed_flat_names = [
+        _match_installed_flat_name(module, binary, name, method)
+        for name in names
+    ]
+    installed_flat_names = ' '.join(installed_flat_names)
+    command = "{0} uninstall -y --{1} {2}".format(binary, method, installed_flat_names)
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
 
-def flatpak_exists(module, binary, name, method):
+def flatpak_exists(module, binary, names, method):
     """Check if the flatpak is installed."""
     command = [binary, "list", "--{0}".format(method), "--app"]
     output = _flatpak_command(module, False, command)
-    name = _parse_flatpak_name(name).lower()
-    if name in output.lower():
-        return True
-    return False
+    installed = []
+    not_installed = []
+    for name in names:
+        name = _parse_flatpak_name(name).lower()
+        if name in output.lower():
+            installed.append(name)
+        else:
+            not_installed.append(name)
+    return installed, not_installed
 
 
 def _match_installed_flat_name(module, binary, name, method):
@@ -253,7 +289,7 @@ def main():
     # This module supports check mode
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='str', required=True),
+            name=dict(type='list', elements='str', required=True),
             remote=dict(type='str', default='flathub'),
             method=dict(type='str', default='system',
                         choices=['user', 'system']),
@@ -264,7 +300,7 @@ def main():
         supports_check_mode=True,
     )
 
-    name = module.params['name']
+    names = [name.strip() for name in module.params['name']]
     state = module.params['state']
     remote = module.params['remote']
     method = module.params['method']
@@ -280,10 +316,11 @@ def main():
     if not binary:
         module.fail_json(msg="Executable '%s' was not found on the system." % executable, **result)
 
-    if state == 'present' and not flatpak_exists(module, binary, name, method):
-        install_flat(module, binary, remote, name, method)
-    elif state == 'absent' and flatpak_exists(module, binary, name, method):
-        uninstall_flat(module, binary, name, method)
+    installed, not_installed = flatpak_exists(module, binary, names, method)
+    if state == 'present' and not_installed:
+        install_flat(module, binary, remote, not_installed, method)
+    elif state == 'absent' and installed:
+        uninstall_flat(module, binary, installed, method)
 
     module.exit_json(**result)
 

--- a/tests/integration/targets/flatpak/tasks/test.yml
+++ b/tests/integration/targets/flatpak/tasks/test.yml
@@ -113,3 +113,135 @@
     that:
       - "double_url_removal_result.changed == false"
     msg: "state=absent with url as name shall not do anything when flatpak is not present"
+
+# state=present with list of packages
+
+- name: Test addition with list - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+    remote: flathub
+    state: present
+    method: "{{ method }}"
+  register: addition_result
+
+- name: Verify addition with list test result - {{ method }}
+  assert:
+    that:
+      - "addition_result.changed == true"
+    msg: "state=present shall add flatpak when absent"
+
+- name: Test idempotency of addition with list - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+    remote: flathub
+    state: present
+    method: "{{ method }}"
+  register: double_addition_result
+
+- name: Verify idempotency of addition with list test result - {{ method }}
+  assert:
+    that:
+      - "double_addition_result.changed == false"
+    msg: "state=present shall not do anything when flatpak is already present"
+
+- name: Test addition with list partially installed - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+      - org.inkscape.Inkscape
+    remote: flathub
+    state: present
+    method: "{{ method }}"
+  register: addition_result
+
+- name: Verify addition with list partially installed test result - {{ method }}
+  assert:
+    that:
+      - "addition_result.changed == true"
+    msg: "state=present shall add flatpak when absent"
+
+- name: Test idempotency of addition with list partially installed - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+      - org.inkscape.Inkscape
+    remote: flathub
+    state: present
+    method: "{{ method }}"
+  register: double_addition_result
+
+- name: Verify idempotency of addition with list partially installed test result - {{ method }}
+  assert:
+    that:
+      - "double_addition_result.changed == false"
+    msg: "state=present shall not do anything when flatpak is already present"
+
+# state=absent with list of packages
+
+- name: Test removal with list - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+    state: absent
+    method: "{{ method }}"
+  register: removal_result
+
+- name: Verify removal with list test result - {{ method }}
+  assert:
+    that:
+      - "removal_result.changed == true"
+    msg: "state=absent shall remove flatpak when present"
+
+- name: Test idempotency of removal with list - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+    state: absent
+    method: "{{ method }}"
+  register: double_removal_result
+
+- name: Verify idempotency of removal with list test result - {{ method }}
+  assert:
+    that:
+      - "double_removal_result.changed == false"
+    msg: "state=absent shall not do anything when flatpak is not present"
+
+- name: Test removal with list partially removed - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+      - org.inkscape.Inkscape
+    state: absent
+    method: "{{ method }}"
+  register: removal_result
+
+- name: Verify removal with list partially removed test result - {{ method }}
+  assert:
+    that:
+      - "removal_result.changed == true"
+    msg: "state=absent shall remove flatpak when present"
+
+- name: Test idempotency of removal with list partially removed - {{ method }}
+  flatpak:
+    name:
+      - org.gnome.Characters
+      - https://flathub.org/repo/appstream/org.gnu.emacs.flatpakref
+      - org.inkscape.Inkscape
+    state: absent
+    method: "{{ method }}"
+  register: double_removal_result
+
+- name: Verify idempotency of removal with list partially removed test result - {{ method }}
+  assert:
+    that:
+      - "double_removal_result.changed == false"
+    msg: "state=absent shall not do anything when flatpak is not present"


### PR DESCRIPTION
##### SUMMARY

Fixes ansible/ansible#41996

To match consistency with other packaging modules, flatpak now accepts a
list packages to install or uninstall. This behavior is described in 2.7
porting guide under the heading "Using a loop on a package module via
squash_actions".

https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
flatpak