### PR TITLE
postgresql_ping: add session_role and trust_input parameters

### DIFF
--- a/changelogs/fragments/312-postgresql_ping_add_trust_input_session_role.yml
+++ b/changelogs/fragments/312-postgresql_ping_add_trust_input_session_role.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- postgresql_ping - add the ``trust_input`` parameter (https://github.com/ansible-collections/community.general/pull/312).
+- postgresql_ping - add the ``session_role`` parameter (https://github.com/ansible-collections/community.general/pull/312).

--- a/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/postgresql_ping_initial.yml
@@ -45,6 +45,7 @@
     login_port: 5432
     ssl_mode: require
     ca_cert: '{{ ssl_rootcert }}'
+    trust_input: yes
   register: result
   when:
   - ansible_os_family == 'Debian'
@@ -56,3 +57,19 @@
   when:
   - ansible_os_family == 'Debian'
   - postgres_version_resp.stdout is version('9.4', '>=')
+
+- name: postgresql_ping - check trust_input
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_ping:
+    db: "{{ db_default }}"
+    login_user: "{{ pg_user }}"
+    trust_input: no
+    session_role: 'curious.anonymous"; SELECT * FROM information_schema.tables; --'
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is failed
+    - result.msg is search('is potentially dangerous')


### PR DESCRIPTION
Related to https://github.com/ansible-collections/community.general/issues/106 and https://github.com/ansible-collections/community.general/issues/210

postgresql_ping:
- add trust_input parameter
- add session_role parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```plugins/modules/database/postgresql/postgresql_ping.py```