### PR TITLE
nmcli: set C locale when executing nmcli

### DIFF
--- a/changelogs/fragments/992-nmcli-locale.yml
+++ b/changelogs/fragments/992-nmcli-locale.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "nmcli - set ``C`` locale when executing ``nmcli`` (https://github.com/ansible-collections/community.general/issues/989)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1760,6 +1760,7 @@ def main():
         ),
         supports_check_mode=True,
     )
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     if not HAVE_DBUS:
         module.fail_json(msg=missing_required_lib('dbus'), exception=DBUS_IMP_ERR)


### PR DESCRIPTION
##### SUMMARY
Set `C` locale when executing `nmcli` binary. This avoids localization problems, such when `nmcli` uses `ja` instead of `yes` because the `LANG=de`.

Fixes #989.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli
