### PR TITLE
airbrake_deployment: Add version param

### DIFF
--- a/changelogs/fragments/airbrake_deployment_add_version.yml
+++ b/changelogs/fragments/airbrake_deployment_add_version.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "airbrake_deployment - Add ``version`` param; clarified docs on ``revision`` param"
+  - "airbrake_deployment - add ``version`` param; clarified docs on ``revision`` param (https://github.com/ansible-collections/community.general/pull/583)."

--- a/changelogs/fragments/airbrake_deployment_add_version.yml
+++ b/changelogs/fragments/airbrake_deployment_add_version.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "airbrake_deployment - Add ``version`` param; clarified docs on ``revision`` param"

--- a/plugins/modules/monitoring/airbrake_deployment.py
+++ b/plugins/modules/monitoring/airbrake_deployment.py
@@ -56,6 +56,7 @@ options:
       - A string identifying what version was deployed
     required: false
     type: str
+    version_added: '1.0.0'
   url:
     description:
       - Optional URL to submit the notification to. Use to send notifications to Airbrake-compliant tools like Errbit.

--- a/plugins/modules/monitoring/airbrake_deployment.py
+++ b/plugins/modules/monitoring/airbrake_deployment.py
@@ -118,7 +118,7 @@ def main():
             user=dict(required=False),
             repo=dict(required=False),
             revision=dict(required=False),
-            version=dict(required=False),
+            version=dict(required=False, type='str'),
             url=dict(required=False, default='https://api.airbrake.io/api/v4/projects/'),
             validate_certs=dict(default=True, type='bool'),
         ),


### PR DESCRIPTION
##### SUMMARY
The aibrake v4 API allows for distinct `version` and `revision` params.
The `revision` param is meant to indicate a revision from the version
control system (such as a Git hash), whereas the `version` param is
meant to be a version number (such as 1.2.3). This is especially
noticeable in the Airbrake UI where revisions are truncated to 7
characters, and used to build GitHub style diff links (such as
`https://github.com/ansible-collections/community.general/compare/689a25edcf03a3b8513faf347a957d2ad443c124...e54dd3a01f2c421b558ef33b5f79db936e2dcf15`).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
airbrake_deployment

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
none

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
