### PR TITLE
Fix lmdb lookup tests

### DIFF
--- a/tests/integration/targets/lookup_lmdb_kv/dependencies.yml
+++ b/tests/integration/targets/lookup_lmdb_kv/dependencies.yml
@@ -4,6 +4,8 @@
     - name: Install LMDB Python package
       pip:
         name: lmdb
+      env:
+        LMDB_PURE: "1"
     - name: Setup test data
       script: test_db.py
       args:

--- a/tests/integration/targets/lookup_lmdb_kv/dependencies.yml
+++ b/tests/integration/targets/lookup_lmdb_kv/dependencies.yml
@@ -4,7 +4,7 @@
     - name: Install LMDB Python package
       pip:
         name: lmdb
-      env:
+      environment:
         LMDB_PURE: "1"
     - name: Setup test data
       script: test_db.py


### PR DESCRIPTION
##### SUMMARY
Since 1.0.0 (released 2020-08-28), lmdb includes a patch for the library (https://lmdb.readthedocs.io/en/release/#installation-unix). Unfortunately in CI, installing lmdb now fails, probably because of this. This PR tries to get it working.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup/lmdb_kv.py
