### PR TITLE
[tests] trivial correction to openldap integration tests

### DIFF
--- a/tests/integration/targets/setup_openldap/tasks/main.yml
+++ b/tests/integration/targets/setup_openldap/tasks/main.yml
@@ -24,7 +24,7 @@
 
     - name: Make sure OpenLDAP service is stopped
       become: True
-      shell: 'cat /var/run/slapd/slapd.pid | xargs kill -9 '
+      shell: 'cat /var/run/slapd/slapd.pid | xargs -r kill -9 '
 
     - name: Debconf
       shell: 'echo "slapd {{ item.question }} {{ item.vtype }} {{ item.value }}" >> /root/debconf-slapd.conf'


### PR DESCRIPTION
##### SUMMARY
Use `xargs -r` in pipe , instead of plain `xargs` in `tests/integration/targets/setup_openldap/tasks/main.yml`

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests

PS: checked all other source code files for `xargs` usage - everything else uses `xargs -r`