### PR TITLE
Specify device for Pushover notification

### DIFF
--- a/changelogs/fragments/802-pushover-device-parameter.yml
+++ b/changelogs/fragments/802-pushover-device-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pushover - add device parameter (https://github.com/ansible-collections/community.general/pull/802).

--- a/plugins/modules/notification/pushover.py
+++ b/plugins/modules/notification/pushover.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2012, Jim Richardson <weaselkeeper@gmail.com>
+# Copyright (c) 2019, Bernd Arnold <wopfel@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -38,8 +39,14 @@ options:
     description:
       - Message priority (see U(https://pushover.net) for details).
     required: false
+  device:
+    description:
+      - A device the message should be sent to. Multiple devices can be specified, separated by a comma.
+    required: false
 
-author: "Jim Richardson (@weaselkeeper)"
+author:
+  - "Jim Richardson (@weaselkeeper)"
+  - "Bernd Arnold (@wopfel)"
 '''
 
 EXAMPLES = '''
@@ -58,6 +65,14 @@ EXAMPLES = '''
     app_token: wxfdksl
     user_key: baa5fe97f2c5ab3ca8f0bb59
   delegate_to: localhost
+
+- name: Send notifications via pushover.net to a specific device
+  community.general.pushover:
+    msg: '{{ inventory_hostname }} has been lost somewhere'
+    app_token: wxfdksl
+    user_key: baa5fe97f2c5ab3ca8f0bb59
+    device: admins-iPhone
+  delegate_to: localhost
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -74,7 +89,7 @@ class Pushover(object):
         self.user = user
         self.token = token
 
-    def run(self, priority, msg, title):
+    def run(self, priority, msg, title, device):
         ''' Do, whatever it is, we do. '''
 
         url = '%s/1/messages.json' % (self.base_uri)
@@ -88,6 +103,10 @@ class Pushover(object):
         if title is not None:
             options = dict(options,
                            title=title)
+
+        if device is not None:
+            options = dict(options,
+                           device=device)
 
         data = urlencode(options)
 
@@ -108,12 +127,13 @@ def main():
             app_token=dict(required=True, no_log=True),
             user_key=dict(required=True, no_log=True),
             pri=dict(required=False, default='0', choices=['-2', '-1', '0', '1', '2']),
+            device=dict(type='str'),
         ),
     )
 
     msg_object = Pushover(module, module.params['user_key'], module.params['app_token'])
     try:
-        response = msg_object.run(module.params['pri'], module.params['msg'], module.params['title'])
+        response = msg_object.run(module.params['pri'], module.params['msg'], module.params['title'], module.params['device'])
     except Exception:
         module.fail_json(msg='Unable to send msg via pushover')
 

--- a/plugins/modules/notification/pushover.py
+++ b/plugins/modules/notification/pushover.py
@@ -43,6 +43,7 @@ options:
     description:
       - A device the message should be sent to. Multiple devices can be specified, separated by a comma.
     required: false
+    version_added: 1.2.0
 
 author:
   - "Jim Richardson (@weaselkeeper)"


### PR DESCRIPTION
##### SUMMARY
When bringing Linux systems up-to-date and rebooting those machines, I'd like to have a notification sent to only one device via Pushover just when the reboot is issued. For this reason, I've enhanced the Pushover module.
With this change, you can specify to which device the notification should be delivered.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pushover

##### ADDITIONAL INFORMATION
New parameter: device

Example:
```
- community.general.pushover:
    msg: '{{ inventory_hostname }} has been lost somewhere'
    app_token: wxfdksl
    user_key: baa5fe97f2c5ab3ca8f0bb59
    device: admins-iPhone
  delegate_to: localhost
```

Using the Pushover API, you can specify a device where the message should be delivered to. Instead of notifying all devices (the default), the message is sent only to the specified device. Multiple devices can be given separated by a comma.

This change is downwards compatible: omitting the device key sends the message to all devices (as before).

Please let me know if you need any additional information. I'd be happy if this PR could be merged.

This is originally from this [PR](https://github.com/ansible/ansible/pull/64655) on ansible/ansible.

Kind regards,
Bernd