### PR TITLE
Added 'extra_install_args' module option to allow extra upgrade/install specific zypper arguments

### DIFF
--- a/changelogs/fragments/382-install_upgrade_specific_args.yaml
+++ b/changelogs/fragments/382-install_upgrade_specific_args.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zypper - Added ``allow_vendor_change`` and ``replacefiles`` zypper options (https://github.com/ansible-collections/community.general/issues/381)

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -194,7 +194,7 @@ EXAMPLES = '''
 import xml
 import re
 from xml.dom.minidom import parseString as parseXML
-#from ansible.module_utils.six import iteritems  # Remove as it is not used
+# from ansible.module_utils.six import iteritems  # Remove as it is not used
 from ansible.module_utils._text import to_native
 
 # import module snippets

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -106,14 +106,20 @@ options:
         description:
           - Add additional options to C(zypper) command.
           - Options should be supplied in a single line as if given in the command line.
-    extra_install_args:
+    allow_vendor_change:
         version_added: "2.10"
-        type: list
-        elements: str
+        type: bool
         required: false
+        default: false
         description:
-          - Add additional options to C(zypper) install/update command.
-          - Options should be supplied as a list
+          - Adds C(--allow_vendor_change) option to I(zypper) install/update command.
+    replacefiles:
+        version_added: "2.10"
+        type: bool
+        required: false
+        default: false
+        description:
+          - Adds C(--replacefiles) option to I(zypper) install/update command.
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -174,13 +180,12 @@ EXAMPLES = '''
     state: dist-upgrade
     extra_args: '--no-allow-vendor-change --allow-arch-change'
 
-- name: Perform a installaion of nmap with the install option --replacefiles and --force-resolution
+- name: Perform a installaion of nmap with the install option replacefiles and allow_vendor_change 
   zypper:
     name: 'nmap'
     state: latest
-    extra_install_args:
-      - '--replacefiles'
-      - '--force-resolution'
+    allow_vendor_change: true
+    replacefiles: true
 
 - name: Refresh repositories and update package openssl
   zypper:
@@ -351,9 +356,10 @@ def get_cmd(m, subcommand):
             cmd.append('--force-resolution')
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
-        if m.params['extra_install_args']:
-            args_list = m.params['extra_install_args']
-            cmd.extend(args_list)
+        if m.params['allow_vendor_change']:
+            cmd.append('--allow-vendor-change')
+        if m.params['replacefiles']:
+            cmd.append('--replacefiles')
     if m.params['extra_args']:
         args_list = m.params['extra_args'].split(' ')
         cmd.extend(args_list)
@@ -497,7 +503,8 @@ def main():
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),
-            extra_install_args=dict(type='list', elements='str', required=False, default=None),
+            allow_vendor_change=dict(False, default=false, type='bool'),
+            replacefiles=dict(False, default=false, type='bool')
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -497,7 +497,7 @@ def main():
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),
-            extra_install_args=dict(type='list', required=False, default=None),
+            extra_install_args=dict(type='list', elements='str', required=False, default=None),
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -181,7 +181,7 @@ EXAMPLES = '''
     allow_vendor_change: true
     extra_args: '--allow-arch-change'
 
-- name: Perform a installaion of nmap with the install option replacefiles and allow_vendor_change
+- name: Perform a installaion of nmap with the install option replacefiles
   zypper:
     name: 'nmap'
     state: latest

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -107,7 +107,9 @@ options:
           - Add additional options to C(zypper) command.
           - Options should be supplied in a single line as if given in the command line.
     extra_install_args:
-        version_added: "2.9"
+        version_added: "2.10"
+        type: list
+        elements: str
         required: false
         description:
           - Add additional options to C(zypper) install/update command.

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -111,7 +111,7 @@ options:
         required: false
         description:
           - Add additional options to C(zypper) install/update command.
-          - Options should be supplied in a single line as if given in the command line.
+          - Options should be supplied as a list
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -171,6 +171,14 @@ EXAMPLES = '''
     name: '*'
     state: dist-upgrade
     extra_args: '--no-allow-vendor-change --allow-arch-change'
+
+- name: Perform a installaion of nmap with the install option --replacefiles and --force-resolution
+  zypper:
+    name: 'nmap'
+    state: latest
+    extra_install_args:
+      - '--replacefiles'
+      - '--force-resolution'
 
 - name: Refresh repositories and update package openssl
   zypper:
@@ -342,7 +350,7 @@ def get_cmd(m, subcommand):
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
         if m.params['extra_install_args']:
-            args_list = m.params['extra_install_args'].split(' ')
+            args_list = m.params['extra_install_args']
             cmd.extend(args_list)
     if m.params['extra_args']:
         args_list = m.params['extra_args'].split(' ')
@@ -487,7 +495,7 @@ def main():
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),
-            extra_install_args=dict(required=False, default=None),
+            extra_install_args=dict(type='list', required=False, default=None),
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -107,14 +107,12 @@ options:
           - Add additional options to C(zypper) command.
           - Options should be supplied in a single line as if given in the command line.
     allow_vendor_change:
-        version_added: "2.10"
         type: bool
         required: false
         default: false
         description:
           - Adds C(--allow_vendor_change) option to I(zypper) dist-upgrade command.
     replacefiles:
-        version_added: "2.10"
         type: bool
         required: false
         default: false

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -106,6 +106,12 @@ options:
         description:
           - Add additional options to C(zypper) command.
           - Options should be supplied in a single line as if given in the command line.
+    extra_install_args:
+        version_added: "2.9"
+        required: false
+        description:
+          - Add additional options to C(zypper) install/update command.
+          - Options should be supplied in a single line as if given in the command line.
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -188,7 +194,7 @@ EXAMPLES = '''
 import xml
 import re
 from xml.dom.minidom import parseString as parseXML
-from ansible.module_utils.six import iteritems
+#from ansible.module_utils.six import iteritems  # Remove as it is not used
 from ansible.module_utils._text import to_native
 
 # import module snippets
@@ -335,6 +341,9 @@ def get_cmd(m, subcommand):
             cmd.append('--force-resolution')
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
+        if m.params['extra_install_args']:
+            args_list = m.params['extra_install_args'].split(' ')
+            cmd.extend(args_list)
     if m.params['extra_args']:
         args_list = m.params['extra_args'].split(' ')
         cmd.extend(args_list)
@@ -478,6 +487,7 @@ def main():
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),
+            extra_install_args=dict(required=False, default=None),
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -209,7 +209,6 @@ EXAMPLES = '''
 import xml
 import re
 from xml.dom.minidom import parseString as parseXML
-# from ansible.module_utils.six import iteritems  # Remove as it is not used
 from ansible.module_utils._text import to_native
 
 # import module snippets

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -112,7 +112,7 @@ options:
         required: false
         default: false
         description:
-          - Adds C(--allow_vendor_change) option to I(zypper) install/update command.
+          - Adds C(--allow_vendor_change) option to I(zypper) dist-upgrade command.
     replacefiles:
         version_added: "2.10"
         type: bool
@@ -178,13 +178,13 @@ EXAMPLES = '''
   zypper:
     name: '*'
     state: dist-upgrade
-    extra_args: '--no-allow-vendor-change --allow-arch-change'
+    allow_vendor_change: true
+    extra_args: '--allow-arch-change'
 
-- name: Perform a installaion of nmap with the install option replacefiles and allow_vendor_change 
+- name: Perform a installaion of nmap with the install option replacefiles and allow_vendor_change
   zypper:
     name: 'nmap'
     state: latest
-    allow_vendor_change: true
     replacefiles: true
 
 - name: Refresh repositories and update package openssl
@@ -356,10 +356,10 @@ def get_cmd(m, subcommand):
             cmd.append('--force-resolution')
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
-        if m.params['allow_vendor_change']:
-            cmd.append('--allow-vendor-change')
         if m.params['replacefiles']:
             cmd.append('--replacefiles')
+    if subcommand == 'dist-upgrade' and m.params['allow_vendor_change']:
+        cmd.append('--allow-vendor-change')
     if m.params['extra_args']:
         args_list = m.params['extra_args'].split(' ')
         cmd.extend(args_list)
@@ -503,8 +503,8 @@ def main():
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),
-            allow_vendor_change=dict(False, default=false, type='bool'),
-            replacefiles=dict(False, default=false, type='bool')
+            allow_vendor_change=dict(required=False, default=False, type='bool'),
+            replacefiles=dict(required=False, default=False, type='bool')
         ),
         supports_check_mode=True
     )

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -472,7 +472,7 @@
         name: >-
           {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
         disable_gpg_check: true
-        ignore_errors: true
+      ignore_errors: true
       register: zypper_duplicate_result
       loop: "{{ looplist }}"
 
@@ -490,7 +490,7 @@
           {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
         disable_gpg_check: true
         replacefiles: true
-        ignore_errors: true
+      ignore_errors: true
       register: zypper_duplicate_result
       loop: "{{ looplist }}"
 

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -419,6 +419,12 @@
       - zypper_result_update_cache_check is successful
       - zypper_result_update_cache_check is not changed
 
+- name: ensure no previous netcat package still exists
+  zypper:
+    name:
+      - netcat-openbsd
+      - gnu-netcat
+    state: absent
 
 - name: install netcat-openbsd which conflicts with gnu-netcat
   zypper:

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -442,3 +442,23 @@
     name: gnu-netcat
     state: present
     force_resolution: True
+
+- name: remove gnu-netcat and re-install netcat-openbsd
+  zypper:
+    name:
+      - -gnu-netcat
+      - +netcat-openbsd
+    state: present
+
+- name: Install gnu-netcat with force_resolution and replacefiles
+  zypper:
+    name: gnu-netcat
+    state: present
+    force_resolution: true
+    replacefiles: true
+
+- name: Dist upgrade with allow_vendor_change
+  zypper:
+    name: '*'
+    state: dist-upgrade
+    allow_vendor_change: true

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -456,9 +456,3 @@
     state: present
     force_resolution: true
     replacefiles: true
-
-- name: Dist upgrade with allow_vendor_change
-  zypper:
-    name: '*'
-    state: dist-upgrade
-    allow_vendor_change: true

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -523,3 +523,9 @@
           - zypper_duplicate_result is successful
           - zypper_duplicate_result is changed
           - '"duplicate2" in duplicate_out.content | b64decode'
+
+    - name: Remove installed duplicate rpms
+      zypper:
+        name: "duplicate{{ item }}-1-0"
+        state: absent
+      loop: "{{ looplist }}"

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -485,7 +485,7 @@
     - name: Read in duplicate file contents
       slurp:
         src: /usr/lib/duplicate/duplicate.txt
-      register: duplicate_content
+      register: duplicate_out
 
     - name: Debug zypper_duplicate_result
       debug:
@@ -497,7 +497,7 @@
           - zypper_duplicate_result.results[1] is failed
           - '"fileconflict" in zypper_duplicate_result.results[1].stdout'
           - '"/usr/lib/duplicate/duplicate.txt" in zypper_duplicate_result.results[1].stdout'
-          - '"duplicate1" in duplicate_content | b64decode'
+          - '"duplicate1" in duplicate_out.content | b64decode'
 
     - name: install duplicate rpms
       zypper:
@@ -512,7 +512,7 @@
     - name: Read in duplicate file contents
       slurp:
         src: /usr/lib/duplicate/duplicate.txt
-      register: duplicate_content
+      register: duplicate_out
 
     - name: Debug zypper_duplicate_result
       debug:
@@ -522,4 +522,4 @@
         that:
           - zypper_duplicate_result is successful
           - zypper_duplicate_result is changed
-          - '"duplicate2" in duplicate_content | b64decode'
+          - '"duplicate2" in duplicate_out.content | b64decode'

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -487,9 +487,6 @@
         src: /usr/lib/duplicate/duplicate.txt
       register: duplicate_out
 
-    - name: Debug zypper_duplicate_result
-      debug:
-        var: zypper_duplicate_result
     - name: Check failure when installing rpms with duplicate files without replacefiles option
       assert:
         that:
@@ -514,9 +511,6 @@
         src: /usr/lib/duplicate/duplicate.txt
       register: duplicate_out
 
-    - name: Debug zypper_duplicate_result
-      debug:
-        var: zypper_duplicate_result
     - name: Check success installing rpms with duplicate files using replacefiles option
       assert:
         that:

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -495,8 +495,8 @@
         that:
           - zypper_duplicate_result.results[0] is successful
           - zypper_duplicate_result.results[1] is failed
-          - '"fileconflict" in zypper_duplicate_results.results[1].stdout'
-          - '"/usr/lib/duplicate/duplicate.txt" in zypper_duplicate_results.results[1].stdout'
+          - '"fileconflict" in zypper_duplicate_result.results[1].stdout'
+          - '"/usr/lib/duplicate/duplicate.txt" in zypper_duplicate_result.results[1].stdout'
           - '"duplicate1" in duplicate_content | b64decode'
 
     - name: install duplicate rpms

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -476,13 +476,22 @@
       register: zypper_duplicate_result
       loop: "{{ looplist }}"
 
+    - name: Read in duplicate file contents
+      slurp:
+        src: /usr/lib/duplicate/duplicate.txt
+      register: duplicate_content
+
     - name: Debug zypper_duplicate_result
       debug:
         var: zypper_duplicate_result
     - name: Check failure when installing rpms with duplicate files without replacefiles option
       assert:
         that:
-          - zypper_duplicate_result is failed
+          - zypper_duplicate_result.results[0] is successful
+          - zypper_duplicate_result.results[1] is failed
+          - '"fileconflict" in zypper_duplicate_results.results[1].stdout'
+          - '"/usr/lib/duplicate/duplicate.txt" in zypper_duplicate_results.results[1].stdout'
+          - '"duplicate1" in duplicate_content | b64decode'
 
     - name: install duplicate rpms
       zypper:
@@ -494,6 +503,11 @@
       register: zypper_duplicate_result
       loop: "{{ looplist }}"
 
+    - name: Read in duplicate file contents
+      slurp:
+        src: /usr/lib/duplicate/duplicate.txt
+      register: duplicate_content
+
     - name: Debug zypper_duplicate_result
       debug:
         var: zypper_duplicate_result
@@ -502,3 +516,4 @@
         that:
           - zypper_duplicate_result is successful
           - zypper_duplicate_result is changed
+          - '"duplicate2" in duplicate_content | b64decode'

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -470,7 +470,7 @@
     - name: install duplicate rpms
       zypper:
         name: >-
-          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
+          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}-1-0.noarch.rpm
         disable_gpg_check: true
       ignore_errors: true
       register: zypper_duplicate_result
@@ -487,7 +487,7 @@
     - name: install duplicate rpms
       zypper:
         name: >-
-          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
+          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}-1-0.noarch.rpm
         disable_gpg_check: true
         replacefiles: true
       ignore_errors: true

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -443,16 +443,62 @@
     state: present
     force_resolution: True
 
-- name: remove gnu-netcat and re-install netcat-openbsd
-  zypper:
-    name:
-      - -gnu-netcat
-      - +netcat-openbsd
-    state: present
+- name: duplicate rpms block
+  vars:
+    looplist:
+      - 1
+      - 2
+  block:
+    - name: Deploy spec files to build 2 packages with duplicate files.
+      template:
+        src: duplicate.spec.j2
+        dest: "{{ output_dir | expanduser }}/zypper2/duplicate{{ item }}.spec"
+      loop: "{{ looplist }}"
 
-- name: Install gnu-netcat with force_resolution and replacefiles
-  zypper:
-    name: gnu-netcat
-    state: present
-    force_resolution: true
-    replacefiles: true
+    - name: build rpms with duplicate files
+      command: |
+        rpmbuild -bb \
+        --define "_topdir {{output_dir | expanduser }}/zypper2/rpm-build"
+        --define "_builddir %{_topdir}" \
+        --define "_rpmdir %{_topdir}" \
+        --define "_srcrpmdir %{_topdir}" \
+        --define "_specdir {{output_dir | expanduser}}/zypper2" \
+        --define "_sourcedir %{_topdir}" \
+        {{ output_dir | expanduser }}/zypper2/duplicate{{ item }}.spec
+      loop: "{{ looplist }}"
+
+    - name: install duplicate rpms
+      zypper:
+        name: >-
+          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
+        disable_gpg_check: true
+        ignore_errors: true
+      register: zypper_duplicate_result
+      loop: "{{ looplist }}"
+
+    - name: Debug zypper_duplicate_result
+      debug:
+        var: zypper_duplicate_result
+    - name: Check failure when installing rpms with duplicate files without replacefiles option
+      assert:
+        that:
+          - zypper_duplicate_result is failed
+
+    - name: install duplicate rpms
+      zypper:
+        name: >-
+          {{ output_dir | expanduser }}/zypper2/rpm-build/noarch/duplicate{{ item }}1-0.noarch.rpm
+        disable_gpg_check: true
+        replacefiles: true
+        ignore_errors: true
+      register: zypper_duplicate_result
+      loop: "{{ looplist }}"
+
+    - name: Debug zypper_duplicate_result
+      debug:
+        var: zypper_duplicate_result
+    - name: Check success installing rpms with duplicate files using replacefiles option
+      assert:
+        that:
+          - zypper_duplicate_result is successful
+          - zypper_duplicate_result is changed

--- a/tests/integration/targets/zypper/templates/duplicate.spec.j2
+++ b/tests/integration/targets/zypper/templates/duplicate.spec.j2
@@ -11,7 +11,8 @@ Duplicate {{ item }} RPM. Package one file that will be a duplicate of other Dup
 This is only for testing of the replacefiles zypper option.
 
 %install
-echo %{name}>%{buildroot}/usr/lib/duplicate/duplicate.txt
+mkdir -p "%{buildroot}/usr/lib/duplicate"
+echo "%{name}" > "%{buildroot}/usr/lib/duplicate/duplicate.txt"
 
 %files
 /usr/lib/duplicate/duplicate.txt

--- a/tests/integration/targets/zypper/templates/duplicate.spec.j2
+++ b/tests/integration/targets/zypper/templates/duplicate.spec.j2
@@ -1,0 +1,17 @@
+Summary:   Duplicate{{ item }} RPM. Installs one file that is a duplicate of other Duplicate# RPMs
+Name:      duplicate{{ item }}
+Version:   1
+Release:   0
+License:   GPLv3
+Group:     Applications/System
+BuildArch: noarch
+
+%description
+Duplicate {{ item }} RPM. Package one file that will be a duplicate of other Duplicate RPM contents.
+This is only for testing of the replacefiles zypper option.
+
+%install
+echo %{name}>%{buildroot}/usr/lib/duplicate/duplicate.txt
+
+%files
+/usr/lib/duplicate/duplicate.txt


### PR DESCRIPTION
Add `extra_install_args` to zypper to allow for installation / upgrade specific arguments.

Example install / upgrade zypper arguments that faisl using the `extra_args`

* --allow-vendor-change
* --replacefiles and
* --force-resolution

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Some zypper installation / upgrade options could not be used with the zypper module. Added a new `extra_install_args` argument to the module to handle install / upgrade specific zypper arguments.

Fixes issue #381

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zypper

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Please issue #381
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
