### PR TITLE
Fix for lookup/consul_kv environment varibles handling

### DIFF
--- a/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
+++ b/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
-  - consul_kv lookup - fix ``ANSIBLE_CONSUL_URL`` environment variable handling (https://github.com/ansible/ansible/issues/51960)
+  - consul_kv lookup - fix ``ANSIBLE_CONSUL_URL`` environment variable handling (https://github.com/ansible/ansible/issues/51960).
+  - consul_kv lookup - fix arguments handling.

--- a/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
+++ b/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - consul_kv lookup - fix ``ANSIBLE_CONSUL_URL`` environment variable handling (https://github.com/ansible/ansible/issues/51960).
-  - consul_kv lookup - fix arguments handling.
+  - consul_kv lookup - fix arguments handling (https://github.com/ansible-collections/community.general/pull/303).

--- a/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
+++ b/changelogs/fragments/303-consul_kv-fix-env-variables-handling.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - consul_kv lookup - fix ``ANSIBLE_CONSUL_URL`` environment variable handling (https://github.com/ansible/ansible/issues/51960)

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -67,7 +67,7 @@ DOCUMENTATION = '''
           - section: lookup_consul
             key: client_cert
       url:
-        description: "The target to connect to, should look like this: C(https://my.consul.server:8500)."
+        description: "The target to connect to, should look like this: C(https://my.consul.server:8500)"
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -70,9 +70,6 @@ DOCUMENTATION = '''
         description: The target to connect to, should look like this: C(https://my.consul.server:8500).
         env:
           - name: ANSIBLE_CONSUL_URL
-        ini:
-          - section: lookup_consul
-            key: url
 '''
 
 EXAMPLES = """

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -68,6 +68,8 @@ DOCUMENTATION = '''
             key: client_cert
       url:
         description: "The target to connect to, should look like this: C(https://my.consul.server:8500)."
+        type: str
+        version_added: 1.0.0
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -129,9 +129,11 @@ class LookupModule(LookupBase):
         url = self.get_option('url')
         if url is not None:
             u = urlparse(url)
-            scheme = u.scheme
+            if u.scheme:
+                scheme = u.scheme
             host = u.hostname
-            port = u.port
+            if u.port is not None:
+                port = u.port
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -120,8 +120,8 @@ class LookupModule(LookupBase):
                 params = self.parse_params(term)
                 try:
                     url = os.environ['ANSIBLE_CONSUL_URL']
-                    validate_certs = os.environ['ANSIBLE_CONSUL_VALIDATE_CERTS'] or True
-                    client_cert = os.environ['ANSIBLE_CONSUL_CLIENT_CERT'] or None
+                    validate_certs = os.environ.get('ANSIBLE_CONSUL_VALIDATE_CERTS') or True
+                    client_cert = os.environ.get('ANSIBLE_CONSUL_CLIENT_CERT') or None
                     u = urlparse(url)
                     consul_api = consul.Consul(host=u.hostname, port=u.port, scheme=u.scheme, verify=validate_certs,
                                                cert=client_cert)

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -15,6 +15,9 @@ DOCUMENTATION = '''
     requirements:
       - 'python-consul python library U(https://python-consul.readthedocs.io/en/latest/#installation)'
     options:
+      _raw:
+        description: List of key(s) to retrieve.
+        type: list
       recurse:
         type: boolean
         description: If true, will retrieve all the values that have the given key as prefix.

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -67,9 +67,12 @@ DOCUMENTATION = '''
           - section: lookup_consul
             key: client_cert
       url:
-        description: The target to connect to, should look like this: C(https://my.consul.server:8500).
+        description: "The target to connect to, should look like this: C(https://my.consul.server:8500)."
         env:
           - name: ANSIBLE_CONSUL_URL
+        ini:
+          - section: lookup_consul
+            key: url
 '''
 
 EXAMPLES = """

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -67,8 +67,7 @@ DOCUMENTATION = '''
           - section: lookup_consul
             key: client_cert
       url:
-        description:
-          - The target to connect to, should look like this: C(https://my.consul.server:8500).
+        description: The target to connect to, should look like this: C(https://my.consul.server:8500).
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -67,7 +67,7 @@ DOCUMENTATION = '''
           - section: lookup_consul
             key: client_cert
       url:
-        description: "The target to connect to, should look like this: C(https://my.consul.server:8500)"
+        description: "The target to connect to, should look like this: C(https://my.consul.server:8500)."
         env:
           - name: ANSIBLE_CONSUL_URL
         ini:


### PR DESCRIPTION
##### SUMMARY
ANSIBLE_CONSUL_URL variable is ignored if ANSIBLE_CLIENT_CERT or ANSIBLE_VALIDATE_CERTS are undefined.

Fixes ansible/ansible#51960

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup/consul_kv

##### ADDITIONAL INFORMATION
- ``_raw`` is not required anymore since this option was never used in plugin
- Options handling was switched to ``get_option`` approach
- ``url`` option for scheme/host/port override is now available not only as env variable, but as argument/ini setting as well