### PR TITLE
Fix for error trying to install cask with '@' in the name

### DIFF
--- a/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
+++ b/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew_cask - fixed issue where a cask with `@` in the name is incorrectly reported as invalid (https://github.com/ansible-collections/community.general/issues/733).
+  - homebrew_cask - fixed issue where a cask with ``@`` in the name is incorrectly reported as invalid (https://github.com/ansible-collections/community.general/issues/733).

--- a/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
+++ b/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew_cask - fixed issue where a cask with `@` in the name is incorrectly reported as invalid (https://github.com/ansible-collections/community.general/issues/733)
+  - homebrew_cask - fixed issue where a cask with `@` in the name is incorrectly reported as invalid (https://github.com/ansible-collections/community.general/issues/733).

--- a/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
+++ b/changelogs/fragments/homebrew-cask-at-symbol-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew_cask - fixed issue where a cask with `@` in the name is incorrectly reported as invalid (https://github.com/ansible-collections/community.general/issues/733)

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -186,6 +186,7 @@ class HomebrewCask(object):
         .                   # dots
         /                   # slash (for taps)
         -                   # dashes
+        @                   # at symbol
     '''
 
     INVALID_PATH_REGEX = _create_regex_group(VALID_PATH_CHARS)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Allow Homebrew casks with `@` in the name to be installed/removed correctly.  Fixes #733 .

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
homebrew_cask

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Fixes a valid cask with `@` in the name incorrectly being reported as invalid:
```
"msg": "Invalid cask: unity@2019.3.9f1."
```
