### PR TITLE
Updated listen_ports_facts documentation

### DIFF
--- a/changelogs/fragments/listen_ports_facts_doc.yml
+++ b/changelogs/fragments/listen_ports_facts_doc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated documentation about netstat command requirement for listen_ports_facts module (https://github.com/ansible/ansible/issues/68077).

--- a/plugins/modules/system/listen_ports_facts.py
+++ b/plugins/modules/system/listen_ports_facts.py
@@ -14,14 +14,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: listen_ports_facts
-
 author:
     - Nathan Davison (@ndavison)
-
-
 description:
-    - Gather facts on processes listening on TCP and UDP ports.
-
+    - Gather facts on processes listening on TCP and UDP ports using netstat command.
+    - This module currently supports Linux only.
+requirements:
+  - netstat
 short_description: Gather facts on processes listening on TCP and UDP ports.
 '''
 


### PR DESCRIPTION
##### SUMMARY

Updated listen_ports_facts module documentation to reflect
- Linux only support
- Required netstat command

Fixes: ansible/ansible#68077

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/listen_ports_facts_doc.yml
plugins/modules/system/listen_ports_facts.py
