### PR TITLE
slackpkg: fix matching some special cases in package names.

### DIFF
--- a/changelogs/fragments/505-slackpkg_fix_matching_some_special_cases_in_package_names.yml
+++ b/changelogs/fragments/505-slackpkg_fix_matching_some_special_cases_in_package_names.yml
@@ -1,2 +1,2 @@
 bugfixes:
- - slackpkg - fix matching some special cases in package names.
+ - slackpkg - fix matching some special cases in package names (https://github.com/ansible-collections/community.general/pull/505).

--- a/changelogs/fragments/505-slackpkg_fix_matching_some_special_cases_in_package_names.yml
+++ b/changelogs/fragments/505-slackpkg_fix_matching_some_special_cases_in_package_names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - slackpkg - fix matching some special cases in package names.

--- a/plugins/modules/packaging/os/slackpkg.py
+++ b/plugins/modules/packaging/os/slackpkg.py
@@ -72,7 +72,10 @@ def query_package(module, slackpkg_path, name):
     import re
 
     machine = platform.machine()
-    pattern = re.compile('^%s-[^-]+-(%s|noarch)-[^-]+$' % (re.escape(name), re.escape(machine)))
+    # Exception for kernel-headers package on x86_64
+    if name == 'kernel-headers' and machine == 'x86_64':
+        machine = 'x86'
+    pattern = re.compile('^%s-[^-]+-(%s|noarch|fw)-[^-]+$' % (re.escape(name), re.escape(machine)))
     packages = [f for f in os.listdir('/var/log/packages') if pattern.match(f)]
 
     if len(packages) > 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are some special cases in Slackware package naming which are not covered by `$ARCH|noarch` condition:
- package `kernel-headers` has architecture set to `x86` on `x86_64`
- there are also some firmware packages with architecture set to `fw`

This PR adds check for `kernel-headers` special case and adds `fw` to other expected architectures.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
slackpkg.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For example, try to install package `kernel-headers`.
Module runs `slackpkg install kernel-headers` (installs it if package is not present), then check is run if package is installed, but it can't find it because architecture part of package name is different (`x86` instead of expected `x86_64`) and task fails.

Similar thing for firmware files, for example `zd1211-firmware-1.4-fw-1`. It fails because architecture part is set to `fw` and doesn't match current condition.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example output from system where `kernel-headers` are already installed
```paste below
$ansible mii -m slackpkg -a "name=kernel-headers"
mii | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "msg": "failed to install kernel-headers: \nLooking for kernel-headers in package list. Please wait... DONE\n\nNo packages match the pattern for install. Try:\n\n\t/usr/sbin/slackpkg reinstall|upgrade \n\n\n",
    "stderr": "",
    "stderr_lines": []
}
```
