### PR TITLE
postgresql_info: add in_recovery return value to show if a service in recovery mode or not

### DIFF
--- a/changelogs/fragments/1091-postgresql_info_add_in_recovery_ret_val.yml
+++ b/changelogs/fragments/1091-postgresql_info_add_in_recovery_ret_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add ``in_recovery`` return value to show if a service in recovery mode or not (https://github.com/ansible-collections/community.general/issues/1068).

--- a/plugins/modules/database/postgresql/postgresql_info.py
+++ b/plugins/modules/database/postgresql/postgresql_info.py
@@ -121,7 +121,6 @@ in_recovery:
   description: Indicates if the service is in recovery mode or not.
   returned: always
   type: bool
-  returned: always
   sample: false
 databases:
   description: Information about databases.

--- a/plugins/modules/database/postgresql/postgresql_info.py
+++ b/plugins/modules/database/postgresql/postgresql_info.py
@@ -18,7 +18,7 @@ options:
     description:
     - Limit the collected information by comma separated string or YAML list.
     - Allowable values are C(version),
-      C(databases), C(settings), C(tablespaces), C(roles),
+      C(databases), C(in_recovery), C(settings), C(tablespaces), C(roles),
       C(replications), C(repl_slots).
     - By default, collects all subsets.
     - You can use shell-style (fnmatch) wildcard to pass groups of values (see Examples).
@@ -117,6 +117,12 @@ version:
       returned: always
       type: int
       sample: 1
+in_recovery:
+  description: Indicates if the service is in recovery mode or not.
+  returned: always
+  type: bool
+  returned: always
+  sample: false
 databases:
   description: Information about databases.
   returned: always
@@ -550,6 +556,7 @@ class PgClusterInfo(object):
         self.cursor = db_conn_obj.connect()
         self.pg_info = {
             "version": {},
+            "in_recovery": None,
             "tablespaces": {},
             "databases": {},
             "replications": {},
@@ -563,6 +570,7 @@ class PgClusterInfo(object):
         """Collect information based on 'filter' option."""
         subset_map = {
             "version": self.get_pg_version,
+            "in_recovery": self.get_recovery_state,
             "tablespaces": self.get_tablespaces,
             "databases": self.get_db_info,
             "replications": self.get_repl_info,
@@ -921,6 +929,10 @@ class PgClusterInfo(object):
             major=int(raw[0]),
             minor=int(raw[1]),
         )
+
+    def get_recovery_state(self):
+        """Get if the service is in recovery mode."""
+        self.pg_info["in_recovery"] = self.__exec_sql("SELECT pg_is_in_recovery()")[0][0]
 
     def get_db_info(self):
         """Get information about the current database."""

--- a/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/tests/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -63,6 +63,7 @@
   - assert:
       that:
       - result.version != {}
+      - result.in_recovery == false
       - result.databases.{{ db_default }}.collate
       - result.databases.{{ db_default }}.languages
       - result.databases.{{ db_default }}.namespaces
@@ -81,11 +82,13 @@
       filter:
         - ver*
         - rol*
+        - in_recov*
 
   - assert:
       that:
       - result.version != {}
       - result.roles
+      - result.in_recovery == false
       - result.databases == {}
       - result.repl_slots == {}
       - result.replications == {}
@@ -126,10 +129,12 @@
       filter:
       - "!ver*"
       - "!rol*"
+      - "!in_rec*"
 
   - assert:
       that:
       - result.version == {}
+      - result.in_recovery == None
       - result.roles == {}
       - result.databases
 
@@ -144,6 +149,7 @@
   - assert:
       that:
       - result.version != {}
+      - result.in_recovery == false
       - result.databases.{{ db_default }}.collate
       - result.databases.{{ db_default }}.languages
       - result.databases.{{ db_default }}.namespaces


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/1068

postgresql_info: add in_recovery return value to show if a service in recovery mode or not 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`plugins/modules/database/postgresql/postgresql_info.py`