### PR TITLE
nmcli: fix package name

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -21,9 +21,9 @@ requirements:
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
     - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
-      libsemanage-python, policycoreutils-python.'
+      python3-libsemanage, python3-policycoreutils.'
     - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
-      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, libsemanage-python, policycoreutils-python.'
+      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python3-libsemanage, python3-policycoreutils.'
     - 'On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
       python-dbus (or python3-dbus, depending on the Python version in use), libnm-dev.'
     - 'On older Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -23,7 +23,7 @@ description:
     - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-libnm,
       python3-libsemanage, python3-policycoreutils.'
     - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
-      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python3-libsemanage, python3-policycoreutils.'
+      libnm-qt-devel.x86_64, nm-connection-editor.x86_64, python-libsemanage, python-policycoreutils.'
     - 'On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
       python-dbus (or python3-dbus, depending on the Python version in use), libnm-dev.'
     - 'On older Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,


### PR DESCRIPTION
##### SUMMARY
Fixes package names for CentOS and Fedora.

Replaces #668.

Thanks to @fbruetting for reporting this and preparing a fix.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nmcli
