### PR TITLE
update django_manage migrate docs to include database param

### DIFF
--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -57,7 +57,7 @@ options:
     type: bool
   database:
     description:
-      - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', 'syncdb', and 'migrate' commands.
+      - The database to target. Used by the C(createcachetable), C(flush), C(loaddata), C(syncdb), and C(migrate) I(command).
     required: false
   failfast:
     description:

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -57,7 +57,7 @@ options:
     type: bool
   database:
     description:
-      - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.
+      - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', 'syncdb', and 'migrate' commands.
     required: false
   failfast:
     description:


### PR DESCRIPTION
##### SUMMARY
Updates the django_manage database parameter docs to show that it can be used with migrate. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/django_manage.py

##### ADDITIONAL INFORMATION
Here are the parameters supported by django_manage migrate (you can see it includes "database"): https://github.com/ansible-collections/community.general/blob/3d19e15a7d97f2e956722522a58c612c706098f9/plugins/modules/web_infrastructure/django_manage.py#L200
