### PR TITLE
[capabilities] fix for a newer versions of libcap

### DIFF
--- a/changelogs/fragments/993-file-capabilities.yml
+++ b/changelogs/fragments/993-file-capabilities.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - capabilities - fix for a newer version of libcap release (https://github.com/ansible-collections/community.general/pull/1061).

--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -113,7 +113,7 @@ class CapabilitiesModule(object):
         if rc != 0 or stderr != "":
             self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)
         if stdout.strip() != path:
-            if stdout.count(' ='):
+            if ' =' in stdout:
                 # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
             else:

--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -110,21 +110,27 @@ class CapabilitiesModule(object):
         #   '/foo'
         # If the file does not exist the output will be (with rc == 0...):
         #   '/foo (No such file or directory)'
-        if rc != 0 or (stdout.strip() != path and stdout.count(' =') != 1):
+        if rc != 0 or (stdout.count('=') != 1):
             self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)
-        if stdout.strip() != path:
-            caps = stdout.split(' =')[1].strip().split()
-            for cap in caps:
-                cap = cap.lower()
-                # getcap condenses capabilities with the same op/flags into a
-                # comma-separated list, so we have to parse that
-                if ',' in cap:
-                    cap_group = cap.split(',')
-                    cap_group[-1], op, flags = self._parse_cap(cap_group[-1])
-                    for subcap in cap_group:
-                        rval.append((subcap, op, flags))
-                else:
-                    rval.append(self._parse_cap(cap))
+        if stdout.count(' ='):
+            # process output of an older version of libcap
+            if stdout.strip() != path:
+                caps = stdout.split(' =')[1].strip().split()
+        else:
+            # otherwise, we have a newer version here
+            # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git
+            caps = stdout.split()[1].strip().split()
+        for cap in caps:
+            cap = cap.lower()
+            # getcap condenses capabilities with the same op/flags into a
+            # comma-separated list, so we have to parse that
+            if ',' in cap:
+                cap_group = cap.split(',')
+                cap_group[-1], op, flags = self._parse_cap(cap_group[-1])
+                for subcap in cap_group:
+                    rval.append((subcap, op, flags))
+            else:
+                rval.append(self._parse_cap(cap))
         return rval
 
     def setcap(self, path, caps):

--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -110,27 +110,27 @@ class CapabilitiesModule(object):
         #   '/foo'
         # If the file does not exist the output will be (with rc == 0...):
         #   '/foo (No such file or directory)'
-        if rc != 0 or (stdout.count('=') != 1):
+        if rc != 0 or stderr != "":
             self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)
-        if stdout.count(' ='):
-            # process output of an older version of libcap
-            if stdout.strip() != path:
+        if stdout.strip() != path:
+            if stdout.count(' ='):
+                # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
-        else:
-            # otherwise, we have a newer version here
-            # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git
-            caps = stdout.split()[1].strip().split()
-        for cap in caps:
-            cap = cap.lower()
-            # getcap condenses capabilities with the same op/flags into a
-            # comma-separated list, so we have to parse that
-            if ',' in cap:
-                cap_group = cap.split(',')
-                cap_group[-1], op, flags = self._parse_cap(cap_group[-1])
-                for subcap in cap_group:
-                    rval.append((subcap, op, flags))
             else:
-                rval.append(self._parse_cap(cap))
+                # otherwise, we have a newer version here
+                # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git
+                caps = stdout.split()[1].strip().split()
+            for cap in caps:
+                cap = cap.lower()
+                # getcap condenses capabilities with the same op/flags into a
+                # comma-separated list, so we have to parse that
+                if ',' in cap:
+                    cap_group = cap.split(',')
+                    cap_group[-1], op, flags = self._parse_cap(cap_group[-1])
+                    for subcap in cap_group:
+                        rval.append((subcap, op, flags))
+                else:
+                    rval.append(self._parse_cap(cap))
         return rval
 
     def setcap(self, path, caps):

--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -108,7 +108,7 @@ class CapabilitiesModule(object):
         #   '/foo ='
         # If file xattrs are unset the output will be:
         #   '/foo'
-        # If the file does not exist the output will be (with rc == 0...):
+        # If the file does not exist, the stderr will be (with rc == 0...):
         #   '/foo (No such file or directory)'
         if rc != 0 or stderr != "":
             self.module.fail_json(msg="Unable to get capabilities of %s" % path, stdout=stdout.strip(), stderr=stderr)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When module is run with recent version of libcap (getcap / setcap), playbook run returns error, since libcap has changed output of getcap. Fix it with this PR.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #993 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/system/capabilities.py

##### ADDITIONAL INFORMATION

Tested on debian 10 (version 2.25-2 of libcap) and debian sid (libcap version 2.43-1). 

Works, with `state:` variable `present` and/or `absent`, on the following playbook : 
```
$ cat ~/ansible.dev/playbooks/getcap.yml
---
- name: community.general/issues/993
  hosts: debian10
  become: true
  gather_facts: false
  tasks:
    - name: ensure capabilities for ping are set
      community.general.capabilities:
        path: /bin/ping
        capability: cap_net_raw+ep
        state: present
```

will try to write a test unit as well (if there's no globals or whatever)...