### PR TITLE
Add info command to redis module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.ansible-test-timeout.json
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -227,7 +227,6 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-.ansible-test-timeout.json
 
 # Translations
 *.mo

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -24,9 +24,8 @@ options:
             - C(config) (new in 1.6), ensures a configuration setting on an instance.
             - C(flush) flushes all the instance or a specified db.
             - C(slave) sets a redis instance in slave or master mode.
-            - C(info) returns information and statistics about the server.
         required: true
-        choices: [ config, flush, slave, info ]
+        choices: [ config, flush, slave ]
     login_password:
         description:
             - The password used to authenticate with (usually not used)
@@ -66,7 +65,6 @@ options:
             - A redis config value. When memory size is needed, it is possible
               to specify it in the usal form of 1KB, 2M, 400MB where the base is 1024.
               Units are case insensitive i.e. 1m = 1mb = 1M = 1MB.
-
 notes:
    - Requires the redis-py Python package on the remote host. You can
      install it with pip (pip install redis) or with a package manager.
@@ -74,6 +72,8 @@ notes:
    - If the redis master instance we are making slave of is password protected
      this needs to be in the redis.conf in the masterauth variable
 
+seealso:
+    - module: redis_info
 requirements: [ redis ]
 author: "Xabier Larrakoetxea (@slok)"
 '''
@@ -101,15 +101,6 @@ EXAMPLES = '''
     db: 1
     flush_mode: db
 
-- name: Get server information
-  redis:
-    command: info
-  register: result
-
-- name: Print server information
-  debug:
-    var: result.info
-
 - name: Configure local redis to have 10000 max clients
   redis:
     command: config
@@ -127,18 +118,6 @@ EXAMPLES = '''
     command: config
     name: lua-time-limit
     value: 100
-'''
-
-RETURN = '''
-info:
-  description: The default set of server information sections U(https://redis.io/commands/info).
-  returned: success
-  type: dict
-  sample: {"arch_bits": 64, "atomicvar_api": "atomic-builtin", "config_file": "", "configured_hz": 10,
-    "executable": "/data/redis-server", "gcc_version": "8.3.0", "lru_clock": 11603906, "multiplexing_api": "epoll",
-    "os": "Linux 3.10.0-1062.12.1.el7.x86_64", "process_id": 1, "redis_build_id": "4d072dc1c62d5672",
-    "redis_git_dirty": 0, "redis_git_sha1": 0, "redis_mode": "standalone", "redis_version": "999.999.999",
-    "run_id": "8d252f66c3ef89bd60a060cf8dc5cfe3d511c5e4", "tcp_port": 6379, "uptime_in_days": 53, "uptime_in_seconds": 4631778}
 '''
 
 import traceback
@@ -187,7 +166,7 @@ def flush(client, db=None):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            command=dict(type='str', choices=['config', 'flush', 'slave', 'info']),
+            command=dict(type='str', choices=['config', 'flush', 'slave']),
             login_password=dict(type='str', no_log=True),
             login_host=dict(type='str', default='localhost'),
             login_port=dict(type='int', default=6379),
@@ -297,8 +276,6 @@ def main():
                 module.exit_json(changed=True, flushed=True, db=db)
             else:  # Flush never fails :)
                 module.fail_json(msg="Unable to flush '%d' database" % db)
-
-    # Config Command section -----------
     elif command == 'config':
         name = module.params['name']
 
@@ -328,18 +305,6 @@ def main():
             except Exception as e:
                 module.fail_json(msg="unable to write config: %s" % to_native(e), exception=traceback.format_exc())
             module.exit_json(changed=changed, name=name, value=value)
-
-    # Info Command section -----------
-    elif command == "info":
-        # Connect and check
-        r = redis.StrictRedis(host=login_host, port=login_port, password=login_password)
-        try:
-            r.ping()
-        except Exception as e:
-            module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
-
-        info = r.info()
-        module.exit_json(changed=False, info=info)
     else:
         module.fail_json(msg='A valid command must be provided')
 

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -129,7 +129,7 @@ EXAMPLES = '''
     value: 100
 '''
 
-RETURN='''
+RETURN = '''
 info:
   description: The default set of server information sections U(https://redis.io/commands/info).
   returned: success

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -65,6 +65,7 @@ options:
             - A redis config value. When memory size is needed, it is possible
               to specify it in the usal form of 1KB, 2M, 400MB where the base is 1024.
               Units are case insensitive i.e. 1m = 1mb = 1M = 1MB.
+
 notes:
    - Requires the redis-py Python package on the remote host. You can
      install it with pip (pip install redis) or with a package manager.

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -28,12 +28,12 @@ options:
     default: localhost
   login_port:
     description:
-    - The port to connect to
+    - The port to connect to.
     type: int
     default: 6379
   login_password:
     description:
-    - The password used to authenticate with (usually not used)
+    - The password used to authenticate with, when authentication is enabled for the Redis server.
     type: str
 notes:
 - Requires the redis-py Python package on the remote host. You can

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: redis_info
+short_description: Gather information about Redis servers
+description:
+- Gathers information and statistics about Redis servers.
+options:
+  login_host:
+    description:
+    - The host running the database
+    default: localhost
+  login_port:
+    description:
+    - The port to connect to
+    default: 6379
+  login_password:
+    description:
+    - The password used to authenticate with (usually not used)
+notes:
+- Requires the redis-py Python package on the remote host. You can
+  install it with pip (pip install redis) or with a package manager.
+  U(https://github.com/andymccurdy/redis-py)
+seealso:
+- module: redis
+requirements: [ redis ]
+author: "Pavlo Bashynskyi (@levonet)"
+'''
+
+EXAMPLES = r'''
+- name: Get server information
+  redis_info:
+  register: result
+
+- name: Print server information
+  debug:
+    var: result.info
+'''
+
+RETURN = r'''
+info:
+  description: The default set of server information sections U(https://redis.io/commands/info).
+  returned: success
+  type: dict
+  sample: {
+      "active_defrag_hits": 0,
+      "active_defrag_key_hits": 0,
+      "active_defrag_key_misses": 0,
+      "active_defrag_misses": 0,
+      "active_defrag_running": 0,
+      "allocator_active": 932409344,
+      "allocator_allocated": 932062792,
+      "allocator_frag_bytes": 346552,
+      "allocator_frag_ratio": 1.0,
+      "allocator_resident": 947253248,
+      "allocator_rss_bytes": 14843904,
+      "allocator_rss_ratio": 1.02,
+      "aof_current_rewrite_time_sec": -1,
+      "aof_enabled": 0,
+      "aof_last_bgrewrite_status": "ok",
+      "aof_last_cow_size": 0,
+      "aof_last_rewrite_time_sec": -1,
+      "aof_last_write_status": "ok",
+      "aof_rewrite_in_progress": 0,
+      "aof_rewrite_scheduled": 0,
+      "arch_bits": 64,
+      "atomicvar_api": "atomic-builtin",
+      "blocked_clients": 0,
+      "client_recent_max_input_buffer": 4,
+      "client_recent_max_output_buffer": 0,
+      "cluster_enabled": 0,
+      "config_file": "",
+      "configured_hz": 10,
+      "connected_clients": 4,
+      "connected_slaves": 0,
+      "db0": {
+        "avg_ttl": 1945628530,
+        "expires": 16,
+        "keys": 3341411
+      },
+      "evicted_keys": 0,
+      "executable": "/data/redis-server",
+      "expired_keys": 9,
+      "expired_stale_perc": 1.72,
+      "expired_time_cap_reached_count": 0,
+      "gcc_version": "9.2.0",
+      "hz": 10,
+      "instantaneous_input_kbps": 0.0,
+      "instantaneous_ops_per_sec": 0,
+      "instantaneous_output_kbps": 0.0,
+      "keyspace_hits": 0,
+      "keyspace_misses": 0,
+      "latest_fork_usec": 0,
+      "lazyfree_pending_objects": 0,
+      "loading": 0,
+      "lru_clock": 11603632,
+      "master_repl_offset": 118831417,
+      "master_replid": "0d904704e424e38c3cd896783e9f9d28d4836e5e",
+      "master_replid2": "0000000000000000000000000000000000000000",
+      "maxmemory": 0,
+      "maxmemory_human": "0B",
+      "maxmemory_policy": "noeviction",
+      "mem_allocator": "jemalloc-5.1.0",
+      "mem_aof_buffer": 0,
+      "mem_clients_normal": 49694,
+      "mem_clients_slaves": 0,
+      "mem_fragmentation_bytes": 12355480,
+      "mem_fragmentation_ratio": 1.01,
+      "mem_not_counted_for_evict": 0,
+      "mem_replication_backlog": 1048576,
+      "migrate_cached_sockets": 0,
+      "multiplexing_api": "epoll",
+      "number_of_cached_scripts": 0,
+      "os": "Linux 3.10.0-862.14.4.el7.x86_64 x86_64",
+      "process_id": 1,
+      "pubsub_channels": 0,
+      "pubsub_patterns": 0,
+      "rdb_bgsave_in_progress": 0,
+      "rdb_changes_since_last_save": 671,
+      "rdb_current_bgsave_time_sec": -1,
+      "rdb_last_bgsave_status": "ok",
+      "rdb_last_bgsave_time_sec": -1,
+      "rdb_last_cow_size": 0,
+      "rdb_last_save_time": 1588702236,
+      "redis_build_id": "a31260535f820267",
+      "redis_git_dirty": 0,
+      "redis_git_sha1": 0,
+      "redis_mode": "standalone",
+      "redis_version": "999.999.999",
+      "rejected_connections": 0,
+      "repl_backlog_active": 1,
+      "repl_backlog_first_byte_offset": 118707937,
+      "repl_backlog_histlen": 123481,
+      "repl_backlog_size": 1048576,
+      "role": "master",
+      "rss_overhead_bytes": -3051520,
+      "rss_overhead_ratio": 1.0,
+      "run_id": "8d252f66c3ef89bd60a060cf8dc5cfe3d511c5e4",
+      "second_repl_offset": 118830003,
+      "slave_expires_tracked_keys": 0,
+      "sync_full": 0,
+      "sync_partial_err": 0,
+      "sync_partial_ok": 0,
+      "tcp_port": 6379,
+      "total_commands_processed": 885,
+      "total_connections_received": 10,
+      "total_net_input_bytes": 802709255,
+      "total_net_output_bytes": 31754,
+      "total_system_memory": 135029538816,
+      "total_system_memory_human": "125.76G",
+      "uptime_in_days": 53,
+      "uptime_in_seconds": 4631778,
+      "used_cpu_sys": 4.668282,
+      "used_cpu_sys_children": 0.002191,
+      "used_cpu_user": 4.21088,
+      "used_cpu_user_children": 0.0,
+      "used_memory": 931908760,
+      "used_memory_dataset": 910774306,
+      "used_memory_dataset_perc": "97.82%",
+      "used_memory_human": "888.74M",
+      "used_memory_lua": 37888,
+      "used_memory_lua_human": "37.00K",
+      "used_memory_overhead": 21134454,
+      "used_memory_peak": 932015216,
+      "used_memory_peak_human": "888.84M",
+      "used_memory_peak_perc": "99.99%",
+      "used_memory_rss": 944201728,
+      "used_memory_rss_human": "900.46M",
+      "used_memory_scripts": 0,
+      "used_memory_scripts_human": "0B",
+      "used_memory_startup": 791264
+    }
+'''
+
+import traceback
+
+REDIS_IMP_ERR = None
+try:
+    import redis
+except ImportError:
+    REDIS_IMP_ERR = traceback.format_exc()
+    redis_found = False
+else:
+    redis_found = True
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils._text import to_native
+
+# Module execution.
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            login_host=dict(type='str', default='localhost'),
+            login_port=dict(type='int', default=6379),
+            login_password=dict(type='str', no_log=True)
+        ),
+        supports_check_mode=True,
+    )
+
+    if not redis_found:
+        module.fail_json(msg=missing_required_lib('redis'), exception=REDIS_IMP_ERR)
+
+    login_host = module.params['login_host']
+    login_port = module.params['login_port']
+    login_password = module.params['login_password']
+
+    # Connect and check
+    r = redis.StrictRedis(host=login_host, port=login_port, password=login_password)
+    try:
+        r.ping()
+    except Exception as e:
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
+
+    info = r.info()
+    module.exit_json(changed=False, info=info)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -23,14 +23,17 @@ options:
   login_host:
     description:
     - The host running the database
+    type: str
     default: localhost
   login_port:
     description:
     - The port to connect to
+    type: int
     default: 6379
   login_password:
     description:
     - The password used to authenticate with (usually not used)
+    type: str
 notes:
 - Requires the redis-py Python package on the remote host. You can
   install it with pip (pip install redis) or with a package manager.
@@ -199,6 +202,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
+
 
 # Module execution.
 def main():

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2020, Pavlo Bashynskyi
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/redis_info.py
+++ b/plugins/modules/redis_info.py
@@ -1,0 +1,1 @@
+./database/misc/redis_info.py

--- a/tests/integration/targets/redis_info/aliases
+++ b/tests/integration/targets/redis_info/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/redis_info/aliases
+++ b/tests/integration/targets/redis_info/aliases
@@ -2,5 +2,5 @@ destructive
 shippable/posix/group1
 skip/aix
 skip/osx
-skip/freebsd
 skip/rhel
+skip/python2.6 # installing redis python module will fail on python < 2.7

--- a/tests/integration/targets/redis_info/aliases
+++ b/tests/integration/targets/redis_info/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/aix
 skip/osx
 skip/rhel
-skip/python2.6 # installing redis python module will fail on python < 2.7

--- a/tests/integration/targets/redis_info/defaults/main.yml
+++ b/tests/integration/targets/redis_info/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+redis_password: PASS
+master_port: 6379
+slave_port: 6380

--- a/tests/integration/targets/redis_info/meta/main.yml
+++ b/tests/integration/targets/redis_info/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_redis_replication

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -13,11 +13,12 @@
     - result.info.tcp_port == master_port
     - result.info.role == 'master'
 
-- name: redis_info - connect to master with all parameters
+- name: redis_info - connect to master (check)
   community.general.redis_info:
     login_host: 127.0.0.1
     login_port: "{{ master_port }}"
     login_password: "{{ redis_password }}"
+  check_mode: yes
   register: result
 
 - assert:

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -1,0 +1,41 @@
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: redis_info - connect to master with default host/port
+  community.general.redis_info:
+    login_password: "{{ redis_password }}"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.info is defined
+    - result.info.tcp_port == master_port
+    - result.info.role == 'master'
+
+- name: redis_info - connect to master with all parameters
+  community.general.redis_info:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    login_password: "{{ redis_password }}"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.info is defined
+    - result.info.tcp_port == master_port
+    - result.info.role == 'master'
+
+- name: redis_info - connect to slave
+  community.general.redis_info:
+    login_port: "{{ slave_port }}"
+    login_password: "{{ redis_password }}"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.info is defined
+    - result.info.tcp_port == slave_port
+    - result.info.role == 'slave'

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: redis_info - connect to master with default host/port

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -1,4 +1,23 @@
 # General
+redis_packages:
+  Ubuntu:
+  - redis-server
+  openSUSE Leap:
+  - redis
+  Fedora:
+  - redis
+  CentOS:
+  - redis
+  FreeBSD:
+  - redis
+
+redis_bin:
+  Ubuntu: /usr/bin/redis-server
+  openSUSE Leap: /usr/sbin/redis-server
+  Fedora: /usr/bin/redis-server
+  CentOS: /usr/bin/redis-server
+  FreeBSD: /usr/local/bin/redis-server
+
 redis_password: PASS
 
 # Master

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -18,6 +18,8 @@ redis_bin:
   CentOS: /usr/bin/redis-server
   FreeBSD: /usr/local/bin/redis-server
 
+redis_module: "{{ (ansible_python_version is version('2.7', '>=')) | ternary('redis', 'redis==2.10.6') }}"
+
 redis_password: PASS
 
 # Master

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -1,0 +1,14 @@
+# General
+redis_password: PASS
+
+# Master
+master_port: 6379
+master_conf: /etc/redis-master.conf
+master_datadir: /var/lib/redis-master
+master_logdir: /var/log/redis-master
+
+# Slave
+slave_port: 6380
+slave_conf: /etc/redis-slave.conf
+slave_datadir: /var/lib/redis-slave
+slave_logdir: /var/log/redis-slave

--- a/tests/integration/targets/setup_redis_replication/handlers/main.yml
+++ b/tests/integration/targets/setup_redis_replication/handlers/main.yml
@@ -1,0 +1,34 @@
+- name: stop redis services
+  shell: |
+    kill -TERM $(cat /var/run/redis_{{ master_port }}.pid)
+    kill -TERM $(cat /var/run/redis_{{ slave_port }}.pid)
+  listen: cleanup redis
+
+- name: remove redis packages
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ redis_packages[ansible_distribution] }}"
+  listen: cleanup redis
+
+- name: remove pip packages
+  pip:
+    name: redis
+    state: absent
+  listen: cleanup redis
+
+- name: remove redis data
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+  - "{{ master_conf }}"
+  - "{{ master_datadir }}"
+  - "{{ master_logdir }}"
+  - /var/run/redis_{{ master_port }}.pid
+  - "{{ slave_conf }}"
+  - "{{ slave_datadir }}"
+  - "{{ slave_logdir }}"
+  - /var/run/redis_{{ slave_port }}.pid
+  listen: cleanup redis

--- a/tests/integration/targets/setup_redis_replication/meta/main.yml
+++ b/tests/integration/targets/setup_redis_replication/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_pkg_mgr

--- a/tests/integration/targets/setup_redis_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/main.yml
@@ -1,0 +1,8 @@
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Setup Redis master-slave replication into one container:
+- import_tasks: setup_redis_cluster.yml
+  when:
+  - ansible_distribution == 'Ubuntu'
+  - ansible_distribution_major_version >= '18'

--- a/tests/integration/targets/setup_redis_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - import_tasks: setup_redis_cluster.yml

--- a/tests/integration/targets/setup_redis_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/main.yml
@@ -1,8 +1,6 @@
 # Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Setup Redis master-slave replication into one container:
 - import_tasks: setup_redis_cluster.yml
   when:
-  - ansible_distribution == 'Ubuntu'
-  - ansible_distribution_major_version >= '18'
+  - ansible_distribution in ['CentOS', 'Fedora', 'FreeBSD', 'openSUSE Leap', 'Ubuntu']

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -1,0 +1,70 @@
+# We run two servers listening different ports
+# to be able to check replication (one server for master, another for slave).
+
+- name: Install redis server
+  apt:
+    name: redis-server
+    state: present
+    policy_rc_d: 101
+
+- name: Install redis module
+  pip:
+    state: present
+    name: redis
+
+- name: Create redis directories
+  file:                                                                                                                                                                                                 
+    path: "{{ item }}"
+    state: directory                                                                                                                                                                                    
+    owner: redis
+    group: redis
+  loop:
+  - "{{ master_datadir }}"
+  - "{{ master_logdir }}"
+  - "{{ slave_datadir }}"
+  - "{{ slave_logdir }}"
+
+- name: Create redis configs
+  copy:
+    dest: "{{ item.file }}"
+    content: |
+      daemonize yes
+      port {{ item.port }}
+      pidfile /var/run/redis_{{ item.port }}.pid
+      logfile {{ item.logdir }}/redis.log
+      dir {{ item.datadir }}
+      requirepass {{ redis_password }}
+      masterauth {{ redis_password }}
+  loop:
+  - file: "{{ master_conf }}"
+    port: "{{ master_port }}"
+    logdir: "{{ master_logdir }}"
+    datadir: "{{ master_datadir }}"
+  - file: "{{ slave_conf }}"
+    port: "{{ slave_port }}"
+    logdir: "{{ slave_logdir }}"
+    datadir: "{{ slave_datadir }}"
+
+- name: Start redis master
+  shell: /usr/bin/redis-server {{ master_conf }}
+
+- name: Start redis slave
+  shell: /usr/bin/redis-server {{ slave_conf }} --slaveof 127.0.0.1 {{ master_port }}
+
+- name: Wait for redis master to be started
+  wait_for:
+    host: 127.0.0.1
+    port: "{{ master_port }}"
+    state: started
+    delay: 1
+    connect_timeout: 5
+    timeout: 30
+
+- name: Wait for redis slave to be started
+  wait_for:
+    host: 127.0.0.1
+    port: "{{ slave_port }}"
+    state: started
+    delay: 1
+    connect_timeout: 5
+    timeout: 30

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -1,16 +1,51 @@
 # We run two servers listening different ports
 # to be able to check replication (one server for master, another for slave).
 
-- name: Install redis server
+- name: Install redis server apt dependencies
   apt:
-    name: redis-server
-    state: present
+    name: "{{ redis_packages[ansible_distribution] }}"
+    state: latest
     policy_rc_d: 101
+  when:
+  - ansible_facts.pkg_mgr == 'apt'
+  notify: cleanup redis
+
+- name: Install redis server rpm dependencies
+  yum:
+    name: "{{ redis_packages[ansible_distribution] }}"
+    state: latest
+  when:
+  - ansible_facts.pkg_mgr == 'yum'
+  notify: cleanup redis
+
+- name: Install redis rpm dependencies
+  dnf:
+    name: "{{ redis_packages[ansible_distribution] }}"
+    state: latest
+  when: ansible_facts.pkg_mgr == 'dnf'
+  notify: cleanup redis
+
+- name: Install redis server zypper dependencies
+  zypper:
+    name: "{{ redis_packages[ansible_distribution] }}"
+    state: latest
+  when:
+  - ansible_facts.pkg_mgr == 'community.general.zypper'
+  notify: cleanup redis
+
+- name: Install redis FreeBSD dependencies
+  community.general.pkgng:
+    name: "{{ redis_packages[ansible_distribution] }}"
+    state: latest
+  when:
+  - ansible_facts.pkg_mgr == 'community.general.pkgng'
+  notify: cleanup redis
 
 - name: Install redis module
   pip:
     state: present
     name: redis
+  notify: cleanup redis
 
 - name: Create redis directories
   file:                                                                                                                                                                                                 
@@ -46,10 +81,10 @@
     datadir: "{{ slave_datadir }}"
 
 - name: Start redis master
-  shell: /usr/bin/redis-server {{ master_conf }}
+  shell: "{{ redis_bin[ansible_distribution] }} {{ master_conf }}"
 
 - name: Start redis slave
-  shell: /usr/bin/redis-server {{ slave_conf }} --slaveof 127.0.0.1 {{ master_port }}
+  shell: "{{ redis_bin[ansible_distribution] }} {{ slave_conf }} --slaveof 127.0.0.1 {{ master_port }}"
 
 - name: Wait for redis master to be started
   wait_for:

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -43,8 +43,8 @@
 
 - name: Install redis module
   pip:
+    name: "{{ redis_module }}"
     state: present
-    name: redis
   notify: cleanup redis
 
 - name: Create redis directories

--- a/tests/unit/plugins/modules/database/misc/test_redis_info.py
+++ b/tests/unit/plugins/modules/database/misc/test_redis_info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2020, Pavlo Bashynskyi
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -33,7 +33,7 @@ class TestRedisInfoModule(ModuleTestCase):
 
     def setUp(self):
         super(TestRedisInfoModule, self).setUp()
-        redis_info.REDIS_FOUND = True
+        redis_info.HAS_REDIS_PACKAGE = True
         self.module = redis_info
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/database/misc/test_redis_info.py
+++ b/tests/unit/plugins/modules/database/misc/test_redis_info.py
@@ -39,9 +39,12 @@ class TestRedisInfoModule(ModuleTestCase):
     def tearDown(self):
         super(TestRedisInfoModule, self).tearDown()
 
+    def patch_redis_client(self, **kwds):
+        return patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, **kwds)
+
     def test_without_parameters(self):
         """Test without parameters"""
-        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClient) as redis_client:
+        with self.patch_redis_client(side_effect=FakeRedisClient) as redis_client:
             with self.assertRaises(AnsibleExitJson) as result:
                 set_module_args({})
                 self.module.main()
@@ -51,7 +54,7 @@ class TestRedisInfoModule(ModuleTestCase):
 
     def test_with_parameters(self):
         """Test with all parameters"""
-        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClient) as redis_client:
+        with self.patch_redis_client(side_effect=FakeRedisClient) as redis_client:
             with self.assertRaises(AnsibleExitJson) as result:
                 set_module_args({
                     'login_host': 'test',
@@ -65,7 +68,7 @@ class TestRedisInfoModule(ModuleTestCase):
 
     def test_with_fail_client(self):
         """Test failure message"""
-        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClientFail) as redis_client:
+        with self.patch_redis_client(side_effect=FakeRedisClientFail) as redis_client:
             with self.assertRaises(AnsibleFailJson) as result:
                 set_module_args({})
                 self.module.main()

--- a/tests/unit/plugins/modules/database/misc/test_redis_info.py
+++ b/tests/unit/plugins/modules/database/misc/test_redis_info.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Pavlo Bashynskyi
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.community.general.plugins.modules.database.misc import redis_info
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class FakeRedisClient(MagicMock):
+
+    def ping(self):
+        pass
+
+    def info(self):
+        return {'redis_version': '999.999.999'}
+
+
+class FakeRedisClientFail(MagicMock):
+
+    def ping(self):
+        raise Exception('Test Error')
+
+    def info(self):
+        pass
+
+
+class TestRedisInfoModule(ModuleTestCase):
+
+    def setUp(self):
+        super(TestRedisInfoModule, self).setUp()
+        redis_info.REDIS_FOUND = True
+        self.module = redis_info
+
+    def tearDown(self):
+        super(TestRedisInfoModule, self).tearDown()
+
+    def test_without_parameters(self):
+        """Test without parameters"""
+        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClient) as redis_client:
+            with self.assertRaises(AnsibleExitJson) as result:
+                set_module_args({})
+                self.module.main()
+            self.assertEqual(redis_client.call_count, 1)
+            self.assertEqual(redis_client.call_args, ({'host': 'localhost', 'port': 6379, 'password': None},))
+            self.assertEqual(result.exception.args[0]['info']['redis_version'], '999.999.999')
+
+    def test_with_parameters(self):
+        """Test with all parameters"""
+        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClient) as redis_client:
+            with self.assertRaises(AnsibleExitJson) as result:
+                set_module_args({
+                    'login_host': 'test',
+                    'login_port': 1234,
+                    'login_password': 'PASS'
+                })
+                self.module.main()
+            self.assertEqual(redis_client.call_count, 1)
+            self.assertEqual(redis_client.call_args, ({'host': 'test', 'port': 1234, 'password': 'PASS'},))
+            self.assertEqual(result.exception.args[0]['info']['redis_version'], '999.999.999')
+
+    def test_with_fail_client(self):
+        """Test failure message"""
+        with patch('ansible_collections.community.general.plugins.modules.database.misc.redis_info.redis_client', autospec=True, side_effect=FakeRedisClientFail) as redis_client:
+            with self.assertRaises(AnsibleFailJson) as result:
+                set_module_args({})
+                self.module.main()
+            self.assertEqual(redis_client.call_count, 1)
+            self.assertEqual(result.exception.args[0]['msg'], 'unable to connect to database: Test Error')

--- a/tests/unit/plugins/modules/database/misc/test_redis_info.py
+++ b/tests/unit/plugins/modules/database/misc/test_redis_info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet)
+# Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a new command `info` to retrieve information and statistics about the Redis server.
This will be useful for getting server status.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

In my case, I use Redis server information to data migration between old and new versions of environment. Example:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
  - name: "start_redis : Activate slave mode"
    redis:
      login_host: "{{ project_redis_host }}"
      login_port: "{{ project_redis_port }}"
      command: slave
      master_host: "{{ _project_redis_source_address }}"
      master_port: "{{ _project_redis_source_port }}"

  - name: "start_redis : Wait to sync to be done"
    redis:
      command: info
      login_host: "{{ project_redis_host }}"
      login_port: "{{ project_redis_port }}"
    register: _result
    until: (_result.info.master_link_status | default('down')) == 'up'
    retries: 150
    delay: 1

  - name: "start_redis : Deactivate slave mode"
    redis:
      login_host: "{{ project_redis_host }}"
      login_port: "{{ project_redis_port }}"
      command: slave
      slave_mode: master
```
