### PR TITLE
Try to fix docker tests

### DIFF
--- a/tests/integration/targets/setup_docker/defaults/main.yml
+++ b/tests/integration/targets/setup_docker/defaults/main.yml
@@ -7,8 +7,8 @@ docker_packages:
   - docker-ce
 
 docker_pip_extra_packages: []
-docker_pip_packages:
-  - docker
+docker_pip_package: docker
+docker_pip_package_limit: ''
 
 docker_cleanup_packages:
   - docker

--- a/tests/integration/targets/setup_docker/handlers/main.yml
+++ b/tests/integration/targets/setup_docker/handlers/main.yml
@@ -1,7 +1,7 @@
 - name: remove pip packages
   pip:
     state: present
-    name: "{{ docker_pip_packages | union(docker_pip_extra_packages) }}"
+    name: "{{ [docker_pip_package] | union(docker_pip_extra_packages) }}"
   listen: cleanup docker
   when: not docker_skip_cleanup | bool
 

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -41,16 +41,8 @@
     - name: Install Python requirements
       pip:
         state: present
-        name: "{{ docker_pip_package }}{{ docker_pip_package_limit }}"
+        name: "{{ [docker_pip_package ~ docker_pip_package_limit] + docker_pip_extra_packages }}"
         extra_args: "-c {{ remote_constraints }}"
-      notify: cleanup docker
-
-    - name: Install Python requirements
-      pip:
-        state: present
-        name: "{{ docker_pip_extra_packages }}"
-        extra_args: "-c {{ remote_constraints }}"
-      when: docker_pip_extra_packages | length > 0
       notify: cleanup docker
 
     # Detect docker CLI, API and docker-py versions

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -36,7 +36,7 @@
     - name: Limit docker pypi package version to < 4.3.0
       set_fact:
         docker_pip_package_limit: '<4.3.0'
-      when: docker_api_version_stdout is version('1.39', '<')
+      when: (docker_api_version_stdout.stdout | default('0.0')) is version('1.39', '<')
 
     - name: Install Python requirements
       pip:

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -27,11 +27,30 @@
           paths:
             - "{{ role_path }}/tasks"
 
+    # Detect docker API version
+    - name: Check Docker API version
+      command: "docker version -f {% raw %}'{{(index .Server.Components 0).Details.ApiVersion}}'{% endraw %}"
+      register: docker_api_version_stdout
+      ignore_errors: yes
+
+    - name: Limit docker pypi package version to < 4.3.0
+      set_fact:
+        docker_pip_package_limit: '<4.3.0'
+      when: docker_api_version_stdout is version('1.39', '<')
+
     - name: Install Python requirements
       pip:
         state: present
-        name: "{{ docker_pip_packages | union(docker_pip_extra_packages) }}"
+        name: "{{ docker_pip_package }}{{ docker_pip_package_limit }}"
         extra_args: "-c {{ remote_constraints }}"
+      notify: cleanup docker
+
+    - name: Install Python requirements
+      pip:
+        state: present
+        name: "{{ docker_pip_extra_packages }}"
+        extra_args: "-c {{ remote_constraints }}"
+      when: docker_pip_extra_packages | length > 0
       notify: cleanup docker
 
     # Detect docker CLI, API and docker-py versions


### PR DESCRIPTION
##### SUMMARY
The docker pypi package bumped its default API version to 1.39. Since some of the CI nodes have an older docker daemon version, this will break the docker tests. One way to fix this is to restrict docker pypi to < 4.3.0 (see https://github.com/ansible/ansible#71193). Since we want to be able to use the new docker pypi package, we make sure to install < 4.3.0 only when the API version of the docker daemon is < 1.39.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
