### PR TITLE
use FQCN when calling a module from action plugin

### DIFF
--- a/changelogs/fragments/967-use-fqcn-when-calling-a-module-from-action-plugin.yml
+++ b/changelogs/fragments/967-use-fqcn-when-calling-a-module-from-action-plugin.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - iptables_state - use FQCN when calling a module from action plugin
+    (https://github.com/ansible-collections/community.general/pull/967).

--- a/plugins/action/system/iptables_state.py
+++ b/plugins/action/system/iptables_state.py
@@ -48,7 +48,7 @@ class ActionModule(ActionBase):
         # At least one iteration is required, even if timeout is 0.
         for i in range(max(1, timeout)):
             async_result = self._execute_module(
-                module_name='async_status',
+                module_name='ansible.builtin.async_status',
                 module_args=module_args,
                 task_vars=task_vars,
                 wrap_async=False)
@@ -177,7 +177,7 @@ class ActionModule(ActionBase):
 
                 async_status_args['mode'] = 'cleanup'
                 garbage = self._execute_module(
-                    module_name='async_status',
+                    module_name='ansible.builtin.async_status',
                     module_args=async_status_args,
                     task_vars=task_vars,
                     wrap_async=False)

--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 skip/docker             # kernel modules not loadable
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)

--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 skip/docker             # kernel modules not loadable
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)


### PR DESCRIPTION
##### SUMMARY
The ansible builtin module `async_status` is called 2 times, each by its short name, by the `iptables_state` action plugin.
This update uses FQCN instead, following [porting guide 2.10 guidelines](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.10.html#action-plugins-which-execute-modules-should-use-fully-qualified-module-names)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iptables_state