### PR TITLE
Fix decoding of response payloads for python 3.5

### DIFF
--- a/changelogs/fragments/687-fix-redfish-payload-decode-python35.yml
+++ b/changelogs/fragments/687-fix-redfish-payload-decode-python35.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_info, redfish_config, redfish_command - Fix Redfish response payload decode on Python 3.5 (https://github.com/ansible-collections/community.general/issues/686)

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -6,6 +6,7 @@ __metaclass__ = type
 
 import json
 from ansible.module_utils.urls import open_url
+from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six.moves import http_client
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
@@ -47,7 +48,7 @@ class RedfishUtils(object):
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
                             use_proxy=True, timeout=self.timeout)
-            data = json.loads(resp.read())
+            data = json.loads(to_native(resp.read()))
             headers = dict((k.lower(), v) for (k, v) in resp.info().items())
         except HTTPError as e:
             msg = self._get_extended_message(e)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added to_native() wrapper around the read of the Redfish response payload to ensure proper decoding of the bytes on all supported Python versions (2.7, 3.5, 3.6, 3.7, 3.8).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #686 

Also, see the original issue in https://github.com/ansible/ansible/issues/65889

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_info
redfish_config
redfish_command
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The original code (`json.loads(resp.read())`) is failing on Python 3.5 because `json.loads()` expects a `str` and the `HTTPResponse.read()` returns `bytes`.

In Python 3.6 and later,  `json.loads()` will also take `bytes`, so it worked there. And in Python 2.7 the `HTTPResponse.read()` returns `str`, so it worked there as well.

**Before** the fix, running a play with the Python 3.5 interpreter:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/get_system_inventory.yml

PLAY [System Inventory] ********************************************************

TASK [Define output file] ******************************************************
included: $HOME/playbooks/systems/create_output_file.yml for hpe, dell, lenovo

TASK [Define timestamp] ********************************************************
ok: [hpe]

TASK [Define file to place results] ********************************************
ok: [hpe]
ok: [dell]
ok: [lenovo]

TASK [Create dropoff directory for host] ***************************************
ok: [lenovo]
ok: [dell]
ok: [hpe]

TASK [Getting system inventory] ************************************************
fatal: [lenovo]: FAILED! => {"changed": false, "msg": "Failed GET request to 'https://10.1.0.3/redfish/v1/': 'the JSON object must be str, not 'bytes''"}
fatal: [dell]: FAILED! => {"changed": false, "msg": "Failed GET request to 'https://10.1.0.2/redfish/v1/': 'the JSON object must be str, not 'bytes''"}
fatal: [hpe]: FAILED! => {"changed": false, "msg": "Failed GET request to 'https://10.1.0.1/redfish/v1/': 'the JSON object must be str, not 'bytes''"}

PLAY RECAP *********************************************************************
dell                       : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
hpe                        : ok=4    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
lenovo                     : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```

**After** the fix, running a play with the Python 3.5 interpreter:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/get_system_inventory.yml

PLAY [System Inventory] ********************************************************

TASK [Define output file] ******************************************************
included: $HOME/playbooks/systems/create_output_file.yml for hpe, dell, lenovo

TASK [Define timestamp] ********************************************************
ok: [hpe]

TASK [Define file to place results] ********************************************
ok: [hpe]
ok: [dell]
ok: [lenovo]

TASK [Create dropoff directory for host] ***************************************
ok: [lenovo]
ok: [hpe]
ok: [dell]

TASK [Getting system inventory] ************************************************
ok: [dell]
ok: [lenovo]
ok: [hpe]

TASK [Copy results to output file] *********************************************
changed: [lenovo]
changed: [hpe]
changed: [dell]

PLAY RECAP *********************************************************************
dell                       : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
hpe                        : ok=6    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
lenovo                     : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
