### PR TITLE
Add trust_input to postgresql_user_obj_stat_info

### DIFF
--- a/changelogs/fragments/310-postgresql_user_obj_stat_info_add_trust_input.yml
+++ b/changelogs/fragments/310-postgresql_user_obj_stat_info_add_trust_input.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - postgresql_user_obj_stat_info - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/310).

--- a/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/tasks/postgresql_user_obj_stat_info.yml
@@ -1,3 +1,4 @@
+---
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -156,6 +157,20 @@
       - result is failed
       - result.msg == "Schema 'nonexistent' does not exist"
 
+  # 4. Test Trust Input
+  - name: Try running with SQL injection
+    <<: *task_parameters
+    postgresql_user_obj_stat_info:
+      <<: *pg_parameters
+      session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+      trust_input: no
+    ignore_errors: yes
+
+  - assert:
+      that:
+        - result is failed
+        - result.msg is search('is potentially dangerous')
+    
   ##########
   # Clean up
   ##########


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Have added a trust_input option to the postgresql_user_obj_stat_info
module. This only checks the session_role since all other options are
passed as parameters. Have also refactored the module to try to simplify
the code.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related to #106 and #210

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/modules/database/postgresql/postgresql_user_obj_stat_info.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
