### PR TITLE
redis: use regexp to check if the value matches expected form

### DIFF
--- a/changelogs/fragments/1079-redis-use-regexp-to-check-if-the-value-matches-expected-form.yaml
+++ b/changelogs/fragments/1079-redis-use-regexp-to-check-if-the-value-matches-expected-form.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes redis parsing of config values which should not be converted to bytes

--- a/changelogs/fragments/1079-redis-use-regexp-to-check-if-the-value-matches-expected-form.yaml
+++ b/changelogs/fragments/1079-redis-use-regexp-to-check-if-the-value-matches-expected-form.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes redis parsing of config values which should not be converted to bytes
+  - redis - fixes parsing of config values which should not be converted to bytes (https://github.com/ansible-collections/community.general/pull/1079).

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -131,6 +131,7 @@ else:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.formatters import human_to_bytes
 from ansible.module_utils._text import to_native
+import re
 
 
 # Redis module specific support methods.
@@ -277,7 +278,10 @@ def main():
         name = module.params['name']
 
         try:  # try to parse the value as if it were the memory size
-            value = str(human_to_bytes(module.params['value'].upper()))
+            if re.match(r'^\s*(\d*\.?\d*)\s*([A-Za-z]+)?\s*$', module.params['value'].upper()):
+                value = str(human_to_bytes(module.params['value'].upper()))
+            else:
+                value = module.params['value']
         except ValueError:
             value = module.params['value']
 


### PR DESCRIPTION

##### SUMMARY
Fixes #1076 

check the value with a regexp to check if it matches something like
regexp should match values like:
- 1B
- 10MB
- 10mb
- 1.0kB

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
redis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible -m community.general.redis -b -a"command=config name=save value='900 1 300 10 60 10000'" aio
aio | SUCCESS => {
    "changed": false,
    "name": "save",
    "value": "900 1 300 10 60 10000"
}

```
