### PR TITLE
Improve group expansion speed: query list of pacman groups once (#349)

### DIFF
--- a/changelogs/fragments/349-pacman_improve_group_expansion_speed.yml
+++ b/changelogs/fragments/349-pacman_improve_group_expansion_speed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "pacman - improve group expansion speed: query list of pacman groups once (https://github.com/ansible-collections/community.general/pull/349)."

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -396,17 +396,16 @@ def check_packages(module, pacman_path, packages, state):
 def expand_package_groups(module, pacman_path, pkgs):
     expanded = []
 
+    __, stdout, __ = module.run_command([pacman_path, "--sync", "--groups", "--quiet"], check_rc=True)
+    available_groups = stdout.splitlines()
+
     for pkg in pkgs:
         if pkg:  # avoid empty strings
-            cmd = "%s --sync --groups --quiet %s" % (pacman_path, pkg)
-            rc, stdout, stderr = module.run_command(cmd, check_rc=False)
-
-            if rc == 0:
-                # A group was found matching the name, so expand it
-                for name in stdout.split('\n'):
-                    name = name.strip()
-                    if name:
-                        expanded.append(name)
+            if pkg in available_groups:
+                # A group was found matching the package name: expand it
+                cmd = [pacman_path, "--sync", "--groups", "--quiet", pkg]
+                rc, stdout, stderr = module.run_command(cmd, check_rc=True)
+                expanded.extend([name.strip() for name in stdout.splitlines()])
             else:
                 expanded.append(pkg)
 


### PR DESCRIPTION
For each package check membership in the list instead of checking each
package individually using pacman to see if it is a pacman group.

##### SUMMARY
When using a large amount packages the pacman module takes very long to generate the final list of packages, because it checks each pkg individually for group membership via `pacman --sync --groups --quiet pkgname`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
pacman

##### ADDITIONAL INFORMATION
This improves package installation by 50% on my system (when all packages are already installed).

Master:
```
- Play recap -
  herakles                   : ok=1    changed=0    unreachable=0    failed=0    rescued=0    ignored=0   
Friday 15 May 2020  19:34:58 +0200 (0:00:17.214)       0:00:17.231 ************ 
```
PR:
```
- Play recap -
  herakles                   : ok=1    changed=0    unreachable=0    failed=0    rescued=0    ignored=0   
Friday 15 May 2020  19:33:51 +0200 (0:00:08.191)       0:00:08.211 ************ 
```
