### PR TITLE
removes advertise_addr from required parameters when state is "join"

### DIFF
--- a/plugins/modules/cloud/docker/docker_swarm.py
+++ b/plugins/modules/cloud/docker/docker_swarm.py
@@ -627,7 +627,7 @@ def main():
     )
 
     required_if = [
-        ('state', 'join', ['advertise_addr', 'remote_addrs', 'join_token']),
+        ('state', 'join', ['remote_addrs', 'join_token']),
         ('state', 'remove', ['node_id'])
     ]
 


### PR DESCRIPTION
addressing this issue: https://github.com/ansible-collections/community.general/issues/439

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
