### PR TITLE
Support same reset actions on Managers as on Systems

### DIFF
--- a/changelogs/fragments/903-enhance-redfish-manager-reset-actions.yml
+++ b/changelogs/fragments/903-enhance-redfish-manager-reset-actions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - Support same reset actions on Managers as on Systems (https://github.com/ansible-collections/community.general/issues/901)

--- a/changelogs/fragments/903-enhance-redfish-manager-reset-actions.yml
+++ b/changelogs/fragments/903-enhance-redfish-manager-reset-actions.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - Support same reset actions on Managers as on Systems (https://github.com/ansible-collections/community.general/issues/901)
+  - redfish_command - support same reset actions on Managers as on Systems (https://github.com/ansible-collections/community.general/issues/901).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -710,24 +710,6 @@ class RedfishUtils(object):
     def get_multi_volume_inventory(self):
         return self.aggregate_systems(self.get_volume_inventory)
 
-    def restart_manager_gracefully(self):
-        result = {}
-        key = "Actions"
-
-        # Search for 'key' entry and extract URI from it
-        response = self.get_request(self.root_uri + self.manager_uri)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-        action_uri = data[key]["#Manager.Reset"]["target"]
-
-        payload = {'ResetType': 'GracefulRestart'}
-        response = self.post_request(self.root_uri + action_uri, payload)
-        if response['ret'] is False:
-            return response
-        return {'ret': True}
-
     def manage_indicator_led(self, command):
         result = {}
         key = 'IndicatorLED'
@@ -773,6 +755,14 @@ class RedfishUtils(object):
         return reset_type
 
     def manage_system_power(self, command):
+        return self.manage_power(command, self.systems_uri,
+                                 '#ComputerSystem.Reset')
+
+    def manage_manager_power(self, command):
+        return self.manage_power(command, self.manager_uri,
+                                 '#Manager.Reset')
+
+    def manage_power(self, command, resource_uri, action_name):
         key = "Actions"
         reset_type_values = ['On', 'ForceOff', 'GracefulShutdown',
                              'GracefulRestart', 'ForceRestart', 'Nmi',
@@ -790,8 +780,8 @@ class RedfishUtils(object):
         if reset_type not in reset_type_values:
             return {'ret': False, 'msg': 'Invalid Command (%s)' % command}
 
-        # read the system resource and get the current power state
-        response = self.get_request(self.root_uri + self.systems_uri)
+        # read the resource and get the current power state
+        response = self.get_request(self.root_uri + resource_uri)
         if response['ret'] is False:
             return response
         data = response['data']
@@ -803,13 +793,13 @@ class RedfishUtils(object):
         if power_state == "Off" and reset_type in ['GracefulShutdown', 'ForceOff']:
             return {'ret': True, 'changed': False}
 
-        # get the #ComputerSystem.Reset Action and target URI
-        if key not in data or '#ComputerSystem.Reset' not in data[key]:
-            return {'ret': False, 'msg': 'Action #ComputerSystem.Reset not found'}
-        reset_action = data[key]['#ComputerSystem.Reset']
+        # get the reset Action and target URI
+        if key not in data or action_name not in data[key]:
+            return {'ret': False, 'msg': 'Action %s not found' % action_name}
+        reset_action = data[key][action_name]
         if 'target' not in reset_action:
             return {'ret': False,
-                    'msg': 'target URI missing from Action #ComputerSystem.Reset'}
+                    'msg': 'target URI missing from Action %s' % action_name}
         action_uri = reset_action['target']
 
         # get AllowableValues


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support the same power reset actions on Managers as on Systems.

Fixes #901 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
After the change, a play like this can be created:
```paste below
---
- hosts: myhosts
  connection: local
  name: Turn manager power on
  gather_facts: False

  tasks:

  - name: Turn manager power on
    redfish_command:
      category: Manager
      command: PowerOn
      resource_id: BMC
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

Running it will produce output like this:
```
$ ansible-playbook -i myinventory.yml  playbooks/manager/power_on.yml

PLAY [Turn manager power on] *********************************************************

TASK [Turn manager power on] ***************************************************
ok: [mockup-localstorage]

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
