### PR TITLE
jira: remove global try/except

### DIFF
--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -519,17 +519,12 @@ def main():
     restbase = uri + 'rest/api/2'
 
     # Dispatch
-    try:
+    # Lookup the corresponding method for this operation. This is
+    # safe as the AnsibleModule should remove any unknown operations.
+    thismod = sys.modules[__name__]
+    method = getattr(thismod, op)
 
-        # Lookup the corresponding method for this operation. This is
-        # safe as the AnsibleModule should remove any unknown operations.
-        thismod = sys.modules[__name__]
-        method = getattr(thismod, op)
-
-        ret = method(restbase, user, passwd, module.params)
-
-    except Exception as e:
-        return module.fail_json(msg=e.message)
+    ret = method(restbase, user, passwd, module.params)
 
     module.exit_json(changed=True, meta=ret)
 


### PR DESCRIPTION
##### SUMMARY
I've hit a couple different backtraces in the `jira` module. The `try` / `except Exception` pattern hides the true causes. Let's remove it so bug reports are more useful.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jira

##### ADDITIONAL INFORMATION
If a user encounters an exception, we want them to report a useful stack trace so that we understand the bug they hit. This PR removes the "try/except" block that would catch the base `Exception` class so we can see the full call stack and proper line numbers.

Sometimes I hit these exceptions because Jira is offline and I get an HTTP 503 with a blank body and we get `json.decoder.JSONDecodeError`. Other times it is a `TypeError` because of other bugs in the module (eg. #707).

In both of those cases (and probably others), the exceptions do not have a "`.message`" attribute. When we hit `AttributeError` in the except block, this would also disguise the real error.