### PR TITLE
postgresql_privs: allow lowercased PUBLIC role

### DIFF
--- a/changelogs/fragments/858-postgresql_privs_should_allow_public_role_lowercased.yml
+++ b/changelogs/fragments/858-postgresql_privs_should_allow_public_role_lowercased.yml
@@ -1,0 +1,2 @@
+bugfix:
+- postgresql_privs - allow to pass ``PUBLIC`` role written in lowercase letters (https://github.com/ansible-collections/community.general/issues/857).

--- a/changelogs/fragments/858-postgresql_privs_should_allow_public_role_lowercased.yml
+++ b/changelogs/fragments/858-postgresql_privs_should_allow_public_role_lowercased.yml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
 - postgresql_privs - allow to pass ``PUBLIC`` role written in lowercase letters (https://github.com/ansible-collections/community.general/issues/857).

--- a/plugins/modules/database/postgresql/postgresql_privs.py
+++ b/plugins/modules/database/postgresql/postgresql_privs.py
@@ -169,6 +169,7 @@ notes:
   C(present) and I(grant_option) to C(no) (see examples).
 - Note that when revoking privileges from a role R, this role  may still have
   access via privileges granted to any role R is a member of including C(PUBLIC).
+- Note that when you use C(PUBLIC) role, the module always reports that the state has been changed.
 - Note that when revoking privileges from a role R, you do so as the user
   specified via I(login). If R has been granted the same privileges by
   another user also, R can still access database objects via these privileges.
@@ -783,6 +784,9 @@ class Connection(object):
 
         executed_queries.append(query)
         self.cursor.execute(query)
+        if roles == 'PUBLIC':
+            return True
+
         status_after = get_status(objs)
 
         def nonesorted(e):
@@ -1053,7 +1057,7 @@ def main():
                 objs = [obj.replace(':', ',') for obj in objs]
 
         # roles
-        if p.roles == 'PUBLIC':
+        if p.roles.upper() == 'PUBLIC':
             roles = 'PUBLIC'
         else:
             roles = p.roles.split(',')

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
@@ -343,6 +343,22 @@
     target_roles: "{{ db_user_with_dots2 }}"
     trust_input: no
 
+- name: Test
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_privs:
+    db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
+    type: 'database'
+    privs: 'connect'
+    role: 'public'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["GRANT CONNECT ON database \"{{ db_name }}\" TO PUBLIC;"]
+
 #
 # Cleanup
 #

--- a/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/postgresql_privs_initial.yml
@@ -343,7 +343,8 @@
     target_roles: "{{ db_user_with_dots2 }}"
     trust_input: no
 
-- name: Test
+# Bugfix for https://github.com/ansible-collections/community.general/issues/857
+- name: Test passing lowercase PUBLIC role
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_privs:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/857

1. Allow passing PUBLIC role written in lowercase letters.
2. Also, in case of PUBLIC, the module reports that nothing has been changed, fixed to `always changed`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_privs