### PR TITLE
jira: cast individual error messages to strings

### DIFF
--- a/changelogs/fragments/707-jira-error-handling.yaml
+++ b/changelogs/fragments/707-jira-error-handling.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- jira - improve error message handling with multiple errors (https://github.com/ansible-collections/community.general/pull/707).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -314,9 +314,9 @@ def request(url, user, passwd, timeout, data=None, method=None):
             msg = []
             for key in ('errorMessages', 'errors'):
                 if error.get(key):
-                    msg.append(error[key])
+                    msg.append(to_native(error[key]))
             if msg:
-                module.fail_json(msg=to_native(', '.join(msg)))
+                module.fail_json(msg=', '.join(msg))
             else:
                 module.fail_json(msg=to_native(error))
         else:


### PR DESCRIPTION
##### SUMMARY
This is a follow-on fix for a corner case I uncovered while testing https://github.com/ansible-collections/community.general/pull/311

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jira

##### ADDITIONAL INFORMATION
Sometimes Jira returns dicts as "`errors`" instead of simple strings. For example, when a user specifies a field that cannot be set, Jira returns a dict with the field name as a key and the error message as the value.

In the rare case that we have both a "`errorMessages`" list and an "`errors`" dict, when we combine those values later with `join()`, Python raises a `TypeError`.

Transform each individual error message into a string, and then `join()` the list of strings.