### PR TITLE
postgresql modules: improve trust_input parameter's documentation, improve CI tests

### DIFF
--- a/plugins/modules/database/postgresql/postgresql_db.py
+++ b/plugins/modules/database/postgresql/postgresql_db.py
@@ -107,7 +107,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(owner), I(conn_limit), I(encoding),
+      I(db), I(template), I(tablespace), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_ext.py
+++ b/plugins/modules/database/postgresql/postgresql_ext.py
@@ -82,7 +82,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(ext), I(schema),
+      I(version), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_idx.py
+++ b/plugins/modules/database/postgresql/postgresql_idx.py
@@ -116,7 +116,10 @@ options:
     default: no
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(idxname), I(session_role),
+      I(schema), I(table), I(columns), I(tablespace), I(storage_params),
+      I(cond) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 

--- a/plugins/modules/database/postgresql/postgresql_lang.py
+++ b/plugins/modules/database/postgresql/postgresql_lang.py
@@ -73,7 +73,8 @@ options:
     description:
     - Switch to session_role after connecting.
     - The specified I(session_role) must be a role that the current I(login_user) is a member of.
-    - Permissions checking for SQL commands is carried out as though the I(session_role) were the one that had logged in originally.
+    - Permissions checking for SQL commands is carried out as though the
+      I(session_role) were the one that had logged in originally.
     type: str
   state:
     description:
@@ -106,7 +107,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(lang), I(session_role),
+      I(owner) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_membership.py
+++ b/plugins/modules/database/postgresql/postgresql_membership.py
@@ -74,7 +74,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(groups),
+      I(target_roles), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_owner.py
+++ b/plugins/modules/database/postgresql/postgresql_owner.py
@@ -72,7 +72,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(new_owner), I(obj_name),
+      I(reassign_owned_by), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_privs.py
+++ b/plugins/modules/database/postgresql/postgresql_privs.py
@@ -159,7 +159,9 @@ options:
     - ssl_rootcert
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(roles), I(target_roles), I(session_role),
+      I(schema) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 

--- a/plugins/modules/database/postgresql/postgresql_publication.py
+++ b/plugins/modules/database/postgresql/postgresql_publication.py
@@ -71,7 +71,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(name), I(tables), I(owner),
+      I(session_role), I(params) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 notes:

--- a/plugins/modules/database/postgresql/postgresql_schema.py
+++ b/plugins/modules/database/postgresql/postgresql_schema.py
@@ -71,7 +71,8 @@ options:
     aliases: [ ssl_rootcert ]
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(schema), I(owner), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 seealso:

--- a/plugins/modules/database/postgresql/postgresql_sequence.py
+++ b/plugins/modules/database/postgresql/postgresql_sequence.py
@@ -137,7 +137,9 @@ options:
     - login_db
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(sequence), I(schema), I(rename_to),
+      I(owner), I(newschema), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 notes:

--- a/plugins/modules/database/postgresql/postgresql_subscription.py
+++ b/plugins/modules/database/postgresql/postgresql_subscription.py
@@ -89,7 +89,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(name), I(publications), I(owner),
+      I(session_role), I(connparams), I(subsparams) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 

--- a/plugins/modules/database/postgresql/postgresql_tablespace.py
+++ b/plugins/modules/database/postgresql/postgresql_tablespace.py
@@ -77,7 +77,9 @@ options:
     - login_db
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(tablespace), I(location), I(owner),
+      I(rename_to), I(session_role), I(settings_list) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 

--- a/plugins/modules/database/postgresql/postgresql_user.py
+++ b/plugins/modules/database/postgresql/postgresql_user.py
@@ -149,7 +149,9 @@ options:
     type: str
   trust_input:
     description:
-    - If C(no), check whether values of some parameters are potentially dangerous.
+    - If C(no), check whether values of parameters I(name), I(password), I(privs), I(expires),
+      I(role_attr_flags), I(groups), I(comment), I(session_role) are potentially dangerous.
+    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
 notes:

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_general.yml
@@ -96,6 +96,7 @@
     type: table
     objs: test_view
     roles: "{{ db_user2 }}"
+    trust_input: no
   register: result
 
 - assert:
@@ -128,6 +129,7 @@
     type: table
     objs: test_view
     roles: "{{ db_user2 }}"
+    trust_input: no
   register: result
 
 - assert:
@@ -182,6 +184,7 @@
     objs: dummy
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -215,6 +218,7 @@
     objs: dummy
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -233,6 +237,7 @@
     objs: dummy
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -266,6 +271,7 @@
     objs: dummy
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -284,6 +290,7 @@
     objs: dummy_server
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -317,6 +324,7 @@
     objs: dummy_server
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -335,6 +343,7 @@
     objs: dummy_server
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -368,6 +377,7 @@
     objs: dummy_server
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -416,6 +426,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -444,6 +455,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -463,6 +475,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -482,6 +495,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
 
@@ -525,6 +539,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -562,6 +577,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -601,6 +617,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -622,6 +639,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -661,6 +679,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   register: result
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -676,6 +695,7 @@
     db: "{{ db_name }}"
     login_user: "{{ db_user3 }}"
     login_password: password
+    trust_input: no
   ignore_errors: yes
   when: postgres_version_resp.stdout is version('10', '>=')
 
@@ -696,6 +716,7 @@
     schema: pg_catalog
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   when: postgres_version_resp.stdout is version('10', '>=')
 
@@ -732,6 +753,7 @@
     schema: pg_catalog
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   check_mode: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -769,6 +791,7 @@
     schema: pg_catalog
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   when: postgres_version_resp.stdout is version('10', '>=')
 
@@ -805,6 +828,7 @@
     schema: pg_catalog
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   check_mode: yes
   when: postgres_version_resp.stdout is version('10', '>=')
@@ -842,6 +866,7 @@
     schema: pg_catalog
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   when: postgres_version_resp.stdout is version('10', '>=')
 
@@ -888,6 +913,7 @@
     objs: compfoo
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
   when: postgres_version_resp.stdout is version('10', '>=')
 
@@ -926,6 +952,7 @@
     objs: compfoo
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   when: postgres_version_resp.stdout is version('10', '>=')
 
 - name: Reassign ownership

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
@@ -116,6 +116,7 @@
     objs: "test_table2"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
 
 - name: Check that ansible reports it changed the user
@@ -144,6 +145,7 @@
     objs: "test_table2,test_table1"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
 
 - name: Check that ansible reports it changed the user
@@ -179,6 +181,7 @@
     objs: "{{ db_name }}"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
 
 - name: Check that the user has the requested permissions (database)
   become_user: "{{ pg_user }}"
@@ -202,6 +205,7 @@
     objs: "{{ db_name }}"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
   register: result
 
 - name: Check that ansible reports it changed the user
@@ -230,6 +234,7 @@
     objs: "test_table1"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
 
 - name: Check that permissions were added (table1)
   become_user: "{{ pg_user }}"
@@ -252,6 +257,7 @@
     objs: "test_table2,test_table1"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
 
 - name: Check that permissions were added (table1)
   become_user: "{{ pg_user }}"
@@ -307,6 +313,7 @@
     objs: "test_table1"
     db: "{{ db_name }}"
     login_user: "{{ pg_user }}"
+    trust_input: no
 
 - name: Check that permissions were added (table1)
   become_user: "{{ pg_user }}"
@@ -334,6 +341,7 @@
     objs: TABLES
     type: default_privs
     target_roles: "{{ db_user_with_dots2 }}"
+    trust_input: no
 
 #
 # Cleanup

--- a/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
@@ -182,7 +182,6 @@
       tables:
       - '{{ test_table1 }}'
       - '{{ test_schema }}.{{ test_table2 }}'
-      trust_input: yes
       parameters:
         publish: 'insert'
       trust_input: no

--- a/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/postgresql_publication_initial.yml
@@ -64,6 +64,7 @@
     postgresql_publication: 
       <<: *pg_parameters
       name: '{{ test_pub }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -89,6 +90,7 @@
     postgresql_publication: 
       <<: *pg_parameters
       name: '{{ test_pub }}'
+      trust_input: no
 
   - assert:
       that:
@@ -120,6 +122,7 @@
       <<: *pg_parameters
       name: '{{ test_pub }}'
       state: absent
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -182,6 +185,7 @@
       trust_input: yes
       parameters:
         publish: 'insert'
+      trust_input: no
 
   - assert:
       that:
@@ -254,6 +258,7 @@
       - '{{ test_table1 }}'
       - '{{ test_schema }}.{{ test_table2 }}'
       - '{{ test_table3 }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -297,6 +302,7 @@
       - '{{ test_table1 }}'
       - '{{ test_schema }}.{{ test_table2 }}'
       - '{{ test_table3 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -338,6 +344,7 @@
       - '{{ test_schema }}.{{ test_table2 }}'
       parameters:
         publish: 'insert'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -379,6 +386,7 @@
       - '{{ test_schema }}.{{ test_table2 }}'
       parameters:
         publish: 'delete'
+      trust_input: no
 
   - assert:
       that:

--- a/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -41,6 +41,7 @@
         user: '{{ replication_role }}'
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
+      trust_input: no
 
   - assert:
       that:
@@ -82,6 +83,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: absent
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -145,6 +147,7 @@
         user: '{{ replication_role }}'
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
+      trust_input: no
 
   - assert:
       that:
@@ -160,6 +163,7 @@
       state: present
       publications: '{{ test_pub }}'
       owner: '{{ test_role1 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -190,6 +194,7 @@
       state: present
       publications: '{{ test_pub }}'
       owner: '{{ test_role2 }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -222,6 +227,7 @@
       state: present
       publications: '{{ test_pub }}'
       owner: '{{ test_role2 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -284,6 +290,7 @@
       name: '{{ test_subscription }}'
       state: absent
       cascade: yes
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -350,6 +357,7 @@
       subsparams:
         enabled: no
         synchronous_commit: no
+      trust_input: no
 
   - assert:
       that:
@@ -383,6 +391,7 @@
       subsparams:
         enabled: yes
         synchronous_commit: yes
+      trust_input: no
 
   - assert:
       that:
@@ -416,6 +425,7 @@
       subsparams:
         enabled: yes
         synchronous_commit: yes
+      trust_input: no
 
   - assert:
       that:
@@ -441,6 +451,7 @@
       publications:
       - '{{ test_pub }}'
       - '{{ test_pub2 }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -474,6 +485,7 @@
       publications:
       - '{{ test_pub }}'
       - '{{ test_pub2 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -506,6 +518,7 @@
       publications:
       - '{{ test_pub }}'
       - '{{ test_pub2 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -546,6 +559,7 @@
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
         connect_timeout: '{{ conn_timeout }}'
+      trust_input: no
     check_mode: yes
 
   - assert:
@@ -569,6 +583,7 @@
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
         connect_timeout: '{{ conn_timeout }}'
+      trust_input: no
 
   - assert:
       that:
@@ -602,6 +617,7 @@
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
         connect_timeout: '{{ conn_timeout }}'
+      trust_input: no
 
   - assert:
       that:

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -28,6 +28,7 @@
     postgresql_user:
       <<: *pg_parameters
       name: '{{ test_user }}'
+      trust_input: no
 
   - assert:
       that:
@@ -96,6 +97,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       comment: '{{ test_comment1 }}'
+      trust_input: no
 
   - assert:
       that:
@@ -346,6 +348,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       expires: 'Jan 31 2020'
+      trust_input: no
 
   - assert:
       that:
@@ -397,6 +400,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       role_attr_flags: CREATEROLE,CREATEDB
+      trust_input: no
 
   - assert:
       that:
@@ -516,6 +520,7 @@
       <<: *pg_parameters
       name: '{{ test_user }}'
       priv: '{{ test_table }}:SELECT'
+      trust_input: no
 
   - assert:
       that:
@@ -643,6 +648,7 @@
       name: '{{ test_group1 }}'
       groups: '{{ test_group2 }}'
       role_attr_flags: NOLOGIN
+      trust_input: no
 
   - assert:
       that:
@@ -700,6 +706,7 @@
       groups:
       - '{{ test_group1 }}'
       - '{{ test_group2 }}'
+      trust_input: no
 
   - assert:
       that:

--- a/tests/integration/targets/postgresql_user/tasks/postgresql_user_initial.yml
+++ b/tests/integration/targets/postgresql_user/tasks/postgresql_user_initial.yml
@@ -50,6 +50,7 @@
     password: "password"
     role_attr_flags: "CREATEDB,LOGIN,CREATEROLE"
     login_user: "{{ pg_user }}"
+    trust_input: no
     db: postgres
 
 - name: Create db
@@ -80,6 +81,7 @@
     login_user: "{{ db_user1 }}"
     login_password: "password"
     login_host: "localhost"
+    trust_input: no
 
 - name: Check that it was created
   become: yes
@@ -123,6 +125,7 @@
     login_user: "{{ db_user1 }}"
     login_password: "password"
     login_host: "localhost"
+    trust_input: no
 
 - name: Check that they were removed
   become: yes


### PR DESCRIPTION

##### SUMMARY
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql modules: improve `trust_input` parameter's documentation, improve CI tests

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENTS
```plugins/modules/database/postgresql/postgresql_db.py```
...
