### PR TITLE
Rollback if nothing changed

### DIFF
--- a/changelogs/fragments/887-rollback-if-nothing-changed.yml
+++ b/changelogs/fragments/887-rollback-if-nothing-changed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - rollback if nothing changed (https://github.com/ansible-collections/community.general/issues/885).

--- a/plugins/modules/database/postgresql/postgresql_privs.py
+++ b/plugins/modules/database/postgresql/postgresql_privs.py
@@ -1102,7 +1102,7 @@ def main():
         conn.rollback()
         module.fail_json(msg=to_native(e.message))
 
-    if module.check_mode:
+    if module.check_mode or not changed:
         conn.rollback()
     else:
         conn.commit()


### PR DESCRIPTION
Since the module unconditionally issues ALTER statements in order to
observe their effect on the postgres catalog - to determine whether the
privileges have changes - a rollback is thus advisable when in fact
nothing has changed.

fix #885

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #885

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_privs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
