### PR TITLE
Update unit test requirements

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,27 +1,15 @@
-boto3
-placebo
-pycrypto
-passlib
-pypsrp
-python-memcached
-pytz
-pyvmomi
-redis
-requests
-setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools (sanity_ok)
 unittest2 ; python_version < '2.7'
 importlib ; python_version < '2.7'
-netaddr
-ipaddress
-netapp-lib
-solidfire-sdk-python
 
-# requirement for winrm connection plugin tests
-pexpect
+# requirement for the memcached cache plugin
+python-memcached
+
+# requirement for the redis cache plugin
+redis
 
 # requirement for the linode module
-linode-python # APIv3
-linode_api4 ; python_version > '2.6' # APIv4
+linode-python  # APIv3
+linode_api4 ; python_version > '2.6'  # APIv4
 
 # requirement for the gitlab module
 python-gitlab < 2.3.0  # version 2.3.0 makes gitlab_runner tests fail
@@ -31,4 +19,5 @@ httmock
 openshift ; python_version >= '2.7'
 
 # requirement for maven_artifact module
+lxml
 semantic_version


### PR DESCRIPTION
##### SUMMARY
None were missing. The only consistently skipped test is `modules/packaging/os/test_rhn_register.py`, which requires libxml/libxml2 (which is not available properly via PyPI).

Fixes #488.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unit tests
