### PR TITLE
pam_limits: add support nice and priority limits

### DIFF
--- a/changelogs/fragments/47680_pam_limits.yml
+++ b/changelogs/fragments/47680_pam_limits.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- pam_limits - add support for nice and priority limits (https://github.com/ansible/ansible/pull/47680).


### PR DESCRIPTION
##### SUMMARY

Migrated from ansible/ansible#47680

Based upon the work of pgerber

Unlike all other limits, nice and priority must have a value between -19 and 20 and -1,
unlimited and infinity are unsupported. See limits.conf(5) for details.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/47680_pam_limits.yml
plugins/modules/system/pam_limits.py
