### PR TITLE
pacman: Treat .zst package names as files

### DIFF
--- a/changelogs/fragments/650_pacman_support_zst_package_files.yaml
+++ b/changelogs/fragments/650_pacman_support_zst_package_files.yaml
@@ -1,3 +1,4 @@
 bugfixes:
   - pacman - treat package names containing .zst as package files during installation
-    (https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/).
+    (https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/,
+    https://github.com/ansible-collections/community.general/pull/650).

--- a/changelogs/fragments/650_pacman_support_zst_package_files.yaml
+++ b/changelogs/fragments/650_pacman_support_zst_package_files.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - pacman - treat package names containing .zst as package files during installation
+    (https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -459,7 +459,7 @@ def main():
         for i, pkg in enumerate(pkgs):
             if not pkg:  # avoid empty strings
                 continue
-            elif re.match(r".*\.pkg\.tar(\.(gz|bz2|xz|lrz|lzo|Z))?$", pkg):
+            elif re.match(r".*\.pkg\.tar(\.(gz|bz2|xz|lrz|lzo|Z|zst))?$", pkg):
                 # The package given is a filename, extract the raw pkg name from
                 # it and store the filename
                 pkg_files.append(pkg)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Archlinux switched default package compression to Zstandard [recently](https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/). That means that new packages files have a .zst extension.

This PR add .zst extension to the heuristic determining whether a `name` is a file or an Archlinux package name.

Side note : Wouldn't it better to allow any extension after `.pkg.tar` instead of listing them ?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pacman

##### ADDITIONAL INFORMATION

Playbook triggering the problem :
```paste below
- pacman:
    name: /tmp/example.pkg.tar.zst
```