### PR TITLE
rshm_repository: reduce execution time when changed == False

### DIFF
--- a/changelogs/fragments/458-rshm_repository-reduce_execution_time_when_changed_is_false.yml
+++ b/changelogs/fragments/458-rshm_repository-reduce_execution_time_when_changed_is_false.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rshm_repository - reduce execution time when changed is False
+    (https://github.com/ansible-collections/community.general/pull/458).

--- a/plugins/modules/packaging/os/rhsm_repository.py
+++ b/plugins/modules/packaging/os/rhsm_repository.py
@@ -217,7 +217,7 @@ def repository_modify(module, state, name, purge=False):
             'before_header': "RHSM repositories",
             'after_header': "RHSM repositories"}
 
-    if not module.check_mode:
+    if not module.check_mode and changed:
         rc, out, err = run_subscription_manager(module, rhsm_arguments)
         results = out.splitlines()
     module.exit_json(results=results, changed=changed, repositories=updated_repo_list, diff=diff)


### PR DESCRIPTION
##### SUMMARY
This PR reduce of about 50% the execution time of this module when the module doesn't change the state of RHSM repositories.

Fixes #452 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rhsm_repository

##### ADDITIONAL INFORMATION
This module execute the command subscription-manager two times:

1. Executing "subscription-manager repos --list" to identify enabled/disabled repositories before execute any change
2. Executing "subscription-manager repos <variable arguments>" to enable/disable repositories and change the state of enabled/disabled repositories

The execution of subscription-manager command in some condition is slow (it can take about 40 seconds)
Before this PR, this module call subscription-manager always two times also when there aren't changes.
After this PR, this module skip the second execution of subscription-manager when there aren't changes.

**Before PR**
```
$ time ansible all -i /tmp/tmp -m rhsm_repository -a 'name=codeready-builder-for-rhel-8-x86_64-rpms'
...
    "changed": false,
...
    "results": [
        "Repository 'codeready-builder-for-rhel-8-x86_64-rpms' is enabled for this system."
    ]
}
real	1m31,856s
user	0m15,253s
sys	0m0,885s
```
**After PR**
```
$ time ansible all -i /tmp/tmp -m rhsm_repository -a 'name=codeready-builder-for-rhel-8-x86_64-rpms'
...
    "changed": false,
...
    "results": [
        "Repository 'codeready-builder-for-rhel-8-x86_64-rpms' is enabled for this system."
    ]
}
real	0m43,459s
user	0m7,632s
sys	0m0,498s
```

