### PR TITLE
module lxd_container - added target parameter for cluster deployments

### DIFF
--- a/changelogs/fragments/711-lxd-target.yml
+++ b/changelogs/fragments/711-lxd-target.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lxd_container - added support of ``--target`` flag for cluster deployments (https://github.com/ansible-collections/community.general/issues/637).

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -255,7 +255,7 @@ EXAMPLES = '''
 # An example for LXD cluster deployments. This example will create two new container on specific
 # nodes - 'node01' and 'node02'. In 'target:', 'node01' and 'node02' are names of LXD cluster
 # members that LXD cluster recognizes, not ansible inventory names, see: 'lxc cluster list'.
-# LXD API calls can be made to any LXD member, in this example, we send API requests to 
+# LXD API calls can be made to any LXD member, in this example, we send API requests to
 #'node01.example.com', which matches ansible inventory name.
 - hosts: node01.example.com
   tasks:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -77,6 +77,7 @@ options:
           - For cluster deployments. Will attempt to create a container on a target node.
             If container exists elsewhere in a cluster, then container will not be replaced or moved.
             The name should respond to same name of the node you see in C(lxc cluster list).
+        type: str
         required: false
         version_added: 1.0.0
     timeout:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -74,9 +74,9 @@ options:
         default: started
     target:
         description:
-          - For cluster deployments. Will attempt to create a container on a target node. 
-            If container exists elsewhere in a cluster, then container will not be replaced or moved. 
-            The name should respond to same name of the node you see in `lxc cluster list`.
+          - For cluster deployments. Will attempt to create a container on a target node.
+            If container exists elsewhere in a cluster, then container will not be replaced or moved.
+            The name should respond to same name of the node you see in `lxc cluster list`
         required: false
     timeout:
         description:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -251,6 +251,32 @@ EXAMPLES = '''
         src: /etc/hosts
         dest: /tmp/mycontainer-hosts
         flat: true
+
+# An example for LXD cluster deployments. This example will create two new container on specific
+# nodes - 'node01' and 'node02'. In 'target:', 'node01' and 'node02' are names of LXD cluster
+# members that LXD cluster recognizes, not ansible inventory names, see: 'lxc cluster list'.
+# LXD API calls can be made to any LXD member, in this example, we send API requests to 
+#'node01.example.com', which matches ansible inventory name.
+- hosts: node01.example.com
+  tasks:
+    - name: Create LXD container
+      community.general.lxd_container:
+        name: new-container-1
+        state: started
+        source:
+          type: image
+          mode: pull
+          alias: ubuntu/xenial/amd64
+        target: node01
+    - name: Create container on another node
+      community.general.lxd_container:
+        name: new-container-2
+        state: started
+        source:
+          type: image
+          mode: pull
+          alias: ubuntu/xenial/amd64
+        target: node02
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -76,7 +76,7 @@ options:
         description:
           - For cluster deployments. Will attempt to create a container on a target node.
             If container exists elsewhere in a cluster, then container will not be replaced or moved.
-            The name should respond to same name of the node you see in `lxc cluster list`
+            The name should respond to same name of the node you see in C(lxc cluster list).
         required: false
     timeout:
         description:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -78,6 +78,7 @@ options:
             If container exists elsewhere in a cluster, then container will not be replaced or moved.
             The name should respond to same name of the node you see in C(lxc cluster list).
         required: false
+        version_added: 1.0.0
     timeout:
         description:
           - A timeout for changing the state of the container.

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -268,6 +268,7 @@ EXAMPLES = '''
           mode: pull
           alias: ubuntu/xenial/amd64
         target: node01
+
     - name: Create container on another node
       community.general.lxd_container:
         name: new-container-2


### PR DESCRIPTION
##### SUMMARY
When creating new container in LXD cluster deployment, LXD algorithm will decide on which node new container must be created. [POST (optional ?target=<member>)](https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-optional-targetmember) can create container on a specific node in the cluster.

Some LXD cluster operators may prefer this approach of distributing containers in cluster, rather than letting LXD decide that. 

For example, one particular container will require a lot of resources, and not all cluster members can provide or share them.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lxd_container

##### ADDITIONAL INFORMATION
You can control LXD via HTTPS API. Most of container configuration is passed via json payload, however this particular - target - is passed in URL. `target` is optional parameter.

URL would look like `https://host:8443/1.0/instances?target=node1`

That is why I took this approach:
1. check whether `self.target` has value, and if yes
2. create a different URL to pass to lxd.py client.
```
        if self.target:
            self.client.do('POST', '/1.0/containers?' + urlencode(dict(target=self.target)), config)
```
Issue #637 

New parameter: `target`

Example ansible task would look like:
```
- name: Create LXD container
  lxd_container:
    name: my-container
    state: started
    source:
      type: image
      mode: pull
      alias: ubuntu/xenial/amd64
    target: node01
```

Setting up LXD cluster is easy with this documentation https://lxd.readthedocs.io/en/latest/clustering/
2 LXD members are enough for a test. LXD is not very resource intensive system.