### PR TITLE
Enable ignored sanity tests for apk module

### DIFF
--- a/changelogs/fragments/557_apk.yml
+++ b/changelogs/fragments/557_apk.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- apk - Enable ignored sanity tests for apk module (https://github.com/ansible-collections/community.general/pull/557).

--- a/plugins/modules/packaging/os/apk.py
+++ b/plugins/modules/packaging/os/apk.py
@@ -34,12 +34,15 @@ options:
     description:
       - A package repository or multiple repositories.
         Unlike with the underlying apk command, this list will override the system repositories rather than supplement them.
+    type: list
+    elements: str
   state:
     description:
       - Indicates the desired package(s) state.
       - C(present) ensures the package(s) is/are present.
       - C(absent) ensures the package(s) is/are absent.
       - C(latest) ensures the package(s) is/are present and the latest version(s).
+    type: str
     default: present
     choices: [ "present", "absent", "latest" ]
   update_cache:
@@ -293,7 +296,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'installed', 'absent', 'removed', 'latest']),
             name=dict(type='list', elements='str'),
-            repository=dict(type='list'),
+            repository=dict(type='list', elements='str'),
             update_cache=dict(default=False, type='bool'),
             upgrade=dict(default=False, type='bool'),
             available=dict(default=False, type='bool'),

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1179,9 +1179,6 @@ plugins/modules/packaging/language/pip_package_info.py validate-modules:paramete
 plugins/modules/packaging/language/yarn.py validate-modules:doc-missing-type
 plugins/modules/packaging/language/yarn.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apk.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/packaging/os/apk.py validate-modules:doc-missing-type
-plugins/modules/packaging/os/apk.py validate-modules:parameter-list-no-elements
-plugins/modules/packaging/os/apk.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_repo.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-default-does-not-match-spec

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1178,10 +1178,6 @@ plugins/modules/packaging/language/pear.py validate-modules:undocumented-paramet
 plugins/modules/packaging/language/pip_package_info.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/yarn.py validate-modules:doc-missing-type
 plugins/modules/packaging/language/yarn.py validate-modules:parameter-type-not-in-doc
-plugins/modules/packaging/os/apk.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/packaging/os/apk.py validate-modules:doc-missing-type
-plugins/modules/packaging/os/apk.py validate-modules:parameter-list-no-elements
-plugins/modules/packaging/os/apk.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_repo.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-default-does-not-match-spec

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1178,6 +1178,7 @@ plugins/modules/packaging/language/pear.py validate-modules:undocumented-paramet
 plugins/modules/packaging/language/pip_package_info.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/yarn.py validate-modules:doc-missing-type
 plugins/modules/packaging/language/yarn.py validate-modules:parameter-type-not-in-doc
+plugins/modules/packaging/os/apk.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/packaging/os/apt_repo.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/packaging/os/apt_rpm.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
##### SUMMARY
Fixes #555 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apk
tests/unit/plugins/modules/packaging/os/test_apk.py