### PR TITLE
haproxy: Enable/disable health and agent checks

### DIFF
--- a/changelogs/fragments/689-haproxy_agent_and_health.yml
+++ b/changelogs/fragments/689-haproxy_agent_and_health.yml
@@ -3,4 +3,5 @@ minor_changes:
   - haproxy - add options to dis/enable health and agent checks.  When health
     and agent checks are enabled for a service, a disabled service will
     re-enable itself automatically.  These options also change the state of
-    the agent checks to match the requested state for the backend.
+    the agent checks to match the requested state for the backend
+    (https://github.com/ansible-collections/community.general/issues/684).

--- a/changelogs/fragments/689-haproxy_agent_and_health.yml
+++ b/changelogs/fragments/689-haproxy_agent_and_health.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - haproxy - Add options to dis/enable health and agent checks.  When health
+    and agent checks are enabled for a service, a disabled service will
+    re-enable itself automatically.  These options also change the state of
+    the agent checks to match the requested state for the backend.

--- a/changelogs/fragments/689-haproxy_agent_and_health.yml
+++ b/changelogs/fragments/689-haproxy_agent_and_health.yml
@@ -1,6 +1,6 @@
 ---
 minor_changes:
-  - haproxy - Add options to dis/enable health and agent checks.  When health
+  - haproxy - add options to dis/enable health and agent checks.  When health
     and agent checks are enabled for a service, a disabled service will
     re-enable itself automatically.  These options also change the state of
     the agent checks to match the requested state for the backend.

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -64,7 +64,7 @@ options:
     choices: [ disabled, drain, enabled ]
   agent:
     description:
-      - Disable/enable agent checks (depending on`state` value).
+      - Disable/enable agent checks (depending on I(state) value).
     type: bool
     default: no
     version_added: 1.0.0

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -65,7 +65,6 @@ options:
   agent:
     description:
       - Disable/enable agent checks (depending on`state` value).
-    required: false
     default: false
     version_added: 1.0.0
   health:

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -70,7 +70,7 @@ options:
     version_added: 1.0.0
   health:
     description:
-      - Disable/enable health checks (depending on`state` value).
+      - Disable/enable health checks (depending on I(state) value).
     type: bool
     default: no
     version_added: "1.0.0"

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -112,6 +112,13 @@ EXAMPLES = r'''
     host: '{{ inventory_hostname }}'
     backend: www
 
+- name: Disable server in 'www' backend pool, also stop health/agent checks
+  community.general.haproxy:
+    state: disabled
+    host: '{{ inventory_hostname }}'
+    health: yes
+    agent: yes
+
 - name: Disable server without backend pool name (apply to all available backend pool)
   community.general.haproxy:
     state: disabled

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -65,6 +65,7 @@ options:
   agent:
     description:
       - Disable/enable agent checks (depending on`state` value).
+    type: bool
     default: false
     version_added: 1.0.0
   health:

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -66,13 +66,13 @@ options:
     description:
       - Disable/enable agent checks (depending on`state` value).
     type: bool
-    default: false
+    default: no
     version_added: 1.0.0
   health:
     description:
       - Disable/enable health checks (depending on`state` value).
-    required: false
-    default: false
+    type: bool
+    default: no
     version_added: "1.0.0"
   fail_on_not_found:
     description:

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -73,7 +73,7 @@ options:
       - Disable/enable health checks (depending on`state` value).
     required: false
     default: false
-    version_added: "2.10"
+    version_added: "1.0.0"
   fail_on_not_found:
     description:
       - Fail whenever trying to enable/disable a backend host that does not exist

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -67,6 +67,7 @@ options:
       - Disable/enable agent checks (depending on`state` value).
     required: false
     default: false
+    version_added: 1.0.0
   health:
     description:
       - Disable/enable health checks (depending on`state` value).


### PR DESCRIPTION
Health and agent checks can cause a disabled service to re-enable
itself.  This adds "health" and "agent" options that will also
enable or disable those checks, matching if the service is to be
enabled/disabled.

##### SUMMARY
The haproxy module sends the "disable server" command, but if health and agent checks are enabled, the server immediately re-enables itself due to these checks passing.

I have a fix on https://github.com/linsomniac/ansible-modules-extras/tree/haproxy-agent-health which adds "health" and "agent" options and will send "disable health" and "disable agent" commands in addition to "disable server". The same is done for the "enable".

I was unable to figure out how to submit a PR of this change in this repo, because ansible-modules-extra is a locked repo and instructions on how to submit PRs in that repo reference a URL that no longer exists (issue for that filed separately).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
haproxy

##### ADDITIONAL INFORMATION
```
tasks:
  - name: Disable server
    haproxy:
      host: web1
      state: disabled
      agent: true
      health: true
```
Fixes #684 