### PR TITLE
Update tests/unit/requirements.txt for maven_artifact

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -27,5 +27,8 @@ linode_api4 ; python_version > '2.6' # APIv4
 python-gitlab
 httmock
 
-# requirment for kubevirt modules
+# requirement for kubevirt modules
 openshift ; python_version >= '2.7'
+
+# requirement for maven_artifact module
+semantic_version


### PR DESCRIPTION
##### SUMMARY
One part of #296 I forgot to include into #306: make sure that `semantic_version` is included in unit test requirements. (It is included in the `default` docker container for Ansible 2.10, but not for 2.9.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/unit/requirements.txt
