### PR TITLE
zfs.py: treated received properties as local and added diff mode support

### DIFF
--- a/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
+++ b/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zfs.py - treated received properties as local
+  - zfs - treated received properties as local
 minor_changes:
-  - zfs.py - added diff mode support
+  - zfs - added diff mode support

--- a/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
+++ b/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zfs.py: treated received properties as local
+  - zfs.py - treated received properties as local
 minor_changes:
-  - zfs.py: added diff mode support
+  - zfs.py - added diff mode support

--- a/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
+++ b/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zfs - treated received properties as local
+  - zfs - treated received properties as local (https://github.com/ansible-collections/community.general/pull/502).
 minor_changes:
-  - zfs - added diff mode support
+  - zfs - added diff mode support (https://github.com/ansible-collections/community.general/pull/502).

--- a/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
+++ b/changelogs/fragments/502-zfs_bugfix_and_diff_mode_support.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zfs.py: treated received properties as local
+minor_changes:
+  - zfs.py: added diff mode support

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -205,13 +205,14 @@ class Zfs(object):
         if self.module.check_mode:
             return diff
         updated_properties = self.get_current_properties()
-        for prop in diff['before']:
+        for prop in self.properties:
             value = updated_properties.get(prop, None)
             if value is None:
                 self.module.fail_json(msg="zfsprop was not present after being successfully set: %s" % prop)
-            if diff['before'][prop] != value:
+            if current_properties.get(prop, None) != value:
                 self.changed = True
-            diff['after'][prop] = value
+            if prop in diff['after']:
+                diff['after'][prop] = value
         return diff
 
     def get_current_properties(self):

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -194,14 +194,14 @@ class Zfs(object):
             self.module.fail_json(msg=err)
 
     def set_properties_if_changed(self):
-        diff = {'before': {}, 'after': {}}
+        diff = {'before': {'extra_zfs_properties': {}}, 'after': {'extra_zfs_properties': {}}}
         current_properties = self.get_current_properties()
         for prop, value in self.properties.items():
             current_value = current_properties.get(prop, None)
             if current_value != value:
                 self.set_property(prop, value)
-                diff['before'][prop] = current_value
-                diff['after'][prop] = value
+                diff['before']['extra_zfs_properties'][prop] = current_value
+                diff['after']['extra_zfs_properties'][prop] = value
         if self.module.check_mode:
             return diff
         updated_properties = self.get_current_properties()
@@ -211,8 +211,8 @@ class Zfs(object):
                 self.module.fail_json(msg="zfsprop was not present after being successfully set: %s" % prop)
             if current_properties.get(prop, None) != value:
                 self.changed = True
-            if prop in diff['after']:
-                diff['after'][prop] = value
+            if prop in diff['after']['extra_zfs_properties']:
+                diff['after']['extra_zfs_properties'][prop] = value
         return diff
 
     def get_current_properties(self):

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -194,7 +194,7 @@ class Zfs(object):
             self.module.fail_json(msg=err)
 
     def set_properties_if_changed(self):
-        diff = {'before': {}, 'after': {}}
+        diff = {'before': {'name': self.name}, 'after': {'name': self.name}}
         current_properties = self.get_current_properties()
         for prop, value in self.properties.items():
             current_value = current_properties.get(prop, None)
@@ -274,12 +274,14 @@ def main():
             result['diff'] = zfs.set_properties_if_changed()
         else:
             zfs.create()
-            result['diff'] = {'before': {'state': 'absent'}, 'after': {'state': state}}
+            result['diff'] = {'before': {'name': name, 'state': 'absent'},
+                               'after': {'name': name, 'state': state}}
 
     elif state == 'absent':
         if zfs.exists():
             zfs.destroy()
-            result['diff'] = {'before': {'state': 'present'}, 'after': {'state': state}}
+            result['diff'] = {'before': {'name': name, 'state': 'present'},
+                               'after': {'name': name, 'state': state}}
 
     result.update(zfs.properties)
     result['changed'] = zfs.changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If you use "zfs set" to explicitly set ZFS properties, they are marked as from source "local". If ZFS properties are implicitly set by using "zfs send" and "zfs receive", for example as part of a template based installation, they are marked as from source "received". But as there is no technical difference between both types of them, the “received” ZFS properties should also be considered “local”. Otherwise Ansible would detect changes, which aren’t actual changes. Therefore I changed line 202/207 to reflect this.

For us it’s quite important, that Ansible modules support the diff mode in order to qualify changes. Therefore I added some code lines to address this.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
