### PR TITLE
Update postgresql_pg_hba.py

### DIFF
--- a/changelogs/fragments/1124-pg_hba-dictkey bugfix.yaml
+++ b/changelogs/fragments/1124-pg_hba-dictkey bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pg_hba - fix a crash when a new rule with an 'options' field replaces a rule without or vice versa (https://github.com/ansible-collections/community.general/pull/1124).

--- a/plugins/modules/database/postgresql/postgresql_pg_hba.py
+++ b/plugins/modules/database/postgresql/postgresql_pg_hba.py
@@ -335,7 +335,7 @@ class PgHba(object):
             ekeys = set(list(oldrule.keys()) + list(rule.keys()))
             ekeys.remove('line')
             for k in ekeys:
-                if oldrule[k] != rule[k]:
+                if oldrule.get(k) != rule.get(k):
                     raise PgHbaRuleChanged('{0} changes {1}'.format(rule, oldrule))
         except PgHbaRuleChanged:
             self.rules[key] = rule

--- a/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
+++ b/tests/integration/targets/postgresql_pg_hba/tasks/postgresql_pg_hba_initial.yml
@@ -58,6 +58,20 @@
   register: pg_hba_change
   with_items: "{{pg_hba_test_ips}}"
 
+- name: Able to add options on rule without
+  postgresql_pg_hba:
+    dest: "/tmp/pg_hba.conf"
+    users: "+some"
+    order: "sud"
+    state: "present"
+    contype: "local"
+    method: "cert"
+    options: "{{ item }}"
+    address: ""
+  with_items:
+  - ""
+  - "clientcert=1"
+
 - name: Retain options even if they contain spaces
   postgresql_pg_hba:
     dest: "/tmp/pg_hba.conf"


### PR DESCRIPTION
Fixes #1108

##### SUMMARY
Fixes #1108

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_pg_hba.py

##### ADDITIONAL INFORMATION
The module was accessing dict values using square brackets, and apparently in this case, the old rule did not have 'options' set, and new one has.
Using the .get method is safer (returns None if key not set).
With this change, if oldrule does not have options set, and rule does(or the other way around), a PgHbaRuleChanged is raised, which will replace the old rule for the new, which is as expected. 