### PR TITLE
mysql_user: fix overriding user passowrd to the same

### DIFF
--- a/changelogs/fragments/609-mysql_user_fix_overriding_password_to_the_same.yml
+++ b/changelogs/fragments/609-mysql_user_fix_overriding_password_to_the_same.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix overriding password to the same (https://github.com/ansible-collections/community.general/issues/543).

--- a/tests/integration/targets/mysql_user/tasks/user_password_update_test.yml
+++ b/tests/integration/targets/mysql_user/tasks/user_password_update_test.yml
@@ -46,18 +46,17 @@
   register: user_password_old  
   when: user_password_old_create is failed
 
-# FIXME: not sure why this is failing, but it looks like it should expect changed=true
-#- name: update user2 state=present with same password (expect changed=false)
-#  mysql_user:
-#    name: '{{ user_name_2 }}'
-#    password: '{{ user_password_2 }}'
-#    priv: '*.*:ALL'
-#    state: present
-#    login_unix_socket: '{{ mysql_socket }}'
-#  register: result
-#
-#- name: assert output user2 was not updated 
-#  assert: { that: "result.changed == false" }
+- name: update user2 state=present with same password (expect changed=false)
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:ALL'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: assert output user2 was not updated 
+  assert: { that: "result.changed == false" }
 
 - include: assert_user.yml user_name={{user_name_2}} priv='ALL PRIVILEGES'
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/543

mysql_user: fix overriding user passowrd to the same

`user_mod` function checks a server version and compare two hashed passwords (current and new)
but `user_add` stores a new password in a different form (but they are actually the same),
so `user_mod` wrong considers that the passwords are different.

The fix makes `user_add` to store a password in the proper encrypted form at once.

For details see `user_mod` function.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user
