### PR TITLE
wip: add new module to support adding and deleting FreeIPA Auto Membership Rules

### DIFF
--- a/plugins/modules/identity/ipa/ipa_automember.py
+++ b/plugins/modules/identity/ipa/ipa_automember.py
@@ -120,7 +120,7 @@ class AutoMemberIPAClient(IPAClient):
     def automember_add(self, name, rule):
         return self._post_json(method='automember_add', name=name, item=rule)
 
-    def automember_mod(self, name, member_type, rule):
+    def automember_mod(self, name, rule):
         return self._post_json(method='automember_mod', name=name, item=rule)
 
     def automember_del(self, name, member_type):
@@ -219,11 +219,11 @@ def ensure(module, client):
             if not module.check_mode:
                 client.automember_del(name=name, member_type=member_type)
 
-    if inclusive_regex is not None:
+    if inclusive_regex:
         changed = automember_condition_changed(
-            module, client, ipa_automember, exclusive_regex, 'automemberinclusiveregex') or changed
+            module, client, ipa_automember, inclusive_regex, 'automemberinclusiveregex') or changed
 
-    if exclusive_regex is not None:
+    if exclusive_regex:
         changed = automember_condition_changed(
             module, client, ipa_automember, exclusive_regex, 'automemberexclusiveregex') or changed
 

--- a/plugins/modules/identity/ipa/ipa_automember.py
+++ b/plugins/modules/identity/ipa/ipa_automember.py
@@ -3,13 +3,6 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-from ansible.module_utils._text import to_native
-from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils.basic import AnsibleModule
-import traceback
-__metaclass__ = type
-
 DOCUMENTATION = r'''
 ---
 module: ipa_automember
@@ -45,7 +38,14 @@ options:
     description:
     - Grouping to which the rule applies
     required: true
+    type: str
     choices: ["group", "hostgroup"]
+  state:
+    description: State to ensure
+    required: false
+    default: present
+    choices: ["absent", "present"]
+    type: str
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -109,6 +109,12 @@ automember:
   type: dict
 '''
 
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
+from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+import traceback
+__metaclass__ = type
 
 class AutoMemberIPAClient(IPAClient):
     def __init__(self, module, host, port, protocol):
@@ -234,7 +240,7 @@ def main():
     argument_spec = ipa_argument_spec()
     argument_spec.update(description=dict(type='str'),
                          cn=dict(type='str', required=True, aliases=['name']),
-                         type=dict(type='str', choices=['group', 'hostgroup']),
+                         type=dict(type='str', required=True, choices=['group', 'hostgroup']),
                          inclusive_regex=dict(type='list', elements='dict', aliases=[
                                               'automemberinclusiveregex']),
                          exclusive_regex=dict(type='list', elements='dict', aliases=[
@@ -260,4 +266,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/plugins/modules/identity/ipa/ipa_automember.py
+++ b/plugins/modules/identity/ipa/ipa_automember.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_native
+from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+import traceback
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ipa_automember
+author: Mark Hahl (@wolskie)
+short_description: Add and delete FreeIPA Auto Membership Rules.
+description:
+- Add, modify and delete an IPA Auto Membership Rule using IPA API.
+options:
+  cn:
+    description:
+    - Automember Rule.
+    - Can not be changed as it is the unique identifier.
+    required: true
+    aliases: ["name"]
+    type: str
+  description:
+    description:
+    - A description of this auto member rule.
+    type: str
+  type:
+    description:
+    - Grouping to which the rule applies
+    required: true
+    choices: ["group", "hostgroup"]
+extends_documentation_fragment:
+- community.general.ipa.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Ensure user group rule is present
+  community.general.ipa_automember:
+    name: admins
+    type: group
+    description: Example user group rule
+    community.general.ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+
+- name: Ensure hostgroup group rule is present
+  community.general.ipa_automember:
+    name: ipaservers
+    type: hostgroup
+    description: Example host group rule
+    community.general.ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+
+- name: Ensure user group rule is is absent
+  community.general.ipa_automember:
+    name: admins
+    type: group
+    state: absent
+    community.general.ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+
+- name: Ensure host group rule is is absent
+  community.general.ipa_automember:
+    name: admins
+    type: hostgroup
+    state: absent
+    community.general.ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+'''
+
+RETURN = r'''
+automember:
+  description: Automember Rule as returned by IPA API.
+  returned: always
+  type: dict
+'''
+
+
+class AutoMemberIPAClient(IPAClient):
+    def __init__(self, module, host, port, protocol):
+        super(AutoMemberIPAClient, self).__init__(module, host, port, protocol)
+
+    def automember_find(self, name, member_type):
+        return self._post_json(method='automember_find', name=name, item={'type': member_type, 'all': True})
+
+    def automember_add(self, name, rule):
+        return self._post_json(method='automember_add', name=name, item=rule)
+
+    def automember_mod(self, name, rule):
+        return self._post_json(method='automember_mod', name=name, item=rule)
+
+    def automember_del(self, name, member_type):
+        return self._post_json(method='automember_del', name=name, item={'type': member_type})
+
+
+def get_automember_dict(member_type, description=None):
+    data = {}
+    data['type'] = member_type
+    if description is not None:
+        data['description'] = description
+    return data
+
+
+def get_automember_diff(client, ipa_automember, module_automember):
+    non_updateable_keys = ['cn', 'dn', 'automembertargetgroup']
+    for key in non_updateable_keys:
+        if key in module_automember:
+            del module_automember[key]
+    return client.get_diff(ipa_data=ipa_automember, module_data=module_automember)
+
+
+def ensure(module, client):
+    name = module.params['cn']
+    state = module.params['state']
+    description = module.params['description']
+    member_type = module.params['type']
+
+    module_automember = get_automember_dict(description=description,
+                                            member_type=member_type)
+    ipa_automember = client.automember_find(name=name, member_type=member_type)
+    changed = False
+    diff = None
+    if state == 'present':
+        if not ipa_automember:
+            changed = True
+            if not module.check_mode:
+                ipa_automember = client.automember_add(
+                    name=name, rule=module_automember)
+        else:
+            diff = get_automember_diff(
+                client, ipa_automember, module_automember)
+            if len(diff) > 0:
+                changed = True
+                if not module.check_mode:
+                    data = {}
+                    for key in diff:
+                        data[key] = module_automember.get(key)
+                    return changed, client.automember_mod(name=name, rule=data)
+    else:
+        if ipa_automember:
+            changed = True
+            if not module.check_mode:
+                client.automember_del(name=name, member_type=member_type)
+
+    return changed, client.automember_find(name=name, member_type=member_type)
+
+
+def main():
+    argument_spec = ipa_argument_spec()
+    argument_spec.update(description=dict(type='str'),
+                         cn=dict(type='str', required=True, aliases=['name']),
+                         type=dict(type='str', choices=['group', 'hostgroup']),
+                         state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']))
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    client = AutoMemberIPAClient(module=module,
+                                 host=module.params['ipa_host'],
+                                 port=module.params['ipa_port'],
+                                 protocol=module.params['ipa_prot'])
+
+    try:
+        client.login(username=module.params['ipa_user'],
+                     password=module.params['ipa_pass'])
+        changed, automember = ensure(module, client)
+        module.exit_json(changed=changed, automember=automember)
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/identity/ipa/ipa_automember.py
+++ b/plugins/modules/identity/ipa/ipa_automember.py
@@ -34,7 +34,7 @@ options:
     - List of dictionaries containing the attribute and expression.
     type: list
     elements: dict
-    aliases: ["automemberinclusiveregex"]
+    aliases: ["automemberexclusiveregex"]
   inclusive_regex:
     description:
     - List of dictionaries containing the attribute and expression.

--- a/plugins/modules/identity/ipa/ipa_automember.py
+++ b/plugins/modules/identity/ipa/ipa_automember.py
@@ -29,6 +29,18 @@ options:
     description:
     - A description of this auto member rule.
     type: str
+  exclusive_regex:
+    description:
+    - List of dictionaries containing the attribute and expression.
+    type: list
+    elements: dict
+    aliases: ["automemberinclusiveregex"]
+  inclusive_regex:
+    description:
+    - List of dictionaries containing the attribute and expression.
+    type: list
+    elements: dict
+    aliases: ["automemberinclusiveregex"]
   type:
     description:
     - Grouping to which the rule applies
@@ -61,6 +73,12 @@ EXAMPLES = r'''
     name: ipaservers
     type: hostgroup
     description: Example host group rule
+    exclusive_regex:
+      - key: uid
+        expression: '^1234'
+    inclusive_regex:
+      - key: mail
+        expression: 'example\.com$'
     community.general.ipa_host: ipa.example.com
     ipa_user: admin
     ipa_pass: topsecret
@@ -217,9 +235,9 @@ def main():
     argument_spec.update(description=dict(type='str'),
                          cn=dict(type='str', required=True, aliases=['name']),
                          type=dict(type='str', choices=['group', 'hostgroup']),
-                         inclusive_regex=dict(type='list', aliases=[
+                         inclusive_regex=dict(type='list', elements='dict', aliases=[
                                               'automemberinclusiveregex']),
-                         exclusive_regex=dict(type='list', aliases=[
+                         exclusive_regex=dict(type='list', elements='dict', aliases=[
                                               'automemberexclusiveregex']),
                          state=dict(type='str', default='present', choices=['present', 'absent']))
 

--- a/plugins/modules/ipa_automember.py
+++ b/plugins/modules/ipa_automember.py
@@ -1,0 +1,1 @@
+./identity/ipa/ipa_automember.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add new module to support adding and deleting FreeIPA Auto Membership Rules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
ipa_automember.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Based very heavily on the existing ipa modules, I tried to keep the code as similar as I could.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```lang=yaml
- name: Ensure user group rule is present
  community.general.ipa_automember:
    name: admins
    type: group
    description: Example user group rule
    exclusive_regex:
      - key: uid
        expression: '^1234'
    inclusive_regex:
      - key: mail
        expression: 'example\.com$'
    community.general.ipa_host: ipa.example.com
    ipa_user: admin
    ipa_pass: topsecret

- name: Ensure hostgroup group rule is present
  community.general.ipa_automember:
    name: ipaservers
    type: hostgroup
    description: Example host group rule
    exclusive_regex:
      - key: uid
        expression: '^1234'
    inclusive_regex:
      - key: mail
        expression: 'example\.com$'
    community.general.ipa_host: ipa.example.com
    ipa_user: admin
    ipa_pass: topsecret


```
