### PR TITLE
hashi_vault - Change token_path env var loading precedence

### DIFF
--- a/changelogs/fragments/902-hashi_vault-token-path.yml
+++ b/changelogs/fragments/902-hashi_vault-token-path.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - hashi_vault lookup - add ``VAULT_TOKEN_PATH`` as env option to specify ``token_path`` param
+  - hashi_vault lookup - add ``VAULT_TOKEN_FILE`` as env option to specify ``token_file`` param
+bugfixes:
+  - hashi_vault lookup - token_path in config file overridden by env HOME (https://github.com/ansible-collections/community.general/issues/373)

--- a/changelogs/fragments/902-hashi_vault-token-path.yml
+++ b/changelogs/fragments/902-hashi_vault-token-path.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - hashi_vault lookup - add ``VAULT_TOKEN_PATH`` as env option to specify ``token_path`` param
-  - hashi_vault lookup - add ``VAULT_TOKEN_FILE`` as env option to specify ``token_file`` param
+  - hashi_vault lookup - add ``VAULT_TOKEN_PATH`` as env option to specify ``token_path`` param (https://github.com/ansible-collections/community.general/issues/373).
+  - hashi_vault lookup - add ``VAULT_TOKEN_FILE`` as env option to specify ``token_file`` param (https://github.com/ansible-collections/community.general/issues/373).
 bugfixes:
-  - hashi_vault lookup - token_path in config file overridden by env HOME (https://github.com/ansible-collections/community.general/issues/373)
+  - hashi_vault lookup - ``token_path`` in config file overridden by env ``HOME`` (https://github.com/ansible-collections/community.general/issues/373).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -47,6 +47,7 @@ DOCUMENTATION = """
       description: If no token is specified, will try to read the token from this file in C(token_path).
       env:
         - name: VAULT_TOKEN_FILE
+          version_added: 1.2.0
       ini:
         - section: lookup_hashi_vault
           key: token_file

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -38,13 +38,15 @@ DOCUMENTATION = """
     token_path:
       description: If no token is specified, will try to read the token file from this path.
       env:
-        - name: HOME
+        - name: VAULT_TOKEN_PATH
       ini:
         - section: lookup_hashi_vault
           key: token_path
       version_added: '0.2.0'
     token_file:
       description: If no token is specified, will try to read the token from this file in C(token_path).
+      env:
+        - name: VAULT_TOKEN_FILE
       ini:
         - section: lookup_hashi_vault
           key: token_file
@@ -534,6 +536,11 @@ class LookupModule(LookupBase):
 
     def validate_auth_token(self, auth_method):
         if auth_method == 'token':
+            if not self.get_option('token_path'):
+                # generally we want env vars defined in the spec, but in this case we want
+                # the env var HOME to have lower precedence than any other value source,
+                # including ini, so we're doing it here after all other processing has taken place
+                self.set_option('token_path', os.environ.get('HOME'))
             if not self.get_option('token') and self.get_option('token_path'):
                 token_filename = os.path.join(
                     self.get_option('token_path'),

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -39,6 +39,7 @@ DOCUMENTATION = """
       description: If no token is specified, will try to read the token file from this path.
       env:
         - name: VAULT_TOKEN_PATH
+          version_added: 1.2.0
       ini:
         - section: lookup_hashi_vault
           key: token_path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #373 

As pointed out in that issue, setting the `token_path` via ini config is practically unusable, since the parameter also allows setting via the `$HOME` env var (which is pretty much always set, and can't be changed without affecting other things), and in Ansible env vars take precedence over ini values.

This is usually correct; but in most cases the env var is very specific to that config value and not really something that would be set accidentally.

The original intention of this setup was to fall back to the default location where the vault cli places the token file, but to be able to override the value via config.

----

This PR makes a few changes toward that:

* Removes `HOME` from the env vars in spec for `vault_path`
* Adds `VAULT_TOKEN_PATH` to the env vars in spec for `vault_path`
* Adds `VAULT_TOKEN_FILE` to the env vars in spec for `vault_file`
* Adds code that sets `vault_path` to the value of `$HOME` if no other values for `vault_path` are set first (effectively making the `HOME` var the value with the lowest precedence)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

