### PR TITLE
Fix the environment variable

### DIFF
--- a/plugins/connection/oc.py
+++ b/plugins/connection/oc.py
@@ -85,7 +85,7 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_oc_context
         env:
-          - name: k8S_AUTH_CONTEXT
+          - name: K8S_AUTH_CONTEXT
       oc_host:
         description:
           - URL for accessing the API.


### PR DESCRIPTION
This was using k8S_AUTH_CONTEXT with a lowercase k.  That doesn't match
with any of the other K8s stuff so users would probably be confused why
their envvar wasn't working.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
community.general/plugins/connection/oc.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
