### PR TITLE
Prevent CI failure with older pip versions

### DIFF
--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -3,7 +3,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 - name: "Installing the psutil module"
   pip:
-    name: psutil
+    name: psutil < 5.7.0
+    # Version 5.7.0 breaks on older pip versions. See https://github.com/ansible/ansible/pull/70667
 
 - name: "Checking the empty result" 
   pids: 


### PR DESCRIPTION
##### SUMMARY
Currently the `pids` tests fail because the latest psutil package breaks with older pip versions. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pids
