### PR TITLE
terraform module: Added backend_config_file and multiple variables_file

### DIFF
--- a/changelogs/fragments/394-terraform-add-config_file.yml
+++ b/changelogs/fragments/394-terraform-add-config_file.yml
@@ -1,3 +1,3 @@
 minor_changes:
-- terraform - Adds support for multiple ``variables_file`` (https://github.com/ansible-collections/community.general/issues/224).
-- terraform - Adds support for ``backend_config_file``. This can accept a list of paths to multiple configuration files.
+- terraform - Adds option ``variables_files`` for multiple var-files (https://github.com/ansible-collections/community.general/issues/224).
+- terraform - Adds option ``backend_config_files``. This can accept a list of paths to multiple configuration files.

--- a/changelogs/fragments/394-terraform-add-config_file.yml
+++ b/changelogs/fragments/394-terraform-add-config_file.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- terraform - Adds support for multiple ``variables_file`` (https://github.com/ansible-collections/community.general/issues/224).
+- terraform - Adds support for ``backend_config_file``. This can accept a list of paths to multiple configuration files.

--- a/changelogs/fragments/394-terraform-add-config_file.yml
+++ b/changelogs/fragments/394-terraform-add-config_file.yml
@@ -1,3 +1,3 @@
 minor_changes:
 - terraform - Adds option ``variables_files`` for multiple var-files (https://github.com/ansible-collections/community.general/issues/224).
-- terraform - Adds option ``backend_config_files``. This can accept a list of paths to multiple configuration files.
+- terraform - Adds option ``backend_config_files``. This can accept a list of paths to multiple configuration files (https://github.com/ansible-collections/community.general/pull/394).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -88,7 +88,7 @@ options:
   backend_config_files:
     description:
       - The path to a configuration file to provide at init state to the -backend-config parameter.
-        This can accept a list of pathes to multiple configuration files.
+        This can accept a list of paths to multiple configuration files.
     type: list
     elements: path
 notes:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -20,13 +20,11 @@ options:
     choices: ['planned', 'present', 'absent']
     description:
       - Goal state of given stage/project
-    required: false
     default: present
   binary_path:
     description:
       - The path of a terraform binary to use, relative to the 'service_path'
         unless you supply an absolute path.
-    required: false
   project_path:
     description:
       - The path to the root of the Terraform directory with the
@@ -35,14 +33,12 @@ options:
   workspace:
     description:
       - The terraform workspace to work with.
-    required: false
     default: default
   purge_workspace:
     description:
       - Only works with state = absent
       - If true, the workspace will be deleted after the "terraform destroy" action.
       - The 'default' workspace will not be deleted.
-    required: false
     default: false
     type: bool
   plan_file:
@@ -50,51 +46,44 @@ options:
       - The path to an existing Terraform plan file to apply. If this is not
         specified, Ansible will build a new TF plan and execute it.
         Note that this option is required if 'state' has the 'planned' value.
-    required: false
   state_file:
     description:
       - The path to an existing Terraform state file to use when building plan.
         If this is not specified, the default `terraform.tfstate` will be used.
       - This option is ignored when plan is specified.
-    required: false
   variables_file:
     description:
       - The path to a variables file for Terraform to fill into the TF
         configurations. This can accept a list of paths to multiple variables files.
-    required: false
+    type: list
+    elements: path
   variables:
     description:
       - A group of key-values to override template variables or those in
         variables files.
-    required: false
   targets:
     description:
       - A list of specific resources to target in this plan/application. The
         resources selected here will also auto-include any dependencies.
-    required: false
   lock:
     description:
       - Enable statefile locking, if you use a service that accepts locks (such
         as S3+DynamoDB) to store your statefile.
-    required: false
     type: bool
   lock_timeout:
     description:
       - How long to maintain the lock on the statefile, if you use a service
         that accepts locks (such as S3+DynamoDB).
-    required: false
   force_init:
     description:
       - To avoid duplicating infra, if a state file can't be found this will
         force a `terraform init`. Generally, this should be turned off unless
         you intend to provision an entirely new Terraform deployment.
     default: false
-    required: false
     type: bool
   backend_config:
     description:
       - A group of key-values to provide at init stage to the -backend-config parameter.
-    required: false
   backend_config_file:
     description:
       - The path to a configuration file to provide at init state to the -backend-config parameter.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -99,7 +99,8 @@ options:
     description:
       - The path to a configuration file to provide at init state to the -backend-config parameter.
         This can accept a list of pathes to multiple configuration files.
-    required: false
+    type: list
+    elements: path
 notes:
    - To just run a `terraform plan`, use check mode.
 requirements: [ "terraform" ]

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -293,7 +293,7 @@ def main():
             lock_timeout=dict(type='int',),
             force_init=dict(type='bool', default=False),
             backend_config=dict(type='dict', default=None),
-            backend_config_file=dict(type='list', default=None),
+            backend_config_file=dict(type='list', elements='path', default=None),
         ),
         required_if=[('state', 'planned', ['plan_file'])],
         supports_check_mode=True,

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -60,7 +60,7 @@ options:
   variables_file:
     description:
       - The path to a variables file for Terraform to fill into the TF
-        configurations. This can accept a list of pathes to multiple variables files.
+        configurations. This can accept a list of paths to multiple variables files.
     required: false
   variables:
     description:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -276,7 +276,7 @@ def main():
             purge_workspace=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'planned']),
             variables=dict(type='dict'),
-            variables_files=dict(aliases=['variabels_file'], type='list', elements='path', default=None),
+            variables_files=dict(aliases=['variables_file'], type='list', elements='path', default=None),
             plan_file=dict(type='path'),
             state_file=dict(type='path'),
             targets=dict(type='list', default=[]),

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -97,7 +97,8 @@ options:
     required: false
   backend_config_file:
     description:
-      - The path to a configuration file to provide at init state to the -backend-config parameter. This can accept a list of pathes to multiple configuration files.
+      - The path to a configuration file to provide at init state to the -backend-config parameter.
+        This can accept a list of pathes to multiple configuration files.
     required: false
 notes:
    - To just run a `terraform plan`, use check mode.
@@ -284,7 +285,7 @@ def main():
             purge_workspace=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'planned']),
             variables=dict(type='dict'),
-            variables_file=dict(type='list',default=None),
+            variables_file=dict(type='list', default=None),
             plan_file=dict(type='path'),
             state_file=dict(type='path'),
             targets=dict(type='list', default=[]),
@@ -317,7 +318,7 @@ def main():
         command = [module.get_bin_path('terraform', required=True)]
 
     if force_init:
-        init_plugins(command[0], project_path, backend_config,backend_config_file)
+        init_plugins(command[0], project_path, backend_config, backend_config_file)
 
     workspace_ctx = get_workspace_context(command[0], project_path)
     if workspace_ctx["current"] != workspace:
@@ -339,7 +340,7 @@ def main():
         ])
     if variables_file:
         for f in variables_file:
-          variables_args.extend(['-var-file', f])
+            variables_args.extend(['-var-file', f])
 
     preflight_validation(command[0], project_path, variables_args)
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -285,7 +285,7 @@ def main():
             purge_workspace=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'planned']),
             variables=dict(type='dict'),
-            variables_file=dict(type='list', default=None),
+            variables_file=dict(type='list', elements='path', default=None),
             plan_file=dict(type='path'),
             state_file=dict(type='path'),
             targets=dict(type='list', default=[]),


### PR DESCRIPTION
##### SUMMARY
This PR adds support for multiple variables_file for "terraform" module, Fixes #224 issue. Moreover, this adds support for "backend_config_file" to provide at init state to the -backend-config parameter. This can accept a list of paths to multiple configuration files.


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
terraform module

##### ADDITIONAL INFORMATION
It is possible to pass multiple var-files in terraform cli:

```
terraform apply -var-file="file-1.tfvars" -var-file="file-2.tfvars" -var-file="file-3.tfvars"
```
This is required when there are multiple var-files in different locations.

Also the "-backend-config" parameter, accepts both "key=value" type and "PATH" type. This parameter can also be passed multiple backend config files:
```
terraform init -backend-config=path/to/backend_config_file_1 -backend-config=path/to/backend_config_file_2
```