### PR TITLE
[aerospike_migrations] - handle exception for unstable-cluster

### DIFF
--- a/changelogs/fragments/900-aerospike-migration-handle-unstable-cluster.yaml
+++ b/changelogs/fragments/900-aerospike-migration-handle-unstable-cluster.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - aerospike_migrations - handle exception when unstable-cluster is returned

--- a/changelogs/fragments/900-aerospike-migration-handle-unstable-cluster.yaml
+++ b/changelogs/fragments/900-aerospike-migration-handle-unstable-cluster.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - aerospike_migrations - handle exception when unstable-cluster is returned
+  - aerospike_migrations - handle exception when unstable-cluster is returned (https://github.com/ansible-collections/community.general/pull/900).

--- a/plugins/modules/database/aerospike/aerospike_migrations.py
+++ b/plugins/modules/database/aerospike/aerospike_migrations.py
@@ -439,7 +439,12 @@ class Migrations:
         if target_cluster_size is not None:
             cmd = cmd + "size=" + str(target_cluster_size) + ";"
         for node in self._nodes:
-            cluster_key.add(self._info_cmd_helper(cmd, node))
+            try:
+                cluster_key.add(self._info_cmd_helper(cmd, node))
+            except aerospike.exception.ServerError as e: # unstable-cluster is returned in form of Exception
+                if 'unstable-cluster' in e.msg:
+                    return False
+                raise e
         if len(cluster_key) == 1:
             return True
         return False

--- a/plugins/modules/database/aerospike/aerospike_migrations.py
+++ b/plugins/modules/database/aerospike/aerospike_migrations.py
@@ -441,7 +441,7 @@ class Migrations:
         for node in self._nodes:
             try:
                 cluster_key.add(self._info_cmd_helper(cmd, node))
-            except aerospike.exception.ServerError as e: # unstable-cluster is returned in form of Exception
+            except aerospike.exception.ServerError as e:  # unstable-cluster is returned in form of Exception
                 if 'unstable-cluster' in e.msg:
                     return False
                 raise e


### PR DESCRIPTION
##### SUMMARY
When cluster is unstable, aerospike client raises a ServerError. We need to handle it in `_cluster_stable` so it doesn't bubble up to the module. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aerospike_migrations

##### ADDITIONAL INFORMATION
Before the fix, a cluster with pending migration will error out with the following error
```
FAILED! => {"changed": false, "msg": "Error: (1L, 'unstable-cluster, 127.0.0.1:3000', 'src/main/client/info_node.c', 177, False)"}
```
After:
it will continue to try until `tries_limit` is reached. which is working properly. 
