### PR TITLE
lxd_container - added target variable to support  flag for cluster deployments

### DIFF
--- a/changelogs/fragments/710-lxd-target-flag.yml
+++ b/changelogs/fragments/710-lxd-target-flag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lxd_container - added support of ``--target`` flag for cluster deployments (https://github.com/ansible-collections/community.general/issues/637).


### PR DESCRIPTION
##### SUMMARY
When creating new container in LXD cluster deployment, LXD algorithm will decide on which node new container must be created. [POST (optional ?target=<member>)](https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-optional-targetmember) can create container on a specific node in the cluster.

Some LXD cluster operators may prefer this approach of distributing containers in cluster, rather than letting LXD decide that. 

For example, one particular container will require a lot of resources, and not all cluster members can provide or share them.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lxd_container

##### ADDITIONAL INFORMATION
n/a
Issue #637 