### PR TITLE
Disable notifications for jose-delarosa

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -987,8 +987,9 @@ files:
   $modules/remote_management/oneview/oneview_fcoe_network.py:
     authors: fgbulsoni
   $modules/remote_management/redfish/:
-    authors: jose-delarosa
+    authors: jose-delarosa billdodd
     maintainers: $team_redfish
+    ignore: jose-delarosa
   $modules/remote_management/stacki/stacki_host.py:
     authors: bbyhuy
     maintainers: bsanders


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Disable notifications for jose-delarosa from team_redfish. Jose moved to a new company and new role last year and is no longer involved with the Redfish module maintenance. I had previously removed him from the team_redfish list, but he was still getting notifications via the `authors` keyword. In this PR I disabled notifications for him via the `ignore` keyword.

I also added myself to the authors list since I have been adding new features for a while. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Other

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansibullbot configuration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
