### PR TITLE
postgresql_publication: add trust_input and session_role parameters

### DIFF
--- a/changelogs/fragments/279-postgresql_publication_add_trust_input_session_role.yml
+++ b/changelogs/fragments/279-postgresql_publication_add_trust_input_session_role.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- postgresql_publication - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/279).
+- postgresql_publication - add the ``session_role`` parameter (https://github.com/ansible-collections/community.general/pull/279).

--- a/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
@@ -8,6 +8,7 @@
     test_table3: acme3
     test_pub: acme_publ
     test_role: alice
+    dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
     test_schema: acme_schema
     test_db: acme_db
     task_parameters: &task_parameters
@@ -178,6 +179,7 @@
       tables:
       - '{{ test_table1 }}'
       - '{{ test_schema }}.{{ test_table2 }}'
+      trust_input: yes
       parameters:
         publish: 'insert'
 
@@ -224,6 +226,22 @@
   - assert:
       that:
       - result.rowcount == 1
+
+  # Test
+  - name: postgresql_publication - test trust_input parameter
+    <<: *task_parameters
+    postgresql_publication: 
+      <<: *pg_parameters
+      name: '{{ test_pub }}'
+      session_role: '{{ dangerous_name }}'
+      owner: '{{ dangerous_name }}'
+      trust_input: no
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')
 
   # Test
   - name: postgresql_publication - add table to publication, change owner, check_mode


### PR DESCRIPTION
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_publication:
- add trust_input parameter
- add session_role parameter, i missed it creating the module:(

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_publication.py```