### PR TITLE
docker_container: fix idempotency problem with empty published_ports list

### DIFF
--- a/changelogs/fragments/979-docker_container-published_ports-empty-idempotency.yml
+++ b/changelogs/fragments/979-docker_container-published_ports-empty-idempotency.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_container - fix idempotency problem with ``published_ports`` when strict comparison is used and list is empty (https://github.com/ansible-collections/community.general/issues/978).
+- "docker_container - fix idempotency problem with ``published_ports`` when strict comparison is used and list is empty (https://github.com/ansible-collections/community.general/issues/978)."

--- a/changelogs/fragments/979-docker_container-published_ports-empty-idempotency.yml
+++ b/changelogs/fragments/979-docker_container-published_ports-empty-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_container - fix idempotency problem with ``published_ports`` when strict comparison is used and list is empty (https://github.com/ansible-collections/community.general/issues/978).

--- a/plugins/modules/cloud/docker/docker_container.py
+++ b/plugins/modules/cloud/docker/docker_container.py
@@ -2400,7 +2400,7 @@ class Container(DockerBaseClass):
         return shlex.split(self.parameters.entrypoint)
 
     def _get_expected_ports(self):
-        if not self.parameters.published_ports:
+        if self.parameters.published_ports is None:
             return None
         expected_bound_ports = {}
         for container_port, config in self.parameters.published_ports.items():

--- a/tests/integration/targets/docker_container/tasks/tests/options.yml
+++ b/tests/integration/targets/docker_container/tasks/tests/options.yml
@@ -2873,6 +2873,18 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     force_kill: yes
   register: published_ports_5
 
+- name: published_ports (no published ports)
+  docker_container:
+    image: alpine:3.8
+    command: '/bin/sh -c "sleep 10m"'
+    name: "{{ cname }}"
+    state: started
+    published_ports: []
+    comparisons:
+      published_ports: strict
+    force_kill: yes
+  register: published_ports_6
+
 - name: cleanup
   docker_container:
     name: "{{ cname }}"
@@ -2887,6 +2899,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
     - published_ports_3 is not changed
     - published_ports_4 is changed
     - published_ports_5 is changed
+    - published_ports_6 is changed
 
 ####################################################################
 ## pull ############################################################


### PR DESCRIPTION
##### SUMMARY
When strict comparison is used and `published_ports` is `[]`, it is treated the same as not specified, i.e. `[]` is not enforced.

Fixes #978.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
