### PR TITLE
postgresql_set: add trust_input parameter

### DIFF
--- a/changelogs/fragments/302-postgresql_set_add_trust_input_parameter.yml
+++ b/changelogs/fragments/302-postgresql_set_add_trust_input_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_set - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/302).

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -306,7 +306,7 @@ def main():
     name = module.params['name']
     value = module.params['value']
     reset = module.params['reset']
-    session_role =  module.params['session_role']
+    session_role = module.params['session_role']
     trust_input = module.params['trust_input']
 
     if not trust_input:

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -288,6 +288,7 @@
     <<: *task_parameters
     postgresql_set:
       <<: *pg_parameters
+      trust_input: yes
       name: archive_command
       value: 'test ! -f /mnt/postgres/mb/%f && cp %p /mnt/postgres/mb/%f'
 
@@ -302,3 +303,21 @@
   - assert:
       that:
       - result.query_result.0.reset_val == "test ! -f /mnt/postgres/mb/%f && cp %p /mnt/postgres/mb/%f"
+
+  #############################
+  # Check trust_input parameter
+  - name: postgresql_set - check trust_input
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: shared_buffers
+      value: 111MB
+      trust_input: no
+      session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+    register: result
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')


### PR DESCRIPTION
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_set: add trust_input parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_set.py```
