### PR TITLE
archive: exclude_path documentation

### DIFF
--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -38,7 +38,7 @@ options:
     type: path
   exclude_path:
     description:
-      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from C(path) list and glob expansion.
+      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from I(path) list and glob expansion.
     type: list
   force_archive:
     description:

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -38,7 +38,7 @@ options:
     type: path
   exclude_path:
     description:
-      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive.
+      - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from C(path) list and glob expansion.
     type: list
   force_archive:
     description:


### PR DESCRIPTION
Describe more precisely how exclude_path works: it used only to limit results of `path` glob expansion.

##### SUMMARY
Fixes: #593 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
archive

