### PR TITLE
datadog_monitor: adds missing 'log alert' type to supported types

### DIFF
--- a/changelogs/fragments/277-datadog_monitor-adds-missing-log-alert-type.yml
+++ b/changelogs/fragments/277-datadog_monitor-adds-missing-log-alert-type.yml
@@ -1,2 +1,2 @@
-bugfix:
-    - datadog_monitor - Added missing ``log alert`` type to ``type`` choices. (https://github.com/ansible-collections/community.general/issues/251)
+bugfixes:
+    - datadog_monitor - added missing ``log alert`` type to ``type`` choices (https://github.com/ansible-collections/community.general/issues/251).

--- a/changelogs/fragments/277-datadog_monitor-adds-missing-log-alert-type.yml
+++ b/changelogs/fragments/277-datadog_monitor-adds-missing-log-alert-type.yml
@@ -1,0 +1,2 @@
+bugfix:
+    - datadog_monitor - Added missing ``log alert`` type to ``type`` choices. (https://github.com/ansible-collections/community.general/issues/251)

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -53,7 +53,7 @@ options:
     type:
         description:
           - The type of the monitor.
-        choices: ['metric alert', 'service check', 'event alert', 'process alert']
+        choices: ['metric alert', 'service check', 'event alert', 'process alert', 'log alert']
         type: str
     query:
         description:
@@ -204,7 +204,7 @@ def main():
             api_host=dict(required=False),
             app_key=dict(required=True, no_log=True),
             state=dict(required=True, choices=['present', 'absent', 'mute', 'unmute']),
-            type=dict(required=False, choices=['metric alert', 'service check', 'event alert', 'process alert']),
+            type=dict(required=False, choices=['metric alert', 'service check', 'event alert', 'process alert', 'log alert']),
             name=dict(required=True),
             query=dict(required=False),
             notification_message=dict(required=False, default=None, aliases=['message'], deprecated_aliases=[dict(name='message', version='2.14')]),


### PR DESCRIPTION
##### SUMMARY
Fixes #251

Adds missing `'log alert'` type supported by the datadog python module



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
datadog_monitor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before (using old code before process alert even):
```
"msg": "value of type must be one of: metric alert, service check, event alert, got: log alert"}
```

after:
```
  datadog_monitor:
      type: "log alert"
      ...
      query: "@msg:\"some log message\"\").index(\"main\").rollup(\"count\").last(\"10m\") >= 1"
```
creates the monitor (tested) and log output is nominal