### PR TITLE
postgresql_subscription: add trust_input and session_role parameters

### DIFF
--- a/changelogs/fragments/280-postgresql_subscription_add_trust_input_session_role.yml
+++ b/changelogs/fragments/280-postgresql_subscription_add_trust_input_session_role.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- postgresql_subscription - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/280).
+- postgresql_subscription - add the ``session_role`` parameter (https://github.com/ansible-collections/community.general/pull/280).

--- a/plugins/modules/database/postgresql/postgresql_subscription.py
+++ b/plugins/modules/database/postgresql/postgresql_subscription.py
@@ -80,6 +80,18 @@ options:
       on U(https://www.postgresql.org/docs/current/sql-createsubscription.html).
     - Ignored when I(state) is not C(present).
     type: dict
+  session_role:
+    description:
+    - Switch to session_role after connecting. The specified session_role must
+      be a role that the current login_user is a member of.
+    - Permissions checking for SQL commands is carried out as though
+      the session_role were the one that had logged in originally.
+    type: str
+  trust_input:
+    description:
+    - If C(no), check whether values of some parameters are potentially dangerous.
+    type: bool
+    default: yes
 
 notes:
 - PostgreSQL version must be 10 or greater.
@@ -196,6 +208,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.general.plugins.module_utils.database import check_input
 from ansible_collections.community.general.plugins.module_utils.postgres import (
     connect_to_db,
     exec_sql,
@@ -581,6 +594,8 @@ def main():
         cascade=dict(type='bool', default=False),
         owner=dict(type='str'),
         subsparams=dict(type='dict'),
+        session_role=dict(type='str'),
+        trust_input=dict(type='bool', default=True),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -596,6 +611,23 @@ def main():
     owner = module.params['owner']
     subsparams = module.params['subsparams']
     connparams = module.params['connparams']
+    session_role = module.params['session_role']
+    trust_input = module.params['trust_input']
+
+    if not trust_input:
+        # Check input for potentially dangerous elements:
+        if not subsparams:
+            subsparams_str = None
+        else:
+            subsparams_str = convert_subscr_params(subsparams)
+
+        if not connparams:
+            connparams_str = None
+        else:
+            connparams_str = convert_conn_params(connparams)
+
+        check_input(module, name, publications, owner, session_role,
+                    connparams_str, subsparams_str)
 
     if state == 'present' and cascade:
         module.warn('parameter "cascade" is ignored when state is not absent')

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - vars:
+    dangerous_name: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
     task_parameters: &task_parameters
       become_user: '{{ pg_user }}'
       become: yes
@@ -242,6 +243,34 @@
   - assert:
       that:
       - result.rowcount == 1
+
+  ##########################
+  # Test trust_input param #
+  ##########################
+
+  - name: Test trust_input parameter
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications: '{{ test_pub }}'
+      session_role: '{{ dangerous_name }}'
+      owner: '{{ test_role1 }}'
+      trust_input: no
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')
 
   ##############
   # Test cascade


### PR DESCRIPTION
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_subscription:
- add trust_input parameter
- add session_role parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_subscription.py```