### PR TITLE
Added information to be returened when proxmox_kvm is called with state: 'current'

### DIFF
--- a/changelogs/fragments/658_proxmox_kvm_current_results.yaml
+++ b/changelogs/fragments/658_proxmox_kvm_current_results.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - Added additional information to be returned when the option state: 'current' is used. The current runtime information of the virtual machine is returned in the dictionary 'current' and the configuration information is returned in the dictionary 'config'.
+- "proxmox_kvm - Added additional information to be returned when the option state: current' is used. The current runtime information of the virtual machine is returned in the dictionary 'current' and the configuration information is returned in the dictionary 'config'."

--- a/changelogs/fragments/658_proxmox_kvm_current_results.yaml
+++ b/changelogs/fragments/658_proxmox_kvm_current_results.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- "proxmox_kvm - Added additional information to be returned when the option state: current' is used. The current runtime information of the virtual machine is returned in the dictionary 'current' and the configuration information is returned in the dictionary 'config'."
+- "proxmox_kvm - added additional information to be returned when the option ``state: current`` is used. The current runtime information of the virtual machine is returned in the dictionary ``current`` and the configuration information is returned in the dictionary ``config`` (https://github.com/ansible-collections/community.general/issues/657)."

--- a/changelogs/fragments/658_proxmox_kvm_current_results.yaml
+++ b/changelogs/fragments/658_proxmox_kvm_current_results.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - Added additional information to be returned when the option state: 'current' is used. The current runtime information of the virtual machine is returned in the dictionary 'current' and the configuration information is returned in the dictionary 'config'.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -595,6 +595,7 @@ config:
       memory: 2048,
       "...": "...",
     }'
+    version_added: 1.0.0
 '''
 
 import os

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -583,6 +583,7 @@ current:
       balloon: 2147483648,
       "...": "...",
     }'
+    version_added: 1.0.0
 config:
     description:
       - The current virtual maching configuration.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -579,14 +579,9 @@ current:
     returned: success
     type: dict
     sample: '{
-      "changed": false,
-      "msg": "VM kropta with vmid = 110 is running",
-      "status": "running"
-      "current: {
-        agent: 1,
-        balloon: 2147483648,
-        ...
-      }"
+      agent: 1,
+      balloon: 2147483648,
+      "...": "...",
     }'
 config:
     description:
@@ -595,14 +590,9 @@ config:
     returned: success
     type: dict
     sample: '{
-      "changed": false,
-      "msg": "VM kropta with vmid = 110 is running",
-      "status": "running"
-      "config: {
-        cors: 2,
-        memory: 2048,
-        ...
-      }"
+      cores: 2,
+      memory: 2048,
+      "...": "...",
     }'
 '''
 

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -295,7 +295,9 @@ options:
   state:
     description:
       - Indicates desired state of the instance.
-      - If C(current), the current state of the VM will be fetched. You can access it with C(results.status), C(results.current) will have the current VMs information, C(results.config) will have the current VMs configuration.
+      - If C(current), the current state of the VM will be fetched. You can access it with C(results.status)
+      - If C(current), C(results.current) will have the current VMs information
+      - If C(current), C(results.config) will have the current VMs configuration.
     choices: ['present', 'started', 'absent', 'stopped', 'restarted','current']
     default: present
   storage:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -572,6 +572,13 @@ status:
       "msg": "VM kropta with vmid = 110 is running",
       "status": "running"
     }'
+node:
+    description:
+      - The current node the virtual machine is located on.
+      - Returned only when C(state=current)
+    returned: success
+    type: str
+    version_added: 1.0.0
 current:
     description:
       - The current virtual maching runtime information.
@@ -1137,6 +1144,7 @@ def main():
             current = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()
             config = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).config.get()
             status['status'] = current['status']
+            status['node'] = vm[0]['node']
             status['current'] = current
             status['config'] = config
             if status:


### PR DESCRIPTION
##### SUMMARY
Updated the results returned from the proxmox_kvm module to return
the current virtual machine's runtime information and configuration
when the state: 'current' options is passed.

The results still contains the 'status' element but now a dictionary
called 'current' will contain the the current runtime information
and a dictionary called 'config' will contain the current
configuration.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
#657
