### PR TITLE
parted option align: undefined to maintain parted 1.8.3 compatibility

### DIFF
--- a/changelogs/fragments/405-parted_align_undefined.yml
+++ b/changelogs/fragments/405-parted_align_undefined.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "parted - added 'undefined' align option to support parted versions < 2.1"

--- a/changelogs/fragments/405-parted_align_undefined.yml
+++ b/changelogs/fragments/405-parted_align_undefined.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "parted - added 'undefined' align option to support parted versions < 2.1"
+  - "parted - added 'undefined' align option to support parted versions < 2.1 (https://github.com/ansible-collections/community.general/pull/405)."

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -19,7 +19,8 @@ description:
     command line tool. For a full description of the fields and the options
     check the GNU parted manual.
 requirements:
-  - This module requires parted version 1.8.3 and above.
+  - This module requires parted version 1.8.3 and above
+  - align option (except 'undefined') requires parted 2.1 and above
   - If the version of parted is below 3.1, it requires a Linux version running
     the sysfs file system C(/sys/).
 options:
@@ -28,9 +29,9 @@ options:
     type: str
     required: True
   align:
-    description: Set alignment for newly created partitions.
+    description: Set alignment for newly created partitions. Use 'undefined' for parted default aligment.
     type: str
-    choices: [ cylinder, minimal, none, optimal ]
+    choices: [ cylinder, minimal, none, optimal, undefined ]
     default: optimal
   number:
     description:
@@ -483,8 +484,12 @@ def parted(script, device, align):
     """
     global module, parted_exec
 
+    align_option = '-a %s' % align
+    if align == 'undefined':
+        align_option = ''
+
     if script and not module.check_mode:
-        command = "%s -s -m -a %s %s -- %s" % (parted_exec, align, device, script)
+        command = "%s -s -m %s %s -- %s" % (parted_exec, align_option, device, script)
         rc, out, err = module.run_command(command)
 
         if rc != 0:

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -541,7 +541,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             device=dict(type='str', required=True),
-            align=dict(type='str', default='optimal', choices=['cylinder', 'minimal', 'none', 'optimal']),
+            align=dict(type='str', default='optimal', choices=['cylinder', 'minimal', 'none', 'optimal', 'undefined']),
             number=dict(type='int'),
 
             # unit <unit> command


### PR DESCRIPTION
##### SUMMARY
Added option align: undefined to support parted versions < 2.1

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION
I've actually tested parted 1.8.3 on some ancient system, but it failed. The reason was that -a option was added in parted 2.1.

Alternative solutions:
* omit -a option for 'optimal' (parted's default setting is 'optimal' too, works in my patched ansible 2.7)
* update required version of parted to 2.1 instead