### PR TITLE
Fix NetworkManager-libnm typo in nmcli.py documentation.

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -20,7 +20,7 @@ requirements:
 - nmcli
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
-    - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-nmlib,
+    - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
       libsemanage-python, policycoreutils-python.'
     - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
       libnm-qt-devel.x86_64, nm-connection-editor.x86_64, libsemanage-python, policycoreutils-python.'


### PR DESCRIPTION
##### SUMMARY
Fix typo in nmcli.py documentation for prerequisite package name NetworkManager-**libnm** (reads NetworkManager-**nmlib** on this one line in the documentation, but is correct elsewhere).

##### ISSUE TYPE
- BugFix (Documentation) Pull Request

##### COMPONENT NAME
nmcli.py
