### PR TITLE
Add include_tags to datadog_monitor

### DIFF
--- a/changelogs/fragments/409-datadog-monitor-include-tags.yaml
+++ b/changelogs/fragments/409-datadog-monitor-include-tags.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - datadog_monitor - Add include_tags option (https://github.com/ansible/ansible/issues/57441)

--- a/changelogs/fragments/409-datadog-monitor-include-tags.yaml
+++ b/changelogs/fragments/409-datadog-monitor-include-tags.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - datadog_monitor - Add include_tags option (https://github.com/ansible/ansible/issues/57441)
+  - datadog_monitor - add ``include_tags`` option (https://github.com/ansible/ansible/issues/57441).

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -134,6 +134,11 @@ options:
           - The ID of the alert.
           - If set, will be used instead of the name to locate the alert.
         type: str
+    include_tags:
+        description:
+          - Whether notifications from this monitor automatically inserts its triggering tags into the title.
+        type: bool
+        default: 'yes'
 '''
 
 EXAMPLES = '''
@@ -216,7 +221,8 @@ def main():
             require_full_window=dict(required=False, default=None, type='bool'),
             new_host_delay=dict(required=False, default=None),
             evaluation_delay=dict(required=False, default=None),
-            id=dict(required=False)
+            id=dict(required=False),
+            include_tags=dict(required=False, default=True, type='bool')
         )
     )
 
@@ -330,7 +336,8 @@ def install_monitor(module):
         "locked": module.boolean(module.params['locked']),
         "require_full_window": module.params['require_full_window'],
         "new_host_delay": module.params['new_host_delay'],
-        "evaluation_delay": module.params['evaluation_delay']
+        "evaluation_delay": module.params['evaluation_delay'],
+        "include_tags": module.boolean(module.params['include_tags'])
     }
 
     if module.params['type'] == "service check":

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -139,6 +139,7 @@ options:
           - Whether notifications from this monitor automatically inserts its triggering tags into the title.
         type: bool
         default: yes
+        version_added: 1.3.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -138,7 +138,7 @@ options:
         description:
           - Whether notifications from this monitor automatically inserts its triggering tags into the title.
         type: bool
-        default: 'yes'
+        default: yes
 '''
 
 EXAMPLES = '''
@@ -222,7 +222,7 @@ def main():
             new_host_delay=dict(required=False, default=None),
             evaluation_delay=dict(required=False, default=None),
             id=dict(required=False),
-            include_tags=dict(required=False, default=True, type='bool')
+            include_tags=dict(required=False, default=True, type='bool'),
         )
     )
 
@@ -337,7 +337,7 @@ def install_monitor(module):
         "require_full_window": module.params['require_full_window'],
         "new_host_delay": module.params['new_host_delay'],
         "evaluation_delay": module.params['evaluation_delay'],
-        "include_tags": module.boolean(module.params['include_tags'])
+        "include_tags": module.params['include_tags'],
     }
 
     if module.params['type'] == "service check":


### PR DESCRIPTION
##### SUMMARY

Add `include_tags` option to `datadog_monitor` module.

Closes https://github.com/ansible/ansible/issues/57441

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- `datadog_monitor`

##### ADDITIONAL INFORMATION

- https://docs.datadoghq.com/api/?lang=python#create-a-monitor
