### PR TITLE
nmcli: Type: Wrong package names

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -21,9 +21,9 @@ requirements:
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
     - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
-      libsemanage-python, policycoreutils-python.'
+      python3-libsemanage, python3-policycoreutils.'
     - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
-      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, libsemanage-python, policycoreutils-python.'
+      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python3-libsemanage, python3-policycoreutils.'
     - 'On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
       python-dbus (or python3-dbus, depending on the Python version in use), libnm-dev.'
     - 'On older Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -20,10 +20,10 @@ requirements:
 - nmcli
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
-    - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
-      python3-libsemanage, python3-policycoreutils.'
-    - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
-      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python3-libsemanage, python3-policycoreutils.'
+    - 'On CentOS/RHEL 8 and Fedora systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
+      python3-libsemanage and python3-policycoreutils.'
+    - 'On CentOS/RHEL 6/7 systems, the requirements can be met by installing the following packages: NetworkManager-glib,
+      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python-libsemanage, python-policycoreutils.'
     - 'On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
       python-dbus (or python3-dbus, depending on the Python version in use), libnm-dev.'
     - 'On older Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,


### PR DESCRIPTION
In Red Hat systems, python packages are preceeded by `python3-`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
