### PR TITLE
Fix documentation mistakes for docker_swarm_info and docker_swarm_service

### DIFF
--- a/plugins/modules/cloud/docker/docker_swarm_info.py
+++ b/plugins/modules/cloud/docker/docker_swarm_info.py
@@ -116,7 +116,7 @@ EXAMPLES = '''
 - name: Get info on Docker Swarm and filtered list of registered nodes
   docker_swarm_info:
     nodes: yes
-    nodes_filter:
+    nodes_filters:
       name: mynode
   register: result
 

--- a/plugins/modules/cloud/docker/docker_swarm_service.py
+++ b/plugins/modules/cloud/docker/docker_swarm_service.py
@@ -307,7 +307,7 @@ options:
       propagation:
         description:
           - The propagation mode to use.
-          - Can only be used when I(mode) is C(bind).
+          - Can only be used when I(type) is C(bind).
         type: str
         choices:
           - shared
@@ -319,12 +319,12 @@ options:
       no_copy:
         description:
           - Disable copying of data from a container when a volume is created.
-          - Can only be used when I(mode) is C(volume).
+          - Can only be used when I(type) is C(volume).
         type: bool
       driver_config:
         description:
           - Volume driver configuration.
-          - Can only be used when I(mode) is C(volume).
+          - Can only be used when I(type) is C(volume).
         suboptions:
           name:
             description:
@@ -340,12 +340,12 @@ options:
           - "Size of the tmpfs mount in format C(<number>[<unit>]). Number is a positive integer.
             Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
             C(T) (tebibyte), or C(P) (pebibyte)."
-          - Can only be used when I(mode) is C(tmpfs).
+          - Can only be used when I(type) is C(tmpfs).
         type: str
       tmpfs_mode:
         description:
           - File mode of the tmpfs in octal.
-          - Can only be used when I(mode) is C(tmpfs).
+          - Can only be used when I(type) is C(tmpfs).
         type: int
   name:
     description:


### PR DESCRIPTION
##### SUMMARY
This PR combines two PRs from the original ansible repository: https://github.com/ansible/ansible/pull/67991 (opened by @aniejek) and https://github.com/ansible/ansible/pull/68335 (opened by @teadur). Picking up these small fixes due to inactivity in original PRs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_swarm_info
docker_swarm_service

##### ADDITIONAL INFORMATION
In docker_swarm_info the option fixing typo in example
In docker_swarm_service the `mount` property doesn't have property mode, but `type`