### PR TITLE
[stable-1] interfaces_file: re.escape() old value

### DIFF
--- a/changelogs/fragments/777-interfaces_file-re-escape.yml
+++ b/changelogs/fragments/777-interfaces_file-re-escape.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- interfaces_file - escape regular expression characters in old value (https://github.com/ansible-collections/community.general/issues/777).

--- a/plugins/modules/system/interfaces_file.py
+++ b/plugins/modules/system/interfaces_file.py
@@ -284,7 +284,7 @@ def setInterfaceOption(module, lines, iface, option, raw_value, state, address_f
                     address_family = target_option['address_family']
                     prefix_start = old_line.find(option)
                     optionLen = len(option)
-                    old_value_position = re.search(r"\s+".join(old_value.split()), old_line[prefix_start + optionLen:])
+                    old_value_position = re.search(r"\s+".join(map(re.escape, old_value.split())), old_line[prefix_start + optionLen:])
                     start = old_value_position.start() + prefix_start + optionLen
                     end = old_value_position.end() + prefix_start + optionLen
                     line = old_line[:start] + value + old_line[end:]


### PR DESCRIPTION
(cherry-picked from commit b87eb7e91120a6758f751eeab6b7acace73c5a50)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of interfaces_file: re.escape() old value (#873)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
interfaces_file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
