### PR TITLE
docker_compose: dont start the service if parameter stopped is true

### DIFF
--- a/changelogs/fragments/547-start-service-condition.yaml
+++ b/changelogs/fragments/547-start-service-condition.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - docker_compose - Add a condition to prevent service startup
+    if parameter ``stopped`` is true. Otherwise, the service will be
+    started on each play and stopped again immediately due to
+    the ``stopped`` parameter and breaks the idempotency of the module.

--- a/changelogs/fragments/547-start-service-condition.yaml
+++ b/changelogs/fragments/547-start-service-condition.yaml
@@ -1,6 +1,7 @@
 ---
 bugfixes:
-  - docker_compose - Add a condition to prevent service startup
+  - docker_compose - add a condition to prevent service startup
     if parameter ``stopped`` is true. Otherwise, the service will be
     started on each play and stopped again immediately due to
-    the ``stopped`` parameter and breaks the idempotency of the module.
+    the ``stopped`` parameter and breaks the idempotency of the module
+    (https://github.com/ansible-collections/community.general/issues/532).

--- a/changelogs/fragments/547-start-service-condition.yaml
+++ b/changelogs/fragments/547-start-service-condition.yaml
@@ -5,3 +5,5 @@ bugfixes:
     started on each play and stopped again immediately due to
     the ``stopped`` parameter and breaks the idempotency of the module
     (https://github.com/ansible-collections/community.general/issues/532).
+  - docker_compose - disallow usage of the parameters ``stopped`` and ``restarted``
+    at the same time. This breaks also the idempotency.

--- a/changelogs/fragments/547-start-service-condition.yaml
+++ b/changelogs/fragments/547-start-service-condition.yaml
@@ -6,4 +6,5 @@ bugfixes:
     the ``stopped`` parameter and breaks the idempotency of the module
     (https://github.com/ansible-collections/community.general/issues/532).
   - docker_compose - disallow usage of the parameters ``stopped`` and ``restarted``
-    at the same time. This breaks also the idempotency.
+    at the same time. This breaks also the idempotency
+    (https://github.com/ansible-collections/community.general/issues/532).

--- a/plugins/modules/cloud/docker/docker_compose.py
+++ b/plugins/modules/cloud/docker/docker_compose.py
@@ -639,6 +639,9 @@ class ContainerManager(DockerBaseClass):
                              "Upgrade docker-compose to a min version of %s." %
                              (compose_version, MINIMUM_COMPOSE_VERSION, MINIMUM_COMPOSE_VERSION))
 
+        if self.restarted and self.stopped:
+            self.client.fail("Cannot use restarted and stopped at the same time.")
+
         self.log("options: ")
         self.log(self.options, pretty_print=True)
 

--- a/plugins/modules/cloud/docker/docker_compose.py
+++ b/plugins/modules/cloud/docker/docker_compose.py
@@ -767,7 +767,7 @@ class ContainerManager(DockerBaseClass):
                         ))
                     result['actions'].append(result_action)
 
-        if not self.check_mode and result['changed']:
+        if not self.check_mode and result['changed'] and not self.stopped:
             out_redir_name, err_redir_name = make_redirection_tempfiles()
             try:
                 with stdout_redirector(out_redir_name):


### PR DESCRIPTION
##### SUMMARY
Fixes #532. This PR adds a condition to prevent service startup if parameter `stopped: yes` is set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_compose
