### PR TITLE
yarn: Fix handling of empty outdated & scoped packages

### DIFF
--- a/changelogs/fragments/474-yarn_fix-outdated-fix-list.yml
+++ b/changelogs/fragments/474-yarn_fix-outdated-fix-list.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - yarn - Fixed an index out of range error when no outdated packages where returned by yarn executable (see https://github.com/ansible-collections/community.general/pull/474)
+  - yarn - Fixed an too many values to unpack error when scoped packages are installed (see https://github.com/ansible-collections/community.general/pull/474)

--- a/changelogs/fragments/474-yarn_fix-outdated-fix-list.yml
+++ b/changelogs/fragments/474-yarn_fix-outdated-fix-list.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - yarn - Fixed an index out of range error when no outdated packages where returned by yarn executable (see https://github.com/ansible-collections/community.general/pull/474)
-  - yarn - Fixed an too many values to unpack error when scoped packages are installed (see https://github.com/ansible-collections/community.general/pull/474)
+  - yarn - fixed an index out of range error when no outdated packages where returned by yarn executable (see https://github.com/ansible-collections/community.general/pull/474).
+  - yarn - fixed an too many values to unpack error when scoped packages are installed (see https://github.com/ansible-collections/community.general/pull/474).

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -274,6 +274,9 @@ class Yarn(object):
         if err:
             self.module.fail_json(msg=err)
 
+        if not cmd_result:
+            return outdated
+
         outdated_packages_data = cmd_result.splitlines()[1]
 
         data = json.loads(outdated_packages_data)

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -243,7 +243,7 @@ class Yarn(object):
             return installed, missing
 
         for dep in dependencies:
-            name, version = dep['name'].split('@')
+            name, version = dep['name'].rsplit('@', 1)
             installed.append(name)
 
         if self.name not in installed:

--- a/tests/integration/targets/yarn/templates/package.j2
+++ b/tests/integration/targets/yarn/templates/package.j2
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "iconv-lite": "^0.4.21"
+    "iconv-lite": "^0.4.21",
+    "@types/node": "^12.0.0"
   }
 }


### PR DESCRIPTION
##### SUMMARY
This PR fixes two issues with the yarn module:
1. `Index out of range` with `state: 'latest'` and no outdated packages
2. `Too many values to unpack` with scoped packages installed

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yarn

##### ADDITIONAL INFORMATION
###### 1. `Index out of range` with `state: 'latest'` and no outdated packages
Example:
```yaml
- yarn:
    path: '/var/www/test.domain.tld/some_app'
    name: 'imagemin'
    state: 'latest'
```
```bash
Traceback (most recent call last):
  File "/var/tmp/ansible-tmp-1591514673.7097096-9690-36426478672085/AnsiballZ_yarn.py", line 102, in <module>
    _ansiballz_main()
  File "/var/tmp/ansible-tmp-1591514673.7097096-9690-36426478672085/AnsiballZ_yarn.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/var/tmp/ansible-tmp-1591514673.7097096-9690-36426478672085/AnsiballZ_yarn.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.packaging.language.yarn', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_yarn_payload_6g8x8vs_/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 389, in <module>
  File "/tmp/ansible_yarn_payload_6g8x8vs_/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 371, in main
  File "/tmp/ansible_yarn_payload_6g8x8vs_/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 281, in list_outdated
IndexError: list index out of range
```
Situation on machine would be e.g.:
```bash
centos8:/var/www/test.domain.tld/some_app $ cat package.json 
{
  "name": "some_app",
  "license": "UNLICENSED",
  "scripts": [
    {
      "start": "/var/www/test.domain.tld/some_app/some_script.js"
    }
  ],
  "dependencies": {
    "imagemin": "^7.0.1",
    "package": "^1.0.1"
  }
}
centos8:/var/www/test.domain.tld/some_app $ yarn outdated --json
centos8:/var/www/test.domain.tld/some_app $ yarn -v
1.22.4
centos8:/var/www/test.domain.tld/some_app $
```


###### 2. `Too many values to unpack` with scoped packages installed
Example:
```yaml
- yarn:
    path: '/var/www/test.domain.tld/some_app'
    name: 'imagemin'
    state: 'latest'
```
```bash
Traceback (most recent call last):
  File "/var/tmp/ansible-tmp-1591518509.349181-16492-49670775886975/AnsiballZ_yarn.py", line 102, in <module>
    _ansiballz_main()
  File "/var/tmp/ansible-tmp-1591518509.349181-16492-49670775886975/AnsiballZ_yarn.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/var/tmp/ansible-tmp-1591518509.349181-16492-49670775886975/AnsiballZ_yarn.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.packaging.language.yarn', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_yarn_payload_jzqnrkyd/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 392, in <module>
  File "/tmp/ansible_yarn_payload_jzqnrkyd/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 373, in main
  File "/tmp/ansible_yarn_payload_jzqnrkyd/ansible_yarn_payload.zip/ansible/modules/packaging/language/yarn.py", line 250, in list
ValueError: too many values to unpack (expected 2)
```
Situation on machine would be e.g.:
```bash
centos8:/var/www/test.domain.tld/some_app $ yarn list --depth=0 --json | jq
{
  "type": "tree",
  "data": {
    "type": "list",
    "trees": [
      {
        "name": "imagemin@7.0.1",
        "children": [],
        "hint": null,
        "color": null,
        "depth": 0
      },
      (...)
      {
        "name": "@nodelib/fs.stat@2.0.3",
        "children": [],
        "hint": null,
        "color": null,
        "depth": 0
      },
      {
        "name": "@types/node@14.0.11",
        "children": [],
        "hint": null,
        "color": null,
        "depth": 0
      },
      (...)
    ]
  }
}
```
