### PR TITLE
proxmox_kvm: support version 6 using dynamic version

### DIFF
--- a/changelogs/fragments/780-hotfix-proxmox-kvm-version-6.yml
+++ b/changelogs/fragments/780-hotfix-proxmox-kvm-version-6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- proxmox_kvm - adapt to PVE 6 version scheme (fixes https://github.com/swayf/proxmoxer/issues/79).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -681,7 +681,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
     kwargs.update(dict([k, int(v)] for k, v in kwargs.items() if isinstance(v, bool)))
 
     # The features work only on PVE 4
-    if PVE_MAJOR_VERSION < 4:
+    if PVE_VERSION < '4':
         for p in only_v4:
             if p in kwargs:
                 del kwargs[p]
@@ -899,8 +899,8 @@ def main():
     try:
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
-        global PVE_MAJOR_VERSION
-        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
+        global PVE_VERSION
+        PVE_VERSION = proxmox_version(proxmox)
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 


### PR DESCRIPTION
##### SUMMARY

Proxmox VE Version 6 Release slightly changed it's API regarding the version string (original issue: https://github.com/swayf/proxmoxer/issues/79). This fix picks up the new version scheme and still supports the old one.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_kvm