### PR TITLE
add module pacman_key

### DIFF
--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -143,6 +143,15 @@ class PacmanKey(object):
             fingerprint = self.sanitise_fingerprint(fingerprint)
         key_present = self.key_in_keyring(keyid, keyring)
 
+        if (
+            state == "present"
+            and data is None
+            and file is None
+            and url is None
+            and keyserver is None
+        ):
+            module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
+
         if module.check_mode:
             if state == "present":
                 if (key_present and force_update) or not key_present:
@@ -172,8 +181,6 @@ class PacmanKey(object):
             elif keyserver:
                 self.recv_key(keyid, keyserver, keyring)
                 module.exit_json(changed=True)
-            else:
-                module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
         elif state == "absent":
             if key_present:
                 self.remove_key(keyid)

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -1,0 +1,334 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, George Rawlinson <george@rawlinson.net.nz>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: pacman_key
+author:
+- George Rawlinson (@grawlinson) <george@rawlinson.net.nz>
+version_added: "2.10"
+short_description: Manage pacman's list of trusted keys
+description:
+- Add or remove gpg keys from the pacman keyring.
+notes:
+- Use full key id (16 characters) and fingerprint (40 characters) to avoid key collisions.
+- If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
+- By default, keys will be locally signed after being imported into the keyring.
+- If the specified key id exists in the keyring, the key will not be added.
+requirements:
+- gpg
+- pacman-key
+options:
+    id:
+        description:
+            - The 16 character identifier of the key.
+            - Including this allows check mode to correctly report the changed state.
+            - Do not specify a subkey id, instead specify the master key id.
+        required: yes
+        type: str
+    data:
+        description:
+            - The keyfile contents to add to the keyring.
+            - Must be of "PGP PUBLIC KEY BLOCK" type.
+        type: str
+    file:
+        description:
+            - The path to a keyfile on the remote server to add to the keyring.
+            - Remote file should be of "PGP PUBLIC KEY BLOCK" type.
+        type: path
+    url:
+        description:
+            - The URL to retrieve keyfile from.
+            - Remote file should be of "PGP PUBLIC KEY BLOCK" type.
+        type: str
+    keyserver:
+        description:
+            - The keyserver used to retrieve key from.
+        type: str
+    fingerprint:
+        description:
+            - 40 character fingerprint of the key.
+            - When specified, it is used for verification.
+        type: str
+    force_update:
+        description:
+            - This forces the key to be updated if it already exists in the keyring.
+        type: bool
+        default: no
+    keyring:
+        description:
+            - The full path to the keyring folder on the remote server.
+            - If not specified, module will use pacman's default (/etc/pacman.d/gnupg).
+            - Useful if the remote system requires an alternative gnupg directory.
+        type: path
+    state:
+        description:
+            - Ensures that the key is present (added) or absent (revoked).
+        default: present
+        choices: [ absent, present ]
+        type: str
+'''
+
+EXAMPLES = '''
+- name: Import a key via local file
+  pacman_key:
+    data: "{{ lookup('file', 'keyfile.asc') }}"
+    state: present
+
+- name: Import a key via remote file
+  pacman_key:
+    file: /tmp/keyfile.asc
+    state: present
+
+- name: Import a key via url
+  pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
+    url: https://domain.tld/keys/keyfile.asc
+    state: present
+
+- name: Import a key via keyserver
+  pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
+    keyserver: keyserver.domain.tld
+
+- name: Import a key into an alternative keyring
+  pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
+    file: /tmp/keyfile.asc
+    keyring: /etc/pacman.d/gnupg-alternative
+
+- name: Remove a key from the keyring
+  pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
+    state: absent
+'''
+
+RETURN = r''' # '''
+
+import os.path
+import tempfile
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_native
+
+
+class PacmanKey(object):
+    def __init__(self, module):
+        self.module = module
+        self.gpg = module.get_bin_path('gpg', required=True)
+        self.pacman_key = module.get_bin_path('pacman-key', required=True)
+        keyid = module.params['id']
+        url = module.params['url']
+        data = module.params['data']
+        file = module.params['file']
+        keyserver = module.params['keyserver']
+        fingerprint = module.params['fingerprint']
+        force_update = module.params['force_update']
+        keyring = module.params['keyring']
+        state = module.params['state']
+
+        keyid = self.sanitise_keyid(keyid)
+        if fingerprint:
+            fingerprint = self.sanitise_fingerprint(fingerprint)
+        key_present = self.key_in_keyring(keyid, keyring)
+
+        if module.check_mode:
+            if state == "present":
+                if (key_present and force_update) or not key_present:
+                    module.exit_json(changed=True)
+                module.exit_json(changed=False)
+            elif state == "absent":
+                if key_present:
+                    module.exit_json(changed=True)
+                module.exit_json(changed=False)
+
+        if state == "present":
+            if key_present and not force_update:
+                module.exit_json(changed=False)
+
+            if data:
+                file = self.save_key(data)
+                self.add_key(file, keyid, fingerprint, keyring)
+                module.exit_json(changed=True)
+            elif file:
+                self.add_key(file, keyid, fingerprint, keyring)
+                module.exit_json(changed=True)
+            elif url:
+                data = self.fetch_key(url)
+                file = self.save_key(data)
+                self.add_key(file, keyid, fingerprint, keyring)
+                module.exit_json(changed=True)
+            elif keyserver:
+                self.recv_key(keyid, keyserver, keyring)
+                module.exit_json(changed=True)
+            else:
+                module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
+        elif state == "absent":
+            if key_present:
+                self.remove_key(keyid)
+                module.exit_json(changed=True)
+            module.exit_json(changed=False)
+
+    def is_hexadecimal(self, string):
+        """Check if a given string is valid hexadecimal"""
+        try:
+            int(string, 16)
+        except ValueError:
+            return False
+        return True
+
+    def sanitise_keyid(self, keyid):
+        """Sanitise given keyid"""
+        keyid = keyid.strip().upper().replace('0X', '')
+        if len(keyid) != 16:
+            self.module.fail_json(msg="keyid is not 16 characters: %s" % keyid)
+        if not self.is_hexadecimal(keyid):
+            self.module.fail_json(msg="keyid is not hexadecimal: %s" % keyid)
+        return keyid
+
+    def sanitise_fingerprint(self, fingerprint):
+        """Sanitise given fingerprint"""
+        fingerprint = fingerprint.strip().upper().replace(' ', '').replace('0X', '')
+        if len(fingerprint) != 40:
+            self.module.fail_json(msg="fingerprint is not 40 characters: %s" % fingerprint)
+        if not self.is_hexadecimal(fingerprint):
+            self.module.fail_json(msg="fingerprint is not hexadecimal: %s" % fingerprint)
+        return fingerprint
+
+    def fetch_key(self, url):
+        """Downloads a key from url"""
+        response, info = fetch_url(self.module, url)
+        if info['status'] != 200:
+            self.module.fail_json(msg="failed to fetch key at %s, error was %s" % (url, info['msg']))
+        return to_native(response.read())
+
+    def recv_key(self, keyid, keyserver=None, keyring=None):
+        """Receives key via keyserver"""
+        cmd = [self.pacman_key]
+        if keyring is not None:
+            cmd.extend(['--gpgdir', keyring])
+        if keyserver is not None:
+            cmd.extend(['--keyserver', keyserver])
+
+        rc, stdout, stderr = self.module.run_command(cmd + ['--recv-keys', keyid])
+        if rc != 0:
+            self.module.fail_json(msg="failed to receive key %s from %s, error: %s" % (keyid, keyserver, stderr))
+        self.lsign_key(keyid, keyring)
+
+    def lsign_key(self, keyid, keyring=None):
+        """Locally sign key"""
+        cmd = [self.pacman_key]
+        if keyring is not None:
+            cmd.extend(['--gpgdir', keyring])
+
+        rc, stdout, stderr = self.module.run_command(cmd + ['--lsign-key', keyid])
+        if rc != 0:
+            self.module.fail_json(msg="error locally signing key: %s" % stderr)
+
+    def save_key(self, data):
+        "Saves key data to a temporary file"
+        tmpfd, tmpname = tempfile.mkstemp()
+        self.module.add_cleanup_file(tmpname)
+        tmpfile = os.fdopen(tmpfd, "w")
+        tmpfile.write(data)
+        tmpfile.close()
+        return tmpname
+
+    def add_key(self, keyfile, keyid, fingerprint=None, keyring=None):
+        """Add key to pacman's keyring"""
+        cmd = [self.pacman_key]
+        if keyring is not None:
+            cmd.extend(['--gpgdir', keyring])
+
+        if fingerprint is not None:
+            self.verify_keyfile(keyfile, keyid, fingerprint)
+
+        rc, stdout, stderr = self.module.run_command(cmd + ['--add', keyfile])
+        if rc != 0:
+            self.module.fail_json(msg="error adding key to keyring: %s" % stderr)
+        self.lsign_key(keyid, keyring)
+
+    def remove_key(self, keyid, keyring=None):
+        """Remove key from pacman's keyring"""
+        cmd = [self.pacman_key]
+        if keyring is not None:
+            cmd.extend(['--gpgdir', keyring])
+
+        rc, stdout, stderr = self.module.run_command(cmd + ['--delete', keyid])
+        if rc != 0:
+            self.module.fail_json(msg="error removing key from keyring: %s" % stderr)
+
+    def verify_keyfile(self, keyfile, keyid, fingerprint):
+        """Verify that keyfile matches the specified keyid & fingerprint"""
+        if keyfile is None:
+            self.module.fail_json(msg="expected a key, got none")
+        elif keyid is None:
+            self.module.fail_json(msg="expected a keyid, got none")
+        elif fingerprint is None:
+            self.module.fail_json(msg="expected a fingerprint, got none")
+
+        rc, stdout, stderr = self.module.run_command([self.gpg, '--with-colons', '--with-fingerprint', '--batch', '--no-tty', '--show-keys', keyfile])
+        if rc != 0:
+            self.module.fail_json(msg="gpg returned an error: %s" % stderr)
+
+        extracted_keyid = extracted_fingerprint = None
+        for line in stdout.splitlines():
+            if line.startswith('pub:'):
+                extracted_keyid = line.split(':')[4]
+            elif line.startswith('fpr:'):
+                extracted_fingerprint = line.split(':')[9]
+                break
+
+        if extracted_keyid != keyid:
+            self.module.fail_json(msg="keyid does not match. expected %s, got %s" % (keyid, extracted_keyid))
+        elif extracted_fingerprint != fingerprint:
+            self.module.fail_json(msg="fingerprint does not match. expected %s, got %s" % (fingerprint, extracted_fingerprint))
+
+    def key_in_keyring(self, keyid, keyring=None):
+        "Check if the keyid is in pacman's keyring"
+        if keyring is None:
+            keyring = '/etc/pacman.d/gnupg'
+
+        rc, stdout, stderr = self.module.run_command(
+            [self.gpg, '--with-colons', '--batch', '--no-tty',
+                '--no-default-keyring', '--keyring=' + keyring + '/pubring.gpg',
+                '--list-keys', keyid])
+        if rc != 0:
+            if stderr.find("No public key") >= 0:
+                return False
+            else:
+                self.module.fail_json(msg="gpg returned an error: %s" % stderr)
+        return True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            id=dict(type='str', required=True),
+            data=dict(type='str'),
+            file=dict(type='path'),
+            url=dict(type='str'),
+            keyserver=dict(type='str'),
+            fingerprint=dict(type='str'),
+            force_update=dict(type='bool', default=False),
+            keyring=dict(type='path'),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=(('data', 'file', 'url', 'keyserver'),),
+    )
+    PacmanKey(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -16,15 +16,16 @@ DOCUMENTATION = '''
 module: pacman_key
 author:
 - George Rawlinson (@grawlinson) <george@rawlinson.net.nz>
-version_added: "2.10"
+version_added: "1.1.0"
 short_description: Manage pacman's list of trusted keys
 description:
 - Add or remove gpg keys from the pacman keyring.
 notes:
-- Use full key id (16 characters) and fingerprint (40 characters) to avoid key collisions.
+- Use full key ID (16 characters) and fingerprint (40 characters) to avoid key collisions.
 - If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
 - By default, keys will be locally signed after being imported into the keyring.
 - If the specified key id exists in the keyring, the key will not be added.
+- data, file, and url are mutually exclusive.
 requirements:
 - gpg
 - pacman-key

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -25,7 +25,7 @@ notes:
 - If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
 - By default, keys will be locally signed after being imported into the keyring.
 - If the specified key id exists in the keyring, the key will not be added.
-- data, file, and url are mutually exclusive.
+- I(data), I(file), and I(url) are mutually exclusive.
 requirements:
 - gpg
 - pacman-key

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -22,6 +22,7 @@ notes:
 - By default, keys will be locally signed after being imported into the keyring.
 - If the specified key id exists in the keyring, the key will not be added.
 - I(data), I(file), and I(url) are mutually exclusive.
+- Supports C(check_mode).
 requirements:
 - gpg
 - pacman-key

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -7,10 +7,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 ---
 module: pacman_key

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
     state: present
 
 - name: Import a key via remote file
-  pacman_key:
+  community.general.pacman_key:
     file: /tmp/keyfile.asc
     state: present
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -88,7 +88,7 @@ EXAMPLES = '''
     state: present
 
 - name: Import a key via url
-  pacman_key:
+  community.general.pacman_key:
     id: 01234567890ABCDE01234567890ABCDE12345678
     url: https://domain.tld/keys/keyfile.asc
     state: present

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -99,7 +99,7 @@ EXAMPLES = '''
     keyserver: keyserver.domain.tld
 
 - name: Import a key into an alternative keyring
-  pacman_key:
+  community.general.pacman_key:
     id: 01234567890ABCDE01234567890ABCDE12345678
     file: /tmp/keyfile.asc
     keyring: /etc/pacman.d/gnupg-alternative

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 module: pacman_key
 author:
 - George Rawlinson (@grawlinson) <george@rawlinson.net.nz>
-version_added: "1.1.0"
+version_added: "1.3.0"
 short_description: Manage pacman's list of trusted keys
 description:
 - Add or remove gpg keys from the pacman keyring.

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -141,15 +141,6 @@ class PacmanKey(object):
             fingerprint = self.sanitise_identifier(fingerprint)
         key_present = self.key_in_keyring(keyring, keyid)
 
-        if (
-            state == "present"
-            and data is None
-            and file is None
-            and url is None
-            and keyserver is None
-        ):
-            module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
-
         if module.check_mode:
             if state == "present":
                 if (key_present and force_update) or not key_present:
@@ -300,6 +291,7 @@ def main():
         ),
         supports_check_mode=True,
         mutually_exclusive=(('data', 'file', 'url', 'keyserver'),),
+        required_if=[('state', 'present', ('data', 'file', 'url', 'keyserver'), True)],
     )
     PacmanKey(module)
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 module: pacman_key
 author:
 - George Rawlinson (@grawlinson)
-version_added: "1.3.0"
+version_added: "3.2.0"
 short_description: Manage pacman's list of trusted keys
 description:
 - Add or remove gpg keys from the pacman keyring.
@@ -21,7 +21,7 @@ notes:
 - If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
 - By default, keys will be locally signed after being imported into the keyring.
 - If the specified key id exists in the keyring, the key will not be added.
-- I(data), I(file), and I(url) are mutually exclusive.
+- I(data), I(file), I(url), and I(keyserver) are mutually exclusive.
 - Supports C(check_mode).
 requirements:
 - gpg

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -140,6 +140,15 @@ class PacmanKey(object):
             fingerprint = self.sanitise_fingerprint(fingerprint)
         key_present = self.key_in_keyring(keyid, keyring)
 
+        if (
+            state == "present"
+            and data is None
+            and file is None
+            and url is None
+            and keyserver is None
+        ):
+            module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
+
         if module.check_mode:
             if state == "present":
                 if (key_present and force_update) or not key_present:
@@ -322,7 +331,6 @@ def main():
         ),
         supports_check_mode=True,
         mutually_exclusive=(('data', 'file', 'url', 'keyserver'),),
-        required_one_of=[('data', 'file', 'url', 'keyserver'),],
     )
     PacmanKey(module)
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -139,7 +139,7 @@ class PacmanKey(object):
         keyid = self.sanitise_identifier(keyid)
         if fingerprint:
             fingerprint = self.sanitise_identifier(fingerprint)
-        key_present = self.key_in_keyring(keyid, keyring)
+        key_present = self.key_in_keyring(keyring, keyid)
 
         if (
             state == "present"
@@ -218,7 +218,7 @@ class PacmanKey(object):
         if keyserver is not None:
             cmd.extend(['--keyserver', keyserver])
         self.module.run_command(cmd + ['--recv-keys', keyid], check_rc=True)
-        self.lsign_key(keyid, keyring)
+        self.lsign_key(keyring, keyid)
 
     def lsign_key(self, keyring, keyid):
         """Locally sign key"""
@@ -240,7 +240,7 @@ class PacmanKey(object):
         if fingerprint is not None:
             self.verify_keyfile(keyfile, keyid, fingerprint)
         self.module.run_command(cmd + ['--add', keyfile], check_rc=True)
-        self.lsign_key(keyid, keyring)
+        self.lsign_key(keyring, keyid)
 
     def remove_key(self, keyring, keyid):
         """Remove key from pacman's keyring"""

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -147,9 +147,8 @@ class PacmanKey(object):
         # check mode
         if module.check_mode:
             if state == "present":
-                if (key_present and force_update) or not key_present:
-                    module.exit_json(changed=True)
-                module.exit_json(changed=False)
+                changed = (key_present and force_update) or not key_present
+                module.exit_json(changed=changed)
             elif state == "absent":
                 if key_present:
                     module.exit_json(changed=True)

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -140,15 +140,6 @@ class PacmanKey(object):
             fingerprint = self.sanitise_fingerprint(fingerprint)
         key_present = self.key_in_keyring(keyid, keyring)
 
-        if (
-            state == "present"
-            and data is None
-            and file is None
-            and url is None
-            and keyserver is None
-        ):
-            module.fail_json(msg="expected one of: data, file, url, keyserver. got none")
-
         if module.check_mode:
             if state == "present":
                 if (key_present and force_update) or not key_present:
@@ -331,6 +322,7 @@ def main():
         ),
         supports_check_mode=True,
         mutually_exclusive=(('data', 'file', 'url', 'keyserver'),),
+        required_one_of=[('data', 'file', 'url', 'keyserver'),],
     )
     PacmanKey(module)
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
     keyring: /etc/pacman.d/gnupg-alternative
 
 - name: Remove a key from the keyring
-  pacman_key:
+  community.general.pacman_key:
     id: 01234567890ABCDE01234567890ABCDE12345678
     state: absent
 '''

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -69,6 +69,7 @@ options:
             - If not specified, module will use pacman's default (/etc/pacman.d/gnupg).
             - Useful if the remote system requires an alternative gnupg directory.
         type: path
+        default: /etc/pacman.d/gnupg
     state:
         description:
             - Ensures that the key is present (added) or absent (revoked).

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 ---
 module: pacman_key
 author:
-- George Rawlinson (@grawlinson) <george@rawlinson.net.nz>
+- George Rawlinson (@grawlinson)
 version_added: "1.3.0"
 short_description: Manage pacman's list of trusted keys
 description:

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -249,8 +249,16 @@ class PacmanKey(object):
             self.module.fail_json(msg="expected a fingerprint, got none")
 
         rc, stdout, stderr = self.module.run_command(
-            [self.gpg, '--with-colons', '--with-fingerprint', '--batch', '--no-tty', '--show-keys', keyfile],
-            check_rc=True
+            [
+                self.gpg,
+                '--with-colons',
+                '--with-fingerprint',
+                '--batch',
+                '--no-tty',
+                '--show-keys',
+                keyfile
+            ],
+            check_rc=True,
         )
 
         extracted_keyid = extracted_fingerprint = None
@@ -269,9 +277,17 @@ class PacmanKey(object):
     def key_in_keyring(self, keyring, keyid):
         "Check if the keyid is in pacman's keyring"
         rc, stdout, stderr = self.module.run_command(
-            [self.gpg, '--with-colons', '--batch', '--no-tty',
-                '--no-default-keyring', '--keyring=' + keyring + '/pubring.gpg',
-                '--list-keys', keyid])
+            [
+                self.gpg,
+                '--with-colons',
+                '--batch',
+                '--no-tty',
+                '--no-default-keyring',
+                '--keyring=' + keyring + '/pubring.gpg',
+                '--list-keys', keyid
+            ],
+            check_rc=False,
+        )
         if rc != 0:
             if stderr.find("No public key") >= 0:
                 return False

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -18,9 +18,9 @@ description:
 - Add or remove gpg keys from the pacman keyring.
 notes:
 - Use full-length identifier (40 characters) for key ID and fingerprint to avoid key collisions.
-- If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
+- If you specify both the key ID and the URL with I(state=present), the task can verify or add the key as needed.
 - By default, keys will be locally signed after being imported into the keyring.
-- If the specified key id exists in the keyring, the key will not be added.
+- If the specified key ID exists in the keyring, the key will not be added.
 - I(data), I(file), I(url), and I(keyserver) are mutually exclusive.
 - Supports C(check_mode).
 requirements:
@@ -31,23 +31,23 @@ options:
         description:
             - The 40 character identifier of the key.
             - Including this allows check mode to correctly report the changed state.
-            - Do not specify a subkey id, instead specify the master key id.
+            - Do not specify a subkey ID, instead specify the master key ID.
         required: yes
         type: str
     data:
         description:
             - The keyfile contents to add to the keyring.
-            - Must be of "PGP PUBLIC KEY BLOCK" type.
+            - Must be of C(PGP PUBLIC KEY BLOCK) type.
         type: str
     file:
         description:
             - The path to a keyfile on the remote server to add to the keyring.
-            - Remote file should be of "PGP PUBLIC KEY BLOCK" type.
+            - Remote file must be of C(PGP PUBLIC KEY BLOCK) type.
         type: path
     url:
         description:
             - The URL to retrieve keyfile from.
-            - Remote file should be of "PGP PUBLIC KEY BLOCK" type.
+            - Remote file must be of C(PGP PUBLIC KEY BLOCK) type.
         type: str
     keyserver:
         description:
@@ -66,7 +66,7 @@ options:
     keyring:
         description:
             - The full path to the keyring folder on the remote server.
-            - If not specified, module will use pacman's default (/etc/pacman.d/gnupg).
+            - If not specified, module will use pacman's default (C(/etc/pacman.d/gnupg)).
             - Useful if the remote system requires an alternative gnupg directory.
         type: path
         default: /etc/pacman.d/gnupg
@@ -186,7 +186,7 @@ class PacmanKey(object):
         return True
 
     def sanitise_identifier(self, identifier):
-        """Sanitise given key id or fingerprint.
+        """Sanitise given key ID or fingerprint.
 
         Strips whitespace, uppercases all characters, and strips leading `0X`.
         """
@@ -240,11 +240,11 @@ class PacmanKey(object):
         self.module.run_command(cmd + ['--delete', keyid], check_rc=True)
 
     def verify_keyfile(self, keyfile, keyid, fingerprint):
-        """Verify that keyfile matches the specified keyid & fingerprint"""
+        """Verify that keyfile matches the specified key ID & fingerprint"""
         if keyfile is None:
             self.module.fail_json(msg="expected a key, got none")
         elif keyid is None:
-            self.module.fail_json(msg="expected a keyid, got none")
+            self.module.fail_json(msg="expected a key ID, got none")
         elif fingerprint is None:
             self.module.fail_json(msg="expected a fingerprint, got none")
 
@@ -270,12 +270,12 @@ class PacmanKey(object):
                 break
 
         if extracted_keyid != keyid:
-            self.module.fail_json(msg="keyid does not match. expected %s, got %s" % (keyid, extracted_keyid))
+            self.module.fail_json(msg="key ID does not match. expected %s, got %s" % (keyid, extracted_keyid))
         elif extracted_fingerprint != fingerprint:
             self.module.fail_json(msg="fingerprint does not match. expected %s, got %s" % (fingerprint, extracted_fingerprint))
 
     def key_in_keyring(self, keyring, keyid):
-        "Check if the keyid is in pacman's keyring"
+        "Check if the key ID is in pacman's keyring"
         rc, stdout, stderr = self.module.run_command(
             [
                 self.gpg,
@@ -283,7 +283,7 @@ class PacmanKey(object):
                 '--batch',
                 '--no-tty',
                 '--no-default-keyring',
-                '--keyring=' + keyring + '/pubring.gpg',
+                '--keyring=%s/pubring.gpg' % keyring,
                 '--list-keys', keyid
             ],
             check_rc=False,

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -78,7 +78,7 @@ options:
 
 EXAMPLES = '''
 - name: Import a key via local file
-  pacman_key:
+  community.general.pacman_key:
     data: "{{ lookup('file', 'keyfile.asc') }}"
     state: present
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -94,7 +94,7 @@ EXAMPLES = '''
     state: present
 
 - name: Import a key via keyserver
-  pacman_key:
+  community.general.pacman_key:
     id: 01234567890ABCDE01234567890ABCDE12345678
     keyserver: keyserver.domain.tld
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -248,7 +248,10 @@ class PacmanKey(object):
         elif fingerprint is None:
             self.module.fail_json(msg="expected a fingerprint, got none")
 
-        _, stdout, _ = self.module.run_command([self.gpg, '--with-colons', '--with-fingerprint', '--batch', '--no-tty', '--show-keys', keyfile], check_rc=True)
+        rc, stdout, stderr = self.module.run_command(
+            [self.gpg, '--with-colons', '--with-fingerprint', '--batch', '--no-tty', '--show-keys', keyfile],
+            check_rc=True
+        )
 
         extracted_keyid = extracted_fingerprint = None
         for line in stdout.splitlines():
@@ -265,7 +268,7 @@ class PacmanKey(object):
 
     def key_in_keyring(self, keyring, keyid):
         "Check if the keyid is in pacman's keyring"
-        rc, _, stderr = self.module.run_command(
+        rc, stdout, stderr = self.module.run_command(
             [self.gpg, '--with-colons', '--batch', '--no-tty',
                 '--no-default-keyring', '--keyring=' + keyring + '/pubring.gpg',
                 '--list-keys', keyid])

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -32,7 +32,7 @@ options:
             - The 40 character identifier of the key.
             - Including this allows check mode to correctly report the changed state.
             - Do not specify a subkey ID, instead specify the primary key ID.
-        required: yes
+        required: true
         type: str
     data:
         description:
@@ -57,12 +57,12 @@ options:
         description:
             - Whether or not to verify the keyfile's key ID against specified key ID.
         type: bool
-        default: yes
+        default: true
     force_update:
         description:
             - This forces the key to be updated if it already exists in the keyring.
         type: bool
-        default: no
+        default: false
     keyring:
         description:
             - The full path to the keyring folder on the remote server.

--- a/plugins/modules/pacman_key.py
+++ b/plugins/modules/pacman_key.py
@@ -1,0 +1,1 @@
+packaging/os/pacman_key.py

--- a/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
@@ -100,8 +100,8 @@ def test_failing_params(mocker, capfd, patch_pacman_key_calls, expected):
     print(results)
 
     # assertion time!
-    assert 'failed' in results
-    if 'msg' in results:
+    assert results['failed']
+    if 'msg' in expected:
         assert results['msg'] == expected['msg']
 
 
@@ -408,15 +408,15 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
 
 
 @pytest.mark.parametrize(
-    'patch_ansible_module, testcase',
+    'patch_ansible_module, expected',
     TEST_CASES,
     ids=[item[1]['id'] for item in TEST_CASES],
     indirect=['patch_ansible_module']
 )
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_normal_operation(mocker, capfd, patch_pacman_key_calls, testcase):
+def test_normal_operation(mocker, capfd, patch_pacman_key_calls, expected):
     # patch run_command invocations with mock data
-    call_results = [item[2] for item in testcase['run_command.calls']]
+    call_results = [item[2] for item in expected['run_command.calls']]
     mock_run_command = mocker.patch.object(
         AnsibleModule,
         'run_command',
@@ -433,12 +433,12 @@ def test_normal_operation(mocker, capfd, patch_pacman_key_calls, testcase):
 
     # assertion time!
     assert 'changed' in results
-    assert results['changed'] == testcase['changed']
-    if 'msg' in results:
-        assert results['msg'] == testcase['msg']
+    assert results['changed'] == expected['changed']
+    if 'msg' in expected:
+        assert results['msg'] == expected['msg']
 
-    assert AnsibleModule.run_command.call_count == len(testcase['run_command.calls'])
+    assert AnsibleModule.run_command.call_count == len(expected['run_command.calls'])
     if AnsibleModule.run_command.call_count:
         call_args_list = [(item[0][0], item[1]) for item in AnsibleModule.run_command.call_args_list]
-        expected_call_args_list = [(item[0], item[1]) for item in testcase['run_command.calls']]
+        expected_call_args_list = [(item[0], item[1]) for item in expected['run_command.calls']]
         assert call_args_list == expected_call_args_list

--- a/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
@@ -1,6 +1,10 @@
+# Copyright: (c) 2019, George Rawlinson <george@rawlinson.net.nz>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.modules.packaging.os import pacman_key
 import pytest
 import json
@@ -8,12 +12,16 @@ import json
 
 @pytest.fixture
 def patch_pacman_key_calls(mocker):
-    get_bin_path = mocker.patch(
-        'ansible.module_utils.basic.AnsibleModule.get_bin_path',
+    get_bin_path = mocker.patch.object(
+        AnsibleModule,
+        'get_bin_path',
         return_value="/mocked/path",
     )
 
 
+#
+# test invalid user input
+#
 TEST_FAILING_PARAMS = [
     # state: present, id: absent
     [
@@ -95,3 +103,342 @@ def test_failing_params(mocker, capfd, patch_pacman_key_calls, expected):
     assert 'failed' in results
     if 'msg' in results:
         assert results['msg'] == expected['msg']
+
+
+#
+# test normal operation
+#
+TEST_CASES = [
+    # check mode: state & key present
+    [
+        {
+            'state': 'present',
+            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'data': 'FAKEDATA',
+            '_ansible_check_mode': True,
+        },
+        {
+            'id': 'checkmode_state_and_key_present',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                    ],
+                    {'check_rc': False},
+                    (
+                        0,
+                        '''
+tru::1:1616373715:0:3:1:5
+pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
+fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
+uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
+sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
+fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
+sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
+fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
+sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
+fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
+''',
+                        '',
+                    ),
+                ),
+            ],
+            'changed': False,
+        },
+    ],
+    # check mode: state present, key absent
+    [
+        {
+            'state': 'present',
+            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            'data': 'FAKEDATA',
+            '_ansible_check_mode': True,
+        },
+        {
+            'id': 'checkmode_state_present_key_absent',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '01234567890ABCDE01234567890ABCDE12345678',
+                    ],
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        '''
+                        gpg: error reading key: No public key
+                        tru::1:1616373715:0:3:1:5
+                        ''',
+                    ),
+                ),
+            ],
+            'changed': True,
+        },
+    ],
+    # check mode: state & key absent
+    [
+        {
+            'state': 'absent',
+            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            '_ansible_check_mode': True,
+        },
+        {
+            'id': 'checkmode_state_and_key_absent',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '01234567890ABCDE01234567890ABCDE12345678',
+                    ],
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        '''
+                        gpg: error reading key: No public key
+                        tru::1:1616373715:0:3:1:5
+                        ''',
+                    ),
+                ),
+            ],
+            'changed': False,
+        },
+    ],
+    # check mode: state absent, key present
+    [
+        {
+            'state': 'absent',
+            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            '_ansible_check_mode': True,
+        },
+        {
+            'id': 'check_mode_state_absent_key_present',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                    ],
+                    {'check_rc': False},
+                    (
+                        0,
+                        '''
+tru::1:1616373715:0:3:1:5
+pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
+fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
+uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
+sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
+fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
+sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
+fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
+sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
+fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
+                        ''',
+                        '',
+                    ),
+                ),
+            ],
+            'changed': True,
+        },
+    ],
+    # state & key present
+    [
+        {
+            'state': 'present',
+            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'data': 'FAKEDATA',
+        },
+        {
+            'id': 'state_and_key_present',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                    ],
+                    {'check_rc': False},
+                    (
+                        0,
+                        '''
+tru::1:1616373715:0:3:1:5
+pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
+fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
+uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
+sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
+fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
+sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
+fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
+sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
+fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
+''',
+                        '',
+                    ),
+                ),
+            ],
+            'changed': False,
+        },
+    ],
+    # state absent, key present
+    [
+        {
+            'state': 'absent',
+            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+        },
+        {
+            'id': 'state_absent_key_present',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                    ],
+                    {'check_rc': False},
+                    (
+                        0,
+                        '''
+tru::1:1616373715:0:3:1:5
+pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
+fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
+uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
+sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
+fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
+sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
+fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
+sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
+fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
+''',
+                        '',
+                    ),
+                ),
+                (
+                    [
+                        '/mocked/path',
+                        '--gpgdir',
+                        '/etc/pacman.d/gnupg',
+                        '--delete',
+                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                    ],
+                    {'check_rc': True},
+                    (
+                        0,
+                        '''
+                        ==> Updating trust database...
+                        gpg: next trustdb check due at 2021-08-02
+                        ''',
+                        '',
+                    ),
+                ),
+            ],
+            'changed': True,
+        },
+    ],
+    # state & key absent
+    [
+        {
+            'state': 'absent',
+            'id': '01234567890ABCDE01234567890ABCDE12345678',
+        },
+        {
+            'id': 'state_and_key_absent',
+            'run_command.calls': [
+                (
+                    [
+                        '/mocked/path',
+                        '--with-colons',
+                        '--batch',
+                        '--no-tty',
+                        '--no-default-keyring',
+                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+                        '--list-keys',
+                        '01234567890ABCDE01234567890ABCDE12345678',
+                    ],
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        '''
+                        gpg: error reading key: No public key
+                        tru::1:1616373715:0:3:1:5
+                        ''',
+                    ),
+                ),
+            ],
+            'changed': False,
+        },
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    'patch_ansible_module, testcase',
+    TEST_CASES,
+    ids=[item[1]['id'] for item in TEST_CASES],
+    indirect=['patch_ansible_module']
+)
+@pytest.mark.usefixtures('patch_ansible_module')
+def test_normal_operation(mocker, capfd, patch_pacman_key_calls, testcase):
+    # patch run_command invocations with mock data
+    call_results = [item[2] for item in testcase['run_command.calls']]
+    mock_run_command = mocker.patch.object(
+        AnsibleModule,
+        'run_command',
+        side_effect=call_results,
+    )
+
+    # invoke module
+    with pytest.raises(SystemExit):
+        pacman_key.main()
+
+    # capture std{out,err}
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+
+    # assertion time!
+    assert 'changed' in results
+    assert results['changed'] == testcase['changed']
+    if 'msg' in results:
+        assert results['msg'] == testcase['msg']
+
+    assert AnsibleModule.run_command.call_count == len(testcase['run_command.calls'])
+    if AnsibleModule.run_command.call_count:
+        call_args_list = [(item[0][0], item[1]) for item in AnsibleModule.run_command.call_args_list]
+        expected_call_args_list = [(item[0], item[1]) for item in testcase['run_command.calls']]
+        assert call_args_list == expected_call_args_list

--- a/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
@@ -9,28 +9,79 @@ from ansible_collections.community.general.plugins.modules.packaging.os import p
 import pytest
 import json
 
+# path used for mocking get_bin_path()
+MOCK_BIN_PATH = '/mocked/path'
 
-@pytest.fixture
-def patch_pacman_key_calls(mocker):
-    get_bin_path = mocker.patch.object(
-        AnsibleModule,
-        'get_bin_path',
-        return_value="/mocked/path",
-    )
+# Key ID used for tests
+TESTING_KEYID = '14F26682D0916CDD81E37B6D61B7B526D98F0353'
+TESTING_KEYFILE_PATH = '/tmp/pubkey.asc'
+
+# gpg --{show,list}-key output (key present)
+GPG_SHOWKEY_OUTPUT = '''tru::1:1616373715:0:3:1:5
+pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
+fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
+uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
+sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
+fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
+sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
+fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
+sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
+fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:'''
+
+# gpg --{show,list}-key output (key absent)
+GPG_NOKEY_OUTPUT = '''gpg: error reading key: No public key
+tru::1:1616373715:0:3:1:5'''
+
+# pacman-key output (successful invocation)
+PACMAN_KEY_SUCCESS = '''==> Updating trust database...
+gpg: next trustdb check due at 2021-08-02'''
+
+# expected command for gpg --list-keys KEYID
+RUN_CMD_LISTKEYS = [
+    MOCK_BIN_PATH,
+    '--with-colons',
+    '--batch',
+    '--no-tty',
+    '--no-default-keyring',
+    '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
+    '--list-keys',
+    TESTING_KEYID,
+]
+
+# expected command for gpg --show-keys KEYFILE
+RUN_CMD_SHOW_KEYFILE = [
+    MOCK_BIN_PATH,
+    '--with-colons',
+    '--with-fingerprint',
+    '--batch',
+    '--no-tty',
+    '--show-keys',
+    TESTING_KEYFILE_PATH,
+]
+
+# expected command for pacman-key --lsign-key KEYID
+RUN_CMD_LSIGN_KEY = [
+    MOCK_BIN_PATH,
+    '--gpgdir',
+    '/etc/pacman.d/gnupg',
+    '--lsign-key',
+    TESTING_KEYID,
+]
 
 
-#
-# test invalid user input
-#
-TEST_FAILING_PARAMS = [
+TESTCASES = [
+    #
+    # invalid user input
+    #
     # state: present, id: absent
     [
         {
             'state': 'present',
         },
         {
-            'id': 'state_present_id_missing',
+            'id': 'param_missing_id',
             'msg': 'missing required arguments: id',
+            'failed': True,
         },
     ],
     # state: present, required parameters: missing
@@ -40,33 +91,34 @@ TEST_FAILING_PARAMS = [
             'id': '0xDOESNTMATTER',
         },
         {
-            'id': 'state_present_required_param_missing',
+            'id': 'param_missing_method',
             'msg': 'state is present but any of the following are missing: data, file, url, keyserver',
+            'failed': True,
         },
     ],
     # state: present, id: invalid (not full-length)
     [
         {
-            # default state: present
             'id': '0xDOESNTMATTER',
             'data': 'FAKEDATA',
         },
         {
-            'id': 'state_present_id_invalid',
-            'msg': 'identifier is not full-length: DOESNTMATTER',
+            'id': 'param_id_not_full',
+            'msg': 'key ID is not full-length: DOESNTMATTER',
+            'failed': True,
         },
     ],
-    # state: present, fingerprint: invalid (not hexadecimal)
+    # state: present, id: invalid (not hexadecimal)
     [
         {
             'state': 'present',
-            'id': '01234567890ABCDE01234567890ABCDE12345678',
-            'fingerprint': '01234567890ABCDE01234567890ABCDE1234567M',
+            'id': '01234567890ABCDE01234567890ABCDE1234567M',
             'data': 'FAKEDATA',
         },
         {
-            'id': 'state_present_fpr_invalid',
-            'msg': 'identifier is not hexadecimal: 01234567890ABCDE01234567890ABCDE1234567M',
+            'id': 'param_id_not_hex',
+            'msg': 'key ID is not hexadecimal: 01234567890ABCDE01234567890ABCDE1234567M',
+            'failed': True,
         },
     ],
     # state: absent, id: absent
@@ -75,45 +127,19 @@ TEST_FAILING_PARAMS = [
             'state': 'absent',
         },
         {
-            'id': 'state_absent_id_missing',
+            'id': 'param_absent_state_missing_id',
             'msg': 'missing required arguments: id',
+            'failed': True,
         },
     ],
-]
-
-
-@pytest.mark.parametrize(
-    'patch_ansible_module, expected',
-    TEST_FAILING_PARAMS,
-    ids=[item[1]['id'] for item in TEST_FAILING_PARAMS],
-    indirect=['patch_ansible_module']
-)
-@pytest.mark.usefixtures('patch_ansible_module')
-def test_failing_params(mocker, capfd, patch_pacman_key_calls, expected):
-    # invoke module
-    with pytest.raises(SystemExit):
-        pacman_key.main()
-
-    # capture std{out,err}
-    out, err = capfd.readouterr()
-    results = json.loads(out)
-    print(results)
-
-    # assertion time!
-    assert results['failed']
-    if 'msg' in expected:
-        assert results['msg'] == expected['msg']
-
-
-#
-# test normal operation
-#
-TEST_CASES = [
-    # check mode: state & key present
+    #
+    # check mode
+    #
+    # state & key present
     [
         {
             'state': 'present',
-            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'id': TESTING_KEYID,
             'data': 'FAKEDATA',
             '_ansible_check_mode': True,
         },
@@ -121,31 +147,11 @@ TEST_CASES = [
             'id': 'checkmode_state_and_key_present',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         0,
-                        '''
-tru::1:1616373715:0:3:1:5
-pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
-fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
-uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
-sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
-fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
-sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
-fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
-sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
-fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
-''',
+                        GPG_SHOWKEY_OUTPUT,
                         '',
                     ),
                 ),
@@ -153,11 +159,11 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
             'changed': False,
         },
     ],
-    # check mode: state present, key absent
+    # state present, key absent
     [
         {
             'state': 'present',
-            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            'id': TESTING_KEYID,
             'data': 'FAKEDATA',
             '_ansible_check_mode': True,
         },
@@ -165,101 +171,57 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
             'id': 'checkmode_state_present_key_absent',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '01234567890ABCDE01234567890ABCDE12345678',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         2,
                         '',
-                        '''
-                        gpg: error reading key: No public key
-                        tru::1:1616373715:0:3:1:5
-                        ''',
+                        GPG_NOKEY_OUTPUT,
                     ),
                 ),
             ],
             'changed': True,
         },
     ],
-    # check mode: state & key absent
+    # state & key absent
     [
         {
             'state': 'absent',
-            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            'id': TESTING_KEYID,
             '_ansible_check_mode': True,
         },
         {
             'id': 'checkmode_state_and_key_absent',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '01234567890ABCDE01234567890ABCDE12345678',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         2,
                         '',
-                        '''
-                        gpg: error reading key: No public key
-                        tru::1:1616373715:0:3:1:5
-                        ''',
+                        GPG_NOKEY_OUTPUT,
                     ),
                 ),
             ],
             'changed': False,
         },
     ],
-    # check mode: state absent, key present
+    # state absent, key present
     [
         {
             'state': 'absent',
-            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'id': TESTING_KEYID,
             '_ansible_check_mode': True,
         },
         {
             'id': 'check_mode_state_absent_key_present',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         0,
-                        '''
-tru::1:1616373715:0:3:1:5
-pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
-fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
-uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
-sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
-fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
-sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
-fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
-sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
-fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
-                        ''',
+                        GPG_SHOWKEY_OUTPUT,
                         '',
                     ),
                 ),
@@ -267,42 +229,25 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
             'changed': True,
         },
     ],
+    #
+    # normal operation
+    #
     # state & key present
     [
         {
             'state': 'present',
-            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'id': TESTING_KEYID,
             'data': 'FAKEDATA',
         },
         {
             'id': 'state_and_key_present',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         0,
-                        '''
-tru::1:1616373715:0:3:1:5
-pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
-fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
-uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
-sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
-fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
-sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
-fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
-sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
-fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
-''',
+                        GPG_SHOWKEY_OUTPUT,
                         '',
                     ),
                 ),
@@ -314,55 +259,32 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
     [
         {
             'state': 'absent',
-            'id': '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+            'id': TESTING_KEYID,
         },
         {
             'id': 'state_absent_key_present',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         0,
-                        '''
-tru::1:1616373715:0:3:1:5
-pub:-:4096:1:61B7B526D98F0353:1437155332:::-:::scSC::::::23::0:
-fpr:::::::::14F26682D0916CDD81E37B6D61B7B526D98F0353:
-uid:-::::1437155332::E57D1F9BFF3B404F9F30333629369B08DF5E2161::Mozilla Software Releases <release@mozilla.com>::::::::::0:
-sub:e:4096:1:1C69C4E55E9905DB:1437155572:1500227572:::::s::::::23:
-fpr:::::::::F2EF4E6E6AE75B95F11F1EB51C69C4E55E9905DB:
-sub:e:4096:1:BBBEBDBB24C6F355:1498143157:1561215157:::::s::::::23:
-fpr:::::::::DCEAC5D96135B91C4EA672ABBBBEBDBB24C6F355:
-sub:e:4096:1:F1A6668FBB7D572E:1559247338:1622319338:::::s::::::23:
-fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
-''',
+                        GPG_SHOWKEY_OUTPUT,
                         '',
                     ),
                 ),
                 (
                     [
-                        '/mocked/path',
+                        MOCK_BIN_PATH,
                         '--gpgdir',
                         '/etc/pacman.d/gnupg',
                         '--delete',
-                        '14F26682D0916CDD81E37B6D61B7B526D98F0353',
+                        TESTING_KEYID,
                     ],
                     {'check_rc': True},
                     (
                         0,
-                        '''
-                        ==> Updating trust database...
-                        gpg: next trustdb check due at 2021-08-02
-                        ''',
+                        PACMAN_KEY_SUCCESS,
                         '',
                     ),
                 ),
@@ -374,54 +296,197 @@ fpr:::::::::097B313077AE62A02F84DA4DF1A6668FBB7D572E:
     [
         {
             'state': 'absent',
-            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            'id': TESTING_KEYID,
         },
         {
             'id': 'state_and_key_absent',
             'run_command.calls': [
                 (
-                    [
-                        '/mocked/path',
-                        '--with-colons',
-                        '--batch',
-                        '--no-tty',
-                        '--no-default-keyring',
-                        '--keyring=/etc/pacman.d/gnupg/pubring.gpg',
-                        '--list-keys',
-                        '01234567890ABCDE01234567890ABCDE12345678',
-                    ],
+                    RUN_CMD_LISTKEYS,
                     {'check_rc': False},
                     (
                         2,
                         '',
-                        '''
-                        gpg: error reading key: No public key
-                        tru::1:1616373715:0:3:1:5
-                        ''',
+                        GPG_NOKEY_OUTPUT,
                     ),
                 ),
             ],
             'changed': False,
         },
     ],
+    # TODO
+    # state: present, key: absent
+    [
+        {
+            'state': 'present',
+            'id': TESTING_KEYID,
+            'file': TESTING_KEYFILE_PATH,
+        },
+        {
+            'id': 'state_present_key_absent_method_file',
+            'run_command.calls': [
+                (
+                    RUN_CMD_LISTKEYS,
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        GPG_NOKEY_OUTPUT,
+                    ),
+                ),
+                (
+                    RUN_CMD_SHOW_KEYFILE,
+                    {'check_rc': True},
+                    (
+                        0,
+                        GPG_SHOWKEY_OUTPUT,
+                        '',
+                    ),
+                ),
+                (
+                    [
+                        MOCK_BIN_PATH,
+                        '--gpgdir',
+                        '/etc/pacman.d/gnupg',
+                        '--add',
+                        '/tmp/pubkey.asc',
+                    ],
+                    {'check_rc': True},
+                    (
+                        0,
+                        PACMAN_KEY_SUCCESS,
+                        '',
+                    ),
+                ),
+                (
+                    RUN_CMD_LSIGN_KEY,
+                    {'check_rc': True},
+                    (
+                        0,
+                        PACMAN_KEY_SUCCESS,
+                        '',
+                    ),
+                ),
+            ],
+            'changed': True,
+        },
+    ],
+    # state: present, key: absent, keyid & keyfile don't match
+    [
+        {
+            'state': 'present',
+            'id': TESTING_KEYID,
+            'file': TESTING_KEYFILE_PATH,
+        },
+        {
+            'id': 'state_present_key_absent_verify_failed',
+            'msg': 'key ID does not match. expected 14F26682D0916CDD81E37B6D61B7B526D98F0353, got 14F26682D0916CDD81E37B6D61B7B526D98F0354',
+            'run_command.calls': [
+                (
+                    RUN_CMD_LISTKEYS,
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        GPG_NOKEY_OUTPUT,
+                    ),
+                ),
+                (
+                    RUN_CMD_SHOW_KEYFILE,
+                    {'check_rc': True},
+                    (
+                        0,
+                        GPG_SHOWKEY_OUTPUT.replace('61B7B526D98F0353', '61B7B526D98F0354'),
+                        '',
+                    ),
+                ),
+            ],
+            'failed': True,
+        },
+    ],
+    # state: present, key: absent, method: keyserver
+    [
+        {
+            'state': 'present',
+            'id': TESTING_KEYID,
+            'keyserver': 'pgp.mit.edu',
+        },
+        {
+            'id': 'state_present_key_absent_method_keyserver',
+            'run_command.calls': [
+                (
+                    RUN_CMD_LISTKEYS,
+                    {'check_rc': False},
+                    (
+                        2,
+                        '',
+                        GPG_NOKEY_OUTPUT,
+                    ),
+                ),
+                (
+                    [
+                        MOCK_BIN_PATH,
+                        '--gpgdir',
+                        '/etc/pacman.d/gnupg',
+                        '--keyserver',
+                        'pgp.mit.edu',
+                        '--recv-keys',
+                        TESTING_KEYID,
+                    ],
+                    {'check_rc': True},
+                    (
+                        0,
+                        '''
+gpg: key 0x61B7B526D98F0353: 32 signatures not checked due to missing keys
+gpg: key 0x61B7B526D98F0353: public key "Mozilla Software Releases <release@mozilla.com>" imported
+gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
+gpg: Total number processed: 1
+gpg:               imported: 1
+''',
+                        '',
+                    ),
+                ),
+                (
+                    RUN_CMD_LSIGN_KEY,
+                    {'check_rc': True},
+                    (
+                        0,
+                        PACMAN_KEY_SUCCESS,
+                        '',
+                    ),
+                ),
+            ],
+            'changed': True,
+        },
+    ],
 ]
+
+
+@pytest.fixture
+def patch_get_bin_path(mocker):
+    get_bin_path = mocker.patch.object(
+        AnsibleModule,
+        'get_bin_path',
+        return_value=MOCK_BIN_PATH,
+    )
 
 
 @pytest.mark.parametrize(
     'patch_ansible_module, expected',
-    TEST_CASES,
-    ids=[item[1]['id'] for item in TEST_CASES],
+    TESTCASES,
+    ids=[item[1]['id'] for item in TESTCASES],
     indirect=['patch_ansible_module']
 )
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_normal_operation(mocker, capfd, patch_pacman_key_calls, expected):
+def test_operation(mocker, capfd, patch_get_bin_path, expected):
     # patch run_command invocations with mock data
-    call_results = [item[2] for item in expected['run_command.calls']]
-    mock_run_command = mocker.patch.object(
-        AnsibleModule,
-        'run_command',
-        side_effect=call_results,
-    )
+    if 'run_command.calls' in expected:
+        mock_run_command = mocker.patch.object(
+            AnsibleModule,
+            'run_command',
+            side_effect=[item[2] for item in expected['run_command.calls']],
+        )
 
     # invoke module
     with pytest.raises(SystemExit):
@@ -432,13 +497,15 @@ def test_normal_operation(mocker, capfd, patch_pacman_key_calls, expected):
     results = json.loads(out)
 
     # assertion time!
-    assert 'changed' in results
-    assert results['changed'] == expected['changed']
     if 'msg' in expected:
         assert results['msg'] == expected['msg']
+    if 'changed' in expected:
+        assert results['changed'] == expected['changed']
+    if 'failed' in expected:
+        assert results['failed'] == expected['failed']
 
-    assert AnsibleModule.run_command.call_count == len(expected['run_command.calls'])
-    if AnsibleModule.run_command.call_count:
+    if 'run_command.calls' in expected:
+        assert AnsibleModule.run_command.call_count == len(expected['run_command.calls'])
         call_args_list = [(item[0][0], item[1]) for item in AnsibleModule.run_command.call_args_list]
         expected_call_args_list = [(item[0], item[1]) for item in expected['run_command.calls']]
         assert call_args_list == expected_call_args_list

--- a/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
@@ -1,0 +1,95 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.general.plugins.modules.packaging.os import pacman_key
+import pytest
+import json
+
+@pytest.fixture
+def patch_pacman_key_calls(mocker):
+    get_bin_path = mocker.patch(
+        'ansible.module_utils.basic.AnsibleModule.get_bin_path',
+        return_value="/mocked/path",
+    )
+
+TEST_FAILING_PARAMS = [
+    # state: present, id: absent
+    [
+        {
+            'state': 'present',
+        },
+        {
+            'id': 'state_present_id_missing',
+            'msg': 'missing required arguments: id',
+        },
+    ],
+    # state: present, required parameters: missing
+    [
+        {
+            'state': 'present',
+            'id': '0xDOESNTMATTER',
+        },
+        {
+            'id': 'state_present_required_param_missing',
+            'msg': 'state is present but any of the following are missing: data, file, url, keyserver',
+        },
+    ],
+    # state: present, id: invalid (not full-length)
+    [
+        {
+            # default state: present
+            'id': '0xDOESNTMATTER',
+            'data': 'FAKEDATA',
+        },
+        {
+            'id': 'state_present_id_invalid',
+            'msg': 'identifier is not full-length: DOESNTMATTER',
+        },
+    ],
+    # state: present, fingerprint: invalid (not hexadecimal)
+    [
+        {
+            'state': 'present',
+            'id': '01234567890ABCDE01234567890ABCDE12345678',
+            'fingerprint': '01234567890ABCDE01234567890ABCDE1234567M',
+            'data': 'FAKEDATA',
+        },
+        {
+            'id': 'state_present_fpr_invalid',
+            'msg': 'identifier is not hexadecimal: 01234567890ABCDE01234567890ABCDE1234567M',
+        },
+    ],
+    # state: absent, id: absent
+    [
+        {
+            'state': 'absent',
+        },
+        {
+            'id': 'state_absent_id_missing',
+            'msg': 'missing required arguments: id',
+        },
+    ],
+]
+
+@pytest.mark.parametrize(
+    'patch_ansible_module, expected',
+    TEST_FAILING_PARAMS,
+    ids=[item[1]['id'] for item in TEST_FAILING_PARAMS],
+    indirect=['patch_ansible_module']
+)
+@pytest.mark.usefixtures('patch_ansible_module')
+def test_failing_params(mocker, capfd, patch_pacman_key_calls, expected):
+    # invoke module
+    with pytest.raises(SystemExit):
+        pacman_key.main()
+
+    # capture std{out,err}
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    print(results)
+
+    # assertion time!
+    assert 'failed' in results
+    if 'msg' in results:
+        assert results['msg'] == expected['msg']
+

--- a/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman_key.py
@@ -5,12 +5,14 @@ from ansible_collections.community.general.plugins.modules.packaging.os import p
 import pytest
 import json
 
+
 @pytest.fixture
 def patch_pacman_key_calls(mocker):
     get_bin_path = mocker.patch(
         'ansible.module_utils.basic.AnsibleModule.get_bin_path',
         return_value="/mocked/path",
     )
+
 
 TEST_FAILING_PARAMS = [
     # state: present, id: absent
@@ -71,6 +73,7 @@ TEST_FAILING_PARAMS = [
     ],
 ]
 
+
 @pytest.mark.parametrize(
     'patch_ansible_module, expected',
     TEST_FAILING_PARAMS,
@@ -92,4 +95,3 @@ def test_failing_params(mocker, capfd, patch_pacman_key_calls, expected):
     assert 'failed' in results
     if 'msg' in results:
         assert results['msg'] == expected['msg']
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Manage [pacman](https://wiki.archlinux.org/index.php/Pacman)'s keyring of trusted keys with [pacman-key](https://wiki.archlinux.org/index.php/Pacman/Package_signing). Similar to the [apt_key](https://docs.ansible.com/ansible/latest/modules/apt_key_module.html) & [rpm_key](https://docs.ansible.com/ansible/latest/modules/rpm_key_module.html) modules. Useful when adding additional repositories that have signed packages/databases.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
pacman_key

EDIT: This is originally from this [PR](https://github.com/ansible/ansible/pull/68232) on ansible/ansible.