### PR TITLE
Add Fedora 32 to CI; drop Fedora 30 which is soon EOL

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,8 +30,8 @@ matrix:
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
     - env: T=linux/centos8/1
-    - env: T=linux/fedora30/1
     - env: T=linux/fedora31/1
+    - env: T=linux/fedora32/1
     - env: T=linux/opensuse15py2/1
     - env: T=linux/opensuse15/1
     - env: T=linux/ubuntu1604/1
@@ -46,8 +46,8 @@ matrix:
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
     - env: T=linux/centos8/2
-    - env: T=linux/fedora30/2
     - env: T=linux/fedora31/2
+    - env: T=linux/fedora32/2
     - env: T=linux/opensuse15py2/2
     - env: T=linux/opensuse15/2
     - env: T=linux/ubuntu1604/2
@@ -62,8 +62,8 @@ matrix:
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
     - env: T=linux/centos8/3
-    - env: T=linux/fedora30/3
     - env: T=linux/fedora31/3
+    - env: T=linux/fedora32/3
     - env: T=linux/opensuse15py2/3
     - env: T=linux/opensuse15/3
     - env: T=linux/ubuntu1604/3
@@ -78,8 +78,8 @@ matrix:
     - env: T=linux/centos6/4
     - env: T=linux/centos7/4
     - env: T=linux/centos8/4
-    - env: T=linux/fedora30/4
     - env: T=linux/fedora31/4
+    - env: T=linux/fedora32/4
     - env: T=linux/opensuse15py2/4
     - env: T=linux/opensuse15/4
     - env: T=linux/ubuntu1604/4
@@ -94,8 +94,8 @@ matrix:
     - env: T=linux/centos6/5
     - env: T=linux/centos7/5
     - env: T=linux/centos8/5
-    - env: T=linux/fedora30/5
     - env: T=linux/fedora31/5
+    - env: T=linux/fedora32/5
     - env: T=linux/opensuse15py2/5
     - env: T=linux/opensuse15/5
     - env: T=linux/ubuntu1604/5

--- a/tests/integration/targets/setup_docker/tasks/Fedora.yml
+++ b/tests/integration/targets/setup_docker/tasks/Fedora.yml
@@ -4,7 +4,7 @@
     file: docker-ce
     name: docker-ce-stable
     description: Docker CE Stable - $basearch
-    baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
+    baseurl: https://download.docker.com/linux/fedora/{{ 31 if ansible_facts.distribution_major_version|int > 31 else '$releasever' }}/$basearch/stable
     enabled: yes
     gpgcheck: yes
     gpgkey: https://download.docker.com/linux/fedora/gpg

--- a/tests/integration/targets/timezone/tasks/main.yml
+++ b/tests/integration/targets/timezone/tasks/main.yml
@@ -49,15 +49,19 @@
 
 
 - name: Run tests
-  # Skip tests on Fedora 31 because dbus fails to start unless the container is run in priveleged mode.
-  # Even then, it starts unreliably. This may be due to the move to cgroup v2 in Fedora 31.
+  # Skip tests on Fedora 31 and 32 because dbus fails to start unless the container is run in priveleged mode.
+  # Even then, it starts unreliably. This may be due to the move to cgroup v2 in Fedora 31 and 32.
   # https://www.redhat.com/sysadmin/fedora-31-control-group-v2
-  when: ansible_facts.distribution ~ ansible_facts.distribution_major_version != 'Fedora31'
+  when: ansible_facts.distribution ~ ansible_facts.distribution_major_version not in ['Fedora31', 'Fedora32']
   block:
     - name: set timezone to Etc/UTC
       timezone:
         name: Etc/UTC
       register: original_timezone
+
+    - name: Value of original_timezone
+      debug:
+        msg: "{{ original_timezone }}"
 
     - block:
         - include_tasks: test.yml


### PR DESCRIPTION
##### SUMMARY
Implements ansible-collections/overview#59. I opted to drop Fedora 30 from CI since community.general is already eating a lot of CI resources, and since it is EOL soon.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
CI
