### PR TITLE
inventory_docker_swarm test - Remove exit code from trap

### DIFF
--- a/tests/integration/targets/inventory_docker_swarm/runme.sh
+++ b/tests/integration/targets/inventory_docker_swarm/runme.sh
@@ -8,7 +8,6 @@ cleanup() {
     echo "Cleanup"
     ansible-playbook playbooks/swarm_cleanup.yml
     echo "Done"
-    exit 0
 }
 
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Setting the exit code in a trap overrides the exit code that caused the trap to be called. This means if the test failed and called the trap, the test will exit with 0 rather than the failure exit code.<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`tests/integration/targets/inventory_docker_swarm/runme.sh`