### PR TITLE
[WIP] Remove significant whitespace in hashi_vault tests

### DIFF
--- a/changelogs/fragments/1024-vault-skip-verify-support.yml
+++ b/changelogs/fragments/1024-vault-skip-verify-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - hashi_vault - support ``VAULT_SKIP_VERIFY`` environment variable for determining if to verify certificates (in addition to the ``validate_certs=`` flag supported today) (https://github.com/ansible-collections/community.general/pull/1024).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -119,7 +119,7 @@ DOCUMENTATION = """
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
         - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and I(validate_certs) is not explicitly
-        - provided (added in community.general 1.3.0).
+          provided (added in community.general 1.3.0).
         - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
       type: boolean
     namespace:

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -118,7 +118,7 @@ DOCUMENTATION = """
     validate_certs:
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
-        - Will be populated with the inverse of VAULT_SKIP_VERIFY if it is set (added in community.general 1.3.0).
+        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and `validate_certs` is not explicitly provided (added in community.general 1.3.0).
         - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
       type: boolean
     namespace:

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -119,6 +119,12 @@ DOCUMENTATION = """
       description: Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
       type: boolean
       default: True
+    skip_certificate_validation:
+      description: Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones. This takes precedence over validate_certs
+      type: boolean
+      env:
+        - name: VAULT_SKIP_VERIFY
+          version_added: 1.2.1
     namespace:
       description: Namespace where secrets reside. Requires HVAC 0.7.0+ and Vault 0.11+.
       env:
@@ -486,7 +492,13 @@ class LookupModule(LookupBase):
         #
         '''' return a bool or cacert '''
         ca_cert = self.get_option('ca_cert')
-        validate_certs = self.get_option('validate_certs')
+
+        skip_certificate_validation = self.get_option('skip_certificate_validation')
+        
+        if skip_certificate_validation != None:
+          validate_certs = not skip_certificate_validation
+        else:
+          validate_certs = self.get_option('validate_certs')
 
         if not (validate_certs and ca_cert):
             self.set_option('ca_cert', validate_certs)

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -116,7 +116,9 @@ DOCUMENTATION = """
       description: Path to certificate to use for authentication.
       aliases: [ cacert ]
     validate_certs:
-      description: Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones. Will be populated with the inverse of VAULT_SKIP_VERIFY if it is set.
+      description:
+        - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
+        - Will be populated with the inverse of VAULT_SKIP_VERIFY if it is set (added in community.general 1.3.0).
       type: boolean
       default: True
     namespace:
@@ -489,18 +491,18 @@ class LookupModule(LookupBase):
         ca_cert = self.get_option('ca_cert')
 
         vault_skip_verify = os.environ.get('VAULT_SKIP_VERIFY')
-        
-        if vault_skip_verify != None:
-          try:
-            # Check that we have a boolean value
-            vault_skip_verify = boolean(vault_skip_verify)
-            # Use the inverse of VAULT_SKIP_VERIFY 
-            validate_certs = not vault_skip_verify
-          except TypeError:
-            # Not a boolean value fallback to validate_certs option
-            validate_certs = self.get_option('validate_certs')
+
+        if vault_skip_verify is not None:
+            try:
+                # Check that we have a boolean value
+                vault_skip_verify = boolean(vault_skip_verify)
+                # Use the inverse of VAULT_SKIP_VERIFY
+                validate_certs = not vault_skip_verify
+            except TypeError:
+                # Not a boolean value fallback to validate_certs option
+                validate_certs = self.get_option('validate_certs')
         else:
-          validate_certs = self.get_option('validate_certs')
+            validate_certs = self.get_option('validate_certs')
 
         if not (validate_certs and ca_cert):
             self.set_option('ca_cert', validate_certs)

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -119,7 +119,7 @@ DOCUMENTATION = """
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
         - Will be populated with the inverse of VAULT_SKIP_VERIFY if it is set (added in community.general 1.3.0).
-        - Will default to True if neither validate_certs or VAULT_SKIP_VERIFY are set.
+        - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
       type: boolean
     namespace:
       description: Namespace where secrets reside. Requires HVAC 0.7.0+ and Vault 0.11+.

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -118,7 +118,8 @@ DOCUMENTATION = """
     validate_certs:
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
-        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and `validate_certs` is not explicitly provided (added in community.general 1.3.0).
+        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and `validate_certs` is not explicitly
+        - provided (added in community.general 1.3.0).
         - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
       type: boolean
     namespace:

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -492,7 +492,7 @@ class LookupModule(LookupBase):
 
         validate_certs = self.get_option('validate_certs')
 
-        if validate_certs is not None:
+        if validate_certs is None:
             # Validate certs option was not explicitly set
 
             # Check if VAULT_SKIP_VERIFY is set

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -118,7 +118,7 @@ DOCUMENTATION = """
     validate_certs:
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
-        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and `validate_certs` is not explicitly
+        - Will be populated with the inverse of C(VAULT_SKIP_VERIFY) if that is set and I(validate_certs) is not explicitly
         - provided (added in community.general 1.3.0).
         - Will default to C(true) if neither I(validate_certs) or C(VAULT_SKIP_VERIFY) are set.
       type: boolean

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -119,8 +119,8 @@ DOCUMENTATION = """
       description:
         - Controls verification and validation of SSL certificates, mostly you only want to turn off with self signed ones.
         - Will be populated with the inverse of VAULT_SKIP_VERIFY if it is set (added in community.general 1.3.0).
+        - Will default to True if neither validate_certs or VAULT_SKIP_VERIFY are set.
       type: boolean
-      default: True
     namespace:
       description: Namespace where secrets reside. Requires HVAC 0.7.0+ and Vault 0.11+.
       env:
@@ -490,19 +490,26 @@ class LookupModule(LookupBase):
         '''' return a bool or cacert '''
         ca_cert = self.get_option('ca_cert')
 
-        vault_skip_verify = os.environ.get('VAULT_SKIP_VERIFY')
+        validate_certs = self.get_option('validate_certs')
 
-        if vault_skip_verify is not None:
-            try:
-                # Check that we have a boolean value
-                vault_skip_verify = boolean(vault_skip_verify)
-                # Use the inverse of VAULT_SKIP_VERIFY
-                validate_certs = not vault_skip_verify
-            except TypeError:
-                # Not a boolean value fallback to validate_certs option
-                validate_certs = self.get_option('validate_certs')
-        else:
-            validate_certs = self.get_option('validate_certs')
+        if validate_certs is not None:
+            # Validate certs option was not explicitly set
+
+            # Check if VAULT_SKIP_VERIFY is set
+            vault_skip_verify = os.environ.get('VAULT_SKIP_VERIFY')
+
+            if vault_skip_verify is not None:
+                # VAULT_SKIP_VERIFY is set
+                try:
+                    # Check that we have a boolean value
+                    vault_skip_verify = boolean(vault_skip_verify)
+                    # Use the inverse of VAULT_SKIP_VERIFY
+                    validate_certs = not vault_skip_verify
+                except TypeError:
+                    # Not a boolean value fallback to default value (True)
+                    validate_certs = True
+            else:
+                validate_certs = True
 
         if not (validate_certs and ca_cert):
             self.set_option('ca_cert', validate_certs)

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
@@ -30,7 +30,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-          secret_inexistent: "{{ lookup('community.general.:qhashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+          secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/non_existent_secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
@@ -4,8 +4,8 @@
   block:
     - name: 'Fetch secrets using "hashi_vault" lookup'
       set_fact:
-        secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
-        secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret1 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
 
     - name: 'Check secret values'
       fail:
@@ -14,7 +14,7 @@
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:
-        secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=toto role_id=' ~ role_id) }}"
+        secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret2 auth_method=approle secret_id=toto role_id=' ~ role_id) }}"
       debug:
         msg: 'Failure is expected ({{ secret_wrong_cred }})'
       register: test_wrong_cred
@@ -22,7 +22,7 @@
 
     - name: 'Failure expected when unauthorized secret is read'
       vars:
-        secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret3 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret3 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
         msg: 'Failure is expected ({{ secret_unauthorized }})'
       register: test_unauthorized
@@ -30,7 +30,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-          secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/non_existent_secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+          secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/non_existent_secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -39,8 +39,28 @@
       args:
         apply:
           vars:
-            conn_params: 'validate_certs=True' # Here we are testing that VAULT_SKIP_VERIFY takes precedence
+            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
+          environment:
+            VAULT_ADDR: 'https://localhost:8201'
+            VAULT_SKIP_VERIFY: 1
+
+    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      args:
+        apply:
+          vars:
+            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
           environment:
             VAULT_ADDR: 'https://localhost:8201'
             VAULT_SKIP_VERIFY: True
+
+    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      args:
+        apply:
+          vars:
+            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
+          environment:
+            VAULT_ADDR: 'https://localhost:8201'
+            VAULT_SKIP_VERIFY: y
       

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -33,3 +33,14 @@
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
         conn_params: 'url=https://localhost:8201 validate_certs=False '
+
+    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      args:
+        apply:
+          vars:
+            conn_params: 'validate_certs=True' # Here we are testing that VAULT_SKIP_VERIFY takes precedence
+          environment:
+            VAULT_ADDR: 'https://localhost:8201'
+            VAULT_SKIP_VERIFY: True
+      

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -1,7 +1,7 @@
 - name: 'test {{ auth_type }} auth without SSL (lookup parameters)'
   include_tasks: '{{ auth_type }}_test.yml'
   vars:
-    conn_params: 'url=http://localhost:8200 '
+    conn_params: 'url=http://localhost:8200'
 
 - name: 'test {{ auth_type }} auth without SSL (environment variable)'
   include_tasks: '{{ auth_type }}_test.yml'
@@ -17,7 +17,7 @@
     - name: 'test {{ auth_type }} auth with certs (validation enabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True '
+        conn_params: 'url=https://localhost:8201 ca_cert={{ local_temp_dir }}/cert.pem validate_certs=True'
 
     - name: 'test {{ auth_type }} auth with certs (validation enabled, environment variables)'
       include_tasks: '{{ auth_type }}_test.yml'
@@ -32,7 +32,7 @@
     - name: 'test {{ auth_type }} auth with certs (validation disabled, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       vars:
-        conn_params: 'url=https://localhost:8201 validate_certs=False '
+        conn_params: 'url=https://localhost:8201 validate_certs=False'
 
     - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
@@ -69,7 +69,7 @@
       args:
         apply:
           vars:
-            conn_params: 'validate_certs=False '
+            conn_params: 'validate_certs=False'
           environment:
             VAULT_ADDR: 'https://localhost:8201'
             VAULT_SKIP_VERIFY: False

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/tests.yml
@@ -39,28 +39,38 @@
       args:
         apply:
           vars:
-            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
+            conn_params: ''
           environment:
             VAULT_ADDR: 'https://localhost:8201'
             VAULT_SKIP_VERIFY: 1
 
-    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
+    - name: 'test {{ auth_type }} auth with certs (validation using env VAR (True), lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       args:
         apply:
           vars:
-            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
+            conn_params: ''
           environment:
             VAULT_ADDR: 'https://localhost:8201'
             VAULT_SKIP_VERIFY: True
 
-    - name: 'test {{ auth_type }} auth with certs (validation using env VAR, lookup parameters)'
+    - name: 'test {{ auth_type }} auth with certs (validation using env VAR (y), lookup parameters)'
       include_tasks: '{{ auth_type }}_test.yml'
       args:
         apply:
           vars:
-            conn_params: 'validate_certs=True ' # VAULT_SKIP_VERIFY should take precedence
+            conn_params: ''
           environment:
             VAULT_ADDR: 'https://localhost:8201'
             VAULT_SKIP_VERIFY: y
+
+    - name: 'test {{ auth_type }} auth with certs (precedence of validate_certs over env VAR, lookup parameters)'
+      include_tasks: '{{ auth_type }}_test.yml'
+      args:
+        apply:
+          vars:
+            conn_params: 'validate_certs=False '
+          environment:
+            VAULT_ADDR: 'https://localhost:8201'
+            VAULT_SKIP_VERIFY: False
       

--- a/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/tests/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -3,13 +3,13 @@
   block:
     - name: 'Fetch secrets using "hashi_vault" lookup'
       set_fact:
-        gen_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_gen_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        gen_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_gen_path ~ '/secret2 token=' ~ user_token) }}"
-        kv1_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        kv1_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2 token=' ~ user_token) }}"
-        kv2_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
-        kv2_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 token=' ~ user_token) }}"
-        kv2_secret4: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret4?version=2 token=' ~ user_token) }}"
+        gen_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_gen_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
+        gen_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_gen_path ~ '/secret2 token=' ~ user_token) }}"
+        kv1_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv1_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
+        kv1_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv1_path ~ '/secret2 token=' ~ user_token) }}"
+        kv2_secret1: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
+        kv2_secret2: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret2 token=' ~ user_token) }}"
+        kv2_secret4: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret4?version=2 token=' ~ user_token) }}"
         kv2_secret2_as_raw: "{{ lookup('community.general.hashi_vault', vault_kv2_path ~ '/secret2 ' ~  conn_params, auth_method='token', token=user_token, return_format='raw') }}"
         kv2_secrets_as_dict: "{{ lookup('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token) }}"
         kv2_secrets_as_values: "{{ query('community.general.hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token, return_format='values') }}"
@@ -57,7 +57,7 @@
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:
-        secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 auth_method=token token=wrong_token') }}"
+        secret_wrong_cred: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret2 auth_method=token token=wrong_token') }}"
       debug:
         msg: 'Failure is expected ({{ secret_wrong_cred }})'
       register: test_wrong_cred
@@ -65,7 +65,7 @@
 
     - name: 'Failure expected when unauthorized secret is read'
       vars:
-        secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret3 token=' ~ user_token) }}"
+        secret_unauthorized: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/secret3 token=' ~ user_token) }}"
       debug:
         msg: 'Failure is expected ({{ secret_unauthorized }})'
       register: test_unauthorized
@@ -73,7 +73,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-        secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/non_existent_secret4 token=' ~ user_token) }}"
+        secret_inexistent: "{{ lookup('community.general.hashi_vault', conn_params ~ ' secret=' ~ vault_kv2_path ~ '/non_existent_secret4 token=' ~ user_token) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent


### PR DESCRIPTION
##### SUMMARY
Currently it is required that in hashi_vault tests the `conn_params` variable must end in a space or the tests will fail.

This removes that requirement and adjusts existing tests to remove the space from the end of `conn_params`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
