### PR TITLE
Add ability to resize existing partition

### DIFF
--- a/changelogs/fragments/773-resize-partition.yml
+++ b/changelogs/fragments/773-resize-partition.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - parted - add ``--resize`` flag to resize existing partitions (https://github.com/ansible-collections/community.general/pull/773)

--- a/changelogs/fragments/773-resize-partition.yml
+++ b/changelogs/fragments/773-resize-partition.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted - add ``--resize`` flag to resize existing partitions (https://github.com/ansible-collections/community.general/pull/773).
+  - parted - add ``resize`` option to resize existing partitions (https://github.com/ansible-collections/community.general/pull/773).

--- a/changelogs/fragments/773-resize-partition.yml
+++ b/changelogs/fragments/773-resize-partition.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted - add ``--resize`` flag to resize existing partitions (https://github.com/ansible-collections/community.general/pull/773)
+  - parted - add ``--resize`` flag to resize existing partitions (https://github.com/ansible-collections/community.general/pull/773).

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -106,8 +106,7 @@ options:
     description:
       - Call 'resizepart' on existing partitions to match the size specified by part_end.
     type: bool
-    default: false
-    version_added: '1.2.0'
+    version_added: '1.3.0'
 
 notes:
   - When fetching information about a new disk and when the version of parted
@@ -616,7 +615,7 @@ def main():
             state=dict(type='str', default='info', choices=['absent', 'info', 'present']),
 
             # resize part
-            resize=dict(type='bool', default=False)
+            resize=dict(type='bool', default=False),
         ),
         required_if=[
             ['state', 'present', ['number']],

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -106,7 +106,7 @@ options:
     description:
       - Call C(resizepart) on existing partitions to match the size specified by I(part_end).
     type: bool
-    default: False
+    default: false
     version_added: '1.3.0'
 
 notes:
@@ -684,7 +684,7 @@ def main():
             script = "unit %s %s" % (unit, script)
 
         # If partition exists, try to resize
-        if part_exists(current_parts, 'num', number) and resize:
+        if resize and part_exists(current_parts, 'num', number):
             # Ensure new end is different to current
             partition = [p for p in current_parts if p['num'] == number][0]
             current_part_end = convert_to_bytes(partition['end'], unit)

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -106,7 +106,8 @@ options:
     description:
       - Call 'resizepart' on existing partitions to match the size specified by part_end
     type: bool
-    default: False
+    default: false
+    version_added: '1.2.0'
 
 notes:
   - When fetching information about a new disk and when the version of parted

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -104,7 +104,7 @@ options:
     version_added: '0.2.0'
   resize:
     description:
-      - Call 'resizepart' on existing partitions to match the size specified by part_end.
+      - Call C(resizepart) on existing partitions to match the size specified by I(part_end).
     type: bool
     version_added: '1.3.0'
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -104,7 +104,7 @@ options:
     version_added: '0.2.0'
   resize:
     description:
-      - Call 'resizepart' on existing partitions to match the size specified by part_end
+      - Call 'resizepart' on existing partitions to match the size specified by part_end.
     type: bool
     default: false
     version_added: '1.2.0'

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -106,6 +106,7 @@ options:
     description:
       - Call C(resizepart) on existing partitions to match the size specified by I(part_end).
     type: bool
+    default: False
     version_added: '1.3.0'
 
 notes:
@@ -218,7 +219,7 @@ EXAMPLES = r'''
     decice: /dev/sdb
     number: "{{ sdb_info.partitions | length }}"
     part_end: "100%"
-    resize: True
+    resize: true
 '''
 
 

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -206,6 +206,17 @@ class TestParted(ModuleTestCase):
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):
             self.execute_module(changed=True, script='rm 1')
 
+    def test_resize_partition(self):
+        set_module_args({
+            'device': '/dev/sdb',
+            'number': 3,
+            'state': 'present',
+            'part_end': '100%',
+            'resize': True
+        })
+        with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict1):
+            self.execute_module(changed=True, script='resizepart 3 100%')
+
     def test_change_flag(self):
         # Flags are set in a second run of parted().
         # Between the two runs, the partition dict is updated.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows parted to resize existing partitions if they exist and part_end doesn't match the current value.

Has a safety check and fails if the given part_end would shrink the partition rather than extend it.

A typical use-case I have for this is to allow the OS of a virtual machine to update the partitions on a disk following a disk resize - hypervisors typically don't have functionality to do this. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parted

