### PR TITLE
mysql_user: add missed privileges

### DIFF
--- a/changelogs/fragments/618-mysql_user_add_missed_privileges.yml
+++ b/changelogs/fragments/618-mysql_user_add_missed_privileges.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - add missed privileges to support (https://github.com/ansible-collections/community.general/issues/617).

--- a/plugins/modules/database/mysql/mysql_user.py
+++ b/plugins/modules/database/mysql/mysql_user.py
@@ -295,7 +295,17 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'SYSTEM_USER', 'SYSTEM_VARIABLES_ADMIN', 'SYSTEM_USER',
                          'TABLE_ENCRYPTION_ADMIN', 'VERSION_TOKEN_ADMIN',
                          'XA_RECOVER_ADMIN', 'LOAD FROM S3', 'SELECT INTO S3',
-                         'INVOKE LAMBDA'))
+                         'INVOKE LAMBDA',
+                         'ALTER ROUTINE',
+                         'BINLOG ADMIN',
+                         'BINLOG MONITOR',
+                         'BINLOG REPLAY',
+                         'CONNECTION ADMIN',
+                         'READ_ONLY ADMIN',
+                         'REPLICATION MASTER ADMIN',
+                         'REPLICATION SLAVE',
+                         'REPLICATION SLAVE ADMIN',
+                         'SET USER',))
 
 
 class InvalidPrivsError(Exception):


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/617
mysql_user: add missed privileges

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user
