### PR TITLE
Fix modules/packaging/os/pkg5 authors/maintainers in BOTMETA.yml

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -899,7 +899,7 @@ files:
     ignore: kbrebanov
   $modules/packaging/os/apt_rpm.py:
     authors: evgkrsk
-  $modules/packaging/os/:
+  $modules/packaging/os/pkg5:
     authors: mavit
     maintainers: $team_solaris
     labels: pkg5 solaris


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Entry in `BOTMETA.yml` for `modules/packaging/os/` should be in fact `modules/packaging/os/pkg5` as in https://github.com/ansible/ansible/blob/stable-2.9/.github/BOTMETA.yml#L411
This mistake have also side effect that for all modules in `modules/packaging/os/` without `maintainers` field, people from `team_solaris` were mentioned in issues and PRs.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #469

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/BOTMETA.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
