### PR TITLE
python_requirements_info: Bugfix/issue 731

### DIFF
--- a/changelogs/fragments/890-python_requirements_info-extra-checks.yaml
+++ b/changelogs/fragments/890-python_requirements_info-extra-checks.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - python_requirements_info does not parse poject[extra] syntax (https://github.com/ansible-collections/community.general/issues/731)
+  - python_requirements_info - does now parse ``project[extra]`` syntax (https://github.com/ansible-collections/community.general/issues/731).

--- a/changelogs/fragments/890-python_requirements_info-extra-checks.yaml
+++ b/changelogs/fragments/890-python_requirements_info-extra-checks.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - python_requirements_info does not parse poject[extra] syntax (https://github.com/ansible-collections/community.general/issues/731)

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -142,6 +142,8 @@ def main():
             except (pkg_resources.DistributionNotFound, pkg_resources.UnknownExtra):
                 results['not_found'].append(pkg + extra)
                 continue
+            else:
+                existing = pkg_resources.get_distribution(pkg).version
         else:
             try:
                 existing = pkg_resources.get_distribution(pkg).version

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -121,7 +121,8 @@ def main():
             python_version=sys.version,
             python_system_path=sys.path,
         )
-    pkg_dep_re = re.compile(r'(^[a-zA-Z][a-zA-Z0-9_-]+)(\[[a-zA-Z]+\])?(==|[><]=?)?([0-9.]+)?$')
+    pkg_dep_re = re.compile(
+        r'(^[a-zA-Z][a-zA-Z0-9_-]+)(\[[a-zA-Z]+\])?(==|[><]=?)?([0-9.]+)?$')
 
     results = dict(
         not_found=[],

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -13,7 +13,8 @@
     dependencies:
       - notreal<1
       - pip>1
-      - ansible[azure]>2.9.0
+      - notreal[nothingreal]<1
+      - ansible[azuree]>2.8.0
   register: dep_info
 
 - name: ensure python_requirements_info returns desired info
@@ -21,3 +22,5 @@
     that:
       - "'installed' in dep_info.valid.pip"
       - "'notreal' in dep_info.not_found"
+      - "'notreal[nothingreal]' in dep_info.not_found"
+      - "'ansible[azuree]' in dep_info.not_found"

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -8,8 +8,14 @@
       - "'python' in basic_info"
       - "'python_version' in basic_info"
 
+- name: uninstall enum34 to avoid AttributeError
+  pip: 
+    name: enum34
+    state: absent
+
 - name: install sampleprojectpy2 to test extras
-  shell: pip uninstall -y enum34 && pip install --user sampleprojectpy2[test]
+  pip:
+    name: sampleprojectpy2[test]
 
 - name: run python_requirements_info module
   python_requirements_info:

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -17,8 +17,7 @@
       - notreal<1
       - pip>1
       - sampleprojectpy2[test]>1
-      - ansible>2.8.0
-      - ansible[notextra]>2.8.0
+      - sampleprojectpy2[notreal]>1
   register: dep_info
 
 - name: ensure python_requirements_info returns desired info
@@ -27,5 +26,4 @@
       - "'installed' in dep_info.valid.pip"
       - "'notreal' in dep_info.not_found"
       - "'installed' in dep_info.valid.sampleprojectpy2"
-      - "'installed' in dep_info.valid.ansible"
-      - "'ansible[notextra]' in dep_info.not_found"
+      - "'sampleprojectpy2[notreal]' in dep_info.not_found"

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -13,6 +13,7 @@
     dependencies:
       - notreal<1
       - pip>1
+      - ansible[azure]>2.9.0
   register: dep_info
 
 - name: ensure python_requirements_info returns desired info

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -8,13 +8,17 @@
       - "'python' in basic_info"
       - "'python_version' in basic_info"
 
+- name: install sampleprojectpy2 to test extras
+  shell: pip uninstall -y enum34 && pip install --user sampleprojectpy2[test]
+
 - name: run python_requirements_info module
   python_requirements_info:
     dependencies:
       - notreal<1
       - pip>1
-      - notreal[nothingreal]<1
-      - ansible[azuree]>2.8.0
+      - sampleprojectpy2[test]>1
+      - ansible>2.8.0
+      - ansible[notextra]>2.8.0
   register: dep_info
 
 - name: ensure python_requirements_info returns desired info
@@ -22,5 +26,6 @@
     that:
       - "'installed' in dep_info.valid.pip"
       - "'notreal' in dep_info.not_found"
-      - "'notreal[nothingreal]' in dep_info.not_found"
-      - "'ansible[azuree]' in dep_info.not_found"
+      - "'installed' in dep_info.valid.sampleprojectpy2"
+      - "'installed' in dep_info.valid.ansible"
+      - "'ansible[notextra]' in dep_info.not_found"


### PR DESCRIPTION
##### SUMMARY
Fixes #731 
python_requirements_info (previously python_requirements_facts) is not parsing pip packages if started with project[extra] (similar to command pip install "project[extra]") + info

Ansible version: 2.9.x

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
python_requirements_info

##### ADDITIONAL INFORMATION
Following changes have been committed:

- New regex added to allow matches with extras
- New logic for extra analysis including UnknownExtra exception:
- Test modified in /tests/integration/targets/python_requirements_info/tasks/main.yml:
  - 2 tasks added:
    - **uninstall enum34**: this was needed to avoid the following error in python 3 AttributeError: module 'enum' has no attribute 'IntFlag'
    - **install sampleprojectpy2 to test extras**: a sample project with an extra was installed to test the case.
  - **run python_requirements_info module** and **ensure python_requirements_info returns desired info** modified.

Tested via `ansible-test integration --docker default -v python_requirements_info`
