### PR TITLE
infoblox inventory script: Use stderr, and allow use of environment for config

### DIFF
--- a/changelogs/fragments/436-infoblox-use-stderr-and-environment-for-config.yaml
+++ b/changelogs/fragments/436-infoblox-use-stderr-and-environment-for-config.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - infoblox.py - infoblox inventory script: Use stderr, and allow use of environment for config (https://github.com/ansible-collections/community.general/pull/436)

--- a/changelogs/fragments/436-infoblox-use-stderr-and-environment-for-config.yaml
+++ b/changelogs/fragments/436-infoblox-use-stderr-and-environment-for-config.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - infoblox.py - infoblox inventory script: Use stderr, and allow use of environment for config (https://github.com/ansible-collections/community.general/pull/436)
+  - infoblox inventory script - use stderr for reporting errors, and allow use of environment for configuration (https://github.com/ansible-collections/community.general/pull/436).

--- a/scripts/inventory/infoblox.py
+++ b/scripts/inventory/infoblox.py
@@ -30,7 +30,7 @@ from ansible_collections.community.general.plugins.module_utils.net_tools.nios.a
 
 
 CONFIG_FILES = [
-    os.environ.get('INFOBLOX_CONFIG_FILE', None),
+    os.environ.get('INFOBLOX_CONFIG_FILE', ''),
     '/etc/ansible/infoblox.yaml',
     '/etc/ansible/infoblox.yml'
 ]

--- a/scripts/inventory/infoblox.py
+++ b/scripts/inventory/infoblox.py
@@ -30,6 +30,7 @@ from ansible_collections.community.general.plugins.module_utils.net_tools.nios.a
 
 
 CONFIG_FILES = [
+    os.environ.get('INFOBLOX_CONFIG_FILE', None),
     '/etc/ansible/infoblox.yaml',
     '/etc/ansible/infoblox.yml'
 ]
@@ -54,7 +55,7 @@ def main():
         if os.path.exists(config_file):
             break
     else:
-        sys.stdout.write('unable to locate config file at /etc/ansible/infoblox.yaml\n')
+        sys.stderr.write('unable to locate config file at /etc/ansible/infoblox.yaml\n')
         sys.exit(-1)
 
     try:
@@ -63,7 +64,7 @@ def main():
         provider = config.get('provider') or {}
         wapi = WapiInventory(provider)
     except Exception as exc:
-        sys.stdout.write(to_text(exc))
+        sys.stderr.write(to_text(exc))
         sys.exit(-1)
 
     if args.host:


### PR DESCRIPTION
Originally from https://github.com/ansible/ansible/pull/49685

##### SUMMARY
Errors should send to stderr, and this allows the use of an environment var to point to where the YAML config lives.

This is particularly useful when using this script with AWX and custom credentials (injecting YAML config).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
infoblox.py
