### PR TITLE
gitlab_runners inventory plugin: runtime en var and list default behavior

### DIFF
--- a/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
+++ b/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
@@ -1,4 +1,2 @@
-bugfixes:
-  - gitlab_runners inventory plugin - make sure that all runners are returned, and not only the first 20 items (https://github.com/ansible-collections/community.general/pull/611).
 minor_changes:
   - gitlab_runners inventory plugin - permit environment variable input for ``server_url`` and ``api_token`` options (https://github.com/ansible-collections/community.general/pull/611).

--- a/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
+++ b/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-  - plugin inventory gitlab_runners - Remove default 20 items limit to runners list by adding "all" bool to True 
-  in gl.runners.all (https://github.com/python-gitlab/python-gitlab/blob/df485a92b713a0f2f983c72d9d41ea3a771abf88/gitlab/v4/objects.py#L4922)
-  Permit env var input for server_url and api_token options values
+  - gitlab_runners inventory plugin - make sure that all runners are returned, and not only the first 20 items (https://github.com/ansible-collections/community.general/pull/611).
+minor_changes:
+  - gitlab_runners inventory plugin - permit environment variable input for ``server_url`` and ``api_token`` options (https://github.com/ansible-collections/community.general/pull/611). values.

--- a/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
+++ b/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
@@ -1,4 +1,4 @@
 bugfixes:
   - gitlab_runners inventory plugin - make sure that all runners are returned, and not only the first 20 items (https://github.com/ansible-collections/community.general/pull/611).
 minor_changes:
-  - gitlab_runners inventory plugin - permit environment variable input for ``server_url`` and ``api_token`` options (https://github.com/ansible-collections/community.general/pull/611). values.
+  - gitlab_runners inventory plugin - permit environment variable input for ``server_url`` and ``api_token`` options (https://github.com/ansible-collections/community.general/pull/611).

--- a/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
+++ b/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - plugin inventory gitlab_runners - Remove default 20 items limit to runners list by adding "all" bool to True 
+  in gl.runners.all (https://github.com/python-gitlab/python-gitlab/blob/df485a92b713a0f2f983c72d9d41ea3a771abf88/gitlab/v4/objects.py#L4922)
+  Permit env var input for server_url and api_token options values

--- a/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
+++ b/changelogs/fragments/611-gitlab-runners-env-vars-intput-and-default-item-limit.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab_runners inventory plugin - permit environment variable input for ``server_url`` and ``api_token`` options (https://github.com/ansible-collections/community.general/pull/611).
+  - gitlab_runners inventory plugin - permit environment variable input for ``server_url``, ``api_token`` and ``filter`` options (https://github.com/ansible-collections/community.general/pull/611).

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -101,7 +101,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 runners = gl.runners.all(scope=self.get_option('filter'))
             else:
                 runners = gl.runners.all(all=True)
-                version_added: 1.0.0
             for runner in runners:
                 host = str(runner['id'])
                 ip_address = runner['ip_address']

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -47,6 +47,9 @@ DOCUMENTATION = '''
               - access_token
         filter:
             description: filter runners from GitLab API
+            env:
+              - name: GITLAB_FILTER
+                version_added: 1.0.0
             type: str
             choices: ['active', 'paused', 'online', 'specific', 'shared']
         verbose_output:

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -101,7 +101,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if self.get_option('filter'):
                 runners = gl.runners.all(scope=self.get_option('filter'))
             else:
-                runners = gl.runners.all(all=True)
+                runners = gl.runners.all()
             for runner in runners:
                 host = str(runner['id'])
                 ip_address = runner['ip_address']

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -32,6 +32,7 @@ DOCUMENTATION = '''
             description: The URL of the GitLab server, with protocol (i.e. http or https).
             env:
               - name: GITLAB_SERVER_URL
+                version_added: 1.0.0
             type: str
             required: true
             default: https://gitlab.com

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -101,6 +101,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 runners = gl.runners.all(scope=self.get_option('filter'))
             else:
                 runners = gl.runners.all(all=True)
+                version_added: 1.0.0
             for runner in runners:
                 host = str(runner['id'])
                 ip_address = runner['ip_address']

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -30,11 +30,15 @@ DOCUMENTATION = '''
               - gitlab_runners
         server_url:
             description: The URL of the GitLab server, with protocol (i.e. http or https).
+            env:
+              - name: GITLAB_SERVER_URL
             type: str
             required: true
             default: https://gitlab.com
         api_token:
             description: GitLab token for logging in.
+            env:
+              - name: GITLAB_API_TOKEN
             type: str
             aliases:
               - private_token
@@ -95,7 +99,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if self.get_option('filter'):
                 runners = gl.runners.all(scope=self.get_option('filter'))
             else:
-                runners = gl.runners.all()
+                runners = gl.runners.all(all=True)
             for runner in runners:
                 host = str(runner['id'])
                 ip_address = runner['ip_address']

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -40,6 +40,7 @@ DOCUMENTATION = '''
             description: GitLab token for logging in.
             env:
               - name: GITLAB_API_TOKEN
+                version_added: 1.0.0
             type: str
             aliases:
               - private_token


### PR DESCRIPTION
Ability to pick options values from env vars on gitlab_runners inventory plugin
Remove default 20 items limit to runners list on gitlab_runners inventory plugin

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove default 20 items limit to runners list by adding "all" bool to True in gl.runners.all ref
Permit env var input for server_url and api_token options values
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/gitlab_runners.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
