### PR TITLE
Fix CI (problem with cffi)

### DIFF
--- a/tests/integration/targets/setup_docker/meta/main.yml
+++ b/tests/integration/targets/setup_docker/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - setup_remote_constraints
+  - setup_pkg_mgr

--- a/tests/integration/targets/setup_openssl/meta/main.yml
+++ b/tests/integration/targets/setup_openssl/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - setup_remote_constraints
   - setup_pkg_mgr

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -24,10 +24,8 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name:
-      - pyOpenSSL
-      # Yanked version which older versions of pip will still install:
-      - cffi>=1.14.2,!=1.14.3
+    name: pyOpenSSL
+    extra_args: "-c {{ remote_constraints }}"
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -27,7 +27,7 @@
     name:
       - pyOpenSSL
       # Yanked version which older versions of pip will still install:
-      - cffi!=1.14.3
+      - cffi>=1.14.2,!=1.14.3
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -24,7 +24,10 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL
+    name:
+      - pyOpenSSL
+      # Yanked version which older versions of pip will still install:
+      - cffi!=1.14.3
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -40,6 +40,7 @@ boto3 < 1.11 ; python_version < '2.7' # boto3 1.11 drops Python 2.6 support
 botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca; botocore 1.14 drops Python 2.6 support
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
+cffi != 1.14.3 # Yanked version which older versions of pip will still install:
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -40,7 +40,7 @@ boto3 < 1.11 ; python_version < '2.7' # boto3 1.11 drops Python 2.6 support
 botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca; botocore 1.14 drops Python 2.6 support
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
-cffi != 1.14.3 # Yanked version which older versions of pip will still install:
+cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
A version of cffi was yanked which makes pyOpenSSL crash, but pip on macOS is too old to know about yanked packages.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_openssl
