### PR TITLE
Fix bug in digital_ocean_tag_info module

### DIFF
--- a/changelogs/fragments/615-digital-ocean-tag-info-bugfix.yml
+++ b/changelogs/fragments/615-digital-ocean-tag-info-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_tag_info - fix crash when querying for an individual tag

--- a/changelogs/fragments/615-digital-ocean-tag-info-bugfix.yml
+++ b/changelogs/fragments/615-digital-ocean-tag-info-bugfix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - digital_ocean_tag_info - fix crash when querying for an individual tag
+  - digital_ocean_tag_info - fix crash when querying for an individual tag (https://github.com/ansible-collections/community.general/pull/615).

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
@@ -79,7 +79,7 @@ def core(module):
     tag_name = module.params.get('tag_name', None)
     rest = DigitalOceanHelper(module)
 
-    base_url = 'tags?'
+    base_url = 'tags'
     if tag_name is not None:
         response = rest.get("%s/%s" % (base_url, tag_name))
         status_code = response.status_code
@@ -90,7 +90,7 @@ def core(module):
         resp_json = response.json
         tag = resp_json['tag']
     else:
-        tag = rest.get_paginated_data(base_url=base_url, data_key_name='tags')
+        tag = rest.get_paginated_data(base_url=base_url+'?', data_key_name='tags')
 
     module.exit_json(changed=False, data=tag)
 

--- a/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
+++ b/plugins/modules/cloud/digital_ocean/digital_ocean_tag_info.py
@@ -90,7 +90,7 @@ def core(module):
         resp_json = response.json
         tag = resp_json['tag']
     else:
-        tag = rest.get_paginated_data(base_url=base_url+'?', data_key_name='tags')
+        tag = rest.get_paginated_data(base_url=base_url + '?', data_key_name='tags')
 
     module.exit_json(changed=False, data=tag)
 


### PR DESCRIPTION
##### SUMMARY
This fixes a bug in the digital_ocean_tag_info module. Previously, it crashed with a `KeyError` if you tried to retrieve a single tag. After this change, it works correctly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_tag_info module

