### PR TITLE
[seport] fix the processing of a list of integers as per the ports spec

### DIFF
--- a/changelogs/fragments/480-seport-fix-ports-spec.yml
+++ b/changelogs/fragments/480-seport-fix-ports-spec.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - seport module - fix the specification of the `ports` argument, type cast to string

--- a/plugins/modules/system/seport.py
+++ b/plugins/modules/system/seport.py
@@ -278,7 +278,7 @@ def main():
     if not get_runtime_status(ignore_selinux_state):
         module.fail_json(msg="SELinux is disabled on this host.")
 
-    ports = module.params['ports']
+    ports = list(map(str, module.params['ports']))
     proto = module.params['proto']
     setype = module.params['setype']
     state = module.params['state']

--- a/plugins/modules/system/seport.py
+++ b/plugins/modules/system/seport.py
@@ -258,7 +258,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             ignore_selinux_state=dict(type='bool', default=False),
-            ports=dict(type='list', required=True),
+            ports=dict(type='list', elements='str', required=True),
             proto=dict(type='str', required=True, choices=['tcp', 'udp']),
             setype=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['absent', 'present']),
@@ -278,7 +278,7 @@ def main():
     if not get_runtime_status(ignore_selinux_state):
         module.fail_json(msg="SELinux is disabled on this host.")
 
-    ports = list(map(str, module.params['ports']))
+    ports = module.params['ports']
     proto = module.params['proto']
     setype = module.params['setype']
     state = module.params['state']


### PR DESCRIPTION
##### SUMMARY

Port https://github.com/ansible/ansible/pull/58637

> The seport module does not enforce an element type for the ports and the example shows a mixed usage of strings and integers as a list item.
> 
> Using an integer as port breaks the port handling in this module and the handling in the seobject package on the node.
> 
> Casting every port as string fixes the handling.
> 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
seport

##### ADDITIONAL INFORMATION
<details>

```paste below
# traceback in this module
{"changed": false, "module_stderr": "Shared connection to SNIP closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077098.42-100783222996536/AnsiballZ_seport.py\", line 125, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077098.42-100783222996536/AnsiballZ_seport.py\", line 117, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077098.42-100783222996536/AnsiballZ_seport.py\", line 54, in invoke_module\r\n    imp.load_module('__main__', mod, module, MOD_DESC)\r\n  File \"/tmp/ansible_seport_payload_YvGtLh/__main__.py\", line 307, in <module>\r\n  File \"/tmp/ansible_seport_payload_YvGtLh/__main__.py\", line 297, in main\r\n  File \"/tmp/ansible_seport_payload_YvGtLh/__main__.py\", line 206, in semanage_port_add\r\n  File \"/tmp/ansible_seport_payload_YvGtLh/__main__.py\", line 159, in semanage_port_get_type\r\nAttributeError: 'int' object has no attribute 'split'\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

# traceback in seobject, string handling fixed in the semanage_port_get_type function
{"changed": false, "module_stderr": "Shared connection to SNIP closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077932.73-31177858006091/AnsiballZ_seport.py\", line 125, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077932.73-31177858006091/AnsiballZ_seport.py\", line 117, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1562077932.73-31177858006091/AnsiballZ_seport.py\", line 54, in invoke_module\r\n    imp.load_module('__main__', mod, module, MOD_DESC)\r\n  File \"/tmp/ansible_seport_payload_Iz0NRY/__main__.py\", line 310, in <module>\r\n  File \"/tmp/ansible_seport_payload_Iz0NRY/__main__.py\", line 300, in main\r\n  File \"/tmp/ansible_seport_payload_Iz0NRY/__main__.py\", line 213, in semanage_port_add\r\n  File \"/usr/lib64/python2.7/site-packages/seobject/__init__.py\", line 1200, in modify\r\n    self.__modify(port, proto, serange, setype)\r\n  File \"/usr/lib64/python2.7/site-packages/seobject/__init__.py\", line 1168, in __modify\r\n    (k, proto_d, low, high) = self.__genkey(port, proto)\r\n  File \"/usr/lib64/python2.7/site-packages/seobject/__init__.py\", line 1074, in __genkey\r\n    ports = port.split(\"-\")\r\nAttributeError: 'int' object has no attribute 'split'\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
</details>
