### PR TITLE
selective: mark task failed correctly

### DIFF
--- a/changelogs/fragments/63767_selective.yml
+++ b/changelogs/fragments/63767_selective.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- selective - mark task failed correctly (https://github.com/ansible/ansible/issues/63767).

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -201,7 +201,7 @@ class CallbackModule(CallbackBase):
                                      )
             if 'results' in result._result:
                 for r in result._result['results']:
-                    failed = 'failed' in r
+                    failed = 'failed' in r and r['failed']
 
                     stderr = [r.get('exception', None), r.get('module_stderr', None)]
                     stderr = "\n".join([e for e in stderr if e]).strip()


### PR DESCRIPTION
##### SUMMARY

Added additional condition to detect failed task in
selective callback plugin when ran with loop or with_items.

Fixes: ansible/ansible#63767

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/63767_selective.yml
plugins/callback/selective.py
