### PR TITLE
postgresql_set: allow to pass an empty string as a value

### DIFF
--- a/changelogs/fragments/776-postgresql_set_allow_empty_string.yaml
+++ b/changelogs/fragments/776-postgresql_set_allow_empty_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - allow to pass an empty string to the ``value`` parameter (https://github.com/ansible-collections/community.general/issues/775).

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -314,7 +314,8 @@ def main():
             if value[:-2].isdigit() and unit in value[-2:]:
                 value = value.upper()
 
-    if value and reset:
+    # value can be an empty string but can't be None
+    if (value or value == '') and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -317,6 +317,9 @@ def main():
     if value is not None and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
+    if value is None and not reset:
+        module.fail_json(msg="%s: at least one of value or reset param must be specified" % name)
+
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -317,9 +317,6 @@ def main():
     if value and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
-    if not value and not reset:
-        module.fail_json(msg="%s: at least one of value or reset param must be specified" % name)
-
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
@@ -388,8 +385,8 @@ def main():
         kw['restart_required'] = restart_required
         module.exit_json(**kw)
 
-    # Set param:
-    if value and value != current_value:
+    # Set param (value can be an empty string):
+    if (value or value == '') and value != current_value:
         changed = param_set(cursor, module, name, value, context)
 
         kw['value_pretty'] = value

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -314,8 +314,7 @@ def main():
             if value[:-2].isdigit() and unit in value[-2:]:
                 value = value.upper()
 
-    # value can be an empty string but can't be None
-    if (value or value == '') and reset:
+    if value is not None and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
@@ -387,7 +386,7 @@ def main():
         module.exit_json(**kw)
 
     # Set param (value can be an empty string):
-    if (value or value == '') and value != current_value:
+    if value is not None and value != current_value:
         changed = param_set(cursor, module, name, value, context)
 
         kw['value_pretty'] = value

--- a/tests/integration/targets/postgresql_set/tasks/main.yml
+++ b/tests/integration/targets/postgresql_set/tasks/main.yml
@@ -1,3 +1,3 @@
 # Initial CI tests of postgresql_initial module
 - include_tasks: postgresql_set_initial.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  when: postgres_version_resp.stdout is version('9.6', '>=')

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -359,3 +359,16 @@
   - assert:
       that:
       - result is not changed
+
+  - name: postgresql_set - set empty string as value again in check mode
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is not changed

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -327,33 +327,15 @@
   - name: postgresql_set - turn on archive mode
     <<: *task_parameters
     postgresql_set:
-      <<: *pg_parameters
+    <<: *pg_parameters
       name: archive_mode
       value: 'on'
 
-  # To avoid CI timeouts
-  - name: Kill all postgres processes
-    shell: 'pkill -u {{ pg_user }}'
-    become: yes
-    when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
-    ignore_errors: yes
-
-  - name: Stop PostgreSQL
+  - name: Restart PostgreSQL
     become: yes
     service:
       name: "{{ postgresql_service }}"
-      state: stopped
-    when: (ansible_facts.distribution_major_version != '8' and ansible_facts.distribution == 'CentOS') or ansible_facts.distribution != 'CentOS'
-
-  - name: Pause between stop and start PosgreSQL
-    pause:
-      seconds: 5
-
-  - name: Start PostgreSQL
-    become: yes
-    service:
-      name: "{{ postgresql_service }}"
-      state: started
+      state: restarted
 
   - name: postgresql_set - set empty string as value
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -331,13 +331,29 @@
       name: archive_mode
       value: 'on'
 
-  - name: postgresql_set - restart service
-    service:
-      name: postgresql
-      state: restarted
+  # To avoid CI timeouts
+  - name: Kill all postgres processes
+    shell: 'pkill -u {{ pg_user }}'
+    become: yes
+    when: ansible_facts.distribution == 'CentOS' and ansible_facts.distribution_major_version == '8'
+    ignore_errors: yes
 
-  - pause:
+  - name: Stop PostgreSQL
+    become: yes
+    service:
+      name: "{{ postgresql_service }}"
+      state: stopped
+    when: (ansible_facts.distribution_major_version != '8' and ansible_facts.distribution == 'CentOS') or ansible_facts.distribution != 'CentOS'
+
+  - name: Pause between stop and start PosgreSQL
+    pause:
       seconds: 5
+
+  - name: Start PostgreSQL
+    become: yes
+    service:
+      name: "{{ postgresql_service }}"
+      state: started
 
   - name: postgresql_set - set empty string as value
     <<: *task_parameters

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -336,6 +336,9 @@
       name: postgresql
       state: restarted
 
+  - pause:
+      seconds: 5
+
   - name: postgresql_set - set empty string as value
     <<: *task_parameters
     postgresql_set:

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -327,7 +327,7 @@
   - name: postgresql_set - turn on archive mode
     <<: *task_parameters
     postgresql_set:
-    <<: *pg_parameters
+      <<: *pg_parameters
       name: archive_mode
       value: 'on'
 

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -321,3 +321,41 @@
       that:
       - result is failed
       - result.msg is search('is potentially dangerous')
+
+  ###############################################################################
+  # Bugfix of https://github.com/ansible-collections/community.general/issues/775
+  - name: postgresql_set - turn on archive mode
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_mode
+      value: 'on'
+
+  - name: postgresql_set - restart service
+    service:
+      name: postgresql
+      state: restarted
+
+  - name: postgresql_set - set empty string as value
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: postgresql_set - set empty string as value again
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+
+  - assert:
+      that:
+      - result is not changed


### PR DESCRIPTION
##### SUMMARY
postgresql_set: allow to pass an empty string as a value

Fixes https://github.com/ansible-collections/community.general/issues/775

(there are unrelated CI problems with restarting unsupported 9.4 on ubuntu 16 and freebsd 11, so i increased the min postgres version to 9.6)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_set
