### PR TITLE
parted: Fix 2 regex expressions in parted related to parted version string and to parsing…

### DIFF
--- a/changelogs/fragments/813-parted-updatedregex.yaml
+++ b/changelogs/fragments/813-parted-updatedregex.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - parted.py - Change the regex that decodes the partition size  to better support different formats that parted uses. Change the regex that validate partted's version string.

--- a/changelogs/fragments/813-parted-updatedregex.yaml
+++ b/changelogs/fragments/813-parted-updatedregex.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - parted.py - Change the regex that decodes the partition size  to better support different formats that parted uses. Change the regex that validate partted's version string.
+  - parted - change the regex that decodes the partition size to better support different formats that parted uses. Change the regex that validate parted's version string (https://github.com/ansible-collections/community.general/pull/817).

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -485,7 +485,7 @@ def parted_version():
     if len(lines) == 0:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 
-    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.+$', lines[0])
+    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.?$', lines[0])
     if matches is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -225,7 +225,7 @@ def parse_unit(size_str, unit=''):
     """
     Parses a string containing a size or boundary information
     """
-    matches = re.search(r'^(-?[\d.]+)([\w%]+)?$', size_str)
+    matches = re.search(r'^(-?[\d.]+) *([\w%]+)?$', size_str)
     if matches is None:
         # "<cylinder>,<head>,<sector>" format
         matches = re.search(r'^(\d+),(\d+),(\d+)$', size_str)
@@ -485,7 +485,7 @@ def parted_version():
     if len(lines) == 0:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 
-    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?$', lines[0])
+    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.+$', lines[0])
     if matches is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 


### PR DESCRIPTION
… partition size output.

##### SUMMARY
Modify 2 regex expressions to support 
1 - Different version string
2 - Support optional white space between numeral and unit designator in partition size output from parted

This fixes the following 2 bug reports:
https://github.com/ansible-collections/community.general/issues/812#issue-683856020
https://github.com/ansible-collections/community.general/issues/813#issue-683856891

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/parted.py

