### PR TITLE
Fix udm_dns_record example, fixing #315

### DIFF
--- a/plugins/modules/cloud/univention/udm_dns_record.py
+++ b/plugins/modules/cloud/univention/udm_dns_record.py
@@ -65,7 +65,9 @@ EXAMPLES = '''
     zone: example.com
     type: host_record
     data:
-      - a: 192.0.2.1
+      a:
+         - 192.0.2.1
+         - 2001:0db8::42
 '''
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing #315 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
udm_dns_record

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Please note, that IPv6 addresses are stored in the univention ldap as "A" records, not "AAAA"
This is my first pull-request to ansible, please be kind.
```
