### PR TITLE
scaleway_compute: When removing node, wait for transition

### DIFF
--- a/changelogs/fragments/444-scaleway-improve_removal_handling.yml
+++ b/changelogs/fragments/444-scaleway-improve_removal_handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - scaleway_compute - fix transition handling that could cause errors when removing a node (https://github.com/ansible-collections/community.general/pull/444).

--- a/plugins/modules/cloud/scaleway/scaleway_compute.py
+++ b/plugins/modules/cloud/scaleway/scaleway_compute.py
@@ -196,10 +196,12 @@ def fetch_state(compute_api, server):
         compute_api.module.fail_json(msg="Could not fetch state in %s" % response.json)
 
 
-def wait_to_complete_state_transition(compute_api, server):
-    wait = compute_api.module.params["wait"]
+def wait_to_complete_state_transition(compute_api, server, wait=None):
+    if wait is None:
+        wait = compute_api.module.params["wait"]
     if not wait:
         return
+
     wait_timeout = compute_api.module.params["wait_timeout"]
     wait_sleep_time = compute_api.module.params["wait_sleep_time"]
 
@@ -353,7 +355,7 @@ def absent_strategy(compute_api, wished_server):
 
     # A server MUST be stopped to be deleted.
     while fetch_state(compute_api=compute_api, server=target_server) != "stopped":
-        wait_to_complete_state_transition(compute_api=compute_api, server=target_server)
+        wait_to_complete_state_transition(compute_api=compute_api, server=target_server, wait=True)
         response = stop_server(compute_api=compute_api, server=target_server)
 
         if not response.ok:
@@ -361,7 +363,7 @@ def absent_strategy(compute_api, wished_server):
                                                                                            response.json)
             compute_api.module.fail_json(msg=err_msg)
 
-        wait_to_complete_state_transition(compute_api=compute_api, server=target_server)
+        wait_to_complete_state_transition(compute_api=compute_api, server=target_server, wait=True)
 
     response = remove_server(compute_api=compute_api, server=target_server)
 


### PR DESCRIPTION
##### SUMMARY
To remove a scaleway compute node, one needs to stop it first. This is
handled internally within the module by shutting down before removing.
Shutting down the node transitions it to a "stopping" state, which is
not the "stopped" state we expect. We thus need the transition to
complete so that we can put it in the actual target state (absent, i.e.
delete it).

The mechanism for waiting for such transitions today is controlled by
module parameters, with default to not being enabled at all, which
includes the transition from ([running] -(stopping)-> [stopped]).

Without this chage, in case of a running node, we would shut it down
(transition it to "stopping"), not wait for it complete the transition,
realize that it's not yet stopped and issue a second shut down command
to the api. This would fail with a 400 Bad Request error, "already
stopped".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
scaleway_compute

##### ADDITIONAL INFORMATION
This was originally reported as https://github.com/ansible/ansible/issues/45740, and proposed in https://github.com/ansible/ansible/pull/68392.

(Edit: initially wrong component name. Updated.)