### PR TITLE
Gitlab variables pagination

### DIFF
--- a/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
+++ b/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - gitlab_project_variable - workaround unsupported GitLab pagination limitation by setting GitLab ``per_page`` property to max 100 elements (https://github.com/ansible-collections/community.general/pull/968).
-  - gitlab_group_variable - workaround unsupported gitlab pagination limitation by setting gitlab ``per_page`` property to max 100 (https://github.com/ansible-collections/community.general/pull/968)
+  - gitlab_group_variable - workaround unsupported GitLab pagination limitation by setting GitLab ``per_page`` property to max 100 elements (https://github.com/ansible-collections/community.general/pull/968).

--- a/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
+++ b/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - gitlab_project_variable - workaround unsupported gitlab pagination limitation by setting gitlab ``per_page`` property to max 100 (https://github.com/ansible-collections/community.general/pull/968)
+  - gitlab_project_variable - workaround unsupported GitLab pagination limitation by setting GitLab ``per_page`` property to max 100 elements (https://github.com/ansible-collections/community.general/pull/968).
   - gitlab_group_variable - workaround unsupported gitlab pagination limitation by setting gitlab ``per_page`` property to max 100 (https://github.com/ansible-collections/community.general/pull/968)

--- a/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
+++ b/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - gitlab_project_variable - workaround unsupported gitlab pagination limitation by setting gitlab ``per_page`` property to max 100 (https://github.com/ansible-collections/community.general/pull/968)
+  - gitlab_group_variable - workaround unsupported gitlab pagination limitation by setting gitlab ``per_page`` property to max 100 (https://github.com/ansible-collections/community.general/pull/968)

--- a/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
+++ b/changelogs/fragments/968-gitlab_variables-pagination-increase.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - gitlab_project_variable - workaround unsupported GitLab pagination limitation by setting GitLab ``per_page`` property to max 100 elements (https://github.com/ansible-collections/community.general/pull/968).
-  - gitlab_group_variable - workaround unsupported GitLab pagination limitation by setting GitLab ``per_page`` property to max 100 elements (https://github.com/ansible-collections/community.general/pull/968).

--- a/changelogs/fragments/968-gitlab_variables-pagination.yml
+++ b/changelogs/fragments/968-gitlab_variables-pagination.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - gitlab_project_variable - support for GitLab pagination limitation by iterating over GitLab variable pages (https://github.com/ansible-collections/community.general/pull/968).
+  - gitlab_group_variable - support for GitLab pagination limitation by iterating over GitLab variable pages (https://github.com/ansible-collections/community.general/pull/968).

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -151,7 +151,6 @@ class GitlabGroupVariables(object):
 
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
-        self.repo.per_page = 100
         self.group = self.get_group(module.params['group'])
         self._module = module
 
@@ -159,7 +158,15 @@ class GitlabGroupVariables(object):
         return self.repo.groups.get(group_name)
 
     def list_all_group_variables(self):
-        return self.group.variables.list()
+        page_nb = 1
+        variables = []
+        vars_page = self.group.variables.list(page=page_nb)
+        while len(vars_page) > 0:
+            variables += vars_page
+            page_nb += 1
+            vars_page = self.group.variables.list(page=page_nb)
+        return variables
+
 
     def create_variable(self, key, value, masked, protected, variable_type):
         if self._module.check_mode:

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -151,6 +151,7 @@ class GitlabGroupVariables(object):
 
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
+        self.group.per_page = 100
         self.group = self.get_group(module.params['group'])
         self._module = module
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -151,7 +151,7 @@ class GitlabGroupVariables(object):
 
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
-        self.group.per_page = 100
+        self.repo.per_page = 100
         self.group = self.get_group(module.params['group'])
         self._module = module
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -167,7 +167,6 @@ class GitlabGroupVariables(object):
             vars_page = self.group.variables.list(page=page_nb)
         return variables
 
-
     def create_variable(self, key, value, masked, protected, variable_type):
         if self._module.check_mode:
             return

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -148,6 +148,7 @@ class GitlabProjectVariables(object):
 
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
+        self.repo.per_page = 100
         self.project = self.get_project(module.params['project'])
         self._module = module
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -148,7 +148,6 @@ class GitlabProjectVariables(object):
 
     def __init__(self, module, gitlab_instance):
         self.repo = gitlab_instance
-        self.repo.per_page = 100
         self.project = self.get_project(module.params['project'])
         self._module = module
 
@@ -156,7 +155,14 @@ class GitlabProjectVariables(object):
         return self.repo.projects.get(project_name)
 
     def list_all_project_variables(self):
-        return self.project.variables.list()
+        page_nb = 1
+        variables = []
+        vars_page = self.project.variables.list(page=page_nb)
+        while len(vars_page) > 0:
+            variables += vars_page
+            page_nb += 1
+            vars_page = self.project.variables.list(page=page_nb)
+        return variables
 
     def create_variable(self, key, value, masked, protected, variable_type):
         if self._module.check_mode:

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -495,6 +495,78 @@
       - gitlab_group_variable_state.group_variable.updated|length == 0
       - gitlab_group_variable_state.group_variable.removed[0] == "my_test_var"
 
+- name: set complete page and purge existing ones
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    vars:
+      page1_var01: value
+      page1_var02: value
+      page1_var03: value
+      page1_var04: value
+      page1_var05: value
+      page1_var06: value
+      page1_var07: value
+      page1_var08: value
+      page1_var09: value
+      page1_var10: value
+      page1_var11: value
+      page1_var12: value
+      page1_var13: value
+      page1_var14: value
+      page1_var15: value
+      page1_var16: value
+      page1_var17: value
+      page1_var18: value
+      page1_var19: value
+      page1_var20: value
+    purge: True
+  register: gitlab_group_variable_state
+
+- name: complete page added state must be changed
+  assert:
+    that:
+      - gitlab_group_variable_state is changed
+      - gitlab_group_variable_state.group_variable.added|length == 20
+      - gitlab_group_variable_state.group_variable.untouched|length == 0
+
+- name: set complete page and keep existing ones
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    vars:
+      page2_var01: value
+      page2_var02: value
+      page2_var03: value
+      page2_var04: value
+      page2_var05: value
+      page2_var06: value
+      page2_var07: value
+      page2_var08: value
+      page2_var09: value
+      page2_var10: value
+      page2_var11: value
+      page2_var12: value
+      page2_var13: value
+      page2_var14: value
+      page2_var15: value
+      page2_var16: value
+      page2_var17: value
+      page2_var18: value
+      page2_var19: value
+      page2_var20: value
+    purge: False
+  register: gitlab_group_variable_state
+
+- name: existing page untouched state must be changed
+  assert:
+    that:
+      - gitlab_group_variable_state is changed
+      - gitlab_group_variable_state.group_variable.added|length == 20
+      - gitlab_group_variable_state.group_variable.untouched|length == 20
+
 - name: check that no variables are left
   gitlab_group_variable:
     api_url: "{{ gitlab_host }}"

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -578,7 +578,7 @@
 - name: check that no variables are untouched state must be changed
   assert:
     that:
-      - not gitlab_group_variable_state.changed
+      - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
       - gitlab_group_variable_state.group_variable.untouched|length == 0
       - gitlab_group_variable_state.group_variable.removed|length == 40

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -575,11 +575,11 @@
     purge: True
   register: gitlab_group_variable_state
 
-- name: check that no variables are untoucheded state must be changed
+- name: check that no variables are untouched state must be changed
   assert:
     that:
       - not gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.added|length == 0
       - gitlab_group_variable_state.group_variable.untouched|length == 0
-      - gitlab_group_variable_state.group_variable.removed|length == 0
+      - gitlab_group_variable_state.group_variable.removed|length == 40
       - gitlab_group_variable_state.group_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -574,11 +574,11 @@
     purge: True
   register: gitlab_project_variable_state
 
-- name: check that no variables are untoucheded state must be changed
+- name: check that no variables are untouched state must be changed
   assert:
     that:
       - not gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
       - gitlab_project_variable_state.project_variable.untouched|length == 0
-      - gitlab_project_variable_state.project_variable.removed|length == 0
+      - gitlab_project_variable_state.project_variable.removed|length == 40
       - gitlab_project_variable_state.project_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -577,7 +577,7 @@
 - name: check that no variables are untouched state must be changed
   assert:
     that:
-      - not gitlab_project_variable_state.changed
+      - gitlab_project_variable_state.changed
       - gitlab_project_variable_state.project_variable.added|length == 0
       - gitlab_project_variable_state.project_variable.untouched|length == 0
       - gitlab_project_variable_state.project_variable.removed|length == 40

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -494,6 +494,78 @@
       - gitlab_project_variable_state.project_variable.updated|length == 0
       - gitlab_project_variable_state.project_variable.removed[0] == "my_test_var"
 
+- name: set complete page and purge existing ones
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      page1_var01: value
+      page1_var02: value
+      page1_var03: value
+      page1_var04: value
+      page1_var05: value
+      page1_var06: value
+      page1_var07: value
+      page1_var08: value
+      page1_var09: value
+      page1_var10: value
+      page1_var11: value
+      page1_var12: value
+      page1_var13: value
+      page1_var14: value
+      page1_var15: value
+      page1_var16: value
+      page1_var17: value
+      page1_var18: value
+      page1_var19: value
+      page1_var20: value
+    purge: True
+  register: gitlab_project_variable_state
+
+- name: complete page added state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+      - gitlab_project_variable_state.project_variable.added|length == 20
+      - gitlab_project_variable_state.project_variable.untouched|length == 0
+
+- name: set complete page and keep existing ones
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      page2_var01: value
+      page2_var02: value
+      page2_var03: value
+      page2_var04: value
+      page2_var05: value
+      page2_var06: value
+      page2_var07: value
+      page2_var08: value
+      page2_var09: value
+      page2_var10: value
+      page2_var11: value
+      page2_var12: value
+      page2_var13: value
+      page2_var14: value
+      page2_var15: value
+      page2_var16: value
+      page2_var17: value
+      page2_var18: value
+      page2_var19: value
+      page2_var20: value
+    purge: False
+  register: gitlab_project_variable_state
+
+- name: existing page untouched state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+      - gitlab_project_variable_state.project_variable.added|length == 20
+      - gitlab_project_variable_state.project_variable.untouched|length == 20
+
 - name: check that no variables are left
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"


### PR DESCRIPTION
##### SUMMARY
The ansible `gitlab` module_utils does not enable support for gitlab pagination at Gitlab object instanciation, so at the moment the queries to the API end up using the default pagination of **20** items to list per page  thus limiting to 20 the number of variables returned to  both `gitlab_project_variables` and `gitlab_group_variable` ansible modules.

As a temporary measure the instantiated gitlab object `per_page` property could be set  to its [max value of 100](https://docs.gitlab.com/ee/api/#pagination) at class init  and before performing the API call for groups and projects.

Long term solution beyond 100 variables would need to  cater for pagination support. 
What is not clear to me  yet is if in the underlying [python-gitlab](https://github.com/python-gitlab/python-gitlab) python module the pagination supported through RESTObjectList  extends to Project and Group Variable Managers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
+ gitlab
+ gitlab_group_variable
+ gitlab_project_variable

##### ADDITIONAL INFORMATION
