### PR TITLE
OpenBSD Syspatch: Apply patches by default. Minor module cleanup

### DIFF
--- a/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
+++ b/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - syspatch - Fix bug where not setting `apply=true` would result in error (https://github.com/ansible-collections/community.general/pull/360).
+  - syspatch - fix bug where not setting ``apply=true`` would result in error (https://github.com/ansible-collections/community.general/pull/360).
 deprecated_features:
   - syspatch - Deprecate the redundant apply argument (https://github.com/ansible-collections/community.general/pull/360).

--- a/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
+++ b/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - syspatch - Fix bug where not setting `apply=true` would result in error (https://github.com/ansible-collections/community.general/pull/360).
+deprecated_features:
+  - syspatch - Deprecate the redundant apply argument (https://github.com/ansible-collections/community.general/pull/360).

--- a/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
+++ b/changelogs/fragments/360_syspatch_apply_patches_by_default.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - syspatch - fix bug where not setting ``apply=true`` would result in error (https://github.com/ansible-collections/community.general/pull/360).
 deprecated_features:
-  - syspatch - Deprecate the redundant apply argument (https://github.com/ansible-collections/community.general/pull/360).
+  - syspatch - deprecate the redundant ``apply`` argument (https://github.com/ansible-collections/community.general/pull/360).

--- a/plugins/modules/system/syspatch.py
+++ b/plugins/modules/system/syspatch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2019, Andrew Klaus <andrewklaus@gmail.com>
+# Copyright: (c) 2020, Andrew Klaus <andrewklaus@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -10,7 +10,7 @@ DOCUMENTATION = r'''
 ---
 module: syspatch
 
-short_description: Manage OpenBSD system patches.
+short_description: Manage OpenBSD system patches
 
 
 description:
@@ -21,6 +21,7 @@ options:
         description:
             - Apply all available system patches.
             - By default, apply all patches.
+            - Deprecated. Will be removed in community.general 3.0.0.
         default: yes
     revert:
         description:
@@ -84,7 +85,7 @@ from ansible.module_utils.basic import AnsibleModule
 def run_module():
     # define available arguments/parameters a user can pass to the module
     module_args = dict(
-        apply=dict(type='bool', default=True),
+        apply=dict(type='bool', default=True, removed_in_version='3.0.0', removed_from_collection='community.general'),
         revert=dict(type='str', choices=['all', 'one'])
     )
 

--- a/plugins/modules/system/syspatch.py
+++ b/plugins/modules/system/syspatch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2020, Andrew Klaus <andrewklaus@gmail.com>
+# Copyright: (c) 2019-2020, Andrew Klaus <andrewklaus@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)

--- a/plugins/modules/system/syspatch.py
+++ b/plugins/modules/system/syspatch.py
@@ -6,26 +6,25 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: syspatch
 
-short_description: Manage OpenBSD system patches
+short_description: Manage OpenBSD system patches.
 
 
 description:
-    - "Manage OpenBSD system patches using syspatch"
+    - "Manage OpenBSD system patches using syspatch."
 
 options:
     apply:
         description:
-            - Apply all available system patches
-        default: False
-        required: false
+            - Apply all available system patches.
+            - By default, apply all patches.
+        default: yes
     revert:
         description:
-            - Revert system patches
-        required: false
+            - Revert system patches.
         type: str
         choices: [ all, one ]
 
@@ -63,17 +62,17 @@ rc:
   returned: always
   type: int
 stdout:
-  description: syspatch standard output
+  description: syspatch standard output.
   returned: always
   type: str
   sample: "001_rip6cksum"
 stderr:
-  description: syspatch standard error
+  description: syspatch standard error.
   returned: always
   type: str
   sample: "syspatch: need root privileges"
 reboot_needed:
-  description: Whether or not a reboot is required after an update
+  description: Whether or not a reboot is required after an update.
   returned: always
   type: bool
   sample: True
@@ -85,7 +84,7 @@ from ansible.module_utils.basic import AnsibleModule
 def run_module():
     # define available arguments/parameters a user can pass to the module
     module_args = dict(
-        apply=dict(type='bool'),
+        apply=dict(type='bool', default=True),
         revert=dict(type='str', choices=['all', 'one'])
     )
 
@@ -142,10 +141,10 @@ def syspatch_run(module):
         # http://openbsd-archive.7691.n7.nabble.com/Warning-applying-latest-syspatch-td354250.html
         if rc != 0 and err != 'ln: /usr/X11R6/bin/X: No such file or directory\n':
             module.fail_json(msg="Command %s failed rc=%d, out=%s, err=%s" % (cmd, rc, out, err))
-        elif out.lower().find('create unique kernel') > 0:
+        elif out.lower().find('create unique kernel') >= 0:
             # Kernel update applied
             reboot_needed = True
-        elif out.lower().find('syspatch updated itself') > 0:
+        elif out.lower().find('syspatch updated itself') >= 0:
             warnings.append('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user


### PR DESCRIPTION
##### SUMMARY
I've made syspatch apply patches by default, so one can call it without any parameters. This is how the command line tool is used, so this will make the module work similarly.

I also made minor documentation cleanup updates, and used a better comparison operator for when calling `.find()` on stdout output. This would likely never be an issue in the real world, but figured I should do it anyways.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
syspatch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# Before (required):
- name: Calling with parameter
  syspatch:
    apply: True

# After:
- name: Calling with parameter
  syspatch:
    apply: True

# or optionally:
- name: Call without parameter
  syspatch:
```
