### PR TITLE
Support use of VAULT_NAMESPACE env var

### DIFF
--- a/changelogs/fragments/929-vault-namespace-support.yml
+++ b/changelogs/fragments/929-vault-namespace-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hashi_vault - support ``VAULT_NAMESPACE`` environment variable for namespaced lookups against Vault Enterprise (in addition to the ``namespace=`` flag supported today) (https://github.com/ansible-collections/community.general/pull/929).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -117,6 +117,9 @@ DOCUMENTATION = """
       default: True
     namespace:
       description: Namespace where secrets reside. Requires HVAC 0.7.0+ and Vault 0.11+.
+      env:
+        - name: VAULT_NAMESPACE
+          version_added: 1.2.0
     aws_profile:
         description: The AWS profile
         type: str


### PR DESCRIPTION
As per https://learn.hashicorp.com/tutorials/vault/namespaces, setting VAULT_NAMESPACE env var is a completely supported mechanism to make all vault command use said namespace, so hashi_vault lookup function should do the same.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix namespace support for the `hashi_vault` lookup function by allowing use of `VAULT_NAMESPACE`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`lookup('hashi_vault')`

##### ADDITIONAL INFORMATION
My local ansible environment is using an older version of this file where I also had to do this:

```
        self.namespace = kwargs.get('namespace', os.environ.get('VAULT_NAMESPACE'))
```

but it seems like with this version, adding this env var field here is all that needs to happen. This would be pretty hard to test with a non-empty `VAULT_NAMESPACE` value, given that the server in question would have to be running Vault Enterprise for the test to work.
