### PR TITLE
add possibility to modify zypper repo

### DIFF
--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -3,6 +3,7 @@
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
 # (c) 2014, Justin Lecher <jlec@gentoo.org>
+# (c) 2017, Christian Wittmer <chris@computersalat.de>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -14,9 +15,9 @@ DOCUMENTATION = '''
 ---
 module: zypper_repository
 author: "Matthias Vogelgesang (@matze)"
-short_description: Add and remove Zypper repositories
+short_description: Add, modify or remove zypper repositories
 description:
-    - Add or remove Zypper repositories on SUSE and openSUSE
+    - Add, modify or remove zypper repositories on SLE and openSUSE
 options:
     name:
         description:
@@ -24,13 +25,23 @@ options:
         type: str
     repo:
         description:
-            - URI of the repository or .repo file. Required when state=present.
+            - URI of the repository or .repo file. Required when I(state=present) and I(action=add).
+        type: str
+    action:
+        choices: [ "add", "remove", "modify" ]
+        default: "add"
+        description:
+            - The action you want to perform. C(add, modify or remove)
+            - When wanting to C(add) a repo you can omit either I(action=add) or I(state=present) cause of their defaults.
+            - When wanting to C(modify) a repo then just use I(action=modify)
+            - When wanting to C(remove) a repo then just use one of I(state=absent) or I(action=remove)
+            - When using with C(modify) you should not run another task with C(add) before or afterwards cause of idempotency.
         type: str
     state:
-        description:
-            - A source string state.
         choices: [ "absent", "present" ]
         default: "present"
+        description:
+            - A source string state.
         type: str
     description:
         description:
@@ -261,6 +272,36 @@ def addmodify_repo(module, repodata, old_repos, zypper_version, warnings):
     return rc, stdout, stderr
 
 
+def modify_repo(module, repodata, zypper_version, warnings):
+    "Modifys the repo like name, enable/disable, refresh/no-refresh, priority"
+    cmd = _get_cmd('modifyrepo')
+    if repodata['name']:
+        cmd.extend(['--name', repodata['name']])
+
+    # priority on addrepo available since 1.12.25
+    # https://github.com/openSUSE/zypper/blob/b9b3cb6db76c47dc4c47e26f6a4d2d4a0d12b06d/package/zypper.changes#L327-L336
+    if repodata['priority']:
+        if zypper_version >= LooseVersion('1.12.25'):
+            cmd.extend(['--priority', str(repodata['priority'])])
+        else:
+            warnings.append("Setting priority only available for zypper >= 1.12.25. Ignoring priority argument.")
+
+    if repodata['enabled'] == '1':
+        cmd.append('--enable')
+    else:
+        cmd.append('--disable')
+
+    if repodata['autorefresh'] == '1':
+        cmd.append('--refresh')
+    else:
+        cmd.append('--no-refresh')
+
+    cmd.append(repodata['alias'])
+
+    rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+    return rc, stdout, stderr
+
+
 def remove_repo(module, repo):
     "Removes the repo."
     cmd = _get_cmd('removerepo', repo)
@@ -293,6 +334,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=False),
+            action=dict(choices=['add', 'remove', 'modify'], default='add'),
             repo=dict(required=False),
             state=dict(choices=['present', 'absent'], default='present'),
             runrefresh=dict(required=False, default=False, type='bool'),
@@ -305,11 +347,12 @@ def main():
             auto_import_keys=dict(required=False, default=False, type='bool'),
         ),
         supports_check_mode=False,
-        required_one_of=[['state', 'runrefresh']],
+        required_one_of=[['action', 'state','runrefresh']],
     )
 
     repo = module.params['repo']
     alias = module.params['name']
+    action = module.params['action']
     state = module.params['state']
     overwrite_multiple = module.params['overwrite_multiple']
     auto_import_keys = module.params['auto_import_keys']
@@ -349,17 +392,19 @@ def main():
         else:
             module.fail_json(msg='repo=* can only be used with the runrefresh option.')
 
-    if state == 'present' and not repo:
-        module.fail_json(msg='Module option state=present requires repo')
-    if state == 'absent' and not repo and not alias:
-        module.fail_json(msg='Alias or repo parameter required when state=absent')
+    if state == 'present' and action == 'add' and not repo:
+        module.fail_json(msg='Missing option: \'repo\' (URI). Required when state=present and action=add')
+    if action == 'modify' and not alias:
+        module.fail_json(msg='Missing option: \'name\' (Alias). Required when action=modify')
+    if (state == 'absent' or action == 'remove') and not alias:
+        module.fail_json(msg='Missing option: \'name\' (Alias). Required when state=absent or action=remove')
 
     if repo and repo.endswith('.repo'):
         if alias:
             module.fail_json(msg='Incompatible option: \'name\'. Do not use name when adding .repo files')
     else:
-        if not alias and state == "present":
-            module.fail_json(msg='Name required when adding non-repo files.')
+        if not alias and state == 'present' and action == 'add':
+            module.fail_json(msg='Missing option: \'name\' (Alias). Required when adding non-repo files.')
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 
@@ -368,7 +413,7 @@ def main():
     else:
         shortname = alias
 
-    if state == 'present':
+    if action == 'add' and state == 'present':
         if exists and not mod:
             if runrefresh:
                 runrefreshrepo(module, auto_import_keys, shortname)
@@ -376,15 +421,22 @@ def main():
         rc, stdout, stderr = addmodify_repo(module, repodata, old_repos, zypper_version, warnings)
         if rc == 0 and (runrefresh or auto_import_keys):
             runrefreshrepo(module, auto_import_keys, shortname)
-    elif state == 'absent':
+    elif action == 'modify' and state == 'present':
+        if exists and not mod:
+            exit_unchanged()
+        if not exists:
+            exit_unchanged()
+        rc, stdout, stderr = modify_repo(module, repodata, zypper_version, warnings)
+    elif action == 'remove' or state == 'absent':
         if not exists:
             exit_unchanged()
         rc, stdout, stderr = remove_repo(module, shortname)
 
     if rc == 0:
-        module.exit_json(changed=True, repodata=repodata, state=state, warnings=warnings)
+        module.exit_json(changed=True, repodata=repodata, action=action, state=state, warnings=warnings)
     else:
-        module.fail_json(msg="Zypper failed with rc %s" % rc, rc=rc, stdout=stdout, stderr=stderr, repodata=repodata, state=state, warnings=warnings)
+        module.fail_json(msg="zypper failed with rc %s" % rc, rc=rc, stdout=stdout, stderr=stderr, repodata=repodata, action=action, state=state,
+                         warnings=warnings)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
add missing possibility to `modify` repo
```
zypper modifyrepo <options> <Alias|#|URI>
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zypper_repository

##### ADDITIONAL INFORMATION
being restricted to `present` or `absent` is somehow sometimes not flexible enough.
Sometimes you want to keep the ` repo` but just `disable` it, e.g.
```
zypper modifyrepo <options> <Alias|#|URI>
```
