### PR TITLE
BOTMETA: ignore joshuaconner for docker_container module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -257,7 +257,7 @@ files:
   $modules/cloud/docker/docker_config.py:
     authors: chouseknecht ushuz
   $modules/cloud/docker/docker_container.py:
-    authors: ThomasSteinbach chouseknecht cove dusdanig felixfontein joshuaconner kassiansun softzilla zfil
+    authors: ThomasSteinbach chouseknecht cove dusdanig felixfontein kassiansun softzilla zfil
     maintainers: DBendit WojciechowskiPiotr akshay196 danihodovic dariko jwitko tbouvet
     ignore: ThomasSteinbach cove joshuaconner
   $modules/cloud/docker/docker_container_info.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -259,7 +259,7 @@ files:
   $modules/cloud/docker/docker_container.py:
     authors: ThomasSteinbach chouseknecht cove dusdanig felixfontein joshuaconner kassiansun softzilla zfil
     maintainers: DBendit WojciechowskiPiotr akshay196 danihodovic dariko jwitko tbouvet
-    ignore: ThomasSteinbach cove
+    ignore: ThomasSteinbach cove joshuaconner
   $modules/cloud/docker/docker_container_info.py:
     authors: felixfontein
     maintainers: DBendit WojciechowskiPiotr akshay196 danihodovic dariko jwitko kassiansun tbouvet


### PR DESCRIPTION
##### SUMMARY
Adds me (`joshuaconner`) to ignore list for `docker_container` module in `BOTMETA`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
BOTMETA

##### ADDITIONAL INFORMATION
I'm not an active user of this module anymore, so am unable to provide meaningful review.