### PR TITLE
support for explicit brick list in the fromat of "host1:/brick_path,h…

### DIFF
--- a/plugins/modules/storage/glusterfs/gluster_volume.py
+++ b/plugins/modules/storage/glusterfs/gluster_volume.py
@@ -336,8 +336,11 @@ def create_volume(name, stripe, replica, arbiter, disperse, redundancy, transpor
     args.append('transport')
     args.append(transport)
     for brick in bricks:
-        for host in hosts:
-            args.append(('%s:%s' % (host, brick)))
+        if ':' in brick:
+            args.append(str(brick))
+        else:
+            for host in hosts:
+                args.append(('%s:%s' % (host, brick)))
     if force:
         args.append('force')
     run_gluster(args)
@@ -535,7 +538,10 @@ def main():
 
             for node in cluster:
                 for brick_path in brick_paths:
-                    brick = '%s:%s' % (node, brick_path)
+                    if ':' in brick_path:
+                        brick = str(brick_path)
+                    else:
+                        brick = '%s:%s' % (node, brick_path)
                     all_bricks.append(brick)
                     if brick not in bricks_in_volume:
                         new_bricks.append(brick)


### PR DESCRIPTION
…ost1:/brick_path" which is almost (removing the commas) exactly what is "gluster volume create" command excepts.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current gluster_volume arbiter option is limited. it support only the form of dedicated arbiter peer for each subvolume. This means for example that for replica 3 with arbiter the brick list will be host1:/data, host2:/data, host3:/arbitrer, host4:/data, host5:/data, host6:/arbitrer.... Currently chain arbitration (host1:/data, host2:/data, host3:/arbitrer, host3:/data, host4:/data, host5:/arbitrer, host5:/data...) or single arbiter configuration (host1:/data, host2:/data, host6:/arbitrer1, host3:/data, host4:/data, host6:/arbitrer2...) are not possible.
We handle this limitation by adding support for explicit brick list in the format of "host1:/brick_path,host1:/brick_path" which is almost (removing the commas) exactly what is accepted by "gluster volume create" command. We distinct between the legacy and new format by the character ":" that must be specified between the peer hostname to the brick local path.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gluster_volume arbiter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
