### PR TITLE
doas: ensure the module works with default parameters

### DIFF
--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -111,15 +111,14 @@ class BecomeModule(BecomeBase):
 
         self.prompt = True
 
-        become_exe = self.get_option('become_exe')
+        become_exe = self.get_option('become_exe') or "doas"
 
-        flags = self.get_option('become_flags')
+        flags = self.get_option('become_flags') or ''
         if not self.get_option('become_pass') and '-n' not in flags:
             flags += ' -n'
 
-        user = self.get_option('become_user')
-        if user:
-            user = '-u %s' % (user)
+        become_user = self.get_option('become_user')
+        user = '-u %s' % (become_user) if become_user else ''
 
         success_cmd = self._build_success_command(cmd, shell, noexe=True)
         executable = getattr(shell, 'executable', shell.SHELL_FAMILY)


### PR DESCRIPTION
##### SUMMARY

Ensure the module still works if the following parameters are not
defined. The regression was introduced by
0026c9f5b22fda3037b2d5e9518f8905b8051a39.

- `become_exe`: default to `/usr/bin/doas` as documented
- `become_user`: default to empty.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

doas