### PR TITLE
Fix docker_stack_task_info tests

### DIFF
--- a/tests/integration/targets/docker_stack_task_info/tasks/test_stack_task_info.yml
+++ b/tests/integration/targets/docker_stack_task_info/tasks/test_stack_task_info.yml
@@ -56,6 +56,10 @@
       that:
         - output is changed
 
+  - name: Wait a bit to make sure stack is running
+    pause:
+      seconds: 5
+
   - name: Get docker_stack_info when docker is running
     docker_stack_info:
     register: output


### PR DESCRIPTION
##### SUMMARY
The tests sometimes result in errors because the stack hasn't been started yet: https://app.shippable.com/github/ansible-collections/community.general/runs/3249/35/console

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_stack_task_info
