### PR TITLE
[datadog_event] Add an option to manage EU site

### DIFF
--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -61,6 +61,10 @@ options:
               on personally controlled sites using self-signed certificates.
         type: bool
         default: 'yes'
+    site:
+        description: ["The Datadog site."]
+        default: us
+        choices: ['us', 'eu']
 '''
 
 EXAMPLES = '''
@@ -79,6 +83,14 @@ EXAMPLES = '''
     api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     tags: 'aa,bb,#host:{{ inventory_hostname }}'
+
+- name: Post an event using an eu site
+  community.general.datadog_event:
+    title: Testing from ansible
+    text: Test
+    api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
+    app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
+    site: eu
 '''
 
 import platform
@@ -116,6 +128,10 @@ def main():
             ),
             aggregation_key=dict(required=False, default=None),
             validate_certs=dict(default=True, type='bool'),
+            site=dict(
+                required=False, default='us',
+                choices=['us', 'eu']
+            ),
         )
     )
 
@@ -124,6 +140,7 @@ def main():
         module.fail_json(msg=missing_required_lib('datadogpy'), exception=DATADOG_IMP_ERR)
 
     options = {
+        'site': module.params['site'],
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key']
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR aims to allow the `datadog_event` module usage with an .eu domain account.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
datadog_event

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

With a datadoghq.eu related account, it seems impossible to create a datadog event because the module doesn't allow to select the datadog site used by datadogpy. This PR aims to fix that !

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
