### PR TITLE
nagios: force an active service check for all services of a particular host or for the host itself

### DIFF
--- a/changelogs/fragments/998-nagios-added_forced_check_for_all_services_or_host.yml
+++ b/changelogs/fragments/998-nagios-added_forced_check_for_all_services_or_host.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- nagios - rename the ``service_check`` action to ``forced_check`` since we now are able to check both a particular service, all services of a particular host and the host itself (https://github.com/ansible-collections/community.general/pull/998).
+- nagios - add the ``host`` and ``all`` values for the ``forced_check`` action (https://github.com/ansible-collections/community.general/pull/998).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added functionality to force an active service check for all services of a particular host or for the host itself.

Note that I've renamed the `service_check` command to `forced_check` since we now are able to check both a particular service, all services of a particular host and the host itself. This aligns to the `downtime` command.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nagios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
