### PR TITLE
Fix failing FreeBSD CI

### DIFF
--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -8,13 +8,21 @@ fi
 
 set -eux
 
-uname
-uname -o
 uname -a
+if [[ $(uname -a) =~ FreeBSD\ 12\.0-RELEASE ]]
+  then
+    # On FreeBSD 12.0 images, upgrade setuptools to avoid error with multidict
+    # This is a bug in pip, which happens because the old setuptools from outside
+    # the venv leaks into the venv (https://github.com/pypa/pip/issues/6264).
+    # Since it is not fixed in latest pip (which is available in the venv), we
+    # need to upgrade setuptools outside the venv.
+    pip36 install --upgrade setuptools
+fi
+
 source virtualenv.sh
 python --version
 pip --version
-pip install --upgrade setuptools -c constraints.txt
+pip show setuptools
 pip install openshift -c constraints.txt
 
 ./server.py &

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -9,6 +9,8 @@ fi
 set -eux
 
 source virtualenv.sh
+python --version
+pip --version
 pip install openshift -c constraints.txt
 
 ./server.py &

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -16,7 +16,7 @@ if [[ $(uname -a) =~ FreeBSD\ 12\.0-RELEASE ]]
     # the venv leaks into the venv (https://github.com/pypa/pip/issues/6264).
     # Since it is not fixed in latest pip (which is available in the venv), we
     # need to upgrade setuptools outside the venv.
-    pip36 install --upgrade setuptools
+    pip3 install --upgrade setuptools
 fi
 
 source virtualenv.sh

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -11,6 +11,7 @@ set -eux
 source virtualenv.sh
 python --version
 pip --version
+pip install --upgrade setuptools -c constraints.txt
 pip install openshift -c constraints.txt
 
 ./server.py &

--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -8,6 +8,9 @@ fi
 
 set -eux
 
+uname
+uname -o
+uname -a
 source virtualenv.sh
 python --version
 pip --version


### PR DESCRIPTION
##### SUMMARY
Since yesterday one of the FreeBSD CI nodes constantly fails: https://app.shippable.com/github/ansible-collections/community.general/runs/4094/115/console

It did work two days ago: https://app.shippable.com/github/ansible-collections/community.general/runs/4050/115/console

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kubevirt
