### PR TITLE
Added uint type to xfconf module

### DIFF
--- a/changelogs/fragments/xfconf_add_uint_type.yml
+++ b/changelogs/fragments/xfconf_add_uint_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xfconf - add support for ``uint`` type (https://github.com/ansible-collections/community.general/pull/692).

--- a/changelogs/fragments/xfconf_add_uint_type.yml
+++ b/changelogs/fragments/xfconf_add_uint_type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - xfconf - add support for ``uint`` type (https://github.com/ansible-collections/community.general/pull/692).
+  - xfconf - add support for ``uint`` type (https://github.com/ansible-collections/community.general/pull/696).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -44,7 +44,7 @@ options:
       For array mode, use a list of types.
     type: list
     elements: str
-    choices: [ int, bool, float, string ]
+    choices: [ int, uint, bool, float, string ]
   state:
     description:
     - The action to take upon the property/value.
@@ -124,7 +124,7 @@ class XfConfProperty(object):
     GET = "get"
     RESET = "absent"
     VALID_STATES = (SET, GET, RESET)
-    VALID_VALUE_TYPES = ('int', 'bool', 'float', 'string')
+    VALID_VALUE_TYPES = ('int', 'uint', 'bool', 'float', 'string')
     previous_value = None
     is_array = None
 


### PR DESCRIPTION
##### SUMMARY
This MR adds support for the `uint` type in the xfconf module.

When set from the UI (ie. xfce4-settings-manager), some XFCE settings are of type `Unsigned Int`.
In xfce4-settings-editor, though they appear as `Integer` in the type column of the _table_ view; their actual type is revealed to be `Unsigned Int` in the type _drop-down list_, shown when editing the property.

For most properties, creating an `int` property from Ansible is properly handled by XFCE, but not for all.
When the following properties are created as `int`, their value does not show properly in xfce4-settings-manager and may not be taken into account by the system
- /xfce4-power-manager/inactivity-on-battery
- /xfce4-power-manager/inactivity-on-ac
- (not exhaustive)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
xfconf

##### ADDITIONAL INFORMATION
Was initially submitted as [PR 692](https://github.com/ansible-collections/community.general/pull/692)
