### PR TITLE
datadog_monitor: kwargs for _update_monitor used message vs notification_message

### DIFF
--- a/changelogs/fragments/389-datadog_monitor-corrects-deprecated-message-param.yml
+++ b/changelogs/fragments/389-datadog_monitor-corrects-deprecated-message-param.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - datadog_monitor - Corrects ``_update_monitor`` to use ``notification_message`` insteade of deprecated ``message``
+    - datadog_monitor - Corrects ``_update_monitor`` to use ``notification_message`` insteade of deprecated ``message`` (https://github.com/ansible-collections/community.general/pull/389).

--- a/changelogs/fragments/389-datadog_monitor-corrects-deprecated-message-param.yml
+++ b/changelogs/fragments/389-datadog_monitor-corrects-deprecated-message-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - datadog_monitor - Corrects ``_update_monitor`` to use ``notification_message`` insteade of deprecated ``message``

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -301,7 +301,7 @@ def _update_monitor(module, monitor, options):
     try:
         kwargs = dict(id=monitor['id'], query=module.params['query'],
                       name=_fix_template_vars(module.params['name']),
-                      message=_fix_template_vars(module.params['message']),
+                      message=_fix_template_vars(module.params['notification_message']),
                       escalation_message=_fix_template_vars(module.params['escalation_message']),
                       options=options)
         if module.params['tags'] is not None:


### PR DESCRIPTION
##### SUMMARY
Noticed that `datadog_monitor.py` had not updated `_update_monitor` to use `notification_message` which deprecated `message` due to being a reserved keyword.

This PR makes that small correction.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Monitoring / datadog_monitor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
The error was: KeyError: 'message'
failed:
```
after:
works as expected