### PR TITLE
Do domain resolution for portal

### DIFF
--- a/changelogs/fragments/461-resolve-domain-for-iscsi-portal.yml
+++ b/changelogs/fragments/461-resolve-domain-for-iscsi-portal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- allow open_iscsi module's portal field to be a domain name by resolving the portal ip address beforehand

--- a/changelogs/fragments/461-resolve-domain-for-iscsi-portal.yml
+++ b/changelogs/fragments/461-resolve-domain-for-iscsi-portal.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- allow open_iscsi module's portal field to be a domain name by resolving the portal ip address beforehand
+- open_iscsi - allow ``portal`` parameter to be a domain name by resolving the portal ip address beforehand (https://github.com/ansible-collections/community.general/pull/461).

--- a/plugins/modules/system/open_iscsi.py
+++ b/plugins/modules/system/open_iscsi.py
@@ -21,7 +21,7 @@ requirements:
 options:
     portal:
         description:
-        - The IP address of the iSCSI target.
+        - The domain name or IP address of the iSCSI target.
         type: str
         aliases: [ ip ]
     port:
@@ -72,11 +72,17 @@ options:
 '''
 
 EXAMPLES = r'''
+- name: Perform a discovery on sun.com and show available target nodes
+  open_iscsi:
+    show_nodes: yes
+    discover: yes
+    portal: sun.com
+
 - name: Perform a discovery on 10.1.2.3 and show available target nodes
   open_iscsi:
     show_nodes: yes
     discover: yes
-    portal: 10.1.2.3
+    ip: 10.1.2.3
 
 # NOTE: Only works if exactly one target is exported to the initiator
 - name: Discover targets on portal and login to the one available
@@ -98,6 +104,7 @@ EXAMPLES = r'''
 
 import glob
 import os
+import socket
 import time
 
 from ansible.module_utils.basic import AnsibleModule
@@ -270,6 +277,12 @@ def main():
 
     # parameters
     portal = module.params['portal']
+    if portal:
+        try:
+            portal = socket.getaddrinfo(portal, None)[0][4][0]
+        except socket.gaierror:
+            module.fail_json(msg="Portal address is incorrect")
+
     target = module.params['target']
     port = module.params['port']
     login = module.params['login']


### PR DESCRIPTION
iscsiadm support domain resolution (ex: iscsiadm -m discovery -t sendtargets -p iscsi.chiehmin.com).
However, open_iscsi module will try to match the portal with discovered results which will never
matched cause the discovered results use IP to represent node.

This patch do portal DNS resolution first to solve this situation.

Signed-off-by: Chieh-Min Wang <chiehminw@synology.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
