### PR TITLE
postgresql_info: add the trust_input parameter

### DIFF
--- a/changelogs/fragments/308-postgresql_info_add_trust_input_parameter.yml
+++ b/changelogs/fragments/308-postgresql_info_add_trust_input_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/308).

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -139,6 +139,7 @@
       <<: *pg_parameters
       login_db: '{{ test_db }}'
       login_port: '{{ master_port }}'
+      trust_input: yes
 
   - assert:
       that:
@@ -152,3 +153,19 @@
       - result.settings
       - result.tablespaces
       - result.roles
+
+  - name: postgresql_info - test trust_input parameter
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      login_db: '{{ test_db }}'
+      login_port: '{{ master_port }}'
+      trust_input: no
+      session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+    register: result
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result is failed
+      - result.msg is search('is potentially dangerous')


### PR DESCRIPTION
##### SUMMARY
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_info: add trust_input parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_info.py```

