### PR TITLE
[WIP] nmcli: ensure modify_ethernet_connection is idempotent

### DIFF
--- a/changelogs/fragments/508-ensure-modify-ethernet-connection-is-idempotent.yaml
+++ b/changelogs/fragments/508-ensure-modify-ethernet-connection-is-idempotent.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - ensures modify_ethernet_connection is idempotent (https://github.com/ansible-collections/community.general/issues/481)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -988,10 +988,10 @@ class Nmcli(object):
         # - nmcli: conn_name=my-eth1 ifname=eth1 type=ethernet ip4=192.0.2.100/24 gw4=192.0.2.1 state=present
         # nmcli con mod con-name my-eth1 ifname eth1 type ethernet ipv4.address 192.0.2.100/24 ipv4.gateway 192.0.2.1
         options = {
-            'ipv4.address': self.ip4,
+            'ipv4.addresses': self.ip4,
             'ipv4.gateway': self.gw4,
             'ipv4.dns': self.dns4,
-            'ipv6.address': self.ip6,
+            'ipv6.addresses': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
             'connection.autoconnect': self.bool_to_string(self.autoconnect),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The PR checks the before and after diff to see if any changes are made. If no changes are made, the module reports back `"changed": false` (changed=0).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #481.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/net_tools/nmcli.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue description for reproducing. The following output is displayed after running the playbook twice with the same information, resulting in Ansible reporting no changes.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [192.168.1.70] => {
    "changed": false,
    "conn_name": "System ens192"
....
PLAY RECAP *************************************************************************************************************************************************************************
192.168.1.70               : ok=2    changed=0 
```
