### PR TITLE
Legacy Python certificate validation fixed

### DIFF
--- a/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
+++ b/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - rhn_channel.py (spacewalk) - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ssl_context. (https://github.com/ansible-collections/community.general/pull/470)
+  - rhn_channel - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ssl_context (https://github.com/ansible-collections/community.general/pull/470).

--- a/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
+++ b/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rhn_channel.py (spacewalk) - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ssl_context. (https://github.com/ansible-collections/community.general/pull/470)
+

--- a/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
+++ b/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - rhn_channel - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ssl_context (https://github.com/ansible-collections/community.general/pull/470).
+  - rhn_channel - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ``ssl_context`` (https://github.com/ansible-collections/community.general/pull/470).

--- a/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
+++ b/changelogs/fragments/470-spacewalk-legacy-python-certificate-validation.yaml
@@ -1,3 +1,2 @@
 bugfixes:
   - rhn_channel.py (spacewalk) - Python 2.7.5 fails if the certificate should not be validated. Fixed this by creating the correct ssl_context. (https://github.com/ansible-collections/community.general/pull/470)
-

--- a/plugins/modules/packaging/os/rhn_channel.py
+++ b/plugins/modules/packaging/os/rhn_channel.py
@@ -126,7 +126,7 @@ def main():
         try:  # Python 2.7.9 and newer
             ssl_context = ssl.create_unverified_context()
         except AttributeError:  # Legacy Python that doesn't verify HTTPS certificates by default
-            ssl._create_default_context = ssl._create_unverified_context
+            ssl_context = ssl._create_unverified_context()
         else:  # Python 2.7.8 and older
             ssl._create_default_https_context = ssl._create_unverified_https_context
 


### PR DESCRIPTION
##### SUMMARY
Fix Python 2.7.5 problem with ssl certificate validation.
See: https://github.com/ansible-collections/community.general/pull/79

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/rhn_channel.py
