### PR TITLE
Update: only "warn" when restart is required

### DIFF
--- a/changelogs/fragments/651-fix-postgresql_set-warning.yaml
+++ b/changelogs/fragments/651-fix-postgresql_set-warning.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - postgresql_set - only display a warning about restarts, when
+    restarting is needed

--- a/changelogs/fragments/651-fix-postgresql_set-warning.yaml
+++ b/changelogs/fragments/651-fix-postgresql_set-warning.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - postgresql_set - only display a warning about restarts, when
-    restarting is needed
+    restarting is needed (https://github.com/ansible-collections/community.general/pull/651).

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -406,9 +406,6 @@ def main():
 
         changed = param_set(cursor, module, name, boot_val, context)
 
-    if restart_required:
-        module.warn("Restart of PostgreSQL is required for setting %s" % name)
-
     cursor.close()
     db_connection.close()
 
@@ -439,6 +436,10 @@ def main():
 
     kw['changed'] = changed
     kw['restart_required'] = restart_required
+
+    if restart_required and changed:
+        module.warn("Restart of PostgreSQL is required for setting %s" % name)
+
     module.exit_json(**kw)
 
 


### PR DESCRIPTION
### SUMMARY

Motivation: my logs are flooded with "warnings" when I run roles against instances. So even though I understand the need for this "warning", it's a false positive when nothing needs to be done.

I would also argue an "INFO" is more suited? Thoughts? I can add that to `AnsibleMolecule` if wanted.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
postgresql_set