### PR TITLE
slack: support for blocks

### DIFF
--- a/changelogs/fragments/702-slack-support-for-blocks.yaml
+++ b/changelogs/fragments/702-slack-support-for-blocks.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - slack - add support for sending messages built with block kit (https://github.com/ansible-collections/community.general/issues/380).

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -105,6 +105,9 @@ options:
     description:
       - Define a list of blocks. This list mirrors the Slack JSON API.
       - For more information, see U(https://api.slack.com/block-kit).
+    type: list
+    elements: dict
+    version_added: 1.0.0
 """
 
 EXAMPLES = """
@@ -243,7 +246,7 @@ def recursive_escape_quotes(obj, keys):
     elif isinstance(obj, list):
         escaped = [recursive_escape_quotes(v, keys) for v in obj]
     else:
-        return obj
+        escaped = obj
     return escaped
 
 
@@ -359,7 +362,7 @@ def main():
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
             attachments=dict(type='list', required=False, default=None),
-            blocks=dict(type='list', required=False, default=None),
+            blocks=dict(type='list', elements='dict'),
         )
     )
 

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -86,12 +86,6 @@ options:
     choices:
       - 'full'
       - 'none'
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites using self-signed certificates.
-    type: bool
-    default: 'yes'
   color:
     description:
       - Allow text to use default colors - use the default of 'normal' to not send a custom color bar at the start of the message.
@@ -354,7 +348,6 @@ def main():
             icon_emoji=dict(type='str', default=None),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             parse=dict(type='str', default=None, choices=['none', 'full']),
-            validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
             attachments=dict(type='list', required=False, default=None),
             blocks=dict(type='list', required=False, default=None)

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -46,8 +46,7 @@ options:
         URL given to you in that section."
       - "WebAPI token:
         Slack WebAPI requires a personal, bot or work application token. These tokens start with C(xoxp-), C(xoxb-)
-        or C(xoxa-), eg. C(xoxb-1234-56789abcdefghijklmnop). WebAPI token is required if you inted to receive and use
-        thread_id.
+        or C(xoxa-), eg. C(xoxb-1234-56789abcdefghijklmnop). WebAPI token is required if you inted to receive thread_id.
         See Slack's documentation (U(https://api.slack.com/docs/token-types)) for more information."
     required: true
   msg:

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -85,6 +85,12 @@ options:
     choices:
       - 'full'
       - 'none'
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled sites using self-signed certificates.
+    type: bool
+    default: 'yes'
   color:
     description:
       - Allow text to use default colors - use the default of 'normal' to not send a custom color bar at the start of the message.
@@ -347,6 +353,7 @@ def main():
             icon_emoji=dict(type='str', default=None),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             parse=dict(type='str', default=None, choices=['none', 'full']),
+            validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
             attachments=dict(type='list', required=False, default=None),
             blocks=dict(type='list', required=False, default=None)

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -100,11 +100,11 @@ options:
   attachments:
     description:
       - Define a list of attachments. This list mirrors the Slack JSON API.
-      - For more information, see (U(https://api.slack.com/docs/attachments)).
+      - For more information, see U(https://api.slack.com/docs/attachments).
   blocks:
     description:
       - Define a list of blocks. This list mirrors the Slack JSON API.
-      - For more information, see (U(https://api.slack.com/block-kit)).
+      - For more information, see U(https://api.slack.com/block-kit).
 """
 
 EXAMPLES = """
@@ -356,7 +356,7 @@ def main():
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
             attachments=dict(type='list', required=False, default=None),
-            blocks=dict(type='list', required=False, default=None)
+            blocks=dict(type='list', required=False, default=None),
         )
     )
 

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -46,7 +46,7 @@ options:
         URL given to you in that section."
       - "WebAPI token:
         Slack WebAPI requires a personal, bot or work application token. These tokens start with C(xoxp-), C(xoxb-)
-        or C(xoxa-), eg. C(xoxb-1234-56789abcdefghijklmnop). WebAPI token is required if you inted to receive thread_id.
+        or C(xoxa-), eg. C(xoxb-1234-56789abcdefghijklmnop). WebAPI token is required if you intend to receive thread_id.
         See Slack's documentation (U(https://api.slack.com/docs/token-types)) for more information."
     required: true
   msg:

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# (c) 2020, Lee Goolsbee <lgoolsbee@atlassian.com>
 # (c) 2020, Michal Middleton <mm.404@icloud.com>
 # (c) 2017, Steve Pletcher <steve@steve-pletcher.com>
 # (c) 2016, René Moser <mail@renemoser.net>
@@ -100,7 +101,11 @@ options:
   attachments:
     description:
       - Define a list of attachments. This list mirrors the Slack JSON API.
-      - For more information, see also in the (U(https://api.slack.com/docs/attachments)).
+      - For more information, see (U(https://api.slack.com/docs/attachments)).
+  blocks:
+    description:
+      - Define a list of blocks. This list mirrors the Slack JSON API.
+      - For more information, see (U(https://api.slack.com/block-kit)).
 """
 
 EXAMPLES = """
@@ -152,6 +157,27 @@ EXAMPLES = """
           - title: System B
             value: 'load average: 5,16, 4,64, 2,43'
             short: True
+
+- name: Use the blocks API
+  community.general.slack:
+    token: thetoken/generatedby/slack
+    blocks:
+      - type: section
+        text:
+          type: mrkdwn
+          text: |-
+            *System load*
+            Display my system load on host A and B
+      - type: context
+        elements:
+        - type: mrkdwn
+          text: |-
+            *System A*
+            load average: 0,74, 0,66, 0,63
+        - type: mrkdwn
+          text: |-
+            *System B*
+            load average: 5,16, 4,64, 2,43
 
 - name: Send a message with a link using Slack markup
   community.general.slack:
@@ -206,8 +232,25 @@ def escape_quotes(text):
     return "".join(escape_table.get(c, c) for c in text)
 
 
+def recursive_escape(obj):
+    '''Recursively escape quotes inside "text" and "alt_text" strings inside block kit objects'''
+    block_keys_to_escape = ['text', 'alt_text']
+    if isinstance(obj, dict):
+        escaped = {}
+        for k, v in obj.items():
+            if isinstance(v, str) and k in block_keys_to_escape:
+                escaped[k] = escape_quotes(v)
+            else:
+                escaped[k] = recursive_escape(v)
+    elif isinstance(obj, list):
+        escaped = [recursive_escape(v) for v in obj]
+    else:
+        return obj
+    return escaped
+
+
 def build_payload_for_slack(module, text, channel, thread_id, username, icon_url, icon_emoji, link_names,
-                            parse, color, attachments):
+                            parse, color, attachments, blocks):
     payload = {}
     if color == "normal" and text is not None:
         payload = dict(text=escape_quotes(text))
@@ -237,7 +280,7 @@ def build_payload_for_slack(module, text, channel, thread_id, username, icon_url
             payload['attachments'] = []
 
     if attachments is not None:
-        keys_to_escape = [
+        attachment_keys_to_escape = [
             'title',
             'text',
             'author_name',
@@ -245,7 +288,7 @@ def build_payload_for_slack(module, text, channel, thread_id, username, icon_url
             'fallback',
         ]
         for attachment in attachments:
-            for key in keys_to_escape:
+            for key in attachment_keys_to_escape:
                 if key in attachment:
                     attachment[key] = escape_quotes(attachment[key])
 
@@ -253,6 +296,9 @@ def build_payload_for_slack(module, text, channel, thread_id, username, icon_url
                 attachment['fallback'] = attachment['text']
 
             payload['attachments'].append(attachment)
+
+    if blocks is not None:
+        payload['blocks'] = recursive_escape(blocks)
 
     payload = module.jsonify(payload)
     return payload
@@ -310,7 +356,8 @@ def main():
             parse=dict(type='str', default=None, choices=['none', 'full']),
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
-            attachments=dict(type='list', required=False, default=None)
+            attachments=dict(type='list', required=False, default=None),
+            blocks=dict(type='list', required=False, default=None)
         )
     )
 
@@ -326,6 +373,7 @@ def main():
     parse = module.params['parse']
     color = module.params['color']
     attachments = module.params['attachments']
+    blocks = module.params['blocks']
 
     color_choices = ['normal', 'good', 'warning', 'danger']
     if color not in color_choices and not is_valid_hex_color(color):
@@ -333,7 +381,7 @@ def main():
                              "or any valid hex value with length 3 or 6." % color_choices)
 
     payload = build_payload_for_slack(module, text, channel, thread_id, username, icon_url, icon_emoji, link_names,
-                                      parse, color, attachments)
+                                      parse, color, attachments, blocks)
     slack_response = do_notify_slack(module, domain, token, payload)
 
     if 'ok' in slack_response:

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -206,6 +206,13 @@ OLD_SLACK_INCOMING_WEBHOOK = 'https://%s/services/hooks/incoming-webhook?token=%
 SLACK_INCOMING_WEBHOOK = 'https://hooks.slack.com/services/%s'
 SLACK_POSTMESSAGE_WEBAPI = 'https://slack.com/api/chat.postMessage'
 
+# Escaping quotes and apostrophes to avoid ending string prematurely in ansible call.
+# We do not escape other characters used as Slack metacharacters (e.g. &, <, >).
+escape_table = {
+    '"': "\"",
+    "'": "\'",
+}
+
 
 def is_valid_hex_color(color_choice):
     if re.match(r'^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$', color_choice):
@@ -213,14 +220,36 @@ def is_valid_hex_color(color_choice):
     return False
 
 
+def escape_quotes(text):
+    '''Backslash any quotes within text.'''
+    return "".join(escape_table.get(c, c) for c in text)
+
+
+def recursive_escape(obj):
+    '''Recursively escape quotes inside "text" and "alt_text" strings inside block kit objects'''
+    block_keys_to_escape = ['text', 'alt_text']
+    if isinstance(obj, dict):
+        escaped = {}
+        for k, v in obj.items():
+            if isinstance(v, str) and k in block_keys_to_escape:
+                escaped[k] = escape_quotes(v)
+            else:
+                escaped[k] = recursive_escape(v)
+    elif isinstance(obj, list):
+        escaped = [recursive_escape(v) for v in obj]
+    else:
+        return obj
+    return escaped
+
+
 def build_payload_for_slack(module, text, channel, thread_id, username, icon_url, icon_emoji, link_names,
                             parse, color, attachments, blocks):
     payload = {}
     if color == "normal" and text is not None:
-        payload['text'] = text
+        payload = dict(text=escape_quotes(text))
     elif text is not None:
         # With a custom color we have to set the message as attachment, and explicitly turn markdown parsing on for it.
-        payload = dict(attachments=[dict(text=text, color=color, mrkdwn_in=["text"])])
+        payload = dict(attachments=[dict(text=escape_quotes(text), color=color, mrkdwn_in=["text"])])
     if channel is not None:
         if (channel[0] == '#') or (channel[0] == '@'):
             payload['channel'] = channel
@@ -242,13 +271,27 @@ def build_payload_for_slack(module, text, channel, thread_id, username, icon_url
     if attachments is not None:
         if 'attachments' not in payload:
             payload['attachments'] = []
+
+    if attachments is not None:
+        attachment_keys_to_escape = [
+            'title',
+            'text',
+            'author_name',
+            'pretext',
+            'fallback',
+        ]
         for attachment in attachments:
+            for key in attachment_keys_to_escape:
+                if key in attachment:
+                    attachment[key] = escape_quotes(attachment[key])
+
             if 'fallback' not in attachment:
                 attachment['fallback'] = attachment['text']
+
             payload['attachments'].append(attachment)
 
     if blocks is not None:
-        payload['blocks'] = blocks
+        payload['blocks'] = recursive_escape(blocks)
 
     payload = module.jsonify(payload)
     return payload

--- a/tests/unit/plugins/modules/notification/test_slack.py
+++ b/tests/unit/plugins/modules/notification/test_slack.py
@@ -88,6 +88,43 @@ class TestSlackModule(ModuleTestCase):
             assert call_data['thread_ts'] == '100.00'
             assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
 
+    def test_message_with_blocks(self):
+        """tests sending a message with blocks"""
+        set_module_args({
+            'token': 'XXXX/YYYY/ZZZZ',
+            'msg': 'test',
+            'blocks': [{
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': '*test*'
+                },
+                'accessory': {
+                    'type': 'image',
+                    'image_url': 'https://www.ansible.com/favicon.ico',
+                    'alt_text': 'test'
+                }
+            }, {
+                'type': 'section',
+                'text': {
+                    'type': 'plain_text',
+                    'text': 'test',
+                    'emoji': True
+                }
+            }]
+        })
+
+        with patch.object(slack, "fetch_url") as fetch_url_mock:
+            fetch_url_mock.return_value = (None, {"status": 200})
+            with self.assertRaises(AnsibleExitJson):
+                self.module.main()
+
+            self.assertTrue(fetch_url_mock.call_count, 1)
+            call_data = json.loads(fetch_url_mock.call_args[1]['data'])
+            assert call_data['username'] == "Ansible"
+            assert call_data['blocks'][1]['text']['text'] == "test"
+            assert fetch_url_mock.call_args[1]['url'] == "https://hooks.slack.com/services/XXXX/YYYY/ZZZZ"
+
     def test_message_with_invalid_color(self):
         """tests sending invalid color value to module"""
         set_module_args({


### PR DESCRIPTION
##### SUMMARY

Adds basic support for building Slack messages with blocks. I say basic, but the affordances here are the same as for attachments, in that whatever structure of blocks a user wants to send (mirroring [Slack’s documentation](https://api.slack.com/block-kit) for building Block Kit messages) should be defined directly in the YAML, and no altering or modification of that structure is done before the message is sent.

Fixes #380.

Example:

```
- name: Use the blocks API
  community.general.slack:
    token: thetoken/generatedby/slack
    blocks:
      - type: section
        text:
          type: mrkdwn
          text: |-
            *System load*
            Display my system load on host A and B
      - type: context
        elements:
        - type: mrkdwn
          text: |-
            *System A*
            load average: 0,74, 0,66, 0,63
        - type: mrkdwn
          text: |-
            *System B*
            load average: 5,16, 4,64, 2,43
```

<img width="571" alt="Screen Shot 2020-07-27 at 9 01 17 PM" src="https://user-images.githubusercontent.com/438555/88697439-2cb12700-d0ca-11ea-9588-ff2a51c5ae89.png">

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

slack

##### ADDITIONAL INFORMATION

I also did a little cleanup:
* Dropped the `validate_certs` option from the docs and argument spec; it’s never been used for anything, as far as I can tell (it’s in [the original commit for the module](https://github.com/ansible/ansible-modules-extras/commit/e15af949a86a303d4bf96a97259ab8ae55a161f7), and even there it seems unused, unless I misunderstand something?).
* Updated the docs to reflect that Web API tokens are no longer required to _send_ messages with `thread_id`, just to _receive responses_ that include that information ([Slack changelog, Dec 2018](https://api.slack.com/changelog#December_2018)).
* Dropped escaping of quotes and apostrophes. Originally [added in Sept 2016](https://github.com/ansible/ansible-modules-extras/pull/3032/files) and [modified in Jan 2017](https://github.com/ansible/ansible/pull/19980/files), I’m 99% sure this isn’t necessary anymore for a few reasons:
  1. In [October 2017](https://api.slack.com/changelog#October_2017), Slack added the ability to send JSON directly to their Web API methods ([more docs here](https://api.slack.com/changelog/2017-10-keeping-up-with-the-jsons); other methods of sending messages to Slack (including incoming webhooks) had already supported this).
  1. The original commit to add the escaping also [dropped the old form-encdoed `payload=` method of sending the POST data](https://github.com/ansible/ansible-modules-extras/pull/3032/files#diff-bd8d05bbd5b603181d453fa3bb1ec879L202), and [added `application/json` as the Content-Type for all requests](https://github.com/ansible/ansible-modules-extras/pull/3032/files#diff-bd8d05bbd5b603181d453fa3bb1ec879R241-R244); I think this means that for about a year, this module was sending JSON POST bodies and Content-Type `application/json` requests to Web API endpoints before it was supported, and I guess either nobody used that style of token/endpoint, or Slack was silently accepting those requests anyways? Either way, it _seems_ likely that the quote escaping was only necessary in the old world where JSON was actually sent as a form-encoded POST body?
  1. I’ve tested many methods and combinations of sending unbalanced/unescaped quotes as content directly in a task, resolved from variables, and doing lookups from a text file, and I can’t reproduce any errors related to unescaped quotes – in all cases, messages are sent successfully and displayed by Slack preserving all content and formatting: <img width="574" alt="Screen Shot 2020-07-28 at 12 14 18 PM" src="https://user-images.githubusercontent.com/438555/88698752-173cfc80-d0cc-11ea-8dc8-7ce5c1cd2353.png">


If any of these cleanup items are cause for concern (or you feel they should be delayed), I’ve made them separate commits that are easily reverted / moved to other PRs. Note that reverting the last item (escaping of quotes and apostrophes) would potentially mean needing to include a recursive function for escaping quotes in every `text` and `alt_text` field embedded in any blocks defined by the user; code to handle this already exists in my original commit to add support for blocks, but it felt very heavy for something that might be totally unnecessary, which is why I went down the road of investigating the need (or perhaps lack thereof) for that escaping in the first place.