### PR TITLE
linode inventory plugin: fix parsing of access_token

### DIFF
--- a/changelogs/fragments/318-linode-inventory-access_token-fix.yaml
+++ b/changelogs/fragments/318-linode-inventory-access_token-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linode inventory plugin - fix parsing of access_token (https://github.com/ansible/ansible/issues/66874)

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -194,11 +194,11 @@ class InventoryModule(BaseInventoryPlugin):
         """Dynamically parse Linode the cloud inventory."""
         super(InventoryModule, self).parse(inventory, loader, path)
 
+        config_data = self._read_config_data(path)
         self._build_client()
 
         self._get_instances_inventory()
 
-        config_data = self._read_config_data(path)
         regions, types = self._get_query_options(config_data)
         self._filter_by_config(regions, types)
 


### PR DESCRIPTION
##### SUMMARY
Read config before trying to use the config.

Original issue: https://github.com/ansible/ansible/issues/66874

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
linode inventory plugin