### PR TITLE
postgresql_lang: add trust_input parameter

### DIFF
--- a/changelogs/fragments/272-postgresql_lang_add_trust_input_parameter.yml
+++ b/changelogs/fragments/272-postgresql_lang_add_trust_input_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_lang - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/272).

--- a/tests/integration/targets/postgresql_lang/tasks/postgresql_lang_add_owner_param.yml
+++ b/tests/integration/targets/postgresql_lang/tasks/postgresql_lang_add_owner_param.yml
@@ -30,6 +30,7 @@
       <<: *pg_parameters
       name: '{{ test_lang }}'
       owner: '{{ test_user1 }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -57,11 +58,12 @@
       <<: *pg_parameters
       name: '{{ test_lang }}'
       owner: '{{ test_user1 }}'
+      trust_input: no
 
   - assert:
       that:
       - result is changed
-      - result.queries == ['CREATE LANGUAGE "{{ test_lang }}"', 'ALTER LANGUAGE "{{ test_lang }}" OWNER TO {{ test_user1 }}']
+      - result.queries == ['CREATE LANGUAGE "{{ test_lang }}"', 'ALTER LANGUAGE "{{ test_lang }}" OWNER TO "{{ test_user1 }}"']
 
   - name: Check
     <<: *task_parameters
@@ -83,12 +85,13 @@
       <<: *pg_parameters
       name: '{{ test_lang }}'
       owner: '{{ test_user2 }}'
+      trust_input: yes
     check_mode: yes
 
   - assert:
       that:
       - result is changed
-      - result.queries == ['ALTER LANGUAGE "{{ test_lang }}" OWNER TO {{ test_user2 }}']
+      - result.queries == ['ALTER LANGUAGE "{{ test_lang }}" OWNER TO "{{ test_user2 }}"']
 
   - name: Check that nothing was actually changed
     <<: *task_parameters
@@ -116,7 +119,7 @@
       - result is changed
       # TODO: the first elem of the returned list below
       # looks like a bug, not related with the option owner, needs to be checked
-      - result.queries == ["UPDATE pg_language SET lanpltrusted = false WHERE lanname = '{{ test_lang }}'", 'ALTER LANGUAGE "{{ test_lang }}" OWNER TO {{ test_user2 }}']
+      - result.queries == ["UPDATE pg_language SET lanpltrusted = false WHERE lanname = '{{ test_lang }}'", 'ALTER LANGUAGE "{{ test_lang }}" OWNER TO "{{ test_user2 }}"']
 
   - name: Check
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_lang:
- add trust_input parameter
- we can pass parameters where spec symbols are technically allowed

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_lang.py```