### PR TITLE
redfish_command: allow setting the BootSourceOverrideEnabled property

### DIFF
--- a/changelogs/fragments/825-bootsource-override-option.yaml
+++ b/changelogs/fragments/825-bootsource-override-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - add sub-command for ``EnableContinuousBootOverride`` and ``DisableBootOverride`` to allow setting BootSourceOverrideEnabled Redfish property (https://github.com/ansible-collections/community.general/issues/824).


### PR DESCRIPTION
#### SUMMARY
Fixes #824  

##### COMPONENT NAME
Updates redfish_command and redfish_utils to allow setting BootSourceOverrideEnabled to all allowable schema values.