### PR TITLE
Fix Ansible documentation in part of example formatting. Part 1

### DIFF
--- a/plugins/modules/cloud/atomic/atomic_container.py
+++ b/plugins/modules/cloud/atomic/atomic_container.py
@@ -62,8 +62,8 @@ options:
 
 EXAMPLES = '''
 
-# Install the etcd system container
-- atomic_container:
+- name: Install the etcd system container
+  atomic_container:
     name: etcd
     image: rhel/etcd
     backend: ostree
@@ -72,8 +72,8 @@ EXAMPLES = '''
     values:
         - ETCD_NAME=etcd.server
 
-# Uninstall the etcd system container
-- atomic_container:
+- name: Uninstall the etcd system container
+  atomic_container:
     name: etcd
     image: rhel/etcd
     backend: ostree

--- a/plugins/modules/cloud/digital_ocean/digital_ocean.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean.py
@@ -123,9 +123,8 @@ EXAMPLES = '''
     ssh_pub_key: 'ssh-rsa AAAA...'
     api_token: XXX
 
-- name: >
-    Create a new Droplet.
-    Will return the droplet details including the droplet id (used for idempotence)
+# Will return the droplet details including the droplet id (used for idempotence)
+- name: Create a new Droplet
   digital_ocean:
     state: present
     command: droplet

--- a/plugins/modules/cloud/digital_ocean/digital_ocean.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean.py
@@ -115,17 +115,18 @@ EXAMPLES = '''
 # If a key matches this name, will return the ssh key id and changed = False
 # If no existing key matches this name, a new key is created, the ssh key id is returned and changed = False
 
-- digital_ocean:
+- name: Ensure a SSH key is present
+  digital_ocean:
     state: present
     command: ssh
     name: my_ssh_key
     ssh_pub_key: 'ssh-rsa AAAA...'
     api_token: XXX
 
-# Create a new Droplet
-# Will return the droplet details including the droplet id (used for idempotence)
-
-- digital_ocean:
+- name: >
+    Create a new Droplet.
+    Will return the droplet details including the droplet id (used for idempotence)
+  digital_ocean:
     state: present
     command: droplet
     name: mydroplet
@@ -146,7 +147,8 @@ EXAMPLES = '''
 # If droplet id already exist, will return the droplet details and changed = False
 # If no droplet matches the id, a new droplet will be created and the droplet details (including the new id) are returned, changed = True.
 
-- digital_ocean:
+- name: Ensure a droplet is present
+  digital_ocean:
     state: present
     command: droplet
     id: 123
@@ -162,7 +164,8 @@ EXAMPLES = '''
 # Several keys can be added to ssh_key_ids as id1,id2,id3
 # The keys are used to connect as root to the droplet.
 
-- digital_ocean:
+- name: Create a droplet with ssh key
+  digital_ocean:
     state: present
     ssh_key_ids: 123,456
     name: mydroplet
@@ -170,7 +173,6 @@ EXAMPLES = '''
     size_id: 2gb
     region_id: ams2
     image_id: fedora-19-x64
-
 '''
 
 import os

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -63,31 +63,34 @@ author:
 '''
 
 EXAMPLES = '''
-# Create new Block Storage
-- digital_ocean_block_storage:
+- name: Create new Block Storage
+  digital_ocean_block_storage:
     state: present
     command: create
     api_token: <TOKEN>
     region: nyc1
     block_size: 10
     volume_name: nyc1-block-storage
-# Delete Block Storage
-- digital_ocean_block_storage:
+
+- name: Delete Block Storage
+  digital_ocean_block_storage:
     state: absent
     command: create
     api_token: <TOKEN>
     region: nyc1
     volume_name: nyc1-block-storage
-# Attach Block Storage to a Droplet
-- digital_ocean_block_storage:
+
+- name: Attach Block Storage to a Droplet
+  digital_ocean_block_storage:
     state: present
     command: attach
     api_token: <TOKEN>
     volume_name: nyc1-block-storage
     region: nyc1
     droplet_id: <ID>
-# Detach Block Storage from a Droplet
-- digital_ocean_block_storage:
+
+- name: Detach Block Storage from a Droplet
+  digital_ocean_block_storage:
     state: absent
     command: attach
     api_token: <TOKEN>

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -50,26 +50,24 @@ requirements:
 
 
 EXAMPLES = '''
-# Create a domain
-
-- digital_ocean_domain:
+- name: Create a domain
+  digital_ocean_domain:
     state: present
     name: my.digitalocean.domain
     ip: 127.0.0.1
 
-# Create a droplet and a corresponding domain
-
-- digital_ocean:
+# Create a droplet and corresponding domain
+- name: Create a droplet
+  digital_ocean:
     state: present
     name: test_droplet
     size_id: 1gb
     region_id: sgp1
     image_id: ubuntu-14-04-x64
-
-
   register: test_droplet
 
-- digital_ocean_domain:
+- name: Create a corresponding domain
+  digital_ocean_domain:
     state: present
     name: "{{ test_droplet.droplet.name }}.my.domain"
     ip: "{{ test_droplet.droplet.ip_address }}"

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
@@ -33,17 +33,20 @@ requirements:
 
 
 EXAMPLES = '''
-- digital_ocean_sshkey_info:
+- name: Gather information about DigitalOcean SSH keys
+  digital_ocean_sshkey_info:
     oauth_token: "{{ my_do_key }}"
   register: ssh_keys
 
-- set_fact:
+- name: Set facts based on the gathered information
+  set_fact:
     pubkey: "{{ item.public_key }}"
   loop: "{{ ssh_keys.data|json_query(ssh_pubkey) }}"
   vars:
     ssh_pubkey: "[?name=='ansible_ctrl']"
 
-- debug:
+- name: Print SSH public key
+  debug:
     msg: "{{ pubkey }}"
 '''
 

--- a/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
+++ b/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
@@ -52,21 +52,23 @@ options:
 '''
 
 EXAMPLES = '''
-# Create an MCP 1.0 network
-- dimensiondata_network:
+- name: Create an MCP 1.0 network
+  dimensiondata_network:
     region: na
     location: NA5
     name: mynet
-# Create an MCP 2.0 network
-- dimensiondata_network:
+
+- name: Create an MCP 2.0 network
+  dimensiondata_network:
     region: na
     mcp_user: my_user
     mcp_password: my_password
     location: NA9
     name: mynet
     service_plan: ADVANCED
-# Delete a network
-- dimensiondata_network:
+
+- name: Delete a network
+  dimensiondata_network:
     region: na
     location: NA1
     name: mynet

--- a/plugins/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/plugins/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -75,8 +75,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Add or update VLAN
-- dimensiondata_vlan:
+- name: Add or update VLAN
+  dimensiondata_vlan:
     region: na
     location: NA5
     network_domain: test_network
@@ -86,16 +86,18 @@ EXAMPLES = '''
     private_ipv4_prefix_size: 24
     state: present
     wait: yes
-# Read / get VLAN details
-- dimensiondata_vlan:
+
+- name: Read / get VLAN details
+  dimensiondata_vlan:
     region: na
     location: NA5
     network_domain: test_network
     name: my_vlan1
     state: readonly
     wait: yes
-# Delete a VLAN
-- dimensiondata_vlan:
+
+- name: Delete a VLAN
+  dimensiondata_vlan:
     region: na
     location: NA5
     network_domain: test_network

--- a/plugins/modules/cloud/google/gcdns_record.py
+++ b/plugins/modules/cloud/google/gcdns_record.py
@@ -133,46 +133,46 @@ notes:
 '''
 
 EXAMPLES = '''
-# Create an A record.
-- gcdns_record:
+- name: Create an A record
+  gcdns_record:
     record: 'www1.example.com'
     zone: 'example.com'
     type: A
     value: '1.2.3.4'
 
-# Update an existing record.
-- gcdns_record:
+- name: Update an existing record
+  gcdns_record:
     record: 'www1.example.com'
     zone: 'example.com'
     type: A
     overwrite: true
     value: '5.6.7.8'
 
-# Remove an A record.
-- gcdns_record:
+- name: Remove an A record
+  gcdns_record:
     record: 'www1.example.com'
     zone_id: 'example-com'
     state: absent
     type: A
     value: '5.6.7.8'
 
-# Create a CNAME record.
-- gcdns_record:
+- name: Create a CNAME record. Note the trailing dot of value
+  gcdns_record:
     record: 'www.example.com'
     zone_id: 'example-com'
     type: CNAME
-    value: 'www.example.com.'    # Note the trailing dot
+    value: 'www.example.com.'
 
-# Create an MX record with a custom TTL.
-- gcdns_record:
+- name: Create an MX record with a custom TTL. Note the trailing dot of value
+  gcdns_record:
     record: 'example.com'
     zone: 'example.com'
     type: MX
     ttl: 3600
-    value: '10 mail.example.com.'    # Note the trailing dot
+    value: '10 mail.example.com.'
 
-# Create multiple A records with the same name.
-- gcdns_record:
+- name: Create multiple A records with the same name
+  gcdns_record:
     record: 'api.example.com'
     zone_id: 'example-com'
     type: A
@@ -182,54 +182,54 @@ EXAMPLES = '''
       - '198.51.100.5'
       - '203.0.113.10'
 
-# Change the value of an existing record with multiple record_data.
-- gcdns_record:
+- name: Change the value of an existing record with multiple record_data
+  gcdns_record:
     record: 'api.example.com'
     zone: 'example.com'
     type: A
     overwrite: true
-    record_data:           # WARNING: All values in a record will be replaced
+    record_data:        # WARNING: All values in a record will be replaced
       - '192.0.2.23'
       - '192.0.2.42'    # The changed record
       - '198.51.100.5'
       - '203.0.113.10'
 
-# Safely remove a multi-line record.
-- gcdns_record:
+- name: Safely remove a multi-line record
+  gcdns_record:
     record: 'api.example.com'
     zone_id: 'example-com'
     state: absent
     type: A
-    record_data:           # NOTE: All of the values must match exactly
+    record_data:        # NOTE: All of the values must match exactly
       - '192.0.2.23'
       - '192.0.2.42'
       - '198.51.100.5'
       - '203.0.113.10'
 
-# Unconditionally remove a record.
-- gcdns_record:
+- name: Unconditionally remove a record
+  gcdns_record:
     record: 'api.example.com'
     zone_id: 'example-com'
     state: absent
     overwrite: true   # overwrite is true, so no values are needed
     type: A
 
-# Create an AAAA record
-- gcdns_record:
+- name: Create an AAAA record
+  gcdns_record:
     record: 'www1.example.com'
     zone: 'example.com'
     type: AAAA
     value: 'fd00:db8::1'
 
-# Create a PTR record
-- gcdns_record:
+- name: Create a PTR record
+  gcdns_record:
     record: '10.5.168.192.in-addr.arpa'
     zone: '5.168.192.in-addr.arpa'
     type: PTR
     value: 'api.example.com.'    # Note the trailing dot.
 
-# Create an NS record
-- gcdns_record:
+- name: Create an NS record
+  gcdns_record:
     record: 'subdomain.example.com'
     zone: 'example.com'
     type: NS
@@ -240,8 +240,8 @@ EXAMPLES = '''
       - 'ns-cloud-d3.googledomains.com.'
       - 'ns-cloud-d4.googledomains.com.'
 
-# Create a TXT record
-- gcdns_record:
+- name: Create a TXT record
+  gcdns_record:
     record: 'example.com'
     zone_id: 'example-com'
     type: TXT

--- a/plugins/modules/cloud/google/gce_eip.py
+++ b/plugins/modules/cloud/google/gce_eip.py
@@ -40,8 +40,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a Global external IP address
-- gce_eip:
+- name: Create a Global external IP address
+  gce_eip:
     service_account_email: "{{ service_account_email }}"
     credentials_file: "{{ credentials_file }}"
     project_id: "{{ project_id }}"
@@ -49,8 +49,8 @@ EXAMPLES = '''
     region: global
     state: present
 
-# Create a Regional external IP address
-- gce_eip:
+- name: Create a Regional external IP address
+  gce_eip:
     service_account_email: "{{ service_account_email }}"
     credentials_file: "{{ credentials_file }}"
     project_id: "{{ project_id }}"

--- a/plugins/modules/cloud/google/gce_img.py
+++ b/plugins/modules/cloud/google/gce_img.py
@@ -64,25 +64,25 @@ author: "Tom Melendez (@supertom)"
 '''
 
 EXAMPLES = '''
-# Create an image named test-image from the disk 'test-disk' in zone us-central1-a.
-- gce_img:
+- name: Create an image named test-image from the disk 'test-disk' in zone us-central1-a
+  gce_img:
     name: test-image
     source: test-disk
     zone: us-central1-a
     state: present
 
-# Create an image named test-image from a tarball in Google Cloud Storage.
-- gce_img:
+- name: Create an image named test-image from a tarball in Google Cloud Storage
+  gce_img:
     name: test-image
     source: https://storage.googleapis.com/bucket/path/to/image.tgz
 
-# Alternatively use the gs scheme
-- gce_img:
+- name: Alternatively use the gs scheme
+  gce_img:
     name: test-image
     source: gs://bucket/path/to/image.tgz
 
-# Delete an image named test-image.
-- gce_img:
+- name: Delete an image named test-image
+  gce_img:
     name: test-image
     state: absent
 '''

--- a/plugins/modules/cloud/google/gce_lb.py
+++ b/plugins/modules/cloud/google/gce_lb.py
@@ -104,8 +104,8 @@ author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 
 EXAMPLES = '''
-# Simple example of creating a new LB, adding members, and a health check
-- local_action:
+- name: Simple example of creating a new LB, adding members, and a health check
+  local_action:
     module: gce_lb
     name: testlb
     region: us-central1

--- a/plugins/modules/cloud/google/gce_pd.py
+++ b/plugins/modules/cloud/google/gce_pd.py
@@ -89,8 +89,8 @@ author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 
 EXAMPLES = '''
-# Simple attachment action to an existing instance
-- local_action:
+- name: Simple attachment action to an existing instance
+  local_action:
     module: gce_pd
     instance_name: notlocalhost
     size_gb: 5

--- a/plugins/modules/cloud/google/gcpubsub_info.py
+++ b/plugins/modules/cloud/google/gcpubsub_info.py
@@ -44,18 +44,18 @@ options:
 '''
 
 EXAMPLES = '''
-## List all Topics in a project
-- gcpubsub_info:
+- name: List all Topics in a project
+  gcpubsub_info:
     view: topics
     state: list
 
-## List all Subscriptions in a project
-- gcpubsub_info:
+- name: List all Subscriptions in a project
+  gcpubsub_info:
     view: subscriptions
     state: list
 
-## List all Subscriptions for a Topic in a project
-- gcpubsub_info:
+- name: List all Subscriptions for a Topic in a project
+  gcpubsub_info:
     view: subscriptions
     topic: my-topic
     state: list

--- a/plugins/modules/cloud/heroku/heroku_collaborator.py
+++ b/plugins/modules/cloud/heroku/heroku_collaborator.py
@@ -51,13 +51,15 @@ notes:
 '''
 
 EXAMPLES = '''
-- heroku_collaborator:
+- name: Create a heroku collaborator
+  heroku_collaborator:
     api_key: YOUR_API_KEY
     user: max.mustermann@example.com
     apps: heroku-example-app
     state: present
 
-- heroku_collaborator:
+- name: An example of using the module in loop
+  heroku_collaborator:
     api_key: YOUR_API_KEY
     user: '{{ item.user }}'
     apps: '{{ item.apps | default(apps) }}'

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -367,171 +367,174 @@ requirements: [ "proxmoxer", "requests" ]
 '''
 
 EXAMPLES = '''
-# Create new VM with minimal options
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM with minimal options
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
 
-# Create new VM with minimal options and given vmid
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM with minimal options and given vmid
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    vmid        : 100
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    vmid: 100
 
-# Create new VM with two network interface options.
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM with two network interface options
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    net         : '{"net0":"virtio,bridge=vmbr1,rate=200", "net1":"e1000,bridge=vmbr2,"}'
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    net: '{"net0":"virtio,bridge=vmbr1,rate=200", "net1":"e1000,bridge=vmbr2,"}'
 
-# Create new VM with one network interface, three virto hard disk, 4 cores, and 2 vcpus.
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM with one network interface, three virto hard disk, 4 cores, and 2 vcpus
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    net         : '{"net0":"virtio,bridge=vmbr1,rate=200"}'
-    virtio      : '{"virtio0":"VMs_LVM:10", "virtio1":"VMs:2,format=qcow2", "virtio2":"VMs:5,format=raw"}'
-    cores       : 4
-    vcpus       : 2
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    net: '{"net0":"virtio,bridge=vmbr1,rate=200"}'
+    virtio: '{"virtio0":"VMs_LVM:10", "virtio1":"VMs:2,format=qcow2", "virtio2":"VMs:5,format=raw"}'
+    cores: 4
+    vcpus: 2
 
-# Clone VM with only source VM name
-- proxmox_kvm:
-    api_user    : root@pam
+- name: >
+    Clone VM with only source VM name.
+    The VM source is spynal.
+    The target VM name is zavala
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    clone       : spynal   # The VM source
-    name        : zavala  # The target VM name
-    node        : sabrewulf
-    storage     : VMs
-    format      : qcow2
-    timeout     : 500  # Note: The task can take a while. Adapt
+    api_host: helldorado
+    clone: spynal
+    name: zavala
+    node: sabrewulf
+    storage: VMs
+    format: qcow2
+    timeout: 500
 
-# Clone VM with source vmid and target newid and raw format
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Clone VM with source vmid and target newid and raw format
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    clone       : arbitrary_name
-    vmid        : 108
-    newid       : 152
-    name        : zavala  # The target VM name
-    node        : sabrewulf
-    storage     : LVM_STO
-    format      : raw
-    timeout     : 300  # Note: The task can take a while. Adapt
+    api_host: helldorado
+    clone: arbitrary_name
+    vmid: 108
+    newid: 152
+    name: zavala
+    node: sabrewulf
+    storage: LVM_STO
+    format: raw
+    timeout: 300
 
-# Create new VM and lock it for snapashot.
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM and lock it for snapashot
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    lock        : snapshot
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    lock: snapshot
 
-# Create new VM and set protection to disable the remove VM and remove disk operations
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Create new VM and set protection to disable the remove VM and remove disk operations
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    protection  : yes
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    protection: yes
 
-# Start VM
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Start VM
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : started
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: started
 
-# Stop VM
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Stop VM
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : stopped
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: stopped
 
-# Stop VM with force
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Stop VM with force
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : stopped
-    force       : yes
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: stopped
+    force: yes
 
-# Restart VM
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Restart VM
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : restarted
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: restarted
 
-# Remove VM
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Remove VM
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : absent
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: absent
 
-# Get VM current state
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Get VM current state
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    state       : current
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    state: current
 
-# Update VM configuration
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Update VM configuration
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    cores       : 8
-    memory      : 16384
-    update      : yes
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    cores: 8
+    memory: 16384
+    update: yes
 
-# Delete QEMU parameters
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Delete QEMU parameters
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    delete      : 'args,template,cpulimit'
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    delete: 'args,template,cpulimit'
 
-# Revert a pending change
-- proxmox_kvm:
-    api_user    : root@pam
+- name: Revert a pending change
+  proxmox_kvm:
+    api_user: root@pam
     api_password: secret
-    api_host    : helldorado
-    name        : spynal
-    node        : sabrewulf
-    revert      : 'template,cpulimit'
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    revert: 'template,cpulimit'
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/misc/proxmox_template.py
+++ b/plugins/modules/cloud/misc/proxmox_template.py
@@ -81,23 +81,25 @@ author: Sergei Antipov (@UnderGreen)
 '''
 
 EXAMPLES = '''
-# Upload new openvz template with minimal options
-- proxmox_template:
+- name: Upload new openvz template with minimal options
+  proxmox_template:
     node: uk-mc02
     api_user: root@pam
     api_password: 1q2w3e
     api_host: node1
     src: ~/ubuntu-14.04-x86_64.tar.gz
 
-# Upload new openvz template with minimal options use environment PROXMOX_PASSWORD variable(you should export it before)
-- proxmox_template:
+- name: >
+    Upload new openvz template with minimal options use environment
+    PROXMOX_PASSWORD variable(you should export it before)
+  proxmox_template:
     node: uk-mc02
     api_user: root@pam
     api_host: node1
     src: ~/ubuntu-14.04-x86_64.tar.gz
 
-# Upload new openvz template with all options and force overwrite
-- proxmox_template:
+- name: Upload new openvz template with all options and force overwrite
+  proxmox_template:
     node: uk-mc02
     api_user: root@pam
     api_password: 1q2w3e
@@ -107,8 +109,8 @@ EXAMPLES = '''
     src: ~/ubuntu-14.04-x86_64.tar.gz
     force: yes
 
-# Delete template with minimal options
-- proxmox_template:
+- name: Delete template with minimal options
+  proxmox_template:
     node: uk-mc02
     api_user: root@pam
     api_password: 1q2w3e

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -107,13 +107,13 @@ author: "Ryan Scott Brown (@ryansb)"
 '''
 
 EXAMPLES = """
-# Basic deploy of a service
-- terraform:
+- name: Basic deploy of a service
+  terraform:
     project_path: '{{ project_dir }}'
     state: present
 
-# Define the backend configuration at init
-- terraform:
+- name: Define the backend configuration at init
+  terraform:
     project_path: 'project/'
     state: "{{ state }}"
     force_init: true

--- a/plugins/modules/cloud/oneandone/oneandone_firewall_policy.py
+++ b/plugins/modules/cloud/oneandone/oneandone_firewall_policy.py
@@ -106,10 +106,8 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Provisioning example. Create and destroy a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Create a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     name: ansible-firewall-policy
     description: Testing creation of firewall policies with ansible
@@ -122,23 +120,22 @@ EXAMPLES = '''
     wait: true
     wait_timeout: 500
 
-- oneandone_firewall_policy:
+- name: Destroy a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     state: absent
     name: ansible-firewall-policy
 
-# Update a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Update a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     state: update
     firewall_policy: ansible-firewall-policy
     name: ansible-firewall-policy-updated
     description: Testing creation of firewall policies with ansible - updated
 
-# Add server to a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Add server to a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     firewall_policy: ansible-firewall-policy-updated
     add_server_ips:
@@ -148,9 +145,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Remove server from a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Remove server from a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     firewall_policy: ansible-firewall-policy-updated
     remove_server_ips:
@@ -159,9 +155,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Add rules to a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Add rules to a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     firewall_policy: ansible-firewall-policy-updated
     description: Adding rules to an existing firewall policy
@@ -180,9 +175,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Remove rules from a firewall policy.
-
-- oneandone_firewall_policy:
+- name: Remove rules from a firewall policy
+  oneandone_firewall_policy:
     auth_token: oneandone_private_api_key
     firewall_policy: ansible-firewall-policy-updated
     remove_rules:
@@ -192,7 +186,6 @@ EXAMPLES = '''
     wait: true
     wait_timeout: 500
     state: update
-
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/oneandone/oneandone_load_balancer.py
+++ b/plugins/modules/cloud/oneandone/oneandone_load_balancer.py
@@ -142,10 +142,8 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Provisioning example. Create and destroy a load balancer.
-
-- oneandone_load_balancer:
+- name: Create a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     name: ansible load balancer
     description: Testing creation of load balancer with ansible
@@ -164,16 +162,16 @@ EXAMPLES = '''
     wait: true
     wait_timeout: 500
 
-- oneandone_load_balancer:
+- name: Destroy a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     name: ansible load balancer
     wait: true
     wait_timeout: 500
     state: absent
 
-# Update a load balancer.
-
-- oneandone_load_balancer:
+- name: Update a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     load_balancer: ansible load balancer
     name: ansible load balancer updated
@@ -182,9 +180,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Add server to a load balancer.
-
-- oneandone_load_balancer:
+- name: Add server to a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     load_balancer: ansible load balancer updated
     description: Adding server to a load balancer with ansible
@@ -194,9 +191,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Remove server from a load balancer.
-
-- oneandone_load_balancer:
+- name: Remove server from a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     load_balancer: ansible load balancer updated
     description: Removing server from a load balancer with ansible
@@ -206,9 +202,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Add rules to a load balancer.
-
-- oneandone_load_balancer:
+- name: Add rules to a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     load_balancer: ansible load balancer updated
     description: Adding rules to a load balancer with ansible
@@ -227,9 +222,8 @@ EXAMPLES = '''
     wait_timeout: 500
     state: update
 
-# Remove rules from a load balancer.
-
-- oneandone_load_balancer:
+- name: Remove rules from a load balancer
+  oneandone_load_balancer:
     auth_token: oneandone_private_api_key
     load_balancer: ansible load balancer updated
     description: Adding rules to a load balancer with ansible

--- a/plugins/modules/cloud/oneandone/oneandone_monitoring_policy.py
+++ b/plugins/modules/cloud/oneandone/oneandone_monitoring_policy.py
@@ -187,10 +187,8 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Provisioning example. Create and destroy a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Create a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     name: ansible monitoring policy
     description: Testing creation of a monitoring policy with ansible
@@ -250,14 +248,14 @@ EXAMPLES = '''
        email_notification: false
     wait: true
 
-- oneandone_moitoring_policy:
+- name: Destroy a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     state: absent
     name: ansible monitoring policy
 
-# Update a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Update a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy
     name: ansible monitoring policy updated
@@ -307,9 +305,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Add a port to a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Add a port to a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     add_ports:
@@ -321,9 +318,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Update existing ports of a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Update existing ports of a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     update_ports:
@@ -342,18 +338,16 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Remove a port from a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Remove a port from a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     remove_ports:
      - port_id
     state: update
 
-# Add a process to a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Add a process to a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     add_processes:
@@ -364,9 +358,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Update existing processes of a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Update existing processes of a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     update_processes:
@@ -383,9 +376,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Remove a process from a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Remove a process from a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     remove_processes:
@@ -393,9 +385,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Add server to a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Add server to a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     add_servers:
@@ -403,9 +394,8 @@ EXAMPLES = '''
     wait: true
     state: update
 
-# Remove server from a monitoring policy.
-
-- oneandone_moitoring_policy:
+- name: Remove server from a monitoring policy
+  oneandone_moitoring_policy:
     auth_token: oneandone_private_api_key
     monitoring_policy: ansible monitoring policy updated
     remove_servers:

--- a/plugins/modules/cloud/oneandone/oneandone_private_network.py
+++ b/plugins/modules/cloud/oneandone/oneandone_private_network.py
@@ -95,10 +95,8 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Provisioning example. Create and destroy private networks.
-
-- oneandone_private_network:
+- name: Create a private network
+  oneandone_private_network:
     auth_token: oneandone_private_api_key
     name: backup_network
     description: Testing creation of a private network with ansible
@@ -106,38 +104,35 @@ EXAMPLES = '''
     subnet_mask: 255.0.0.0
     datacenter: US
 
-- oneandone_private_network:
+- name: Destroy a private network
+  oneandone_private_network:
     auth_token: oneandone_private_api_key
     state: absent
     name: backup_network
 
-# Modify the private network.
-
-- oneandone_private_network:
+- name: Modify the private network
+  oneandone_private_network:
     auth_token: oneandone_private_api_key
     state: update
     private_network: backup_network
     network_address: 192.168.2.0
     subnet_mask: 255.255.255.0
 
-# Add members to the private network.
-
-- oneandone_private_network:
+- name: Add members to the private network
+  oneandone_private_network:
     auth_token: oneandone_private_api_key
     state: update
     private_network: backup_network
     add_members:
      - server identifier (id or name)
 
-# Remove members from the private network.
-
-- oneandone_private_network:
+- name: Remove members from the private network
+  oneandone_private_network:
     auth_token: oneandone_private_api_key
     state: update
     private_network: backup_network
     remove_members:
      - server identifier (id or name)
-
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/oneandone/oneandone_public_ip.py
+++ b/plugins/modules/cloud/oneandone/oneandone_public_ip.py
@@ -87,31 +87,25 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Create a public IP.
-
-- oneandone_public_ip:
+- name: Create a public IP
+  oneandone_public_ip:
     auth_token: oneandone_private_api_key
     reverse_dns: example.com
     datacenter: US
     type: IPV4
 
-# Update a public IP.
-
-- oneandone_public_ip:
+- name: Update a public IP
+  oneandone_public_ip:
     auth_token: oneandone_private_api_key
     public_ip_id: public ip id
     reverse_dns: secondexample.com
     state: update
 
-
-# Delete a public IP
-
-- oneandone_public_ip:
+- name: Delete a public IP
+  oneandone_public_ip:
     auth_token: oneandone_private_api_key
     public_ip_id: public ip id
     state: absent
-
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/oneandone/oneandone_server.py
+++ b/plugins/modules/cloud/oneandone/oneandone_server.py
@@ -144,10 +144,8 @@ author:
 '''
 
 EXAMPLES = '''
-
-# Provisioning example. Creates three servers and enumerate their names.
-
-- oneandone_server:
+- name: Create three servers and enumerate their names
+  oneandone_server:
     auth_token: oneandone_private_api_key
     hostname: node%02d
     fixed_instance_size: XL
@@ -156,9 +154,8 @@ EXAMPLES = '''
     auto_increment: true
     count: 3
 
-# Create three servers, passing in an ssh_key.
-
-- oneandone_server:
+- name: Create three servers, passing in an ssh_key
+  oneandone_server:
     auth_token: oneandone_private_api_key
     hostname: node%02d
     vcore: 2
@@ -175,23 +172,20 @@ EXAMPLES = '''
     wait_interval: 10
     ssh_key: SSH_PUBLIC_KEY
 
-# Removing server
-
-- oneandone_server:
+- name: Removing server
+  oneandone_server:
     auth_token: oneandone_private_api_key
     state: absent
     server: 'node01'
 
-# Starting server.
-
-- oneandone_server:
+- name: Starting server
+  oneandone_server:
     auth_token: oneandone_private_api_key
     state: running
     server: 'node01'
 
-# Stopping server
-
-- oneandone_server:
+- name: Stopping server
+  oneandone_server:
     auth_token: oneandone_private_api_key
     state: stopped
     server: 'node01'

--- a/plugins/modules/cloud/opennebula/one_image.py
+++ b/plugins/modules/cloud/opennebula/one_image.py
@@ -78,40 +78,40 @@ author:
 '''
 
 EXAMPLES = '''
-# Fetch the IMAGE by id
-- one_image:
+- name: Fetch the IMAGE by id
+  one_image:
     id: 45
   register: result
 
-# Print the IMAGE properties
-- debug:
+- name: Print the IMAGE properties
+  debug:
     msg: result
 
-# Rename existing IMAGE
-- one_image:
+- name: Rename existing IMAGE
+  one_image:
     id: 34
     state: renamed
     new_name: bar-image
 
-# Disable the IMAGE by id
-- one_image:
+- name: Disable the IMAGE by id
+  one_image:
     id: 37
     enabled: no
 
-# Enable the IMAGE by name
-- one_image:
+- name: Enable the IMAGE by name
+  one_image:
     name: bar-image
     enabled: yes
 
-# Clone the IMAGE by name
-- one_image:
+- name: Clone the IMAGE by name
+  one_image:
     name: bar-image
     state: cloned
     new_name: bar-image-clone
   register: result
 
-# Delete the IMAGE by id
-- one_image:
+- name: Delete the IMAGE by id
+  one_image:
     id: '{{ result.id }}'
     state: absent
 '''

--- a/plugins/modules/cloud/opennebula/one_image_info.py
+++ b/plugins/modules/cloud/opennebula/one_image_info.py
@@ -69,31 +69,31 @@ author:
 '''
 
 EXAMPLES = '''
-# Gather facts about all images
-- one_image_info:
+- name: Gather facts about all images
+  one_image_info:
   register: result
 
-# Print all images facts
-- debug:
+- name: Print all images facts
+  debug:
     msg: result
 
-# Gather facts about an image using ID
-- one_image_info:
+- name: Gather facts about an image using ID
+  one_image_info:
     ids:
       - 123
 
-# Gather facts about an image using the name
-- one_image_info:
+- name: Gather facts about an image using the name
+  one_image_info:
     name: 'foo-image'
   register: foo_image
 
-# Gather facts about all IMAGEs whose name matches regex 'app-image-.*'
-- one_image_info:
+- name: Gather facts about all IMAGEs whose name matches regex 'app-image-.*'
+  one_image_info:
     name: '~app-image-.*'
   register: app_images
 
-# Gather facts about all IMAGEs whose name matches regex 'foo-image-.*' ignoring cases
-- one_image_info:
+- name: Gather facts about all IMAGEs whose name matches regex 'foo-image-.*' ignoring cases
+  one_image_info:
     name: '~*foo-image-.*'
   register: foo_images
 '''

--- a/plugins/modules/cloud/opennebula/one_service.py
+++ b/plugins/modules/cloud/opennebula/one_service.py
@@ -108,70 +108,70 @@ author:
 '''
 
 EXAMPLES = '''
-# Instantiate a new service
-- one_service:
+- name: Instantiate a new service
+  one_service:
     template_id: 90
   register: result
 
-# Print service properties
-- debug:
+- name: Print service properties
+  debug:
     msg: result
 
-# Instantiate a new service with specified service_name, service group and mode
-- one_service:
+- name: Instantiate a new service with specified service_name, service group and mode
+  one_service:
     template_name: 'app1_template'
     service_name: 'app1'
     group_id: 1
     mode: '660'
 
-# Instantiate a new service with template_id and pass custom_attrs dict
-- one_service:
+- name: Instantiate a new service with template_id and pass custom_attrs dict
+  one_service:
     template_id: 90
     custom_attrs:
       public_network_id: 21
       private_network_id: 26
 
-# Instantiate a new service 'foo' if the service doesn't already exist, otherwise do nothing
-- one_service:
+- name: Instantiate a new service 'foo' if the service doesn't already exist, otherwise do nothing
+  one_service:
     template_id: 53
     service_name: 'foo'
     unique: yes
 
-# Delete a service by ID
-- one_service:
+- name: Delete a service by ID
+  one_service:
     service_id: 153
     state: absent
 
-# Get service info
-- one_service:
+- name: Get service info
+  one_service:
     service_id: 153
   register: service_info
 
-# Change service owner, group and mode
-- one_service:
+- name: Change service owner, group and mode
+  one_service:
     service_name: 'app2'
     owner_id: 34
     group_id: 113
     mode: '600'
 
-# Instantiate service and wait for it to become RUNNING
--  one_service:
+- name: Instantiate service and wait for it to become RUNNING
+  one_service:
     template_id: 43
     service_name: 'foo1'
 
-# Wait service to become RUNNING
-- one_service:
+- name: Wait service to become RUNNING
+  one_service:
     service_id: 112
     wait: yes
 
-# Change role cardinality
-- one_service:
+- name: Change role cardinality
+  one_service:
     service_id: 153
     role: bar
     cardinality: 5
 
-# Change role cardinality and wait for it to be applied
-- one_service:
+- name: Change role cardinality and wait for it to be applied
+  one_service:
     service_id: 112
     role: foo
     cardinality: 7

--- a/plugins/modules/cloud/opennebula/one_vm.py
+++ b/plugins/modules/cloud/opennebula/one_vm.py
@@ -189,44 +189,44 @@ author:
 
 
 EXAMPLES = '''
-# Create a new instance
-- one_vm:
+- name: Create a new instance
+  one_vm:
     template_id: 90
   register: result
 
-# Print VM properties
-- debug:
+- name: Print VM properties
+  debug:
     msg: result
 
-# Deploy a new VM on hold
-- one_vm:
+- name: Deploy a new VM on hold
+  one_vm:
     template_name: 'app1_template'
     vm_start_on_hold: 'True'
 
-# Deploy a new VM and set its name to 'foo'
-- one_vm:
+- name: Deploy a new VM and set its name to 'foo'
+  one_vm:
     template_name: 'app1_template'
     attributes:
       name: foo
 
-# Deploy a new VM and set its group_id and mode
-- one_vm:
+- name: Deploy a new VM and set its group_id and mode
+  one_vm:
     template_id: 90
     group_id: 16
     mode: 660
 
-# Deploy a new VM  as persistent
-- one_vm:
+- name: Deploy a new VM  as persistent
+  one_vm:
     template_id: 90
     persistent: yes
 
-# Change VM's permissions to 640
-- one_vm:
+- name: Change VM's permissions to 640
+  one_vm:
     instance_ids: 5
     mode: 640
 
-# Deploy 2 new instances and set memory, vcpu, disk_size and 3 networks
-- one_vm:
+- name: Deploy 2 new instances and set memory, vcpu, disk_size and 3 networks
+  one_vm:
     template_id: 15
     disk_size: 35.2 GB
     memory: 4 GB
@@ -240,8 +240,8 @@ EXAMPLES = '''
       - NETWORK_ID: 27
         SECURITY_GROUPS: "10"
 
-# Deploy a new instance which uses a Template with two Disks
-- one_vm:
+- name: Deploy a new instance which uses a Template with two Disks
+  one_vm:
     template_id: 42
     disk_size:
       - 35.2 GB
@@ -252,15 +252,15 @@ EXAMPLES = '''
     networks:
       - NETWORK_ID: 27
 
-# Deploy an new instance with attribute 'bar: bar1' and set its name to 'foo'
-- one_vm:
+- name: "Deploy an new instance with attribute 'bar: bar1' and set its name to 'foo'"
+  one_vm:
     template_id: 53
     attributes:
       name: foo
       bar: bar1
 
-# Enforce that 2 instances with attributes 'foo1: app1' and 'foo2: app2' are deployed
-- one_vm:
+- name: "Enforce that 2 instances with attributes 'foo1: app1' and 'foo2: app2' are deployed"
+  one_vm:
     template_id: 53
     attributes:
       foo1: app1
@@ -270,8 +270,8 @@ EXAMPLES = '''
       foo1: app1
       foo2: app2
 
-# Enforce that 4 instances with an attribute 'bar' are deployed
-- one_vm:
+- name: Enforce that 4 instances with an attribute 'bar' are deployed
+  one_vm:
     template_id: 53
     attributes:
       name: app
@@ -282,7 +282,8 @@ EXAMPLES = '''
 
 # Deploy 2 new instances with attribute 'foo: bar' and labels 'app1' and 'app2' and names in format 'fooapp-##'
 # Names will be: fooapp-00 and fooapp-01
-- one_vm:
+- name: Deploy 2 new instances
+  one_vm:
     template_id: 53
     attributes:
       name: fooapp-##
@@ -294,7 +295,8 @@ EXAMPLES = '''
 
 # Deploy 2 new instances with attribute 'app: app1' and names in format 'fooapp-###'
 # Names will be: fooapp-002 and fooapp-003
-- one_vm:
+- name: Deploy 2 new instances
+  one_vm:
     template_id: 53
     attributes:
       name: fooapp-###
@@ -303,61 +305,63 @@ EXAMPLES = '''
 
 # Reboot all instances with name in format 'fooapp-#'
 # Instances 'fooapp-00', 'fooapp-01', 'fooapp-002' and 'fooapp-003' will be rebooted
-- one_vm:
+- name: Reboot all instances with names in a certain format
+  one_vm:
     attributes:
       name: fooapp-#
     state: rebooted
 
 # Enforce that only 1 instance with name in format 'fooapp-#' is deployed
 # The task will delete oldest instances, so only the 'fooapp-003' will remain
-- one_vm:
+- name: Enforce that only 1 instance with name in a certain format is deployed
+  one_vm:
     template_id: 53
     exact_count: 1
     count_attributes:
       name: fooapp-#
 
-# Deploy an new instance with a network
-- one_vm:
+- name: Deploy an new instance with a network
+  one_vm:
     template_id: 53
     networks:
       - NETWORK_ID: 27
   register: vm
 
-# Wait for SSH to come up
-- wait_for_connection:
+- name: Wait for SSH to come up
+  wait_for_connection:
   delegate_to: '{{ vm.instances[0].networks[0].ip }}'
 
-# Terminate VMs by ids
-- one_vm:
+- name: Terminate VMs by ids
+  one_vm:
     instance_ids:
       - 153
       - 160
     state: absent
 
-# Reboot all VMs that have labels 'foo' and 'app1'
-- one_vm:
+- name: Reboot all VMs that have labels 'foo' and 'app1'
+  one_vm:
     labels:
       - foo
       - app1
     state: rebooted
 
-# Fetch all VMs that have name 'foo' and attribute 'app: bar'
-- one_vm:
+- name: "Fetch all VMs that have name 'foo' and attribute 'app: bar'"
+  one_vm:
     attributes:
       name: foo
       app: bar
   register: results
 
-# Deploy 2 new instances with labels 'foo1' and 'foo2'
-- one_vm:
+- name: Deploy 2 new instances with labels 'foo1' and 'foo2'
+  one_vm:
     template_name: app_template
     labels:
       - foo1
       - foo2
     count: 2
 
-# Enforce that only 1 instance with label 'foo1' will be running
-- one_vm:
+- name: Enforce that only 1 instance with label 'foo1' will be running
+  one_vm:
     template_name: app_template
     labels:
       - foo1
@@ -365,22 +369,22 @@ EXAMPLES = '''
     count_labels:
       - foo1
 
-# Terminate all instances that have attribute foo
-- one_vm:
+- name: Terminate all instances that have attribute foo
+  one_vm:
     template_id: 53
     exact_count: 0
     count_attributes:
       foo:
 
-# Power-off the VM and save VM's disk with id=0 to the image with name 'foo-image'
-- one_vm:
+- name: "Power-off the VM and save VM's disk with id=0 to the image with name 'foo-image'"
+  one_vm:
     instance_ids: 351
     state: poweredoff
     disk_saveas:
       name: foo-image
 
-# Save VM's disk with id=1 to the image with name 'bar-image'
-- one_vm:
+- name: "Save VM's disk with id=1 to the image with name 'bar-image'"
+  one_vm:
     instance_ids: 351
     disk_saveas:
       name: bar-image

--- a/plugins/modules/cloud/ovh/ovh_ip_loadbalancing_backend.py
+++ b/plugins/modules/cloud/ovh/ovh_ip_loadbalancing_backend.py
@@ -74,9 +74,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Adds or modify the backend '212.1.1.1' to a
-# loadbalancing 'ip-1.1.1.1'
-- ovh_ip_loadbalancing:
+- name: Adds or modify the backend '212.1.1.1' to a loadbalancing 'ip-1.1.1.1'
+  ovh_ip_loadbalancing:
     name: ip-1.1.1.1
     backend: 212.1.1.1
     state: present
@@ -87,8 +86,8 @@ EXAMPLES = '''
     application_secret: yoursecret
     consumer_key: yourconsumerkey
 
-# Removes a backend '212.1.1.1' from a loadbalancing 'ip-1.1.1.1'
-- ovh_ip_loadbalancing:
+- name: Removes a backend '212.1.1.1' from a loadbalancing 'ip-1.1.1.1'
+  ovh_ip_loadbalancing:
     name: ip-1.1.1.1
     backend: 212.1.1.1
     state: absent

--- a/plugins/modules/cloud/ovh/ovh_monthly_billing.py
+++ b/plugins/modules/cloud/ovh/ovh_monthly_billing.py
@@ -52,27 +52,26 @@ options:
 '''
 
 EXAMPLES = '''
-# basic usage, using auth from /etc/ovh.conf
-  - ovh_monthly_billing:
-       project_id: 0c727a20aa144485b70c44dee9123b46
-       instance_id: 8fa89ad2-8f08-4220-9fa4-9695ea23e948
+- name: Basic usage, using auth from /etc/ovh.conf
+  ovh_monthly_billing:
+    project_id: 0c727a20aa144485b70c44dee9123b46
+    instance_id: 8fa89ad2-8f08-4220-9fa4-9695ea23e948
 
-# a bit more more complex
-  # get openstack cloud ID and instance ID, OVH use them in its API
-  - os_server_info:
-      cloud: myProjectName
-      region_name: myRegionName
-      server: myServerName
-    # force run even in check_mode
-    check_mode: no
+# Get openstack cloud ID and instance ID, OVH use them in its API
+- name: Get openstack cloud ID and instance ID
+  os_server_info:
+    cloud: myProjectName
+    region_name: myRegionName
+    server: myServerName
+  register: openstack_servers
 
-  # use theses IDs
-  - ovh_monthly_billing:
-      project_id: "{{ openstack_servers.0.tenant_id }}"
-      instance_id: "{{ openstack_servers.0.id }}"
-      application_key: yourkey
-      application_secret: yoursecret
-      consumer_key: yourconsumerkey
+- name: Use IDs
+  ovh_monthly_billing:
+    project_id: "{{ openstack_servers.0.tenant_id }}"
+    instance_id: "{{ openstack_servers.0.id }}"
+    application_key: yourkey
+    application_secret: yoursecret
+    consumer_key: yourconsumerkey
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py
@@ -63,36 +63,47 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all affinity labels, which names start with C(label):
-- ovirt_affinity_label_info:
+- name: Gather information about all affinity labels, which names start with label
+  ovirt_affinity_label_info:
     name: label*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_affinity_labels }}"
 
-# Gather information about all affinity labels, which are assigned to VMs
-# which names start with C(postgres):
-- ovirt_affinity_label_info:
+- name: >
+    Gather information about all affinity labels, which are assigned to VMs
+    which names start with postgres
+  ovirt_affinity_label_info:
     vm: postgres*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_affinity_labels }}"
 
-# Gather information about all affinity labels, which are assigned to hosts
-# which names start with C(west):
-- ovirt_affinity_label_info:
+- name: >
+    Gather information about all affinity labels, which are assigned to hosts
+    which names start with west
+  ovirt_affinity_label_info:
     host: west*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_affinity_labels }}"
 
-# Gather information about all affinity labels, which are assigned to hosts
-# which names start with C(west) or VMs which names start with C(postgres):
-- ovirt_affinity_label_info:
+- name: >
+    Gather information about all affinity labels, which are assigned to hosts
+    which names start with west or VMs which names start with postgres
+  ovirt_affinity_label_info:
     host: west*
     vm: postgres*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_affinity_labels }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_api_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_api_facts.py
@@ -40,10 +40,12 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information oVirt API:
-- ovirt_api_info:
+- name: Gather information oVirt API
+  ovirt_api_info:
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_api }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_cluster_facts.py
@@ -59,12 +59,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all clusters which names start with C<production>:
-- ovirt_cluster_info:
+- name: Gather information about all clusters which names start with production
+  ovirt_cluster_info:
     pattern:
       name: 'production*'
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_clusters }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py
@@ -43,11 +43,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all data centers which names start with C(production):
-- ovirt_datacenter_info:
+- name: Gather information about all data centers which names start with production
+  ovirt_datacenter_info:
     pattern: name=production*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_datacenters }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_disk_facts.py
@@ -59,11 +59,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all Disks which names start with C(centos)
-- ovirt_disk_info:
+- name: Gather information about all Disks which names start with centos
+  ovirt_disk_info:
     pattern: name=centos*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_disks }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -62,12 +62,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all image external providers named C<glance>:
-- ovirt_external_provider_info:
+- name: Gather information about all image external providers named glance
+  ovirt_external_provider_info:
     type: os_image
     name: glance
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_external_providers }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_group_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_group_facts.py
@@ -58,11 +58,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all groups which names start with C(admin):
-- ovirt_group_info:
+- name: Gather information about all groups which names start with admin
+  ovirt_group_info:
     pattern: name=admin*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_groups }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_host_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_facts.py
@@ -55,19 +55,23 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all hosts which names start with C(host) and
-# belong to data center C(west):
-- ovirt_host_info:
+- name: Gather information about all hosts which names start with host and belong to data center west
+  ovirt_host_info:
     pattern: name=host* and datacenter=west
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_hosts }}"
-# All hosts with cluster version 4.2:
-- ovirt_host_info:
+
+- name: Gather information about all hosts with cluster version 4.2
+  ovirt_host_info:
     pattern: name=host*
     cluster_version: "4.2"
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_hosts }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_host_storage_facts.py
@@ -70,14 +70,16 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about HostStorages with specified target and address:
-- ovirt_host_storage_info:
+- name: Gather information about HostStorages with specified target and address
+  ovirt_host_storage_info:
     host: myhost
     iscsi:
       target: iqn.2016-08-09.domain-01:nickname
       address: 10.34.63.204
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_host_storages }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_network_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_network_facts.py
@@ -59,11 +59,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all networks which names start with C(vlan1):
-- ovirt_network_info:
+- name: Gather information about all networks which names start with vlan1
+  ovirt_network_info:
     pattern: name=vlan1*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_networks }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_nic_facts.py
@@ -61,12 +61,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all NICs which names start with C(eth) for VM named C(centos7):
-- ovirt_nic_info:
+- name: Gather information about all NICs which names start with eth for VM named centos7
+  ovirt_nic_info:
     vm: centos7
     name: eth*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_nics }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_permission_facts.py
@@ -69,12 +69,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all permissions of user with username C(john):
-- ovirt_permission_info:
+- name: Gather information about all permissions of user with username john
+  ovirt_permission_info:
     user_name: john
     authz_name: example.com-authz
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_permissions }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_quota_facts.py
@@ -61,12 +61,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about quota named C<myquota> in Default datacenter:
-- ovirt_quota_info:
+- name: Gather information about quota named C<myquota> in Default datacenter
+  ovirt_quota_info:
     data_center: Default
     name: myquota
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_quotas }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_scheduling_policy_facts.py
@@ -61,11 +61,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all scheduling policies with name InClusterUpgrade:
-- ovirt_scheduling_policy_info:
+- name: Gather information about all scheduling policies with name InClusterUpgrade
+  ovirt_scheduling_policy_info:
     name: InClusterUpgrade
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_scheduling_policies }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_snapshot_facts.py
@@ -49,12 +49,14 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all snapshots which description start with C(update) for VM named C(centos7):
-- ovirt_snapshot_info:
+- name: Gather information about all snapshots which description start with update for VM named centos7
+  ovirt_snapshot_info:
     vm: centos7
     description: update*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_snapshots }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_domain_facts.py
@@ -59,12 +59,15 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all storage domains which names start with C(data) and
-# belong to data center C(west):
-- ovirt_storage_domain_info:
+- name: >
+    Gather information about all storage domains which names
+    start with data and belong to data center west
+  ovirt_storage_domain_info:
     pattern: name=data* and datacenter=west
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_storage_domains }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_template_facts.py
@@ -66,12 +66,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all Templates which relate to a storage domain and
-# are unregistered:
-- ovirt_storage_template_info:
-    unregistered=True
+- name: Gather information about all templates which relate to a storage domain and are unregistered
+  ovirt_storage_template_info:
+    unregistered: yes
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_storage_templates }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_storage_vm_facts.py
@@ -66,12 +66,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all VMs which relate to a storage domain and
-# are unregistered:
-- ovirt_vms_info:
-    unregistered=True
+- name: Gather information about all VMs which relate to a storage domain and are unregistered
+  ovirt_vms_info:
+    unregistered: yes
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_storage_vms }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_tag_facts.py
@@ -63,25 +63,31 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all tags, which names start with C(tag):
-- ovirt_tag_info:
+- name: Gather information about all tags, which names start with tag
+  ovirt_tag_info:
     name: tag*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_tags }}"
 
-# Gather information about all tags, which are assigned to VM C(postgres):
-- ovirt_tag_info:
+- name: Gather information about all tags, which are assigned to VM postgres
+  ovirt_tag_info:
     vm: postgres
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_tags }}"
 
-# Gather information about all tags, which are assigned to host C(west):
-- ovirt_tag_info:
+- name: Gather information about all tags, which are assigned to host west
+  ovirt_tag_info:
     host: west
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_tags }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_template_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_template_facts.py
@@ -59,12 +59,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all templates which names start with C(centos) and
-# belongs to data center C(west):
-- ovirt_template_info:
+- name: Gather information about all templates which names start with centos and belongs to data center west
+  ovirt_template_info:
     pattern: name=centos* and datacenter=west
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_templates }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_user_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_user_facts.py
@@ -58,11 +58,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all users which first names start with C(john):
-- ovirt_user_info:
+- name: Gather information about all users which first names start with john
+  ovirt_user_info:
     pattern: name=john*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_users }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vm_facts.py
@@ -78,20 +78,23 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all VMs which names start with C(centos) and
-# belong to cluster C(west):
-- ovirt_vm_info:
+- name: Gather information about all VMs which names start with centos and belong to cluster west
+  ovirt_vm_info:
     pattern: name=centos* and cluster=west
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_vms }}"
 
-# Gather info about next run configuration of virtual machine named myvm
-- ovirt_vm_info:
+- name: Gather info about next run configuration of virtual machine named myvm
+  ovirt_vm_info:
     pattern: name=myvm
     next_run: true
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_vms[0] }}"
 '''
 

--- a/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py
@@ -58,11 +58,13 @@ EXAMPLES = '''
 # Examples don't contain auth parameter for simplicity,
 # look at ovirt_auth module to see how to reuse authentication:
 
-# Gather information about all vm pools which names start with C(centos):
-- ovirt_vmpool_info:
+- name: Gather information about all vm pools which names start with centos
+  ovirt_vmpool_info:
     pattern: name=centos*
   register: result
-- debug:
+
+- name: Print gathered information
+  debug:
     msg: "{{ result.ovirt_vm_pools }}"
 '''
 

--- a/plugins/modules/clustering/etcd3.py
+++ b/plugins/modules/clustering/etcd3.py
@@ -72,16 +72,16 @@ author:
 '''
 
 EXAMPLES = """
-# Store a value "bar" under the key "foo" for a cluster located "http://localhost:2379"
-- etcd3:
+- name: Store a value "bar" under the key "foo" for a cluster located "http://localhost:2379"
+  etcd3:
     key: "foo"
     value: "baz3"
     host: "localhost"
     port: 2379
     state: "present"
 
-# Authenticate using user/password combination with a timeout of 10 seconds
-- etcd3:
+- name: Authenticate using user/password combination with a timeout of 10 seconds
+  etcd3:
     key: "foo"
     value: "baz3"
     state: "present"
@@ -89,8 +89,8 @@ EXAMPLES = """
     password: "password123"
     timeout: 10
 
-# Authenticate using TLS certificates
-- etcd3:
+- name: Authenticate using TLS certificates
+  etcd3:
     key: "foo"
     value: "baz3"
     state: "present"

--- a/plugins/modules/database/misc/elasticsearch_plugin.py
+++ b/plugins/modules/database/misc/elasticsearch_plugin.py
@@ -81,28 +81,28 @@ options:
 '''
 
 EXAMPLES = '''
-# Install Elasticsearch Head plugin in Elasticsearch 2.x
-- elasticsearch_plugin:
+- name: Install Elasticsearch Head plugin in Elasticsearch 2.x
+  elasticsearch_plugin:
     name: mobz/elasticsearch-head
     state: present
 
-# Install a specific version of Elasticsearch Head in Elasticsearch 2.x
-- elasticsearch_plugin:
+- name: Install a specific version of Elasticsearch Head in Elasticsearch 2.x
+  elasticsearch_plugin:
     name: mobz/elasticsearch-head
     version: 2.0.0
 
-# Uninstall Elasticsearch head plugin in Elasticsearch 2.x
-- elasticsearch_plugin:
+- name: Uninstall Elasticsearch head plugin in Elasticsearch 2.x
+  elasticsearch_plugin:
     name: mobz/elasticsearch-head
     state: absent
 
-# Install a specific plugin in Elasticsearch >= 5.0
-- elasticsearch_plugin:
+- name: Install a specific plugin in Elasticsearch >= 5.0
+  elasticsearch_plugin:
     name: analysis-icu
     state: present
 
-# Install the ingest-geoip plugin with a forced installation
-- elasticsearch_plugin:
+- name: Install the ingest-geoip plugin with a forced installation
+  elasticsearch_plugin:
     name: ingest-geoip
     state: present
     force: yes

--- a/plugins/modules/database/misc/riak.py
+++ b/plugins/modules/database/misc/riak.py
@@ -59,17 +59,17 @@ options:
 '''
 
 EXAMPLES = '''
-# Join's a Riak node to another node
-- riak:
+- name: "Join's a Riak node to another node"
+  riak:
     command: join
     target_node: riak@10.1.1.1
 
-# Wait for handoffs to finish.  Use with async and poll.
-- riak:
+- name: Wait for handoffs to finish. Use with async and poll.
+  riak:
     wait_for_handoffs: yes
 
-# Wait for riak_kv service to startup
-- riak:
+- name: Wait for riak_kv service to startup
+  riak:
     wait_for_service: kv
 '''
 

--- a/plugins/modules/database/mssql/mssql_db.py
+++ b/plugins/modules/database/mssql/mssql_db.py
@@ -64,17 +64,19 @@ author: Vedit Firat Arig (@vedit)
 '''
 
 EXAMPLES = '''
-# Create a new database with name 'jackdata'
-- mssql_db:
+- name: Create a new database with name 'jackdata'
+  mssql_db:
     name: jackdata
     state: present
 
 # Copy database dump file to remote host and restore it to database 'my_db'
-- copy:
+- name: Copy database dump file to remote host
+  copy:
     src: dump.sql
     dest: /tmp
 
-- mssql_db:
+- name: Restore the dump file to database 'my_db'
+  mssql_db:
     name: my_db
     state: import
     target: /tmp/dump.sql

--- a/plugins/modules/database/proxysql/proxysql_backend_servers.py
+++ b/plugins/modules/database/proxysql/proxysql_backend_servers.py
@@ -99,7 +99,8 @@ EXAMPLES = '''
 # runtime in a single batch using the M(proxysql_manage_config) module).  It
 # uses supplied credentials to connect to the proxysql admin interface.
 
-- proxysql_backend_servers:
+- name: Add a server
+  proxysql_backend_servers:
     login_user: 'admin'
     login_password: 'admin'
     hostname: 'mysql01'
@@ -110,7 +111,8 @@ EXAMPLES = '''
 # dynamically loads the mysql server config to runtime.  It uses credentials
 # in a supplied config file to connect to the proxysql admin interface.
 
-- proxysql_backend_servers:
+- name: Remove a server
+  proxysql_backend_servers:
     config_file: '~/proxysql.cnf'
     hostname: 'mysql02'
     state: absent

--- a/plugins/modules/database/proxysql/proxysql_global_variables.py
+++ b/plugins/modules/database/proxysql/proxysql_global_variables.py
@@ -37,7 +37,8 @@ EXAMPLES = '''
 # runtime. It uses supplied credentials to connect to the proxysql admin
 # interface.
 
-- proxysql_global_variables:
+- name: Set the value of a variable
+  proxysql_global_variables:
     login_user: 'admin'
     login_password: 'admin'
     variable: 'mysql-max_connections'
@@ -46,7 +47,8 @@ EXAMPLES = '''
 # This example gets the value of a variable.  It uses credentials in a
 # supplied config file to connect to the proxysql admin interface.
 
-- proxysql_global_variables:
+- name: Get the value of a variable
+  proxysql_global_variables:
     config_file: '~/proxysql.cnf'
     variable: 'mysql-default_query_delay'
 '''

--- a/plugins/modules/database/proxysql/proxysql_manage_config.py
+++ b/plugins/modules/database/proxysql/proxysql_manage_config.py
@@ -61,7 +61,8 @@ EXAMPLES = '''
 # This example saves the mysql users config from memory to disk. It uses
 # supplied credentials to connect to the proxysql admin interface.
 
-- proxysql_manage_config:
+- name: Save the mysql users config from memory to disk
+  proxysql_manage_config:
     login_user: 'admin'
     login_password: 'admin'
     action: "SAVE"
@@ -69,10 +70,11 @@ EXAMPLES = '''
     direction: "FROM"
     config_layer: "MEMORY"
 
-# This example loads the mysql query rules config from memory to to runtime. It
+# This example loads the mysql query rules config from memory to runtime. It
 # uses supplied credentials to connect to the proxysql admin interface.
 
-- proxysql_manage_config:
+- name: Load the mysql query rules config from memory to runtime
+  proxysql_manage_config:
     config_file: '~/proxysql.cnf'
     action: "LOAD"
     config_settings: "MYSQL QUERY RULES"

--- a/plugins/modules/database/proxysql/proxysql_mysql_users.py
+++ b/plugins/modules/database/proxysql/proxysql_mysql_users.py
@@ -94,7 +94,8 @@ EXAMPLES = '''
 # runtime in a single batch using the M(proxysql_manage_config) module).  It
 # uses supplied credentials to connect to the proxysql admin interface.
 
-- proxysql_mysql_users:
+- name: Add a user
+  proxysql_mysql_users:
     login_user: 'admin'
     login_password: 'admin'
     username: 'productiondba'
@@ -105,7 +106,8 @@ EXAMPLES = '''
 # dynamically loads the mysql user config to runtime.  It uses credentials
 # in a supplied config file to connect to the proxysql admin interface.
 
-- proxysql_mysql_users:
+- name: Remove a user
+  proxysql_mysql_users:
     config_file: '~/proxysql.cnf'
     username: 'mysqlboy'
     state: absent

--- a/plugins/modules/database/proxysql/proxysql_query_rules.py
+++ b/plugins/modules/database/proxysql/proxysql_query_rules.py
@@ -153,7 +153,8 @@ EXAMPLES = '''
 # single batch using the M(proxysql_manage_config) module). It uses supplied
 # credentials to connect to the proxysql admin interface.
 
-- proxysql_query_rules:
+- name: Add a rule
+  proxysql_query_rules:
     login_user: admin
     login_password: admin
     username: 'guest_ro'
@@ -169,7 +170,8 @@ EXAMPLES = '''
 # config to runtime.  It uses credentials in a supplied config file to connect
 # to the proxysql admin interface.
 
-- proxysql_query_rules:
+- name: Remove rules
+  proxysql_query_rules:
     config_file: '~/proxysql.cnf'
     username: 'guest_ro'
     state: absent

--- a/plugins/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/plugins/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -51,7 +51,8 @@ EXAMPLES = '''
 # M(proxysql_manage_config) module).  It uses supplied credentials to connect
 # to the proxysql admin interface.
 
-- proxysql_replication_hostgroups:
+- name: Add a replication hostgroup
+  proxysql_replication_hostgroups:
     login_user: 'admin'
     login_password: 'admin'
     writer_hostgroup: 1
@@ -64,7 +65,8 @@ EXAMPLES = '''
 # credentials in a supplied config file to connect to the proxysql admin
 # interface.
 
-- proxysql_replication_hostgroups:
+- name: Remove a replication hostgroup
+  proxysql_replication_hostgroups:
     config_file: '~/proxysql.cnf'
     writer_hostgroup: 3
     reader_hostgroup: 4

--- a/plugins/modules/database/proxysql/proxysql_scheduler.py
+++ b/plugins/modules/database/proxysql/proxysql_scheduler.py
@@ -75,7 +75,8 @@ EXAMPLES = '''
 # runtime in a single batch using the M(proxysql_manage_config) module).  It
 # uses supplied credentials to connect to the proxysql admin interface.
 
-- proxysql_scheduler:
+- name: Add a schedule
+  proxysql_scheduler:
     login_user: 'admin'
     login_password: 'admin'
     interval_ms: 1000
@@ -87,7 +88,8 @@ EXAMPLES = '''
 # dynamically loads the scheduler config to runtime.  It uses credentials
 # in a supplied config file to connect to the proxysql admin interface.
 
-- proxysql_scheduler:
+- name: Remove a schedule
+  proxysql_scheduler:
     config_file: '~/proxysql.cnf'
     filename: "/opt/old_script.py"
     state: absent

--- a/plugins/modules/net_tools/dnsmadeeasy.py
+++ b/plugins/modules/net_tools/dnsmadeeasy.py
@@ -188,16 +188,16 @@ author: "Brice Burgess (@briceburg)"
 '''
 
 EXAMPLES = '''
-# fetch my.com domain records
-- dnsmadeeasy:
+- name: Fetch my.com domain records
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
     state: present
   register: response
 
-# create / ensure the presence of a record
-- dnsmadeeasy:
+- name: Create a record
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -206,8 +206,8 @@ EXAMPLES = '''
     record_type: A
     record_value: 127.0.0.1
 
-# update the previously created record
-- dnsmadeeasy:
+- name: Update the previously created record
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -215,8 +215,8 @@ EXAMPLES = '''
     record_name: test
     record_value: 192.0.2.23
 
-# fetch a specific record
-- dnsmadeeasy:
+- name: Fetch a specific record
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -224,8 +224,8 @@ EXAMPLES = '''
     record_name: test
   register: response
 
-# delete a record / ensure it is absent
-- dnsmadeeasy:
+- name: Delete a record
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -233,8 +233,8 @@ EXAMPLES = '''
     state: absent
     record_name: test
 
-# Add a failover
-- dnsmadeeasy:
+- name: Add a failover
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -246,7 +246,8 @@ EXAMPLES = '''
     ip1: 127.0.0.2
     ip2: 127.0.0.3
 
-- dnsmadeeasy:
+- name: Add a failover
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -261,8 +262,8 @@ EXAMPLES = '''
     ip4: 127.0.0.5
     ip5: 127.0.0.6
 
-# Add a monitor
-- dnsmadeeasy:
+- name: Add a monitor
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -278,8 +279,8 @@ EXAMPLES = '''
     systemDescription: Monitor Test A record
     contactList: my contact list
 
-# Add a monitor with http options
-- dnsmadeeasy:
+- name: Add a monitor with http options
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -298,8 +299,8 @@ EXAMPLES = '''
     httpFile: example
     httpQueryString: some string
 
-# Add a monitor and a failover
-- dnsmadeeasy:
+- name: Add a monitor and a failover
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -317,8 +318,8 @@ EXAMPLES = '''
     systemDescription: monitoring my.com status
     contactList: emergencycontacts
 
-# Remove a failover
-- dnsmadeeasy:
+- name: Remove a failover
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com
@@ -328,8 +329,8 @@ EXAMPLES = '''
     record_value: 127.0.0.1
     failover: no
 
-# Remove a monitor
-- dnsmadeeasy:
+- name: Remove a monitor
+  dnsmadeeasy:
     account_key: key
     account_secret: secret
     domain: my.com

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -122,68 +122,68 @@ requirements:
 '''
 
 EXAMPLES = '''
-# Install "nmap"
-- zypper:
+- name: Install nmap
+  zypper:
     name: nmap
     state: present
 
-# Install apache2 with recommended packages
-- zypper:
+- name: Install apache2 with recommended packages
+  zypper:
     name: apache2
     state: present
     disable_recommends: no
 
-# Apply a given patch
-- zypper:
+- name: Apply a given patch
+  zypper:
     name: openSUSE-2016-128
     state: present
     type: patch
 
-# Remove the "nmap" package
-- zypper:
+- name: Remove the nmap package
+  zypper:
     name: nmap
     state: absent
 
-# Install the nginx rpm from a remote repo
-- zypper:
+- name: Install the nginx rpm from a remote repo
+  zypper:
     name: 'http://nginx.org/packages/sles/12/x86_64/RPMS/nginx-1.8.0-1.sles12.ngx.x86_64.rpm'
     state: present
 
-# Install local rpm file
-- zypper:
+- name: Install local rpm file
+  zypper:
     name: /tmp/fancy-software.rpm
     state: present
 
-# Update all packages
-- zypper:
+- name: Update all packages
+  zypper:
     name: '*'
     state: latest
 
-# Apply all available patches
-- zypper:
+- name: Apply all available patches
+  zypper:
     name: '*'
     state: latest
     type: patch
 
-# Perform a dist-upgrade with additional arguments
-- zypper:
+- name: Perform a dist-upgrade with additional arguments
+  zypper:
     name: '*'
     state: dist-upgrade
     extra_args: '--no-allow-vendor-change --allow-arch-change'
 
-# Refresh repositories and update package "openssl"
-- zypper:
+- name: Refresh repositories and update package openssl
+  zypper:
     name: openssl
     state: present
     update_cache: yes
 
-# Install specific version (possible comparisons: <, >, <=, >=, =)
-- zypper:
+- name: "Install specific version (possible comparisons: <, >, <=, >=, =)"
+  zypper:
     name: 'docker>=1.10'
     state: present
 
-# Wait 20 seconds to acquire the lock before failing
-- zypper:
+- name: Wait 20 seconds to acquire the lock before failing
+  zypper:
     name: mosh
     state: present
   environment:

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -89,34 +89,34 @@ requirements:
 '''
 
 EXAMPLES = '''
-# Add NVIDIA repository for graphics drivers
-- zypper_repository:
+- name: Add NVIDIA repository for graphics drivers
+  zypper_repository:
     name: nvidia-repo
     repo: 'ftp://download.nvidia.com/opensuse/12.2'
     state: present
 
-# Remove NVIDIA repository
-- zypper_repository:
+- name: Remove NVIDIA repository
+  zypper_repository:
     name: nvidia-repo
     repo: 'ftp://download.nvidia.com/opensuse/12.2'
     state: absent
 
-# Add python development repository
-- zypper_repository:
+- name: Add python development repository
+  zypper_repository:
     repo: 'http://download.opensuse.org/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo'
 
-# Refresh all repos
-- zypper_repository:
+- name: Refresh all repos
+  zypper_repository:
     repo: '*'
     runrefresh: yes
 
-# Add a repo and add it's gpg key
-- zypper_repository:
+- name: Add a repo and add its gpg key
+  zypper_repository:
     repo: 'http://download.opensuse.org/repositories/systemsmanagement/openSUSE_Leap_42.1/'
     auto_import_keys: yes
 
-# Force refresh of a repository
-- zypper_repository:
+- name: Force refresh of a repository
+  zypper_repository:
     repo: 'http://my_internal_ci_repo/repo'
     name: my_ci_repo
     state: present

--- a/plugins/modules/storage/zfs/zpool_facts.py
+++ b/plugins/modules/storage/zfs/zpool_facts.py
@@ -50,7 +50,8 @@ EXAMPLES = '''
   zpool_facts: properties='free,size'
 
 - name: Print gathered information
-  debug: msg='ZFS pool {{ item.name }} has {{ item.free }} free space out of {{ item.size }}.'
+  debug:
+    msg: 'ZFS pool {{ item.name }} has {{ item.free }} free space out of {{ item.size }}.'
   with_items: '{{ ansible_zfs_pools }}'
 '''
 

--- a/plugins/modules/storage/zfs/zpool_facts.py
+++ b/plugins/modules/storage/zfs/zpool_facts.py
@@ -43,13 +43,14 @@ options:
 '''
 
 EXAMPLES = '''
-# Gather facts about ZFS pool rpool
-- zpool_facts: pool=rpool
+- name: Gather facts about ZFS pool rpool
+  zpool_facts: pool=rpool
 
-# Gather space usage about all imported ZFS pools
-- zpool_facts: properties='free,size'
+- name: Gather space usage about all imported ZFS pools
+  zpool_facts: properties='free,size'
 
-- debug: msg='ZFS pool {{ item.name }} has {{ item.free }} free space out of {{ item.size }}.'
+- name: Print gathered information
+  debug: msg='ZFS pool {{ item.name }} has {{ item.free }} free space out of {{ item.size }}.'
   with_items: '{{ ansible_zfs_pools }}'
 '''
 

--- a/plugins/modules/system/interfaces_file.py
+++ b/plugins/modules/system/interfaces_file.py
@@ -127,8 +127,8 @@ ifaces:
 '''
 
 EXAMPLES = '''
-# Set eth1 mtu configuration value to 8000
-- interfaces_file:
+- name: Set eth1 mtu configuration value to 8000
+  interfaces_file:
     dest: /etc/network/interfaces.d/eth1.cfg
     iface: eth1
     option: mtu

--- a/plugins/modules/system/selogin.py
+++ b/plugins/modules/system/selogin.py
@@ -69,21 +69,21 @@ author:
 '''
 
 EXAMPLES = '''
-# Modify the default user on the system to the guest_u user
-- selogin:
+- name: Modify the default user on the system to the guest_u user
+  selogin:
     login: __default__
     seuser: guest_u
     state: present
 
-# Assign gijoe user on an MLS machine a range and to the staff_u user
-- selogin:
+- name: Assign gijoe user on an MLS machine a range and to the staff_u user
+  selogin:
     login: gijoe
     seuser: staff_u
     serange: SystemLow-Secret
     state: present
 
-# Assign all users in the engineering group to the staff_u user
-- selogin:
+- name: Assign all users in the engineering group to the staff_u user
+  selogin:
     login: '%engineering'
     seuser: staff_u
     state: present

--- a/plugins/modules/web_infrastructure/jenkins_job.py
+++ b/plugins/modules/web_infrastructure/jenkins_job.py
@@ -66,48 +66,48 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a jenkins job using basic authentication
-- jenkins_job:
+- name: Create a jenkins job using basic authentication
+  jenkins_job:
     config: "{{ lookup('file', 'templates/test.xml') }}"
     name: test
     password: admin
     url: http://localhost:8080
     user: admin
 
-# Create a jenkins job using the token
-- jenkins_job:
+- name: Create a jenkins job using the token
+  jenkins_job:
     config: "{{ lookup('template', 'templates/test.xml.j2') }}"
     name: test
     token: asdfasfasfasdfasdfadfasfasdfasdfc
     url: http://localhost:8080
     user: admin
 
-# Delete a jenkins job using basic authentication
-- jenkins_job:
+- name: Delete a jenkins job using basic authentication
+  jenkins_job:
     name: test
     password: admin
     state: absent
     url: http://localhost:8080
     user: admin
 
-# Delete a jenkins job using the token
-- jenkins_job:
+- name: Delete a jenkins job using the token
+  jenkins_job:
     name: test
     token: asdfasfasfasdfasdfadfasfasdfasdfc
     state: absent
     url: http://localhost:8080
     user: admin
 
-# Disable a jenkins job using basic authentication
-- jenkins_job:
+- name: Disable a jenkins job using basic authentication
+  jenkins_job:
     name: test
     password: admin
     enabled: False
     url: http://localhost:8080
     user: admin
 
-# Disable a jenkins job using the token
-- jenkins_job:
+- name: Disable a jenkins job using the token
+  jenkins_job:
     name: test
     token: asdfasfasfasdfasdfadfasfasdfasdfc
     enabled: False


### PR DESCRIPTION
##### SUMMARY
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#examples-block

Per playbook best practices, each example should include a name: line:
```
EXAMPLES = r'''
- name: Ensure foo is installed
  modulename:
    name: foo
    state: present
'''
```
The name: line should be capitalized and not include a trailing dot.

**I'm gonna fix all modules in next PRs**

##### ISSUE TYPE
- Docs Pull Request
