### PR TITLE
Shameless recommit of changes in jesstruck/ansible:jenkins_plugins_sha1

### DIFF
--- a/changelogs/fragments/677-jenkins_plugins_sha1.yaml
+++ b/changelogs/fragments/677-jenkins_plugins_sha1.yaml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - jenkins_plugins - replace MD5 checksum verification with SHA1 due to MD5
+  - jenkins_plugin - replace MD5 checksum verification with SHA1 due to MD5
     being disabled on systems with FIPS-only algorithms enabled
-    (https://github.com/ansible/ansible/issues/34304)
+    (https://github.com/ansible/ansible/issues/34304).

--- a/changelogs/fragments/677-jenkins_plugins_sha1.yaml
+++ b/changelogs/fragments/677-jenkins_plugins_sha1.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - jenkins_plugins - replace MD5 checksum verification with SHA1 due to MD5
+    being disabled on systems with FIPS-only algorithms enabled
+    (https://github.com/ansible/ansible/issues/34304)

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -429,12 +429,12 @@ class JenkinsPlugin(object):
                 self.module.fail_json(
                     msg="Jenkins home directory doesn't exist.")
 
-            md5sum_old = None
+            sha1sum_old = None
             if os.path.isfile(plugin_file):
                 # Make the checksum of the currently installed plugin
-                with open(plugin_file, 'rb') as md5_plugin_fh:
-                    md5_plugin_content = md5_plugin_fh.read()
-                md5sum_old = hashlib.md5(md5_plugin_content).hexdigest()
+                with open(plugin_file, 'rb') as sha1_plugin_fh:
+                    sha1_plugin_content = sha1_plugin_fh.read()
+                sha1sum_old = hashlib.sha1(sha1_plugin_content).hexdigest()
 
             if self.params['version'] in [None, 'latest']:
                 # Take latest version
@@ -454,13 +454,13 @@ class JenkinsPlugin(object):
             if (
                     self.params['updates_expiration'] == 0 or
                     self.params['version'] not in [None, 'latest'] or
-                    md5sum_old is None):
+                    sha1sum_old is None):
 
                 # Download the plugin file directly
                 r = self._download_plugin(plugin_url)
 
                 # Write downloaded plugin into file if checksums don't match
-                if md5sum_old is None:
+                if sha1sum_old is None:
                     # No previously installed plugin
                     if not self.module.check_mode:
                         self._write_file(plugin_file, r)
@@ -471,11 +471,11 @@ class JenkinsPlugin(object):
                     data = r.read()
 
                     # Make new checksum
-                    md5sum_new = hashlib.md5(data).hexdigest()
+                    sha1sum_new = hashlib.sha1(data).hexdigest()
 
                     # If the checksum is different from the currently installed
                     # plugin, store the new plugin
-                    if md5sum_old != md5sum_new:
+                    if sha1sum_old != sha1sum_new:
                         if not self.module.check_mode:
                             self._write_file(plugin_file, data)
 
@@ -483,17 +483,6 @@ class JenkinsPlugin(object):
             elif self.params['version'] == 'latest':
                 # Check for update from the updates JSON file
                 plugin_data = self._download_updates()
-
-                try:
-                    with open(plugin_file, 'rb') as sha1_plugin_fh:
-                        sha1_plugin_content = sha1_plugin_fh.read()
-                    sha1_old = hashlib.sha1(sha1_plugin_content)
-                except Exception as e:
-                    self.module.fail_json(
-                        msg="Cannot calculate SHA1 of the old plugin.",
-                        details=to_native(e))
-
-                sha1sum_old = base64.b64encode(sha1_old.digest())
 
                 # If the latest version changed, download it
                 if sha1sum_old != to_bytes(plugin_data['sha1']):


### PR DESCRIPTION
##### SUMMARY
Fixes ansible/ansible issue number 34304 (https://github.com/ansible/ansible/issues/34304)
Re-do of ansible/ansible PR number  50234 (https://github.com/ansible/ansible/pull/50234)

All content in this description and code changes originally by @jesstruck

The hashlib.md5(...) function is disabled on systems running in FIPS 140-2 mode. To accommodate that, this commit just switches to a hash function (hashlib.sha1(...)) that is allowed by FIPS 140-2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jenkins_plugin

##### ADDITIONAL INFORMATION
From @jesstruck:
```This is a second try of getting 34349 accepted and merged in, I have simply reimplemented @karlmdavis solution in the previous mentioned pull request, together with the suggested changes he got.```