### PR TITLE
Fix zfs snapshot handling on root zvols

### DIFF
--- a/changelogs/fragments/zfs-root-snapshot.yml
+++ b/changelogs/fragments/zfs-root-snapshot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zfs - fixed ``invalid character '@' in pool name"`` error when working with snapshots on a root zvol (https://github.com/ansible-collections/community.general/issues/932).

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -90,7 +90,7 @@ class Zfs(object):
         self.changed = False
         self.zfs_cmd = module.get_bin_path('zfs', True)
         self.zpool_cmd = module.get_bin_path('zpool', True)
-        self.pool = name.split('/')[0]
+        self.pool = name.split('/')[0].split('@')[0]
         self.is_solaris = os.uname()[0] == 'SunOS'
         self.is_openzfs = self.check_openzfs()
         self.enhanced_sharing = self.check_enhanced_sharing()


### PR DESCRIPTION
Added support for snapshots when working with a root zvol that contains no / in its path.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated zfs.py to support working with snapshots when on the root zvol, Fixes #932 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zfs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The issue in #932 is caused because when working with a root zvol, there is no / i.e:
normally, when you have subvolumes, creating a snapshot would look like this: `myvol/mysubvol@snapshotname`
the code in the zfs.py module finds the root volume name by splitting out the /, which works fine for subvolumes.
but when you try to create a snapshot on the root volume, i.e `myvol@snapshotname` it errors, as the `.split('/')` doesn't split anything out, and so the full name `myvol@snapshotname` gets passed to `zpool version` hence the error. 
<!--- Paste verbatim command output below, e.g. before and after your change -->

before:
```
fatal: [hob-ssv]: FAILED! => {
    "changed": false,
    "cmd": "/usr/sbin/zpool get version ''",
    "invocation": {
        "module_args": {
            "extra_zfs_properties": {},
            "name": "hobraid2@daily_2020-09-18",
            "origin": null,
            "state": "present"
        }
    },
    "msg": "cannot open 'hobraid2@daily_2020-09-18':********@' in pool name",
    "rc": 1,
    "stderr": "cannot open 'hobraid2@daily_2020-09-18': invalid character '@' in pool name\n",
    "stderr_lines": [
        "cannot open 'hobraid2@daily_2020-09-18': invalid character '@' in pool name"
    ],
    "stdout": "",
    "stdout_lines": []
}
```
after:
```
ok: [hob-ssv] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "extra_zfs_properties": {},
            "name": "hobraid2@test",
            "origin": null,
            "state": "present"
        }
    },
    "name": "hobraid2@test",
    "state": "present"
}
```
