### PR TITLE
[stable-1] postgresql_set: allow to pass an empty string as a value (#776)

### DIFF
--- a/changelogs/fragments/776-postgresql_set_allow_empty_string.yaml
+++ b/changelogs/fragments/776-postgresql_set_allow_empty_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - allow to pass an empty string to the ``value`` parameter (https://github.com/ansible-collections/community.general/issues/775).

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -314,10 +314,10 @@ def main():
             if value[:-2].isdigit() and unit in value[-2:]:
                 value = value.upper()
 
-    if value and reset:
+    if value is not None and reset:
         module.fail_json(msg="%s: value and reset params are mutually exclusive" % name)
 
-    if not value and not reset:
+    if value is None and not reset:
         module.fail_json(msg="%s: at least one of value or reset param must be specified" % name)
 
     conn_params = get_conn_params(module, module.params, warn_db_default=False)
@@ -388,8 +388,8 @@ def main():
         kw['restart_required'] = restart_required
         module.exit_json(**kw)
 
-    # Set param:
-    if value and value != current_value:
+    # Set param (value can be an empty string):
+    if value is not None and value != current_value:
         changed = param_set(cursor, module, name, value, context)
 
         kw['value_pretty'] = value

--- a/tests/integration/targets/postgresql_set/tasks/main.yml
+++ b/tests/integration/targets/postgresql_set/tasks/main.yml
@@ -1,3 +1,3 @@
 # Initial CI tests of postgresql_initial module
 - include_tasks: postgresql_set_initial.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=')
+  when: postgres_version_resp.stdout is version('9.6', '>=')

--- a/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
+++ b/tests/integration/targets/postgresql_set/tasks/postgresql_set_initial.yml
@@ -321,3 +321,55 @@
       that:
       - result is failed
       - result.msg is search('is potentially dangerous')
+
+  ###############################################################################
+  # Bugfix of https://github.com/ansible-collections/community.general/issues/775
+  - name: postgresql_set - turn on archive mode
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_mode
+      value: 'on'
+
+  - name: Restart PostgreSQL
+    become: yes
+    service:
+      name: "{{ postgresql_service }}"
+      state: restarted
+
+  - name: postgresql_set - set empty string as value
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+
+  - name: postgresql_set - set empty string as value again
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+
+  - assert:
+      that:
+      - result is not changed
+
+  - name: postgresql_set - set empty string as value again in check mode
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: ''
+    register: result
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is not changed


### PR DESCRIPTION
(cherry picked from commit 05556dc67161c28eee72e25bf4690641ff4fa37a)

##### SUMMARY
Backport of postgresql_set: allow to pass an empty string as a value (#776)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_set.py
