### PR TITLE
Bugfix: Fix parsing array values from osx_defaults

### DIFF
--- a/changelogs/fragments/fix_parsing_array_values_in_osx_defaults.yml
+++ b/changelogs/fragments/fix_parsing_array_values_in_osx_defaults.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Unquote values and unescape double quotes when reading array values from osx defaults.

--- a/changelogs/fragments/fix_parsing_array_values_in_osx_defaults.yml
+++ b/changelogs/fragments/fix_parsing_array_values_in_osx_defaults.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Unquote values and unescape double quotes when reading array values from osx defaults.
+  - osx_defaults - unquote values and unescape double quotes when reading array values (https://github.com/ansible-collections/community.general/pull/358).

--- a/plugins/modules/system/osx_defaults.py
+++ b/plugins/modules/system/osx_defaults.py
@@ -229,8 +229,8 @@ class OSXDefaults(object):
         value.pop(0)
         value.pop(-1)
 
-        # Remove extra spaces and comma (,) at the end of values
-        value = [re.sub(',$', '', x.strip(' ')) for x in value]
+        # Remove spaces at beginning and comma (,) at the end, unquote and unescape double quotes
+        value = [re.sub('^ *"?|"?,?$', '', x.replace('\\"', '"')) for x in value]
 
         return value
 

--- a/plugins/modules/system/osx_defaults.py
+++ b/plugins/modules/system/osx_defaults.py
@@ -230,7 +230,7 @@ class OSXDefaults(object):
         value.pop(-1)
 
         # Remove spaces at beginning and comma (,) at the end, unquote and unescape double quotes
-        value = [re.sub('^ *"?|"?,?$', '', x.replace('\\"', '"')) for x in value]
+        value = [re.sub('^ *"?|"?,? *$', '', x.replace('\\"', '"')) for x in value]
 
         return value
 

--- a/tests/integration/targets/osx_defaults/tasks/main.yml
+++ b/tests/integration/targets/osx_defaults/tasks/main.yml
@@ -202,3 +202,46 @@
 - assert:
     that: "{{ item.changed }}"
   with_items: "{{ test_data_types.results }}"
+
+
+- name: Ensure test key does not exist
+  osx_defaults:
+    domain: com.ansible.fake_array_value
+    key: ExampleArrayKey
+    state: absent
+
+- name: add array value for the first time
+  osx_defaults:
+    domain: com.ansible.fake_array_value
+    key: ExampleArrayKey
+    value:
+      - 'Value with spaces'
+    type: array
+    array_add: yes
+  register: test_array_add
+
+- assert:
+    that: test_array_add.changed
+
+- name: add for the second time, should be skipped
+  osx_defaults:
+    domain: com.ansible.fake_array_value
+    key: ExampleArrayKey
+    value:
+      - 'Value with spaces'
+    type: array
+    array_add: yes
+  register: test_array_add
+
+- assert:
+    that: not test_array_add.changed
+
+- name: Clean up test key
+  osx_defaults:
+    domain: com.ansible.fake_array_value
+    key: ExampleArrayKey
+    state: absent
+  register: test_array_add
+
+- assert:
+    that: test_array_add.changed


### PR DESCRIPTION
Unquote values and unescape double quotes when reading array values from osx defaults.

##### SUMMARY

When reading array values from defaults on osx, some value may be double-quoted.
But osx_defaults module do not unquote them currently.
In some cases, array_add option may not idempotent because of this.

Additionally, double quotes in the value is escaped like `\\"`.
They also should be unescaped.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

osx_defaults

##### ADDITIONAL INFORMATION

For example, the task below adds value every time even if the value is already added.

```
- osx_defaults:
    domain: com.apple.systemuiserver
    key: menuExtras
    value:
      - '/System/Library/CoreServices/Menu Extras/Volume.menu'
    type: array
    array_add: yes
```

Values read from osx is double-quoted, and it's different from the value in task(not quoted).
So ansible always try to add the value.

