### PR TITLE
postgresql_sequence: add trust_input option

### DIFF
--- a/changelogs/fragments/295-postgresql_sequence_add_trust_input.yml
+++ b/changelogs/fragments/295-postgresql_sequence_add_trust_input.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - postgresql_sequence - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/295).

--- a/tests/integration/targets/postgresql_sequence/tasks/postgresql_sequence_initial.yml
+++ b/tests/integration/targets/postgresql_sequence/tasks/postgresql_sequence_initial.yml
@@ -1,3 +1,4 @@
+---
 # Copyright: (c) 2019, Tobias Birkefeld (@tcraxs) <t@craxs.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -685,6 +686,27 @@
   assert:
     that:
       - result.rowcount == 1
+
+####################
+# Test: create sequence with trust_input
+- name: postgresql_sequence - check that trust_input works as expected
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_sequence:
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+    name: 'just_a_name"; SELECT * FROM information_schema.tables; --'
+    trust_input: no
+    owner: "{{ db_user2 }}"
+  ignore_errors: yes
+  register: result
+
+# Checks
+- name: postgresql_sequence - check with assert the output
+  assert:
+    that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')
 
 # Cleanup
 - name: postgresql_sequence - destroy DB


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Have added the trust_input option to the postgresql_sequence module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related to: #106 and #210 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/modules/database/postgresql/postgresql_sequence.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
