### PR TITLE
Remove extra field from meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -56,14 +56,6 @@ action_groups:
   - ovirt_vm_facts
   - ovirt_vmpool_facts
 
-action_groups_redirection:
-  docker:
-    redirect: docker
-  k8s:
-    redirect: k8s
-  ovirt:
-    redirect: ovirt
-
 plugin_routing:
   modules:
     ali_instance_facts:


### PR DESCRIPTION
##### SUMMARY
The action_groups_redirection field is not being added for 2.10

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meta/runtime.yml
