### PR TITLE
[icinga2_host.py] Actually return codes instead of data

### DIFF
--- a/changelogs/fragments/335-icinga2_host-return-error-code.yaml
+++ b/changelogs/fragments/335-icinga2_host-return-error-code.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - icinga2_host - fix returning error codes
+  - icinga2_host - fix returning error codes (https://github.com/ansible-collections/community.general/pull/335).

--- a/changelogs/fragments/335-icinga2_host-return-error-code.yaml
+++ b/changelogs/fragments/335-icinga2_host-return-error-code.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - icinga2_host - fix returning error codes

--- a/plugins/modules/monitoring/icinga2_host.py
+++ b/plugins/modules/monitoring/icinga2_host.py
@@ -282,7 +282,7 @@ def main():
                     if ret['code'] == 200:
                         changed = True
                     else:
-                        module.fail_json(msg="bad return code deleting host: %s" % (ret['data']))
+                        module.fail_json(msg="bad return code deleting host: %s" % (ret['code']))
                 except Exception as e:
                     module.fail_json(msg="exception deleting host: " + str(e))
 
@@ -298,7 +298,7 @@ def main():
             if ret['code'] == 200:
                 changed = True
             else:
-                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))
+                module.fail_json(msg="bad return code modifying host: %s" % (ret['code']))
 
     else:
         if state == "present":
@@ -310,7 +310,7 @@ def main():
                     if ret['code'] == 200:
                         changed = True
                     else:
-                        module.fail_json(msg="bad return code creating host: %s" % (ret['data']))
+                        module.fail_json(msg="bad return code creating host: %s" % (ret['code']))
                 except Exception as e:
                     module.fail_json(msg="exception creating host: " + str(e))
 

--- a/plugins/modules/monitoring/icinga2_host.py
+++ b/plugins/modules/monitoring/icinga2_host.py
@@ -282,7 +282,7 @@ def main():
                     if ret['code'] == 200:
                         changed = True
                     else:
-                        module.fail_json(msg="bad return code deleting host: %s" % (ret['code']))
+                        module.fail_json(msg="bad return code (%s) deleting host: '%s'" % (ret['code'], ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception deleting host: " + str(e))
 
@@ -298,7 +298,7 @@ def main():
             if ret['code'] == 200:
                 changed = True
             else:
-                module.fail_json(msg="bad return code modifying host: %s" % (ret['code']))
+                module.fail_json(msg="bad return code (%s) modifying host: '%s'" % (ret['code'], ret['data']))
 
     else:
         if state == "present":
@@ -310,7 +310,7 @@ def main():
                     if ret['code'] == 200:
                         changed = True
                     else:
-                        module.fail_json(msg="bad return code creating host: %s" % (ret['code']))
+                        module.fail_json(msg="bad return code (%s) creating host: '%s'" % (ret['code'], ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception creating host: " + str(e))
 


### PR DESCRIPTION
##### SUMMARY
Currently the module tries to return the `data`, which can result in a blank message instead of the code being shown.

```
 "msg": "bad return code creating host: "
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
icinga2_host.py

##### ADDITIONAL INFORMATION
Trying to access an API with invalid cert and `validate_certs` set to `no` will reproduce this.
