### PR TITLE
hashi_vault: Handle equal sign in secret name value

### DIFF
--- a/changelogs/fragments/55658_hashi_vault.yml
+++ b/changelogs/fragments/55658_hashi_vault.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- hashi_vault - Handle equal sign in key=value (https://github.com/ansible/ansible/issues/55658).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -444,7 +444,7 @@ class LookupModule(LookupBase):
 
         for i, param in enumerate(term.split()):
             try:
-                key, value = param.split('=')
+                key, value = param.split('=', 1)
             except ValueError:
                 if (i == 0):
                     # allow secret to be specified as value only if it's first

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -115,6 +115,9 @@
                   path "{{ vault_kv2_multi_path }}/secrets" {
                     capabilities = ["read"]
                   }
+                  path "{{ vault_kv2_path }}/secret4" {
+                    capabilities = ["read", "update"]
+                  }
 
             - name: 'Create generic secrets'
               command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
@@ -126,7 +129,10 @@
 
             - name: 'Create KV v2 secrets'
               command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
-              loop: [1, 2, 3]
+              loop: [1, 2, 3, 4]
+
+            - name: 'Update KV v2 secret4 with new value to create version'
+              command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret4 value=foo5'
 
             - name: 'Create multiple KV v2 secrets under one path'
               command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -9,6 +9,7 @@
         kv1_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2 token=' ~ user_token) }}"
         kv2_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
         kv2_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 token=' ~ user_token) }}"
+        kv2_secret4: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4?version=2 token=' ~ user_token) }}"
         kv2_secret2_as_raw: "{{ lookup('community.general.hashi_vault', vault_kv2_path ~ '/secret2 ' ~  conn_params, auth_method='token', token=user_token, return_format='raw') }}"
         kv2_secrets_as_dict: "{{ lookup('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token) }}"
         kv2_secrets_as_values: "{{ query('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token, return_format='values') }}"
@@ -26,7 +27,7 @@
     - name: 'Check secret kv2 values'
       fail:
         msg: 'unexpected secret values'
-      when: kv2_secret1['value'] != 'foo1' or kv2_secret2['value'] != 'foo2'
+      when: kv2_secret1['value'] != 'foo1' or kv2_secret2['value'] != 'foo2' or kv2_secret4['value'] != 'foo5'
 
     - name: 'Check kv2 secret raw return value'
       fail:
@@ -72,7 +73,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-        secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 token=' ~ user_token) }}"
+        secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/non_existent_secret4 token=' ~ user_token) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent


### PR DESCRIPTION
##### SUMMARY

Fixes: ansible/ansible#55658

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/55658_hashi_vault.yml
plugins/lookup/hashi_vault.py
tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
