### PR TITLE
zypper_repository: Proper failure when python-xml is missing

### DIFF
--- a/changelogs/fragments/939-zypper_repository_proper_failure_on_missing_python-xml.yml
+++ b/changelogs/fragments/939-zypper_repository_proper_failure_on_missing_python-xml.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zypper_repository - proper failure when python-xml is missing (https://github.com/ansible-collections/community.general/pull/939).

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -143,7 +143,10 @@ def _parse_repos(module):
     """parses the output of zypper --xmlout repos and return a parse repo dictionary"""
     cmd = _get_cmd('--xmlout', 'repos')
 
-    from xml.dom.minidom import parseString as parseXML
+    try:
+        from xml.dom.minidom import parseString as parseXML
+    except ImportError:
+        module.fail_json(msg="python-xml is a requirement for zypper_repository module")
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc == 0:
         repos = []


### PR DESCRIPTION
##### SUMMARY
Fail appropriately when `python-xml` is missing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository

##### ADDITIONAL INFORMATION
This has been brought up on `#ansible IRC` first and someone faced this error when `python-xml` was missing:

```
- name: Repositorio > Agrega repositorio de descarga
  zypper_repository:
      name: bareos
      description: "{{ bareos_repo_desc }}"
      repo: "{{ bareos_repo_url }}"
      autorefresh: no
      auto_import_keys: yes
      runrefresh: yes
      state: present

{"changed": false, "module_stderr": "Shared connection to servidor.lan closed.
", "module_stdout": "Traceback (most recent call last):
  File \"/root/.ansible/tmp/ansible-tmp-1600580309.7887352-52465957645063/AnsiballZ_zypper_repository.py\", line 102, in <module>
    _ansiballz_main()
  File \"/root/.ansible/tmp/ansible-tmp-1600580309.7887352-52465957645063/AnsiballZ_zypper_repository.py\", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/root/.ansible/tmp/ansible-tmp-1600580309.7887352-52465957645063/AnsiballZ_zypper_repository.py\", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.packaging.os.zypper_repository', init_globals=None, run_name='__main__', alter_sys=True)
  File \"/usr/lib64/python2.7/runpy.py\", line 188, in run_module
    fname, loader, pkg_name)
  File \"/usr/lib64/python2.7/runpy.py\", line 82, in _run_module_code
    mod_name, mod_fname, mod_loader, pkg_name)
  File \"/usr/lib64/python2.7/runpy.py\", line 72, in _run_code
    exec code in run_globals
  File \"/tmp/ansible_zypper_repository_payload_unvp2R/ansible_zypper_repository_payload.zip/ansible/modules/packaging/os/zypper_repository.py\", line 397, in <module>
  File \"/tmp/ansible_zypper_repository_payload_unvp2R/ansible_zypper_repository_payload.zip/ansible/modules/packaging/os/zypper_repository.py\", line 370, in main
  File \"/tmp/ansible_zypper_repository_payload_unvp2R/ansible_zypper_repository_payload.zip/ansible/modules/packaging/os/zypper_repository.py\", line 198, in repo_exists
  File \"/tmp/ansible_zypper_repository_payload_unvp2R/ansible_zypper_repository_payload.zip/ansible/modules/packaging/os/zypper_repository.py\", line 152, in _parse_repos
ImportError: No module named xml.dom.minidom
", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

This PR tries to give a hint when the module cannot import `xml.dom.minidom`.