### PR TITLE
[PR #831 backport][stable-1] proxmox_kvm: new function wait_for_task()

### DIFF
--- a/changelogs/fragments/831-proxmox-kvm-wait.yml
+++ b/changelogs/fragments/831-proxmox-kvm-wait.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_kvm - improve handling of long-running tasks by creating a dedicated function (https://github.com/ansible-collections/community.general/pull/831).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1153,7 +1153,7 @@ def main():
 
             proxmox_node = proxmox.nodes(vm[0]['node'])
             if getattr(proxmox_node, VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
-              module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion or use force=yes." % vmid)
+                module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion." % vmid)
             taskid = getattr(proxmox_node, VZ_TYPE).delete(vmid)
             if not wait_for_task(module, proxmox, vm[0]['node'], taskid):
                 module.fail_json(msg='Reached timeout while waiting for removing VM. Last line in task before timeout: %s' %


### PR DESCRIPTION
Allows some factorization of redundant code in stop_vm(), start_vm(),
create_vm() and main().
This new function also waits one extra second after a successful task execution as the API can be a bit ahead of Proxmox.

Before:

    TASK [ansible-role-proxmox-instance : Ensure test-instance is created]
    changed: [localhost]

    TASK [ansible-role-proxmox-instance : Ensure test-instance is updated]
    fatal: [localhost]: FAILED! => changed=false
      msg: VM test-instance does not exist in cluster.

After:

    TASK [ansible-role-proxmox-instance : Ensure test-instance is created]
    changed: [localhost]

    TASK [ansible-role-proxmox-instance : Ensure test-instance is updated]
    changed: [localhost]

With suggestions from Felix Fontein <felix@fontein.de>.

(cherry picked from commit 9a5fe4c9afffed61e24b0493be663cbac746ee5f)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
