### PR TITLE
ipa_user: Add userauthtype param

### DIFF
--- a/changelogs/fragments/951-ipa_user-add-userauthtype-param.yaml
+++ b/changelogs/fragments/951-ipa_user-add-userauthtype-param.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "ipa_user - add ``userauthtype`` param (https://github.com/ansible-collections/community.general/pull/951)."
+  - "ipa_user - add ``userauthtype`` option (https://github.com/ansible-collections/community.general/pull/951)."

--- a/changelogs/fragments/951-ipa_user-add-userauthtype-param.yaml
+++ b/changelogs/fragments/951-ipa_user-add-userauthtype-param.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "ipa_user - add ``userauthtype`` param (https://github.com/ansible-collections/community.general/pull/951)."

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -145,6 +145,15 @@ EXAMPLES = r'''
     ipa_user: admin
     ipa_pass: topsecret
     update_password: on_create
+
+- name: Ensure pinky is present and using one time password authentication
+  community.general.ipa_user:
+    name: pinky
+    state: present
+    userauthtype: otp
+    ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
 '''
 
 RETURN = r'''

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -95,6 +95,7 @@ options:
     - The authentication type to use for the user.
     choices: ["password", "radius", "otp", "pkinit", "hardened"]
     type: str
+    version_added: '1.2.0'
 extends_documentation_fragment:
 - community.general.ipa.documentation
 

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -90,6 +90,11 @@ options:
     - Default home directory of the user.
     type: str
     version_added: '0.2.0'
+  userauthtype:
+    description:
+    - The authentication type to use for the user.
+    choices: ["password", "radius", "otp", "pkinit", "hardened"]
+    type: str
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -182,7 +187,8 @@ class UserIPAClient(IPAClient):
 
 def get_user_dict(displayname=None, givenname=None, krbpasswordexpiration=None, loginshell=None,
                   mail=None, nsaccountlock=False, sn=None, sshpubkey=None, telephonenumber=None,
-                  title=None, userpassword=None, gidnumber=None, uidnumber=None, homedirectory=None):
+                  title=None, userpassword=None, gidnumber=None, uidnumber=None, homedirectory=None,
+                  userauthtype=None):
     user = {}
     if displayname is not None:
         user['displayname'] = displayname
@@ -211,6 +217,8 @@ def get_user_dict(displayname=None, givenname=None, krbpasswordexpiration=None, 
         user['uidnumber'] = uidnumber
     if homedirectory is not None:
         user['homedirectory'] = homedirectory
+    if userauthtype is not None:
+        user['ipauserauthtype'] = userauthtype
 
     return user
 
@@ -293,7 +301,8 @@ def ensure(module, client):
                                 telephonenumber=module.params['telephonenumber'], title=module.params['title'],
                                 userpassword=module.params['password'],
                                 gidnumber=module.params.get('gidnumber'), uidnumber=module.params.get('uidnumber'),
-                                homedirectory=module.params.get('homedirectory'))
+                                homedirectory=module.params.get('homedirectory'),
+                                userauthtype=module.params.get('userauthtype'))
 
     update_password = module.params.get('update_password')
     ipa_user = client.user_find(name=name)
@@ -340,7 +349,9 @@ def main():
                                     choices=['present', 'absent', 'enabled', 'disabled']),
                          telephonenumber=dict(type='list', elements='str'),
                          title=dict(type='str'),
-                         homedirectory=dict(type='str'))
+                         homedirectory=dict(type='str'),
+                         userauthtype=dict(type='str',
+                                           choices=['password', 'radius', 'otp', 'pkinit', 'hardened']))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `userauthtype` param to allow setting an IPA user's authentication type.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipa_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
[Freeipa client API docs for ipauserauthtype param](https://python-freeipa.readthedocs.io/en/latest/index.html?highlight=user_mod#python_freeipa.client_meta.ClientMeta.user_mod)
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```