### PR TITLE
hashi_vault: restore compatibility with <=v2.9

### DIFF
--- a/changelogs/fragments/64288-fix-hashi-vault-kv-v2.yaml
+++ b/changelogs/fragments/64288-fix-hashi-vault-kv-v2.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "hashi_vault - Fix KV v2 lookup to always return latest version"
+- "hashi_vault - added support for returning a specific field from KV v2 secrets"

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
@@ -1,45 +1,45 @@
 - vars:
-    role_id: '{{ role_id_cmd.stdout }}'
-    secret_id: '{{ secret_id_cmd.stdout }}'
+    role_id: "{{ role_id_cmd.stdout }}"
+    secret_id: "{{ secret_id_cmd.stdout }}"
   block:
-    - name: 'Fetch secrets using "hashi_vault" lookup'
+    - name: Fetch secrets using "hashi_vault" lookup
       set_fact:
-        secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
-        secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1:value auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2:value auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
 
-    - name: 'Check secret values'
-      fail:
-        msg: 'unexpected secret values'
-      when: secret1['value'] != 'foo1' or secret2['value'] != 'foo2'
+    - name: Check secret values
+      assert:
+        that:
+          - secret1 == 'foo1'
+          - secret2 == 'foo2'
 
-    - name: 'Failure expected when erroneous credentials are used'
+    - name: Failure expected when erroneous credentials are used
       vars:
         secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=toto role_id=' ~ role_id) }}"
       debug:
-        msg: 'Failure is expected ({{ secret_wrong_cred }})'
+        msg: Failure is expected ({{ secret_wrong_cred }})
       register: test_wrong_cred
       ignore_errors: true
 
-    - name: 'Failure expected when unauthorized secret is read'
+    - name: Failure expected when unauthorized secret is read
       vars:
         secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret3 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
-        msg: 'Failure is expected ({{ secret_unauthorized }})'
+        msg: Failure is expected ({{ secret_unauthorized }})
       register: test_unauthorized
       ignore_errors: true
 
-    - name: 'Failure expected when inexistent secret is read'
+    - name: Failure expected when nonexistent secret is read
       vars:
-          secret_inexistent: "{{ lookup('community.general.:qhashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+          secret_nonexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
-        msg: 'Failure is expected ({{ secret_inexistent }})'
-      register: test_inexistent
+        msg: Failure is expected ({{ secret_nonexistent }})
+      register: test_nonexistent
       ignore_errors: true
 
-    - name: 'Check expected failures'
+    - name: Check expected failures
       assert:
-        msg: "an expected failure didn't occur"
         that:
           - test_wrong_cred is failed
           - test_unauthorized is failed
-          - test_inexistent is failed
+          - test_nonexistent is failed

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -103,6 +103,9 @@
                   path "{{ vault_kv1_path }}/secret3" {
                     capabilities = ["deny"]
                   }
+                  path "{{ vault_kv1_path }}/secrets" {
+                    capabilities = ["read"]
+                  }
                   path "{{ vault_kv2_path }}/secret1" {
                     capabilities = ["read"]
                   }
@@ -116,19 +119,22 @@
                     capabilities = ["read"]
                   }
 
-            - name: 'Create generic secrets'
+            - name: Create generic secrets
               command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
 
-            - name: 'Create KV v1 secrets'
+            - name: Create KV v1 secrets
               command: '{{ vault_cmd }} kv put {{ vault_kv1_path }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
 
-            - name: 'Create KV v2 secrets'
+            - name: Create a KV v1 secret with multiple fields
+              command: '{{ vault_cmd }} kv put {{ vault_kv1_path }}/secrets value1=foo1 value2=foo2 value3=foo3'
+
+            - name: Create KV v2 secrets
               command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
 
-            - name: 'Create multiple KV v2 secrets under one path'
+            - name: Create a KV v2 secret with multiple fields
               command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'
 
             - name: setup approle auth

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -1,87 +1,134 @@
 - vars:
-    user_token: '{{ user_token_cmd.stdout }}'
+    user_token: "{{ user_token_cmd.stdout }}"
   block:
-    - name: 'Fetch secrets using "hashi_vault" lookup'
+    - name: Fetch secrets using "hashi_vault" lookup
       set_fact:
         gen_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_gen_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        gen_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_gen_path ~ '/secret2 token=' ~ user_token) }}"
+        gen_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_gen_path ~ '/secret2: token=' ~ user_token) }}"
         kv1_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        kv1_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2 token=' ~ user_token) }}"
+        kv1_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2: token=' ~ user_token) }}"
+        kv1_secret1_value: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret1:value auth_method=token token=' ~ user_token) }}"
+        kv1_secret2_as_raw: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2: token=' ~ user_token, return_format='raw') }}"
+        kv1_secrets_as_dict: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secrets token=' ~ user_token, return_format='dict') }}"
+        kv1_secrets_as_values: "{{ query('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secrets token=' ~ user_token, return_format='values') }}"
         kv2_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        kv2_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 token=' ~ user_token) }}"
-        kv2_secret2_as_raw: "{{ lookup('community.general.hashi_vault', vault_kv2_path ~ '/secret2 ' ~  conn_params, auth_method='token', token=user_token, return_format='raw') }}"
-        kv2_secrets_as_dict: "{{ lookup('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token) }}"
-        kv2_secrets_as_values: "{{ query('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token, return_format='values') }}"
+        kv2_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2: token=' ~ user_token) }}"
+        kv2_secret1_value: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1:value auth_method=token token=' ~ user_token) }}"
+        kv2_secret2_as_raw: "{{ lookup('community.general.hashi_vault', vault_kv2_path ~ '/secret2 ' ~ conn_params, auth_method='token', token=user_token, return_format='raw') }}"
+        kv2_secrets_as_dict: "{{ lookup('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~ conn_params, auth_method='token', token=user_token) }}"
+        kv2_secrets_as_values: "{{ query('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~ conn_params, auth_method='token', token=user_token, return_format='values') }}"
 
-    - name: 'Check secret generic values'
-      fail:
-        msg: 'unexpected secret values'
-      when: gen_secret1['value'] != 'foo1' or gen_secret2['value'] != 'foo2'
+    - name: Check secret generic values
+      assert:
+        that:
+          - "gen_secret1 == {'value': 'foo1'}"
+          - "gen_secret2 == {'value': 'foo2'}"
 
-    - name: 'Check secret kv1 values'
-      fail:
-        msg: 'unexpected secret values'
-      when: kv1_secret1['value'] != 'foo1' or kv1_secret2['value'] != 'foo2'
+    - name: Check KV v1 secret values
+      assert:
+        that:
+          - "kv1_secret1 == {'value': 'foo1'}"
+          - "kv1_secret2 == {'value': 'foo2'}"
+          - kv1_secret1_value == 'foo1'
 
-    - name: 'Check secret kv2 values'
-      fail:
-        msg: 'unexpected secret values'
-      when: kv2_secret1['value'] != 'foo1' or kv2_secret2['value'] != 'foo2'
+    - name: Check KV v1 secret raw return value
+      assert:
+        that:
+          - "'data' in kv1_secret2_as_raw"
+          - kv1_secret2_as_raw.data == kv1_secret2
 
-    - name: 'Check kv2 secret raw return value'
-      fail:
-        msg:
-      when: >-
-        'data' not in kv2_secret2_as_raw
-        or 'data' not in kv2_secret2_as_raw['data']
-        or 'metadata' not in kv2_secret2_as_raw['data']
+    - name: Check KV v1 multiple fields as values
+      assert:
+        that:
+          - kv1_secrets_as_values | type_debug == 'list'
+          - kv1_secrets_as_values | symmetric_difference(['foo1', 'foo2', 'foo3']) | length == 0
 
-    - name: "Check multiple secrets as dict"
-      fail:
-        msg: 'Return value was not dict or items do not match.'
-      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
-      loop: [1, 2, 3]
+    - name: Check KV v1 multiple fields as dict
+      assert:
+        that:
+          - kv1_secrets_as_dict | type_debug == 'dict'
+          - kv1_secrets_as_dict | length == 3
+          - kv1_secrets_as_dict.value1 == 'foo1'
+          - kv1_secrets_as_dict.value2 == 'foo2'
+          - kv1_secrets_as_dict.value3 == 'foo3'
 
-    - name: "Check multiple secrets as values"
-      fail:
-        msg: 'Return value was not list or items do not match.'
-      when: (kv2_secrets_as_values | type_debug != 'list') or ('foo{{ item }}' not in kv2_secrets_as_values)
-      loop: [1, 2, 3]
+    - name: Check KV v2 secret values
+      assert:
+        that:
+          - "kv2_secret1.data == {'value': 'foo1'}"
+          - "kv2_secret2.data == {'value': 'foo2'}"
+          - kv2_secret1_value == 'foo1'
 
-    - name: "Check multiple secrets as dict"
-      fail:
-        msg: 'Return value was not dict or items do not match.'
-      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
-      loop: [1, 2, 3]
+    - name: Check KV v2 secret raw return value
+      assert:
+        that:
+          - "'data' in kv2_secret2_as_raw"
+          - "'data' in kv2_secret2_as_raw.data"
+          - "'metadata' in kv2_secret2_as_raw.data"
+          - kv2_secret2_as_raw.data.data == kv2_secret2.data
 
-    - name: 'Failure expected when erroneous credentials are used'
+    - name: Check KV v2 multiple fields as values
+      assert:
+        that:
+          - kv2_secrets_as_values | type_debug == 'list'
+          - kv2_secrets_as_values | symmetric_difference(['foo1', 'foo2', 'foo3']) | length == 0
+
+    - name: Check KV v2 multiple fields as dict
+      assert:
+        that:
+          - "'data' in kv2_secrets_as_dict"
+          - "'metadata' in kv2_secrets_as_dict"
+          - kv2_secrets_as_dict.data | type_debug == 'dict'
+          - kv2_secrets_as_dict.data | length == 3
+          - kv2_secrets_as_dict.data.value1 == 'foo1'
+          - kv2_secrets_as_dict.data.value2 == 'foo2'
+          - kv2_secrets_as_dict.data.value3 == 'foo3'
+
+    - name: Failure expected when erroneous credentials are used
       vars:
         secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=token token=wrong_token') }}"
       debug:
-        msg: 'Failure is expected ({{ secret_wrong_cred }})'
+        msg: Failure is expected ({{ secret_wrong_cred }})
       register: test_wrong_cred
       ignore_errors: true
 
-    - name: 'Failure expected when unauthorized secret is read'
+    - name: Failure expected when unauthorized secret is read
       vars:
         secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret3 token=' ~ user_token) }}"
       debug:
-        msg: 'Failure is expected ({{ secret_unauthorized }})'
+        msg: Failure is expected ({{ secret_unauthorized }})
       register: test_unauthorized
       ignore_errors: true
 
-    - name: 'Failure expected when inexistent secret is read'
+    - name: Failure expected when nonexistent secret is read
       vars:
-        secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 token=' ~ user_token) }}"
+        secret_nonexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 token=' ~ user_token) }}"
       debug:
-        msg: 'Failure is expected ({{ secret_inexistent }})'
-      register: test_inexistent
+        msg: Failure is expected ({{ secret_nonexistent }})
+      register: test_nonexistent
       ignore_errors: true
 
-    - name: 'Check expected failures'
+    - name: Failure expected when nonexistent field is requested from KV v1
+      vars:
+        secret_badfield: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret1:value2 token=' ~ user_token) }}"
+      debug:
+        msg: Failure is expected ({{ secret_badfield }})
+      register: test_badfield_kv1
+      ignore_errors: true
+
+    - name: Failure expected when nonexistent field is requested from KV v2
+      vars:
+        secret_badfield: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1:value2 token=' ~ user_token) }}"
+      debug:
+        msg: Failure is expected ({{ secret_badfield }})
+      register: test_badfield_kv2
+      ignore_errors: true
+
+    - name: Check expected failures
       assert:
-        msg: "an expected failure didn't occur"
         that:
           - test_wrong_cred is failed
           - test_unauthorized is failed
-          - test_inexistent is failed
+          - test_nonexistent is failed
+          - test_badfield_kv1 is failed
+          - test_badfield_kv2 is failed


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As noted in https://github.com/ansible-collections/community.general/pull/23#issuecomment-612984880, https://github.com/ansible/ansible/pull/64288 changed the data returned by the `hashi_vault` lookup in a backwards-incompatible way. It would be nice to fix this before the next stable release and avoid introducing a regression.

This PR retains the new ability to request a specific field or all field values for KV v2, but returns the same structure that Ansible v2.9 does in other cases.

I also reworked the tests slightly, mainly making sure we test all of the permutations of return values for both KV versions and trying to specify the return values as tightly as possible to prevent future
regressions.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
stable-2.9:
```
TASK [No field specified] ******************************************************
ok: [localhost] => 
  lookup('hashi_vault', 'secret=moresecrets/data/foo:'):
    data:
      field1: hay
      field2: clover
    metadata:
      created_time: '2020-05-06T05:33:27.650170871Z'
      deletion_time: ''
      destroyed: false
      version: 1

TASK [data field] **************************************************************
ok: [localhost] => 
  lookup('hashi_vault', 'secret=moresecrets/data/foo:data'):
    field1: hay
    field2: clover

TASK [real field] **************************************************************
fatal: [localhost]: FAILED! => 
  msg: 'An unhandled exception occurred while running the lookup plugin ''hashi_vault''. Error was a <class ''ansible.errors.AnsibleError''>, original message: The secret moresecrets/data/foo does not contain the field ''field1''. for hashi_vault lookup'
...ignoring
```

Current state:
```
TASK [No field specified] ******************************************************
ok: [localhost] => 
  lookup('community.general.hashi_vault', 'secret=moresecrets/data/foo:'):
    field1: hay
    field2: clover

TASK [data field] **************************************************************
fatal: [localhost]: FAILED! => 
  msg: 'An unhandled exception occurred while running the lookup plugin ''community.general.hashi_vault''. Error was a <class ''ansible.errors.AnsibleError''>, original message: The secret moresecrets/data/foo does not contain the field ''data''. for hashi_vault lookup'
...ignoring

TASK [real field] **************************************************************
ok: [localhost] => 
  lookup('community.general.hashi_vault', 'secret=moresecrets/data/foo:field1'): hay
```

After this change:
```
TASK [No field specified] ******************************************************
ok: [localhost] => 
  lookup('community.general.hashi_vault', 'secret=moresecrets/data/foo:'):
    data:
      field1: hay
      field2: clover
    metadata:
      created_time: '2020-05-06T05:33:27.650170871Z'
      deletion_time: ''
      destroyed: false
      version: 1

TASK [data field] **************************************************************
ok: [localhost] => 
  lookup('community.general.hashi_vault', 'secret=moresecrets/data/foo:data'):
    field1: hay
    field2: clover

TASK [real field] **************************************************************
ok: [localhost] => 
  lookup('community.general.hashi_vault', 'secret=moresecrets/data/foo:field1'): hay
```