### PR TITLE
Fix bug in digital_ocean_tag_info

### DIFF
--- a/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
@@ -88,7 +88,7 @@ def core(module):
             module.fail_json(msg="Failed to retrieve tags for DigitalOcean")
 
         resp_json = response.json
-        tag = resp_json['tag']
+        tag = resp_json['tags']
     else:
         tag = rest.get_paginated_data(base_url=base_url, data_key_name='tags')
 


### PR DESCRIPTION
##### SUMMARY
 
This is one character change that fixes a bug in the `digital_ocean_tag_info` module. Per [the documentation](https://developers.digitalocean.com/documentation/v2/#tags), the correct key to look under is `tags`, regardless of if a single tag or multiple is requested. Previously, the module would crash if the `tag_name` argument was specified. After this change, it returns the data as expected.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_tag_info module
