### PR TITLE
postgresql_ext: sort list of available versions

### DIFF
--- a/changelogs/fragments/1078-postgresql_ext_fix_version_selection_when_version_is_latest.yml
+++ b/changelogs/fragments/1078-postgresql_ext_fix_version_selection_when_version_is_latest.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- postgresql_ext - fix version selection when ``version=latest``
+- postgresql_ext - fix version selection when ``version=latest`` (https://github.com/ansible-collections/community.general/pull/1078).

--- a/changelogs/fragments/1078-postgresql_ext_fix_version_selection_when_version_is_latest.yml
+++ b/changelogs/fragments/1078-postgresql_ext_fix_version_selection_when_version_is_latest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_ext - fix version selection when ``version=latest``

--- a/plugins/modules/database/postgresql/postgresql_ext.py
+++ b/plugins/modules/database/postgresql/postgresql_ext.py
@@ -295,7 +295,7 @@ def ext_get_versions(cursor, ext):
     if current_version == '0':
         current_version = False
 
-    return (current_version, available_versions)
+    return (current_version, sorted(available_versions, key=lambda v: LooseVersion(v)))
 
 # ===========================================
 # Module execution.

--- a/plugins/modules/database/postgresql/postgresql_ext.py
+++ b/plugins/modules/database/postgresql/postgresql_ext.py
@@ -295,7 +295,7 @@ def ext_get_versions(cursor, ext):
     if current_version == '0':
         current_version = False
 
-    return (current_version, sorted(available_versions, key=lambda v: LooseVersion(v)))
+    return (current_version, sorted(available_versions, key=LooseVersion))
 
 # ===========================================
 # Module execution.


### PR DESCRIPTION
##### SUMMARY
If `version == 'latest'` then the version is set to `available_versions[-1]` however `available_versions` was not previously sorted so the ordering was the natural order of the `pg_available_extension_versions` view.

This PR sorts the version using `LooseVersion` so that the version taken is in fact the latest available version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_ext