### PR TITLE
adding fix for packet_net.py

### DIFF
--- a/changelogs/fragments/891-packet_net-fix-not-subscriptable.yaml
+++ b/changelogs/fragments/891-packet_net-fix-not-subscriptable.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- packet_net.py - fixed failure by changing object to use ``__dict__`` method.

--- a/changelogs/fragments/891-packet_net-fix-not-subscriptable.yaml
+++ b/changelogs/fragments/891-packet_net-fix-not-subscriptable.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- packet_net.py - fixed failure by changing object to use ``__dict__`` method.
+- packet_net.py inventory script - fixed failure w.r.t. operating system retrieval by changing array subscription back to attribute access (https://github.com/ansible-collections/community.general/pull/891).

--- a/scripts/inventory/packet_net.py
+++ b/scripts/inventory/packet_net.py
@@ -346,9 +346,9 @@ class PacketInventory(object):
 
         # Inventory: Group by OS
         if self.group_by_operating_system:
-            self.push(self.inventory, device.operating_system['slug'], dest)
+            self.push(self.inventory, device.operating_system.__dict__['slug'], dest)
             if self.nested_groups:
-                self.push_group(self.inventory, 'operating_systems', device.operating_system['slug'])
+                self.push_group(self.inventory, 'operating_systems', device.operating_system.__dict__['slug'])
 
         # Inventory: Group by plan type
         if self.group_by_plan_type:
@@ -395,7 +395,7 @@ class PacketInventory(object):
             elif key == 'packet_facility':
                 device_vars[key] = value['code']
             elif key == 'packet_operating_system':
-                device_vars[key] = value['slug']
+                device_vars[key] = value.__dict__['slug']
             elif key == 'packet_plan':
                 device_vars[key] = value['slug']
             elif key == 'packet_tags':

--- a/scripts/inventory/packet_net.py
+++ b/scripts/inventory/packet_net.py
@@ -346,9 +346,9 @@ class PacketInventory(object):
 
         # Inventory: Group by OS
         if self.group_by_operating_system:
-            self.push(self.inventory, device.operating_system.__dict__['slug'], dest)
+            self.push(self.inventory, device.operating_system.slug, dest)
             if self.nested_groups:
-                self.push_group(self.inventory, 'operating_systems', device.operating_system.__dict__['slug'])
+                self.push_group(self.inventory, 'operating_systems', device.operating_system.slug)
 
         # Inventory: Group by plan type
         if self.group_by_plan_type:
@@ -395,7 +395,7 @@ class PacketInventory(object):
             elif key == 'packet_facility':
                 device_vars[key] = value['code']
             elif key == 'packet_operating_system':
-                device_vars[key] = value.__dict__['slug']
+                device_vars[key] = value.slug
             elif key == 'packet_plan':
                 device_vars[key] = value['slug']
             elif key == 'packet_tags':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fixed the broken inventory script for [packet_net.py](https://github.com/ansible-collections/community.general/blob/905239f530b712c3609ef375a2587dfe48d0a846/scripts/inventory/packet_net.py), and I have no idea why it was broken before (I am not the creator), but it appeared that it needed a dictionary object (or subscriptable object (don't know what that means, but looked it up [here](https://stackoverflow.com/questions/216972/what-does-it-mean-if-a-python-object-is-subscriptable-or-not)) and the object had a built in function called `__dict__` (which I figured out by importing the `python-packet` package (`import packet`) and did a `help(packet.OperatingSystem)` in python). So, I added that to the objects and the script worked... :slightly_smiling_face: 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
packet_net.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I added the `community.general` to my collections and did the ansible-galaxy 

<!--- Paste verbatim command output below, e.g. before and after your change -->

### Before change
#### command
```bash
$ python3 ~/.ansible/collections/ansible_collections/community/general/scripts/inventory/packet_net.py --list
```
#### result
```
Traceback (most recent call last):
  File "/home/vagrant/.ansible/collections/ansible_collections/community/general/scripts/inventory/packet_net.py", line 268, in get_devices_by_project
    self.add_device(device, project)
  File "/home/vagrant/.ansible/collections/ansible_collections/community/general/scripts/inventory/packet_net.py", line 349, in add_device
    self.push(self.inventory, device.operating_system['slug'], dest)
TypeError: 'OperatingSystem' object is not subscriptable
ERROR: "'OperatingSystem' object is not subscriptable", while: getting Packet devices
```

### After change
**NOTE:** yes, I know there is a root password pasted in the debug logs below, I have already deleted the instances so it is irrelevant
#### command
```bash
$ python3 /vagrant/packet_net.py --list
```
#### result
```yaml
{
  "1d51bfc2-da8d-45fb-9ecd-0585ed4665de": [
    "147.75.198.137"
  ],
  "35659f60-efc5-4a67-a458-d2f6d7badf6e": [
    "147.75.194.173"
  ],
  "_meta": {
    "hostvars": {
      "147.75.194.173": {
        "packet_always_pxe": false,
        "packet_billing_cycle": "hourly",
        "packet_bonding_mode": 5,
        "packet_created_at": "2020-09-16T05:17:57Z",
        "packet_description": "",
        "packet_facility": "ewr1",
        "packet_hardware_reservation_id": "",
        "packet_hostname": "ewr1-t1.small.x86-01",
        "packet_href": "/devices/35659f60-efc5-4a67-a458-d2f6d7badf6e",
        "packet_id": "35659f60-efc5-4a67-a458-d2f6d7badf6e",
        "packet_image_url": "",
        "packet_ipxe_script_url": "",
        "packet_iqn": "iqn.2020-09.net.packet:device.35659f60",
        "packet_locked": false,
        "packet_operating_system": "ubuntu_20_04",
        "packet_plan": "baremetal_0",
        "packet_provisioning_percentage": "",
        "packet_root_password": "9@H3$3Ox>Z",
        "packet_short_id": "35659f60",
        "packet_spot_instance": false,
        "packet_spot_price_max": "",
        "packet_state": "active",
        "packet_switch_uuid": "004ef92c",
        "packet_termination_time": "",
        "packet_updated_at": "2020-09-16T05:21:51Z",
        "packet_user": "root",
        "packet_userdata": ""
      },
      "147.75.198.137": {
        "packet_always_pxe": false,
        "packet_billing_cycle": "hourly",
        "packet_bonding_mode": 5,
        "packet_created_at": "2020-09-16T04:58:49Z",
        "packet_description": "",
        "packet_facility": "ewr1",
        "packet_hardware_reservation_id": "",
        "packet_hostname": "ewr1-t1.small.x86-01",
        "packet_href": "/devices/1d51bfc2-da8d-45fb-9ecd-0585ed4665de",
        "packet_id": "1d51bfc2-da8d-45fb-9ecd-0585ed4665de",
        "packet_image_url": "",
        "packet_ipxe_script_url": "",
        "packet_iqn": "iqn.2020-09.net.packet:device.1d51bfc2",
        "packet_locked": false,
        "packet_operating_system": "ubuntu_20_04",
        "packet_plan": "baremetal_0",
        "packet_provisioning_percentage": "",
        "packet_root_password": "tu)9nGV^32",
        "packet_short_id": "1d51bfc2",
        "packet_spot_instance": false,
        "packet_spot_price_max": "",
        "packet_state": "active",
        "packet_switch_uuid": "675d8200",
        "packet_termination_time": "",
        "packet_updated_at": "2020-09-16T05:02:10Z",
        "packet_user": "root",
        "packet_userdata": ""
      }
    }
  },
  "baremetal_0": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "dev-packer_kali_linux": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "ewr1": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "ewr1-t1.small.x86-01": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "packet": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "tag_none": [
    "147.75.194.173",
    "147.75.198.137"
  ],
  "ubuntu_20_04": [
    "147.75.194.173",
    "147.75.198.137"
  ]
}

```