### PR TITLE
proxmox_kvm: allow setting format to null (None)

### DIFF
--- a/changelogs/fragments/1028-proxmox-kvm-linked-clone.yml
+++ b/changelogs/fragments/1028-proxmox-kvm-linked-clone.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox_kvm - fix issue causing linked clones not being create by allowing ``format=unspecified`` (https://github.com/ansible-collections/community.general/issues/1027)
+  - proxmox_kvm - fix issue causing linked clones not being create by allowing ``format=unspecified`` (https://github.com/ansible-collections/community.general/issues/1027).

--- a/changelogs/fragments/1028-proxmox-kvm-linked-clone.yml
+++ b/changelogs/fragments/1028-proxmox-kvm-linked-clone.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_kvm - fix issue causing linked clones not being create by allowing ``format=unspecified`` (https://github.com/ansible-collections/community.general/issues/1027)

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -120,7 +120,7 @@ options:
     description:
       - Target drive's backing file's data format.
       - Used only with clone
-      - Use I(format=unspecified) and I(full=false) for linked clone.
+      - Use I(format=unspecified) and I(full=false) for a linked clone.
     type: str
     default: qcow2
     choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk", "unspecified" ]

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -120,9 +120,10 @@ options:
     description:
       - Target drive's backing file's data format.
       - Used only with clone
+      - Use format: null and full: no for linked clone
     type: str
     default: qcow2
-    choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk" ]
+    choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk", null ]
   freeze:
     description:
       - Specify if PVE should freeze CPU at startup (use 'c' monitor command to start execution).
@@ -470,6 +471,22 @@ EXAMPLES = '''
     node: sabrewulf
     storage: VMs
     format: qcow2
+    timeout: 500
+
+- name: >
+    Create linked clone VM with only source VM name.
+    The VM source is spynal.
+    The target VM name is zavala
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    clone: spynal
+    name: zavala
+    node: sabrewulf
+    storage: VMs
+    full: no
+    format: null
     timeout: 500
 
 - name: Clone VM with source vmid and target newid and raw format
@@ -865,7 +882,7 @@ def main():
             description=dict(type='str'),
             digest=dict(type='str'),
             force=dict(type='bool', default=False),
-            format=dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']),
+            format=dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk', None]),
             freeze=dict(type='bool'),
             full=dict(type='bool', default=True),
             hostpci=dict(type='dict'),

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -120,10 +120,10 @@ options:
     description:
       - Target drive's backing file's data format.
       - Used only with clone
-      - Use format: null and full: no for linked clone
+      - Use I(format=unspecified) and I(full=false) for linked clone.
     type: str
     default: qcow2
-    choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk", null ]
+    choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk", "unspecified" ]
   freeze:
     description:
       - Specify if PVE should freeze CPU at startup (use 'c' monitor command to start execution).
@@ -486,7 +486,7 @@ EXAMPLES = '''
     node: sabrewulf
     storage: VMs
     full: no
-    format: null
+    format: unspecified
     timeout: 500
 
 - name: Clone VM with source vmid and target newid and raw format
@@ -818,7 +818,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             return False
     elif module.params['clone'] is not None:
         for param in valid_clone_params:
-            if module.params[param] is not None:
+            if module.params[param] is not None and module.params[param] != 'unspecified':
                 clone_params[param] = module.params[param]
         clone_params.update(dict([k, int(v)] for k, v in clone_params.items() if isinstance(v, bool)))
         taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
@@ -882,7 +882,7 @@ def main():
             description=dict(type='str'),
             digest=dict(type='str'),
             force=dict(type='bool', default=False),
-            format=dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk', None]),
+            format=dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk', 'unspecified']),
             freeze=dict(type='bool'),
             full=dict(type='bool', default=True),
             hostpci=dict(type='dict'),

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -818,7 +818,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             return False
     elif module.params['clone'] is not None:
         for param in valid_clone_params:
-            if module.params[param] is not None and module.params[param] != 'unspecified':
+            if module.params[param] is not None:
                 clone_params[param] = module.params[param]
         clone_params.update(dict([k, int(v)] for k, v in clone_params.items() if isinstance(v, bool)))
         taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
@@ -961,6 +961,9 @@ def main():
     update = bool(module.params['update'])
     vmid = module.params['vmid']
     validate_certs = module.params['validate_certs']
+
+    if module.params['format'] == 'unspecified':
+        module.params['format'] = None
 
     # If password not set get it from PROXMOX_PASSWORD env
     if not api_password:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1027 
The source problem is that _format_ parameter has a default value _qcow2_.
The underlying API does not allow to create a linked clone and at the same time specify _format_ parameter.
For backward compatibility reason, I left the default value of _format_ parameter untouched but allowed to set this parameter to null (None) to cancel it out.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
How to create a linked clone after the change:
```
- name: clone vm
  proxmox_kvm:
    api_host: "{{ hypervisor_ip }}"
    api_password: "{{ pass }}"
    api_user: "{{ user }}"
    node: "{{ proxmox_node }}"
    clone: "{{ clone }}"
    name: "{{ inventory_hostname }}"
    full: no
    format: null
  delegate_to: "{{ hypervisor_ip }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Old response:
```paste below
"Unable to clone vm cysoc-test-first-vm-1 from vmid 30000=500 Internal Server Error: parameter 'format' not allowed for linked clones - {\"data\":null}"
```
New response:
```
"msg": "VM cysoc-test-first-vm-1 with newid 110 cloned from vm with vmid 30000"
```