### PR TITLE
slackpkg: fix name matching in package installation (#450)

### DIFF
--- a/changelogs/fragments/450-slackpkg-package-matching.yml
+++ b/changelogs/fragments/450-slackpkg-package-matching.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - slackpkg - Fix name matching in package installation (https://github.com/ansible-collections/community.general/issues/450).

--- a/changelogs/fragments/450-slackpkg-package-matching.yml
+++ b/changelogs/fragments/450-slackpkg-package-matching.yml
@@ -1,2 +1,2 @@
 bugfixes:
- - slackpkg - Fix name matching in package installation (https://github.com/ansible-collections/community.general/issues/450).
+ - slackpkg - fix name matching in package installation (https://github.com/ansible-collections/community.general/issues/450).

--- a/plugins/modules/packaging/os/slackpkg.py
+++ b/plugins/modules/packaging/os/slackpkg.py
@@ -72,8 +72,8 @@ def query_package(module, slackpkg_path, name):
     import re
 
     machine = platform.machine()
-    pattern = re.compile('^%s-[^-]+-(%s|noarch)-[^-]+$' % (name, machine))
-    packages = [f for f in os.listdir('/var/log/packages') if re.match(pattern, f)]
+    pattern = re.compile('^%s-[^-]+-(%s|noarch)-[^-]+$' % (re.escape(name), re.escape(machine)))
+    packages = [f for f in os.listdir('/var/log/packages') if pattern.match(f)]
 
     if len(packages) > 0:
         return True

--- a/plugins/modules/packaging/os/slackpkg.py
+++ b/plugins/modules/packaging/os/slackpkg.py
@@ -67,12 +67,13 @@ from ansible.module_utils.basic import AnsibleModule
 
 def query_package(module, slackpkg_path, name):
 
-    import glob
     import platform
+    import os
+    import re
 
     machine = platform.machine()
-    packages = glob.glob("/var/log/packages/%s-*-[%s|noarch]*" % (name,
-                                                                  machine))
+    pattern = re.compile('^%s-[^-]+-(%s|noarch)-[^-]+$' % (name, machine))
+    packages = [f for f in os.listdir('/var/log/packages') if re.match(pattern, f)]
 
     if len(packages) > 0:
         return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change glob.glob() to os.listdir() and match name using regular expression.
It fixes case when we want to install package which name is part of other already installed package. For example if `openssl-solibs` is installed, it's not possible to install package `openssl` because module wrongly claim that desired package is already installed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes case described in #450

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
slackpkg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
