### PR TITLE
Add docker build output to task result

### DIFF
--- a/changelogs/fragments/805-docker_image-build-output.yml
+++ b/changelogs/fragments/805-docker_image-build-output.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_image - return docker build output (https://github.com/ansible-collections/community.general/pull/805)."

--- a/tests/integration/targets/docker_image/tasks/tests/docker_image.yml
+++ b/tests/integration/targets/docker_image/tasks/tests/docker_image.yml
@@ -136,6 +136,11 @@
     - repository_1 is changed
     - repository_2 is not changed
 
+# Uncomment in community.docker
+# - assert:
+#     that:
+#       - 'FROM busybox' in repository_1.stdout
+
 - name: Get facts of image
   docker_image_info:
     name: "{{ test_image_base }}:latest"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The build output is only added during failures, but its useful to have this available during normal task execution as well.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_image

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This change adds a new key `build_output` to the task result which includes all the docker build steps. This is useful to understand for e.g. what steps were run for the build, as well as steps that used / not used the image cache.
