### PR TITLE
cache/redis: feature redis sentinel

### DIFF
--- a/changelogs/fragments/1055-redis-cache-sentinel.yaml
+++ b/changelogs/fragments/1055-redis-cache-sentinel.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - redis - add redis sentinel functionality to cache plugin
+  - redis cache plugin - add redis sentinel functionality to cache plugin
     (https://github.com/ansible-collections/community.general/pull/1055).

--- a/changelogs/fragments/1055-redis-cache-sentinel.yaml
+++ b/changelogs/fragments/1055-redis-cache-sentinel.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redis - add redis sentinel functionality to cache plugin
+    (https://github.com/ansible-collections/community.general/pull/1055).

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
           - A colon separated string of connection information for Redis.
           - The format is C(host:port:db:password), for example C(localhost:6379:0:changeme).
           - To use encryption in transit, prefix the connection with C(tls://), as in C(tls://localhost:6379:0:changeme).
-          - To use redis sentinel, use sepparator C(;), for example C(localhost:26379;localhost:26379;0:changeme). Requires redis>=2.9.0.
+          - To use redis sentinel, use separator C(;), for example C(localhost:26379;localhost:26379;0:changeme). Requires redis>=2.9.0.
         required: True
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
           - A colon separated string of connection information for Redis.
           - The format is C(host:port:db:password), for example C(localhost:6379:0:changeme).
           - To use encryption in transit, prefix the connection with C(tls://), as in C(tls://localhost:6379:0:changeme).
-          - To use redis sentinel, use sepparator C(;), for example C(localhost:26379;localhost:26379;0:changeme). Requires redis>=2.9.0
+          - To use redis sentinel, use sepparator C(;), for example C(localhost:26379;localhost:26379;0:changeme). Requires redis>=2.9.0.
         required: True
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
@@ -43,7 +43,7 @@ DOCUMENTATION = '''
             section: defaults
         version_added: 1.3.0
       _sentinel_service_name:
-        description: the redis sentinel service name (or referenced as cluster name)
+        description: The redis sentinel service name (or referenced as cluster name).
         env:
           - name: ANSIBLE_CACHE_REDIS_SENTINEL
         ini:
@@ -158,7 +158,7 @@ class CacheModule(BaseCacheModule):
         try:
             return scon.master_for(self._sentinel_service_name, socket_timeout=0.2)
         except Exception as exc:
-            raise AnsibleError('Could not connect to redis sentinel: %s' % exc)
+            raise AnsibleError('Could not connect to redis sentinel: %s' % to_native(exc))
 
     def _make_key(self, key):
         return self._prefix + key

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -87,6 +87,8 @@ class CacheModule(BaseCacheModule):
     to expire keys. This mechanism is used or a pattern matched 'scan' for
     performance.
     """
+    _sentinel_service_name = None
+
     def __init__(self, *args, **kwargs):
         uri = ''
 
@@ -124,7 +126,7 @@ class CacheModule(BaseCacheModule):
         else:
             connection = uri.split(':')
             self._db = StrictRedis(*connection, **kw)
-        
+
         display.vv('Redis connection: %s' % self._db)
 
     def _get_sentinel_connection(self, uri, kw):
@@ -136,7 +138,7 @@ class CacheModule(BaseCacheModule):
         except ImportError:
             raise AnsibleError("The 'redis' python module (version 2.9.0 or newer) is required to use redis sentinel.")
 
-        if not ';' in uri:
+        if ';' not in uri:
             raise AnsibleError('_uri does not have sentinel syntax.')
 
         # format: "localhost:26379;localhost2:26379;0:changeme"
@@ -148,9 +150,9 @@ class CacheModule(BaseCacheModule):
             try:
                 kw['password'] = connection_args.pop(0)
             except IndexError:
-                pass  # password is optional               
-        
-        sentinels = [ tuple(shost.split(':')) for shost in connections ]
+                pass  # password is optional
+
+        sentinels = [tuple(shost.split(':')) for shost in connections]
         display.vv('\nUsing redis sentinel: %s with %s' % (sentinels, kw))
         scon = Sentinel(sentinels, **kw)
         try:

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -66,6 +66,7 @@ import json
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
 from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
 from ansible.plugins.cache import BaseCacheModule
 from ansible.utils.display import Display

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -154,7 +154,7 @@ class CacheModule(BaseCacheModule):
                 pass  # password is optional
 
         sentinels = [tuple(shost.split(':')) for shost in connections]
-        display.vv('\nUsing redis sentinel: %s with %s' % (sentinels, kw))
+        display.vv('\nUsing redis sentinels: %s' % sentinels)
         scon = Sentinel(sentinels, **kw)
         try:
             return scon.master_for(self._sentinel_service_name, socket_timeout=0.2)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add redis sentinel functionality to redis cache plugin. Used for high available redis setups controlled by redis sentinel.   
The plugin asks the sentinels which redis node is currently the active master and sets the connection internally. There is no change in logic how the redis cache backend works, only where to connect.

Redis Sentinel is available since redis python >=2.9.0 (https://github.com/andymccurdy/redis-py/commit/46e475d9b95501a46c7abba9f05d415e27e9a62d). the minimal requirement at the moment for the redis cache module is >= 2.4.5
To not break backwards compatibility, Sentinel is imported when a sentinel uri is configured. additionally the sentinel config is sepparated by `;` to maintain the existing uri layout.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
merge #1036 first. this PR is built uppon.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example ansible.cfg:
```
[defaults]
fact_caching=redis
fact_caching_connection=localhost:26379;localhost:26380;0:changeme
fact_caching_redis_sentinel=mymaster
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
