### PR TITLE
pkgng: Add stdout and stderr to response object

### DIFF
--- a/changelogs/fragments/560-pkgng-add-stdout-and-stderr.yaml
+++ b/changelogs/fragments/560-pkgng-add-stdout-and-stderr.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pkgng - added stdout and stderr attributes to the result (https://github.com/ansible-collections/community.general/pull/560)

--- a/changelogs/fragments/560-pkgng-add-stdout-and-stderr.yaml
+++ b/changelogs/fragments/560-pkgng-add-stdout-and-stderr.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pkgng - added stdout and stderr attributes to the result (https://github.com/ansible-collections/community.general/pull/560)
+  - pkgng - added ``stdout`` and ``stderr`` attributes to the result (https://github.com/ansible-collections/community.general/pull/560).

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -332,7 +332,7 @@ def autoremove_packages(module, pkgng_path, dir_arg):
         autoremove_c = int(match.group(1))
 
     if autoremove_c == 0:
-        return False, "no package(s) to autoremove"
+        return (False, "no package(s) to autoremove", stdout, stderr)
 
     if not module.check_mode:
         rc, out, err = module.run_command("%s %s autoremove -y" % (pkgng_path, dir_arg))


### PR DESCRIPTION
To ease debugging if something goes wrong during pkg run.

##### SUMMARY
Expose the stdout and stderr of pkg through the result object of the pkgng module. Currently, if something goes wrong during the pkg run, the user has no way to see what happened, which makes recovering from that situation more difficult.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pkgng

##### ADDITIONAL INFORMATION
