### PR TITLE
homebrew_cask: Consider greedy option for upgrades too

### DIFF
--- a/changelogs/fragments/798-homebrew-cask-greedy-for-upgrades-too.yaml
+++ b/changelogs/fragments/798-homebrew-cask-greedy-for-upgrades-too.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew_cask - consider `greedy` option for upgrade_all, too (https://github.com/ansible-collections/community.general/pull/798)

--- a/changelogs/fragments/798-homebrew-cask-greedy-for-upgrades-too.yaml
+++ b/changelogs/fragments/798-homebrew-cask-greedy-for-upgrades-too.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew_cask - consider `greedy` option for upgrade_all, too (https://github.com/ansible-collections/community.general/pull/798)
+  - homebrew_cask - consider ``greedy`` option for upgrade_all, too (https://github.com/ansible-collections/community.general/pull/798).

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -540,6 +540,9 @@ class HomebrewCask(object):
             [self.brew_path, 'cask', 'upgrade']
         )
 
+        if self.greedy:
+            opts.append('--greedy')
+
         cmd = [opt for opt in opts if opt]
 
         rc, out, err = '', '', ''


### PR DESCRIPTION
##### SUMMARY
`brew-cask` accepts `--greedy` for both the upgrade and outdated command (see [their usage reference](https://github.com/Homebrew/homebrew-cask/blob/master/USAGE.md)). So far, only the check for outdated casks considered the Ansible option.

This change aligns Ansible's use of the greedy option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask