### PR TITLE
redis cache - add support for TLS/encryption in transit

### DIFF
--- a/changelogs/fragments/410-redis_cache-add_tls_support.yaml
+++ b/changelogs/fragments/410-redis_cache-add_tls_support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redis - add TLS support to redis cache plugin

--- a/changelogs/fragments/410-redis_cache-add_tls_support.yaml
+++ b/changelogs/fragments/410-redis_cache-add_tls_support.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redis - add TLS support to redis cache plugin
+  - redis - add TLS support to redis cache plugin (https://github.com/ansible-collections/community.general/pull/410).

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -69,7 +69,7 @@ class CacheModule(BaseCacheModule):
     performance.
     """
     def __init__(self, *args, **kwargs):
-        connection = []
+        uri = ''
 
         try:
             super(CacheModule, self).__init__(*args, **kwargs)
@@ -89,8 +89,8 @@ class CacheModule(BaseCacheModule):
         kw = {}
         tlsprefix = 'tls://'
         if uri.startswith(tlsprefix):
-          kw['ssl'] = True
-          uri = uri[len(tlsprefix):]
+            kw['ssl'] = True
+            uri = uri[len(tlsprefix):]
 
         connection = uri.split(':')
         self._db = StrictRedis(*connection, **kw)

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -16,6 +16,7 @@ DOCUMENTATION = '''
         description:
           - A colon separated string of connection information for Redis.
           - The format is C(host:port:db:password), for example C(localhost:6379:0:changeme).
+          - To use encryption in transit, prefix the connection with C(tls://), as in C(tls://localhost:6379:0:changeme).
         required: True
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
@@ -73,19 +74,26 @@ class CacheModule(BaseCacheModule):
         try:
             super(CacheModule, self).__init__(*args, **kwargs)
             if self.get_option('_uri'):
-                connection = self.get_option('_uri').split(':')
+                uri = self.get_option('_uri')
             self._timeout = float(self.get_option('_timeout'))
             self._prefix = self.get_option('_prefix')
         except KeyError:
             display.deprecated('Rather than importing CacheModules directly, '
                                'use ansible.plugins.loader.cache_loader', version='2.12')
             if C.CACHE_PLUGIN_CONNECTION:
-                connection = C.CACHE_PLUGIN_CONNECTION.split(':')
+                uri = C.CACHE_PLUGIN_CONNECTION
             self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
             self._prefix = C.CACHE_PLUGIN_PREFIX
 
         self._cache = {}
-        self._db = StrictRedis(*connection)
+        kw = {}
+        tlsprefix = 'tls://'
+        if uri.startswith(tlsprefix):
+          kw['ssl'] = True
+          uri = uri[len(tlsprefix):]
+
+        connection = uri.split(':')
+        self._db = StrictRedis(*connection, **kw)
         self._keys_set = 'ansible_cache_keys'
 
     def _make_key(self, key):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- Add support for encryption in transit / TLS connections, via a `tls://` prefix added onto the connection uri.
- Update documentation.

Current connection string looks like this: `localhost:6379:0:changeme`.
With this change, above still works, but if you need TLS now you can do: `tls://localhost:6379:0:changeme`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redis.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The connection uri in this plugin is split on `:` and then each element is sent verbatim positionally to [the `Redis` library's constructor](https://redis-py.readthedocs.io/en/latest/#redis.Redis), which works great for the `host`, `port`, `db`, `password` params as they are the first four.


> classredis.Redis(host=u'localhost', port=6379, db=0, password=None, socket_timeout=None, socket_connect_timeout=None, socket_keepalive=None, socket_keepalive_options=None, connection_pool=None, unix_socket_path=None, encoding=u'utf-8', encoding_errors=u'strict', charset=None, errors=None, decode_responses=False, retry_on_timeout=False, ssl=False, ssl_keyfile=None, ssl_certfile=None, ssl_cert_reqs=u'required', ssl_ca_certs=None, ssl_check_hostname=False, max_connections=None, single_connection_client=False, health_check_interval=0, client_name=None, username=None)

But the `ssl` param is way down the list at number 17, so having to supply all those other values that are almost surely defaulted, doesn't really make sense.

I added support to use a prefix, but otherwise didn't change anything about the uri, so it still just works just the same as it did and existing connection strings won't be affected.