### PR TITLE
Add porting guide entries from Ansible-base porting guide

### DIFF
--- a/changelogs/fragments/porting-guide-2.yml
+++ b/changelogs/fragments/porting-guide-2.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - pacman - the deprecated ``recurse`` option has been removed, you should use ``extra_args=--recursive`` instead.
+deprecated_features:
+  - The ldap_attr module has been deprecated and will be removed in a later release; use ldap_attrs instead.

--- a/changelogs/fragments/porting-guide-2.yml
+++ b/changelogs/fragments/porting-guide-2.yml
@@ -1,4 +1,2 @@
-breaking_changes:
-  - pacman - the deprecated ``recurse`` option has been removed, you should use ``extra_args=--recursive`` instead.
 deprecated_features:
   - The ldap_attr module has been deprecated and will be removed in a later release; use ldap_attrs instead.


### PR DESCRIPTION
##### SUMMARY
This adds entries from the Ansible-base porting guide that do not belong there (because they belong to this collection). This data has already been moved to the ansible changelog (https://github.com/ansible-community/ansible-build-data/blob/main/2.10/changelog.yaml), but it would be better if it appears in the changelog of the collection it applies to.

(Looks like I forgot this one earlier...)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
