### PR TITLE
cache/redis: make keyset keyname configurable

### DIFF
--- a/changelogs/fragments/1036-redis-cache-keyset-name.yaml
+++ b/changelogs/fragments/1036-redis-cache-keyset-name.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - redis - make the redis cache keyset name configurable
+  - redis cache plugin - make the redis cache keyset name configurable
     (https://github.com/ansible-collections/community.general/pull/1036).

--- a/changelogs/fragments/1036-redis-cache-keyset-name.yaml
+++ b/changelogs/fragments/1036-redis-cache-keyset-name.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redis - make the redis cache keyset name configurable
+    (https://github.com/ansible-collections/community.general/pull/1036).

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -32,6 +32,14 @@ DOCUMENTATION = '''
         ini:
           - key: fact_caching_prefix
             section: defaults
+      _cache_keys_name:
+        description: User defined name for ansible cache key name
+        default: ansible_cache_keys
+        env:
+          - name: ANSIBLE_CACHE_KEYS_NAME
+        ini:
+          - key: fact_caching_keys_name
+            section: defaults
       _timeout:
         default: 86400
         description: Expiration timeout in seconds for the cache plugin data. Set to 0 to never expire
@@ -78,6 +86,7 @@ class CacheModule(BaseCacheModule):
                 uri = self.get_option('_uri')
             self._timeout = float(self.get_option('_timeout'))
             self._prefix = self.get_option('_prefix')
+            self._keys_set = self.get_option('_cache_keys_name')
         except KeyError:
             display.deprecated('Rather than importing CacheModules directly, '
                                'use ansible.plugins.loader.cache_loader',
@@ -86,6 +95,7 @@ class CacheModule(BaseCacheModule):
                 uri = C.CACHE_PLUGIN_CONNECTION
             self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
             self._prefix = C.CACHE_PLUGIN_PREFIX
+            self._keys_set = 'ansible_cache_keys'
 
         self._cache = {}
         kw = {}
@@ -96,7 +106,6 @@ class CacheModule(BaseCacheModule):
 
         connection = uri.split(':')
         self._db = StrictRedis(*connection, **kw)
-        self._keys_set = 'ansible_cache_keys'
 
     def _make_key(self, key):
         return self._prefix + key

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -40,6 +40,7 @@ DOCUMENTATION = '''
         ini:
           - key: fact_caching_redis_keyset_name
             section: defaults
+        version_added: 1.3.0
       _timeout:
         default: 86400
         description: Expiration timeout in seconds for the cache plugin data. Set to 0 to never expire

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -32,13 +32,13 @@ DOCUMENTATION = '''
         ini:
           - key: fact_caching_prefix
             section: defaults
-      _cache_keys_name:
-        description: User defined name for ansible cache key name
+      _keyset_name:
+        description: User defined name for cache keyset name.
         default: ansible_cache_keys
         env:
-          - name: ANSIBLE_CACHE_KEYS_NAME
+          - name: ANSIBLE_CACHE_REDIS_KEYSET_NAME
         ini:
-          - key: fact_caching_keys_name
+          - key: fact_caching_redis_keyset_name
             section: defaults
       _timeout:
         default: 86400
@@ -86,7 +86,7 @@ class CacheModule(BaseCacheModule):
                 uri = self.get_option('_uri')
             self._timeout = float(self.get_option('_timeout'))
             self._prefix = self.get_option('_prefix')
-            self._keys_set = self.get_option('_cache_keys_name')
+            self._keys_set = self.get_option('_keyset_name')
         except KeyError:
             display.deprecated('Rather than importing CacheModules directly, '
                                'use ansible.plugins.loader.cache_loader',


### PR DESCRIPTION
##### SUMMARY
make the hard coded key of the available key set in redis configurable. default is `ansible_cache_keys`. In my usecase I want to  to cache facts with different prefixes in the same redis db. to prevent mixing of different cache prefix keys,a way to configure the key set name is desirable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cache/redis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
