### PR TITLE
postgresql_ext: fix module's failing when available ext versions contain a pure string

### DIFF
--- a/changelogs/fragments/1099-postgresql_ext_fix_failing_when_version_cannot_be_compared.yml
+++ b/changelogs/fragments/1099-postgresql_ext_fix_failing_when_version_cannot_be_compared.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_ext - fix the module crashes when available ext versions cannot be compared with current version (https://github.com/ansible-collections/community.general/issues/1095).

--- a/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
+++ b/tests/integration/targets/postgresql_ext/tasks/postgresql_ext_version_opt.yml
@@ -330,6 +330,23 @@
       - result.failed == true
       - result.msg == "Extension non_existent is not installed"
 
+  ######################################################################
+  # https://github.com/ansible-collections/community.general/issues/1095
+  - name: Install postgis
+    package:
+      name: postgis
+
+  - name: Create postgis extension
+    <<: *task_parameters
+    postgresql_ext:
+      <<: *pg_parameters
+      name: postgis
+      version: latest
+
+  - assert:
+      that:
+      - result is changed
+
   # Cleanup:
   - name: postgresql_ext_version - drop the extension
     <<: *task_parameters

--- a/tests/unit/plugins/modules/database/postgresql/test_postgresql_ext.py
+++ b/tests/unit/plugins/modules/database/postgresql/test_postgresql_ext.py
@@ -1,0 +1,40 @@
+# Copyright 2020, Andrew Klychkov @Andersson007 <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules.database.postgresql.postgresql_ext import (
+    parse_ext_versions,
+)
+
+
+@pytest.mark.parametrize(
+    'current,test_input,expected',
+    [
+        (
+            '2.0.0',
+            [{'version': '3.1.0dev'}, {'version': '3.1.0devnext'}, {'version': 'unpackaged'}],
+            ['3.1.0dev', '3.1.0devnext', 'unpackaged'],
+        ),
+        (
+            '2.0.0',
+            [{'version': 'unpackaged'}, {'version': '3.1.0dev'}, {'version': '3.1.0devnext'}],
+            ['unpackaged', '3.1.0dev', '3.1.0devnext'],
+        ),
+        (
+            '2.0.1',
+            [{'version': 'unpackaged'}, {'version': '2.0.0'}, {'version': '2.1.0dev'}],
+            ['unpackaged', '2.1.0dev'],
+        ),
+        (
+            '10.1',
+            [{'version': 'blahblah'}, {'version': '8.5'}, {'version': '10.0'}, {'version': '10.2'}, {'version': '10.3'}],
+            ['blahblah', '10.2', '10.3'],
+        ),
+    ]
+)
+def test_parse_ext_versions(current, test_input, expected):
+    assert parse_ext_versions(current, test_input) == expected

--- a/tests/unit/plugins/modules/database/postgresql/test_postgresql_ext.py
+++ b/tests/unit/plugins/modules/database/postgresql/test_postgresql_ext.py
@@ -17,22 +17,17 @@ from ansible_collections.community.general.plugins.modules.database.postgresql.p
         (
             '2.0.0',
             [{'version': '3.1.0dev'}, {'version': '3.1.0devnext'}, {'version': 'unpackaged'}],
-            ['3.1.0dev', '3.1.0devnext', 'unpackaged'],
+            ['3.1.0dev', '3.1.0devnext'],
         ),
         (
             '2.0.0',
             [{'version': 'unpackaged'}, {'version': '3.1.0dev'}, {'version': '3.1.0devnext'}],
-            ['unpackaged', '3.1.0dev', '3.1.0devnext'],
+            ['3.1.0dev', '3.1.0devnext'],
         ),
         (
             '2.0.1',
             [{'version': 'unpackaged'}, {'version': '2.0.0'}, {'version': '2.1.0dev'}],
-            ['unpackaged', '2.1.0dev'],
-        ),
-        (
-            '10.1',
-            [{'version': 'blahblah'}, {'version': '8.5'}, {'version': '10.0'}, {'version': '10.2'}, {'version': '10.3'}],
-            ['blahblah', '10.2', '10.3'],
+            ['2.1.0dev'],
         ),
     ]
 )


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/1095

postgresql_ext: fix module's failing when available ext versions contain a pure string


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/database/postgresql/postgresql_ext.py`
