### PR TITLE
doas: properly set the default values

### DIFF
--- a/changelogs/fragments/704-doas-set-correct-default-values.yml
+++ b/changelogs/fragments/704-doas-set-correct-default-values.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- doas - Address a bug with the parameters handling that was breaking the module with Ansible 2.10.
+- doas become plugin - address a bug with the parameters handling that was breaking the plugin in community.general when `become_flags` and `become_user` were not explicitly specified (https://github.com/ansible-collections/community.general/pull/704).

--- a/changelogs/fragments/704-doas-set-correct-default-values.yml
+++ b/changelogs/fragments/704-doas-set-correct-default-values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- doas - Address a bug with the parameters handling that was breaking the module with Ansible 2.10.

--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -40,7 +40,7 @@ DOCUMENTATION = '''
               - name: ANSIBLE_DOAS_EXE
         become_flags:
             description: Options to pass to doas
-            default:
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_flags
@@ -117,9 +117,8 @@ class BecomeModule(BecomeBase):
         if not self.get_option('become_pass') and '-n' not in flags:
             flags += ' -n'
 
-        user = self.get_option('become_user')
-        if user:
-            user = '-u %s' % (user)
+        become_user = self.get_option('become_user')
+        user = '-u %s' % (become_user) if become_user else ''
 
         success_cmd = self._build_success_command(cmd, shell, noexe=True)
         executable = getattr(shell, 'executable', shell.SHELL_FAMILY)


### PR DESCRIPTION
#### SUMMARY

The module expects `become_user` and `become_flags` to by empty
string by default.

See: https://github.com/ansible-collections/community.general/pull/701
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
doas