### PR TITLE
pkgutil: add update all, check-mode, squashing and examples

### DIFF
--- a/changelogs/fragments/pkgutil-check-mode-etc.yaml
+++ b/changelogs/fragments/pkgutil-check-mode-etc.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - The ``pkgutil`` module now supports check mode.
+  - The ``pkgutil`` module can now accept a list of packages.
+  - The ``pkgutil`` module has a new option, ``force``, equivalent to the ``-f`` option to the `pkgutil <http://pkgutil.net/>` command.

--- a/changelogs/fragments/pkgutil-check-mode-etc.yaml
+++ b/changelogs/fragments/pkgutil-check-mode-etc.yaml
@@ -1,4 +1,4 @@
 minor_changes:
-  - The ``pkgutil`` module now supports check mode.
-  - The ``pkgutil`` module can now accept a list of packages.
-  - The ``pkgutil`` module has a new option, ``force``, equivalent to the ``-f`` option to the `pkgutil <http://pkgutil.net/>` command.
+  - pkgutil - module now supports check mode (https://github.com/ansible-collections/community.general/pull/799).
+  - pkgutil - module can now accept a list of packages (https://github.com/ansible-collections/community.general/pull/799).
+  - pkgutil - module has a new option, ``force``, equivalent to the ``-f`` option to the `pkgutil <http://pkgutil.net/>`_ command (https://github.com/ansible-collections/community.general/pull/799).

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -20,7 +20,6 @@ description:
 - These were the native packages on Solaris <= 10 and are available as a legacy feature in Solaris 11.
 - Pkgutil is an advanced packaging system, which resolves dependency on installation.
   It is designed for CSW packages.
-version_added: '1.3'
 author:
 - Alexander Winkler (@dermute)
 - David Ponessa (@scathatheworm)

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -31,6 +31,7 @@ options:
     type: list
     required: true
     elements: str
+    aliases: [ pkg ]
   site:
     description:
     - The repository path to install the package from.

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -14,12 +14,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: pkgutil
-short_description: Manage CSW-Packages on Solaris
+short_description: OpenCSW package management on Solaris
 description:
-- Manages CSW packages (SVR4 format) on Solaris 10 and 11.
-- These were the native packages on Solaris <= 10 and are available as a legacy feature in Solaris 11.
-- Pkgutil is an advanced packaging system, which resolves dependency on installation.
-  It is designed for CSW packages.
+- This module installs, updates and removes packages from the OpenCSW project for Solaris.
+- Unlike the M(svr4pkg) module, it will resolve and download dependencies.
+- See U(https://www.opencsw.org/) for more information about the project.
 author:
 - Alexander Winkler (@dermute)
 - David Ponessa (@scathatheworm)
@@ -35,7 +34,7 @@ options:
   site:
     description:
     - The repository path to install the package from.
-    - Its global definition is done in C(/etc/opt/csw/pkgutil.conf).
+    - Its global definition is in C(/etc/opt/csw/pkgutil.conf).
     required: false
     type: str
   state:
@@ -47,15 +46,17 @@ options:
     choices: [ absent, installed, latest, present, removed ]
   update_catalog:
     description:
-    - If you want to refresh your catalog from the mirror, set this to C(yes).
+    - If you always want to refresh your catalog from the mirror, even when it's not stale, set this to C(yes).
     type: bool
     default: no
   force:
     description:
     - To allow the update process to downgrade packages to match what is present in the repository, set this to C(yes).
-    - It is useful for rolling back to stable from testing, and similar operations.
+    - This is useful for rolling back to stable from testing, or similar operations.
     type: bool
     version_added: 1.2.0
+notes:
+- In order to check the availability of packages, the catalog cache under C(/var/opt/csw/pkgutil) may be refreshed even in check mode.
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -43,8 +43,8 @@ options:
     - Whether to install (C(present)/C(installed)), or remove (C(absent)/C(removed)) packages.
     - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
     type: str
+    required: true
     choices: [ absent, installed, latest, present, removed ]
-    default: present
   update_catalog:
     description:
     - If you want to refresh your catalog from the mirror, set this to C(yes).
@@ -192,7 +192,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='list', elements='str', required=True, aliases=['pkg']),
-            state=dict(type='str', default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
+            state=dict(type='str', required=True, choices=['absent', 'installed', 'latest', 'present', 'removed']),
             site=dict(type='str'),
             update_catalog=dict(type='bool', default=False),
             force=dict(type='bool', default=False),

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -40,7 +40,7 @@ options:
     type: str
   state:
     description:
-    - Whether to install (C(present)), or remove (C(absent)) packages.
+    - Whether to install (C(present)/C(installed)), or remove (C(absent)/C(removed)) packages.
     - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
     type: str
     choices: [ absent, installed, latest, present, removed ]

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Alexander Winkler <mail () winkler-alexander.de>
+# Copyright: (c) 2013, Alexander Winkler <mail () winkler-alexander.de>
 # based on svr4pkg by
 #  Boyd Adamson <boyd () boydadamson.com> (2012)
 #
@@ -11,46 +11,53 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: pkgutil
 short_description: Manage CSW-Packages on Solaris
 description:
-    - Manages CSW packages (SVR4 format) on Solaris 10 and 11.
-    - These were the native packages on Solaris <= 10 and are available
-      as a legacy feature in Solaris 11.
-    - Pkgutil is an advanced packaging system, which resolves dependency on installation.
-      It is designed for CSW packages.
-author: "Alexander Winkler (@dermute)"
+- Manages CSW packages (SVR4 format) on Solaris 10 and 11.
+- These were the native packages on Solaris <= 10 and are available as a legacy feature in Solaris 11.
+- Pkgutil is an advanced packaging system, which resolves dependency on installation.
+  It is designed for CSW packages.
+version_added: '1.3'
+author:
+- Alexander Winkler (@dermute)
+- David Ponessa (@scathatheworm)
 options:
   name:
     description:
-      - Package name, e.g. (C(CSWnrpe))
+    - The name of the package.
+    - When using C(state=latest), this can be C('*'), which updates all installed packages managed by pkgutil.
+    type: list
     required: true
     type: str
   site:
     description:
-      - Specifies the repository path to install the package from.
-      - Its global definition is done in C(/etc/opt/csw/pkgutil.conf).
+    - The repository path to install the package from.
+    - Its global definition is done in C(/etc/opt/csw/pkgutil.conf).
     required: false
     type: str
   state:
     description:
-      - Whether to install (C(present)), or remove (C(absent)) a package.
-      - The upgrade (C(latest)) operation will update/install the package to the latest version available.
-      - "Note: The module has a limitation that (C(latest)) only works for one package, not lists of them."
-    required: true
-    choices: ["present", "absent", "latest"]
+    - Whether to install (C(present)), or remove (C(absent)) packages.
+    - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
     type: str
+    choices: [ absent, installed, latest, present, removed ]
+    default: present
   update_catalog:
     description:
-      - If you want to refresh your catalog from the mirror, set this to (C(yes)).
-    required: false
+    - If you want to refresh your catalog from the mirror, set this to (C(yes)).
+    type: bool
     default: no
+  force:
+    description:
+    - Allows the update process to downgrade packages to what is present in the repostory set this to (C(yes)).
+    - It is useful as a rollback to stable from testing, and similar operations.
     type: bool
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Install a package
   community.general.pkgutil:
     name: CSWcommon
@@ -59,35 +66,80 @@ EXAMPLES = '''
 - name: Install a package from a specific repository
   community.general.pkgutil:
     name: CSWnrpe
-    site: 'ftp://myinternal.repo/opencsw/kiel'
+    site: ftp://myinternal.repo/opencsw/kiel
     state: latest
+
+- name: Remove a package
+  community.general.pkgutil:
+    name: CSWtop
+    state: absent
+
+- name: Install several packages
+  community.general.pkgutil:
+    name:
+    - CSWsudo
+    - CSWtop
+    state: present
+
+- name: Update all packages
+  community.general.pkgutil:
+    name: '*'
+    state: latest
+
+- name: Update all packages and force versions to match latest in catalog
+  community.general.pkgutil:
+    name: '*'
+    state: latest
+    force: yes
 '''
+
+RETURN = r''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 
 
-def package_installed(module, name):
-    cmd = ['pkginfo']
-    cmd.append('-q')
-    cmd.append(name)
-    rc, out, err = run_command(module, cmd)
-    if rc == 0:
-        return True
-    else:
-        return False
+def packages_not_installed(module, names):
+    ''' Check if each package is installed and return list of the ones absent '''
+    pkgs = []
+    for pkg in names:
+        rc, out, err = run_command(module, ['pkginfo', '-q', pkg])
+        if rc != 0:
+            pkgs.append(pkg)
+    return pkgs
 
 
-def package_latest(module, name, site):
-    # Only supports one package
-    cmd = ['pkgutil', '-U', '--single', '-c']
+def packages_installed(module, names):
+    ''' Check if each package is installed and return list of the ones present '''
+    pkgs = []
+    for pkg in names:
+        if not pkg.startswith('CSW'):
+            continue
+        rc, out, err = run_command(module, ['pkginfo', '-q', pkg])
+        if rc == 0:
+            pkgs.append(pkg)
+    return pkgs
+
+
+def packages_not_latest(module, names, site, update_catalog):
+    ''' Check status of each package and return list of the ones with an upgrade available '''
+    cmd = ['pkgutil']
+    if update_catalog:
+        cmd.append('-U')
+    cmd.append('-c')
     if site is not None:
-        cmd += ['-t', site]
-    cmd.append(name)
+        cmd.extend('-t', site)
+    if names != ['*']:
+        cmd.extend(names)
     rc, out, err = run_command(module, cmd)
-    # replace | tail -1 |grep -v SAME
-    # use -2, because splitting on \n create a empty line
-    # at the end of the list
-    return 'SAME' in out.split('\n')[-2]
+
+    # Find packages in the catalog which are not up to date
+    packages = []
+    for line in out.split('\n')[1:-1]:
+        if 'catalog' not in line and 'SAME' not in line:
+            packages.append(line.split(' ')[0])
+
+    # Remove duplicates
+    return list(set(packages))
 
 
 def run_command(module, cmd, **kwargs):
@@ -96,117 +148,129 @@ def run_command(module, cmd, **kwargs):
     return module.run_command(cmd, **kwargs)
 
 
-def package_install(module, state, name, site, update_catalog):
-    cmd = ['pkgutil', '-iy']
+def package_install(module, state, pkgs, site, update_catalog, force):
+    cmd = ['pkgutil']
+    if module.check_mode:
+        cmd.append('-n')
+    cmd.append('-iy')
     if update_catalog:
-        cmd += ['-U']
+        cmd.append('-U')
     if site is not None:
-        cmd += ['-t', site]
-    if state == 'latest':
-        cmd += ['-f']
-    cmd.append(name)
-    (rc, out, err) = run_command(module, cmd)
-    return (rc, out, err)
+        cmd.extend('-t', site)
+    if force:
+        cmd.append('-f')
+    cmd.extend(pkgs)
+    return run_command(module, cmd)
 
 
-def package_upgrade(module, name, site, update_catalog):
-    cmd = ['pkgutil', '-ufy']
+def package_upgrade(module, pkgs, site, update_catalog, force):
+    cmd = ['pkgutil']
+    if module.check_mode:
+        cmd.append('-n')
+    cmd.append('-uy')
     if update_catalog:
-        cmd += ['-U']
+        cmd.append('-U')
     if site is not None:
-        cmd += ['-t', site]
-    cmd.append(name)
-    (rc, out, err) = run_command(module, cmd)
-    return (rc, out, err)
+        cmd.extend('-t', site)
+    if force:
+        cmd.append('-f')
+    cmd += pkgs
+    return run_command(module, cmd)
 
 
-def package_uninstall(module, name):
-    cmd = ['pkgutil', '-ry', name]
-    (rc, out, err) = run_command(module, cmd)
-    return (rc, out, err)
+def package_uninstall(module, pkgs):
+    cmd = ['pkgutil']
+    if module.check_mode:
+        cmd.append('-n')
+    cmd.append('-ry')
+    cmd.extend(pkgs)
+    return run_command(module, cmd)
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required=True),
-            state=dict(required=True, choices=['present', 'absent', 'latest']),
-            site=dict(default=None),
-            update_catalog=dict(required=False, default=False, type='bool'),
+            name=dict(type='list', required=True, aliases=['pkg']),
+            state=dict(type='str', default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
+            site=dict(type='str'),
+            update_catalog=dict(type='bool', default=False),
+            force=dict(type='bool', default=False),
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
     name = module.params['name']
     state = module.params['state']
     site = module.params['site']
     update_catalog = module.params['update_catalog']
+    force = module.params['force']
+
     rc = None
     out = ''
     err = ''
-    result = {}
-    result['name'] = name
-    result['state'] = state
+    result = dict(
+        name=name,
+        state=state,
+    )
 
-    if state == 'present':
-        if not package_installed(module, name):
-            if module.check_mode:
-                module.exit_json(changed=True)
-            (rc, out, err) = package_install(module, state, name, site, update_catalog)
-            # Stdout is normally empty but for some packages can be
-            # very long and is not often useful
-            if len(out) > 75:
-                out = out[:75] + '...'
+    if state in ['installed', 'present']:
+        # Fail with an explicit error when trying to "install" '*'
+        if name == ['*']:
+            module.fail_json(msg="Can not use 'state: present' with name: '*'")
+
+        # Build list of packages that are actually not installed from the ones requested
+        pkgs = packages_not_installed(module, name)
+
+        # If the package list is empty then all packages are already present
+        if pkgs == []:
+            module.exit_json(changed=False)
+
+        (rc, out, err) = package_install(module, state, pkgs, site, update_catalog, force)
+        if rc != 0:
+            module.fail_json(msg=(err or out))
+
+    elif state in ['latest']:
+        # When using latest for *
+        if name == ['*']:
+            # Check for packages that are actually outdated
+            pkgs = packages_not_latest(module, name, site, update_catalog)
+
+            # If the package list comes up empty, everything is already up to date
+            if pkgs == []:
+                module.exit_json(changed=False)
+
+            # If there are packages to update, just empty the list and run the command without it
+            # pkgutil logic is to update all when run without packages names
+            pkgs = []
+            (rc, out, err) = package_upgrade(module, pkgs, site, update_catalog, force)
             if rc != 0:
-                if err:
-                    msg = err
-                else:
-                    msg = out
-                module.fail_json(msg=msg)
-
-    elif state == 'latest':
-        if not package_installed(module, name):
-            if module.check_mode:
-                module.exit_json(changed=True)
-            (rc, out, err) = package_install(module, state, name, site, update_catalog)
-            if len(out) > 75:
-                out = out[:75] + '...'
-            if rc != 0:
-                if err:
-                    msg = err
-                else:
-                    msg = out
-                module.fail_json(msg=msg)
-
+                module.fail_json(msg=(err or out))
         else:
-            if not package_latest(module, name, site):
-                if module.check_mode:
-                    module.exit_json(changed=True)
-                (rc, out, err) = package_upgrade(module, name, site, update_catalog)
-                if len(out) > 75:
-                    out = out[:75] + '...'
-                if rc != 0:
-                    if err:
-                        msg = err
-                    else:
-                        msg = out
-                    module.fail_json(msg=msg)
+            # Build list of packages that are either outdated or not installed
+            pkgs = packages_not_installed(module, name)
+            pkgs += packages_not_latest(module, name, site, update_catalog)
 
-    elif state == 'absent':
-        if package_installed(module, name):
-            if module.check_mode:
-                module.exit_json(changed=True)
-            (rc, out, err) = package_uninstall(module, name)
-            if len(out) > 75:
-                out = out[:75] + '...'
+            # If the package list is empty that means all packages are installed and up to date
+            if pkgs == []:
+                module.exit_json(changed=False)
+
+            (rc, out, err) = package_upgrade(module, pkgs, site, update_catalog, force)
             if rc != 0:
-                if err:
-                    msg = err
-                else:
-                    msg = out
-                module.fail_json(msg=msg)
+                module.fail_json(msg=(err or out))
+
+    elif state in ['absent', 'removed']:
+        # Build list of packages requested for removal that are actually present
+        pkgs = packages_installed(module, name)
+
+        # If the list is empty, no packages need to be removed
+        if pkgs == []:
+            module.exit_json(changed=False)
+
+        (rc, out, err) = package_uninstall(module, pkgs)
+        if rc != 0:
+            module.fail_json(msg=(err or out))
 
     if rc is None:
-        # pkgutil was not executed because the package was already present/absent
+        # pkgutil was not executed because the package was already present/absent/up to date
         result['changed'] = False
     elif rc == 0:
         result['changed'] = True

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -17,7 +17,7 @@ module: pkgutil
 short_description: OpenCSW package management on Solaris
 description:
 - This module installs, updates and removes packages from the OpenCSW project for Solaris.
-- Unlike the M(svr4pkg) module, it will resolve and download dependencies.
+- Unlike the M(community.general.svr4pkg) module, it will resolve and download dependencies.
 - See U(https://www.opencsw.org/) for more information about the project.
 author:
 - Alexander Winkler (@dermute)

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -46,13 +46,13 @@ options:
     default: present
   update_catalog:
     description:
-    - If you want to refresh your catalog from the mirror, set this to (C(yes)).
+    - If you want to refresh your catalog from the mirror, set this to C(yes).
     type: bool
     default: no
   force:
     description:
-    - Allows the update process to downgrade packages to what is present in the repostory set this to (C(yes)).
-    - It is useful as a rollback to stable from testing, and similar operations.
+    - To allow the update process to downgrade packages to match what is present in the repository, set this to C(yes).
+    - It is useful for rolling back to stable from testing, and similar operations.
     type: bool
 '''
 

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -30,7 +30,7 @@ options:
     - When using C(state=latest), this can be C('*'), which updates all installed packages managed by pkgutil.
     type: list
     required: true
-    type: str
+    elements: str
   site:
     description:
     - The repository path to install the package from.
@@ -189,7 +189,7 @@ def package_uninstall(module, pkgs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='list', required=True, aliases=['pkg']),
+            name=dict(type='list', elements='str', required=True, aliases=['pkg']),
             state=dict(type='str', default='present', choices=['absent', 'installed', 'latest', 'present', 'removed']),
             site=dict(type='str'),
             update_catalog=dict(type='bool', default=False),

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -54,6 +54,7 @@ options:
     - To allow the update process to downgrade packages to match what is present in the repository, set this to C(yes).
     - It is useful for rolling back to stable from testing, and similar operations.
     type: bool
+    version_added: 1.2.0
 '''
 
 EXAMPLES = r'''

--- a/tests/integration/targets/pkgutil/aliases
+++ b/tests/integration/targets/pkgutil/aliases
@@ -1,0 +1,2 @@
+destructive
+unsupported

--- a/tests/integration/targets/pkgutil/tasks/main.yml
+++ b/tests/integration/targets/pkgutil/tasks/main.yml
@@ -1,0 +1,116 @@
+# Test code for the pkgutil module
+
+# Copyright: (c) 2019, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+# CLEAN ENVIRONMENT
+- name: Remove CSWtop
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: originally_installed
+
+
+# ADD PACKAGE
+- name: Add package (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  check_mode: yes
+  register: cm_add_package
+
+- name: Verify cm_add_package
+  assert:
+    that:
+    - cm_add_package is changed
+
+- name: Add package (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  register: nm_add_package
+
+- name: Verify nm_add_package
+  assert:
+    that:
+    - nm_add_package is changed
+
+- name: Add package again (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  check_mode: yes
+  register: cm_add_package_again
+
+- name: Verify cm_add_package_again
+  assert:
+    that:
+    - cm_add_package_again is not changed
+
+- name: Add package again (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: present
+  register: nm_add_package_again
+
+- name: Verify nm_add_package_again
+  assert:
+    that:
+    - nm_add_package_again is not changed
+
+
+# REMOVE PACKAGE
+- name: Remove package (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  check_mode: yes
+  register: cm_remove_package
+
+- name: Verify cm_remove_package
+  assert:
+    that:
+    - cm_remove_package is changed
+
+- name: Remove package (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: nm_remove_package
+
+- name: Verify nm_remove_package
+  assert:
+    that:
+    - nm_remove_package is changed
+
+- name: Remove package again (check_mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  check_mode: yes
+  register: cm_remove_package_again
+
+- name: Verify cm_remove_package_again
+  assert:
+    that:
+    - cm_remove_package_again is not changed
+
+- name: Remove package again (normal mode)
+  pkgutil:
+    name: CSWtop
+    state: absent
+  register: nm_remove_package_again
+
+- name: Verify nm_remove_package_again
+  assert:
+    that:
+    - nm_remove_package_again is not changed
+
+
+# RESTORE ENVIRONMENT
+- name: Reinstall CSWtop
+  pkgutil:
+    name: CSWtop
+    state: present
+  when: originally_installed is changed


### PR DESCRIPTION
Taken from https://github.com/ansible/ansible/pull/51651 by @dagwieers, which was taken from https://github.com/ansible/ansible/pull/27866 by @scathatheworm.  Let’s have one last attempt to get this merged.

> ##### SUMMARY
>
> Original PR #27866 from @scathatheworm
>
> When working with Solaris pkgutil CSW packages, I came across this module
being very basic in functionality, in particular, that I could not use it
to update all CSW packages.
>
> When going into details into the code I also found it did not incorporate
a possibility of doing dry-run from the underlying utility, or supported to
specify multiple packages for operations.
>
> This module probably sees very little use, but it seemed like nice
functionality to add and make it behave a little more like other package
modules.
> ##### ISSUE TYPE
>
>     * Feature Pull Request
>
>
> ##### COMPONENT NAME
>
> pkgutil module
> ##### ANSIBLE VERSION
>
> ```
> ansible 2.3.1.0
>   config file = /etc/ansible/ansible.cfg
>   configured module search path = Default w/o overrides
>   python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5
20150623 (Red Hat 4.8.5-4)]
> ```
>
> ##### ADDITIONAL INFORMATION
>
>     * Added ability to upgrade all packages:
>
>
> ```yaml
> - pkgutil:
>     name: '*'
>     state: latest
> ```
>
>     * Added ability to modify state of a list of packages:
>
>
> ```yaml
> - pkgutil:
>     name:
>     - CSWtop
>     - CSWwget
>     - CSWlsof
>     state: present
> ```
>
>     * Added ability to have underlying tool perform a dry-run when using
check mode, pkgutil -n
>
>     * Added ability to configure force option to force packages to state
determined by repository (downgrade for example)
>
>
> ```yaml
> - pkgutil:
>     name: CSWtop
>     state: latest
>     force: yes
> ```
>
>     * Added more examples and documentation to show the new functionality