### PR TITLE
lxd_container: cleanups, /instances/ API, instance types

### DIFF
--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -61,6 +61,14 @@ options:
           - 'See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1) for complete API documentation.'
           - 'Note that C(protocol) accepts two choices: C(lxd) or C(simplestreams)'
         required: false
+    type:
+        choices:
+          - container
+          - virtual-machine
+        description:
+          - Define the type of instance to be launched
+        required: false
+        default: container
     state:
         choices:
           - started
@@ -166,6 +174,7 @@ EXAMPLES = '''
           server: https://images.linuxcontainers.org
           protocol: lxd # if you get a 404, try setting protocol: simplestreams
           alias: ubuntu/xenial/amd64
+        type: container # optional, set to virtual-machine for a qemu VM
         profiles: ["default"]
         wait_for_ipv4_addresses: true
         timeout: 600

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -331,14 +331,16 @@ ANSIBLE_LXD_STATES = {
 # ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
 ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
+LXD_INSTANCE_TYPES = [ 'container', 'virtual-machine' ]
+
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
-    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source'
+    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source', 'type'
 ]
 
 # CONFIG_CREATION_PARAMS is a list of attribute names that are only applied
 # on instance creation.
-CONFIG_CREATION_PARAMS = [ 'source' ]
+CONFIG_CREATION_PARAMS = [ 'source', 'type' ]
 
 
 class LXDContainerManagement(object):
@@ -637,6 +639,10 @@ def main():
             ),
             source=dict(
                 type='dict',
+            ),
+            type=dict(
+                choices=LXD_INSTANCE_TYPES,
+                default='container'
             ),
             state=dict(
                 choices=LXD_ANSIBLE_STATES.keys(),

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -31,7 +31,7 @@ options:
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1)'
           - If the container already exists and its "config" value in metadata
             obtained from
-            GET /1.0/containers/<name>
+            GET /1.0/instances/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
             are different, they this module tries to apply the configurations.
           - The key starts with 'volatile.' are ignored for this comparison.
@@ -393,13 +393,13 @@ class LXDContainerManagement(object):
 
     def _get_container_json(self):
         return self.client.do(
-            'GET', '/1.0/containers/{0}'.format(self.name),
+            'GET', '/1.0/instances/{0}'.format(self.name),
             ok_error_codes=[404]
         )
 
     def _get_container_state_json(self):
         return self.client.do(
-            'GET', '/1.0/containers/{0}/state'.format(self.name),
+            'GET', '/1.0/instances/{0}/state'.format(self.name),
             ok_error_codes=[404]
         )
 
@@ -413,7 +413,7 @@ class LXDContainerManagement(object):
         body_json = {'action': action, 'timeout': self.timeout}
         if force_stop:
             body_json['force'] = True
-        return self.client.do('PUT', '/1.0/containers/{0}/state'.format(self.name), body_json=body_json)
+        return self.client.do('PUT', '/1.0/instances/{0}/state'.format(self.name), body_json=body_json)
 
     def _create_container(self):
         config = self.config.copy()
@@ -437,7 +437,7 @@ class LXDContainerManagement(object):
         self.actions.append('restart')
 
     def _delete_container(self):
-        self.client.do('DELETE', '/1.0/containers/{0}'.format(self.name))
+        self.client.do('DELETE', '/1.0/instances/{0}'.format(self.name))
         self.actions.append('delete')
 
     def _freeze_container(self):
@@ -572,7 +572,7 @@ class LXDContainerManagement(object):
                 else:
                     body_json[param] = self.config[param]
 
-        self.client.do('PUT', '/1.0/containers/{0}'.format(self.name), body_json=body_json)
+        self.client.do('PUT', '/1.0/instances/{0}'.format(self.name), body_json=body_json)
         self.actions.append('apply_container_configs')
 
     def run(self):

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -331,7 +331,7 @@ ANSIBLE_LXD_STATES = {
 # ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
 ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
-LXD_INSTANCE_TYPES = [ 'container', 'virtual-machine' ]
+LXD_INSTANCE_TYPES = ['container', 'virtual-machine']
 
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
@@ -340,7 +340,7 @@ CONFIG_PARAMS = [
 
 # CONFIG_CREATION_PARAMS is a list of attribute names that are only applied
 # on instance creation.
-CONFIG_CREATION_PARAMS = [ 'source', 'type' ]
+CONFIG_CREATION_PARAMS = ['source', 'type']
 
 
 class LXDContainerManagement(object):


### PR DESCRIPTION
##### SUMMARY
- Replaced the config checking code with general loops.
- Rewrote the API interaction from `/1.0/containers/` to `/1.0/instances/`
- Added a 'type' parameter to specify instance types (at creation) as supported by LXD 4.0+

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxd_container

##### ADDITIONAL INFORMATION

Currently only tested selectively locally. No testing against older LXD versions was performed so far.

Looking for general feedback.

No test cases were modified, added or even run by me.

If someone more experienced with ansible hacking wants to 'quickly finish this up', go ahead.

TODO:

- [x] Doc
- [ ] Tests
- [ ] Check for `/instances/`? (Is this change even required?)