### PR TITLE
WIP: parted refactoring before busy partition fix

### DIFF
--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -105,9 +105,9 @@ options:
   ignore_kernel:
     description:
       - By default parted fails when partition on C(device) is used by kernel and modification script might not be executed in whole.
-      - When C(ingore_kernel) = C(true) module edits table contents on C(device) even if current table is used by kernel 
-      - This is achieved by multiple parted program calls and ignoring "WARNING: the kernel failed to re-read the partition table" messages.
-      - You may need to use partprobe, kpartx or even reboot the system to make the kernel recognize changes in partition table.
+      - When C(ingore_kernel) = C(true) module edits table contents on C(device) even if current table is used by kernel
+      - This is achieved by multiple parted program calls and ignoring kernel re-reading warnings.
+      - You may need to use utilities like partprobe, kpartx or even reboot the system to make the kernel recognize changes in partition table.
     type: bool
     default: False
     version+added: '1.0.0'

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -110,7 +110,7 @@ options:
       - You may need to use utilities like partprobe, kpartx or even reboot the system to make the kernel recognize changes in partition table.
     type: bool
     default: False
-    version+added: '1.0.0'
+    version_added: '1.0.0'
 notes:
   - When fetching information about a new disk and when the version of parted
     installed on the system is before version 3.1, the module queries the kernel

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -105,7 +105,7 @@ options:
   ignore_kernel:
     description:
       - By default parted fails when partition on C(device) is used by kernel and modification script might not be executed in whole.
-      - When C(ingore_kernel) = C(true) module edits table contents on C(device) even if current table is used by kernel
+      - When I(ingore_kernel) = C(true) module edits table contents on C(device) even if current table is used by kernel.
       - This is achieved by multiple parted program calls and ignoring kernel re-reading warnings.
       - You may need to use utilities like partprobe, kpartx or even reboot the system to make the kernel recognize changes in partition table.
     type: bool

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -520,6 +520,7 @@ def parted(script, device, align='', unit=''):
 
     return script
 
+
 def run_parted(command):
     """
     Runs formatted parted script
@@ -530,6 +531,7 @@ def run_parted(command):
             msg="Error while running parted script: %s" % command.strip(),
             rc=rc, out=out, err=err
         )
+
 
 def read_record(file_path, default=None):
     """

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -572,7 +572,7 @@ def main():
     global module, units_si, units_iec, parted_exec
 
     changed = False
-    output_script = ""
+    output_scripts = []
     commands = []
     module = AnsibleModule(
         argument_spec=dict(
@@ -667,7 +667,7 @@ def main():
         # This will create the partition for the next steps
         if commands:
             script = parted(commands, device, align, unit)
-            output_script += script
+            output_scripts.append(script)
             commands = []
             changed = True
 
@@ -711,7 +711,7 @@ def main():
         if commands:
             script = parted(commands, device, align, unit)
             changed = True
-            output_script += script
+            output_scripts.append(script)
 
     elif state == 'absent':
         # Remove the partition
@@ -719,10 +719,10 @@ def main():
             script = "rm %s" % number
             changed = True
             script = parted([script], device)
-            output_script += script
+            output_scripts.append(script)
 
     elif state == 'info':
-        output_script = "unit '%s' print" % unit
+        output_scripts = ["unit '%s' print" % unit]
 
     # Final status of the device
     final_device_status = get_device_info(device, unit)
@@ -730,7 +730,7 @@ def main():
         changed=changed,
         disk=final_device_status['generic'],
         partitions=final_device_status['partitions'],
-        script=output_script.strip()
+        script=" ".join(output_scripts)
     )
 
 


### PR DESCRIPTION
Some parted module refactoring before fixing  #252

I will keep this PR mergeable, but only for reviews and shippable tests, until actual fix is completed.

##### SUMMARY
parted:
* unit parameter and final script formatting in parted()
* align and unit parameters optional
* returns script as formatted by parted()
* parted() takes list of commands to execute

unittests:
* run_parted() to mock instead of parted()
* test_change_flag changed, no need to track mock calls

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION

Goal:
* by default, all commands in script list will be executed at once
* if user requests busy table operation, script commands will be executed one by one
* 'busy partition' errors will be ignored
* additional checks on result table to confirm that partitions were changed on disk, even though kernel info was not updated