### PR TITLE
Add check for rundeck_acl_policy name

### DIFF
--- a/changelogs/fragments/add_argument_check_for_rundeck.yaml
+++ b/changelogs/fragments/add_argument_check_for_rundeck.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- rundeck_acl_policy - Add check for rundeck_acl_policy name parameter
+- rundeck_acl_policy - add check for rundeck_acl_policy name parameter (https://github.com/ansible-collections/community.general/pull/612).

--- a/changelogs/fragments/add_argument_check_for_rundeck.yaml
+++ b/changelogs/fragments/add_argument_check_for_rundeck.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- rundeck_acl_policy - Add check for rundeck_acl_policy name parameter

--- a/plugins/modules/web_infrastructure/rundeck_acl_policy.py
+++ b/plugins/modules/web_infrastructure/rundeck_acl_policy.py
@@ -118,6 +118,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_text
 import json
+import re
 
 
 class RundeckACLManager:
@@ -229,6 +230,9 @@ def main():
         ],
         supports_check_mode=True
     )
+
+    if not bool(re.match("[a-zA-Z0-9,.+_-]+", module.params["name"])):
+        module.fail_json(msg="Name contains forbidden characters. The policy can contain the characters: a-zA-Z0-9,.+_-")
 
     if module.params["api_version"] < 14:
         module.fail_json(msg="API version should be at least 14")


### PR DESCRIPTION
##### SUMMARY
This change simply introduce a sanity check over the name of the policy. 
Using this module and using a name that is not compatible with rundeck prerogatives lead to a cryptic error 
`"Unhandled HTTP status -1, please report the bug"`

This pull request will check if the name passed to the module passes rundeck name policy. If not, it will output a more understandable error.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

rundeck_acl_policy

##### ADDITIONAL INFORMATION
###### How to reproduce ?

Simply execute this task on any rundeck of your choice. 

```
- name: "Create or update a rundeck ACL policy for users to be able to read"
  rundeck_acl_policy:
    name: "Name with forbidden characters ( here , spaces for exemple )"
    api_version: 21
    url: "https://my.rundeck"
    token: "{{ rundeck_api_token }}"
    state: present
    project: "allow_users_for_project_{{ item.name }}"
    policy:
      description: "normal users will only have read permissions for {{ item.name }}"
      context:
        application: rundeck
      for:
        project:
          - match:
              name: "{{ item.name }}"
            allow: [read]
        system:
          - match:
              name: '.*'
            allow: [read]
        storage:
          - match:
              path: 'keys/.*'
            allow: [read]
      by:
        username: "{{ item.users | list }}"

```
