### PR TITLE
LVG: add new parameter pvresize

### DIFF
--- a/changelogs/fragments/442-add-new-parameter-pvresize.yaml
+++ b/changelogs/fragments/442-add-new-parameter-pvresize.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-    - lvg - add ``pvresize`` new parameter (https://link to the issue).
+    - lvg - add ``pvresize`` new parameter (https://github.com/ansible/ansible/issues/29139).

--- a/changelogs/fragments/442-add-new-parameter-pvresize.yaml
+++ b/changelogs/fragments/442-add-new-parameter-pvresize.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - lvg - add ``pvresize`` new parameter (https://link to the issue).

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -42,11 +42,7 @@ options:
     type: str
   pvresize:
     description:
-<<<<<<< HEAD
-    - If C(yes) resize the physical volume to the maximum available size.
-=======
     - If C(yes), resize the physical volume to the maximum available size.
->>>>>>> ac63e2c7506f1aef918dd4a070d5f717f4ce7d55
     type: bool
     default: false
   vg_options:

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -95,7 +95,7 @@ EXAMPLES = r'''
     vg: vg.services
     state: absent
 
-- name: Create a volume group on top of /dev/sda3 that suports increases in /dev/sda3 size
+- name: Create a volume group on top of /dev/sda3 and resize the volume group /dev/sda3 to the maximum possible
   lvg:
     vg: resizableVG
     pvs: /dev/sda3

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -42,7 +42,7 @@ options:
     type: str
   pvresize:
     description:
-    - If C(yes) resize the physical volume to the maximum available size
+    - If C(yes) resize the physical volume to the maximum available size.
     type: bool
     default: false
   vg_options:

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -42,7 +42,7 @@ options:
     type: str
   pvresize:
     description:
-    - If C(yes) resize the physical volume to the maximum available size.
+    - If C(yes), resize the physical volume to the maximum available size.
     type: bool
     default: false
   vg_options:

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -42,7 +42,11 @@ options:
     type: str
   pvresize:
     description:
+<<<<<<< HEAD
+    - If C(yes) resize the physical volume to the maximum available size.
+=======
     - If C(yes), resize the physical volume to the maximum available size.
+>>>>>>> ac63e2c7506f1aef918dd4a070d5f717f4ce7d55
     type: bool
     default: false
   vg_options:
@@ -94,6 +98,12 @@ EXAMPLES = r'''
   lvg:
     vg: vg.services
     state: absent
+
+- name: Create a volume group on top of /dev/sda3 that suports increases in /dev/sda3 size
+  lvg:
+    vg: resizableVG
+    pvs: /dev/sda3
+    pvresize: yes
 '''
 
 import itertools

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -145,7 +145,7 @@ def main():
             pvs=dict(type='list'),
             pesize=dict(type='str', default='4'),
             pv_options=dict(type='str', default=''),
-            pvresize=dict(type='bool', default=True),
+            pvresize=dict(type='bool', default=False),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             force=dict(type='bool', default=False),

--- a/plugins/modules/system/lvg.py
+++ b/plugins/modules/system/lvg.py
@@ -259,22 +259,22 @@ def main():
         if current_devs:
             if state == 'present' and pvresize:
                 for device in current_devs:
+                    pvresize_cmd = module.get_bin_path('pvresize', True)
                     pvdisplay_cmd = module.get_bin_path('pvdisplay', True)
                     pvdisplay_ops = ["--units", "b", "--columns", "--noheadings", "--nosuffix"]
-                    pvdiplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
-                    rc, dev_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "dev_size"])
+                    pvdisplay_cmd_device_options = [pvdisplay_cmd, device] + pvdisplay_ops
+                    rc, dev_size, err = module.run_command(pvdisplay_cmd_device_options + ["-o", "dev_size"])
                     dev_size = int(dev_size.replace(" ", ""))
-                    rc, pv_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pv_size"])
+                    rc, pv_size, err = module.run_command(pvdisplay_cmd_device_options + ["-o", "pv_size"])
                     pv_size = int(pv_size.replace(" ", ""))
-                    rc, pe_start, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "pe_start"])
+                    rc, pe_start, err = module.run_command(pvdisplay_cmd_device_options + ["-o", "pe_start"])
                     pe_start = int(pe_start.replace(" ", ""))
-                    rc, vg_extent_size, err = module.run_command(pvdiplay_cmd_device_options + ["-o", "vg_extent_size"])
+                    rc, vg_extent_size, err = module.run_command(pvdisplay_cmd_device_options + ["-o", "vg_extent_size"])
                     vg_extent_size = int(vg_extent_size.replace(" ", ""))
                     if (dev_size - (pe_start + pv_size)) > vg_extent_size:
                         if module.check_mode:
                             changed = True
                         else:
-                            pvresize_cmd = module.get_bin_path('pvresize', True)
                             rc, _, err = module.run_command([pvresize_cmd, device])
                             if rc != 0:
                                 module.fail_json(msg="Failed executing pvresize command.", rc=rc, err=err)

--- a/tests/integration/targets/lvg/tasks/main.yml
+++ b/tests/integration/targets/lvg/tasks/main.yml
@@ -11,5 +11,7 @@
     - import_tasks: test_indempotency.yml
 
     - import_tasks: test_grow_reduce.yml
+
+    - import_tasks: test_pvresize.yml
   always:
     - import_tasks: teardown.yml

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -39,6 +39,12 @@
    pvs: "{{ loop_device1.stdout }}"
    pvresize: yes
   check_mode: yes
+  register: cmd_result
+  
+- name: Assert that the module returned the state was changed
+  assert:
+    that:
+    - cmd_result is changed
 
 - name: Gets current vg size
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -1,0 +1,49 @@
+- name: "Create volume group on first disk"
+  lvg:
+    vg: testvg
+    pvs: "{{ loop_device1.stdout }}"
+
+- name: Gets current vg size
+  shell: vgs -v testvg -o pv_size --noheading --units b | xargs
+  register: cmd_result
+
+- name: Assert the testvg size is 8388608B
+  assert:
+   that:
+    - "'8388608B' == cmd_result.stdout"
+
+- name: Increases size in file
+  command: "dd if=/dev/zero bs=8MiB count=1 of={{ remote_tmp_dir }}/img1 conv=notrunc oflag=append"
+
+- name: "Reread size of file associated with loop_device1"
+  command: "losetup -c {{ loop_device1.stdout }}"
+
+- name: "Reruns lvg with pvresize:no"
+  lvg:
+   vg: testvg
+   pvs: "{{ loop_device1.stdout }}"
+   pvresize: no
+
+- name: Gets current vg size
+  shell: vgs -v testvg -o pv_size --noheading --units b | xargs
+  register: cmd_result
+
+- name: Assert the testvg size is still 8388608B
+  assert:
+   that:
+    - "'8388608B' == cmd_result.stdout"
+
+- name: "Reruns lvg with pvresize:yes"
+  lvg:
+   vg: testvg
+   pvs: "{{ loop_device1.stdout }}"
+   pvresize: yes
+
+- name: Gets current vg size
+  shell: vgs -v testvg -o pv_size --noheading --units b | xargs
+  register: cmd_result
+
+- name: Assert the testvg size is now 16777216B
+  assert:
+   that:
+    - "'16777216B' == cmd_result.stdout"

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -23,6 +23,11 @@
    vg: testvg
    pvs: "{{ loop_device1.stdout }}"
    pvresize: no
+ register: cmd_result
+ 
+- assert:
+    that:
+    - cmd_result is not changed
 
 - name: Gets current vg size
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -33,6 +33,22 @@
    that:
     - "'8388608B' == cmd_result.stdout"
 
+- name: "Reruns lvg with pvresize:yes and check_mode:yes"
+  lvg:
+   vg: testvg
+   pvs: "{{ loop_device1.stdout }}"
+   pvresize: yes
+  check_mode: yes
+
+- name: Gets current vg size
+   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
+   register: cmd_result
+ 
+- name: Assert the testvg size is still 8388608B
+   assert:
+    that:
+     - "'8388608B' == cmd_result.stdout"
+
 - name: "Reruns lvg with pvresize:yes"
   lvg:
    vg: testvg

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -23,7 +23,7 @@
    vg: testvg
    pvs: "{{ loop_device1.stdout }}"
    pvresize: no
- register: cmd_result
+  register: cmd_result
  
 - assert:
     that:

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -41,13 +41,13 @@
   check_mode: yes
 
 - name: Gets current vg size
-   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
-   register: cmd_result
+  shell: vgs -v testvg -o pv_size --noheading --units b | xargs
+  register: cmd_result
  
 - name: Assert the testvg size is still 8388608B
-   assert:
-    that:
-     - "'8388608B' == cmd_result.stdout"
+  assert:
+   that:
+    - "'8388608B' == cmd_result.stdout"
 
 - name: "Reruns lvg with pvresize:yes"
   lvg:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Prior to this adjustment, if the underlying physical device was resized, the physical volume built on it would not be resized. 

An additional (optional) parameter was added with default to "no" .

In order to detect if the physical volume must be resized, a simple check verifies if the difference between the physical device size and the sum of the physical volume size and extent start size (reserved for metadata) is greater than one extent. If that is the case, the resize occurs

Fixes https://github.com/ansible/ansible/issues/29139

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lvg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
