### PR TITLE
Add OpenBSD pkg_add(1) snapshot support

### DIFF
--- a/changelogs/fragments/openbsd_pkg.yml
+++ b/changelogs/fragments/openbsd_pkg.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - openbsd_pkg - added ``snapshot`` option (https://github.com/ansible-collections/community.general/pull/965).

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -47,7 +47,7 @@ options:
           - Force C(%c) and C(%m) to expand to C(snapshots), even on a release kernel.
         type: bool
         default: no
-        version_added: 1.2.0
+        version_added: 1.3.0
     ports_dir:
         description:
           - When used in combination with the C(build) option, allows overriding

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -48,6 +48,7 @@ options:
             kernel.
         type: bool
         default: no
+        version_added: 1.2.0
     ports_dir:
         description:
           - When used in combination with the C(build) option, allows overriding

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -40,6 +40,7 @@ options:
             a binary. Requires that the port source tree is already installed.
             Automatically builds and installs the 'sqlports' package, if it is
             not already installed.
+          - Mutually exclusive with I(snapshot).
         type: bool
         default: no
     snapshot:
@@ -173,10 +174,6 @@ def get_package_state(names, pkg_spec, module):
 # Function used to make sure a package is present.
 def package_present(names, pkg_spec, module):
     build = module.params['build']
-    snapshot = module.params['snapshot']
-
-    if snapshot is True and build is True:
-        module.fail_json(msg="the combination of build=%s and snapshot is not supported" % module.params['build'])
 
     for name in names:
         # It is possible package_present() has been called from package_latest().
@@ -208,7 +205,7 @@ def package_present(names, pkg_spec, module):
             else:
                 install_cmd = 'pkg_add -Im'
 
-        if snapshot is True:
+        if module.params['snapshot'] is True:
             install_cmd += ' -Dsnap'
 
         if pkg_spec[name]['installed_state'] is False:
@@ -269,9 +266,6 @@ def package_present(names, pkg_spec, module):
 
 # Function used to make sure a package is the latest available version.
 def package_latest(names, pkg_spec, module):
-    if module.params['build'] is True:
-        module.fail_json(msg="the combination of build=%s and state=latest is not supported" % module.params['build'])
-
     upgrade_cmd = 'pkg_add -um'
 
     if module.check_mode:
@@ -545,6 +539,7 @@ def main():
             quick=dict(type='bool', default=False),
             clean=dict(type='bool', default=False),
         ),
+        mutually_exclusive=[['snapshot', 'build']],
         supports_check_mode=True
     )
 

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -44,7 +44,7 @@ options:
         default: no
     snapshot:
         description:
-          - Force `%c` and `%m` to expand to `snapshots`, even on a release
+          - Force C(%c) and C(%m) to expand to C(snapshots), even on a release
             kernel.
         type: bool
         default: no

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -209,7 +209,7 @@ def package_present(names, pkg_spec, module):
             if build is True:
                 module.fail_json(msg="the combination of build=%s and snapshot is not supported" % module.params['build'])
             else:
-                install_cmd += '-Dsnap '
+                install_cmd += ' -Dsnap'
 
         if pkg_spec[name]['installed_state'] is False:
 
@@ -284,7 +284,7 @@ def package_latest(names, pkg_spec, module):
         upgrade_cmd += 'q'
 
     if module.params['snapshot']:
-        upgrade_cmd += '-Dsnap '
+        upgrade_cmd += ' -Dsnap'
 
     for name in names:
         if pkg_spec[name]['installed_state'] is True:
@@ -507,7 +507,7 @@ def upgrade_packages(pkg_spec, module):
         upgrade_cmd = 'pkg_add -Imu'
 
     if module.params['snapshot']:
-        upgrade_cmd += ' -Dsnap '
+        upgrade_cmd += ' -Dsnap'
 
     # Create a minimal pkg_spec entry for '*' to store return values.
     pkg_spec['*'] = {}

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -175,6 +175,9 @@ def package_present(names, pkg_spec, module):
     build = module.params['build']
     snapshot = module.params['snapshot']
 
+    if snapshot is True and build is True:
+        module.fail_json(msg="the combination of build=%s and snapshot is not supported" % module.params['build'])
+
     for name in names:
         # It is possible package_present() has been called from package_latest().
         # In that case we do not want to operate on the whole list of names,
@@ -206,10 +209,7 @@ def package_present(names, pkg_spec, module):
                 install_cmd = 'pkg_add -Im'
 
         if snapshot is True:
-            if build is True:
-                module.fail_json(msg="the combination of build=%s and snapshot is not supported" % module.params['build'])
-            else:
-                install_cmd += ' -Dsnap'
+            install_cmd += ' -Dsnap'
 
         if pkg_spec[name]['installed_state'] is False:
 

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -44,8 +44,7 @@ options:
         default: no
     snapshot:
         description:
-          - Force C(%c) and C(%m) to expand to C(snapshots), even on a release
-            kernel.
+          - Force C(%c) and C(%m) to expand to C(snapshots), even on a release kernel.
         type: bool
         default: no
         version_added: 1.2.0

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -206,7 +206,10 @@ def package_present(names, pkg_spec, module):
                 install_cmd = 'pkg_add -Im'
 
         if snapshot is True:
-            install_cmd += '-Dsnap '
+            if build is True:
+                module.fail_json(msg="the combination of build=%s and snapshot is not supported" % module.params['build'])
+            else:
+                install_cmd += '-Dsnap '
 
         if pkg_spec[name]['installed_state'] is False:
 

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -266,6 +266,9 @@ def package_present(names, pkg_spec, module):
 
 # Function used to make sure a package is the latest available version.
 def package_latest(names, pkg_spec, module):
+    if module.params['build'] is True:
+        module.fail_json(msg="the combination of build=%s and state=latest is not supported" % module.params['build'])
+
     upgrade_cmd = 'pkg_add -um'
 
     if module.check_mode:

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -45,6 +45,7 @@ options:
     snapshot:
         description:
           - Force C(%c) and C(%m) to expand to C(snapshots), even on a release kernel.
+          - Mutually exclusive with I(build).
         type: bool
         default: no
         version_added: 1.3.0

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -206,7 +206,7 @@ def package_present(names, pkg_spec, module):
                 install_cmd = 'pkg_add -Im'
 
         if snapshot is True:
-            install_cmd += ' -Dsnap '
+            install_cmd += '-Dsnap '
 
         if pkg_spec[name]['installed_state'] is False:
 
@@ -281,7 +281,7 @@ def package_latest(names, pkg_spec, module):
         upgrade_cmd += 'q'
 
     if module.params['snapshot']:
-        upgrade_cmd += ' -Dsnap '
+        upgrade_cmd += '-Dsnap '
 
     for name in names:
         if pkg_spec[name]['installed_state'] is True:


### PR DESCRIPTION
##### SUMMARY
Just before an OpenBSD release and after the beta phase the OpenBSD tag points to the next release. If you follow -current, you have to set `-Dsnap` to update/install packages.  However, this was not possible with this module.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request
