### PR TITLE
parted: fix return value documentation

### DIFF
--- a/changelogs/fragments/362-parted_documentation_fix.yml
+++ b/changelogs/fragments/362-parted_documentation_fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "parted - fix return value documentation (#362)"

--- a/changelogs/fragments/362-parted_documentation_fix.yml
+++ b/changelogs/fragments/362-parted_documentation_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "parted - fix return value documentation (#362)"

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -108,12 +108,15 @@ partition_info:
   returned: success
   type: complex
   contains:
-    device:
+    disk:
       description: Generic device information.
       type: dict
     partitions:
       description: List of device partitions.
       type: list
+    script:
+      description: parted script executed by module
+      type: str
   sample: {
       "disk": {
         "dev": "/dev/sdb",
@@ -140,7 +143,8 @@ partition_info:
         "name": "",
         "num": 2,
         "size": 4.0
-      }]
+      }],
+      "script": "unit KiB print "
     }
 '''
 


### PR DESCRIPTION
##### SUMMARY
Corrected documentation of parted module return value
Fixes: #362
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION
* general info is returned id 'disk' key (not 'device')
* documented 'script' key
