### PR TITLE
zfs_delegate_admin: add diff,hold,release to list of permissions

### DIFF
--- a/changelogs/fragments/278-zfs_delegate_admin_add_diff_hold_release.yml
+++ b/changelogs/fragments/278-zfs_delegate_admin_add_diff_hold_release.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - zfs_delegate_admin - add missing choices diff/hold/release to the permissions parameter (https://github.com/ansible-collections/community.general/pull/278)

--- a/plugins/modules/storage/zfs/zfs_delegate_admin.py
+++ b/plugins/modules/storage/zfs/zfs_delegate_admin.py
@@ -54,7 +54,7 @@ options:
     description:
       - The list of permission(s) to delegate (required if C(state) is C(present)).
     type: list
-    choices: [ allow, clone, create, destroy, mount, promote, readonly, receive, rename, rollback, send, share, snapshot, unallow ]
+    choices: [ allow, clone, create, destroy, diff, hold, mount, promote, readonly, receive, release, rename, rollback, send, share, snapshot, unallow ]
   local:
     description:
       - Apply permissions to C(name) locally (C(zfs allow -l)).
@@ -250,8 +250,9 @@ def main():
             groups=dict(type='list'),
             everyone=dict(type='bool', default=False),
             permissions=dict(type='list',
-                             choices=['allow', 'clone', 'create', 'destroy', 'mount', 'promote', 'readonly', 'receive',
-                                      'rename', 'rollback', 'send', 'share', 'snapshot', 'unallow']),
+                             choices=['allow', 'clone', 'create', 'destroy', 'diff', 'hold', 'mount', 'promote',
+                                      'readonly', 'receive', 'release', 'rename', 'rollback', 'send', 'share',
+                                      'snapshot', 'unallow']),
             local=dict(type='bool'),
             descendents=dict(type='bool'),
             recursive=dict(type='bool', default=False),


### PR DESCRIPTION
Moved from https://github.com/ansible/ansible/pull/64562

##### SUMMARY
zfs_delegate_admin module has a whitelist of zfs permissions that it can manage. 'hold', 'release', and 'diff' are missing, so add them (in theory this list should also include all properties, but hold/release fix my immediate problem :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zfs_delegate_admin module