### PR TITLE
nmcli: add idempotent support for any kinds of connections

### DIFF
--- a/changelogs/fragments/562-nmcli-fix-idempotency.yaml
+++ b/changelogs/fragments/562-nmcli-fix-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fix idempotetency when modifying an existing connection (https://github.com/ansible-collections/community.general/issues/481).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -675,6 +675,20 @@ class Nmcli(object):
         self.nmcli_bin = self.module.get_bin_path('nmcli', True)
         self.dhcp_client_id = module.params['dhcp_client_id']
 
+        if self.ip4:
+            self.ipv4_method = 'manual'
+        else:
+            # supported values for 'ipv4.method': [auto, link-local, manual, shared, disabled]
+            # TODO: add a new module parameter to specify a non 'manual' value
+            self.ipv4_method = None
+
+        if self.ip6:
+            self.ipv6_method = 'manual'
+        else:
+            # supported values for 'ipv6.method': [ignore, auto, dhcp, link-local, manual, shared]
+            # TODO: add a new module parameter to specify a non 'manual' value
+            self.ipv6_method = None
+
     def execute_command(self, cmd, use_unsafe_shell=False, data=None):
         if isinstance(cmd, list):
             cmd = [to_text(item) for item in cmd]
@@ -821,9 +835,11 @@ class Nmcli(object):
     def modify_connection_team(self):
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
         options = {
+            'ipv4.method': self.ipv4_method,
             'ipv4.address': self.ip4,
             'ipv4.gateway': self.gw4,
             'ipv4.dns': self.dns4,
+            'ipv6.method': self.ipv6_method,
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
@@ -903,9 +919,11 @@ class Nmcli(object):
         # format for modifying bond interface
 
         options = {
+            'ipv4.method': self.ipv4_method,
             'ipv4.address': self.ip4,
             'ipv4.gateway': self.gw4,
             'ipv4.dns': self.dns4,
+            'ipv6.method': self.ipv6_method,
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
@@ -993,9 +1011,11 @@ class Nmcli(object):
         # - nmcli: conn_name=my-eth1 ifname=eth1 type=ethernet ip4=192.0.2.100/24 gw4=192.0.2.1 state=present
         # nmcli con mod con-name my-eth1 ifname eth1 type ethernet ipv4.address 192.0.2.100/24 ipv4.gateway 192.0.2.1
         options = {
+            'ipv4.method': self.ipv4_method,
             'ipv4.address': self.ip4,
             'ipv4.gateway': self.gw4,
             'ipv4.dns': self.dns4,
+            'ipv6.method': self.ipv6_method,
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
@@ -1059,8 +1079,10 @@ class Nmcli(object):
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
 
         options = {
+            'ipv4.method': self.ipv4_method,
             'ipv4.address': self.ip4,
             'ipv4.gateway': self.gw4,
+            'ipv6.method': self.ipv6_method,
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
@@ -1171,9 +1193,11 @@ class Nmcli(object):
 
         params = {'vlan.parent': self.vlandev,
                   'vlan.id': self.vlanid,
+                  'ipv4.method': self.ipv4_method,
                   'ipv4.address': self.ip4 or '',
                   'ipv4.gateway': self.gw4 or '',
                   'ipv4.dns': self.dns4 or '',
+                  'ipv6.method': self.ipv6_method,
                   'ipv6.address': self.ip6 or '',
                   'ipv6.gateway': self.gw6 or '',
                   'ipv6.dns': self.dns6 or '',
@@ -1537,9 +1561,11 @@ class Nmcli(object):
 
         if self.type == 'team':
             override_options = self._compare_conn_params(conn_info, {
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4,
                 'ipv4.gateway': self.gw4,
                 'ipv4.dns': self.dns4,
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6,
                 'ipv6.gateway': self.gw6,
                 'ipv6.dns': self.dns6,
@@ -1555,9 +1581,11 @@ class Nmcli(object):
             })
         elif self.type == 'bond':
             override_options = self._compare_conn_params(conn_info, {
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4,
                 'ipv4.gateway': self.gw4,
                 'ipv4.dns': self.dns4,
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6,
                 'ipv6.gateway': self.gw6,
                 'ipv6.dns': self.dns6,
@@ -1577,9 +1605,11 @@ class Nmcli(object):
             })
         elif self.type == 'ethernet':
             override_options = self._compare_conn_params(conn_info, {
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4,
                 'ipv4.gateway': self.gw4,
                 'ipv4.dns': self.dns4,
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6,
                 'ipv6.gateway': self.gw6,
                 'ipv6.dns': self.dns6,
@@ -1591,8 +1621,10 @@ class Nmcli(object):
             })
         elif self.type == 'bridge':
             override_options = self._compare_conn_params(conn_info, {
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4,
                 'ipv4.gateway': self.gw4,
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6,
                 'ipv6.gateway': self.gw6,
                 'autoconnect': self.bool_to_string(self.autoconnect),
@@ -1615,9 +1647,11 @@ class Nmcli(object):
             override_options = self._compare_conn_params(conn_info, {
                 'vlan.parent': self.vlandev,
                 'vlan.id': self.vlanid,
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4 or '',
                 'ipv4.gateway': self.gw4 or '',
                 'ipv4.dns': self.dns4 or '',
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6 or '',
                 'ipv6.gateway': self.gw6 or '',
                 'ipv6.dns': self.dns6 or '',
@@ -1644,9 +1678,11 @@ class Nmcli(object):
             })
         elif self.type == 'generic':
             override_options = self._compare_conn_params(conn_info, {
+                'ipv4.method': self.ipv4_method,
                 'ipv4.addresses': self.ip4,
                 'ipv4.gateway': self.gw4,
                 'ipv4.dns': self.dns4,
+                'ipv6.method': self.ipv6_method,
                 'ipv6.addresses': self.ip6,
                 'ipv6.gateway': self.gw6,
                 'ipv6.dns': self.dns6,

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1451,37 +1451,19 @@ class Nmcli(object):
 
     def show_connection(self):
         cmd = [self.nmcli_bin, 'con', 'show']
-        if self.type == 'vlan':
-            if self.conn_name is not None:
-                cmd.append(self.conn_name)
-            elif self.ifname is not None:
-                cmd.append(self.ifname)
-            else:
-                cmd.append('vlan%s' % to_text(self.vlanid))
-        elif self.type == 'vxlan':
-            if self.conn_name is not None:
-                cmd.append(self.conn_name)
-            elif self.ifname is not None:
-                cmd.append(self.ifname)
-            else:
-                cmd.append('vxlan%s' % to_text(self.vxlan_id))
-        elif self.type == 'ipip':
-            if self.conn_name is not None:
-                cmd.append(self.conn_name)
-            elif self.ifname is not None:
-                cmd.append(self.ifname)
-            elif self.ip_tunnel_dev is not None:
-                cmd.append('ipip%s' % self.ip_tunnel_dev)
-        elif self.type == 'sit':
-            if self.conn_name is not None:
-                cmd.append(self.conn_name)
-            elif self.ifname is not None:
-                cmd.append(self.ifname)
-            elif self.ip_tunnel_dev is not None:
-                cmd.append('sit%s' % self.ip_tunnel_dev)
+        if self.conn_name is not None:
+            cmd.append(self.conn_name)
+        elif self.ifname is not None:
+            cmd.append(self.ifname)
         else:
-            if self.conn_name is not None:
-                cmd.append(self.conn_name)
+            if self.type == 'vlan':
+                cmd.append('vlan%s' % to_text(self.vlanid))
+            elif self.type == 'vxlan':
+                cmd.append('vxlan%s' % to_text(self.vxlan_id))
+            elif self.type == 'ipip':
+                cmd.append('ipip%s' % self.ip_tunnel_dev)
+            elif self.type == 'sit':
+                cmd.append('sit%s' % self.ip_tunnel_dev)
             else:
                 raise NmcliModuleError(
                     "Invalid connection identifier for nmcli")

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -476,7 +476,7 @@ def test_bond_connection_unchanged(mocked_bond_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
@@ -545,7 +545,7 @@ def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
@@ -601,7 +601,7 @@ def test_generic_connection_dns_search_unchanged(mocked_generic_connection_dns_s
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_CONNECTION, indirect=['patch_ansible_module'])
@@ -684,7 +684,7 @@ def test_bridge_connection_unchanged(mocked_bridge_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE_SLAVE, indirect=['patch_ansible_module'])
@@ -755,7 +755,7 @@ def test_bridge_slave_unchanged(mocked_bridge_slave_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VLAN, indirect=['patch_ansible_module'])
@@ -826,7 +826,7 @@ def test_vlan_connection_unchanged(mocked_vlan_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VXLAN, indirect=['patch_ansible_module'])
@@ -896,7 +896,7 @@ def test_vxlan_connection_unchanged(mocked_vxlan_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_IPIP, indirect=['patch_ansible_module'])
@@ -971,7 +971,7 @@ def test_ipip_connection_unchanged(mocked_ipip_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SIT, indirect=['patch_ansible_module'])
@@ -1046,7 +1046,7 @@ def test_sit_connection_unchanged(mocked_sit_connection_unchanged, capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_ETHERNET_DHCP, indirect=['patch_ansible_module'])
@@ -1080,4 +1080,4 @@ def test_ethernet_connection_dhcp_unchanged(mocked_ethernet_connection_dhcp_unch
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
-    assert results['changed'] == False
+    assert not results['changed']

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -203,8 +203,7 @@ TESTCASE_ETHERNET_DHCP = [
     }
 ]
 
-
-def mocker_set(mocker, connection_exists=False):
+def mocker_set(mocker, connection_exists=False, is_connection_changed=True):
     """
     Common mocker object
     """
@@ -212,6 +211,8 @@ def mocker_set(mocker, connection_exists=False):
     mocker.patch('ansible_collections.community.general.plugins.modules.net_tools.nmcli.HAVE_NM_CLIENT', True)
     get_bin_path = mocker.patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     get_bin_path.return_value = '/usr/bin/nmcli'
+    connection_changed = mocker.patch.object(nmcli.Nmcli, 'is_connection_changed')
+    connection_changed.return_value = is_connection_changed
     connection = mocker.patch.object(nmcli.Nmcli, 'connection_exists')
     connection.return_value = connection_exists
     return connection

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -78,19 +78,28 @@ TESTCASE_GENERIC = [
         'type': 'generic',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'generic_non_existant',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'state': 'present',
         '_ansible_check_mode': False,
     },
 ]
 
+TESTCASE_GENERIC_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              generic_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+"""
+
 TESTCASE_GENERIC_DNS4_SEARCH = [
     {
         'type': 'generic',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'generic_non_existant',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'state': 'present',
         'dns4_search': 'search.redhat.com',
@@ -99,13 +108,24 @@ TESTCASE_GENERIC_DNS4_SEARCH = [
     }
 ]
 
+TESTCASE_GENERIC_DNS4_SEARCH_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              generic_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.dns-search:                        search.redhat.com
+ipv6.dns-search:                        search6.redhat.com
+"""
+
 TESTCASE_BOND = [
     {
         'type': 'bond',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'bond_non_existant',
         'mode': 'active-backup',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'state': 'present',
         'primary': 'non_existent_primary',
@@ -113,12 +133,22 @@ TESTCASE_BOND = [
     }
 ]
 
+TESTCASE_BOND_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              bond_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+bond.options:                           mode=active-backup,primary=non_existent_primary
+"""
+
 TESTCASE_BRIDGE = [
     {
         'type': 'bridge',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'br0_non_existant',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'maxage': 100,
         'stp': True,
@@ -126,6 +156,21 @@ TESTCASE_BRIDGE = [
         '_ansible_check_mode': False,
     }
 ]
+
+TESTCASE_BRIDGE_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              br0_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+bridge.stp:                             yes
+bridge.max-age:                         100
+bridge.ageing-time:                     300
+bridge.hello-time:                      2
+bridge.priority:                        128
+bridge.forward-delay:                   15
+"""
 
 TESTCASE_BRIDGE_SLAVE = [
     {
@@ -138,18 +183,37 @@ TESTCASE_BRIDGE_SLAVE = [
     }
 ]
 
+TESTCASE_BRIDGE_SLAVE_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              br0_non_existant
+connection.autoconnect:                 yes
+bridge-port.path-cost:                  100
+bridge-port.hairpin-mode:               yes
+bridge-port.priority:                   32
+"""
+
 TESTCASE_VLAN = [
     {
         'type': 'vlan',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'vlan_not_exists',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'vlanid': 10,
         'state': 'present',
         '_ansible_check_mode': False,
     }
 ]
+
+TESTCASE_VLAN_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              vlan_not_exists
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+vlan.id:                                10
+"""
 
 TESTCASE_VXLAN = [
     {
@@ -164,6 +228,15 @@ TESTCASE_VXLAN = [
     }
 ]
 
+TESTCASE_VXLAN_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              existent_nw_device
+connection.autoconnect:                 yes
+vxlan.id:                               11
+vxlan.local:                            192.168.225.5
+vxlan.remote:                           192.168.225.6
+"""
+
 TESTCASE_IPIP = [
     {
         'type': 'ipip',
@@ -176,6 +249,16 @@ TESTCASE_IPIP = [
         '_ansible_check_mode': False,
     }
 ]
+
+TESTCASE_IPIP_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              ipip-existent_nw_device
+connection.autoconnect:                 yes
+ip-tunnel.mode:                         ipip
+ip-tunnel.parent:                       non_existent_ipip_device
+ip-tunnel.local:                        192.168.225.5
+ip-tunnel.remote:                       192.168.225.6
+"""
 
 TESTCASE_SIT = [
     {
@@ -190,12 +273,22 @@ TESTCASE_SIT = [
     }
 ]
 
+TESTCASE_SIT_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              sit-existent_nw_device
+connection.autoconnect:                 yes
+ip-tunnel.mode:                         sit
+ip-tunnel.parent:                       non_existent_sit_device
+ip-tunnel.local:                        192.168.225.5
+ip-tunnel.remote:                       192.168.225.6
+"""
+
 TESTCASE_ETHERNET_DHCP = [
     {
         'type': 'ethernet',
         'conn_name': 'non_existent_nw_device',
         'ifname': 'ethernet_non_existant',
-        'ip4': '10.10.10.10',
+        'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'state': 'present',
         '_ansible_check_mode': False,
@@ -203,7 +296,18 @@ TESTCASE_ETHERNET_DHCP = [
     }
 ]
 
-def mocker_set(mocker, connection_exists=False, is_connection_changed=True):
+TESTCASE_ETHERNET_DHCP_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              vlan_not_exists
+connection.autoconnect:                 yes
+ipv4.method:                            auto
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.dhcp-client-id:                    00:11:22:AA:BB:CC:DD
+"""
+
+
+def mocker_set(mocker, connection_exists=False):
     """
     Common mocker object
     """
@@ -211,8 +315,6 @@ def mocker_set(mocker, connection_exists=False, is_connection_changed=True):
     mocker.patch('ansible_collections.community.general.plugins.modules.net_tools.nmcli.HAVE_NM_CLIENT', True)
     get_bin_path = mocker.patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     get_bin_path.return_value = '/usr/bin/nmcli'
-    connection_changed = mocker.patch.object(nmcli.Nmcli, 'is_connection_changed')
-    connection_changed.return_value = is_connection_changed
     connection = mocker.patch.object(nmcli.Nmcli, 'connection_exists')
     connection.return_value = connection_exists
     return connection
@@ -222,15 +324,7 @@ def mocker_set(mocker, connection_exists=False, is_connection_changed=True):
 def mocked_generic_connection_create(mocker):
     mocker_set(mocker)
     command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
-    command_result.return_value = {"rc": 100, "out": "aaa", "err": "none"}
-    return command_result
-
-
-@pytest.fixture
-def mocked_generic_connection_modify(mocker):
-    mocker_set(mocker, connection_exists=True)
-    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
-    command_result.return_value = {"rc": 100, "out": "aaa", "err": "none"}
+    command_result.return_value = (0, "", "")
     return command_result
 
 
@@ -240,8 +334,108 @@ def mocked_connection_exists(mocker):
     return connection
 
 
+@pytest.fixture
+def mocked_generic_connection_modify(mocker):
+    mocker_set(mocker, connection_exists=True)
+    connection_changed = mocker.patch.object(
+        nmcli.Nmcli, 'is_connection_changed')
+    connection_changed.return_value = True
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, "", "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_generic_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_GENERIC_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_generic_connection_dns_search_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (
+        0, TESTCASE_GENERIC_DNS4_SEARCH_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_bond_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_BOND_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_bridge_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_BRIDGE_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_bridge_slave_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_BRIDGE_SLAVE_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_vlan_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_VLAN_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_vxlan_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_VXLAN_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_ipip_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_IPIP_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_sit_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_SIT_SHOW_OUTPUT, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_ethernet_connection_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_ETHERNET_DHCP, "")
+    return command_result
+
+
+@pytest.fixture
+def mocked_ethernet_connection_dhcp_unchanged(mocker):
+    mocker_set(mocker, connection_exists=True)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = (0, TESTCASE_ETHERNET_DHCP_SHOW_OUTPUT, "")
+    return command_result
+
+
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BOND, indirect=['patch_ansible_module'])
-def test_bond_connection_create(mocked_generic_connection_create):
+def test_bond_connection_create(mocked_generic_connection_create, capfd):
     """
     Test : Bond connection created
     """
@@ -265,9 +459,28 @@ def test_bond_connection_create(mocked_generic_connection_create):
     for param in ['gw4', 'primary', 'autoconnect', 'mode', 'active-backup', 'ip4']:
         assert param in args[0]
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_BOND, indirect=['patch_ansible_module'])
+def test_bond_connection_unchanged(mocked_bond_connection_unchanged, capfd):
+    """
+    Test : Bond connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
-def test_generic_connection_create(mocked_generic_connection_create):
+def test_generic_connection_create(mocked_generic_connection_create, capfd):
     """
     Test : Generic connection created
     """
@@ -289,9 +502,14 @@ def test_generic_connection_create(mocked_generic_connection_create):
     for param in ['autoconnect', 'gw4', 'ip4']:
         assert param in args[0]
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
-def test_generic_connection_modify(mocked_generic_connection_modify):
+def test_generic_connection_modify(mocked_generic_connection_modify, capfd):
     """
     Test : Generic connection modify
     """
@@ -310,9 +528,28 @@ def test_generic_connection_modify(mocked_generic_connection_modify):
     for param in ['ipv4.gateway', 'ipv4.address']:
         assert param in args[0]
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
+def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd):
+    """
+    Test : Generic connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
-def test_generic_connection_create_dns_search(mocked_generic_connection_create):
+def test_generic_connection_create_dns_search(mocked_generic_connection_create, capfd):
     """
     Test : Generic connection created with dns search
     """
@@ -326,9 +563,14 @@ def test_generic_connection_create_dns_search(mocked_generic_connection_create):
     assert 'ipv4.dns-search' in args[0]
     assert 'ipv6.dns-search' in args[0]
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
-def test_generic_connection_modify_dns_search(mocked_generic_connection_create):
+def test_generic_connection_modify_dns_search(mocked_generic_connection_create, capfd):
     """
     Test : Generic connection modified with dns search
     """
@@ -342,6 +584,25 @@ def test_generic_connection_modify_dns_search(mocked_generic_connection_create):
     assert 'ipv4.dns-search' in args[0]
     assert 'ipv6.dns-search' in args[0]
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
+def test_generic_connection_dns_search_unchanged(mocked_generic_connection_dns_search_unchanged, capfd):
+    """
+    Test : Generic connection with dns search unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_CONNECTION, indirect=['patch_ansible_module'])
 def test_dns4_none(mocked_connection_exists, capfd):
@@ -353,11 +614,12 @@ def test_dns4_none(mocked_connection_exists, capfd):
 
     out, err = capfd.readouterr()
     results = json.loads(out)
+    assert not results.get('failed')
     assert results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE, indirect=['patch_ansible_module'])
-def test_create_bridge(mocked_generic_connection_create):
+def test_create_bridge(mocked_generic_connection_create, capfd):
     """
     Test if Bridge created
     """
@@ -376,12 +638,17 @@ def test_create_bridge(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
+    for param in ['ip4', '10.10.10.10/24', 'gw4', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
         assert param in map(to_text, args[0])
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE, indirect=['patch_ansible_module'])
-def test_mod_bridge(mocked_generic_connection_modify):
+def test_mod_bridge(mocked_generic_connection_modify, capfd):
     """
     Test if Bridge modified
     """
@@ -397,12 +664,31 @@ def test_mod_bridge(mocked_generic_connection_modify):
     assert args[0][1] == 'con'
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
-    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
+    for param in ['ipv4.address', '10.10.10.10/24', 'ipv4.gateway', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
         assert param in map(to_text, args[0])
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE, indirect=['patch_ansible_module'])
+def test_bridge_connection_unchanged(mocked_bridge_connection_unchanged, capfd):
+    """
+    Test : Bridge connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE_SLAVE, indirect=['patch_ansible_module'])
-def test_create_bridge_slave(mocked_generic_connection_create):
+def test_create_bridge_slave(mocked_generic_connection_create, capfd):
     """
     Test if Bridge_slave created
     """
@@ -425,9 +711,14 @@ def test_create_bridge_slave(mocked_generic_connection_create):
     for param in ['bridge-port.path-cost', '100']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE_SLAVE, indirect=['patch_ansible_module'])
-def test_mod_bridge_slave(mocked_generic_connection_modify):
+def test_mod_bridge_slave(mocked_generic_connection_modify, capfd):
     """
     Test if Bridge_slave modified
     """
@@ -447,9 +738,28 @@ def test_mod_bridge_slave(mocked_generic_connection_modify):
     for param in ['bridge-port.path-cost', '100']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_BRIDGE_SLAVE, indirect=['patch_ansible_module'])
+def test_bridge_slave_unchanged(mocked_bridge_slave_unchanged, capfd):
+    """
+    Test : Bridge-slave connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VLAN, indirect=['patch_ansible_module'])
-def test_create_vlan_con(mocked_generic_connection_create):
+def test_create_vlan_con(mocked_generic_connection_create, capfd):
     """
     Test if VLAN created
     """
@@ -469,12 +779,17 @@ def test_create_vlan_con(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'id', '10']:
+    for param in ['ip4', '10.10.10.10/24', 'gw4', '10.10.10.1', 'id', '10']:
         assert param in map(to_text, args[0])
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VLAN, indirect=['patch_ansible_module'])
-def test_mod_vlan_conn(mocked_generic_connection_modify):
+def test_mod_vlan_conn(mocked_generic_connection_modify, capfd):
     """
     Test if VLAN modified
     """
@@ -491,12 +806,31 @@ def test_mod_vlan_conn(mocked_generic_connection_modify):
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
 
-    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'vlan.id', '10']:
+    for param in ['ipv4.address', '10.10.10.10/24', 'ipv4.gateway', '10.10.10.1', 'vlan.id', '10']:
         assert param in map(to_text, args[0])
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VLAN, indirect=['patch_ansible_module'])
+def test_vlan_connection_unchanged(mocked_vlan_connection_unchanged, capfd):
+    """
+    Test : VLAN connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VXLAN, indirect=['patch_ansible_module'])
-def test_create_vxlan(mocked_generic_connection_create):
+def test_create_vxlan(mocked_generic_connection_create, capfd):
     """
     Test if vxlan created
     """
@@ -519,9 +853,14 @@ def test_create_vxlan(mocked_generic_connection_create):
     for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', '11']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VXLAN, indirect=['patch_ansible_module'])
-def test_vxlan_mod(mocked_generic_connection_modify):
+def test_vxlan_mod(mocked_generic_connection_modify, capfd):
     """
     Test if vxlan modified
     """
@@ -540,9 +879,28 @@ def test_vxlan_mod(mocked_generic_connection_modify):
     for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', '11']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VXLAN, indirect=['patch_ansible_module'])
+def test_vxlan_connection_unchanged(mocked_vxlan_connection_unchanged, capfd):
+    """
+    Test : VxLAN connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_IPIP, indirect=['patch_ansible_module'])
-def test_create_ipip(mocked_generic_connection_create):
+def test_create_ipip(mocked_generic_connection_create, capfd):
     """
     Test if ipip created
     """
@@ -570,9 +928,14 @@ def test_create_ipip(mocked_generic_connection_create):
     for param in ['ip-tunnel.local', '192.168.225.5', 'ip-tunnel.remote', '192.168.225.6']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_IPIP, indirect=['patch_ansible_module'])
-def test_ipip_mod(mocked_generic_connection_modify):
+def test_ipip_mod(mocked_generic_connection_modify, capfd):
     """
     Test if ipip modified
     """
@@ -591,9 +954,28 @@ def test_ipip_mod(mocked_generic_connection_modify):
     for param in ['ip-tunnel.local', '192.168.225.5', 'ip-tunnel.remote', '192.168.225.6']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_IPIP, indirect=['patch_ansible_module'])
+def test_ipip_connection_unchanged(mocked_ipip_connection_unchanged, capfd):
+    """
+    Test : IPIP connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SIT, indirect=['patch_ansible_module'])
-def test_create_sit(mocked_generic_connection_create):
+def test_create_sit(mocked_generic_connection_create, capfd):
     """
     Test if sit created
     """
@@ -621,9 +1003,14 @@ def test_create_sit(mocked_generic_connection_create):
     for param in ['ip-tunnel.local', '192.168.225.5', 'ip-tunnel.remote', '192.168.225.6']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SIT, indirect=['patch_ansible_module'])
-def test_sit_mod(mocked_generic_connection_modify):
+def test_sit_mod(mocked_generic_connection_modify, capfd):
     """
     Test if sit modified
     """
@@ -642,9 +1029,28 @@ def test_sit_mod(mocked_generic_connection_modify):
     for param in ['ip-tunnel.local', '192.168.225.5', 'ip-tunnel.remote', '192.168.225.6']:
         assert param in map(to_text, args[0])
 
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SIT, indirect=['patch_ansible_module'])
+def test_sit_connection_unchanged(mocked_sit_connection_unchanged, capfd):
+    """
+    Test : SIT connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_ETHERNET_DHCP, indirect=['patch_ansible_module'])
-def test_eth_dhcp_client_id_con_create(mocked_generic_connection_create):
+def test_eth_dhcp_client_id_con_create(mocked_generic_connection_create, capfd):
     """
     Test : Ethernet connection created with DHCP_CLIENT_ID
     """
@@ -656,3 +1062,22 @@ def test_eth_dhcp_client_id_con_create(mocked_generic_connection_create):
     args, kwargs = arg_list[0]
 
     assert 'ipv4.dhcp-client-id' in args[0]
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_ETHERNET_DHCP, indirect=['patch_ansible_module'])
+def test_ethernet_connection_dhcp_unchanged(mocked_ethernet_connection_dhcp_unchanged, capfd):
+    """
+    Test : Ethernet connection with DHCP_CLIENT_ID unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed'] == False

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -365,7 +365,7 @@ def mocked_generic_connection_modify(mocker):
     mocker_set(mocker, connection_exists=True)
     connection_changed = mocker.patch.object(
         nmcli.Nmcli, 'is_connection_changed')
-    connection_changed.return_value = True
+    connection_changed.return_value = (True, dict())
     command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
     command_result.return_value = (0, "", "")
     return command_result
@@ -1165,8 +1165,8 @@ def test_create_ethernet_static(mocked_generic_connection_create, capfd):
 
     assert nmcli.Nmcli.execute_command.call_count == 3
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, _ = arg_list[0]
-    mod_args, _ = arg_list[1]
+    add_args, add_kw = arg_list[0]
+    mod_args, mod_kw = arg_list[1]
 
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'


### PR DESCRIPTION
##### SUMMARY
`nmcli` module does not know the previous state of an interface and always returns a status of "changed" even when nothing does. This PR implemented an idempotent check to modify connections only if changes are detected. The command line arguments and property aliases are slightly different between a variety of connection types.

- Implement show_connection() to retrieve connection profile from command line
- Parse integer enumeration values in show_connection()
- Convert 'bond.options' to alias shortcuts
- Modify connection only if changes are detected
- Support generic alias in during the property comparison

Fixes #481

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py
tests/unit/plugins/modules/net_tools/test_nmcli.py

##### ADDITIONAL INFORMATION
An example of playbook snippet to reproduce this issue:
```yaml
- name: configure network interface
  nmcli:
    conn_name: eth2
    type: ethernet
    mtu: 9000
    ip4: '172.31.250.2/24'
    autoconnect: yes
    state: present
```
