### PR TITLE
cloudflare_dns: Be more verbose on unexpected failure.

### DIFF
--- a/changelogs/fragments/511-cloudflare_dns-verbose-failure.yml
+++ b/changelogs/fragments/511-cloudflare_dns-verbose-failure.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloudflare_dns - Report unexpected failure with more detail (https://github.com/ansible-collections/community.general/pull/511).

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -452,7 +452,7 @@ class CloudflareAPI(object):
                                timeout=self.timeout)
 
         if info['status'] not in [200, 304, 400, 401, 403, 429, 405, 415]:
-            self.module.fail_json(msg="Failed API call {0}; got unexpected HTTP code {1}".format(api_call, info['status']))
+            self.module.fail_json(msg="Failed API call {0}; got unexpected HTTP code {1}: {2}".format(api_call, info['status'], info.get('msg')))
 
         error_msg = ''
         if info['status'] == 401:


### PR DESCRIPTION
This is a very small change, so I open a PR without bug report.

##### SUMMARY
I spent some time debugging an error, where the unexpected HTTP return code was reported to be -1:

> Failed API call /zones?name=example.com; got unexpected HTTP code -1

After searching the internet, I found multiple threads where this was reported (e.g. [this](https://community.cloudflare.com/t/failed-api-call-zones-name-domain-com-got-unexpected-http-code-1/48621)) and it was mostly attributed to a problem with the Cloudflare API, Access Permissions etc.

Digging deeper, I found the cause:

> An unknown error occurred: ~/.netrc access too permissive: access permissions must restrict access to only the owner

So this was just a fault of my local setup, totally unrelated to ansible and cloudflare.

This patch makes this message more verbose. Using `get()` instead of `[]` because I did not find out if the `'msg'` attribute of `info` is always defined.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`cloudflare_dns`

##### ADDITIONAL INFORMATION

Error before patch (cause is obscured):

```
failed: [localhost] (item={'name': 'test77', 'value': '10.10.129.142'}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "test77", "value": "10.10.129.142"}, "msg": "Failed API call /zones?name=example.com; got unexpected HTTP code -1."}
```

Error with patch (cause is clear):

```
failed: [localhost] (item={'name': 'test77', 'value': '10.10.129.142'}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "test77", "value": "10.10.129.142"}, "msg": "Failed API call /zones?name=example.com; got unexpected HTTP code -1: An unknown error occurred: ~/.netrc access too permissive: access permissions must restrict access to only the owner (/home/user/.netrc, line 1)"}
```
