### PR TITLE
Add validity check for [Driver][IPAddress] else use docker-machine ip command.

### DIFF
--- a/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
+++ b/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - docker-machine inventory - fallback to ip subcommand output if IPAddress is missing (https://github.com/ansible-collections/community.general/issues/412).

--- a/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
+++ b/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-    - docker-machine inventory - fallback to ip subcommand output if IPAddress is missing (https://github.com/ansible-collections/community.general/issues/412).
+    - docker_machine - fallback to ip subcommand output if IPAddress is missing (https://github.com/ansible-collections/community.general/issues/412).

--- a/plugins/inventory/docker_machine.py
+++ b/plugins/inventory/docker_machine.py
@@ -176,6 +176,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         return json.loads(inspect_lines)
 
+    def _ip_addr_docker_machine_host(self, node):
+        try:
+            ip_addr = self._run_command(['ip', self.node])
+        except subprocess.CalledProcessError:
+            return None
+
+        return ip_addr
+
     def _should_skip_host(self, machine_name, env_var_tuples, daemon_env):
         if not env_var_tuples:
             warning_prefix = 'Unable to fetch Docker daemon env vars from Docker Machine for host {0}'.format(machine_name)
@@ -210,9 +218,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 # add an entry in the inventory for this host
                 self.inventory.add_host(machine_name)
 
+                # check for valid ip address from inspect output, else explicitly use ip command to find host ip address
+                if self.node_attrs['Driver']['IPAddress']:
+                    ip_addr = self.node_attrs['Driver']['IPAddress']
+                else:
+                    ip_addr = self._ip_addr_docker_machine_host(self.node)
+
                 # set standard Ansible remote host connection settings to details captured from `docker-machine`
                 # see: https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
-                self.inventory.set_variable(machine_name, 'ansible_host', self.node_attrs['Driver']['IPAddress'])
+                self.inventory.set_variable(machine_name, 'ansible_host', ip_addr)
                 self.inventory.set_variable(machine_name, 'ansible_port', self.node_attrs['Driver']['SSHPort'])
                 self.inventory.set_variable(machine_name, 'ansible_user', self.node_attrs['Driver']['SSHUser'])
                 self.inventory.set_variable(machine_name, 'ansible_ssh_private_key_file', self.node_attrs['Driver']['SSHKeyPath'])

--- a/plugins/inventory/docker_machine.py
+++ b/plugins/inventory/docker_machine.py
@@ -219,6 +219,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.inventory.add_host(machine_name)
 
                 # check for valid ip address from inspect output, else explicitly use ip command to find host ip address
+                # this works around an issue seen with Google Compute Platform where the IP address was not available
+                # via the 'inspect' subcommand but was via the 'ip' subcomannd.
                 if self.node_attrs['Driver']['IPAddress']:
                     ip_addr = self.node_attrs['Driver']['IPAddress']
                 else:


### PR DESCRIPTION
##### SUMMARY
This PR addresses an issue observed initially by @benroose whereby the `docker-machine inspect <machine name>` command output unexpectedly lacks an `IPAddress` value but the IP address was/is available via the `docker-machine ip <machine name>` command.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_machine inventory plugin

##### ADDITIONAL INFORMATION
The issue was brought to my attention by @gvashchenkolineate in [PR #1](https://github.com/ximon18/ansible-docker-machine-inventory-plugin/pull/1) against my original plugin repository for the Docker Machine Inventory plugin, along with the information that the issue was seen in the wild on the Google Compute Platform.