### PR TITLE
airbrake_deployment: Add types to the argument_spec

### DIFF
--- a/plugins/modules/monitoring/airbrake_deployment.py
+++ b/plugins/modules/monitoring/airbrake_deployment.py
@@ -111,15 +111,15 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            token=dict(required=False, no_log=True),
-            project_id=dict(required=False, no_log=True),
-            project_key=dict(required=False, no_log=True),
-            environment=dict(required=True),
-            user=dict(required=False),
-            repo=dict(required=False),
-            revision=dict(required=False),
+            token=dict(required=False, no_log=True, type='str'),
+            project_id=dict(required=False, no_log=True, type='str'),
+            project_key=dict(required=False, no_log=True, type='str'),
+            environment=dict(required=True, type='str'),
+            user=dict(required=False, type='str'),
+            repo=dict(required=False, type='str'),
+            revision=dict(required=False, type='str'),
             version=dict(required=False, type='str'),
-            url=dict(required=False, default='https://api.airbrake.io/api/v4/projects/'),
+            url=dict(required=False, default='https://api.airbrake.io/api/v4/projects/', type='str'),
             validate_certs=dict(default=True, type='bool'),
         ),
         supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY
As suggested in #583 ([here](https://github.com/ansible-collections/community.general/pull/583#discussion_r445994800))

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
airbrake_deployment

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
