### PR TITLE
gem: Fix get_installed_versions: correctly parse "default" version.

### DIFF
--- a/changelogs/fragments/783-fix-gem-installed-versions.yaml
+++ b/changelogs/fragments/783-fix-gem-installed-versions.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "Fix gem module get_installed_versions: correctly parse ``default`` version (#782)."
+  - "gem - fix get_installed_versions: correctly parse ``default`` version (https://github.com/ansible-collections/community.general/pull/783)."

--- a/changelogs/fragments/783-fix-gem-installed-versions.yaml
+++ b/changelogs/fragments/783-fix-gem-installed-versions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix gem module get_installed_versions: correctly parse ``default`` version (#782)."

--- a/plugins/modules/packaging/language/gem.py
+++ b/plugins/modules/packaging/language/gem.py
@@ -157,7 +157,7 @@ def get_installed_versions(module, remote=False):
     (rc, out, err) = module.run_command(cmd, environ_update=environ, check_rc=True)
     installed_versions = []
     for line in out.splitlines():
-        match = re.match(r"\S+\s+\((.+)\)", line)
+        match = re.match(r"\S+\s+\((?:default: )?(.+)\)", line)
         if match:
             versions = match.group(1)
             for version in versions.split(', '):


### PR DESCRIPTION
##### SUMMARY

Fix get_installed_versions: correctly parse "default" version.

gem query output of

    bundler (default: 2.1.4, 1.17.2)

Gets parsed as:

    ['default:', '1.17.2']

Fix this by skipping "default: " if present in the list of versions - by adding
it as an optional part of the regex, grouped as a non-capturing group to keep
the index of existing group.

This now correctly parses the above input as

    ['2.1.4:', '1.17.2']

Fixes #782 - makes gem correctly recognize already installed modules and avoids installing them again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gem

##### ADDITIONAL INFORMATION

Details in #782 - and this is a refreshed version of https://github.com/ansible/ansible/pull/57331

Issue can be reproduced e.g. with Ruby 2.7.1 installed into /usr/local/rbenv/versions/2.7.1 - comes with bundler 2.1.4 installed into /usr/local/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/ as the default package.

Invoke the gem module asking it to install bundler 2.1.4

```paste below
- name: Running the playbook
  hosts: all
  become: yes
  gather_facts: no

  tasks:
    - name: Install bundler
      gem:
          name: bundler
          version: "2.1.4"
          executable: "/usr/local/rbenv/versions/2.7.1/bin/gem"
          user_install: False
          install_dir: "/tmp"
```

###### EXPECTED RESULTS

Expected task to do nothing - changed: no

###### ACTUAL RESULTS

Task installs the gem (bundler) into target location, despite the gem already being present.