### PR TITLE
proxmox_kvm: recognize force=yes with state=absent

### DIFF
--- a/changelogs/fragments/849-proxmox-kvm-state-absent-force.yml
+++ b/changelogs/fragments/849-proxmox-kvm-state-absent-force.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - proxmox_kvm - recognize ``force=yes`` in conjunction with ``state=absent`` to forcibly remove a running VM (https://github.com/ansible-collections/community.general/pull/849).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -113,7 +113,7 @@ options:
   force:
     description:
       - Allow to force stop VM.
-      - Can be used with states C(stopped) and C(restarted).
+      - Can be used with states C(stopped), C(restarted) and C(absent).
     default: no
     type: bool
   format:
@@ -1156,7 +1156,10 @@ def main():
                 module.exit_json(changed=False)
 
             if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
-                module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion." % vmid)
+                if module.params['force']:
+                    stop_vm(module, proxmox, vm, vmid, timeout, True)
+                else:
+                    module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion or use force=yes." % vmid)
 
             taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE).delete(vmid)
             while timeout:


### PR DESCRIPTION
##### SUMMARY

Recognize `force=yes` in conjunction with `state=absent` to forcibly remove a running VM instead of issuing a warning.

Requires #811.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

proxmox_kvm

##### ADDITIONAL INFORMATION

Using these tasks:

```
- name: "Ensure test-instance is forcibly removed"
  proxmox_kvm:
    api_host: "{{ host }}"
    api_user: "{{ user }}@{{ method }}"
    api_password: "{{ password }}"
    name: test-instance
    state: absent
    force: yes
  register: test

- debug:
    msg: "{{ test }}"
```

Before:

```
TASK [ansible-role-proxmox-instance : Ensure test-instance is removed] ***
ok: [localhost]

TASK [ansible-role-proxmox-instance : debug] ***********************************
ok: [localhost] => 
  msg:
    changed: false
    failed: false
    msg: VM 42 is running. Stop it before deletion.
```

After:

```
TASK [ansible-role-proxmox-instance : Ensure test-instance is removed] ***
changed: [localhost]

TASK [ansible-role-proxmox-instance : debug] ***********************************
ok: [localhost] => 
  msg:
    changed: true
    failed: false
    msg: VM 42 removed
```