### PR TITLE
Add inventory plugin for Stackpath Edge Compute

### DIFF
--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -199,8 +199,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 cursor = body_json["pageInfo"]["endCursor"]
         return result
 
-    def _get_stack_slugs(self):
-        stacks = self._stackpath_query_get_list(self.api_host + '/stack/v1/stacks')
+    def _get_stack_slugs(self, stacks):
         self.stack_slugs = [stack["slug"] for stack in stacks]
 
     def verify_file(self, path):
@@ -236,7 +235,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.stack_slugs = self.get_option('stack_slugs')
         if not self.stack_slugs:
             try:
-                self._get_stack_slugs()
+                stacks = self._stackpath_query_get_list(self.api_host + '/stack/v1/stacks')
+                self._get_stack_slugs(stacks)
             except Exception:
                 raise AnsibleError("Failed to get stack IDs from the Stackpath API: %s" % traceback.format_exc())
 

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -26,13 +26,13 @@ DOCUMENTATION = '''
         client_id:
             description:
                 - An OAuth client ID generated from the API Management section of the StackPath customer portal
-                - U(https://control.stackpath.net/api-management).
+                  U(https://control.stackpath.net/api-management).
             required: true
             type: str
         client_secret:
             description:
                 - An OAuth client secret generated from the API Management section of the StackPath customer portal
-                - U(https://control.stackpath.net/api-management).
+                  U(https://control.stackpath.net/api-management).
             required: true
             type: str
         stack_slugs:
@@ -106,13 +106,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if client_id != 32:
                 raise AnsibleError("client_id must be 32 characters long")
         except KeyError:
-            raise AnsibleError("config missing client_id, a required paramter")
+            raise AnsibleError("config missing client_id, a required option")
         try:
             client_secret = config['client_secret']
             if client_secret != 64:
                 raise AnsibleError("client_secret must be 64 characters long")
         except KeyError:
-            raise AnsibleError("config missing client_id, a required paramter")
+            raise AnsibleError("config missing client_id, a required option")
         return True
 
     def _set_credentials(self):
@@ -170,8 +170,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         instance["continent"] = instance["location"]["continent"]
                         instance["target"] = instance["metadata"]["labels"]["workload.platform.stackpath.net/target-name"]
                         try:
-                            ip = instance[self.hostname_key]
-                            results.append(instance)
+                            if instance[self.hostname_key]:
+                                results.append(instance)
                         except KeyError:
                             pass
         return results

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -100,18 +100,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             "workloadSlug"
         ]
 
+    def _validate_config(self, config):
+        if config['plugin'] != 'community.general.stackpath_compute':
+            raise AnsibleError("plugin doesn't match this plugin")
+        if not config['client_id']:
+            raise AnsibleError("config missing client_id, a required paramter")
+        if len(config['client_id']) != 32:
+            raise AnsibleError("client_id must be 32 characters long")
+        if not config['client_secret']:
+            raise AnsibleError("config missing client_secret, a required paramter")
+        if len(config['client_secret']) != 64:
+            raise AnsibleError("client_secret must be 64 characters long")
+        return True
+
     def _set_credentials(self):
         '''
             :param config_data: contents of the inventory config file
         '''
-
         self.client_id = self.get_option('client_id')
         self.client_secret = self.get_option('client_secret')
-
-        if not self.client_id or not self.client_secret:
-            raise AnsibleError("Insufficient credentials found."
-                               "Please provide them in your inventory"
-                               " configuration file.")
 
     def _authenticate(self):
         payload = json.dumps(
@@ -168,6 +175,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return results
 
     def _populate(self, instances):
+        instances
         for instance in instances:
             for group_key in self.group_keys:
                 group = group_key + "_" + instance[group_key]
@@ -223,8 +231,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         super(InventoryModule, self).parse(inventory, loader, path)
 
-        self._read_config_data(path)
-
+        config = self._read_config_data(path)
+        self._validate_config(config)
         self._set_credentials()
 
         # get user specifications

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native, to_text
+from ansible.plugins.inventory import (
+    BaseInventoryPlugin,
+    Constructable,
+    Cacheable
+)
+from ansible.utils.display import Display
+
+try:
+    import requests
+except ImportError:
+    raise AnsibleError(
+        'The stackpath_compute dynamic inventory plugin requires requests.'
+    )
+
+DOCUMENTATION = '''
+    name: stackpath_compute
+    plugin_type: inventory
+    short_description: StackPath Edge Computing inventory source
+    requirements:
+        - requests
+    extends_documentation_fragment:
+        - inventory_cache
+        - constructed
+    description:
+        - Get inventory hosts from StackPath Edge Computing.
+        - Uses a YAML configuration file that ends with stackpath_compute.(yml|yaml).
+    options:
+        plugin:
+            description: >
+                A token that ensures this is a source file for the 'stackpath_compute' plugin.
+            required: True
+            choices: ['stackpath_compute']
+        client_id:
+            description: >
+                An OAuth client ID generated from the API Management section of the StackPath customer portal
+                U(https://control.stackpath.net/api-management)
+            requierd: True
+        client_secret:
+            description: >
+                An OAuth client secret generated from the API Management section of the StackPath customer portal
+                U(https://control.stackpath.net/api-management)
+            required: True
+        stack_ids:
+            description: >
+                A list of Stack IDs to query instnaces in. If no entry then get instances in all stacks on the account
+                U(https://developer.stackpath.com/docs/en/getting-started/#get-your-stack-id)
+            required: False
+        use_internal_ip:
+            description: >
+                Whether or not to use internal IP addresses, yes to use internal addresses, no to use external addresses.
+                Defaults to external
+            requiered: False
+            choices: ['yes', 'no']
+'''
+
+EXAMPLES = '''
+
+# example using credentials to fetch all workload instances in a stack.
+---
+plugin: stackpath_compute
+client_id: my_client_id
+client_secret: my_client_secret
+stack_ids:
+- my_first_stack_id
+- my_other_stack_id
+use_internal_ip: no
+
+'''
+
+display = Display()
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+
+    NAME = 'stackpath_compute'
+
+    def __init__(self):
+        super(InventoryModule, self).__init__()
+
+        # credentials
+        self.client_id = None
+        self.client_secret = None
+        self.stack_id = None
+        self.api_host = "https://gateway.stackpath.com"
+        self.group_keys = [
+            "stackId", "workloadId", "cityCode",
+            "countryCode", "continent", "target", "name", "workloadSlug"]
+
+    def _set_credentials(self):
+        '''
+            :param config_data: contents of the inventory config file
+        '''
+
+        self.client_id = self.get_option('client_id')
+        self.client_secret = self.get_option('client_secret')
+
+        if not self.client_id or not self.client_secret:
+            raise AnsibleError("Insufficient credentials found."
+                               "Please provide them in your inventory"
+                               " configuration file.")
+
+    def _authenticate(self):
+        payload = json.dumps(
+            {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "grant_type": "client_credentials"
+            }
+        )
+        headers = {
+            "Content-Type": "application/json"
+        }
+        self.auth_token = requests.post(
+            self.api_host + '/identity/v1/oauth2/token',
+            headers=headers, data=payload).json()["access_token"]
+
+    def _query(self):
+        results = []
+        self._authenticate()
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.auth_token
+        }
+        for stack_id in self.stack_ids:
+            try:
+                workloads = requests.get(self.api_host + '/workload/v1/stacks/' +
+                                         stack_id + '/workloads',
+                                         headers=headers).json()["results"]
+            except Exception as e:
+                raise AnsibleError("Failed to get workloads from the StackPath API: %s" % to_native(e))
+            for workload in workloads:
+                try:
+                    workload_instances = requests.get(
+                        self.api_host + '/workload/v1/stacks/' + stack_id +
+                        '/workloads/' + workload["id"] + '/instances',
+                        headers=headers).json()["results"]
+                except Exception as e:
+                    raise AnsibleError("Failed to get workload instances from the StackPath API: %s" % to_native(e))
+                for instance in workload_instances:
+                    if instance["phase"] == "RUNNING":
+                        instance["stackId"] = stack_id
+                        instance["workloadId"] = workload["id"]
+                        instance["workloadSlug"] = workload["slug"]
+                        instance["cityCode"] = instance["location"]["cityCode"]
+                        instance["countryCode"] = instance["location"]["countryCode"]
+                        instance["continent"] = instance["location"]["continent"]
+                        instance["target"] = instance["metadata"]["labels"]["workload.platform.stackpath.net/target-name"]
+                        results.append(instance)
+        return results
+
+    def _populate(self, instances):
+        for instance in instances:
+            for group_key in self.group_keys:
+                group = group_key + "_" + instance[group_key]
+                group = group.lower().replace(" ", "_").replace("-", "_")
+                self.inventory.add_group(group)
+                self.inventory.add_host(instance[self.hostname_key],
+                                        group=group)
+
+    def _get_stack_ids(self):
+        self._authenticate()
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.auth_token
+        }
+        stacks = requests.get(self.api_host + '/stack/v1/stacks',
+                              headers=headers).json()["results"]
+        self.stack_ids = [stack["id"] for stack in stacks]
+
+    def verify_file(self, path):
+        '''
+            :param loader: an ansible.parsing.dataloader.DataLoader object
+            :param path: the path to the inventory config file
+            :return the contents of the config file
+        '''
+        if super(InventoryModule, self).verify_file(path):
+            if path.endswith(('stackpath_compute.yml', 'stackpath_compute.yaml')):
+                return True
+        display.debug(
+            "stackpath_compute inventory filename must end with \
+            'stackpath_compute.yml' or 'stackpath_compute.yaml'"
+        )
+        return False
+
+    def parse(self, inventory, loader, path, cache=True):
+
+        super(InventoryModule, self).parse(inventory, loader, path)
+
+        self._read_config_data(path)
+
+        self._set_credentials()
+
+        # get user specifications
+        self.use_internal_ip = self.get_option('use_internal_ip')
+        if self.use_internal_ip:
+            self.hostname_key = "ipAddress"
+        else:
+            self.hostname_key = "externalIpAddress"
+
+        self.stack_ids = self.get_option('stack_ids')
+        if not self.stack_ids:
+            try:
+                self._get_stack_ids()
+            except Exception as e:
+                raise AnsibleError("Failed to get stack IDs from the Stackpath API: %s" % to_native(e))
+
+        cache_key = self.get_cache_key(path)
+        # false when refresh_cache or --flush-cache is used
+        if cache:
+            # get the user-specified directive
+            cache = self.get_option('cache')
+
+        # Generate inventory
+        cache_needs_update = False
+        if cache:
+            try:
+                results = self._cache[cache_key]
+            except KeyError:
+                # if cache expires or cache file doesn't exist
+                cache_needs_update = True
+
+        if not cache or cache_needs_update:
+            results = self._query()
+
+        self._populate(results)
+
+        # If the cache has expired/doesn't exist or
+        # if refresh_inventory/flush cache is used
+        # when the user is using caching, update the cached inventory
+        if cache_needs_update or (not cache and self.get_option('cache')):
+            self._cache[cache_key] = results

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -103,14 +103,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _validate_config(self, config):
         if config['plugin'] != 'community.general.stackpath_compute':
             raise AnsibleError("plugin doesn't match this plugin")
-        if not config['client_id']:
+        try:
+            client_id = config['client_id']
+            if client_id != 32:
+                raise AnsibleError("client_id must be 32 characters long")
+        except KeyError:
             raise AnsibleError("config missing client_id, a required paramter")
-        if len(config['client_id']) != 32:
-            raise AnsibleError("client_id must be 32 characters long")
-        if not config['client_secret']:
-            raise AnsibleError("config missing client_secret, a required paramter")
-        if len(config['client_secret']) != 64:
-            raise AnsibleError("client_secret must be 64 characters long")
+        try:
+            client_secret = config['client_secret']
+            if client_secret != 64:
+                raise AnsibleError("client_secret must be 64 characters long")
+        except KeyError:
+            raise AnsibleError("config missing client_id, a required paramter")
         return True
 
     def _set_credentials(self):
@@ -175,7 +179,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return results
 
     def _populate(self, instances):
-        instances
         for instance in instances:
             for group_key in self.group_keys:
                 group = group_key + "_" + instance[group_key]

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -146,7 +146,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 raise AnsibleError("Failed to get workloads from the StackPath API: %s" % traceback.format_exc())
             for workload in workloads:
                 try:
-                    workload_instances = self._stackpath_query_get_list(self.api_host + '/workload/v1/stacks/' + stack_slug + '/workloads/' + workload["id"] + '/instances')
+                    workload_instances = self._stackpath_query_get_list(
+                        self.api_host + '/workload/v1/stacks/' + stack_slug + '/workloads/' + workload["id"] + '/instances'
+                    )
                 except Exception:
                     raise AnsibleError("Failed to get workload instances from the StackPath API: %s" % traceback.format_exc())
                 for instance in workload_instances:

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -28,15 +28,18 @@ DOCUMENTATION = '''
                 An OAuth client ID generated from the API Management section of the StackPath customer portal
                 U(https://control.stackpath.net/api-management)
             requierd: true
+            type: string
         client_secret:
             description: >
                 An OAuth client secret generated from the API Management section of the StackPath customer portal
                 U(https://control.stackpath.net/api-management)
             required: true
-        stack_ids:
+            type: string
+        stack_names:
             description:
-                - A list of Stack slugs or IDs to query instances in. If no entry then get instances in all stacks on the account
+                - A list of Stack names to query instances in. If no entry then get instances in all stacks on the account
             required: false
+            type: list
         use_internal_ip:
             description:
                 - Whether or not to use internal IP addresses, If false, uses external IP addresses, internal otherwise.
@@ -51,9 +54,9 @@ EXAMPLES = '''
 plugin: community.general.stackpath_compute
 client_id: my_client_id
 client_secret: my_client_secret
-stack_ids:
-- my_first_stack_id
-- my_other_stack_id
+stack_names:
+- my_first_stack_name
+- my_other_stack_name
 use_internal_ip: false
 '''
 

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -27,7 +27,7 @@ DOCUMENTATION = '''
             description:
                 - An OAuth client ID generated from the API Management section of the StackPath customer portal
                 - U(https://control.stackpath.net/api-management).
-            requierd: true
+            required: true
             type: str
         client_secret:
             description:

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -20,33 +20,31 @@ DOCUMENTATION = '''
     options:
         plugin:
             description:
-                - A token that ensures this is a source file for the 'stackpath_compute' plugin.
+                - A token that ensures this is a source file for the plugin.
             required: true
             choices: ['community.general.stackpath_compute']
         client_id:
-            description: >
-                An OAuth client ID generated from the API Management section of the StackPath customer portal
-                U(https://control.stackpath.net/api-management)
+            description:
+                - An OAuth client ID generated from the API Management section of the StackPath customer portal
+                - U(https://control.stackpath.net/api-management)
             requierd: true
-            type: string
+            type: str
         client_secret:
-            description: >
-                An OAuth client secret generated from the API Management section of the StackPath customer portal
-                U(https://control.stackpath.net/api-management)
+            description:
+                - An OAuth client secret generated from the API Management section of the StackPath customer portal
+                - U(https://control.stackpath.net/api-management)
             required: true
-            type: string
+            type: str
         stack_slugs:
             description:
                 - A list of Stack slugs to query instances in. If no entry then get instances in all stacks on the account
-            required: false
             type: list
+            elements: str
         use_internal_ip:
-            description: >
-                Whether or not to use internal IP addresses, If false, uses external IP addresses, internal otherwise.
-                If an instance doesn't have an external IP it will not be returned when this option is set to false.
-            requiered: false
+            description:
+                - Whether or not to use internal IP addresses, If false, uses external IP addresses, internal otherwise.
+                - If an instance doesn't have an external IP it will not be returned when this option is set to false.
             type: bool
-            default: false
 '''
 
 EXAMPLES = '''
@@ -133,7 +131,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             }
         )
         headers = {
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         resp = open_url(
             self.api_host + '/identity/v1/oauth2/token',
@@ -191,7 +189,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._authenticate()
         headers = {
             "Content-Type": "application/json",
-            "Authorization": "Bearer " + self.auth_token
+            "Authorization": "Bearer " + self.auth_token,
         }
         next_page = True
         result = []

--- a/plugins/inventory/stackpath_compute.py
+++ b/plugins/inventory/stackpath_compute.py
@@ -26,18 +26,18 @@ DOCUMENTATION = '''
         client_id:
             description:
                 - An OAuth client ID generated from the API Management section of the StackPath customer portal
-                - U(https://control.stackpath.net/api-management)
+                - U(https://control.stackpath.net/api-management).
             requierd: true
             type: str
         client_secret:
             description:
                 - An OAuth client secret generated from the API Management section of the StackPath customer portal
-                - U(https://control.stackpath.net/api-management)
+                - U(https://control.stackpath.net/api-management).
             required: true
             type: str
         stack_slugs:
             description:
-                - A list of Stack slugs to query instances in. If no entry then get instances in all stacks on the account
+                - A list of Stack slugs to query instances in. If no entry then get instances in all stacks on the account.
             type: list
             elements: str
         use_internal_ip:

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -9,12 +9,14 @@ __metaclass__ = type
 import pytest
 
 from ansible.errors import AnsibleError
-from ansible_collections.community.general.plugins.inventory.stackpath_compute import InventoryModule
+from ansible_collections.community.general.plugins.inventory.stackpath_compute import InventoryModule, InventoryData
 
 
 @pytest.fixture(scope="module")
 def inventory():
-    return InventoryModule()
+    r = InventoryModule()
+    r.inventory = InventoryData()
+    return r
 
 
 def test_get_stack_slugs(inventory):
@@ -67,7 +69,7 @@ def test_authenticate(inventory):
     inventory.client_id = "abcdefg"
     inventory.client_secret = "bcdefgh"
     with pytest.raises(AnsibleError) as error_message:
-        inventory._build_client()
+        inventory._authenticate()
         assert 'HTTP Error 404' in error_message
 
 

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -196,6 +196,5 @@ def test_populate(inventory):
     assert group_name_instance1.hosts == [host1]
     assert group_stackslug_stack1.hosts == [host1, host2]
     assert group_target_target1.hosts == [host1, host3]
-    print(group_workloadslug_workload3)
-    assert group_workloadslug_workload3 == [host3, host4]
-    assert group_workloadid_id1 == [host1]
+    assert group_workloadslug_workload3.hosts == [host3, host4]
+    assert group_workloadid_id1.hosts == [host1]

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -142,7 +142,7 @@ def test_populate(inventory):
         {
             "name": "instance3",
             "countryCode": "SE",
-            "workloadSlug": "wokrload3",
+            "workloadSlug": "workload3",
             "continent": "Europe",
             "workloadId": "id3",
             "cityCode": "ARN",
@@ -154,7 +154,7 @@ def test_populate(inventory):
         {
             "name": "instance4",
             "countryCode": "US",
-            "workloadSlug": "wokrload3",
+            "workloadSlug": "workload3",
             "continent": "America",
             "workloadId": "id4",
             "cityCode": "JFK",

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2020 Shay Rybak <shay.rybak@stackpath.com>
+# Copyright (c) 2020 Ansible Project
+# GNGeneral Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible_collections.community.general.plugins.inventory.stackpath_compute import InventoryModule
+
+
+@pytest.fixture(scope="module")
+def inventory():
+    return InventoryModule()
+
+
+def _get_stack_slugs(inventory):
+    stacks = [
+        {
+            'status': 'ACTIVE',
+            'name': 'test1',
+            'id': 'XXXX',
+            'updatedAt': '2020-07-08T01:00:00.000000Z',
+            'slug': 'test1',
+            'createdAt': '2020-07-08T00:00:00.000000Z',
+            'accountId': 'XXXX'
+        }, {
+            'status': 'ACTIVE',
+            'name': 'test2',
+            'id': 'XXXX',
+            'updatedAt': '2019-10-22T18:00:00.000000Z',
+            'slug': 'test2',
+            'createdAt': '2019-10-22T18:00:00.000000Z',
+            'accountId': 'XXXX'
+        }, {
+            'status': 'DISABLED',
+            'name': 'test3',
+            'id': 'XXXX',
+            'updatedAt': '2020-01-16T20:00:00.000000Z',
+            'slug': 'test3',
+            'createdAt': '2019-10-15T13:00:00.000000Z',
+            'accountId': 'XXXX'
+        }, {
+            'status': 'ACTIVE',
+            'name': 'test4',
+            'id': 'XXXX',
+            'updatedAt': '2019-11-20T22:00:00.000000Z',
+            'slug': 'test4',
+            'createdAt': '2019-11-20T22:00:00.000000Z',
+            'accountId': 'XXXX'
+        }
+    ]
+    assert len(inventory._get_stack_slugs(stacks)) == 4
+    assert inventory._get_stack_slugs(stacks) == [
+        "test1",
+        "test2",
+        "test3",
+        "test4"
+    ]

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -9,7 +9,8 @@ __metaclass__ = type
 import pytest
 
 from ansible.errors import AnsibleError
-from ansible_collections.community.general.plugins.inventory.stackpath_compute import InventoryModule, InventoryData
+from ansible.inventory.data import InventoryData
+from ansible_collections.community.general.plugins.inventory.stackpath_compute import InventoryModule
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -196,5 +196,6 @@ def test_populate(inventory):
     assert group_name_instance1.hosts == [host1]
     assert group_stackslug_stack1.hosts == [host1, host2]
     assert group_target_target1.hosts == [host1, host3]
+    print(group_workloadslug_workload3)
     assert group_workloadslug_workload3 == [host3, host4]
     assert group_workloadid_id1 == [host1]

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -62,147 +62,151 @@ def test_get_stack_slugs(inventory):
         "test4"
     ]
 
-    def test_authenticate(inventory):
-        inventory.client_id = "abcdefg"
-        inventory.client_secret = "bcdefgh"
-        with pytest.raises(AnsibleError) as error_message:
-            inventory._build_client()
-            assert 'HTTP Error 404' in error_message
 
-    def test_verify_file_bad_config(inventory):
-        assert inventory.verify_file('foobar.stackpath_compute.yml') is False
+def test_authenticate(inventory):
+    inventory.client_id = "abcdefg"
+    inventory.client_secret = "bcdefgh"
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._build_client()
+        assert 'HTTP Error 404' in error_message
 
-    def test_validate_config(inventory):
-        config = {
-            "client_secret": "short_client_secret",
-            "use_internal_ip": False,
-            "stack_slugs": ["waf-ec-c20059"],
-            "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "plugin": "community.general.stackpath_compute"
-        }
-        with pytest.raises(AnsibleError) as error_message:
-            inventory._validate_config(config)
-            assert "client_secret must be 64 characters long" in error_message
 
-        config = {
-            "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "use_internal_ip": False,
-            "stack_slugs": ["waf-ec-c20059"],
-            "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "plugin": "community.general.stackpath_compute"
-        }
-        assert inventory._validate_config(config) is True
-        config = {
-            "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "use_internal_ip": False,
-            "stack_slugs": ["waf-ec-c20059"],
-            "client_id": "short_client_id",
-            "plugin": "community.general.stackpath_compute"
-        }
-        with pytest.raises(AnsibleError) as error_message:
-            inventory._validate_config(config)
-            assert "client_id must be 32 characters long" in error_message
+def test_verify_file_bad_config(inventory):
+    assert inventory.verify_file('foobar.stackpath_compute.yml') is False
 
-        config = {
-            "use_internal_ip": False,
-            "stack_slugs": ["waf-ec-c20059"],
-            "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "plugin": "community.general.stackpath_compute"
-        }
-        with pytest.raises(AnsibleError) as error_message:
-            inventory._validate_config(config)
-            assert "config missing client_secret, a required paramter" in error_message
 
-        config = {
-            "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "use_internal_ip": False,
-            "plugin": "community.general.stackpath_compute"
-        }
-        with pytest.raises(AnsibleError) as error_message:
-            inventory._validate_config(config)
-            assert "config missing client_id, a required paramter" in error_message
+def test_validate_config(inventory):
+    config = {
+        "client_secret": "short_client_secret",
+        "use_internal_ip": False,
+        "stack_slugs": ["waf-ec-c20059"],
+        "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "plugin": "community.general.stackpath_compute"
+    }
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._validate_config(config)
+        assert "client_secret must be 64 characters long" in error_message
 
-    def test_populate(inventory):
-        instances = [
-            {
-                "name": "instance1",
-                "countryCode": "SE",
-                "workloadSlug": "wokrload1",
-                "continent": "Europe",
-                "workloadId": "id1",
-                "cityCode": "ARN",
-                "externalIpAddress": "20.0.0.1",
-                "target": "target1",
-                "stackSlug": "stack1",
-                "ipAddress": "10.0.0.1"
-            },
-            {
-                "name": "instance2",
-                "countryCode": "US",
-                "workloadSlug": "wokrload2",
-                "continent": "America",
-                "workloadId": "id2",
-                "cityCode": "JFK",
-                "externalIpAddress": "20.0.0.2",
-                "target": "target2",
-                "stackSlug": "stack1",
-                "ipAddress": "10.0.0.2"
-            },
-            {
-                "name": "instance3",
-                "countryCode": "SE",
-                "workloadSlug": "wokrload3",
-                "continent": "Europe",
-                "workloadId": "id3",
-                "cityCode": "ARN",
-                "externalIpAddress": "20.0.0.3",
-                "target": "target1",
-                "stackSlug": "stack2",
-                "ipAddress": "10.0.0.3"
-            },
-            {
-                "name": "instance4",
-                "countryCode": "US",
-                "workloadSlug": "wokrload3",
-                "continent": "America",
-                "workloadId": "id4",
-                "cityCode": "JFK",
-                "externalIpAddress": "20.0.0.4",
-                "target": "target2",
-                "stackSlug": "stack2",
-                "ipAddress": "10.0.0.4"
-            },
-        ]
-        inventory._populate(instances)
-        # get different hosts
-        host1 = inventory.inventory.get_host('20.0.0.1')
-        host2 = inventory.inventory.get_host('20.0.0.2')
-        host3 = inventory.inventory.get_host('20.0.0.3')
-        host4 = inventory.inventory.get_host('20.0.0.4')
+    config = {
+        "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "use_internal_ip": False,
+        "stack_slugs": ["waf-ec-c20059"],
+        "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "plugin": "community.general.stackpath_compute"
+    }
+    assert inventory._validate_config(config) is True
+    config = {
+        "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "use_internal_ip": False,
+        "stack_slugs": ["waf-ec-c20059"],
+        "client_id": "short_client_id",
+        "plugin": "community.general.stackpath_compute"
+    }
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._validate_config(config)
+        assert "client_id must be 32 characters long" in error_message
 
-        # get different groups
-        assert 'citycode_arn' in inventory.inventory.groups
-        group_citycode_arn = inventory.inventory.groups['citycode_arn']
-        assert 'countrycode_se' in inventory.inventory.groups
-        group_countrycode_se = inventory.inventory.groups['countrycode_se']
-        assert 'continent_america' in inventory.inventory.groups
-        group_continent_america = inventory.inventory.groups['continent_america']
-        assert 'name_instance1' in inventory.inventory.groups
-        group_name_instance1 = inventory.inventory.groups['name_instance1']
-        assert 'stackslug_stack1' in inventory.inventory.groups
-        group_stackslug_stack1 = inventory.inventory.groups['stackslug_stack1']
-        assert 'target_target1' in inventory.inventory.groups
-        group_target_target1 = inventory.inventory.groups['target_target1']
-        assert 'workloadslug_workload3' in inventory.inventory.groups
-        group_workloadslug_workload3 = inventory.inventory.groups['workloadslug_workload3']
-        assert 'workloadslug_workload3' in inventory.inventory.groups
-        group_workloadid_id1 = inventory.inventory.groups['workloadid_id1']
+    config = {
+        "use_internal_ip": False,
+        "stack_slugs": ["waf-ec-c20059"],
+        "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "plugin": "community.general.stackpath_compute"
+    }
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._validate_config(config)
+        assert "config missing client_secret, a required paramter" in error_message
 
-        assert group_citycode_arn.hosts == [host1, host3]
-        assert group_countrycode_se.hosts == [host1, host3]
-        assert group_continent_america.hosts == [host2, host4]
-        assert group_name_instance1.hosts == [host1]
-        assert group_stackslug_stack1.hosts == [host1, host2]
-        assert group_target_target1.hosts == [host1, host3]
-        assert group_workloadslug_workload3 == [host3, host4]
-        assert group_workloadid_id1 == [host1]
+    config = {
+        "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "use_internal_ip": False,
+        "plugin": "community.general.stackpath_compute"
+    }
+    with pytest.raises(AnsibleError) as error_message:
+        inventory._validate_config(config)
+        assert "config missing client_id, a required paramter" in error_message
+
+
+def test_populate(inventory):
+    instances = [
+        {
+            "name": "instance1",
+            "countryCode": "SE",
+            "workloadSlug": "wokrload1",
+            "continent": "Europe",
+            "workloadId": "id1",
+            "cityCode": "ARN",
+            "externalIpAddress": "20.0.0.1",
+            "target": "target1",
+            "stackSlug": "stack1",
+            "ipAddress": "10.0.0.1"
+        },
+        {
+            "name": "instance2",
+            "countryCode": "US",
+            "workloadSlug": "wokrload2",
+            "continent": "America",
+            "workloadId": "id2",
+            "cityCode": "JFK",
+            "externalIpAddress": "20.0.0.2",
+            "target": "target2",
+            "stackSlug": "stack1",
+            "ipAddress": "10.0.0.2"
+        },
+        {
+            "name": "instance3",
+            "countryCode": "SE",
+            "workloadSlug": "wokrload3",
+            "continent": "Europe",
+            "workloadId": "id3",
+            "cityCode": "ARN",
+            "externalIpAddress": "20.0.0.3",
+            "target": "target1",
+            "stackSlug": "stack2",
+            "ipAddress": "10.0.0.3"
+        },
+        {
+            "name": "instance4",
+            "countryCode": "US",
+            "workloadSlug": "wokrload3",
+            "continent": "America",
+            "workloadId": "id4",
+            "cityCode": "JFK",
+            "externalIpAddress": "20.0.0.4",
+            "target": "target2",
+            "stackSlug": "stack2",
+            "ipAddress": "10.0.0.4"
+        },
+    ]
+    inventory._populate(instances)
+    # get different hosts
+    host1 = inventory.inventory.get_host('20.0.0.1')
+    host2 = inventory.inventory.get_host('20.0.0.2')
+    host3 = inventory.inventory.get_host('20.0.0.3')
+    host4 = inventory.inventory.get_host('20.0.0.4')
+
+    # get different groups
+    assert 'citycode_arn' in inventory.inventory.groups
+    group_citycode_arn = inventory.inventory.groups['citycode_arn']
+    assert 'countrycode_se' in inventory.inventory.groups
+    group_countrycode_se = inventory.inventory.groups['countrycode_se']
+    assert 'continent_america' in inventory.inventory.groups
+    group_continent_america = inventory.inventory.groups['continent_america']
+    assert 'name_instance1' in inventory.inventory.groups
+    group_name_instance1 = inventory.inventory.groups['name_instance1']
+    assert 'stackslug_stack1' in inventory.inventory.groups
+    group_stackslug_stack1 = inventory.inventory.groups['stackslug_stack1']
+    assert 'target_target1' in inventory.inventory.groups
+    group_target_target1 = inventory.inventory.groups['target_target1']
+    assert 'workloadslug_workload3' in inventory.inventory.groups
+    group_workloadslug_workload3 = inventory.inventory.groups['workloadslug_workload3']
+    assert 'workloadslug_workload3' in inventory.inventory.groups
+    group_workloadid_id1 = inventory.inventory.groups['workloadid_id1']
+
+    assert group_citycode_arn.hosts == [host1, host3]
+    assert group_countrycode_se.hosts == [host1, host3]
+    assert group_continent_america.hosts == [host2, host4]
+    assert group_name_instance1.hosts == [host1]
+    assert group_stackslug_stack1.hosts == [host1, host2]
+    assert group_target_target1.hosts == [host1, host3]
+    assert group_workloadslug_workload3 == [host3, host4]
+    assert group_workloadid_id1 == [host1]

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -187,7 +187,7 @@ def test_populate(inventory):
     group_target_target1 = inventory.inventory.groups['target_target1']
     assert 'workloadslug_workload3' in inventory.inventory.groups
     group_workloadslug_workload3 = inventory.inventory.groups['workloadslug_workload3']
-    assert 'workloadslug_workload3' in inventory.inventory.groups
+    assert 'workloadid_id1' in inventory.inventory.groups
     group_workloadid_id1 = inventory.inventory.groups['workloadid_id1']
 
     assert group_citycode_arn.hosts == [host1, host3]

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -17,7 +17,7 @@ def inventory():
     return InventoryModule()
 
 
-def _get_stack_slugs(inventory):
+def test_get_stack_slugs(inventory):
     stacks = [
         {
             'status': 'ACTIVE',

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -53,8 +53,9 @@ def test_get_stack_slugs(inventory):
             'accountId': 'XXXX'
         }
     ]
-    assert len(inventory._get_stack_slugs(stacks)) == 4
-    assert inventory._get_stack_slugs(stacks) == [
+    inventory._get_stack_slugs(stacks)
+    assert len(inventory.stack_slugs) == 4
+    assert inventory.stack_slugs == [
         "test1",
         "test2",
         "test3",

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -29,7 +29,7 @@ def test_get_stack_slugs(inventory):
             'updatedAt': '2020-07-08T01:00:00.000000Z',
             'slug': 'test1',
             'createdAt': '2020-07-08T00:00:00.000000Z',
-            'accountId': 'XXXX'
+            'accountId': 'XXXX',
         }, {
             'status': 'ACTIVE',
             'name': 'test2',
@@ -37,7 +37,7 @@ def test_get_stack_slugs(inventory):
             'updatedAt': '2019-10-22T18:00:00.000000Z',
             'slug': 'test2',
             'createdAt': '2019-10-22T18:00:00.000000Z',
-            'accountId': 'XXXX'
+            'accountId': 'XXXX',
         }, {
             'status': 'DISABLED',
             'name': 'test3',
@@ -45,7 +45,7 @@ def test_get_stack_slugs(inventory):
             'updatedAt': '2020-01-16T20:00:00.000000Z',
             'slug': 'test3',
             'createdAt': '2019-10-15T13:00:00.000000Z',
-            'accountId': 'XXXX'
+            'accountId': 'XXXX',
         }, {
             'status': 'ACTIVE',
             'name': 'test4',
@@ -53,7 +53,7 @@ def test_get_stack_slugs(inventory):
             'updatedAt': '2019-11-20T22:00:00.000000Z',
             'slug': 'test4',
             'createdAt': '2019-11-20T22:00:00.000000Z',
-            'accountId': 'XXXX'
+            'accountId': 'XXXX',
         }
     ]
     inventory._get_stack_slugs(stacks)
@@ -76,7 +76,7 @@ def test_validate_config(inventory):
         "use_internal_ip": False,
         "stack_slugs": ["test1"],
         "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "plugin": "community.general.stackpath_compute"
+        "plugin": "community.general.stackpath_compute",
     }
     with pytest.raises(AnsibleError) as error_message:
         inventory._validate_config(config)
@@ -87,7 +87,7 @@ def test_validate_config(inventory):
         "use_internal_ip": True,
         "stack_slugs": ["test1"],
         "client_id": "short_client_id",
-        "plugin": "community.general.stackpath_compute"
+        "plugin": "community.general.stackpath_compute",
     }
     with pytest.raises(AnsibleError) as error_message:
         inventory._validate_config(config)
@@ -97,7 +97,7 @@ def test_validate_config(inventory):
         "use_internal_ip": True,
         "stack_slugs": ["test1"],
         "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "plugin": "community.general.stackpath_compute"
+        "plugin": "community.general.stackpath_compute",
     }
     with pytest.raises(AnsibleError) as error_message:
         inventory._validate_config(config)
@@ -106,7 +106,7 @@ def test_validate_config(inventory):
     config = {
         "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "use_internal_ip": False,
-        "plugin": "community.general.stackpath_compute"
+        "plugin": "community.general.stackpath_compute",
     }
     with pytest.raises(AnsibleError) as error_message:
         inventory._validate_config(config)
@@ -125,7 +125,7 @@ def test_populate(inventory):
             "externalIpAddress": "20.0.0.1",
             "target": "target1",
             "stackSlug": "stack1",
-            "ipAddress": "10.0.0.1"
+            "ipAddress": "10.0.0.1",
         },
         {
             "name": "instance2",
@@ -137,7 +137,7 @@ def test_populate(inventory):
             "externalIpAddress": "20.0.0.2",
             "target": "target2",
             "stackSlug": "stack1",
-            "ipAddress": "10.0.0.2"
+            "ipAddress": "10.0.0.2",
         },
         {
             "name": "instance3",
@@ -149,7 +149,7 @@ def test_populate(inventory):
             "externalIpAddress": "20.0.0.3",
             "target": "target1",
             "stackSlug": "stack2",
-            "ipAddress": "10.0.0.3"
+            "ipAddress": "10.0.0.3",
         },
         {
             "name": "instance4",
@@ -161,7 +161,7 @@ def test_populate(inventory):
             "externalIpAddress": "20.0.0.4",
             "target": "target2",
             "stackSlug": "stack2",
-            "ipAddress": "10.0.0.4"
+            "ipAddress": "10.0.0.4",
         },
     ]
     inventory.hostname_key = "externalIpAddress"

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -66,14 +66,6 @@ def test_get_stack_slugs(inventory):
     ]
 
 
-def test_authenticate(inventory):
-    inventory.client_id = "abcdefg"
-    inventory.client_secret = "bcdefgh"
-    with pytest.raises(AnsibleError) as error_message:
-        inventory._authenticate()
-        assert 'HTTP Error 404' in error_message
-
-
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.stackpath_compute.yml') is False
 
@@ -82,7 +74,7 @@ def test_validate_config(inventory):
     config = {
         "client_secret": "short_client_secret",
         "use_internal_ip": False,
-        "stack_slugs": ["waf-ec-c20059"],
+        "stack_slugs": ["test1"],
         "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "plugin": "community.general.stackpath_compute"
     }
@@ -92,16 +84,8 @@ def test_validate_config(inventory):
 
     config = {
         "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "use_internal_ip": False,
-        "stack_slugs": ["waf-ec-c20059"],
-        "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "plugin": "community.general.stackpath_compute"
-    }
-    assert inventory._validate_config(config) is True
-    config = {
-        "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "use_internal_ip": False,
-        "stack_slugs": ["waf-ec-c20059"],
+        "use_internal_ip": True,
+        "stack_slugs": ["test1"],
         "client_id": "short_client_id",
         "plugin": "community.general.stackpath_compute"
     }
@@ -110,8 +94,8 @@ def test_validate_config(inventory):
         assert "client_id must be 32 characters long" in error_message
 
     config = {
-        "use_internal_ip": False,
-        "stack_slugs": ["waf-ec-c20059"],
+        "use_internal_ip": True,
+        "stack_slugs": ["test1"],
         "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "plugin": "community.general.stackpath_compute"
     }
@@ -180,6 +164,7 @@ def test_populate(inventory):
             "ipAddress": "10.0.0.4"
         },
     ]
+    inventory.hostname_key = "externalIpAddress"
     inventory._populate(instances)
     # get different hosts
     host1 = inventory.inventory.get_host('20.0.0.1')


### PR DESCRIPTION
##### SUMMARY
This adds an inventory plugin for Stackpath's Edge Compute product.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
stackpath_compute inventory plugin
##### ADDITIONAL INFORMATION
This leverages the Stackpath public API to get an inventory of hosts for both containers and VM workloads.

Details on Stackpath Edge Compute https://www.stackpath.com/products/edge-compute/
Details on the Stackpath API https://stackpath.dev/reference