### PR TITLE
use Config MacAddress by default instead of Networks

### DIFF
--- a/changelogs/fragments/564-docker_container_use_config_macaddress_by_default.yaml
+++ b/changelogs/fragments/564-docker_container_use_config_macaddress_by_default.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_container - use Config MacAddress by default instead of Networks. Networks MacAddress is empty in some cases (https://github.com/ansible/ansible/issues/70206).

--- a/plugins/modules/cloud/docker/docker_container.py
+++ b/plugins/modules/cloud/docker/docker_container.py
@@ -2122,6 +2122,7 @@ class Container(DockerBaseClass):
             labels=config.get('Labels'),
             expected_links=host_config.get('Links'),
             mac_address=network.get('MacAddress'),
+            mac_address=config.get('MacAddress', network.get('MacAddress')),
             memory_swappiness=host_config.get('MemorySwappiness'),
             network_mode=host_config.get('NetworkMode'),
             userns_mode=host_config.get('UsernsMode'),

--- a/plugins/modules/cloud/docker/docker_container.py
+++ b/plugins/modules/cloud/docker/docker_container.py
@@ -2121,7 +2121,6 @@ class Container(DockerBaseClass):
             ipc_mode=host_config.get("IpcMode"),
             labels=config.get('Labels'),
             expected_links=host_config.get('Links'),
-            mac_address=network.get('MacAddress'),
             mac_address=config.get('MacAddress', network.get('MacAddress')),
             memory_swappiness=host_config.get('MemorySwappiness'),
             network_mode=host_config.get('NetworkMode'),


### PR DESCRIPTION
##### SUMMARY
mac_address in `NetworkSettings`  is empty when using `macvlan` network only

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`docker_container`

##### ADDITIONAL INFORMATION
```
$ ansible --version
ansible 2.9.10
  config file = None
  configured module search path = [u'/Users/k-petrov/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/k-petrov/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Feb 22 2019, 21:55:15) [GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)]
```
##### CONFIGURATION
<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
```
$ ansible-config dump --only-changed
ANSIBLE_NOCOWS(/Users/k-petrov/work/ansible/ansible.cfg) = True
ANSIBLE_PIPELINING(/Users/k-petrov/work/ansible/ansible.cfg) = True
ANSIBLE_SSH_ARGS(/Users/k-petrov/work/ansible/ansible.cfg) =
ANSIBLE_SSH_CONTROL_PATH(/Users/k-petrov/work/ansible/ansible.cfg) = ~/.ssh/mux-%r@%h:%p
DEFAULT_BECOME(/Users/k-petrov/work/ansible/ansible.cfg) = True
DEFAULT_BECOME_METHOD(/Users/k-petrov/work/ansible/ansible.cfg) = sudo
DEFAULT_FORKS(/Users/k-petrov/work/ansible/ansible.cfg) = 12
DEFAULT_GATHERING(/Users/k-petrov/work/ansible/ansible.cfg) = implicit
DEFAULT_HASH_BEHAVIOUR(/Users/k-petrov/work/ansible/ansible.cfg) = merge
DEFAULT_HOST_LIST(/Users/k-petrov/work/ansible/ansible.cfg) = [u'/Users/k-petrov/work/ansible/hosts']
DEFAULT_MANAGED_STR(/Users/k-petrov/work/ansible/ansible.cfg) = Ansible managed: modified on %Y-%m-%d %H:%M:%S by {uid}
DEFAULT_ROLES_PATH(/Users/k-petrov/work/ansible/ansible.cfg) = [u'/Users/k-petrov/work/ansible/roles']
DEFAULT_SCP_IF_SSH(/Users/k-petrov/work/ansible/ansible.cfg) = False
DEFAULT_TIMEOUT(/Users/k-petrov/work/ansible/ansible.cfg) = 30
DEFAULT_VAULT_PASSWORD_FILE(/Users/k-petrov/work/ansible/ansible.cfg) = /Users/k-petrov/work/ansible/pass
DEPRECATION_WARNINGS(/Users/k-petrov/work/ansible/ansible.cfg) = False
HOST_KEY_CHECKING(/Users/k-petrov/work/ansible/ansible.cfg) = False
TRANSFORM_INVALID_GROUP_CHARS(/Users/k-petrov/work/ansible/ansible.cfg) = never
```

##### OS / ENVIRONMENT
```
$ uname -a
Darwin k-petrov-osx.local 18.7.0 Darwin Kernel Version 18.7.0: Tue Aug 20 16:57:14 PDT 2019; root:xnu-4903.271.2~2/RELEASE_X86_64 x86_64
```
on server:
```
$ uname -a
Linux server 4.4.0-109-generic #132-Ubuntu SMP Tue Jan 9 19:52:39 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

$ lsb_release -a
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.3 LTS
Release:	16.04
Codename:	xenial

$ docker info
Client:
 Debug Mode: false

Server:
 Containers: 2
  Running: 2
  Paused: 0
  Stopped: 0
 Images: 3
 Server Version: 19.03.7
 Storage Driver: overlay2
  Backing Filesystem: <unknown>
  Supports d_type: true
  Native Overlay Diff: true
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 7ad184331fa3e55e52b890ea95e65ba581ae3429
 runc version: dc9208a3303feef5b3839f4323d9beb36df0a9dd
 init version: fec3683
 Security Options:
  apparmor
  seccomp
   Profile: default
 Kernel Version: 4.4.0-109-generic
 Operating System: Ubuntu 16.04.3 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 24
 Total Memory: 47.16GiB
 Name: server
 ID: M7FS:WUBW:3XDN:ATTG:OHFB:XOFE:ND4A:A225:LNWO:WYJ5:GI5S:GSLR
 Docker Root Dir: /mnt/data/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false

$ pip freeze | grep -i 'dock'
docker==4.2.1
docker-compose==1.8.0
docker-py==1.9.0
dockerpty==0.4.1

$ dpkg -l | egrep -i 'docker|containerd'
ii  containerd.io                       1.2.13-1                                   amd64        An open and reliable container runtime
ii  docker-ce                           5:19.03.7~3-0~ubuntu-xenial                amd64        Docker: the open-source application container engine
ii  docker-ce-cli                       5:19.03.7~3-0~ubuntu-xenial                amd64        Docker CLI: the open-source application container engine
ii  docker-compose                      1.8.0-2~16.04.1                            all          Punctual, lightweight development environments using Docker
ii  python-docker                       1.9.0-1~16.04.1                            all          Python wrapper to access docker.io's control socket
ii  python-dockerpty                    0.4.1-1~16.04.1                            all          Pseudo-tty handler for docker Python client (Python 2.x)
```


##### STEPS TO REPRODUCE
<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->

<!--- Paste example playbooks or commands between quotes below -->
```yaml
- hosts: all
  tasks:
    - name: ensure docker network is exists
      docker_network:
        name: 'macvlan_network'
        driver: 'macvlan'
        driver_options:
          parent: 'enp1s0f0'
        enable_ipv6: no
        appends: yes
        ipam_config:
          - subnet: '172.16.10.0/24'
            gateway: '172.16.10.252'
        force: no
      tags: [ docker, docker_network ]

    - name: create docker container
      docker_container:
        name: 'docker-mac_address-test'
        image: 'alpine'
        command: 'sleep 3600'
        restart_policy: 'always'
        mac_address: '00:16:3e:dd:be:ef'
        hostname: 'docker-mac_address-test'
        networks_cli_compatible: yes
        networks:
          - name: 'macvlan_network'
            ipv4_address: '172.16.10.18'
      tags: [ docker, docker_container ]
```

##### EXPECTED RESULTS
changed=0 (no diff) for task `create docker container`

##### ACTUAL RESULTS
```
    "diff": {
        "after": {
            "mac_address": "00:16:3e:dd:be:ef",
            "running": true
        },
        "before": {
            "mac_address": "",
            "running": true
        },
        "differences": [
            {
                "mac_address": {
                    "container": "",
                    "parameter": "00:16:3e:dd:be:ef"
                }
            }
        ]
    },
```

on server:
```
$ docker inspect docker-mac_address-test --format '{{.NetworkSettings.MacAddress}},{{.Config.MacAddress}}'
,00:16:3e:dd:be:ef
```