### PR TITLE
kubevirt: Add aliases 'interface_name' for 'network_name'

### DIFF
--- a/changelogs/fragments/55903_kubevirt.yml
+++ b/changelogs/fragments/55903_kubevirt.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- kubevirt - Add aliases 'interface_name' for network_name (https://github.com/ansible/ansible/issues/55641).

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -103,6 +103,7 @@ DOCUMENTATION = '''
                 - In case of multiple network attached to virtual machine, define which interface should be returned as primary IP
                     address.
                 type: str
+                aliases: [ interface_name ]
             api_version:
                 description:
                 - "Specify the KubeVirt API version."


### PR DESCRIPTION
##### SUMMARY

Fixes: ansible/ansible#55641

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/55903_kubevirt.yml
plugins/inventory/kubevirt.py
