### PR TITLE
Update xfconf.py: make locale-independent

### DIFF
--- a/changelogs/fragments/744-xfconf_make_locale-independent.yml
+++ b/changelogs/fragments/744-xfconf_make_locale-independent.yml
@@ -1,0 +1,5 @@
+minor_changes:
+    - xfconf - add support for ``double`` type (https://github.com/ansible-collections/community.general/pull/744).
+bugfixes:
+    - xfconf - make it work in non-english locales (https://github.com/ansible-collections/community.general/pull/744).
+        

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -13,7 +13,6 @@ module: xfconf
 author:
     - "Joseph Benden (@jbenden)"
     - "Alexei Znamensky (@russoz)"
-    - "Adriaan Callaerts (@call-a3)"
 short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
@@ -148,8 +147,7 @@ class XfConfProperty(object):
         self.does_not = 'Property "{0}" does not exist on channel "{1}".'.format(self.property, self.channel)
 
         def run(cmd):
-            # Force language to 'C' to ensure return values are always formatted in english, even in non-english environments
-            return module.run_command(cmd, check_rc=False, environ_update=dict(LANG='C'))
+            return module.run_command(cmd, check_rc=False)
         self._run = run
 
     def _execute_xfconf_query(self, args=None):
@@ -263,6 +261,9 @@ def main():
         ],
         supports_check_mode=True
     )
+
+    # Force language to 'C' to ensure return values are always formatted in english, even in non-english environments
+    module.run_command_environ_update = dict(LANG='C')
 
     state = module.params['state']
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -13,6 +13,7 @@ module: xfconf
 author:
     - "Joseph Benden (@jbenden)"
     - "Alexei Znamensky (@russoz)"
+    - "Adriaan Callaerts (@call-a3)"
 short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
@@ -44,7 +45,7 @@ options:
       For array mode, use a list of types.
     type: list
     elements: str
-    choices: [ int, uint, bool, float, string ]
+    choices: [ int, uint, bool, float, double, string ]
   state:
     description:
     - The action to take upon the property/value.
@@ -124,7 +125,7 @@ class XfConfProperty(object):
     GET = "get"
     RESET = "absent"
     VALID_STATES = (SET, GET, RESET)
-    VALID_VALUE_TYPES = ('int', 'uint', 'bool', 'float', 'string')
+    VALID_VALUE_TYPES = ('int', 'uint', 'bool', 'float', 'double', 'string')
     previous_value = None
     is_array = None
 
@@ -144,12 +145,11 @@ class XfConfProperty(object):
         self.method_map = dict(zip((self.SET, self.GET, self.RESET),
                                    (self.set, self.get, self.reset)))
 
-        # @TODO This will not work with non-English translations, but xfconf-query does not return
-        #       distinct result codes for distinct outcomes.
         self.does_not = 'Property "{0}" does not exist on channel "{1}".'.format(self.property, self.channel)
 
         def run(cmd):
-            return module.run_command(cmd, check_rc=False)
+            # Force language to 'C' to ensure return values are always formatted in english, even in non-english environments
+            return module.run_command(cmd, check_rc=False, environ_update=dict(LANG='C'))
         self._run = run
 
     def _execute_xfconf_query(self, args=None):

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -263,7 +263,7 @@ def main():
     )
 
     # Force language to 'C' to ensure return values are always formatted in english, even in non-english environments
-    module.run_command_environ_update = dict(LANG='C')
+    module.run_command_environ_update = dict(LANGUAGE='C')
 
     state = module.params['state']
 


### PR DESCRIPTION
### SUMMARY
- ensure correct behaviour, even in desktop environments which don't use English as the default language. This is done by providing LANG=C environment variable to the xfconf-query executable.
- add double as content type


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Make xfconf locale-independent

##### ADDITIONAL INFORMATION
In addition to the locale change, also added support for the double type in the process.