### PR TITLE
Fix plugins (names, constants, FQCNs in examples)

### DIFF
--- a/changelogs/fragments/722-plugins.yml
+++ b/changelogs/fragments/722-plugins.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- cobbler inventory plugin - ``name`` needed FQCN (https://github.com/ansible-collections/community.general/pull/722).
+- oc connection plugin - ``transport`` needed FQCN (https://github.com/ansible-collections/community.general/pull/722).
+- inventory plugins - allow FQCN in ``plugin`` option (https://github.com/ansible-collections/community.general/pull/722).

--- a/plugins/callback/logentries.py
+++ b/plugins/callback/logentries.py
@@ -75,7 +75,7 @@ examples: >
   To enable, add this to your ansible.cfg file in the defaults block
 
     [defaults]
-    callback_whitelist = logentries
+    callback_whitelist = community.general.logentries
 
   Either set the environment variables
     export LOGENTRIES_API=data.logentries.com

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -63,7 +63,7 @@ EXAMPLES = '''
 examples: >
   To enable, add this to your ansible.cfg file in the defaults block
     [defaults]
-    callback_whitelist = splunk
+    callback_whitelist = community.general.splunk
   Set the environment variable
     export SPLUNK_URL=http://mysplunkinstance.datapaas.io:8088/services/collector/event
     export SPLUNK_AUTHTOKEN=f23blad6-5965-4537-bf69-5b5a545blabla88

--- a/plugins/callback/sumologic.py
+++ b/plugins/callback/sumologic.py
@@ -42,7 +42,7 @@ EXAMPLES = '''
 examples: >
   To enable, add this to your ansible.cfg file in the defaults block
     [defaults]
-    callback_whitelist = sumologic
+    callback_whitelist = community.general.sumologic
 
   Set the environment variable
     export SUMOLOGIC_URL=https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/R8moSv1d8EW9LAUFZJ6dbxCFxwLH6kfCdcBfddlfxCbLuL-BN5twcTpMk__pYy_cDmp==

--- a/plugins/connection/oc.py
+++ b/plugins/connection/oc.py
@@ -150,7 +150,7 @@ DOCUMENTATION = '''
 from ansible_collections.community.kubernetes.plugins.connection.kubectl import Connection as KubectlConnection
 
 
-CONNECTION_TRANSPORT = 'oc'
+CONNECTION_TRANSPORT = 'community.general.oc'
 
 CONNECTION_OPTIONS = {
     'oc_container': '-c',

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
       plugin:
         description: The name of this plugin, it should always be set to C(cobbler) for this plugin to recognize it as it's own.
         required: yes
-        choices: ['cobbler']
+        choices: [ 'cobbler', 'community.general.cobbler' ]
       url:
         description: URL to cobbler.
         default: 'http://cobbler/cobbler_api'

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
         - inventory_cache
     options:
       plugin:
-        description: The name of this plugin, it should always be set to C(cobbler) for this plugin to recognize it as it's own.
+        description: The name of this plugin, it should always be set to C(community.general.cobbler) for this plugin to recognize it as it's own.
         required: yes
         choices: [ 'cobbler', 'community.general.cobbler' ]
       url:

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -92,7 +92,7 @@ except ImportError:
 class InventoryModule(BaseInventoryPlugin, Cacheable):
     ''' Host inventory parser for ansible using cobbler as source. '''
 
-    NAME = 'cobbler'
+    NAME = 'community.general.cobbler'
 
     def __init__(self):
 

--- a/plugins/inventory/docker_machine.py
+++ b/plugins/inventory/docker_machine.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the C(docker_machine) plugin.
             required: yes
-            choices: ['docker_machine']
+            choices: ['docker_machine', 'community.general.docker_machine']
         daemon_env:
             description:
                 - Whether docker daemon connection environment variables should be fetched, and how to behave if they cannot be fetched.
@@ -54,7 +54,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 # Minimal example
-plugin: docker_machine
+plugin: community.general.docker_machine
 
 # Example using constructed features to create a group per Docker Machine driver
 # (https://docs.docker.com/machine/drivers/), e.g.:

--- a/plugins/inventory/docker_swarm.py
+++ b/plugins/inventory/docker_swarm.py
@@ -26,8 +26,8 @@ DOCUMENTATION = '''
           I(nonleaders) - all nodes except the swarm leader."
     options:
         plugin:
-            description: The name of this plugin, it should always be set to C(docker_swarm) for this plugin to
-                         recognize it as it's own.
+            description: The name of this plugin, it should always be set to C(community.general.docker_swarm)
+                         for this plugin to recognize it as it's own.
             type: str
             required: true
             choices: [ docker_swarm, community.general.docker_swarm ]

--- a/plugins/inventory/docker_swarm.py
+++ b/plugins/inventory/docker_swarm.py
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
                          recognize it as it's own.
             type: str
             required: true
-            choices: docker_swarm
+            choices: [ docker_swarm, community.general.docker_swarm ]
         docker_host:
             description:
                 - Socket of a Docker swarm manager node (C(tcp), C(unix)).
@@ -101,20 +101,20 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 # Minimal example using local docker
-plugin: docker_swarm
+plugin: community.general.docker_swarm
 docker_host: unix://var/run/docker.sock
 
 # Minimal example using remote docker
-plugin: docker_swarm
+plugin: community.general.docker_swarm
 docker_host: tcp://my-docker-host:2375
 
 # Example using remote docker with unverified TLS
-plugin: docker_swarm
+plugin: community.general.docker_swarm
 docker_host: tcp://my-docker-host:2376
 tls: yes
 
 # Example using remote docker with verified TLS and client certificate verification
-plugin: docker_swarm
+plugin: community.general.docker_swarm
 docker_host: tcp://my-docker-host:2376
 validate_certs: yes
 ca_cert: /somewhere/ca.pem
@@ -122,7 +122,7 @@ client_key: /somewhere/key.pem
 client_cert: /somewhere/cert.pem
 
 # Example using constructed features to create groups and set ansible_host
-plugin: docker_swarm
+plugin: community.general.docker_swarm
 docker_host: tcp://my-docker-host:2375
 strict: False
 keyed_groups:

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -28,6 +28,7 @@ DOCUMENTATION = '''
             required: true
             choices:
               - gitlab_runners
+              - community.general.gitlab_runners
         server_url:
             description: The URL of the GitLab server, with protocol (i.e. http or https).
             env:
@@ -60,11 +61,11 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 # gitlab_runners.yml
-plugin: gitlab_runners
+plugin: community.general.gitlab_runners
 host: https://gitlab.com
 
 # Example using constructed features to create groups and set ansible_host
-plugin: gitlab_runners
+plugin: community.general.gitlab_runners
 host: https://gitlab.com
 strict: False
 keyed_groups:

--- a/plugins/inventory/kubevirt.py
+++ b/plugins/inventory/kubevirt.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
       plugin:
         description: token that ensures this is a source file for the 'kubevirt' plugin.
         required: True
-        choices: ['kubevirt']
+        choices: ['kubevirt', 'community.general.kubevirt']
         type: str
       host_format:
         description:
@@ -123,7 +123,7 @@ EXAMPLES = '''
 # File must be named kubevirt.yaml or kubevirt.yml
 
 # Authenticate with token, and return all virtual machines for all namespaces
-plugin: kubevirt
+plugin: community.general.kubevirt
 connections:
  - host: https://kubevirt.io
    token: xxxxxxxxxxxxxxxx
@@ -131,7 +131,7 @@ connections:
 
 # Use default config (~/.kube/config) file and active context, and return vms with interfaces
 # connected to network myovsnetwork and from namespace vms
-plugin: kubevirt
+plugin: community.general.kubevirt
 connections:
   - namespaces:
       - vms

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -22,7 +22,7 @@ DOCUMENTATION = r'''
         plugin:
             description: marks this as an instance of the 'linode' plugin
             required: true
-            choices: ['linode']
+            choices: ['linode', 'community.general.linode']
         access_token:
             description: The Linode account personal access token.
             required: true
@@ -42,10 +42,10 @@ DOCUMENTATION = r'''
 
 EXAMPLES = r'''
 # Minimal example. `LINODE_ACCESS_TOKEN` is exposed in environment.
-plugin: linode
+plugin: community.general.linode
 
 # Example with regions, types, groups and access token
-plugin: linode
+plugin: community.general.linode
 access_token: foobar
 regions:
   - eu-west

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'nmap' plugin.
             required: True
-            choices: ['nmap']
+            choices: ['nmap', 'community.general.nmap']
         address:
             description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
             required: True
@@ -43,10 +43,10 @@ DOCUMENTATION = '''
         - 'TODO: add OS fingerprinting'
 '''
 EXAMPLES = '''
-    # inventory.config file in YAML format
-    plugin: nmap
-    strict: False
-    address: 192.168.0.0/24
+# inventory.config file in YAML format
+plugin: community.general.nmap
+strict: False
+address: 192.168.0.0/24
 '''
 
 import os

--- a/plugins/inventory/online.py
+++ b/plugins/inventory/online.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'online' plugin.
             required: True
-            choices: ['online']
+            choices: ['online', 'community.general.online']
         oauth_token:
             required: True
             description: Online OAuth token.
@@ -49,7 +49,7 @@ EXAMPLES = '''
 # online_inventory.yml file in YAML format
 # Example command line: ansible-inventory --list -i online_inventory.yml
 
-plugin: online
+plugin: community.general.online
 hostnames:
   - public_ipv4
 groups:

--- a/plugins/inventory/scaleway.py
+++ b/plugins/inventory/scaleway.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'scaleway' plugin.
             required: True
-            choices: ['scaleway']
+            choices: ['scaleway', 'community.general.scaleway']
         regions:
             description: Filter results on a specific Scaleway region
             type: list
@@ -60,7 +60,7 @@ EXAMPLES = '''
 
 # use hostname as inventory_hostname
 # use the private IP address to connect to the host
-plugin: scaleway
+plugin: community.general.scaleway
 regions:
   - ams1
   - par1
@@ -73,7 +73,7 @@ variables:
   state: state
 
 # use hostname as inventory_hostname and public IP address to connect to the host
-plugin: scaleway
+plugin: community.general.scaleway
 hostnames:
   - hostname
 regions:

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -19,7 +19,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'virtualbox' plugin
             required: True
-            choices: ['virtualbox']
+            choices: ['virtualbox', 'community.general.virtualbox']
         running_only:
             description: toggles showing all vms vs only those currently running
             type: boolean
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # file must be named vbox.yaml or vbox.yml
 simple_config_file:
-    plugin: virtualbox
+    plugin: community.general.virtualbox
     settings_password_file: /etc/virtulbox/secrets
     query:
       logged_in_users: /VirtualBox/GuestInfo/OS/LoggedInUsersList
@@ -46,7 +46,7 @@ simple_config_file:
       ansible_connection: ('indows' in vbox_Guest_OS)|ternary('winrm', 'ssh')
 
 # add hosts (all match with minishift vm) to the group container if any of the vms are in ansible_inventory'
-plugin: virtualbox
+plugin: community.general.virtualbox
 groups:
   container: "'minis' in (inventory_hostname)"
 '''

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -20,11 +20,13 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: Example of the change in the description
-  ansible.builtin.debug: msg="{{ lookup('cartesian', [1,2,3], [a, b])}}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.cartesian', [1,2,3], [a, b])}}"
 
 - name: loops over the cartesian product of the supplied lists
-  ansible.builtin.debug: msg="{{item}}"
-  with_cartesian:
+  ansible.builtin.debug:
+    msg: "{{item}}"
+  with_community.general.cartesian:
     - "{{list1}}"
     - "{{list2}}"
     - [1,2,3,4,5,6]

--- a/plugins/lookup/chef_databag.py
+++ b/plugins/lookup/chef_databag.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
     - ansible.builtin.debug:
-        msg: "{{ lookup('chef_databag', 'name=data_bag_name item=data_bag_item') }}"
+        msg: "{{ lookup('community.general.chef_databag', 'name=data_bag_name item=data_bag_item') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -80,18 +80,18 @@ DOCUMENTATION = '''
 EXAMPLES = """
   - ansible.builtin.debug:
       msg: 'key contains {{item}}'
-    with_consul_kv:
+    with_community.general.consul_kv:
       - 'key/to/retrieve'
 
   - name: Parameters can be provided after the key be more specific about what to retrieve
     ansible.builtin.debug:
       msg: 'key contains {{item}}'
-    with_consul_kv:
+    with_community.general.consul_kv:
       - 'key/to recurse=true token=E6C060A9-26FB-407A-B83E-12DDAFCB4D98'
 
   - name: retrieving a KV from a remote cluster on non default port
     ansible.builtin.debug:
-      msg: "{{ lookup('consul_kv', 'my/key', host='10.10.10.10', port='2000') }}"
+      msg: "{{ lookup('community.general.consul_kv', 'my/key', host='10.10.10.10', port='2000') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/credstash.py
+++ b/plugins/lookup/credstash.py
@@ -47,13 +47,16 @@ EXAMPLES = """
   ansible.builtin.shell: credstash put my-github-password secure123
 
 - name: "Test credstash lookup plugin -- get my github password"
-  ansible.builtin.debug: msg="Credstash lookup! {{ lookup('credstash', 'my-github-password') }}"
+  ansible.builtin.debug:
+    msg: "Credstash lookup! {{ lookup('community.general.credstash', 'my-github-password') }}"
 
 - name: "Test credstash lookup plugin -- get my other password from us-west-1"
-  ansible.builtin.debug: msg="Credstash lookup! {{ lookup('credstash', 'my-other-password', region='us-west-1') }}"
+  ansible.builtin.debug:
+    msg: "Credstash lookup! {{ lookup('community.general.credstash', 'my-other-password', region='us-west-1') }}"
 
 - name: "Test credstash lookup plugin -- get the company's github password"
-  ansible.builtin.debug: msg="Credstash lookup! {{ lookup('credstash', 'company-github-password', table='company-passwords') }}"
+  ansible.builtin.debug:
+    msg: "Credstash lookup! {{ lookup('community.general.credstash', 'company-github-password', table='company-passwords') }}"
 
 - name: Example play using the 'context' feature
   hosts: localhost
@@ -64,10 +67,12 @@ EXAMPLES = """
   tasks:
 
   - name: "Test credstash lookup plugin -- get the password with a context passed as a variable"
-    ansible.builtin.debug: msg="{{ lookup('credstash', 'some-password', context=context) }}"
+    ansible.builtin.debug:
+      msg: "{{ lookup('community.general.credstash', 'some-password', context=context) }}"
 
   - name: "Test credstash lookup plugin -- get the password with a context defined here"
-    ansible.builtin.debug: msg="{{ lookup('credstash', 'some-password', context=dict(app='my_app', environment='production')) }}"
+    ansible.builtin.debug:
+      msg: "{{ lookup('community.general.credstash', 'some-password', context=dict(app='my_app', environment='production')) }}"
 """
 
 RETURN = """

--- a/plugins/lookup/cyberarkpassword.py
+++ b/plugins/lookup/cyberarkpassword.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
 EXAMPLES = """
   - name: passing options to the lookup
     ansible.builtin.debug:
-        msg: "{{ lookup("community.general.cyberarkpassword", cyquery) }}"
+        msg: '{{ lookup("community.general.cyberarkpassword", cyquery) }}'
     vars:
       cyquery:
         appid: "app_ansible"

--- a/plugins/lookup/cyberarkpassword.py
+++ b/plugins/lookup/cyberarkpassword.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
 EXAMPLES = """
   - name: passing options to the lookup
     ansible.builtin.debug:
-        msg: {{ lookup("community.general.cyberarkpassword", cyquery)}}
+        msg: "{{ lookup("community.general.cyberarkpassword", cyquery) }}"
     vars:
       cyquery:
         appid: "app_ansible"

--- a/plugins/lookup/cyberarkpassword.py
+++ b/plugins/lookup/cyberarkpassword.py
@@ -36,7 +36,8 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
   - name: passing options to the lookup
-    ansible.builtin.debug: msg={{ lookup("cyberarkpassword", cyquery)}}
+    ansible.builtin.debug:
+        msg: {{ lookup("community.general.cyberarkpassword", cyquery)}}
     vars:
       cyquery:
         appid: "app_ansible"
@@ -45,8 +46,9 @@ EXAMPLES = """
 
 
   - name: used in a loop
-    ansible.builtin.debug: msg={{item}}
-    with_cyberarkpassword:
+    ansible.builtin.debug:
+        msg: "{{item}}"
+    with_community.general.cyberarkpassword:
         appid: 'app_ansible'
         query: 'safe=CyberArk_Passwords;folder=root;object=AdminPass'
         output: 'Password,PassProps.UserName,PassProps.Address,PasswordChangeInProcess'

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -44,25 +44,34 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: Simple A record (IPV4 address) lookup for example.com
-  ansible.builtin.debug: msg="{{ lookup('dig', 'example.com.')}}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.dig', 'example.com.')}}"
 
 - name: "The TXT record for example.org."
-  ansible.builtin.debug: msg="{{ lookup('dig', 'example.org.', 'qtype=TXT') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.dig', 'example.org.', 'qtype=TXT') }}"
 
 - name: "The TXT record for example.org, alternative syntax."
-  ansible.builtin.debug: msg="{{ lookup('dig', 'example.org./TXT') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.dig', 'example.org./TXT') }}"
 
 - name: use in a loop
-  ansible.builtin.debug: msg="MX record for gmail.com {{ item }}"
-  with_items: "{{ lookup('dig', 'gmail.com./MX', wantlist=True) }}"
+  ansible.builtin.debug:
+    msg: "MX record for gmail.com {{ item }}"
+  with_items: "{{ lookup('community.general.dig', 'gmail.com./MX', wantlist=True) }}"
 
-- ansible.builtin.debug: msg="Reverse DNS for 192.0.2.5 is {{ lookup('dig', '192.0.2.5/PTR') }}"
-- ansible.builtin.debug: msg="Reverse DNS for 192.0.2.5 is {{ lookup('dig', '5.2.0.192.in-addr.arpa./PTR') }}"
-- ansible.builtin.debug: msg="Reverse DNS for 192.0.2.5 is {{ lookup('dig', '5.2.0.192.in-addr.arpa.', 'qtype=PTR') }}"
-- ansible.builtin.debug: msg="Querying 198.51.100.23 for IPv4 address for example.com. produces {{ lookup('dig', 'example.com', '@198.51.100.23') }}"
+- ansible.builtin.debug:
+    msg: "Reverse DNS for 192.0.2.5 is {{ lookup('community.general.dig', '192.0.2.5/PTR') }}"
+- ansible.builtin.debug:
+    msg: "Reverse DNS for 192.0.2.5 is {{ lookup('community.general.dig', '5.2.0.192.in-addr.arpa./PTR') }}"
+- ansible.builtin.debug:
+    msg: "Reverse DNS for 192.0.2.5 is {{ lookup('community.general.dig', '5.2.0.192.in-addr.arpa.', 'qtype=PTR') }}"
+- ansible.builtin.debug:
+    msg: "Querying 198.51.100.23 for IPv4 address for example.com. produces {{ lookup('dig', 'example.com', '@198.51.100.23') }}"
 
-- ansible.builtin.debug: msg="XMPP service for gmail.com. is available at {{ item.target }} on port {{ item.port }}"
-  with_items: "{{ lookup('dig', '_xmpp-server._tcp.gmail.com./SRV', 'flat=0', wantlist=True) }}"
+- ansible.builtin.debug:
+    msg: "XMPP service for gmail.com. is available at {{ item.target }} on port {{ item.port }}"
+  with_items: "{{ lookup('community.general.dig', '_xmpp-server._tcp.gmail.com./SRV', 'flat=0', wantlist=True) }}"
 """
 
 RETURN = """

--- a/plugins/lookup/dnstxt.py
+++ b/plugins/lookup/dnstxt.py
@@ -21,18 +21,21 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: show txt entry
-  ansible.builtin.debug: msg="{{lookup('dnstxt', ['test.example.com'])}}"
+  ansible.builtin.debug:
+    msg: "{{lookup('community.general.dnstxt', ['test.example.com'])}}"
 
 - name: iterate over txt entries
-  ansible.builtin.debug: msg="{{item}}"
-  with_dnstxt:
+  ansible.builtin.debug:
+    msg: "{{item}}"
+  with_community.general.dnstxt:
     - 'test.example.com'
     - 'other.example.com'
     - 'last.example.com'
 
 - name: iterate of a comma delimited DNS TXT entry
-  ansible.builtin.debug: msg="{{item}}"
-  with_dnstxt: "{{lookup('dnstxt', ['test.example.com']).split(',')}}"
+  ansible.builtin.debug:
+    msg: "{{item}}"
+  with_community.general.dnstxt: "{{lookup('community.general.dnstxt', ['test.example.com']).split(',')}}"
 """
 
 RETURN = """

--- a/plugins/lookup/etcd.py
+++ b/plugins/lookup/etcd.py
@@ -53,14 +53,17 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-    - name: "a value from a locally running etcd"
-      ansible.builtin.debug: msg={{ lookup('etcd', 'foo/bar') }}
+- name: "a value from a locally running etcd"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd', 'foo/bar') }}"
 
-    - name: "values from multiple folders on a locally running etcd"
-      ansible.builtin.debug: msg={{ lookup('etcd', 'foo', 'bar', 'baz') }}
+- name: "values from multiple folders on a locally running etcd"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd', 'foo', 'bar', 'baz') }}"
 
-    - name: "since Ansible 2.5 you can set server options inline"
-      ansible.builtin.debug: msg="{{ lookup('etcd', 'foo', version='v2', url='http://192.168.0.27:4001') }}"
+- name: "since Ansible 2.5 you can set server options inline"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd', 'foo', version='v2', url='http://192.168.0.27:4001') }}"
 '''
 
 RETURN = '''

--- a/plugins/lookup/etcd3.py
+++ b/plugins/lookup/etcd3.py
@@ -100,21 +100,21 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-    - name: "a value from a locally running etcd"
-      ansible.builtin.debug:
-        msg: "{{ lookup('community.general.etcd3', 'foo/bar') }}"
+- name: "a value from a locally running etcd"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd3', 'foo/bar') }}"
 
-    - name: "values from multiple folders on a locally running etcd"
-      ansible.builtin.debug:
-        msg: "{{ lookup('community.general.etcd3', 'foo', 'bar', 'baz') }}"
+- name: "values from multiple folders on a locally running etcd"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd3', 'foo', 'bar', 'baz') }}"
 
-    - name: "look for a key prefix"
-      ansible.builtin.debug:
-        msg: "{{ lookup('community.general.etcd3', '/foo/bar', prefix=True) }}"
+- name: "look for a key prefix"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd3', '/foo/bar', prefix=True) }}"
 
-    - name: "connect to etcd3 with a client certificate"
-      ansible.builtin.debug:
-        msg: "{{ lookup('community.general.etcd3', 'foo/bar', cert_cert='/etc/ssl/etcd/client.pem', cert_key='/etc/ssl/etcd/client.key') }}"
+- name: "connect to etcd3 with a client certificate"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.etcd3', 'foo/bar', cert_cert='/etc/ssl/etcd/client.pem', cert_key='/etc/ssl/etcd/client.key') }}"
 '''
 
 RETURN = '''

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -25,7 +25,7 @@ EXAMPLES = """
     path: /web/{{ item.path }}
     state: directory
     mode: '{{ item.mode }}'
-  with_filetree: web/
+  with_community.general.filetree: web/
   when: item.state == 'directory'
 
 - name: Template files (explicitly skip directories in order to use the 'src' attribute)
@@ -33,7 +33,7 @@ EXAMPLES = """
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     mode: '{{ item.mode }}'
-  with_filetree: web/
+  with_community.general.filetree: web/
   when: item.state == 'file'
 
 - name: Recreate symlinks
@@ -43,7 +43,7 @@ EXAMPLES = """
     state: link
     force: yes
     mode: '{{ item.mode }}'
-  with_filetree: web/
+  with_community.general.filetree: web/
   when: item.state == 'link'
 """
 

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -21,7 +21,8 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: "'unnest' all elements into single list"
-  ansible.builtin.debug: msg="all in one list {{lookup('flattened', [1,2,3,[5,6]], [a,b,c], [[5,6,1,3], [34,a,b,c]])}}"
+  ansible.builtin.debug:
+    msg: "all in one list {{lookup('community.general.flattened', [1,2,3,[5,6]], [a,b,c], [[5,6,1,3], [34,a,b,c]])}}"
 """
 
 RETURN = """

--- a/plugins/lookup/gcp_storage_file.py
+++ b/plugins/lookup/gcp_storage_file.py
@@ -29,9 +29,11 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- ansible.builtin.debug: msg="the value of foo.txt is {{ lookup('gcp_storage_file',
-    bucket='gcp-bucket', src='mydir/foo.txt', project='project-name',
-    auth_kind='serviceaccount', service_account_file='/tmp/myserviceaccountfile.json') }}"
+- ansible.builtin.debug:
+    msg: |
+         the value of foo.txt is {{ lookup('community.general.gcp_storage_file',
+         bucket='gcp-bucket', src='mydir/foo.txt', project='project-name',
+         auth_kind='serviceaccount', service_account_file='/tmp/myserviceaccountfile.json') }}
 '''
 
 RETURN = '''

--- a/plugins/lookup/hiera.py
+++ b/plugins/lookup/hiera.py
@@ -39,13 +39,16 @@ EXAMPLES = """
 # All this examples depends on hiera.yml that describes the hierarchy
 
 - name: "a value from Hiera 'DB'"
-  ansible.builtin.debug: msg={{ lookup('hiera', 'foo') }}
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.hiera', 'foo') }}"
 
 - name: "a value from a Hiera 'DB' on other environment"
-  ansible.builtin.debug: msg={{ lookup('hiera', 'foo environment=production') }}
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.hiera', 'foo environment=production') }}"
 
 - name: "a value from a Hiera 'DB' for a concrete node"
-  ansible.builtin.debug: msg={{ lookup('hiera', 'foo fqdn=puppet01.localdomain') }}
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.hiera', 'foo fqdn=puppet01.localdomain') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/keyring.py
+++ b/plugins/lookup/keyring.py
@@ -20,11 +20,11 @@ EXAMPLES = """
 - name : output secrets to screen (BAD IDEA)
   ansible.builtin.debug:
     msg: "Password: {{item}}"
-  with_keyring:
+  with_community.general.keyring:
     - 'servicename username'
 
 - name: access mysql with password from keyring
-  mysql_db: login_password={{lookup('keyring','mysql joe')}} login_user=joe
+  mysql_db: login_password={{lookup('community.general.keyring','mysql joe')}} login_user=joe
 """
 
 RETURN = """

--- a/plugins/lookup/lastpass.py
+++ b/plugins/lookup/lastpass.py
@@ -26,7 +26,7 @@ DOCUMENTATION = '''
 EXAMPLES = """
 - name: get 'custom_field' from lastpass entry 'entry-name'
   ansible.builtin.debug:
-    msg: "{{ lookup('lastpass', 'entry-name', field='custom_field') }}"
+    msg: "{{ lookup('community.general.lastpass', 'entry-name', field='custom_field') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/lmdb_kv.py
+++ b/plugins/lookup/lmdb_kv.py
@@ -25,14 +25,14 @@ DOCUMENTATION = '''
 EXAMPLES = """
 - name: query LMDB for a list of country codes
   ansible.builtin.debug:
-    msg: "{{ query('lmdb_kv', 'nl', 'be', 'lu', db='jp.mdb') }}"
+    msg: "{{ query('community.general.lmdb_kv', 'nl', 'be', 'lu', db='jp.mdb') }}"
 
 - name: use list of values in a loop by key wildcard
   ansible.builtin.debug:
     msg: "Hello from {{ item.0 }} a.k.a. {{ item.1 }}"
   vars:
     - lmdb_kv_db: jp.mdb
-  with_lmdb_kv:
+  with_community.general.lmdb_kv:
      - "n*"
 
 - name: get an item by key
@@ -41,7 +41,7 @@ EXAMPLES = """
       - item == 'Belgium'
     vars:
       - lmdb_kv_db: jp.mdb
-    with_lmdb_kv:
+    with_community.general.lmdb_kv:
       - be
 """
 

--- a/plugins/lookup/manifold.py
+++ b/plugins/lookup/manifold.py
@@ -40,11 +40,14 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
     - name: all available resources
-      ansible.builtin.debug: msg="{{ lookup('manifold', api_token='SecretToken') }}"
+      ansible.builtin.debug:
+        msg: "{{ lookup('community.general.manifold', api_token='SecretToken') }}"
     - name: all available resources for a specific project in specific team
-      ansible.builtin.debug: msg="{{ lookup('manifold', api_token='SecretToken', project='poject-1', team='team-2') }}"
+      ansible.builtin.debug:
+        msg: "{{ lookup('community.general.manifold', api_token='SecretToken', project='poject-1', team='team-2') }}"
     - name: two specific resources
-      ansible.builtin.debug: msg="{{ lookup('manifold', 'resource-1', 'resource-2') }}"
+      ansible.builtin.debug:
+        msg: "{{ lookup('community.general.manifold', 'resource-1', 'resource-2') }}"
 '''
 
 RETURN = '''

--- a/plugins/lookup/nios.py
+++ b/plugins/lookup/nios.py
@@ -48,11 +48,11 @@ options:
 EXAMPLES = """
 - name: fetch all networkview objects
   ansible.builtin.set_fact:
-    networkviews: "{{ lookup('nios', 'networkview', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    networkviews: "{{ lookup('community.general.nios', 'networkview', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: fetch the default dns view
   ansible.builtin.set_fact:
-    dns_views: "{{ lookup('nios', 'view', filter={'name': 'default'}, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    dns_views: "{{ lookup('community.general.nios', 'view', filter={'name': 'default'}, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 # all of the examples below use credentials that are  set using env variables
 # export INFOBLOX_HOST=nios01
@@ -61,20 +61,20 @@ EXAMPLES = """
 
 - name: fetch all host records and include extended attributes
   ansible.builtin.set_fact:
-    host_records: "{{ lookup('nios', 'record:host', return_fields=['extattrs', 'name', 'view', 'comment']}) }}"
+    host_records: "{{ lookup('community.general.nios', 'record:host', return_fields=['extattrs', 'name', 'view', 'comment']}) }}"
 
 
 - name: use env variables to pass credentials
   ansible.builtin.set_fact:
-    networkviews: "{{ lookup('nios', 'networkview') }}"
+    networkviews: "{{ lookup('community.general.nios', 'networkview') }}"
 
 - name: get a host record
   ansible.builtin.set_fact:
-    host: "{{ lookup('nios', 'record:host', filter={'name': 'hostname.ansible.com'}) }}"
+    host: "{{ lookup('community.general.nios', 'record:host', filter={'name': 'hostname.ansible.com'}) }}"
 
 - name: get the authoritative zone from a non default dns view
   ansible.builtin.set_fact:
-    host: "{{ lookup('nios', 'zone_auth', filter={'fqdn': 'ansible.com', 'view': 'ansible-dns'}) }}"
+    host: "{{ lookup('community.general.nios', 'zone_auth', filter={'fqdn': 'ansible.com', 'view': 'ansible-dns'}) }}"
 """
 
 RETURN = """

--- a/plugins/lookup/nios.py
+++ b/plugins/lookup/nios.py
@@ -48,11 +48,13 @@ options:
 EXAMPLES = """
 - name: fetch all networkview objects
   ansible.builtin.set_fact:
-    networkviews: "{{ lookup('community.general.nios', 'networkview', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    networkviews: "{{ lookup('community.general.nios', 'networkview',
+                         provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: fetch the default dns view
   ansible.builtin.set_fact:
-    dns_views: "{{ lookup('community.general.nios', 'view', filter={'name': 'default'}, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    dns_views: "{{ lookup('community.general.nios', 'view', filter={'name': 'default'},
+                      provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 # all of the examples below use credentials that are  set using env variables
 # export INFOBLOX_HOST=nios01

--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -48,15 +48,15 @@ options:
 EXAMPLES = """
 - name: return next available IP address for network 192.168.10.0/24
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('nios_next_ip', '192.168.10.0/24', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('community.general.nios_next_ip', '192.168.10.0/24', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 3 available IP addresses for network 192.168.10.0/24
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('nios_next_ip', '192.168.10.0/24', num=3, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('community.general.nios_next_ip', '192.168.10.0/24', num=3, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 3 available IP addresses for network 192.168.10.0/24 excluding ip addresses - ['192.168.10.1', '192.168.10.2']
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('nios_next_ip', '192.168.10.0/24', num=3, exclude=['192.168.10.1', '192.168.10.2'],
+    ipaddr: "{{ lookup('community.general.nios_next_ip', '192.168.10.0/24', num=3, exclude=['192.168.10.1', '192.168.10.2'],
                 provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 """
 

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -56,7 +56,8 @@ options:
 EXAMPLES = """
 - name: return next available network for network-container 192.168.10.0/24
   ansible.builtin.set_fact:
-    networkaddr: "{{ lookup('community.general.nios_next_network', '192.168.10.0/24', cidr=25, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    networkaddr: "{{ lookup('community.general.nios_next_network', '192.168.10.0/24', cidr=25,
+                        provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 2 available network addresses for network-container 192.168.10.0/24
   ansible.builtin.set_fact:

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -56,16 +56,16 @@ options:
 EXAMPLES = """
 - name: return next available network for network-container 192.168.10.0/24
   ansible.builtin.set_fact:
-    networkaddr: "{{ lookup('nios_next_network', '192.168.10.0/24', cidr=25, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    networkaddr: "{{ lookup('community.general.nios_next_network', '192.168.10.0/24', cidr=25, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 2 available network addresses for network-container 192.168.10.0/24
   ansible.builtin.set_fact:
-    networkaddr: "{{ lookup('nios_next_network', '192.168.10.0/24', cidr=25, num=2,
+    networkaddr: "{{ lookup('community.general.nios_next_network', '192.168.10.0/24', cidr=25, num=2,
                         provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the available network addresses for network-container 192.168.10.0/24 excluding network range '192.168.10.0/25'
   ansible.builtin.set_fact:
-    networkaddr: "{{ lookup('nios_next_network', '192.168.10.0/24', cidr=25, exclude=['192.168.10.0/25'],
+    networkaddr: "{{ lookup('community.general.nios_next_network', '192.168.10.0/24', cidr=25, exclude=['192.168.10.0/25'],
                         provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 """
 

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -56,26 +56,26 @@ EXAMPLES = """
 # These examples only work when already signed in to 1Password
 - name: Retrieve password for KITT when already signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword', 'KITT')
+    var: lookup('community.general.onepassword', 'KITT')
 
 - name: Retrieve password for Wintermute when already signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword', 'Tessier-Ashpool', section='Wintermute')
+    var: lookup('community.general.onepassword', 'Tessier-Ashpool', section='Wintermute')
 
 - name: Retrieve username for HAL when already signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword', 'HAL 9000', field='username', vault='Discovery')
+    var: lookup('community.general.onepassword', 'HAL 9000', field='username', vault='Discovery')
 
 - name: Retrieve password for HAL when not signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword'
+    var: lookup('community.general.onepassword'
                 'HAL 9000'
                 subdomain='Discovery'
                 master_password=vault_master_password)
 
 - name: Retrieve password for HAL when never signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword'
+    var: lookup('community.general.onepassword'
                 'HAL 9000'
                 subdomain='Discovery'
                 master_password=vault_master_password

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -52,11 +52,11 @@ DOCUMENTATION = '''
 EXAMPLES = """
 - name: Retrieve all data about Wintermute
   ansible.builtin.debug:
-    var: lookup('onepassword_raw', 'Wintermute')
+    var: lookup('community.general.onepassword_raw', 'Wintermute')
 
 - name: Retrieve all data about Wintermute when not signed in to 1Password
   ansible.builtin.debug:
-    var: lookup('onepassword_raw', 'Wintermute', subdomain='Turing', vault_password='DmbslfLvasjdl')
+    var: lookup('community.general.onepassword_raw', 'Wintermute', subdomain='Turing', vault_password='DmbslfLvasjdl')
 """
 
 RETURN = """

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -58,32 +58,33 @@ EXAMPLES = """
 # Debug is used for examples, BAD IDEA to show passwords on screen
 - name: Basic lookup. Fails if example/test doesn't exist
   ansible.builtin.debug:
-    msg: "{{ lookup('passwordstore', 'example/test')}}"
+    msg: "{{ lookup('community.general.passwordstore', 'example/test')}}"
 
 - name: Create pass with random 16 character password. If password exists just give the password
   ansible.builtin.debug:
     var: mypassword
   vars:
-    mypassword: "{{ lookup('passwordstore', 'example/test create=true')}}"
+    mypassword: "{{ lookup('community.general.passwordstore', 'example/test create=true')}}"
 
 - name: Different size password
   ansible.builtin.debug:
-    msg: "{{ lookup('passwordstore', 'example/test create=true length=42')}}"
+    msg: "{{ lookup('community.general.passwordstore', 'example/test create=true length=42')}}"
 
 - name: Create password and overwrite the password if it exists. As a bonus, this module includes the old password inside the pass file
   ansible.builtin.debug:
-    msg: "{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
+    msg: "{{ lookup('community.general.passwordstore', 'example/test create=true overwrite=true')}}"
 
 - name: Create an alphanumeric password
-  ansible.builtin.debug: msg="{{ lookup('passwordstore', 'example/test create=true nosymbols=true') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.passwordstore', 'example/test create=true nosymbols=true') }}"
 
 - name: Return the value for user in the KV pair user, username
   ansible.builtin.debug:
-    msg: "{{ lookup('passwordstore', 'example/test subkey=user')}}"
+    msg: "{{ lookup('community.general.passwordstore', 'example/test subkey=user')}}"
 
 - name: Return the entire password file content
   ansible.builtin.set_fact:
-    passfilecontent: "{{ lookup('passwordstore', 'example/test returnall=true')}}"
+    passfilecontent: "{{ lookup('community.general.passwordstore', 'example/test returnall=true')}}"
 """
 
 RETURN = """

--- a/plugins/lookup/redis.py
+++ b/plugins/lookup/redis.py
@@ -46,17 +46,21 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: query redis for somekey (default or configured settings used)
-  ansible.builtin.debug: msg="{{ lookup('redis', 'somekey') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.redis', 'somekey') }}"
 
 - name: query redis for list of keys and non-default host and port
-  ansible.builtin.debug: msg="{{ lookup('redis', item, host='myredis.internal.com', port=2121) }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.redis', item, host='myredis.internal.com', port=2121) }}"
   loop: '{{list_of_redis_keys}}'
 
 - name: use list directly
-  ansible.builtin.debug: msg="{{ lookup('redis', 'key1', 'key2', 'key3') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.redis', 'key1', 'key2', 'key3') }}"
 
 - name: use list directly with a socket
-  ansible.builtin.debug: msg="{{ lookup('redis', 'key1', 'key2', socket='/var/tmp/redis.sock') }}"
+  ansible.builtin.debug:
+    msg: "{{ lookup('community.general.redis', 'key1', 'key2', socket='/var/tmp/redis.sock') }}"
 
 """
 

--- a/plugins/lookup/shelvefile.py
+++ b/plugins/lookup/shelvefile.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = """
 - name: retrieve a string value corresponding to a key inside a Python shelve file
-  ansible.builtin.debug: msg="{{ lookup('shelvefile', 'file=path_to_some_shelve_file.db key=key_to_retrieve') }}
+  ansible.builtin.debug: msg="{{ lookup('community.general.shelvefile', 'file=path_to_some_shelve_file.db key=key_to_retrieve') }}
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
Various fixes for plugins which we apparently forgot to do:
- cobbler inventory plugin's `name` needs FQCN (5015d180beaeda3af3edf455503aa88a8c8ae7ff)
- oc connection plugin needs FQCN in `transport` (0ce20e22f984d9e6982e1d6fcf2ede239cb31aeb)
- inventory plugins need FQCN in examples, and allow FQCN in `plugin` option (23d9102ddb459ddebbe90186df4dfb41f76872ee)
- lookup plugins need FQCN in examples (d55a3f7295b0d40c79b086e6e9c3d33c18e9b632)
- callback plugins need FQCN in examples (cd7427e93bbfdf349eda3aef6d93e2282f3f3266)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins
