### PR TITLE
Fix changes detection for django_manage createcachetable

### DIFF
--- a/changelogs/fragments/699-django_manage-createcachetable-fix-idempotence.yml
+++ b/changelogs/fragments/699-django_manage-createcachetable-fix-idempotence.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - django_manage - fix idempotence for ``createcachetable`` (https://github.com/ansible-collections/community.general/pull/699).

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -164,8 +164,8 @@ def _ensure_virtualenv(module):
     os.environ["VIRTUAL_ENV"] = venv_param
 
 
-def createcachetable_filter_output(line):
-    return "Already exists" not in line
+def createcachetable_check_changed(output):
+    return "already exists" not in output
 
 
 def flush_filter_output(line):
@@ -282,7 +282,7 @@ def main():
     rc, out, err = module.run_command(cmd, cwd=app_path)
     if rc != 0:
         if command == 'createcachetable' and 'table' in err and 'already exists' in err:
-            out = 'Already exists.'
+            out = 'already exists.'
         else:
             if "Unknown command:" in err:
                 _fail(module, cmd, err, "Unknown django command: %s" % command)
@@ -296,6 +296,9 @@ def main():
         filtered_output = list(filter(filt, lines))
         if len(filtered_output):
             changed = True
+    check_changed = globals().get("{0}_check_changed".format(command), None)
+    if check_changed:
+        changed = check_changed(out)
 
     module.exit_json(changed=changed, out=out, cmd=cmd, app_path=app_path, virtualenv=virtualenv,
                      settings=module.params['settings'], pythonpath=module.params['pythonpath'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This Pull Request fixes the problem that ansible always says that there always was a change made during `manage.py createcachetable`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* django_manage
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The reason why it didn't work before:
* manage.py prints `Cache table 'cache_table' already exists.` to stdout if there is no changes and _nothing_ if there were changes
* the code seems to correctly check this if manage.py returns non-zero exit code and whites its status to _stderr_ (which I didn't observed, no idea which version of Django does this) but fails if manage.py returns 0 and writes its status to stdout (which is what happens in my case) and in that case there are few problems:
  * the code checks for phrase `Already exists` but the real spelling is `already exists` (case differs)
  * there is always an empty line in `lines` variable
  * if there are changes made, there is no output, so even if two problems above are fixed, the problem would be flipped: it would always report that no changes has been made because of the current implementation with `filter()` and `len(filtered_output)`

To be honest, I would refactor the whole changes detection code: I'd get rid of `globals().get` hack and replace it with plain (not so) long `if\elif` block which would be slightly easier to read and won't impose wrong assumptions to future implementations. If maintainers agree with that, I'll update my Pull Request.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
