### PR TITLE
Add support for listing secrets to hashi_vault

### DIFF
--- a/changelogs/fragments/hashi_vault_add_list_support.yml
+++ b/changelogs/fragments/hashi_vault_add_list_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hashi_vault - extended action types that can be performed against HashiCorp's Vault to include list secret as well as the default read secret (https://github.com/ansible-collections/community.general/pull/664).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -496,9 +496,6 @@ class LookupModule(LookupBase):
         # secret field splitter
         self.field_ops()
 
-        # hvac client actions
-        self.action_types()
-
     # begin options processing methods
 
     def boolean_or_cacert(self):
@@ -542,18 +539,6 @@ class LookupModule(LookupBase):
         auth_validator = 'validate_auth_' + auth_method
         if hasattr(self, auth_validator) and callable(getattr(self, auth_validator)):
             getattr(self, auth_validator)(auth_method)
-
-    def action_types(self):
-        # enforce and set the list of available hvac action types
-        # TODO: can this be read from the choices: field in documentation?
-        avail_action_types = ['READ', 'LIST']
-        self.set_option('avail_action_types', avail_action_types)
-        action_type = self.get_option('action_type')
-
-        if action_type not in avail_action_types:
-            raise AnsibleError(
-                "Action type '%s' not supported. Available options are %r" % (action_type, avail_action_types)
-            )
 
     # end options processing methods
 

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -166,9 +166,9 @@ DOCUMENTATION = """
           key: action_type
       version_added: '1.0.0'
       choices:
-        - READ
-        - LIST
-      default: READ
+        - read
+        - list
+      default: read
 """
 
 EXAMPLES = """
@@ -393,10 +393,10 @@ class HashiVault:
 
     def execute_request(self, secret, method):
         httpMethods = {
-            'READ': lambda: self.client.read(secret),
-            'LIST': lambda: self.client.list(secret),
+            'read': lambda: self.client.read(secret),
+            'list': lambda: self.client.list(secret),
         }
-        return httpMethods.get(method, httpMethods.get('READ'))()
+        return httpMethods.get(method, httpMethods.get('read'))()
 
     # begin auth implementation methods
     #

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -160,7 +160,7 @@ DOCUMENTATION = """
         version_added: '0.2.0'
     action_type:
       description:
-        - The action type to be performed for the provided path
+        - The action type to be performed for the provided path.
       ini:
         - section: lookup_hashi_vault
           key: action_type

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -392,11 +392,11 @@ class HashiVault:
         return [data['data'][field]]
 
     def execute_request(self, secret, method):
-      httpMethods = {
-        'READ': lambda: self.client.read(secret),
-        'LIST': lambda: self.client.list(secret),
-      }
-      return httpMethods.get(method, httpMethods.get('READ'))()
+        httpMethods = {
+            'READ': lambda: self.client.read(secret),
+            'LIST': lambda: self.client.list(secret),
+        }
+        return httpMethods.get(method, httpMethods.get('READ'))()
 
     # begin auth implementation methods
     #

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -164,7 +164,7 @@ DOCUMENTATION = """
       ini:
         - section: lookup_hashi_vault
           key: action_type
-          version_added: '0.2.0'
+      version_added: '1.0.0'
       choices:
         - READ
         - LIST


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added parameter to the hashi_vault.py lookup plugin to preserve the functionality for reading and provide support for listing secrets

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`hashi_vault.py`

##### Additional Information
This PR aims to provide a mechanism to walk a path in HashiCorp Vault and extract the secrets recursively, e.g.
`secrets/customer/test/microservice/sensitive.properties` secret has keys:
`{ "some_password": "sadf8j2134!@#" }`
The `LIST` functionality will then accept the path `secrets/customer/test/microservice/` and return as a result all secrets in that folder, like `sensitive.properties` from the example above. This allows for iteration over multiple secrets without having to know their keys in advance, providing more flexibility in HashiCorp Vault secrets definition.

Ultimately, the goal is to be able to work with the individual keys in HashiCorp Vault, while they are still extracted to a complete file via Ansible.
The value of the extracted secrets will later be used from other tooling, e.g. Docker Swarm to register these as secrets - limiting the exposure of sensitive information during deployment.