### PR TITLE
Disable hg tests: these use bitbucket.org, which dropped mercurial support on 2020-08-26

### DIFF
--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group2
 skip/python3
 skip/aix
+disabled  # tests use bitbucket, which dropped mercurial support on 2020-08-26 (https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket)


### PR DESCRIPTION
##### SUMMARY
As topic says.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hg
