### PR TITLE
jira: log error messages in "errors" key

### DIFF
--- a/changelogs/fragments/311-jira-error-handling.yaml
+++ b/changelogs/fragments/311-jira-error-handling.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- jira - improve error message handling (https://github.com/ansible-collections/community.general/pull/311).


### PR DESCRIPTION
##### SUMMARY
Jira's API can return a empty "errorMessages" list, and the real error is in the "errors" object. This happens, for example, if a user tries to file a ticket in a project that does not exist (tested with Jira v7.13.8)

Check both "errorMessages" and "errors", and report both values with `fail_json()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jira
