### PR TITLE
Pear - Add prompt parameter on pear module that allows to specify one or more prompts

### DIFF
--- a/changelogs/fragments/29253-pear_add_prompts_parameter.yml
+++ b/changelogs/fragments/29253-pear_add_prompts_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- pear - added ``prompts`` parameter to allow users to specify expected prompt that could hang Ansible execution
+- pear - added ``prompts`` parameter to allow users to specify expected prompt that could hang Ansible execution (https://github.com/ansible-collections/community.general/pull/530).

--- a/changelogs/fragments/29253-pear_add_prompts_parameter.yml
+++ b/changelogs/fragments/29253-pear_add_prompts_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- added prompts parameter to allow users to specify expected prompt that could hang Ansible execution while using pear
+- pear - added ``prompts`` parameter to allow users to specify expected prompt that could hang Ansible execution

--- a/changelogs/fragments/29253-pear_add_prompts_parameter.yml
+++ b/changelogs/fragments/29253-pear_add_prompts_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- added prompts parameter to allow users to specify expected prompt that could hang Ansible execution while using pear

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -36,6 +36,8 @@ options:
     prompts:
         description:
             - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
+        type: list
+        elements: raw
         version_added: "2.10"
 '''
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -222,7 +222,7 @@ def install_packages(module, state, packages, prompts):
             command = 'upgrade'
 
         current_prompt_regex = (None, None)
-        if has_prompt and (len(prompts) > 0 and i < len(prompts)):
+        if has_prompt and i < len(prompts):
             current_prompt_regex = prompts[i]
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -260,7 +260,7 @@ def main():
             name=dict(aliases=['pkg'], required=True),
             state=dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
             executable=dict(default=None, required=False, type='path'),
-            prompts=dict(default=None, required=False, type='list')),
+            prompts=dict(default=None, required=False, type='list', elements='raw')),
         supports_check_mode=True)
 
     p = module.params

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -261,7 +261,8 @@ def main():
             name=dict(aliases=['pkg'], required=True),
             state=dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
             executable=dict(default=None, required=False, type='path'),
-            prompts=dict(default=None, required=False, type='list', elements='raw')),
+            prompts=dict(default=None, required=False, type='list', elements='raw'),
+        ),
         supports_check_mode=True)
 
     p = module.params

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -76,7 +76,7 @@ EXAMPLES = r'''
 - name: Install multiple pear/pecl packages at once with prompts.
     Prompts will be processed on the same order as the packages order.
     If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
-    If there is more packages than prompts, additionnal prompts will be ignored
+    If there is more packages than prompts, additionnal prompts will be ignored.
   pear:
     name: pecl/gnupg, pecl/apcu
     state: present
@@ -84,10 +84,10 @@ EXAMPLES = r'''
       - I am a test prompt because gnupg doesnt asks anything
       - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
-- name: Install multiple pear/pecl packages at once skipping the first prompt
-  # Prompts will be processed on the same order as the packages order
-  # If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
-  # If there is more packages than prompts, additionnal prompts will be ignored
+- name: Install multiple pear/pecl packages at once skipping the first prompt.
+    Prompts will be processed on the same order as the packages order.
+    If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+    If there is more packages than prompts, additionnal prompts will be ignored.
   pear:
     name: pecl/gnupg, pecl/apcu
     state: present

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -55,14 +55,14 @@ EXAMPLES = '''
     name: pecl/apcu
     state: present
     prompt: 
-        - (.*)Enable internal debugging in APCu \[no\]
+        - (.*)Enable internal debugging in APCu \\[no\\]
 
 - name: Install pecl package with expected prompt and an answer
   pear:
     name: pecl/apcu
     state: present
     prompt:
-        - (.*)Enable internal debugging in APCu \[no\]: "yes"
+        - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
 
 - name: Install multiple pear/pecl packages at once with prompts.
     Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected.
@@ -72,7 +72,7 @@ EXAMPLES = '''
     state: present
     prompt:
       - I am a test prompt cause gnupg doesnt asks anything
-      - (.*)Enable internal debugging in APCu \[no\]: "yes"
+      - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
 
 - name: Upgrade package
   pear:
@@ -181,14 +181,13 @@ def install_packages(module, state, packages, prompts):
         nb_prompts = len(prompts)
         nb_packages = len(packages)
 
-        if nb_prompts > 0 and ( nb_prompts != nb_packages ):
+        if nb_prompts > 0 and (nb_prompts != nb_packages):
             if nb_prompts > nb_packages:
                 diff = nb_prompts - nb_packages
                 msg = "%s packages to install but %s prompts to expect. %s prompts will be ignored" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             else:
                 diff = nb_packages - nb_prompts
                 msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
-            
             module.warn(msg)
 
         # Preparing prompts answer according to item type
@@ -205,9 +204,7 @@ def install_packages(module, state, packages, prompts):
                 tmp_prompts.append((key, answer))
             else:
                 tmp_prompts.append((_item, default_prompt_answer))
-
-        prompts = tmp_prompts                     
-            
+        prompts = tmp_prompts 
     for i, package in enumerate(packages):
         # if the package is installed and state == present
         # or state == latest and is up-to-date then skip
@@ -224,8 +221,6 @@ def install_packages(module, state, packages, prompts):
         current_prompt_regex = (None, None)
         if has_prompt and (len(prompts) > 0 and i < len(prompts)):
             current_prompt_regex = prompts[i]
-
-            print(current_prompt_regex)
 
         cmd = "%s %s %s" % (_get_pear_path(module), command, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1])

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -39,7 +39,7 @@ options:
             - Prompts will be processed in the same order as the packages list
             - You can optionnally specify an answer to any question in the list
             - If no answer is provided, the list item will only contain the regular expression.
-            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value eg: C(my_regular_expression: 'an_answer')"
+            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value C(my_regular_expression: 'an_answer')"
             - You can provide a list containing items with or without answer
             - A prompt list can be shorter or longer than the packages list but will issue a warning
             - If you want to specify that a package will not need prompts in the middle of a list,  C(null)

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -33,6 +33,10 @@ options:
     executable:
       description:
         - Path to the pear executable
+    prompts: 
+        description:
+            - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
+      version_added: "2.10"
 '''
 
 EXAMPLES = '''
@@ -45,6 +49,30 @@ EXAMPLES = '''
   pear:
     name: pecl/json_post
     state: present
+
+- name: Install pecl package with expected prompt
+  pear:
+    name: pecl/apcu
+    state: present
+    prompt: 
+        - (.*)Enable internal debugging in APCu \[no\]
+
+- name: Install pecl package with expected prompt and an answer
+  pear:
+    name: pecl/apcu
+    state: present
+    prompt:
+        - (.*)Enable internal debugging in APCu \[no\]: "yes"
+
+- name: Install multiple pear/pecl packages at once with prompts.
+    Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+    If there is more prompts than packages, additionnal prompts will be ignored
+  pear:
+    name: pecl/gnupg, pecl/apcu
+    state: present
+    prompt:
+      - I am a test prompt cause gnupg doesnt asks anything
+      - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 - name: Upgrade package
   pear:
@@ -145,9 +173,41 @@ def remove_packages(module, packages):
     module.exit_json(changed=False, msg="package(s) already absent")
 
 
-def install_packages(module, state, packages):
+def install_packages(module, state, packages, prompts):
     install_c = 0
+    has_prompt = True if prompts else False
 
+    if has_prompt:
+        nb_prompts = len(prompts)
+        nb_packages = len(packages)
+
+        if nb_prompts > 0 and ( nb_prompts != nb_packages ):
+            if nb_prompts > nb_packages:
+                diff = nb_prompts - nb_packages
+                msg = "%s packages to install but %s prompts to expect. %s prompts will be ignored" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
+            else:
+                diff = nb_packages - nb_prompts
+                msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
+            
+            module.warn(msg)
+
+        # Preparing prompts answer according to item type
+        tmp_prompts = []
+        default_prompt_answer = "\n"
+        for _item in prompts:
+            # If the current item is a dict then we expect it's key to be the prompt regex and it's value to be the answer
+            # We also expect here that the dict only has ONE key and the first key will be taken
+            if isinstance(_item, dict):
+                key = list(_item.keys())[0]
+                answer = _item[key] if _item[key] else default_prompt_answer
+                answer += "\n"
+
+                tmp_prompts.append((key, answer))
+            else:
+                tmp_prompts.append((_item, default_prompt_answer))
+
+        prompts = tmp_prompts                     
+            
     for i, package in enumerate(packages):
         # if the package is installed and state == present
         # or state == latest and is up-to-date then skip
@@ -161,9 +221,14 @@ def install_packages(module, state, packages):
         if state == 'latest':
             command = 'upgrade'
 
-        cmd = "%s %s %s" % (_get_pear_path(module), command, package)
-        rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+        current_prompt_regex = (None, None)
+        if has_prompt and (len(prompts) > 0 and i < len(prompts)):
+            current_prompt_regex = prompts[i]
 
+            print(current_prompt_regex)
+
+        cmd = "%s %s %s" % (_get_pear_path(module), command, package)
+        rc, stdout, stderr = module.run_command(cmd, check_rc=False, prompt_regex=current_prompt_regex[0], data=current_prompt_regex[1])
         if rc != 0:
             module.fail_json(msg="failed to install %s: %s" % (package, to_text(stdout + stderr)))
 
@@ -197,7 +262,8 @@ def main():
         argument_spec=dict(
             name=dict(aliases=['pkg'], required=True),
             state=dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
-            executable=dict(default=None, required=False, type='path')),
+            executable=dict(default=None, required=False, type='path'),
+            prompts=dict(default=None, required=False, type='list')),
         supports_check_mode=True)
 
     p = module.params
@@ -219,7 +285,7 @@ def main():
             check_packages(module, pkgs, p['state'])
 
         if p['state'] in ['present', 'latest']:
-            install_packages(module, p['state'], pkgs)
+            install_packages(module, p['state'], pkgs, p["prompts"])
         elif p['state'] == 'absent':
             remove_packages(module, pkgs)
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -39,7 +39,7 @@ options:
       version_added: "2.10"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Install pear package
   pear:
     name: Net_URL2
@@ -55,14 +55,14 @@ EXAMPLES = '''
     name: pecl/apcu
     state: present
     prompt: 
-        - (.*)Enable internal debugging in APCu \\[no\\]
+        - (.*)Enable internal debugging in APCu \[no\]
 
 - name: Install pecl package with expected prompt and an answer
   pear:
     name: pecl/apcu
     state: present
     prompt:
-        - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
+        - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 - name: Install multiple pear/pecl packages at once with prompts.
     Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected.
@@ -72,7 +72,7 @@ EXAMPLES = '''
     state: present
     prompt:
       - I am a test prompt cause gnupg doesnt asks anything
-      - (.*)Enable internal debugging in APCu \\[no\\]: "yes"
+      - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 - name: Upgrade package
   pear:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -33,7 +33,7 @@ options:
     executable:
         description:
             - Path to the pear executable
-    prompts: 
+    prompts:
         description:
             - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
         version_added: "2.10"
@@ -54,7 +54,7 @@ EXAMPLES = r'''
   pear:
     name: pecl/apcu
     state: present
-    prompts: 
+    prompts:
         - (.*)Enable internal debugging in APCu \[no\]
 
 - name: Install pecl package with expected prompt and an answer
@@ -65,8 +65,9 @@ EXAMPLES = r'''
         - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 - name: Install multiple pear/pecl packages at once with prompts.
-    Prompts will be processed on the same order as the packages order, if there is more prompts than packages, packages without prompts will be installed without any prompt expected.
-    If there is more prompts than packages, additionnal prompts will be ignored
+    Prompts will be processed on the same order as the packages order.
+    If there is more prompts than packages, packages without prompts will be installed without any prompt expected.
+    If there is more packages than prompts, additionnal prompts will be ignored
   pear:
     name: pecl/gnupg, pecl/apcu
     state: present
@@ -187,7 +188,8 @@ def install_packages(module, state, packages, prompts):
                 msg = "%s packages to install but %s prompts to expect. %s prompts will be ignored" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             else:
                 diff = nb_packages - nb_prompts
-                msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
+                msg = "%s packages to install but only %s prompts to expect. %s packages won't be expected to have a prompt" \
+                    % (to_text(nb_packages), to_text(nb_prompts), to_text(diff))
             module.warn(msg)
 
         # Preparing prompts answer according to item type
@@ -204,7 +206,7 @@ def install_packages(module, state, packages, prompts):
                 tmp_prompts.append((key, answer))
             else:
                 tmp_prompts.append((_item, default_prompt_answer))
-        prompts = tmp_prompts 
+        prompts = tmp_prompts
     for i, package in enumerate(packages):
         # if the package is installed and state == present
         # or state == latest and is up-to-date then skip

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -35,7 +35,7 @@ options:
             - Path to the pear executable
     prompts:
         description:
-            - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
+            - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
         version_added: "2.10"
 '''
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -31,12 +31,12 @@ options:
         default: "present"
         choices: ["present", "absent", "latest"]
     executable:
-      description:
-        - Path to the pear executable
+        description:
+            - Path to the pear executable
     prompts: 
         description:
             - List of regex strings which can be used to detect prompts during pear package installation: Optionnal string to answer the expected regex
-      version_added: "2.10"
+        version_added: "2.10"
 '''
 
 EXAMPLES = r'''
@@ -54,14 +54,14 @@ EXAMPLES = r'''
   pear:
     name: pecl/apcu
     state: present
-    prompt: 
+    prompts: 
         - (.*)Enable internal debugging in APCu \[no\]
 
 - name: Install pecl package with expected prompt and an answer
   pear:
     name: pecl/apcu
     state: present
-    prompt:
+    prompts:
         - (.*)Enable internal debugging in APCu \[no\]: "yes"
 
 - name: Install multiple pear/pecl packages at once with prompts.
@@ -70,7 +70,7 @@ EXAMPLES = r'''
   pear:
     name: pecl/gnupg, pecl/apcu
     state: present
-    prompt:
+    prompts:
       - I am a test prompt cause gnupg doesnt asks anything
       - (.*)Enable internal debugging in APCu \[no\]: "yes"
 

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -202,8 +202,7 @@ def install_packages(module, state, packages, prompts):
             # We also expect here that the dict only has ONE key and the first key will be taken
             if isinstance(_item, dict):
                 key = list(_item.keys())[0]
-                answer = _item[key] if _item[key] else default_prompt_answer
-                answer += "\n"
+                answer = _item[key] + "\n"
 
                 tmp_prompts.append((key, answer))
             else:

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -45,7 +45,7 @@ options:
             - If you want to specify that a package will not need prompts in the middle of a list,  C(null)
         type: list
         elements: raw
-        version_added: "2.10"
+        version_added: 0.2.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -35,7 +35,7 @@ options:
             - Path to the pear executable
     prompts:
         description:
-            - List of regex strings which can be used to detect prompts during pear package installation with an ptionnal string to answer the expected regex
+            - List of regular expressions which can be used to detect prompts during pear package installation with an optional string to answer the expected regex.
         type: list
         elements: raw
         version_added: "2.10"

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -178,7 +178,7 @@ def remove_packages(module, packages):
 
 def install_packages(module, state, packages, prompts):
     install_c = 0
-    has_prompt = True if prompts else False
+    has_prompt = bool(prompts)
 
     if has_prompt:
         nb_prompts = len(prompts)

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -32,17 +32,17 @@ options:
         choices: ["present", "absent", "latest"]
     executable:
         description:
-            - Path to the pear executable
+            - Path to the pear executable.
     prompts:
         description:
             - List of regular expressions that can be used to detect prompts during pear package installation to answer the expected question.
-            - Prompts will be processed in the same order as the packages list
-            - You can optionnally specify an answer to any question in the list
+            - Prompts will be processed in the same order as the packages list.
+            - You can optionnally specify an answer to any question in the list.
             - If no answer is provided, the list item will only contain the regular expression.
-            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value C(my_regular_expression: 'an_answer')"
-            - You can provide a list containing items with or without answer
-            - A prompt list can be shorter or longer than the packages list but will issue a warning
-            - If you want to specify that a package will not need prompts in the middle of a list,  C(null)
+            - "To specify an answer, the item will be a dict with the regular expression as key and the answer as value C(my_regular_expression: 'an_answer')."
+            - You can provide a list containing items with or without answer.
+            - A prompt list can be shorter or longer than the packages list but will issue a warning.
+            - If you want to specify that a package will not need prompts in the middle of a list,  C(null).
         type: list
         elements: raw
         version_added: 0.2.0


### PR DESCRIPTION
# SUMMARY

This is a copy of https://github.com/ansible-collections/community.general/pull/233

Add a new parameter to pear module allowing user to pass one or more regex and (optionnally) their answer for each package that will be installed.
Depending on what package we want to install, pear can ask for some information or just typing a character.
This hangs Ansible execution and the added parameter is used to detect these questions and answer them with a newline character by default or a user specified string.

# ISSUE TYPE

* Bugfix Pull Request

# COMPONENT NAME

pear

# ADDITIONAL INFORMATION

This fixes an issue created on repo 2 and half years ago :

Exemple playbook:

The example below have a prompt specified but no answer. Thus, the module will input newline caracter "\n" by default

```yaml
pear:
  name: pecl/apcu
  state: installed
  prompts:
    - (.*)Enable internal debugging in APCu \[no\]
```

The example below is the same except we specify a user answer.

```yaml
pear:
  name: pecl/apcu
  state: installed
  prompts:
    - (.*)Enable internal debugging in APCu \[no\]: "yes"
```