### PR TITLE
parted: proper fix for change of partition label case

### DIFF
--- a/changelogs/fragments/522-parted_change_label.yml
+++ b/changelogs/fragments/522-parted_change_label.yml
@@ -1,2 +1,2 @@
 bugfixes:
- - "parted - fix creating partition when label is changed (https://github.com/ansible-collections/community.general/issues/522)"
+ - "parted - fix creating partition when label is changed (https://github.com/ansible-collections/community.general/issues/522)."

--- a/changelogs/fragments/522-parted_change_label.yml
+++ b/changelogs/fragments/522-parted_change_label.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - "parted - fix creating partition when label is changed (https://github.com/ansible-collections/community.general/issues/522)"

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -634,11 +634,12 @@ def main():
     if state == 'present':
 
         # Assign label if required
-        if current_device['generic'].get('table', None) != label:
+        mklabel_needed = current_device['generic'].get('table', None) != label
+        if mklabel_needed:
             script += "mklabel %s " % label
 
         # Create partition if required
-        if part_type and not part_exists(current_parts, 'num', number):
+        if part_type and (mklabel_needed or not part_exists(current_parts, 'num', number)):
             script += "mkpart %s %s%s %s " % (
                 part_type,
                 '%s ' % fs_type if fs_type is not None else '',

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -262,6 +262,19 @@ class TestParted(ModuleTestCase):
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict2):
             self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
 
+    def test_change_label_gpt(self):
+        # When partitions already exists and label is changes, mkpart should be called even when partition already exists,
+        # because new empty label will be created anyway
+        set_module_args({
+            'device': '/dev/sdb',
+            'number': 1,
+            'state': 'present',
+            'label': 'gpt',
+            '_ansible_check_mode': True,
+        })
+        with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):
+            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100%')
+
     def test_check_mode_unchanged(self):
         # Test that get_device_info result is checked in check mode too
         # No change on partition 1

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -263,7 +263,7 @@ class TestParted(ModuleTestCase):
             self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
 
     def test_change_label_gpt(self):
-        # When partitions already exists and label is changes, mkpart should be called even when partition already exists,
+        # When partitions already exists and label is changed, mkpart should be called even when partition already exists,
         # because new empty label will be created anyway
         set_module_args({
             'device': '/dev/sdb',


### PR DESCRIPTION
calling mkpart even when partition existed before mklabel call 
##### SUMMARY
Fixes #522

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
parted
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Below playbook created empty partition label, even when partition table was not used by kernel.
My first diagnose of #522 was wrong, this is proper fix

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- hosts: localhost
  gather_facts: no
  become: yes
  tasks:
   - name: create msdos partition
     parted: 
       device: /dev/loop0
       number: 1
       state: present
       label: msdos

   - name: create gpt partition
     parted: 
       device: /dev/loop0
       number: 1
       state: present
       label: gpt
```
