### PR TITLE
Fix examples formatting

### DIFF
--- a/plugins/modules/cloud/alicloud/ali_instance.py
+++ b/plugins/modules/cloud/alicloud/ali_instance.py
@@ -246,7 +246,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # basic provisioning example vpc network
-- name: basic provisioning example
+- name: Basic provisioning example
   hosts: localhost
   vars:
     alicloud_access_key: <your-alicloud-access-key-id>
@@ -268,7 +268,7 @@ EXAMPLES = '''
     force: True
 
   tasks:
-    - name: launch ECS instance in VPC network
+    - name: Launch ECS instance in VPC network
       ali_instance:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
@@ -286,7 +286,7 @@ EXAMPLES = '''
         host_name: '{{ host_name }}'
         password: '{{ password }}'
 
-    - name: with count and count_tag to create a number of instances
+    - name: With count and count_tag to create a number of instances
       ali_instance:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
@@ -308,7 +308,7 @@ EXAMPLES = '''
         host_name: '{{ host_name }}'
         password: '{{ password }}'
 
-    - name: start instance
+    - name: Start instance
       ali_instance:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'
@@ -316,7 +316,7 @@ EXAMPLES = '''
         instance_ids: '{{ instance_ids }}'
         state: 'running'
 
-    - name: reboot instance forcibly
+    - name: Reboot instance forcibly
       ecs:
         alicloud_access_key: '{{ alicloud_access_key }}'
         alicloud_secret_key: '{{ alicloud_secret_key }}'

--- a/plugins/modules/cloud/centurylink/clc_aa_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_aa_policy.py
@@ -81,7 +81,7 @@ EXAMPLES = '''
         state: absent
       register: policy
 
-    - name: debug
+    - name: Debug
       debug:
         var: policy
 '''

--- a/plugins/modules/cloud/centurylink/clc_alert_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_alert_policy.py
@@ -86,7 +86,7 @@ EXAMPLES = '''
         state: present
       register: policy
 
-    - name: debug
+    - name: Debug
       debug: var=policy
 
 ---
@@ -102,7 +102,7 @@ EXAMPLES = '''
         state: absent
       register: policy
 
-    - name: debug
+    - name: Debug
       debug: var=policy
 '''
 

--- a/plugins/modules/cloud/centurylink/clc_group.py
+++ b/plugins/modules/cloud/centurylink/clc_group.py
@@ -76,7 +76,7 @@ EXAMPLES = '''
         state: present
       register: clc
 
-    - name: debug
+    - name: Debug
       debug:
         var: clc
 
@@ -95,7 +95,7 @@ EXAMPLES = '''
         state: absent
       register: clc
 
-    - name: debug
+    - name: Debug
       debug:
         var: clc
 '''

--- a/plugins/modules/cloud/centurylink/clc_modify_server.py
+++ b/plugins/modules/cloud/centurylink/clc_modify_server.py
@@ -69,7 +69,7 @@ notes:
 EXAMPLES = '''
 # Note - You must set the CLC_V2_API_USERNAME And CLC_V2_API_PASSWD Environment variables before running these examples
 
-- name: set the cpu count to 4 on a server
+- name: Set the cpu count to 4 on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -77,7 +77,7 @@ EXAMPLES = '''
     cpu: 4
     state: present
 
-- name: set the memory to 8GB on a server
+- name: Set the memory to 8GB on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -85,7 +85,7 @@ EXAMPLES = '''
     memory: 8
     state: present
 
-- name: set the anti affinity policy on a server
+- name: Set the anti affinity policy on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -93,7 +93,7 @@ EXAMPLES = '''
     anti_affinity_policy_name: 'aa_policy'
     state: present
 
-- name: remove the anti affinity policy on a server
+- name: Remove the anti affinity policy on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -101,7 +101,7 @@ EXAMPLES = '''
     anti_affinity_policy_name: 'aa_policy'
     state: absent
 
-- name: add the alert policy on a server
+- name: Add the alert policy on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -109,7 +109,7 @@ EXAMPLES = '''
     alert_policy_name: 'alert_policy'
     state: present
 
-- name: remove the alert policy on a server
+- name: Remove the alert policy on a server
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01
@@ -117,7 +117,7 @@ EXAMPLES = '''
     alert_policy_name: 'alert_policy'
     state: absent
 
-- name: set the memory to 16GB and cpu to 8 core on a lust if servers
+- name: Ret the memory to 16GB and cpu to 8 core on a lust if servers
   clc_modify_server:
     server_ids:
         - UC1TESTSVR01

--- a/plugins/modules/cloud/centurylink/clc_publicip.py
+++ b/plugins/modules/cloud/centurylink/clc_publicip.py
@@ -72,7 +72,7 @@ EXAMPLES = '''
         state: present
       register: clc
 
-    - name: debug
+    - name: Debug
       debug:
         var: clc
 
@@ -89,7 +89,7 @@ EXAMPLES = '''
         state: absent
       register: clc
 
-    - name: debug
+    - name: Debug
       debug:
         var: clc
 '''

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_certificate.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_certificate.py
@@ -43,7 +43,7 @@ notes:
 
 
 EXAMPLES = '''
-- name: create a certificate
+- name: Create a certificate
   digital_ocean_certificate:
     name: production
     state: present
@@ -51,7 +51,7 @@ EXAMPLES = '''
     leaf_certificate: "-----BEGIN CERTIFICATE-----\nMIIFDmg2Iaw==\n-----END CERTIFICATE-----"
     oauth_token: b7d03a6947b217efb6f3ec3bd365652
 
-- name: create a certificate using file lookup plugin
+- name: Create a certificate using file lookup plugin
   digital_ocean_certificate:
     name: production
     state: present
@@ -59,7 +59,7 @@ EXAMPLES = '''
     leaf_certificate: "{{ lookup('file', 'test.cert') }}"
     oauth_token: "{{ oauth_token }}"
 
-- name: create a certificate with trust chain
+- name: Create a certificate with trust chain
   digital_ocean_certificate:
     name: production
     state: present
@@ -68,7 +68,7 @@ EXAMPLES = '''
     certificate_chain: "{{ lookup('file', 'chain.cert') }}"
     oauth_token: "{{ oauth_token }}"
 
-- name: remove a certificate
+- name: Remove a certificate
   digital_ocean_certificate:
     name: production
     state: absent

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_droplet.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_droplet.py
@@ -105,7 +105,7 @@ requirements:
 
 
 EXAMPLES = '''
-- name: create a new droplet
+- name: Create a new droplet
   digital_ocean_droplet:
     state: present
     name: mydroplet
@@ -120,7 +120,7 @@ EXAMPLES = '''
 - debug:
     msg: "ID is {{ my_droplet.data.droplet.id }}, IP is {{ my_droplet.data.ip_address }}"
 
-- name: ensure a droplet is present
+- name: Ensure a droplet is present
   digital_ocean_droplet:
     state: present
     id: 123
@@ -131,7 +131,7 @@ EXAMPLES = '''
     image: ubuntu-16-04-x64
     wait_timeout: 500
 
-- name: ensure a droplet is present with SSH keys installed
+- name: Ensure a droplet is present with SSH keys installed
   digital_ocean_droplet:
     state: present
     id: 123

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -51,12 +51,12 @@ requirements:
 
 
 EXAMPLES = '''
-- name: create a tag
+- name: Create a tag
   digital_ocean_tag:
     name: production
     state: present
 
-- name: tag a resource; creating the tag if it does not exist
+- name: Tag a resource; creating the tag if it does not exist
   digital_ocean_tag:
     name: "{{ item }}"
     resource_id: "73333005"
@@ -65,7 +65,7 @@ EXAMPLES = '''
     - staging
     - dbserver
 
-- name: untag a resource
+- name: Untag a resource
   digital_ocean_tag:
     name: staging
     resource_id: "73333005"
@@ -73,7 +73,7 @@ EXAMPLES = '''
 
 # Deleting a tag also untags all the resources that have previously been
 # tagged with it
-- name: remove a tag
+- name: Remove a tag
   digital_ocean_tag:
     name: dbserver
     state: absent

--- a/plugins/modules/cloud/docker/docker_container.py
+++ b/plugins/modules/cloud/docker/docker_container.py
@@ -892,7 +892,7 @@ EXAMPLES = '''
     command: sleep 1d
   with_sequence: count=4
 
-- name: remove container
+- name: Remove container
   docker_container:
     name: ohno
     state: absent
@@ -1031,7 +1031,7 @@ EXAMPLES = '''
       # The "NONE" check needs to be specified
       test: ["NONE"]
 
-- name: start container with block device read limit
+- name: Start container with block device read limit
   docker_container:
     name: test
     image: ubuntu:18.04

--- a/plugins/modules/cloud/docker/docker_image.py
+++ b/plugins/modules/cloud/docker/docker_image.py
@@ -312,7 +312,7 @@ author:
 
 EXAMPLES = '''
 
-- name: pull an image
+- name: Pull an image
   docker_image:
     name: pacur/centos-7
     source: pull

--- a/plugins/modules/cloud/google/gce.py
+++ b/plugins/modules/cloud/google/gce.py
@@ -220,7 +220,7 @@ EXAMPLES = '''
     credentials_file: "/path/to/your-key.json"
     project_id: "your-project-name"
   tasks:
-    - name: create multiple instances
+    - name: Create multiple instances
       # Basic provisioning example.  Create multiple Debian 8 instances in the
       # us-central1-a Zone of n1-standard-1 machine type.
       gce:
@@ -260,7 +260,7 @@ EXAMPLES = '''
       tags:
         - config
 
-    - name: delete test-instances
+    - name: Delete test-instances
       # Basic termination of instance.
       gce:
         service_account_email: "{{ service_account_email }}"

--- a/plugins/modules/cloud/google/gce_instance_template.py
+++ b/plugins/modules/cloud/google/gce_instance_template.py
@@ -147,7 +147,7 @@ author: "Gwenael Pellen (@GwenaelPellenArkeup) <gwenael.pellen@arkeup.com>"
 
 EXAMPLES = '''
 # Usage
-- name: create instance template named foo
+- name: Create instance template named foo
   gce_instance_template:
     name: foo
     size: n1-standard-1
@@ -165,7 +165,7 @@ EXAMPLES = '''
     credentials_file: "/path/to/your-key.json"
     project_id: "your-project-name"
   tasks:
-    - name: create instance template
+    - name: Create instance template
       gce_instance_template:
         name: my-test-instance-template
         size: n1-standard-1
@@ -174,7 +174,7 @@ EXAMPLES = '''
         project_id: "{{ project_id }}"
         credentials_file: "{{ credentials_file }}"
         service_account_email: "{{ service_account_email }}"
-    - name: delete instance template
+    - name: Delete instance template
       gce_instance_template:
         name: my-test-instance-template
         size: n1-standard-1
@@ -192,7 +192,7 @@ EXAMPLES = '''
     credentials_file: "/path/to/your-key.json"
     project_id: "your-project-name"
   tasks:
-    - name: create instance template
+    - name: Create instance template
       gce_instance_template:
         name: foo
         size: n1-standard-1

--- a/plugins/modules/cloud/google/gcp_bigquery_dataset_info.py
+++ b/plugins/modules/cloud/google/gcp_bigquery_dataset_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a dataset
+- name: Get info on a dataset
   gcp_bigquery_dataset_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_bigquery_table_info.py
+++ b/plugins/modules/cloud/google/gcp_bigquery_table_info.py
@@ -93,7 +93,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a table
+- name: Get info on a table
   gcp_bigquery_table_info:
     dataset: example_dataset
     project: test_project

--- a/plugins/modules/cloud/google/gcp_cloudbuild_trigger_info.py
+++ b/plugins/modules/cloud/google/gcp_cloudbuild_trigger_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a trigger
+- name: Get info on a trigger
   gcp_cloudbuild_trigger_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_compute_address_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_address_info.py
@@ -100,7 +100,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an address
+- name: Get info on an address
   gcp_compute_address_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_backend_bucket_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_backend_bucket_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a backend bucket
+- name: Get info on a backend bucket
   gcp_compute_backend_bucket_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_backend_service_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_backend_service_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a backend service
+- name: Get info on a backend service
   gcp_compute_backend_service_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_disk_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_disk_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a disk
+- name: Get info on a disk
   gcp_compute_disk_info:
     zone: us-central1-a
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_firewall_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_firewall_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a firewall
+- name: Get info on a firewall
   gcp_compute_firewall_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_forwarding_rule_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_forwarding_rule_info.py
@@ -100,7 +100,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a forwarding rule
+- name: Get info on a forwarding rule
   gcp_compute_forwarding_rule_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_global_address_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_global_address_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a global address
+- name: Get info on a global address
   gcp_compute_global_address_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_global_forwarding_rule_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_global_forwarding_rule_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a global forwarding rule
+- name: Get info on a global forwarding rule
   gcp_compute_global_forwarding_rule_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_health_check_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_health_check_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a health check
+- name: Get info on a health check
   gcp_compute_health_check_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_http_health_check_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_http_health_check_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a HTTP health check
+- name: Get info on a HTTP health check
   gcp_compute_http_health_check_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_https_health_check_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_https_health_check_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a HTTPS health check
+- name: Get info on a HTTPS health check
   gcp_compute_https_health_check_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_image_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_image_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an image
+- name: Get info on an image
   gcp_compute_image_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_instance_group_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_instance_group_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance group
+- name: Get info on an instance group
   gcp_compute_instance_group_info:
     zone: us-central1-a
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_instance_group_manager_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_instance_group_manager_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance group manager
+- name: Get info on an instance group manager
   gcp_compute_instance_group_manager_info:
     zone: us-west1-a
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_instance_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_instance_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance
+- name: Get info on an instance
   gcp_compute_instance_info:
     zone: us-central1-a
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_instance_template_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_instance_template_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance template
+- name: Get info on an instance template
   gcp_compute_instance_template_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_interconnect_attachment_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_interconnect_attachment_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an interconnect attachment
+- name: Get info on an interconnect attachment
   gcp_compute_interconnect_attachment_info:
     region: us-central1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_network_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_network_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a network
+- name: Get info on a network
   gcp_compute_network_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_region_disk_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_region_disk_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a region disk
+- name: Get info on a region disk
   gcp_compute_region_disk_info:
     region: us-central1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_route_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_route_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a route
+- name: Get info on a route
   gcp_compute_route_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_router_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_router_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a router
+- name: Get info on a router
   gcp_compute_router_info:
     region: us-central1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_ssl_certificate_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_ssl_certificate_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a SSL certificate
+- name: Get info on a SSL certificate
   gcp_compute_ssl_certificate_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_ssl_policy_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_ssl_policy_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a SSL policy
+- name: Get info on a SSL policy
   gcp_compute_ssl_policy_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_subnetwork_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_subnetwork_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a subnetwork
+- name: Get info on a subnetwork
   gcp_compute_subnetwork_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_target_http_proxy_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_http_proxy_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target HTTP proxy
+- name: Get info on a target HTTP proxy
   gcp_compute_target_http_proxy_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_target_https_proxy_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_https_proxy_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target HTTPS proxy
+- name: Get info on a target HTTPS proxy
   gcp_compute_target_https_proxy_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_target_pool_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_pool_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target pool
+- name: Get info on a target pool
   gcp_compute_target_pool_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_target_ssl_proxy_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_ssl_proxy_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target SSL proxy
+- name: Get info on a target SSL proxy
   gcp_compute_target_ssl_proxy_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_target_tcp_proxy_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_tcp_proxy_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target TCP proxy
+- name: Get info on a target TCP proxy
   gcp_compute_target_tcp_proxy_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_target_vpn_gateway_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_target_vpn_gateway_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a target vpn gateway
+- name: Get info on a target vpn gateway
   gcp_compute_target_vpn_gateway_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_compute_url_map_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_url_map_info.py
@@ -94,7 +94,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an URL map
+- name: Get info on an URL map
   gcp_compute_url_map_info:
     filters:
     - name = test_object

--- a/plugins/modules/cloud/google/gcp_compute_vpn_tunnel_info.py
+++ b/plugins/modules/cloud/google/gcp_compute_vpn_tunnel_info.py
@@ -99,7 +99,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a vpn tunnel
+- name: Get info on a vpn tunnel
   gcp_compute_vpn_tunnel_info:
     region: us-west1
     filters:

--- a/plugins/modules/cloud/google/gcp_container_cluster_info.py
+++ b/plugins/modules/cloud/google/gcp_container_cluster_info.py
@@ -96,7 +96,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a cluster
+- name: Get info on a cluster
   gcp_container_cluster_info:
     location: us-central1-a
     project: test_project

--- a/plugins/modules/cloud/google/gcp_container_node_pool_info.py
+++ b/plugins/modules/cloud/google/gcp_container_node_pool_info.py
@@ -106,7 +106,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a node pool
+- name: Get info on a node pool
   gcp_container_node_pool_info:
     cluster: "{{ cluster }}"
     location: us-central1-a

--- a/plugins/modules/cloud/google/gcp_dns_managed_zone_info.py
+++ b/plugins/modules/cloud/google/gcp_dns_managed_zone_info.py
@@ -92,7 +92,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a managed zone
+- name: Get info on a managed zone
   gcp_dns_managed_zone_info:
     dns_name: test.somewild2.example.com.
     project: test_project

--- a/plugins/modules/cloud/google/gcp_dns_resource_record_set_info.py
+++ b/plugins/modules/cloud/google/gcp_dns_resource_record_set_info.py
@@ -95,7 +95,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a resource record set
+- name: Get info on a resource record set
   gcp_dns_resource_record_set_info:
     managed_zone: "{{ managed_zone }}"
     project: test_project

--- a/plugins/modules/cloud/google/gcp_iam_role_info.py
+++ b/plugins/modules/cloud/google/gcp_iam_role_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a role
+- name: Get info on a role
   gcp_iam_role_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_iam_service_account_info.py
+++ b/plugins/modules/cloud/google/gcp_iam_service_account_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a service account
+- name: Get info on a service account
   gcp_iam_service_account_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/cloud/google/gcp_pubsub_subscription_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a subscription
+- name: Get info on a subscription
   gcp_pubsub_subscription_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_pubsub_topic_info.py
+++ b/plugins/modules/cloud/google/gcp_pubsub_topic_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a topic
+- name: Get info on a topic
   gcp_pubsub_topic_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_redis_instance_info.py
+++ b/plugins/modules/cloud/google/gcp_redis_instance_info.py
@@ -93,7 +93,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance
+- name: Get info on an instance
   gcp_redis_instance_info:
     region: us-central1
     project: test_project

--- a/plugins/modules/cloud/google/gcp_resourcemanager_project_info.py
+++ b/plugins/modules/cloud/google/gcp_resourcemanager_project_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a project
+- name: Get info on a project
   gcp_resourcemanager_project_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_sourcerepo_repository_info.py
+++ b/plugins/modules/cloud/google/gcp_sourcerepo_repository_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a repository
+- name: Get info on a repository
   gcp_sourcerepo_repository_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_spanner_database_info.py
+++ b/plugins/modules/cloud/google/gcp_spanner_database_info.py
@@ -98,7 +98,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a database
+- name: Get info on a database
   gcp_spanner_database_info:
     instance: "{{ instance }}"
     project: test_project

--- a/plugins/modules/cloud/google/gcp_spanner_instance_info.py
+++ b/plugins/modules/cloud/google/gcp_spanner_instance_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance
+- name: Get info on an instance
   gcp_spanner_instance_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_sql_database_info.py
+++ b/plugins/modules/cloud/google/gcp_sql_database_info.py
@@ -93,7 +93,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a database
+- name: Get info on a database
   gcp_sql_database_info:
     instance: "{{ instance.name }}"
     project: test_project

--- a/plugins/modules/cloud/google/gcp_sql_instance_info.py
+++ b/plugins/modules/cloud/google/gcp_sql_instance_info.py
@@ -88,7 +88,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on an instance
+- name: Get info on an instance
   gcp_sql_instance_info:
     project: test_project
     auth_kind: serviceaccount

--- a/plugins/modules/cloud/google/gcp_sql_user_info.py
+++ b/plugins/modules/cloud/google/gcp_sql_user_info.py
@@ -98,7 +98,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a user
+- name: Get info on a user
   gcp_sql_user_info:
     instance: "{{ instance }}"
     project: test_project

--- a/plugins/modules/cloud/google/gcp_tpu_node_info.py
+++ b/plugins/modules/cloud/google/gcp_tpu_node_info.py
@@ -93,7 +93,7 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: get info on a node
+- name: Get info on a node
   gcp_tpu_node_info:
     zone: us-central1-b
     project: test_project

--- a/plugins/modules/cloud/huawei/hwc_ecs_instance.py
+++ b/plugins/modules/cloud/huawei/hwc_ecs_instance.py
@@ -226,12 +226,12 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create an ecs instance
-- name: create a vpc
+- name: Create a vpc
   hwc_network_vpc:
     cidr: "192.168.100.0/24"
     name: "ansible_network_vpc_test"
   register: vpc
-- name: create a subnet
+- name: Create a subnet
   hwc_vpc_subnet:
     gateway_ip: "192.168.100.32"
     name: "ansible_network_subnet_test"
@@ -239,7 +239,7 @@ EXAMPLES = '''
     vpc_id: "{{ vpc.id }}"
     cidr: "192.168.100.0/26"
   register: subnet
-- name: create a eip
+- name: Create a eip
   hwc_vpc_eip:
     dedicated_bandwidth:
       charge_mode: "traffic"
@@ -247,14 +247,14 @@ EXAMPLES = '''
       size: 1
     type: "5_bgp"
   register: eip
-- name: create a disk
+- name: Create a disk
   hwc_evs_disk:
     availability_zone: "cn-north-1a"
     name: "ansible_evs_disk_test"
     volume_type: "SATA"
     size: 10
   register: disk
-- name: create an instance
+- name: Create an instance
   hwc_ecs_instance:
     data_volumes:
       - volume_id: "{{ disk.id }}"

--- a/plugins/modules/cloud/huawei/hwc_evs_disk.py
+++ b/plugins/modules/cloud/huawei/hwc_evs_disk.py
@@ -154,7 +154,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # test create disk
-- name: create a disk
+- name: Create a disk
   hwc_evs_disk:
     availability_zone: "cn-north-1a"
     name: "ansible_evs_disk_test"

--- a/plugins/modules/cloud/huawei/hwc_network_vpc.py
+++ b/plugins/modules/cloud/huawei/hwc_network_vpc.py
@@ -65,7 +65,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: create a vpc
+- name: Create a vpc
   hwc_network_vpc:
       identity_endpoint: "{{ identity_endpoint }}"
       user: "{{ user }}"

--- a/plugins/modules/cloud/huawei/hwc_smn_topic.py
+++ b/plugins/modules/cloud/huawei/hwc_smn_topic.py
@@ -50,7 +50,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: create a smn topic
+- name: Create a smn topic
   hwc_smn_topic:
       identity_endpoint: "{{ identity_endpoint }}"
       user_name: "{{ user_name }}"

--- a/plugins/modules/cloud/huawei/hwc_vpc_eip.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_eip.py
@@ -125,12 +125,12 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create an eip and bind it to a port
-- name: create vpc
+- name: Create vpc
   hwc_network_vpc:
     cidr: "192.168.100.0/24"
     name: "ansible_network_vpc_test"
   register: vpc
-- name: create subnet
+- name: Create subnet
   hwc_vpc_subnet:
     gateway_ip: "192.168.100.32"
     name: "ansible_network_subnet_test"
@@ -138,12 +138,12 @@ EXAMPLES = '''
     vpc_id: "{{ vpc.id }}"
     cidr: "192.168.100.0/26"
   register: subnet
-- name: create a port
+- name: Create a port
   hwc_vpc_port:
     subnet_id: "{{ subnet.id }}"
     ip_address: "192.168.100.33"
   register: port
-- name: create an eip and bind it to a port
+- name: Create an eip and bind it to a port
   hwc_vpc_eip:
     type: "5_bgp"
     dedicated_bandwidth:

--- a/plugins/modules/cloud/huawei/hwc_vpc_peering_connect.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_peering_connect.py
@@ -79,17 +79,17 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a peering connect
-- name: create a local vpc
+- name: Create a local vpc
   hwc_network_vpc:
     cidr: "192.168.0.0/16"
     name: "ansible_network_vpc_test_local"
   register: vpc1
-- name: create a peering vpc
+- name: Create a peering vpc
   hwc_network_vpc:
     cidr: "192.168.0.0/16"
     name: "ansible_network_vpc_test_peering"
   register: vpc2
-- name: create a peering connect
+- name: Create a peering connect
   hwc_vpc_peering_connect:
     local_vpc_id: "{{ vpc1.id }}"
     name: "ansible_network_peering_test"

--- a/plugins/modules/cloud/huawei/hwc_vpc_port.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_port.py
@@ -106,12 +106,12 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a port
-- name: create vpc
+- name: Create vpc
   hwc_network_vpc:
     cidr: "192.168.100.0/24"
     name: "ansible_network_vpc_test"
   register: vpc
-- name: create subnet
+- name: Create subnet
   hwc_vpc_subnet:
     gateway_ip: "192.168.100.32"
     name: "ansible_network_subnet_test"
@@ -119,7 +119,7 @@ EXAMPLES = '''
     vpc_id: "{{ vpc.id }}"
     cidr: "192.168.100.0/26"
   register: subnet
-- name: create a port
+- name: Create a port
   hwc_vpc_port:
     subnet_id: "{{ subnet.id }}"
     ip_address: "192.168.100.33"

--- a/plugins/modules/cloud/huawei/hwc_vpc_private_ip.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_private_ip.py
@@ -53,12 +53,12 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a private ip
-- name: create vpc
+- name: Create vpc
   hwc_network_vpc:
     cidr: "192.168.100.0/24"
     name: "ansible_network_vpc_test"
   register: vpc
-- name: create subnet
+- name: Create subnet
   hwc_vpc_subnet:
     gateway_ip: "192.168.100.32"
     name: "ansible_network_subnet_test"
@@ -66,7 +66,7 @@ EXAMPLES = '''
     vpc_id: "{{ vpc.id }}"
     cidr: "192.168.100.0/26"
   register: subnet
-- name: create a private ip
+- name: Create a private ip
   hwc_vpc_private_ip:
     subnet_id: "{{ subnet.id }}"
     ip_address: "192.168.100.33"

--- a/plugins/modules/cloud/huawei/hwc_vpc_route.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_route.py
@@ -60,17 +60,17 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a peering connect
-- name: create a local vpc
+- name: Create a local vpc
   hwc_network_vpc:
     cidr: "192.168.0.0/16"
     name: "ansible_network_vpc_test_local"
   register: vpc1
-- name: create a peering vpc
+- name: Create a peering vpc
   hwc_network_vpc:
     cidr: "192.168.0.0/16"
     name: "ansible_network_vpc_test_peering"
   register: vpc2
-- name: create a peering connect
+- name: Create a peering connect
   hwc_vpc_peering_connect:
     local_vpc_id: "{{ vpc1.id }}"
     name: "ansible_network_peering_test"
@@ -79,7 +79,7 @@ EXAMPLES = '''
     peering_vpc:
       vpc_id: "{{ vpc2.id }}"
   register: connect
-- name: create a route
+- name: Create a route
   hwc_vpc_route:
     vpc_id: "{{ vpc1.id }}"
     destination: "192.168.0.0/16"

--- a/plugins/modules/cloud/huawei/hwc_vpc_security_group.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_security_group.py
@@ -64,7 +64,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a security group
-- name: create a security group
+- name: Create a security group
   hwc_vpc_security_group:
     name: "ansible_network_security_group_test"
 '''

--- a/plugins/modules/cloud/huawei/hwc_vpc_security_group_rule.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_security_group_rule.py
@@ -105,11 +105,11 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create a security group rule
-- name: create a security group
+- name: Create a security group
   hwc_vpc_security_group:
     name: "ansible_network_security_group_test"
   register: sg
-- name: create a security group rule
+- name: Create a security group rule
   hwc_vpc_security_group_rule:
     direction: "ingress"
     protocol: "tcp"

--- a/plugins/modules/cloud/huawei/hwc_vpc_subnet.py
+++ b/plugins/modules/cloud/huawei/hwc_vpc_subnet.py
@@ -97,12 +97,12 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # create subnet
-- name: create vpc
+- name: Create vpc
   hwc_network_vpc:
     cidr: "192.168.100.0/24"
     name: "ansible_network_vpc_test"
   register: vpc
-- name: create subnet
+- name: Create subnet
   hwc_vpc_subnet:
     vpc_id: "{{ vpc.id }}"
     cidr: "192.168.100.0/26"

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -304,7 +304,7 @@ EXAMPLES = """
     archive_compression: gzip
   register: clone_container_info
 
-- name: debug info on container "test-container"
+- name: Debug info on container "test-container"
   debug:
     var: clone_container_info
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -162,14 +162,14 @@ EXAMPLES = '''
         wait_for_ipv4_addresses: true
         timeout: 600
 
-    - name: check python is installed in container
+    - name: Check python is installed in container
       delegate_to: mycontainer
       raw: dpkg -s python
       register: python_install_check
       failed_when: python_install_check.rc not in [0, 1]
       changed_when: false
 
-    - name: install python in container
+    - name: Install python in container
       delegate_to: mycontainer
       raw: apt-get install -y python
       when: python_install_check.rc == 1
@@ -238,7 +238,7 @@ EXAMPLES = '''
 - hosts:
     - mycontainer
   tasks:
-    - name: copy /etc/hosts in the created container to localhost with name "mycontainer-hosts"
+    - name: Copy /etc/hosts in the created container to localhost with name "mycontainer-hosts"
       fetch:
         src: /etc/hosts
         dest: /tmp/mycontainer-hosts

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -114,7 +114,7 @@ EXAMPLES = '''
 - hosts: localhost
   connection: local
   tasks:
-  - name: create macvlan profile
+  - name: Create macvlan profile
     lxd_profile:
       url: https://127.0.0.1:8443
       # These client_cert and client_key values are equal to the default values.

--- a/plugins/modules/cloud/memset/memset_dns_reload.py
+++ b/plugins/modules/cloud/memset/memset_dns_reload.py
@@ -37,7 +37,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: submit DNS reload and poll.
+- name: Submit DNS reload and poll
   memset_dns_reload:
     api_key: 5eb86c9196ab03919abcf03857163741
     poll: True

--- a/plugins/modules/cloud/memset/memset_memstore_info.py
+++ b/plugins/modules/cloud/memset/memset_memstore_info.py
@@ -30,7 +30,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: get usage for mstestyaa1
+- name: Get usage for mstestyaa1
   memset_memstore_info:
     name: mstestyaa1
     api_key: 5eb86c9896ab03919abcf03857163741

--- a/plugins/modules/cloud/memset/memset_server_info.py
+++ b/plugins/modules/cloud/memset/memset_server_info.py
@@ -30,7 +30,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: get details for testyaa1
+- name: Get details for testyaa1
   memset_server_info:
     name: testyaa1
     api_key: 5eb86c9896ab03919abcf03857163741

--- a/plugins/modules/cloud/memset/memset_zone.py
+++ b/plugins/modules/cloud/memset/memset_zone.py
@@ -50,7 +50,7 @@ options:
 
 EXAMPLES = '''
 # Create the zone 'test'
-- name: create zone
+- name: Create zone
   memset_zone:
     name: test
     state: present
@@ -59,7 +59,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 # Force zone deletion
-- name: force delete zone
+- name: Force delete zone
   memset_zone:
     name: test
     state: absent

--- a/plugins/modules/cloud/memset/memset_zone_domain.py
+++ b/plugins/modules/cloud/memset/memset_zone_domain.py
@@ -44,7 +44,7 @@ options:
 
 EXAMPLES = '''
 # Create the zone domain 'test.com'
-- name: create zone domain
+- name: Create zone domain
   memset_zone_domain:
     domain: test.com
     zone: testzone

--- a/plugins/modules/cloud/memset/memset_zone_record.py
+++ b/plugins/modules/cloud/memset/memset_zone_record.py
@@ -66,7 +66,7 @@ options:
 
 EXAMPLES = '''
 # Create DNS record for www.domain.com
-- name: create DNS record
+- name: Create DNS record
   memset_zone_record:
     api_key: dcf089a2896940da9ffefb307ef49ccd
     state: present
@@ -79,7 +79,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 # create an SPF record for domain.com
-- name: create SPF record for domain.com
+- name: Create SPF record for domain.com
   memset_zone_record:
     api_key: dcf089a2896940da9ffefb307ef49ccd
     state: present
@@ -89,7 +89,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 # create multiple DNS records
-- name: create multiple DNS records
+- name: Create multiple DNS records
   memset_zone_record:
     api_key: dcf089a2896940da9ffefb307ef49ccd
     zone: "{{ item.zone }}"

--- a/plugins/modules/cloud/packet/packet_device.py
+++ b/plugins/modules/cloud/packet/packet_device.py
@@ -131,7 +131,7 @@ EXAMPLES = '''
 
 # Creating devices
 
-- name: create 1 device
+- name: Create 1 device
   hosts: localhost
   tasks:
   - packet_device:
@@ -145,7 +145,7 @@ EXAMPLES = '''
 # ready for other API operations). Fail if the devices in not "active" in
 # 10 minutes.
 
-- name: create device and wait up to 10 minutes for active state
+- name: Create device and wait up to 10 minutes for active state
   hosts: localhost
   tasks:
   - packet_device:
@@ -157,7 +157,7 @@ EXAMPLES = '''
       state: active
       wait_timeout: 600
 
-- name: create 3 ubuntu devices called server-01, server-02 and server-03
+- name: Create 3 ubuntu devices called server-01, server-02 and server-03
   hosts: localhost
   tasks:
   - packet_device:
@@ -171,7 +171,7 @@ EXAMPLES = '''
 - name: Create 3 coreos devices with userdata, wait until they get IPs and then wait for SSH
   hosts: localhost
   tasks:
-  - name: create 3 devices and register their facts
+  - name: Create 3 devices and register their facts
     packet_device:
       hostnames: [coreos-one, coreos-two, coreos-three]
       operating_system: coreos_stable
@@ -198,7 +198,7 @@ EXAMPLES = '''
               command: start
     register: newhosts
 
-  - name: wait for ssh
+  - name: Wait for ssh
     wait_for:
       delay: 1
       host: "{{ item.public_ipv4 }}"
@@ -210,7 +210,7 @@ EXAMPLES = '''
 
 # Other states of devices
 
-- name: remove 3 devices by uuid
+- name: Remove 3 devices by uuid
   hosts: localhost
   tasks:
   - packet_device:

--- a/plugins/modules/cloud/packet/packet_ip_subnet.py
+++ b/plugins/modules/cloud/packet/packet_ip_subnet.py
@@ -82,7 +82,7 @@ EXAMPLES = '''
 # All the examples assume that you have your Packet api token in env var PACKET_API_TOKEN.
 # You can also pass it to the auth_token parameter of the module instead.
 
-- name: create 1 device and assign an arbitrary public IPv4 subnet to it
+- name: Create 1 device and assign an arbitrary public IPv4 subnet to it
   hosts: localhost
   tasks:
 
@@ -103,7 +103,7 @@ EXAMPLES = '''
 
 # Release IP address 147.75.201.78
 
-- name: unassign IP address from any device in your project
+- name: Unassign IP address from any device in your project
   hosts: localhost
   tasks:
   - packet_ip_subnet:

--- a/plugins/modules/cloud/packet/packet_project.py
+++ b/plugins/modules/cloud/packet/packet_project.py
@@ -74,27 +74,27 @@ EXAMPLES = '''
 # All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
 # You can also pass the api token in module param auth_token.
 
-- name: create new project
+- name: Create new project
   hosts: localhost
   tasks:
     packet_project:
       name: "new project"
 
-- name: create new project within non-default organization
+- name: Create new project within non-default organization
   hosts: localhost
   tasks:
     packet_project:
       name: "my org project"
       org_id: a4cc87f9-e00f-48c2-9460-74aa60beb6b0
 
-- name: remove project by id
+- name: Remove project by id
   hosts: localhost
   tasks:
     packet_project:
       state: absent
       id: eef49903-7a09-4ca1-af67-4087c29ab5b6
 
-- name: create new project with non-default billing method
+- name: Create new project with non-default billing method
   hosts: localhost
   tasks:
     packet_project:

--- a/plugins/modules/cloud/packet/packet_sshkey.py
+++ b/plugins/modules/cloud/packet/packet_sshkey.py
@@ -49,20 +49,20 @@ EXAMPLES = '''
 # All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
 # You can also pass the api token in module param auth_token.
 
-- name: create sshkey from string
+- name: Create sshkey from string
   hosts: localhost
   tasks:
     packet_sshkey:
       key: "{{ lookup('file', 'my_packet_sshkey.pub') }}"
 
-- name: create sshkey from file
+- name: Create sshkey from file
   hosts: localhost
   tasks:
     packet_sshkey:
       label: key from file
       key_file: ~/ff.pub
 
-- name: remove sshkey by id
+- name: Remove sshkey by id
   hosts: localhost
   tasks:
     packet_sshkey:

--- a/plugins/modules/cloud/rackspace/rax_keypair.py
+++ b/plugins/modules/cloud/rackspace/rax_keypair.py
@@ -42,7 +42,7 @@ EXAMPLES = '''
   hosts: localhost
   gather_facts: False
   tasks:
-    - name: keypair request
+    - name: Keypair request
       local_action:
         module: rax_keypair
         credentials: ~/.raxpub
@@ -64,7 +64,7 @@ EXAMPLES = '''
   hosts: localhost
   gather_facts: False
   tasks:
-    - name: keypair request
+    - name: Keypair request
       local_action:
         module: rax_keypair
         credentials: ~/.raxpub

--- a/plugins/modules/cloud/smartos/vmadm.py
+++ b/plugins/modules/cloud/smartos/vmadm.py
@@ -288,7 +288,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: create SmartOS zone
+- name: Create SmartOS zone
   vmadm:
     brand: joyent
     state: present

--- a/plugins/modules/clustering/consul/consul.py
+++ b/plugins/modules/clustering/consul/consul.py
@@ -139,32 +139,32 @@ options:
 '''
 
 EXAMPLES = '''
-- name: register nginx service with the local consul agent
+- name: Register nginx service with the local consul agent
   consul:
     service_name: nginx
     service_port: 80
 
-- name: register nginx service with curl check
+- name: Register nginx service with curl check
   consul:
     service_name: nginx
     service_port: 80
     script: curl http://localhost
     interval: 60s
 
-- name: register nginx with an http check
+- name: Register nginx with an http check
   consul:
     service_name: nginx
     service_port: 80
     interval: 60s
     http: http://localhost:80/status
 
-- name: register external service nginx available at 10.1.5.23
+- name: Register external service nginx available at 10.1.5.23
   consul:
     service_name: nginx
     service_port: 80
     service_address: 10.1.5.23
 
-- name: register nginx with some service tags
+- name: Register nginx with some service tags
   consul:
     service_name: nginx
     service_port: 80
@@ -172,26 +172,26 @@ EXAMPLES = '''
       - prod
       - webservers
 
-- name: remove nginx service
+- name: Remove nginx service
   consul:
     service_name: nginx
     state: absent
 
-- name: register celery worker service
+- name: Register celery worker service
   consul:
     service_name: celery-worker
     tags:
       - prod
       - worker
 
-- name: create a node level check to test disk usage
+- name: Create a node level check to test disk usage
   consul:
     check_name: Disk usage
     check_id: disk_usage
     script: /opt/disk_usage.py
     interval: 5m
 
-- name: register an http check against a service that's already registered
+- name: Register an http check against a service that's already registered
   consul:
     check_name: nginx-check2
     check_id: nginx-check2

--- a/plugins/modules/clustering/consul/consul_acl.py
+++ b/plugins/modules/clustering/consul/consul_acl.py
@@ -76,7 +76,7 @@ requirements:
 '''
 
 EXAMPLES = """
-- name: create an ACL with rules
+- name: Create an ACL with rules
   consul_acl:
     host: consul1.example.com
     mgmt_token: some_management_acl
@@ -87,7 +87,7 @@ EXAMPLES = """
       - key: "private/foo"
         policy: deny
 
-- name: create an ACL with a specific token
+- name: Create an ACL with a specific token
   consul_acl:
     host: consul1.example.com
     mgmt_token: some_management_acl
@@ -97,7 +97,7 @@ EXAMPLES = """
       - key: "foo"
         policy: read
 
-- name: update the rules associated to an ACL token
+- name: Update the rules associated to an ACL token
   consul_acl:
     host: consul1.example.com
     mgmt_token: some_management_acl
@@ -121,7 +121,7 @@ EXAMPLES = """
       - session: "standup"
         policy: write
 
-- name: remove a token
+- name: Remove a token
   consul_acl:
     host: consul1.example.com
     mgmt_token: some_management_acl

--- a/plugins/modules/clustering/consul/consul_kv.py
+++ b/plugins/modules/clustering/consul/consul_kv.py
@@ -109,7 +109,7 @@ options:
 EXAMPLES = '''
 # If the key does not exist, the value associated to the "data" property in `retrieved_key` will be `None`
 # If the key value is empty string, `retrieved_key["data"]["Value"]` will be `None`
-- name: retrieve a value from the key/value store
+- name: Retrieve a value from the key/value store
   consul_kv:
     key: somekey
   register: retrieved_key

--- a/plugins/modules/clustering/consul/consul_session.py
+++ b/plugins/modules/clustering/consul/consul_session.py
@@ -97,27 +97,27 @@ options:
 '''
 
 EXAMPLES = '''
-- name: register basic session with consul
+- name: Register basic session with consul
   consul_session:
     name: session1
 
-- name: register a session with an existing check
+- name: Register a session with an existing check
   consul_session:
     name: session_with_check
     checks:
       - existing_check_name
 
-- name: register a session with lock_delay
+- name: Register a session with lock_delay
   consul_session:
     name: session_with_delay
     delay: 20s
 
-- name: retrieve info about session by id
+- name: Retrieve info about session by id
   consul_session:
     id: session_id
     state: info
 
-- name: retrieve active sessions
+- name: Retrieve active sessions
   consul_session:
     state: list
 '''

--- a/plugins/modules/database/aerospike/aerospike_migrations.py
+++ b/plugins/modules/database/aerospike/aerospike_migrations.py
@@ -105,7 +105,7 @@ options:
 '''
 EXAMPLES = '''
 # check for migrations on local node
-- name: wait for migrations on local node before proceeding
+- name: Wait for migrations on local node before proceeding
   aerospike_migrations:
     host: "localhost"
     connect_timeout: 2000
@@ -116,7 +116,7 @@ EXAMPLES = '''
 
 # example playbook:
 ---
-- name: upgrade aerospike
+- name: Upgrade aerospike
   hosts: all
   become: true
   serial: 1
@@ -128,7 +128,7 @@ EXAMPLES = '''
             - python-pip
             - python-setuptools
         state: latest
-    - name: setup aerospike
+    - name: Setup aerospike
       pip:
           name: aerospike
 # check for migrations every (sleep_between_checks)
@@ -137,7 +137,7 @@ EXAMPLES = '''
 # nodes not returning data, or other reasons.
 # Maximum runtime before giving up in this case will be:
 # Tries Limit * Sleep Between Checks * delay * retries
-    - name: wait for aerospike migrations
+    - name: Wait for aerospike migrations
       aerospike_migrations:
           local_only: True
           sleep_between_checks: 1
@@ -151,10 +151,10 @@ EXAMPLES = '''
       changed_when: false
       delay: 60
       retries: 120
-    - name: another thing
+    - name: Another thing
       shell: |
           echo foo
-    - name: reboot
+    - name: Reboot
       reboot:
 '''
 

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -49,7 +49,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 # Example influxdb_retention_policy command from Ansible Playbooks
-- name: create 1 hour retention policy
+- name: Create 1 hour retention policy
   influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
@@ -59,7 +59,7 @@ EXAMPLES = r'''
       ssl: yes
       validate_certs: yes
 
-- name: create 1 day retention policy
+- name: Create 1 day retention policy
   influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
@@ -67,7 +67,7 @@ EXAMPLES = r'''
       duration: 1d
       replication: 1
 
-- name: create 1 week retention policy
+- name: Create 1 week retention policy
   influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
@@ -75,7 +75,7 @@ EXAMPLES = r'''
       duration: 1w
       replication: 1
 
-- name: create infinite retention policy
+- name: Create infinite retention policy
   influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"

--- a/plugins/modules/database/vertica/vertica_configuration.py
+++ b/plugins/modules/database/vertica/vertica_configuration.py
@@ -55,7 +55,7 @@ author: "Dariusz Owczarek (@dareko)"
 '''
 
 EXAMPLES = """
-- name: updating load_balance_policy
+- name: Updating load_balance_policy
   vertica_configuration: name=failovertostandbyafter value='8 hours'
 """
 import traceback

--- a/plugins/modules/database/vertica/vertica_info.py
+++ b/plugins/modules/database/vertica/vertica_info.py
@@ -49,7 +49,7 @@ author: "Dariusz Owczarek (@dareko)"
 '''
 
 EXAMPLES = """
-- name: gathering vertica facts
+- name: Gathering vertica facts
   vertica_info: db=db_name
   register: result
 

--- a/plugins/modules/database/vertica/vertica_role.py
+++ b/plugins/modules/database/vertica/vertica_role.py
@@ -60,10 +60,10 @@ author: "Dariusz Owczarek (@dareko)"
 '''
 
 EXAMPLES = """
-- name: creating a new vertica role
+- name: Creating a new vertica role
   vertica_role: name=role_name db=db_name state=present
 
-- name: creating a new vertica role with other role assigned
+- name: Creating a new vertica role with other role assigned
   vertica_role: name=role_name assigned_role=other_role_name state=present
 """
 import traceback

--- a/plugins/modules/database/vertica/vertica_schema.py
+++ b/plugins/modules/database/vertica/vertica_schema.py
@@ -72,13 +72,13 @@ author: "Dariusz Owczarek (@dareko)"
 '''
 
 EXAMPLES = """
-- name: creating a new vertica schema
+- name: Creating a new vertica schema
   vertica_schema: name=schema_name db=db_name state=present
 
-- name: creating a new schema with specific schema owner
+- name: Creating a new schema with specific schema owner
   vertica_schema: name=schema_name owner=dbowner db=db_name state=present
 
-- name: creating a new schema with roles
+- name: Creating a new schema with roles
   vertica_schema:
     name=schema_name
     create_roles=schema_name_all

--- a/plugins/modules/database/vertica/vertica_user.py
+++ b/plugins/modules/database/vertica/vertica_user.py
@@ -83,10 +83,10 @@ author: "Dariusz Owczarek (@dareko)"
 '''
 
 EXAMPLES = """
-- name: creating a new vertica user with password
+- name: Creating a new vertica user with password
   vertica_user: name=user_name password=md5<encrypted_password> db=db_name state=present
 
-- name: creating a new vertica user authenticated via ldap with roles assigned
+- name: Creating a new vertica user authenticated via ldap with roles assigned
   vertica_user:
     name=user_name
     ldap=true

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -163,7 +163,7 @@ EXAMPLES = '''
     realm: master
     name: this_is_a_test
 
-- name: delete Keycloak client template
+- name: Delete Keycloak client template
   local_action:
     module: keycloak_clienttemplate
     auth_client_id: admin-cli

--- a/plugins/modules/monitoring/logstash_plugin.py
+++ b/plugins/modules/monitoring/logstash_plugin.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
     state: absent
     name: logstash-filter-multiline
 
-- name: install Logstash plugin with alternate heap size
+- name: Install Logstash plugin with alternate heap size
   logstash_plugin:
     state: present
     name: logstash-input-beats

--- a/plugins/modules/monitoring/sensu/sensu_check.py
+++ b/plugins/modules/monitoring/sensu/sensu_check.py
@@ -129,7 +129,7 @@ author: "Anders Ingemann (@andsens)"
 EXAMPLES = '''
 # Fetch metrics about the CPU load every 60 seconds,
 # the sensu server has a handler called 'relay' which forwards stats to graphite
-- name: get cpu metrics
+- name: Get cpu metrics
   sensu_check:
     name: cpu_load
     command: /etc/sensu/plugins/system/cpu-mpstat-metrics.rb
@@ -139,7 +139,7 @@ EXAMPLES = '''
     interval: 60
 
 # Check whether nginx is running
-- name: check nginx process
+- name: Check nginx process
   sensu_check:
     name: nginx_running
     command: /etc/sensu/plugins/processes/check-procs.rb -f /var/run/nginx.pid
@@ -150,7 +150,7 @@ EXAMPLES = '''
 # Stop monitoring the disk capacity.
 # Note that the check will still show up in the sensu dashboard,
 # to remove it completely you need to issue a DELETE request to the sensu api.
-- name: check disk
+- name: Check disk
   sensu_check:
     name: check_disk_capacity
     state: absent

--- a/plugins/modules/monitoring/sensu/sensu_subscription.py
+++ b/plugins/modules/monitoring/sensu/sensu_subscription.py
@@ -51,11 +51,11 @@ reasons:
 
 EXAMPLES = '''
 # Subscribe to the nginx channel
-- name: subscribe to nginx checks
+- name: Subscribe to nginx checks
   sensu_subscription: name=nginx
 
 # Unsubscribe from the common checks channel
-- name: unsubscribe from common checks
+- name: Unsubscribe from common checks
   sensu_subscription: name=common state=absent
 '''
 

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -196,7 +196,7 @@ EXAMPLES = r'''
     account_api_key: dummyapitoken
     state: absent
 
-- name: create a example.net CNAME record to example.com and proxy through Cloudflare's network
+- name: Create a example.net CNAME record to example.com and proxy through Cloudflare's network
   cloudflare_dns:
     zone: example.net
     type: CNAME

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -121,7 +121,7 @@ EXAMPLES = '''
     state: present
   delegate_to: localhost
 
-- name: change TTL value for a record
+- name: Change TTL value for a record
   dnsimple:
     domain: my.com
     record: ''

--- a/plugins/modules/net_tools/ipinfoio_facts.py
+++ b/plugins/modules/net_tools/ipinfoio_facts.py
@@ -32,7 +32,7 @@ notes:
 
 EXAMPLES = '''
 # Retrieve geolocation data of a host's IP address
-- name: get IP geolocation data
+- name: Get IP geolocation data
   ipinfoio_facts:
 '''
 

--- a/plugins/modules/net_tools/nios/nios_a_record.py
+++ b/plugins/modules/net_tools/nios/nios_a_record.py
@@ -67,7 +67,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure an A record
+- name: Configure an A record
   nios_a_record:
     name: a.ansible.com
     ipv4: 192.168.10.1
@@ -78,7 +78,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing A record
+- name: Add a comment to an existing A record
   nios_a_record:
     name: a.ansible.com
     ipv4: 192.168.10.1
@@ -90,7 +90,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove an A record from the system
+- name: Remove an A record from the system
   nios_a_record:
     name: a.ansible.com
     ipv4: 192.168.10.1
@@ -101,7 +101,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: update an A record name
+- name: Update an A record name
   nios_a_record:
     name: {new_name: a_new.ansible.com, old_name: a.ansible.com}
     ipv4: 192.168.10.1
@@ -112,7 +112,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: dynamically add a record to next available ip
+- name: Dynamically add a record to next available ip
   nios_a_record:
     name: a.ansible.com
     ipv4: {nios_next_ip: 192.168.10.0/24}

--- a/plugins/modules/net_tools/nios/nios_aaaa_record.py
+++ b/plugins/modules/net_tools/nios/nios_aaaa_record.py
@@ -65,7 +65,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure an AAAA record
+- name: Configure an AAAA record
   nios_aaaa_record:
     name: aaaa.ansible.com
     ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
@@ -76,7 +76,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing AAAA record
+- name: Add a comment to an existing AAAA record
   nios_aaaa_record:
     name: aaaa.ansible.com
     ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
@@ -88,7 +88,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove an AAAA record from the system
+- name: Remove an AAAA record from the system
   nios_aaaa_record:
     name: aaaa.ansible.com
     ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
@@ -99,7 +99,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: update an AAAA record name
+- name: Update an AAAA record name
   nios_aaaa_record:
     name: {new_name: aaaa_new.ansible.com, old_name: aaaa.ansible.com}
     ipv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334

--- a/plugins/modules/net_tools/nios/nios_cname_record.py
+++ b/plugins/modules/net_tools/nios/nios_cname_record.py
@@ -65,7 +65,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a CNAME record
+- name: Configure a CNAME record
   nios_cname_record:
     name: cname.ansible.com
     canonical: realhost.ansible.com
@@ -76,7 +76,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing CNAME record
+- name: Add a comment to an existing CNAME record
   nios_cname_record:
     name: cname.ansible.com
     canonical: realhost.ansible.com
@@ -88,7 +88,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove a CNAME record from the system
+- name: Remove a CNAME record from the system
   nios_cname_record:
     name: cname.ansible.com
     canonical: realhost.ansible.com

--- a/plugins/modules/net_tools/nios/nios_dns_view.py
+++ b/plugins/modules/net_tools/nios/nios_dns_view.py
@@ -62,7 +62,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a new dns view instance
+- name: Configure a new dns view instance
   nios_dns_view:
     name: ansible-dns
     state: present
@@ -71,7 +71,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update the comment for dns view
+- name: Update the comment for dns view
   nios_dns_view:
     name: ansible-dns
     comment: this is an example comment
@@ -81,7 +81,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove the dns view instance
+- name: Remove the dns view instance
   nios_dns_view:
     name: ansible-dns
     state: absent
@@ -90,7 +90,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update the dns view instance
+- name: Update the dns view instance
   nios_dns_view:
     name: {new_name: ansible-dns-new, old_name: ansible-dns}
     state: present

--- a/plugins/modules/net_tools/nios/nios_fixed_address.py
+++ b/plugins/modules/net_tools/nios/nios_fixed_address.py
@@ -94,7 +94,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure ipv4 dhcp fixed address
+- name: Configure ipv4 dhcp fixed address
   nios_fixed_address:
     name: ipv4_fixed
     ipaddr: 192.168.10.1
@@ -108,7 +108,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a ipv6 dhcp fixed address
+- name: Configure a ipv6 dhcp fixed address
   nios_fixed_address:
     name: ipv6_fixed
     ipaddr: fe80::1/10
@@ -122,7 +122,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: set dhcp options for a ipv4 fixed address
+- name: Set dhcp options for a ipv4 fixed address
   nios_fixed_address:
     name: ipv4_fixed
     ipaddr: 192.168.10.1
@@ -139,7 +139,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove a ipv4 dhcp fixed address
+- name: Remove a ipv4 dhcp fixed address
   nios_fixed_address:
     name: ipv4_fixed
     ipaddr: 192.168.10.1

--- a/plugins/modules/net_tools/nios/nios_host_record.py
+++ b/plugins/modules/net_tools/nios/nios_host_record.py
@@ -144,7 +144,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure an ipv4 host record
+- name: Configure an ipv4 host record
   nios_host_record:
     name: host.ansible.com
     ipv4:
@@ -157,7 +157,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: add a comment to an existing host record
+- name: Add a comment to an existing host record
   nios_host_record:
     name: host.ansible.com
     ipv4:
@@ -169,7 +169,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove a host record from the system
+- name: Remove a host record from the system
   nios_host_record:
     name: host.ansible.com
     state: absent
@@ -178,7 +178,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update an ipv4 host record
+- name: Update an ipv4 host record
   nios_host_record:
     name: {new_name: host-new.ansible.com, old_name: host.ansible.com}
     ipv4:
@@ -189,7 +189,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: create an ipv4 host record bypassing DNS
+- name: Create an ipv4 host record bypassing DNS
   nios_host_record:
     name: new_host
     ipv4:
@@ -201,7 +201,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: create an ipv4 host record over DHCP
+- name: Create an ipv4 host record over DHCP
   nios_host_record:
     name: host.ansible.com
     ipv4:
@@ -214,7 +214,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: dynamically add host record to next available ip
+- name: Dynamically add host record to next available ip
   nios_host_record:
     name: host.ansible.com
     ipv4:
@@ -226,7 +226,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: add ip to host record
+- name: Add ip to host record
   nios_host_record:
     name: host.ansible.com
     ipv4:
@@ -238,7 +238,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove ip to host record
+- name: Remove ip to host record
   nios_host_record:
     name: host.ansible.com
     ipv4:

--- a/plugins/modules/net_tools/nios/nios_member.py
+++ b/plugins/modules/net_tools/nios/nios_member.py
@@ -298,7 +298,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: add a member to the grid with IPv4 address
+- name: Add a member to the grid with IPv4 address
   nios_member:
     host_name: member01.localdomain
     vip_setting:
@@ -314,7 +314,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: add a HA member to the grid
+- name: Add a HA member to the grid
   nios_member:
     host_name: memberha.localdomain
     vip_setting:
@@ -339,7 +339,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update the member with pre-provisioning details specified
+- name: Update the member with pre-provisioning details specified
   nios_member:
     name: member01.localdomain
     pre_provisioning:
@@ -358,7 +358,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove the member
+- name: Remove the member
   nios_member:
     name: member01.localdomain
     state: absent

--- a/plugins/modules/net_tools/nios/nios_mx_record.py
+++ b/plugins/modules/net_tools/nios/nios_mx_record.py
@@ -69,7 +69,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure an MX record
+- name: Configure an MX record
   nios_mx_record:
     name: ansible.com
     mx: mailhost.ansible.com
@@ -81,7 +81,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing MX record
+- name: Add a comment to an existing MX record
   nios_mx_record:
     name: ansible.com
     mx: mailhost.ansible.com
@@ -94,7 +94,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove an MX record from the system
+- name: Remove an MX record from the system
   nios_mx_record:
     name: ansible.com
     mx: mailhost.ansible.com

--- a/plugins/modules/net_tools/nios/nios_naptr_record.py
+++ b/plugins/modules/net_tools/nios/nios_naptr_record.py
@@ -97,7 +97,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a NAPTR record
+- name: Configure a NAPTR record
   nios_naptr_record:
     name: '*.subscriber-100.ansiblezone.com'
     order: 1000
@@ -110,7 +110,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing NAPTR record
+- name: Add a comment to an existing NAPTR record
   nios_naptr_record:
     name: '*.subscriber-100.ansiblezone.com'
     order: 1000
@@ -124,7 +124,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove a NAPTR record from the system
+- name: Remove a NAPTR record from the system
   nios_naptr_record:
     name: '*.subscriber-100.ansiblezone.com'
     order: 1000

--- a/plugins/modules/net_tools/nios/nios_network.py
+++ b/plugins/modules/net_tools/nios/nios_network.py
@@ -92,7 +92,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a network ipv4
+- name: Configure a network ipv4
   nios_network:
     network: 192.168.10.0/24
     comment: this is a test comment
@@ -102,7 +102,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a network ipv6
+- name: Configure a network ipv6
   nios_network:
     network: fe80::/64
     comment: this is a test comment
@@ -112,7 +112,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: set dhcp options for a network ipv4
+- name: Set dhcp options for a network ipv4
   nios_network:
     network: 192.168.10.0/24
     comment: this is a test comment
@@ -125,7 +125,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove a network ipv4
+- name: Remove a network ipv4
   nios_network:
     network: 192.168.10.0/24
     state: absent
@@ -134,7 +134,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a ipv4 network container
+- name: Configure a ipv4 network container
   nios_network:
     network: 192.168.10.0/24
     container: true
@@ -145,7 +145,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a ipv6 network container
+- name: Configure a ipv6 network container
   nios_network:
     network: fe80::/64
     container: true
@@ -156,7 +156,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove a ipv4 network container
+- name: Remove a ipv4 network container
   nios_network:
     networkr: 192.168.10.0/24
     container: true

--- a/plugins/modules/net_tools/nios/nios_network_view.py
+++ b/plugins/modules/net_tools/nios/nios_network_view.py
@@ -52,7 +52,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a new network view
+- name: Configure a new network view
   nios_network_view:
     name: ansible
     state: present
@@ -61,7 +61,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update the comment for network view
+- name: Update the comment for network view
   nios_network_view:
     name: ansible
     comment: this is an example comment
@@ -71,7 +71,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove the network view
+- name: Remove the network view
   nios_network_view:
     name: ansible
     state: absent
@@ -80,7 +80,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update a existing network view
+- name: Update a existing network view
   nios_network_view:
     name: {new_name: ansible-new, old_name: ansible}
     state: present

--- a/plugins/modules/net_tools/nios/nios_nsgroup.py
+++ b/plugins/modules/net_tools/nios/nios_nsgroup.py
@@ -182,7 +182,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: create simple infoblox nameserver group
+- name: Create simple infoblox nameserver group
   nios_nsgroup:
     name: my-simple-group
     comment: "this is a simple nameserver group"
@@ -195,7 +195,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: create infoblox nameserver group with external primaries
+- name: Create infoblox nameserver group with external primaries
   nios_nsgroup:
     name: my-example-group
     use_external_primary: true
@@ -212,7 +212,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: delete infoblox nameserver group
+- name: Delete infoblox nameserver group
   nios_nsgroup:
     name: my-simple-group
     comment: "this is a simple nameserver group"

--- a/plugins/modules/net_tools/nios/nios_srv_record.py
+++ b/plugins/modules/net_tools/nios/nios_srv_record.py
@@ -75,7 +75,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure an SRV record
+- name: Configure an SRV record
   nios_srv_record:
     name: _sip._tcp.service.ansible.com
     port: 5080
@@ -89,7 +89,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: add a comment to an existing SRV record
+- name: Add a comment to an existing SRV record
   nios_srv_record:
     name: _sip._tcp.service.ansible.com
     port: 5080
@@ -104,7 +104,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: remove an SRV record from the system
+- name: Remove an SRV record from the system
   nios_srv_record:
     name: _sip._tcp.service.ansible.com
     port: 5080

--- a/plugins/modules/net_tools/nios/nios_zone.py
+++ b/plugins/modules/net_tools/nios/nios_zone.py
@@ -89,7 +89,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a zone on the system using grid primary and secondaries
+- name: Configure a zone on the system using grid primary and secondaries
   nios_zone:
     name: ansible.com
     grid_primary:
@@ -104,7 +104,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a zone on the system using a name server group
+- name: Configure a zone on the system using a name server group
   nios_zone:
     name: ansible.com
     ns_group: examplensg
@@ -115,7 +115,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a reverse mapping zone on the system using IPV4 zone format
+- name: Configure a reverse mapping zone on the system using IPV4 zone format
   nios_zone:
     name: 10.10.10.0/24
     zone_format: IPV4
@@ -125,7 +125,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: configure a reverse mapping zone on the system using IPV6 zone format
+- name: Configure a reverse mapping zone on the system using IPV6 zone format
   nios_zone:
     name: 100::1/128
     zone_format: IPV6
@@ -135,7 +135,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: update the comment and ext attributes for an existing zone
+- name: Update the comment and ext attributes for an existing zone
   nios_zone:
     name: ansible.com
     comment: this is an example comment
@@ -147,7 +147,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove the dns zone
+- name: Remove the dns zone
   nios_zone:
     name: ansible.com
     state: absent
@@ -156,7 +156,7 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-- name: remove the reverse mapping dns zone from the system with IPV4 zone format
+- name: Remove the reverse mapping dns zone from the system with IPV4 zone format
   nios_zone:
     name: 10.10.10.0/24
     zone_format: IPV4

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -354,7 +354,7 @@ EXAMPLES = r'''
   remote_user: root
   tasks:
 
-  - name: install needed network manager libs
+  - name: Install needed network manager libs
     package:
       name:
         - NetworkManager-libnm

--- a/plugins/modules/notification/rocketchat.py
+++ b/plugins/modules/notification/rocketchat.py
@@ -101,7 +101,7 @@ EXAMPLES = """
     link_names: 0
   delegate_to: localhost
 
-- name: insert a color bar in front of the message for visibility purposes and use the default webhook icon and name configured in rocketchat
+- name: Insert a color bar in front of the message for visibility purposes and use the default webhook icon and name configured in rocketchat
   rocketchat:
     token: thetoken/generatedby/rocketchat
     domain: chat.example.com

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -122,7 +122,7 @@ EXAMPLES = """
     parse: 'none'
   delegate_to: localhost
 
-- name: insert a color bar in front of the message for visibility purposes and use the default webhook icon and name configured in Slack
+- name: Insert a color bar in front of the message for visibility purposes and use the default webhook icon and name configured in Slack
   slack:
     token: thetoken/generatedby/slack
     msg: '{{ inventory_hostname }} is alive!'
@@ -130,7 +130,7 @@ EXAMPLES = """
     username: ''
     icon_url: ''
 
-- name: insert a color bar in front of the message with valid hex color value
+- name: Insert a color bar in front of the message with valid hex color value
   slack:
     token: thetoken/generatedby/slack
     msg: 'This message uses color in hex value'

--- a/plugins/modules/notification/telegram.py
+++ b/plugins/modules/notification/telegram.py
@@ -44,7 +44,7 @@ options:
 
 EXAMPLES = """
 
-- name: send a message to chat in playbook
+- name: Send a message to chat in playbook
   telegram:
     token: '9999999:XXXXXXXXXXXXXXXXXXXXXXX'
     chat_id: 000000

--- a/plugins/modules/packaging/language/composer.py
+++ b/plugins/modules/packaging/language/composer.py
@@ -116,7 +116,7 @@ EXAMPLES = '''
     command: install
     working_dir: /path/to/project
 
-- name: install a new package
+- name: Install a new package
   composer:
     command: require
     arguments: my/package

--- a/plugins/modules/packaging/language/pip_package_info.py
+++ b/plugins/modules/packaging/language/pip_package_info.py
@@ -32,11 +32,11 @@ EXAMPLES = '''
 - name: Just get the list from default pip
   pip_package_info:
 
-- name: get the facts for default pip, pip2 and pip3.6
+- name: Get the facts for default pip, pip2 and pip3.6
   pip_package_info:
     clients: ['pip', 'pip2', 'pip3.6']
 
-- name: get from specific paths (virtualenvs?)
+- name: Get from specific paths (virtualenvs?)
   pip_package_info:
     clients: '/home/me/projec42/python/pip3.5'
 '''

--- a/plugins/modules/remote_management/lxca/lxca_cmms.py
+++ b/plugins/modules/remote_management/lxca/lxca_cmms.py
@@ -41,14 +41,14 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # get all cmms info
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_cmms:
     login_user: USERID
     login_password: Password
     auth_url: "https://10.243.15.168"
 
 # get specific cmms info by uuid
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_cmms:
     login_user: USERID
     login_password: Password
@@ -57,7 +57,7 @@ EXAMPLES = '''
     command_options: cmms_by_uuid
 
 # get specific cmms info by chassis uuid
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_cmms:
     login_user: USERID
     login_password: Password

--- a/plugins/modules/remote_management/lxca/lxca_nodes.py
+++ b/plugins/modules/remote_management/lxca/lxca_nodes.py
@@ -43,7 +43,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # get all nodes info
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_nodes:
     login_user: USERID
     login_password: Password
@@ -51,7 +51,7 @@ EXAMPLES = '''
     command_options: nodes
 
 # get specific nodes info by uuid
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_nodes:
     login_user: USERID
     login_password: Password
@@ -60,7 +60,7 @@ EXAMPLES = '''
     command_options: nodes_by_uuid
 
 # get specific nodes info by chassis uuid
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_nodes:
     login_user: USERID
     login_password: Password
@@ -69,7 +69,7 @@ EXAMPLES = '''
     command_options: nodes_by_chassis_uuid
 
 # get managed nodes
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_nodes:
     login_user: USERID
     login_password: Password
@@ -77,7 +77,7 @@ EXAMPLES = '''
     command_options: nodes_status_managed
 
 # get unmanaged nodes
-- name: get nodes data from LXCA
+- name: Get nodes data from LXCA
   lxca_nodes:
     login_user: USERID
     login_password: Password

--- a/plugins/modules/source_control/github/github_webhook.py
+++ b/plugins/modules/source_control/github/github_webhook.py
@@ -94,7 +94,7 @@ EXAMPLES = '''
     user: "{{ github_user }}"
     password: "{{ github_password }}"
 
-- name: create a new webhook in a github enterprise installation with multiple event triggers (token auth)
+- name: Create a new webhook in a github enterprise installation with multiple event triggers (token auth)
   github_webhook:
     repository: myorg/myrepo
     url: https://jenkins.example.com/ghprbhook/
@@ -108,7 +108,7 @@ EXAMPLES = '''
     token: "{{ github_user_api_token }}"
     github_url: https://github.example.com
 
-- name: delete a webhook (password auth)
+- name: Delete a webhook (password auth)
   github_webhook:
     repository: ansible/ansible
     url: https://www.example.com/hooks/

--- a/plugins/modules/source_control/github/github_webhook_info.py
+++ b/plugins/modules/source_control/github/github_webhook_info.py
@@ -45,14 +45,14 @@ author:
 '''
 
 EXAMPLES = '''
-- name: list hooks for a repository (password auth)
+- name: List hooks for a repository (password auth)
   github_webhook_info:
     repository: ansible/ansible
     user: "{{ github_user }}"
     password: "{{ github_password }}"
   register: ansible_webhooks
 
-- name: list hooks for a repository on GitHub Enterprise (token auth)
+- name: List hooks for a repository on GitHub Enterprise (token auth)
   github_webhook_info:
     repository: myorg/myrepo
     user: "{{ github_user }}"

--- a/plugins/modules/storage/glusterfs/gluster_volume.py
+++ b/plugins/modules/storage/glusterfs/gluster_volume.py
@@ -86,7 +86,7 @@ author:
 '''
 
 EXAMPLES = """
-- name: create gluster volume
+- name: Create gluster volume
   gluster_volume:
     state: present
     name: test1
@@ -97,7 +97,7 @@ EXAMPLES = """
       - 192.0.2.11
   run_once: true
 
-- name: tune
+- name: Tune
   gluster_volume:
     state: present
     name: test1
@@ -114,29 +114,29 @@ EXAMPLES = """
         quick-read: 'on'
       }
 
-- name: start gluster volume
+- name: Start gluster volume
   gluster_volume:
     state: started
     name: test1
 
-- name: limit usage
+- name: Limit usage
   gluster_volume:
     state: present
     name: test1
     directory: /foo
     quota: 20.0MB
 
-- name: stop gluster volume
+- name: Stop gluster volume
   gluster_volume:
     state: stopped
     name: test1
 
-- name: remove gluster volume
+- name: Remove gluster volume
   gluster_volume:
     state: absent
     name: test1
 
-- name: create gluster volume with multiple bricks
+- name: Create gluster volume with multiple bricks
   gluster_volume:
     state: present
     name: test2

--- a/plugins/modules/storage/purestorage/purefa_facts.py
+++ b/plugins/modules/storage/purestorage/purefa_facts.py
@@ -39,12 +39,12 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: collect default set of facts
+- name: Collect default set of facts
   purefa_facts:
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
-- name: collect configuration and capacity facts
+- name: Collect configuration and capacity facts
   purefa_facts:
     gather_subset:
       - config
@@ -52,7 +52,7 @@ EXAMPLES = r'''
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
-- name: collect all facts
+- name: Collect all facts
   purefa_facts:
     gather_subset:
       - all

--- a/plugins/modules/storage/purestorage/purefb_facts.py
+++ b/plugins/modules/storage/purestorage/purefb_facts.py
@@ -39,12 +39,12 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: collect default set of facts
+- name: Collect default set of facts
   purefb_facts:
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 
-- name: collect configuration and capacity facts
+- name: Collect configuration and capacity facts
   purefb_facts:
     gather_subset:
       - config
@@ -52,7 +52,7 @@ EXAMPLES = r'''
     fb_url: 10.10.10.2
     api_token: T-55a68eb5-c785-4720-a2ca-8b03903bf641
 
-- name: collect all facts
+- name: Collect all facts
   purefb_facts:
     gather_subset:
       - all

--- a/plugins/modules/system/nosh.py
+++ b/plugins/modules/system/nosh.py
@@ -60,42 +60,42 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: start dnscache if not running
+- name: Start dnscache if not running
   nosh: name=dnscache state=started
 
-- name: stop mpd, if running
+- name: Stop mpd, if running
   nosh: name=mpd state=stopped
 
-- name: restart unbound or start it if not already running
+- name: Restart unbound or start it if not already running
   nosh:
     name: unbound
     state: restarted
 
-- name: reload fail2ban or start it if not already running
+- name: Reload fail2ban or start it if not already running
   nosh:
     name: fail2ban
     state: reloaded
 
-- name: disable nsd
+- name: Disable nsd
   nosh: name=nsd enabled=no
 
-- name: for package installers, set nginx running state according to local enable settings, preset and reset
+- name: For package installers, set nginx running state according to local enable settings, preset and reset
   nosh: name=nginx preset=True state=reset
 
-- name: reboot the host if nosh is the system manager, would need a "wait_for*" task at least, not recommended as-is
+- name: Reboot the host if nosh is the system manager, would need a "wait_for*" task at least, not recommended as-is
   nosh: name=reboot state=started
 
-- name: using conditionals with the module facts
+- name: Using conditionals with the module facts
   tasks:
-    - name: obtain information on tinydns service
+    - name: Obtain information on tinydns service
       nosh: name=tinydns
       register: result
 
-    - name: fail if service not loaded
+    - name: Fail if service not loaded
       fail: msg="The {{ result.name }} service is not loaded"
       when: not result.status
 
-    - name: fail if service is running
+    - name: Fail if service is running
       fail: msg="The {{ result.name }} service is running"
       when: result.status and result.status['DaemontoolsEncoreState'] == "running"
 '''

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -24,9 +24,10 @@ author:
 '''
 
 EXAMPLES = '''
-- name: show python lib/site paths
+- name: Show python lib/site paths
   python_requirements_info:
-- name: check for modern boto3 and botocore versions
+
+- name: Check for modern boto3 and botocore versions
   python_requirements_info:
     dependencies:
     - boto3>1.6

--- a/plugins/modules/web_infrastructure/ejabberd_user.py
+++ b/plugins/modules/web_infrastructure/ejabberd_user.py
@@ -50,13 +50,13 @@ notes:
 EXAMPLES = '''
 # Example playbook entries using the ejabberd_user module to manage users state.
 
-- name: create a user if it does not exist
+- name: Create a user if it does not exist
   ejabberd_user:
     username: test
     host: server
     password: password
 
-- name: delete a user if it exists
+- name: Delete a user if it exists
   ejabberd_user:
     username: test
     host: server

--- a/plugins/modules/web_infrastructure/gunicorn.py
+++ b/plugins/modules/web_infrastructure/gunicorn.py
@@ -55,24 +55,24 @@ notes:
 '''
 
 EXAMPLES = '''
-- name: simple gunicorn run example
+- name: Simple gunicorn run example
   gunicorn:
     app: 'wsgi'
     chdir: '/workspace/example'
 
-- name: run gunicorn on a virtualenv
+- name: Run gunicorn on a virtualenv
   gunicorn:
     app: 'wsgi'
     chdir: '/workspace/example'
     venv: '/workspace/example/venv'
 
-- name: run gunicorn with a config file
+- name: Run gunicorn with a config file
   gunicorn:
     app: 'wsgi'
     chdir: '/workspace/example'
     conf: '/workspace/example/gunicorn.cfg'
 
-- name: run gunicorn as ansible user with specified pid and config file
+- name: Run gunicorn as ansible user with specified pid and config file
   gunicorn:
     app: 'wsgi'
     chdir: '/workspace/example'

--- a/plugins/modules/web_infrastructure/jenkins_script.py
+++ b/plugins/modules/web_infrastructure/jenkins_script.py
@@ -72,13 +72,13 @@ EXAMPLES = '''
         instance.setMode(${jenkins_mode})
         instance.save()
 
-- name: use the variable as the script
+- name: Use the variable as the script
   jenkins_script:
     script: "{{ setmaster_mode }}"
     args:
       jenkins_mode: Node.Mode.EXCLUSIVE
 
-- name: interacting with an untrusted HTTPS connection
+- name: Interacting with an untrusted HTTPS connection
   jenkins_script:
     script: "println(Jenkins.instance.pluginManager.plugins)"
     user: admin

--- a/plugins/modules/web_infrastructure/nginx_status_facts.py
+++ b/plugins/modules/web_infrastructure/nginx_status_facts.py
@@ -36,12 +36,12 @@ notes:
 
 EXAMPLES = '''
 # Gather status facts from nginx on localhost
-- name: get current http stats
+- name: Get current http stats
   nginx_status_facts:
     url: http://localhost/nginx_status
 
 # Gather status facts from nginx on localhost with a custom timeout of 20 seconds
-- name: get current http stats
+- name: Get current http stats
   nginx_status_facts:
     url: http://localhost/nginx_status
     timeout: 20

--- a/plugins/modules/web_infrastructure/nginx_status_info.py
+++ b/plugins/modules/web_infrastructure/nginx_status_info.py
@@ -34,13 +34,13 @@ notes:
 
 EXAMPLES = r'''
 # Gather status info from nginx on localhost
-- name: get current http stats
+- name: Get current http stats
   nginx_status_info:
     url: http://localhost/nginx_status
   register: result
 
 # Gather status info from nginx on localhost with a custom timeout of 20 seconds
-- name: get current http stats
+- name: Get current http stats
   nginx_status_info:
     url: http://localhost/nginx_status
     timeout: 20

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert.py
@@ -56,8 +56,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-# Create a ca_host_key_cert entry
-- name: utm ca_host_key_cert
+- name: Create a ca_host_key_cert entry
   utm_ca_host_key_cert:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234
@@ -72,16 +71,14 @@ EXAMPLES = """
       --- END CERTIFICATE ---
     state: present
 
-# Remove a ca_host_key_cert entry
-- name: utm ca_host_key_cert
+- name: Remove a ca_host_key_cert entry
   utm_ca_host_key_cert:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234
     name: TestHostKeyCertEntry
     state: absent
 
-# Read a ca_host_key_cert entry
-- name: utm ca_host_key_cert
+- name: Read a ca_host_key_cert entry
   utm_ca_host_key_cert:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert_info.py
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-- name: utm ca_host_key_cert_info
+- name: Get info for a ca host_key_cert entry
   utm_ca_host_key_cert_info:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
@@ -49,8 +49,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-# Create a network interface address
-- name: utm network interface address
+- name: Create a network interface address
   utm_proxy_backend:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234
@@ -58,8 +57,7 @@ EXAMPLES = """
     address: 0.0.0.0
     state: present
 
-# Remove a network interface address
-- name: utm network interface address
+- name: Remove a network interface address
   network_interface_address:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address_info.py
@@ -31,7 +31,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-- name: utm network interface address
+- name: Get network interface address info
   utm_proxy_interface_address_info:
     utm_host: sophos.host.name
     utm_token: abcdefghijklmno1234


### PR DESCRIPTION
##### SUMMARY
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#examples-block
```
Per playbook best practices, each example should include a name: line:
EXAMPLES = r'''
- name: Ensure foo is installed
  modulename:
    name: foo
    state: present
'''
The name: line should be capitalized and not include a trailing dot.
```

##### ISSUE TYPE
- Docs Pull Request