### PR TITLE
Fix terraform changed status detection test (#561)

### DIFF
--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -368,7 +368,7 @@ def main():
     if needs_application and not module.check_mode and not state == 'planned':
         rc, out, err = module.run_command(command, cwd=project_path)
         # checks out to decide if changes were made during execution
-        if '0 added, 0 changed' not in out and not state == "absent" or '0 destroyed' not in out:
+        if ' 0 added, 0 changed' not in out and not state == "absent" or ' 0 destroyed' not in out:
             changed = True
         if rc != 0:
             module.fail_json(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Closes #561 

Prevents `terraform` module's test for detecting task's `changed` state being incorrectly reported as `False` when number of resources added/deleted are multiples of 10. The original code would incorrectly detect number of changed terrafrom resources ending in 0 (eg 10) as unchanged by matching the pattern `0 added, 0 changed` in the task output if it contained, for example, `Resources: 10 added, 0 changed`.

Considered using regex to tighten the test's search pattern but decided not to progress this route as
1. Resultant code looked overly-complicated
2. Avoids importing `re` module
3. Final fix makes minimal changes to the original code

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`community.general\plugins\modules\cloud\misc\terraform.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
See original issue (#561) for further details.