### PR TITLE
Use platform.system for Darwin comparisons

### DIFF
--- a/changelogs/fragments/945-darwin-timezone-py3.yaml
+++ b/changelogs/fragments/945-darwin-timezone-py3.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- timezone - Support Python3 on macos/darwin (https://github.com/ansible-collections/community.general/pull/945)

--- a/changelogs/fragments/945-darwin-timezone-py3.yaml
+++ b/changelogs/fragments/945-darwin-timezone-py3.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- timezone - Support Python3 on macos/darwin (https://github.com/ansible-collections/community.general/pull/945)
+- timezone - support Python3 on macos/darwin (https://github.com/ansible-collections/community.general/pull/945).

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -122,7 +122,7 @@ class Timezone(object):
                     module.fail_json(msg='Adjusting timezone is not supported in Global Zone')
 
             return super(Timezone, SmartOSTimezone).__new__(SmartOSTimezone)
-        elif re.match('^Darwin', platform.platform()):
+        elif platform.system() == 'Darwin':
             return super(Timezone, DarwinTimezone).__new__(DarwinTimezone)
         elif re.match('^(Free|Net|Open)BSD', platform.platform()):
             return super(Timezone, BSDTimezone).__new__(BSDTimezone)


### PR DESCRIPTION
##### SUMMARY
In Python3, `platform.platform()` returns `macOS-10.15.6-x86_64-i386-64bit` instead of `Darwin-10.15.6-x86_64-i386-64bit`. 

`platform.system()` returns `Darwin` On py2 and py3.
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/timezone.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
