### PR TITLE
scaleway: Fix case mismatch causing key lookup failure

### DIFF
--- a/changelogs/fragments/444-scaleway_fix_http_header_casing.yml
+++ b/changelogs/fragments/444-scaleway_fix_http_header_casing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - scaleway - Fix bug causing KeyError exception on JSON http requests. (https://github.com/ansible-collections/community.general/pull/444)

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -90,7 +90,7 @@ class Scaleway(object):
         self.headers = {
             'X-Auth-Token': self.module.params.get('api_token'),
             'User-Agent': self.get_user_agent_string(module),
-            'Content-type': 'application/json',
+            'Content-Type': 'application/json',
         }
         self.name = None
 


### PR DESCRIPTION
##### SUMMARY
The common http api client class used by the scaleway modules only
enables automatic jsonification of the request body if the
"Content-Type" header is application/json. The client only included
"Content-type" in its default set of headers (notice the case
variation).

This caused a KeyError on send() if the caller relied on the default
content-type value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins.module_utils.scaleway

##### ADDITIONAL INFORMATION
Originally proposed in https://github.com/ansible/ansible/pull/68295