### PR TITLE
Slack: moves to \S+ check instead of \w+-\w+

### DIFF
--- a/changelogs/fragments/892-slack-token-validation.yml
+++ b/changelogs/fragments/892-slack-token-validation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - slack - fix xox[abp] token identification to capture everything after xox[abp], as the token is the only thing that should be in this argument.

--- a/changelogs/fragments/892-slack-token-validation.yml
+++ b/changelogs/fragments/892-slack-token-validation.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - slack - fix xox[abp] token identification to capture everything after xox[abp], as the token is the only thing that should be in this argument.
+  - slack - fix ``xox[abp]`` token identification to capture everything after ``xox[abp]``, as the token is the only thing that should be in this argument (https://github.com/ansible-collections/community.general/issues/862).

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -314,7 +314,7 @@ def do_notify_slack(module, domain, token, payload):
     if token.count('/') >= 2:
         # New style webhook token
         slack_uri = SLACK_INCOMING_WEBHOOK % (token)
-    elif re.match(r'^xox[abp]-\w+-\w+$', token):
+    elif re.match(r'^xox[abp]-\S+$', token):
         slack_uri = SLACK_POSTMESSAGE_WEBAPI
         use_webapi = True
     else:


### PR DESCRIPTION
##### SUMMARY
Changes to support validation for longer token types than what was there

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.general.slack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Moved from `\w+-\w+` to `\S+` to capture until there is a space

<!--- Paste verbatim command output below, e.g. before and after your change -->
*Before*
```paste below
fatal: [host]: FAILED! => changed=false 
  msg: Slack has updated its webhook API.  You need to specify a token of the form XXXX/YYYY/ZZZZ in your playbook
```

*After*
```
changed: [host]
```

Fixes #862 
