### PR TITLE
Add headers to ci tests

### DIFF
--- a/tests/integration/targets/aix_devices/tasks/main.yml
+++ b/tests/integration/targets/aix_devices/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/aix_devices/tasks/main.yml
+++ b/tests/integration/targets/aix_devices/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Scan new devices.
   aix_devices:
     device: all

--- a/tests/integration/targets/aix_filesystem/tasks/main.yml
+++ b/tests/integration/targets/aix_filesystem/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/aix_filesystem/tasks/main.yml
+++ b/tests/integration/targets/aix_filesystem/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Umounting /testfs
   aix_filesystem:
     filesystem: /testfs

--- a/tests/integration/targets/alternatives/tasks/main.yml
+++ b/tests/integration/targets/alternatives/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/alternatives/tasks/main.yml
+++ b/tests/integration/targets/alternatives/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Copyright (c) 2017 Pierre-Louis Bonicoli <pierre-louis.bonicoli@libregerbil.fr>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/apache2_module/tasks/main.yml
+++ b/tests/integration/targets/apache2_module/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 
 
 - name:

--- a/tests/integration/targets/apache2_module/tasks/main.yml
+++ b/tests/integration/targets/apache2_module/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the archive module.
 # (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 

--- a/tests/integration/targets/callback_diy/tasks/main.yml
+++ b/tests/integration/targets/callback_diy/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/callback_diy/tasks/main.yml
+++ b/tests/integration/targets/callback_diy/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Set tests
   set_fact:
     tests:

--- a/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: test cloud-init
   # TODO: check for a workaround
   # install 'cloud-init'' failed: dpkg-divert: error: `diversion of /etc/init/ureadahead.conf

--- a/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install Consul and test
   vars:
     consul_version: 1.5.0

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create EMAIL cron var
   cronvar:
     name: EMAIL

--- a/tests/integration/targets/cronvar/tasks/main.yml
+++ b/tests/integration/targets/cronvar/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/deploy_helper/tasks/main.yml
+++ b/tests/integration/targets/deploy_helper/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: record the output directory
   set_fact: deploy_helper_test_root={{output_dir}}/deploy_helper_test_root
 

--- a/tests/integration/targets/deploy_helper/tasks/main.yml
+++ b/tests/integration/targets/deploy_helper/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_config/tasks/main.yml
+++ b/tests/integration/targets/docker_config/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_config/tasks/main.yml
+++ b/tests/integration/targets/docker_config/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_docker_config.yml
   when: docker_py_version is version('2.6.0', '>=') and docker_api_version is version('1.30', '>=')
 

--- a/tests/integration/targets/docker_container/tasks/main.yml
+++ b/tests/integration/targets/docker_container/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Create random name prefix (for containers, networks, ...)
 - name: Create random container name prefix
   set_fact:

--- a/tests/integration/targets/docker_container/tasks/main.yml
+++ b/tests/integration/targets/docker_container/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_container_info/tasks/main.yml
+++ b/tests/integration/targets/docker_container_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Create random container name
     set_fact:

--- a/tests/integration/targets/docker_container_info/tasks/main.yml
+++ b/tests/integration/targets/docker_container_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_host_info/tasks/main.yml
+++ b/tests/integration/targets/docker_host_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_host_info/tasks/main.yml
+++ b/tests/integration/targets/docker_host_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_host_info.yml
   when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.21', '>=')
 

--- a/tests/integration/targets/docker_image/tasks/main.yml
+++ b/tests/integration/targets/docker_image/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_image/tasks/main.yml
+++ b/tests/integration/targets/docker_image/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - when: ansible_facts.distribution ~ ansible_facts.distribution_major_version not in ['CentOS6', 'RedHat6']
   include_tasks:
     file: test.yml

--- a/tests/integration/targets/docker_image_info/tasks/main.yml
+++ b/tests/integration/targets/docker_image_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Make sure image is not there
     docker_image:

--- a/tests/integration/targets/docker_image_info/tasks/main.yml
+++ b/tests/integration/targets/docker_image_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_login/tasks/main.yml
+++ b/tests/integration/targets/docker_login/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_login/tasks/main.yml
+++ b/tests/integration/targets/docker_login/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - when: ansible_facts.distribution ~ ansible_facts.distribution_major_version not in ['CentOS6', 'RedHat6']
   include_tasks:
     file: test.yml

--- a/tests/integration/targets/docker_network/tasks/main.yml
+++ b/tests/integration/targets/docker_network/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create random name prefix
   set_fact:
     name_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"

--- a/tests/integration/targets/docker_network/tasks/main.yml
+++ b/tests/integration/targets/docker_network/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_network_info/tasks/main.yml
+++ b/tests/integration/targets/docker_network_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Create random network name
     set_fact:

--- a/tests/integration/targets/docker_network_info/tasks/main.yml
+++ b/tests/integration/targets/docker_network_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_node/tasks/main.yml
+++ b/tests/integration/targets/docker_node/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Run the tests
 - block:
   - include_tasks: test_node.yml

--- a/tests/integration/targets/docker_node/tasks/main.yml
+++ b/tests/integration/targets/docker_node/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_node_info/tasks/main.yml
+++ b/tests/integration/targets/docker_node_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_node_info/tasks/main.yml
+++ b/tests/integration/targets/docker_node_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_node_info.yml
   # Maximum of 1.24 (docker API version for docker_node_info) and 1.25 (docker API version for docker_swarm) is 1.25
   when: docker_py_version is version('2.4.0', '>=') and docker_api_version is version('1.25', '>=')

--- a/tests/integration/targets/docker_prune/tasks/main.yml
+++ b/tests/integration/targets/docker_prune/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create random names
   set_fact:
     cname: "{{ 'ansible-container-%0x' % ((2**32) | random) }}"

--- a/tests/integration/targets/docker_prune/tasks/main.yml
+++ b/tests/integration/targets/docker_prune/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_secret/tasks/main.yml
+++ b/tests/integration/targets/docker_secret/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_secret/tasks/main.yml
+++ b/tests/integration/targets/docker_secret/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_secrets.yml
   when: docker_py_version is version('2.1.0', '>=') and docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_stack/tasks/main.yml
+++ b/tests/integration/targets/docker_stack/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_stack/tasks/main.yml
+++ b/tests/integration/targets/docker_stack/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_stack.yml
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_stack_info/tasks/main.yml
+++ b/tests/integration/targets/docker_stack_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_stack_info/tasks/main.yml
+++ b/tests/integration/targets/docker_stack_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_stack_info.yml
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_stack_task_info/tasks/main.yml
+++ b/tests/integration/targets/docker_stack_task_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_stack_task_info/tasks/main.yml
+++ b/tests/integration/targets/docker_stack_task_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_stack_task_info.yml
   when: docker_api_version is version('1.25', '>=')
 

--- a/tests/integration/targets/docker_swarm/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_swarm/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Run Docker Swarm tests
   when:
     - docker_py_version is version('1.10.0', '>=')

--- a/tests/integration/targets/docker_swarm_info/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_swarm_info/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_swarm_info.yml
   # Maximum of 1.24 (docker API version for docker_swarm_info) and 1.25 (docker API version for docker_swarm) is 1.25
   when: docker_py_version is version('1.10.0', '>=') and docker_api_version is version('1.25', '>=')

--- a/tests/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 
 # Create random name prefix (for containers, networks, ...)
 - name: Create random name prefix

--- a/tests/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_service/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_swarm_service_info/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_service_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: test_docker_swarm_service_info.yml
   when: docker_py_version is version('2.0.0', '>=') and docker_api_version is version('1.24', '>=')
 

--- a/tests/integration/targets/docker_swarm_service_info/tasks/main.yml
+++ b/tests/integration/targets/docker_swarm_service_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_volume/tasks/main.yml
+++ b/tests/integration/targets/docker_volume/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create random name prefix
   set_fact:
     name_prefix: "{{ 'ansible-test-%0x' % ((2**32) | random) }}"

--- a/tests/integration/targets/docker_volume/tasks/main.yml
+++ b/tests/integration/targets/docker_volume/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/docker_volume_info/tasks/main.yml
+++ b/tests/integration/targets/docker_volume_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - name: Create random volume name
     set_fact:

--- a/tests/integration/targets/docker_volume_info/tasks/main.yml
+++ b/tests/integration/targets/docker_volume_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/dpkg_divert/tasks/main.yml
+++ b/tests/integration/targets/dpkg_divert/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: "include tasks for Debian family"
   include_tasks: prepare.yml
   when: ansible_pkg_mgr == "apt"

--- a/tests/integration/targets/dpkg_divert/tasks/main.yml
+++ b/tests/integration/targets/dpkg_divert/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/etcd3/tasks/main.yml
+++ b/tests/integration/targets/etcd3/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/etcd3/tasks/main.yml
+++ b/tests/integration/targets/etcd3/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the etcd3 module
 # (c) 2017,  Jean-Philippe Evrard <jean-philippe@evrard.me>
 

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - debug:
     msg: '{{ role_name }}'
 - debug:

--- a/tests/integration/targets/filter_jc/tasks/main.yml
+++ b/tests/integration/targets/filter_jc/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: test jc key/value parser
   assert:
     that:

--- a/tests/integration/targets/filter_jc/tasks/main.yml
+++ b/tests/integration/targets/filter_jc/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/filter_json_query/tasks/main.yml
+++ b/tests/integration/targets/filter_json_query/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Test json_query filter
   assert:
     that:

--- a/tests/integration/targets/filter_json_query/tasks/main.yml
+++ b/tests/integration/targets/filter_json_query/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/filter_random_mac/tasks/main.yml
+++ b/tests/integration/targets/filter_random_mac/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/filter_random_mac/tasks/main.yml
+++ b/tests/integration/targets/filter_random_mac/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for filters
 # Copyright: (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
 # Copyright: (c) 2019, Ansible Project

--- a/tests/integration/targets/filter_time/tasks/main.yml
+++ b/tests/integration/targets/filter_time/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: test to_milliseconds filter
   assert:
     that:

--- a/tests/integration/targets/filter_time/tasks/main.yml
+++ b/tests/integration/targets/filter_time/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/flatpak/tasks/main.yml
+++ b/tests/integration/targets/flatpak/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/flatpak/tasks/main.yml
+++ b/tests/integration/targets/flatpak/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # (c) 2018, Alexander Bethke <oolongbrothers@gmx.net>
 # (c) 2018, Ansible Project
 

--- a/tests/integration/targets/flatpak_remote/tasks/main.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/flatpak_remote/tasks/main.yml
+++ b/tests/integration/targets/flatpak_remote/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # (c) 2018, Alexander Bethke <oolongbrothers@gmx.net>
 # (c) 2018, Ansible Project
 

--- a/tests/integration/targets/gem/tasks/main.yml
+++ b/tests/integration/targets/gem/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gem/tasks/main.yml
+++ b/tests/integration/targets/gem/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the gem module
 # (c) 2014, James Tanner <tanner.jc@gmail.com>
 

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the git_config module
 
 - name: setup

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/github_issue/tasks/main.yml
+++ b/tests/integration/targets/github_issue/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/github_issue/tasks/main.yml
+++ b/tests/integration/targets/github_issue/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the github_issue module.
 #
 # Copyright: (c) 2017-2018, Abhijeet Kasurde <akasurde@redhat.com>

--- a/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
+++ b/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
+++ b/tests/integration/targets/gitlab_deploy_key/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_group_members/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_members/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for gitlab_group_members module
 #
 # Copyright: (c) 2020, Zainab Alsaffar <Zainab.Alsaffar@mail.rit.edu>

--- a/tests/integration/targets/gitlab_group_members/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_members/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_hook/tasks/main.yml
+++ b/tests/integration/targets/gitlab_hook/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_hook/tasks/main.yml
+++ b/tests/integration/targets/gitlab_hook/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_project/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_project/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_runner/tasks/main.yml
+++ b/tests/integration/targets/gitlab_runner/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_runner/tasks/main.yml
+++ b/tests/integration/targets/gitlab_runner/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/gitlab_user/tasks/main.yml
+++ b/tests/integration/targets/gitlab_user/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/gitlab_user/tasks/main.yml
+++ b/tests/integration/targets/gitlab_user/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required libs
   pip:
     name: python-gitlab

--- a/tests/integration/targets/hg/tasks/main.yml
+++ b/tests/integration/targets/hg/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the hg module
 # (c) 2014, James Tanner <tanner.jc@gmail.com>
 

--- a/tests/integration/targets/hg/tasks/main.yml
+++ b/tests/integration/targets/hg/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/homebrew/tasks/main.yml
+++ b/tests/integration/targets/homebrew/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the homebrew module.
 # Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/homebrew/tasks/main.yml
+++ b/tests/integration/targets/homebrew/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
+++ b/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
+++ b/tests/integration/targets/hwc_ecs_instance/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_evs_disk/tasks/main.yml
+++ b/tests/integration/targets/hwc_evs_disk/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: delete a disk
   hwc_evs_disk:
     availability_zone: "cn-north-1a"

--- a/tests/integration/targets/hwc_evs_disk/tasks/main.yml
+++ b/tests/integration/targets/hwc_evs_disk/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_network_vpc/tasks/main.yml
+++ b/tests/integration/targets/hwc_network_vpc/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # ----------------------------------------------------------------------------
 #
 #     ***     AUTO GENERATED CODE    ***    AUTO GENERATED CODE     ***

--- a/tests/integration/targets/hwc_network_vpc/tasks/main.yml
+++ b/tests/integration/targets/hwc_network_vpc/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_smn_topic/tasks/main.yml
+++ b/tests/integration/targets/hwc_smn_topic/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_smn_topic/tasks/main.yml
+++ b/tests/integration/targets/hwc_smn_topic/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: delete a smn topic
   hwc_smn_topic:
       identity_endpoint: "{{ identity_endpoint }}"

--- a/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_eip/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_peering_connect/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_port/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_port/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_port/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_port/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_private_ip/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_route/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_route/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_route/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_route/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: delete a security group
   hwc_vpc_security_group:

--- a/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a security group
   hwc_vpc_security_group:

--- a/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_security_group_rule/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Pre-test setup
 - name: create a vpc
   hwc_network_vpc:

--- a/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/hwc_vpc_subnet/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/influxdb_user/tasks/main.yml
+++ b/tests/integration/targets/influxdb_user/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 
 - include: tests.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/tests/integration/targets/influxdb_user/tasks/main.yml
+++ b/tests/integration/targets/influxdb_user/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ini_file/tasks/main.yml
+++ b/tests/integration/targets/ini_file/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for ini_file plugins
 # (c) 2017 Red Hat Inc.
 

--- a/tests/integration/targets/ini_file/tasks/main.yml
+++ b/tests/integration/targets/ini_file/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ipify_facts/tasks/main.yml
+++ b/tests/integration/targets/ipify_facts/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ipify_facts/tasks/main.yml
+++ b/tests/integration/targets/ipify_facts/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the ipify_facts
 # (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 

--- a/tests/integration/targets/iptables_state/tasks/main.yml
+++ b/tests/integration/targets/iptables_state/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: ensure iptables package is installed
   package:
     name:

--- a/tests/integration/targets/iptables_state/tasks/main.yml
+++ b/tests/integration/targets/iptables_state/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ipwcli_dns/tasks/main.yml
+++ b/tests/integration/targets/ipwcli_dns/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for ipwcli_dns
 
 - name: variables username, password, container, tld must be set

--- a/tests/integration/targets/ipwcli_dns/tasks/main.yml
+++ b/tests/integration/targets/ipwcli_dns/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/iso_create/tasks/main.yml
+++ b/tests/integration/targets/iso_create/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/iso_create/tasks/main.yml
+++ b/tests/integration/targets/iso_create/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for iso_create module
 # Copyright: (c) 2020, Diane Wang (Tomorrow9) <dianew@vmware.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/iso_extract/tasks/main.yml
+++ b/tests/integration/targets/iso_extract/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/iso_extract/tasks/main.yml
+++ b/tests/integration/targets/iso_extract/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the iso_extract module.
 # (c) 2017, James Tanner <tanner.jc@gmail.com>
 # (c) 2017, Dag Wieers <dag@wieers.com>

--- a/tests/integration/targets/java_cert/tasks/main.yml
+++ b/tests/integration/targets/java_cert/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: prep pkcs12 file
   copy: src="{{ test_pkcs12_path }}" dest="{{output_dir}}/{{ test_pkcs12_path }}"
 

--- a/tests/integration/targets/java_cert/tasks/main.yml
+++ b/tests/integration/targets/java_cert/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/jboss/tasks/main.yml
+++ b/tests/integration/targets/jboss/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/jboss/tasks/main.yml
+++ b/tests/integration/targets/jboss/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: jboss.yml

--- a/tests/integration/targets/launchd/tasks/main.yml
+++ b/tests/integration/targets/launchd/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 
 - name: Test launchd module
   block:

--- a/tests/integration/targets/launchd/tasks/main.yml
+++ b/tests/integration/targets/launchd/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ldap_search/tasks/main.yml
+++ b/tests/integration/targets/ldap_search/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/ldap_search/tasks/main.yml
+++ b/tests/integration/targets/ldap_search/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Run LDAP search module tests
   block:
     - include_tasks: "{{ item }}"

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test playbook for the listen_ports_facts module
 # Copyright: (c) 2019, Nathan Davison <ndavison85@gmail.com>
 

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # (c) 2014, James Tanner <tanner.jc@gmail.com>
 
 # This file is part of Ansible

--- a/tests/integration/targets/lookup_cartesian/tasks/main.yml
+++ b/tests/integration/targets/lookup_cartesian/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Test cartesian lookup
   debug: var=item
   register: product

--- a/tests/integration/targets/lookup_cartesian/tasks/main.yml
+++ b/tests/integration/targets/lookup_cartesian/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lookup_etcd3/tasks/main.yml
+++ b/tests/integration/targets/lookup_etcd3/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # lookup_etcd3 integration tests
 # 2020, SCC France, Eric Belhomme <ebelhomme@fr.scc.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/lookup_etcd3/tasks/main.yml
+++ b/tests/integration/targets/lookup_etcd3/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lookup_flattened/tasks/main.yml
+++ b/tests/integration/targets/lookup_flattened/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lookup_flattened/tasks/main.yml
+++ b/tests/integration/targets/lookup_flattened/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: test with_flattened
   set_fact: '{{ item }}=flattened'
   with_community.general.flattened:

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install Hashi Vault on controlled node and test
   vars:
     vault_version: '0.11.0'

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
     - include_tasks: package.yml
     - include_tasks: tests.yml

--- a/tests/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lvg/tasks/main.yml
+++ b/tests/integration/targets/lvg/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/lvg/tasks/main.yml
+++ b/tests/integration/targets/lvg/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install required packages (Linux)
   package:
     name: lvm2

--- a/tests/integration/targets/mail/tasks/main.yml
+++ b/tests/integration/targets/mail/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/mail/tasks/main.yml
+++ b/tests/integration/targets/mail/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # TODO: Our current implementation does not handle SMTP authentication
 
 # NOTE: If the system does not support smtpd-tls (python 2.6 and older) we do basic tests

--- a/tests/integration/targets/mas/tasks/main.yml
+++ b/tests/integration/targets/mas/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/mas/tasks/main.yml
+++ b/tests/integration/targets/mas/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the mas module.
 # Copyright: (c) 2020, Lukas Bestle <project-ansible@lukasbestle.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/memset_dns_reload/tasks/main.yml
+++ b/tests/integration/targets/memset_dns_reload/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_dns_reload/tasks/main.yml
+++ b/tests/integration/targets/memset_dns_reload/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: request reload with invalid API key
   memset_dns_reload:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"

--- a/tests/integration/targets/memset_memstore_info/tasks/main.yml
+++ b/tests/integration/targets/memset_memstore_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: query API with invalid API key
   memset_memstore_info:
     api_key: 'wa9aerahhie0eekee9iaphoorovooyia'

--- a/tests/integration/targets/memset_memstore_info/tasks/main.yml
+++ b/tests/integration/targets/memset_memstore_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_server_info/tasks/main.yml
+++ b/tests/integration/targets/memset_server_info/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: query API with invalid API key
   memset_server_info:
     api_key: 'wa9aerahhie0eekee9iaphoorovooyia'

--- a/tests/integration/targets/memset_server_info/tasks/main.yml
+++ b/tests/integration/targets/memset_server_info/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_zone/tasks/main.yml
+++ b/tests/integration/targets/memset_zone/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: create random string
   set_fact:
     zone_name: "{{ 65535 | random | string }}.ansible.example.com"

--- a/tests/integration/targets/memset_zone/tasks/main.yml
+++ b/tests/integration/targets/memset_zone/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_zone_domain/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_domain/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: create domain with invalid API key
   memset_zone_domain:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"

--- a/tests/integration/targets/memset_zone_domain/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_domain/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_zone_record/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/memset_zone_record/tasks/main.yml
+++ b/tests/integration/targets/memset_zone_record/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: create record with incorrect API key
   memset_zone_record:
     api_key: "wa9aerahhie0eekee9iaphoorovooyia"

--- a/tests/integration/targets/mqtt/tasks/main.yml
+++ b/tests/integration/targets/mqtt/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/mqtt/tasks/main.yml
+++ b/tests/integration/targets/mqtt/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: ubuntu.yml
   when: 
     - ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/nios_a_record/tasks/main.yml
+++ b/tests/integration/targets/nios_a_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_a_record/tasks/main.yml
+++ b/tests/integration/targets/nios_a_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_a_record_idempotence.yml

--- a/tests/integration/targets/nios_aaaa_record/tasks/main.yml
+++ b/tests/integration/targets/nios_aaaa_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_aaaa_record/tasks/main.yml
+++ b/tests/integration/targets/nios_aaaa_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_aaaa_record_idempotence.yml

--- a/tests/integration/targets/nios_cname_record/tasks/main.yml
+++ b/tests/integration/targets/nios_cname_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_cname_record/tasks/main.yml
+++ b/tests/integration/targets/nios_cname_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_cname_record_idempotence.yml

--- a/tests/integration/targets/nios_dns_view/tasks/main.yml
+++ b/tests/integration/targets/nios_dns_view/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_dns_view/tasks/main.yml
+++ b/tests/integration/targets/nios_dns_view/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_dns_view_idempotence.yml

--- a/tests/integration/targets/nios_host_record/tasks/main.yml
+++ b/tests/integration/targets/nios_host_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_host_record_idempotence.yml

--- a/tests/integration/targets/nios_host_record/tasks/main.yml
+++ b/tests/integration/targets/nios_host_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_mx_record/tasks/main.yml
+++ b/tests/integration/targets/nios_mx_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_mx_record/tasks/main.yml
+++ b/tests/integration/targets/nios_mx_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_mx_record_idempotence.yml

--- a/tests/integration/targets/nios_naptr_record/tasks/main.yml
+++ b/tests/integration/targets/nios_naptr_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_naptr_record/tasks/main.yml
+++ b/tests/integration/targets/nios_naptr_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_naptr_record_idempotence.yml

--- a/tests/integration/targets/nios_network/tasks/main.yml
+++ b/tests/integration/targets/nios_network/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_network/tasks/main.yml
+++ b/tests/integration/targets/nios_network/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_network_idempotence.yml

--- a/tests/integration/targets/nios_network_view/tasks/main.yml
+++ b/tests/integration/targets/nios_network_view/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_network_view/tasks/main.yml
+++ b/tests/integration/targets/nios_network_view/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_network_view_idempotence.yml

--- a/tests/integration/targets/nios_ptr_record/tasks/main.yml
+++ b/tests/integration/targets/nios_ptr_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_ptr_record/tasks/main.yml
+++ b/tests/integration/targets/nios_ptr_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_ptr_record_idempotence.yml

--- a/tests/integration/targets/nios_srv_record/tasks/main.yml
+++ b/tests/integration/targets/nios_srv_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_srv_record/tasks/main.yml
+++ b/tests/integration/targets/nios_srv_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_srv_record_idempotence.yml

--- a/tests/integration/targets/nios_txt_record/tasks/main.yml
+++ b/tests/integration/targets/nios_txt_record/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/nios_txt_record/tasks/main.yml
+++ b/tests/integration/targets/nios_txt_record/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_txt_record_idempotence.yml

--- a/tests/integration/targets/nios_zone/tasks/main.yml
+++ b/tests/integration/targets/nios_zone/tasks/main.yml
@@ -1,1 +1,6 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: nios_zone_idempotence.yml

--- a/tests/integration/targets/nios_zone/tasks/main.yml
+++ b/tests/integration/targets/nios_zone/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/npm/tasks/main.yml
+++ b/tests/integration/targets/npm/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/npm/tasks/main.yml
+++ b/tests/integration/targets/npm/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the npm module
 
 # This file is part of Ansible

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 #
 # Test for proper failures without pyodbc
 #

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/one_host/tasks/main.yml
+++ b/tests/integration/targets/one_host/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/one_host/tasks/main.yml
+++ b/tests/integration/targets/one_host/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the one_host module
 
 

--- a/tests/integration/targets/osx_defaults/tasks/main.yml
+++ b/tests/integration/targets/osx_defaults/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/osx_defaults/tasks/main.yml
+++ b/tests/integration/targets/osx_defaults/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the osx_defaults module.
 # Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Test code for the pids module
 # Copyright: (c) 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_copy/tasks/main.yml
+++ b/tests/integration/targets/postgresql_copy/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_copy/tasks/main.yml
+++ b/tests/integration/targets/postgresql_copy/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_copy module
 - import_tasks: postgresql_copy_initial.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/postgresql_db/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/postgresql_db/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: postgresql_db_session_role.yml
 
 # Initial tests of postgresql_db module:

--- a/tests/integration/targets/postgresql_ext/tasks/main.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: postgresql_ext_session_role.yml
 
 # Initial CI tests of postgresql_ext module.

--- a/tests/integration/targets/postgresql_ext/tasks/main.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_idx/tasks/main.yml
+++ b/tests/integration/targets/postgresql_idx/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_idx/tasks/main.yml
+++ b/tests/integration/targets/postgresql_idx/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_idx module
 - import_tasks: postgresql_idx_initial.yml

--- a/tests/integration/targets/postgresql_info/tasks/main.yml
+++ b/tests/integration/targets/postgresql_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_info/tasks/main.yml
+++ b/tests/integration/targets/postgresql_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # For testing getting publication and subscription info
 - import_tasks: setup_publication.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'

--- a/tests/integration/targets/postgresql_lang/tasks/main.yml
+++ b/tests/integration/targets/postgresql_lang/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_lang/tasks/main.yml
+++ b/tests/integration/targets/postgresql_lang/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Include distribution specific variables
   include_vars: "{{ lookup('first_found', params) }}"
   vars:

--- a/tests/integration/targets/postgresql_membership/tasks/main.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_membership/tasks/main.yml
+++ b/tests/integration/targets/postgresql_membership/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_membership module
 - import_tasks: postgresql_membership_initial.yml

--- a/tests/integration/targets/postgresql_owner/tasks/main.yml
+++ b/tests/integration/targets/postgresql_owner/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_owner/tasks/main.yml
+++ b/tests/integration/targets/postgresql_owner/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_owner module
 - import_tasks: postgresql_owner_initial.yml
   when:

--- a/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_pg_hba module
 - import_tasks: postgresql_pg_hba_initial.yml

--- a/tests/integration/targets/postgresql_ping/tasks/main.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_ping/tasks/main.yml
+++ b/tests/integration/targets/postgresql_ping/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_ping module
 - import_tasks: postgresql_ping_initial.yml
   vars:

--- a/tests/integration/targets/postgresql_privs/tasks/main.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_privs/tasks/main.yml
+++ b/tests/integration/targets/postgresql_privs/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: postgresql_privs_session_role.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')
 

--- a/tests/integration/targets/postgresql_publication/tasks/main.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_publication/tasks/main.yml
+++ b/tests/integration/targets/postgresql_publication/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_publication module
 - import_tasks: postgresql_publication_initial.yml
   when: postgres_version_resp.stdout is version('10', '>=')

--- a/tests/integration/targets/postgresql_query/tasks/main.yml
+++ b/tests/integration/targets/postgresql_query/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_query/tasks/main.yml
+++ b/tests/integration/targets/postgresql_query/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_query module
 - import_tasks: postgresql_query_initial.yml

--- a/tests/integration/targets/postgresql_schema/tasks/main.yml
+++ b/tests/integration/targets/postgresql_schema/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_schema/tasks/main.yml
+++ b/tests/integration/targets/postgresql_schema/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - import_tasks: postgresql_schema_session_role.yml
 
 # Initial CI tests of postgresql_schema module

--- a/tests/integration/targets/postgresql_sequence/tasks/main.yml
+++ b/tests/integration/targets/postgresql_sequence/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_sequence/tasks/main.yml
+++ b/tests/integration/targets/postgresql_sequence/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_sequence module
 - import_tasks: postgresql_sequence_initial.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/postgresql_set/tasks/main.yml
+++ b/tests/integration/targets/postgresql_set/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_set/tasks/main.yml
+++ b/tests/integration/targets/postgresql_set/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_initial module
 - include_tasks: postgresql_set_initial.yml
   when: postgres_version_resp.stdout is version('9.6', '>=')

--- a/tests/integration/targets/postgresql_slot/tasks/main.yml
+++ b/tests/integration/targets/postgresql_slot/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_slot/tasks/main.yml
+++ b/tests/integration/targets/postgresql_slot/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_slot module
 # Physical replication slots are available since PostgreSQL 9.4
 - import_tasks: postgresql_slot_initial.yml

--- a/tests/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/tests/integration/targets/postgresql_subscription/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial tests of postgresql_subscription module:
 
 - import_tasks: setup_publication.yml

--- a/tests/integration/targets/postgresql_table/tasks/main.yml
+++ b/tests/integration/targets/postgresql_table/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_table module
 - import_tasks: postgresql_table_initial.yml

--- a/tests/integration/targets/postgresql_table/tasks/main.yml
+++ b/tests/integration/targets/postgresql_table/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_tablespace/tasks/main.yml
+++ b/tests/integration/targets/postgresql_tablespace/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_tablespace/tasks/main.yml
+++ b/tests/integration/targets/postgresql_tablespace/tasks/main.yml
@@ -1,2 +1,7 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_tablespace module
 - import_tasks: postgresql_tablespace_initial.yml

--- a/tests/integration/targets/postgresql_user/tasks/main.yml
+++ b/tests/integration/targets/postgresql_user/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_user/tasks/main.yml
+++ b/tests/integration/targets/postgresql_user/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial CI tests of postgresql_user module
 - import_tasks: postgresql_user_initial.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/postgresql_user_obj_stat_info/tasks/main.yml
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/postgresql_user_obj_stat_info/tasks/main.yml
+++ b/tests/integration/targets/postgresql_user_obj_stat_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Initial tests of postgresql_user_obj_stat_info module:
 - import_tasks: postgresql_user_obj_stat_info.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
     - name: Install Nuage VSD API Simulator
       pip:

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: run python_requirements_info module
   python_requirements_info:
   register: basic_info

--- a/tests/integration/targets/read_csv/tasks/main.yml
+++ b/tests/integration/targets/read_csv/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/read_csv/tasks/main.yml
+++ b/tests/integration/targets/read_csv/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Create basic CSV file
 - name: Create unique CSV file
   copy:

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/scaleway_compute/tasks/main.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_compute/tasks/main.yml
+++ b/tests/integration/targets/scaleway_compute/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include_tasks: state.yml
 - include_tasks: ip.yml
 - include_tasks: security_group.yml

--- a/tests/integration/targets/scaleway_database_backup/tasks/main.yml
+++ b/tests/integration/targets/scaleway_database_backup/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create a backup (Check)
   check_mode: yes
   scaleway_database_backup:

--- a/tests/integration/targets/scaleway_database_backup/tasks/main.yml
+++ b/tests/integration/targets/scaleway_database_backup/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_image_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_image_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_image_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_image_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get image informations and register it in a variable
   scaleway_image_info:
     region: par1

--- a/tests/integration/targets/scaleway_ip/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_ip/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create IP (Check)
   check_mode: yes
   scaleway_ip:

--- a/tests/integration/targets/scaleway_ip_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_ip_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_ip_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get ip informations and register it in a variable
   scaleway_ip_info:
     region: par1

--- a/tests/integration/targets/scaleway_lb/tasks/main.yml
+++ b/tests/integration/targets/scaleway_lb/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create a load-balancer (Check)
   check_mode: yes
   scaleway_lb:

--- a/tests/integration/targets/scaleway_lb/tasks/main.yml
+++ b/tests/integration/targets/scaleway_lb/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_organization_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_organization_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_organization_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_organization_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get organization informations and register it in a variable
   scaleway_organization_info:
   register: organizations

--- a/tests/integration/targets/scaleway_security_group/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_security_group/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create security group check
   check_mode: yes
   scaleway_security_group:

--- a/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get security group informations and register it in a variable
   scaleway_security_group_info:
     region: par1

--- a/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
+++ b/tests/integration/targets/scaleway_security_group_rule/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create a scaleway security_group
   scaleway_security_group:
     state: present

--- a/tests/integration/targets/scaleway_server_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_server_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_server_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_server_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get server informations and register it in a variable
   scaleway_server_info:
     region: par1

--- a/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_snapshot_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get snapshot informations and register it in a variable
   scaleway_snapshot_info:
     region: par1

--- a/tests/integration/targets/scaleway_sshkey/tasks/main.yml
+++ b/tests/integration/targets/scaleway_sshkey/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_sshkey/tasks/main.yml
+++ b/tests/integration/targets/scaleway_sshkey/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - scaleway_sshkey:
     ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDf29yyommeGyKSIgSmX0ISVXP+3x6RUY4JDGLoAMFh2efkfDaRVdsvkvnFuUywgP2RewrjTyLE8w0NpCBHVS5Fm1BAn3yvxOUtTMxTbsQcw6HQ8swJ02+1tewJYjHPwc4GrBqiDo3Nmlq354Us0zBOJg/bBzuEnVD5eJ3GO3gKaCSUYTVrYwO0U4eJE0D9OJeUP9J48kl4ULbCub976+mTHdBvlzRw0Tzfl2kxgdDwlks0l2NefY/uiTdz2oMt092bAY3wZHxjto/DXoChxvaf5s2k8Zb+J7CjimUYnzPlH+zA9F6ROjP5AUu6ZWPd0jOIBl1nDWWb2j/qfNLYM43l sieben@sieben-macbook.local"
     state: present

--- a/tests/integration/targets/scaleway_user_data/tasks/main.yml
+++ b/tests/integration/targets/scaleway_user_data/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_user_data/tasks/main.yml
+++ b/tests/integration/targets/scaleway_user_data/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Create a server
   scaleway_compute:
     name: foobar

--- a/tests/integration/targets/scaleway_volume/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/scaleway_volume/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Make sure volume is not there before tests
   scaleway_volume:
     name: ansible-test-volume

--- a/tests/integration/targets/scaleway_volume_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume_info/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Get volume informations and register it in a variable
   scaleway_volume_info:
     region: par1

--- a/tests/integration/targets/scaleway_volume_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_volume_info/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/sefcontext/tasks/main.yml
+++ b/tests/integration/targets/sefcontext/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/sefcontext/tasks/main.yml
+++ b/tests/integration/targets/sefcontext/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # (c) 2016, Dag Wieers <dag@wieers.com>
 
 # This file is part of Ansible

--- a/tests/integration/targets/sensu_client/tasks/main.yml
+++ b/tests/integration/targets/sensu_client/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/sensu_client/tasks/main.yml
+++ b/tests/integration/targets/sensu_client/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Creating a client if the directory doesn't exist should work
   sensu_client:
     subscriptions:

--- a/tests/integration/targets/sensu_handler/tasks/main.yml
+++ b/tests/integration/targets/sensu_handler/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/sensu_handler/tasks/main.yml
+++ b/tests/integration/targets/sensu_handler/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Creating a handler if the directory doesn't exist should work
   sensu_handler:
     name: "handler"

--- a/tests/integration/targets/setup_cron/tasks/main.yml
+++ b/tests/integration/targets/setup_cron/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_cron/tasks/main.yml
+++ b/tests/integration/targets/setup_cron/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Include distribution specific variables
   include_vars: '{{ lookup(''first_found'', search) }}'
   vars:

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Setup Docker
   when: ansible_facts.distribution ~ ansible_facts.distribution_major_version not in  ['CentOS6', 'RedHat6']
   block:

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_docker_registry/tasks/main.yml
+++ b/tests/integration/targets/setup_docker_registry/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - when: ansible_facts.distribution ~ ansible_facts.distribution_major_version not in ['CentOS6', 'RedHat6']
   include_tasks:
     file: setup.yml

--- a/tests/integration/targets/setup_docker_registry/tasks/main.yml
+++ b/tests/integration/targets/setup_docker_registry/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_epel/tasks/main.yml
+++ b/tests/integration/targets/setup_epel/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_epel/tasks/main.yml
+++ b/tests/integration/targets/setup_epel/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install EPEL
   yum:
     name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm

--- a/tests/integration/targets/setup_etcd3/tasks/main.yml
+++ b/tests/integration/targets/setup_etcd3/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # setup etcd3 for integration tests on module/lookup
 # (c) 2017,  Jean-Philippe Evrard <jean-philippe@evrard.me>
 # 2020, SCC France, Eric Belhomme <ebelhomme@fr.scc.com>

--- a/tests/integration/targets/setup_etcd3/tasks/main.yml
+++ b/tests/integration/targets/setup_etcd3/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_flatpak_remote/tasks/main.yaml
+++ b/tests/integration/targets/setup_flatpak_remote/tasks/main.yaml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_flatpak_remote/tasks/main.yaml
+++ b/tests/integration/targets/setup_flatpak_remote/tasks/main.yaml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Set up dummy flatpak repository remote
   block:
   - name: Copy repo into place

--- a/tests/integration/targets/setup_influxdb/tasks/main.yml
+++ b/tests/integration/targets/setup_influxdb/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 
 - include: setup.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/tests/integration/targets/setup_influxdb/tasks/main.yml
+++ b/tests/integration/targets/setup_influxdb/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_mosquitto/tasks/main.yml
+++ b/tests/integration/targets/setup_mosquitto/tasks/main.yml
@@ -1,3 +1,8 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - include: ubuntu.yml
   when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/setup_mosquitto/tasks/main.yml
+++ b/tests/integration/targets/setup_mosquitto/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_openldap/tasks/main.yml
+++ b/tests/integration/targets/setup_openldap/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Setup OpenLDAP on Debian or Ubuntu
   block:
     - name: Include OS-specific variables

--- a/tests/integration/targets/setup_openldap/tasks/main.yml
+++ b/tests/integration/targets/setup_openldap/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Include OS-specific variables
   include_vars: '{{ ansible_os_family }}.yml'
   when: not ansible_os_family == "Darwin"

--- a/tests/integration/targets/setup_openssl/tasks/main.yml
+++ b/tests/integration/targets/setup_openssl/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - set_fact:
     pkg_mgr: community.general.pkgng
     ansible_pkg_mgr: community.general.pkgng

--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Exit when Suse because it causes CI problems
 - meta: end_play
   when: ansible_os_family == 'Suse'

--- a/tests/integration/targets/setup_postgresql_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_postgresql_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_replication/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/setup_redis_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_redis_replication/tasks/main.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Copyright: (c) 2020, Pavlo Bashynskyi (@levonet) <levonet@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/setup_remote_constraints/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_constraints/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_remote_constraints/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_constraints/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: record constraints.txt path on remote host
   set_fact:
     remote_constraints: "{{ remote_tmp_dir }}/constraints.txt"

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: make sure we have the ansible_os_family and ansible_distribution_version facts
   setup:
     gather_subset: distribution

--- a/tests/integration/targets/setup_tls/tasks/main.yml
+++ b/tests/integration/targets/setup_tls/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Generated certificate with: https://github.com/michaelklishin/tls-gen
 # ~/tls-gen/basic# make PASSWORD=bunnies CN=ansible.tls.tests
 # verify with: make info

--- a/tests/integration/targets/setup_tls/tasks/main.yml
+++ b/tests/integration/targets/setup_tls/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_wildfly_server/tasks/main.yml
+++ b/tests/integration/targets/setup_wildfly_server/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/setup_wildfly_server/tasks/main.yml
+++ b/tests/integration/targets/setup_wildfly_server/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Skip unsupported platforms
   meta: end_play
   when: (ansible_distribution != 'CentOS') or

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install systemd-sysv on ubuntu 18
   apt:
     name: systemd-sysv

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block:
   - tempfile:
       state: directory

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/synchronize-buildah/roles/test_buildah_synchronize/tasks/main.yml
+++ b/tests/integration/targets/synchronize-buildah/roles/test_buildah_synchronize/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/synchronize-buildah/roles/test_buildah_synchronize/tasks/main.yml
+++ b/tests/integration/targets/synchronize-buildah/roles/test_buildah_synchronize/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the synchronize module
 # (c) 2014, James Tanner <tanner.jc@gmail.com>
 

--- a/tests/integration/targets/timezone/tasks/main.yml
+++ b/tests/integration/targets/timezone/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/timezone/tasks/main.yml
+++ b/tests/integration/targets/timezone/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Because hwclock usually isn't available inside Docker containers in Shippable
 # these tasks will detect if hwclock works and only run hwclock tests if it is
 # supported. That is why it is recommended to run these tests locally with

--- a/tests/integration/targets/ufw/tasks/main.yml
+++ b/tests/integration/targets/ufw/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Make sure ufw is installed
 - name: Install EPEL repository (RHEL only)
   include_role:

--- a/tests/integration/targets/ufw/tasks/main.yml
+++ b/tests/integration/targets/ufw/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/wakeonlan/tasks/main.yml
+++ b/tests/integration/targets/wakeonlan/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/wakeonlan/tasks/main.yml
+++ b/tests/integration/targets/wakeonlan/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Send a magic Wake-on-LAN packet to 00:00:5E:00:53:66
   wakeonlan:
     mac: 00:00:5E:00:53:66

--- a/tests/integration/targets/xattr/tasks/main.yml
+++ b/tests/integration/targets/xattr/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/xattr/tasks/main.yml
+++ b/tests/integration/targets/xattr/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Setup
   include: setup.yml
 

--- a/tests/integration/targets/xfs_quota/tasks/main.yml
+++ b/tests/integration/targets/xfs_quota/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/xfs_quota/tasks/main.yml
+++ b/tests/integration/targets/xfs_quota/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - block: 
     - name: Create test user
       user:

--- a/tests/integration/targets/xml/tasks/main.yml
+++ b/tests/integration/targets/xml/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 - name: Install lxml (FreeBSD)
   package:
     name: '{{ "py27-lxml" if ansible_python.version.major == 2 else "py36-lxml" }}'

--- a/tests/integration/targets/xml/tasks/main.yml
+++ b/tests/integration/targets/xml/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/yarn/tasks/main.yml
+++ b/tests/integration/targets/yarn/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/yarn/tasks/main.yml
+++ b/tests/integration/targets/yarn/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # Yarn package manager integration tests
 # (c) 2018 David Gunter, <david.gunter@tivix.com>
 

--- a/tests/integration/targets/zypper/tasks/main.yml
+++ b/tests/integration/targets/zypper/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/zypper/tasks/main.yml
+++ b/tests/integration/targets/zypper/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the zyppe module
 #
 # (c) 2015, Guido Günther <agx@sigxcpu.org>

--- a/tests/integration/targets/zypper_repository/tasks/main.yml
+++ b/tests/integration/targets/zypper_repository/tasks/main.yml
@@ -1,5 +1,5 @@
 ####################################################################
-# These are designed specifically for Ansible tests                #
+# WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 

--- a/tests/integration/targets/zypper_repository/tasks/main.yml
+++ b/tests/integration/targets/zypper_repository/tasks/main.yml
@@ -1,3 +1,8 @@
+####################################################################
+# These are designed specifically for Ansible tests                #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
 # test code for the zypper repository module
 #
 # (c) 2016, Guido Günther <agx@sigxcpu.org>


### PR DESCRIPTION
##### SUMMARY
Tests are added to release tarballs, so it was [decided](https://meetbot.fedoraproject.org/ansible-community/2020-09-23/ansible_community_meeting.2020-09-23-18.01.log.html) to add a note to them to warn users not to use CI tests as a source of truth and an instance of best practices

##### ISSUE TYPE
- Docs Pull Request

