### PR TITLE
New module: proxmox_snap

### DIFF
--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: community.general.proxmox_snap
+module: proxmox_snap
 short_description: Snapshot management of instances in Proxmox VE cluster
 description:
   - Allows you to create/delete snapshots from instances in Proxmox VE cluster.

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -28,7 +28,7 @@ options:
       - you can use PROXMOX_PASSWORD environment variable
     type: str
   hostname:
-    description
+    description:
       - the instance name
     type: str
   vmid:

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -11,6 +11,7 @@ DOCUMENTATION = r'''
 ---
 module: proxmox_snap
 short_description: Snapshot management of instances in Proxmox VE cluster
+version_added: 2.0.0
 description:
   - Allows you to create/delete snapshots from instances in Proxmox VE cluster.
 options:
@@ -100,32 +101,6 @@ EXAMPLES = r'''
     vmid: 100
     state: absent
     snapname: pre-updates
-
-- name: Make snapshots of multiple machines
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Make snapshots using the vmid
-      community.general.proxmox_snap:
-        api_user: root@pam
-        api_password: 1q2w3e
-        api_host: node1
-        vmid: "{{ proxmox_vmid }}"
-        state: present
-        snapname: test
-        vmstate: true
-      delegate_to: localhost
-
-    - name: Remove snapshots using the inventory hostname
-      community.general.proxmox_snap:
-        api_user: root@pam
-        api_password: 1q2w3e
-        api_host: node1
-        hostname: "{{ inventory_hostname }}"
-        state: absent
-        snapname: test
-        force: true
-      delegate_to: localhost
 '''
 
 RETURN = r'''#'''

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
-# Copyright: Ansible Project
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Jeffrey van Pelt (@Thulium-Drake) <jeff@vanpelt.one>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -8,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: community.general.proxmox_snap
-short_description: Snapshot management of instances in Proxmox VE cluster.
+short_description: Snapshot management of instances in Proxmox VE cluster
 description:
   - Allows you to create/delete snapshots from instances in Proxmox VE cluster.
 options:
@@ -102,7 +104,7 @@ EXAMPLES = r'''
   hosts: all
   gather_facts: false
   tasks:
-    - name: make snapshots using the vmid
+    - name: Make snapshots using the vmid
       community.general.proxmox_snap:
         api_user: root@pam
         api_password: 1q2w3e
@@ -112,7 +114,8 @@ EXAMPLES = r'''
         snapname: test
         vmstate: true
       delegate_to: localhost
-    - name: remove snapshots using the inventory hostname
+
+    - name: Remove snapshots using the inventory hostname
       community.general.proxmox_snap:
         api_user: root@pam
         api_password: 1q2w3e
@@ -226,13 +229,13 @@ def main():
         try:
             api_password = os.environ['PROXMOX_PASSWORD']
         except KeyError as e:
-            module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
+            module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable' % to_native(e))
 
     try:
         proxmox = setup_api(api_host, api_user, api_password, validate_certs)
 
     except Exception as e:
-        module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
+        module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % to_native(e))
 
     # If hostname is set get the VM id from ProxmoxAPI
     if not vmid and hostname:
@@ -261,7 +264,7 @@ def main():
             if snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
                 module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
         except Exception as e:
-            module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, e))
+            module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
     elif state == 'absent':
         try:
@@ -282,7 +285,7 @@ def main():
                 if snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
                     module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
         except Exception as e:
-            module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, e))
+            module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -76,7 +76,8 @@ options:
     type: str
 
 notes:
-  - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
+  - Requires proxmoxer and requests modules on host. These modules can be installed with pip.
+  - Supports C(check_mode).
 requirements: [ "proxmoxer", "python >= 2.7", "requests" ]
 author: Jeffrey van Pelt (@Thulium-Drake)
 '''
@@ -126,6 +127,8 @@ EXAMPLES = r'''
         force: true
       delegate_to: localhost
 '''
+
+RETURN = r'''#'''
 
 import os
 import time
@@ -251,7 +254,7 @@ def main():
     if not vmid and hostname:
         hosts = get_vmid(proxmox, hostname)
         if len(hosts) == 0:
-            module.fail_json(msg="Vmid could not be fetched => Hostname doesn't exist (action: %s)" % state)
+            module.fail_json(msg="Vmid could not be fetched => Hostname does not exist (action: %s)" % state)
         vmid = hosts[0]
     elif not vmid:
         module.exit_json(changed=False, msg="Vmid could not be fetched for the following action: %s" % state)

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -131,13 +131,15 @@ import os
 import time
 import traceback
 
+PROXMOXER_IMP_ERR = None
 try:
     from proxmoxer import ProxmoxAPI
     HAS_PROXMOXER = True
 except ImportError:
+    PROXMOXER_IMP_ERR = traceback.format_exc()
     HAS_PROXMOXER = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
 
@@ -209,7 +211,8 @@ def main():
     )
 
     if not HAS_PROXMOXER:
-        module.fail_json(msg='proxmoxer required for this module')
+        module.fail_json(msg=missing_required_lib('python-proxmoxer'),
+                         exception=PROXMOXER_IMP_ERR)
 
     state = module.params['state']
     api_user = module.params['api_user']

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -207,7 +207,8 @@ def main():
             snapname=dict(type='str', default='ansible_snap'),
             force=dict(type='bool', default='no'),
             vmstate=dict(type='bool', default='no'),
-        )
+        ),
+        supports_check_mode=True
     )
 
     if not HAS_PROXMOXER:
@@ -264,8 +265,11 @@ def main():
                 if i['name'] == snapname:
                     module.exit_json(changed=False, msg="Snapshot %s is already present" % snapname)
 
-            if snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
+            if module.check_mode:
+                module.exit_json(changed=False, msg="Would create snapshot %s" % snapname)
+            elif snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
                 module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
+
         except Exception as e:
             module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
@@ -285,8 +289,11 @@ def main():
             if not snap_exist:
                 module.exit_json(changed=False, msg="Snapshot %s does not exist" % snapname)
             else:
-                if snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
+                if module.check_mode:
+                    module.exit_json(changed=False, msg="Would remove snapshot %s" % snapname)
+                elif snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
                     module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
+
         except Exception as e:
             module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -7,55 +7,55 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: proxmox_snap
-short_description: snapshot management of instances in Proxmox VE cluster
+module: community.general.proxmox_snap
+short_description: Snapshot management of instances in Proxmox VE cluster.
 description:
-  - allows you to create/delete snapshots from instances in Proxmox VE cluster
+  - Allows you to create/delete snapshots from instances in Proxmox VE cluster.
 options:
   api_host:
     description:
-      - the host of the Proxmox VE cluster
+      - The host of the Proxmox VE cluster.
     required: true
     type: str
   api_user:
     description:
-      - the user to authenticate with
+      - The user to authenticate with.
     required: true
     type: str
   api_password:
     description:
-      - the password to authenticate with
-      - you can use PROXMOX_PASSWORD environment variable
+      - The password to authenticate with.
+      - You can use PROXMOX_PASSWORD environment variable.
     type: str
   hostname:
     description:
-      - the instance name
+      - The instance name.
     type: str
   vmid:
     description:
-      - the instance id
-      - if not set, will be fetched from PromoxAPI based on the hostname
+      - The instance id.
+      - If not set, will be fetched from PromoxAPI based on the hostname.
     type: str
   validate_certs:
     description:
-      - enable / disable https certificate verification
+      - Enable / disable https certificate verification.
     type: bool
-    default: 'no'
+    default: no
   state:
     description:
-     - Indicate desired state of the instance snapshot
+     - Indicate desired state of the instance snapshot.
     choices: ['present', 'absent']
     default: present
     type: str
   force:
     description:
       - For removal from config file, even if removing disk snapshot fails.
-    default: 'no'
+    default: no
     type: bool
   vmstate:
     description:
-      - Snapshot includes RAM
-    default: 'no'
+      - Snapshot includes RAM.
+    default: no
     type: bool
   description:
     description:
@@ -64,12 +64,12 @@ options:
     type: str
   timeout:
     description:
-      - timeout for operations
+      - Timeout for operations.
     default: 30
     type: int
   snapname:
     description:
-      - Name of the snapshot that has to be created
+      - Name of the snapshot that has to be created.
     default: 'ansible_snap'
     type: str
 
@@ -81,7 +81,7 @@ author: Jeffrey van Pelt (@Thulium-Drake)
 
 EXAMPLES = r'''
 - name: Create new container snapshot
-  proxmox_snap:
+  community.general.proxmox_snap:
     api_user: root@pam
     api_password: 1q2w3e
     api_host: node1
@@ -90,7 +90,7 @@ EXAMPLES = r'''
     snapname: pre-updates
 
 - name: Remove container snapshot
-  proxmox:
+  community.general.proxmox_snap:
     api_user: root@pam
     api_password: 1q2w3e
     api_host: node1
@@ -103,7 +103,7 @@ EXAMPLES = r'''
   gather_facts: false
   tasks:
     - name: make snapshots using the vmid
-      proxmox_snap:
+      community.general.proxmox_snap:
         api_user: root@pam
         api_password: 1q2w3e
         api_host: node1
@@ -113,7 +113,7 @@ EXAMPLES = r'''
         vmstate: true
       delegate_to: localhost
     - name: remove snapshots using the inventory hostname
-      proxmox_snap:
+      community.general.proxmox_snap:
         api_user: root@pam
         api_password: 1q2w3e
         api_host: node1

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -1,0 +1,291 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: proxmox_snap
+short_description: snapshot management of instances in Proxmox VE cluster
+description:
+  - allows you to create/delete snapshots from instances in Proxmox VE cluster
+options:
+  api_host:
+    description:
+      - the host of the Proxmox VE cluster
+    required: true
+    type: str
+  api_user:
+    description:
+      - the user to authenticate with
+    required: true
+    type: str
+  api_password:
+    description:
+      - the password to authenticate with
+      - you can use PROXMOX_PASSWORD environment variable
+    type: str
+  hostname:
+    description
+      - the instance name
+    type: str
+  vmid:
+    description:
+      - the instance id
+      - if not set, will be fetched from PromoxAPI based on the hostname
+    type: int
+  validate_certs:
+    description:
+      - enable / disable https certificate verification
+    type: bool
+    default: 'no'
+  state:
+    description:
+     - Indicate desired state of the instance snapshot
+    choices: ['present', 'absent']
+    default: present
+    type: str
+  force:
+    description:
+      - For removal from config file, even if removing disk snapshot fails.
+    default: 'no'
+    type: bool
+  vmstate:
+    description:
+      - Snapshot includes RAM
+    default: 'no'
+    type: bool
+  description:
+    description:
+      - Specify the description for the snapshot. Only used on the configuration web interface.
+      - This is saved as a comment inside the configuration file.
+    type: str
+    version_added: '0.2.0'
+  timeout:
+    description:
+      - timeout for operations
+    default: 30
+    type: int
+  snapname:
+    description:
+      - Name of the snapshot that has to be created
+    default: 'ansible_snap'
+    type: str
+    version_added: '0.2.0'
+
+notes:
+  - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
+requirements: [ "proxmoxer", "python >= 2.7", "requests" ]
+author: Jeffrey van Pelt (@Thulium-Drake)
+'''
+
+EXAMPLES = r'''
+- name: Create new container snapshot
+  proxmox_snap:
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    vmid: 100
+    state: present
+    snapname: pre-updates
+
+- name: Remove container snapshot
+  proxmox:
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    vmid: 100
+    state: absent
+    snapname: pre-updates
+
+- name: Make snapshots of multiple machines
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: make snapshots using the vmid
+      proxmox_snap:
+        api_user: root@pam
+        api_password: 1q2w3e
+        api_host: node1
+        vmid: "{{ proxmox_vmid }}"
+        state: present
+        snapname: test
+        vmstate: true
+      delegate_to: localhost
+    - name: remove snapshots using the inventory hostname
+      proxmox_snap:
+        api_user: root@pam
+        api_password: 1q2w3e
+        api_host: node1
+        hostname: "{{ inventory_hostname }}"
+        state: absent
+        snapname: test
+        force: true
+      delegate_to: localhost
+'''
+
+import os
+import time
+import traceback
+from distutils.version import LooseVersion
+
+try:
+    from proxmoxer import ProxmoxAPI
+    HAS_PROXMOXER = True
+except ImportError:
+    HAS_PROXMOXER = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+VZ_TYPE = None
+
+
+def get_vmid(proxmox, hostname):
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if 'name' in vm and vm['name'] == hostname]
+
+
+def get_instance(proxmox, vmid):
+    return [vm for vm in proxmox.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
+
+
+def proxmox_version(proxmox):
+    apireturn = proxmox.version.get()
+    return LooseVersion(apireturn['version'])
+
+
+def snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
+    if VZ_TYPE == 'lxc':
+        taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).snapshot.post(snapname=snapname, description=description)
+    else:
+        taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).snapshot.post(snapname=snapname, description=description, vmstate=int(vmstate))
+    while timeout:
+        if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped' and
+                proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            return True
+        timeout -= 1
+        if timeout == 0:
+            module.fail_json(msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
+                                 proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+
+        time.sleep(1)
+    return False
+
+
+def snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
+    taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).snapshot.delete(snapname, force=int(force))
+    while timeout:
+        if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped' and
+                proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            return True
+        timeout -= 1
+        if timeout == 0:
+            module.fail_json(msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
+                                 proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+
+        time.sleep(1)
+    return False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            api_host=dict(required=True),
+            api_user=dict(required=True),
+            api_password=dict(no_log=True),
+            vmid=dict(required=False),
+            validate_certs=dict(type='bool', default='no'),
+            hostname=dict(),
+            timeout=dict(type='int', default=30),
+            state=dict(default='present', choices=['present', 'absent']),
+            description=dict(type='str'),
+            snapname=dict(type='str', default='ansible_snap'),
+            force=dict(type='bool', default='no'),
+            vmstate=dict(type='bool', default='no'),
+        )
+    )
+
+    if not HAS_PROXMOXER:
+        module.fail_json(msg='proxmoxer required for this module')
+
+    state = module.params['state']
+    api_user = module.params['api_user']
+    api_host = module.params['api_host']
+    api_password = module.params['api_password']
+    vmid = module.params['vmid']
+    validate_certs = module.params['validate_certs']
+    hostname = module.params['hostname']
+    description = module.params['description']
+    snapname = module.params['snapname']
+    timeout = module.params['timeout']
+    force = module.params['force']
+    vmstate = module.params['vmstate']
+
+    # If password not set get it from PROXMOX_PASSWORD env
+    if not api_password:
+        try:
+            api_password = os.environ['PROXMOX_PASSWORD']
+        except KeyError as e:
+            module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
+
+    try:
+        proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
+
+    except Exception as e:
+        module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
+
+    # If hostname is set get the VM id from ProxmoxAPI
+    if not vmid and hostname:
+        hosts = get_vmid(proxmox, hostname)
+        if len(hosts) == 0:
+            module.fail_json(msg="Vmid could not be fetched => Hostname doesn't exist (action: %s)" % state)
+        vmid = hosts[0]
+    elif not vmid:
+        module.exit_json(changed=False, msg="Vmid could not be fetched for the following action: %s" % state)
+
+    vm = get_instance(proxmox, vmid)
+    global VZ_TYPE
+    VZ_TYPE = vm[0]['type']
+
+    if state == 'present':
+        try:
+            vm = get_instance(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s not exists in cluster' % vmid)
+
+            for i in getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).snapshot.get():
+                if i['name'] == snapname:
+                    module.exit_json(changed=False, msg="Snapshot %s is already present" % snapname)
+
+            if snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
+                module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
+        except Exception as e:
+            module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, e))
+
+    elif state == 'absent':
+        try:
+            vm = get_instance(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s not exists in cluster' % vmid)
+
+            snap_exist = False
+
+            for i in getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).snapshot.get():
+                if i['name'] == snapname:
+                    snap_exist = True
+                    continue
+
+            if not snap_exist:
+                module.exit_json(changed=False, msg="Snapshot %s does not exist" % snapname)
+            else:
+                if snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
+                    module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
+        except Exception as e:
+            module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -181,9 +181,11 @@ def snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
         time.sleep(1)
     return False
 
+
 def setup_api(api_host, api_user, api_password, validate_certs):
     api = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
     return api
+
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -14,6 +14,7 @@ short_description: Snapshot management of instances in Proxmox VE cluster
 version_added: 2.0.0
 description:
   - Allows you to create/delete snapshots from instances in Proxmox VE cluster.
+  - Supports both KVM and LXC, OpenVZ has not been tested, as it is no longer supported on Proxmox VE.
 options:
   api_host:
     description:

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -35,7 +35,7 @@ options:
     description:
       - the instance id
       - if not set, will be fetched from PromoxAPI based on the hostname
-    type: int
+    type: str
   validate_certs:
     description:
       - enable / disable https certificate verification

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -272,7 +272,10 @@ def main():
                     module.exit_json(changed=False, msg="Snapshot %s is already present" % snapname)
 
             if snapshot_create(module, proxmox, vm, vmid, timeout, snapname, description, vmstate):
-                module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
+                if module.check_mode:
+                    module.exit_json(changed=False, msg="Snapshot %s would be created" % snapname)
+                else:
+                    module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
 
         except Exception as e:
             module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
@@ -294,7 +297,10 @@ def main():
                 module.exit_json(changed=False, msg="Snapshot %s does not exist" % snapname)
             else:
                 if snapshot_remove(module, proxmox, vm, vmid, timeout, snapname, force):
-                    module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
+                    if module.check_mode:
+                        module.exit_json(changed=False, msg="Snapshot %s would be removed" % snapname)
+                    else:
+                        module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
 
         except Exception as e:
             module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -1,0 +1,1 @@
+./cloud/misc/proxmox_snap.py

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -41,32 +41,9 @@ def get_snaps():
     }]
 
 
-def task_start(snapname, description, vmstate):
-    return str("UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:")
-
-
-def task_status():
-    return {
-      "starttime": 100000,
-      "node": "localhost",
-      "upid": "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:",
-      "pstart": 100001,
-      "exitstatus": "OK",
-      "status": "stopped",
-      "type": "vzsnapshot",
-      "id": "100",
-      "user": "root@pam",
-      "pid": 1001}
-
-
 def fake_api(api_host, api_user, api_password, validate_certs):
-    vmid = "100"
-    taskid = "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:"
     r = MagicMock()
     r.cluster.resources.get = MagicMock(side_effect=get_resources)
-    r.nodes.localhost.lxc.vmid.snapshot.get = MagicMock(side_effect=get_snaps)
-    r.nodes.localhost.lxc.vmid.snapshot.post = MagicMock(side_effect=task_start)
-    r.nodes.localhost.tasks.taskid.status.get = MagicMock(side_effect=task_status)
     return r
 
 def test_proxmox_snap_without_argument(capfd):
@@ -80,6 +57,7 @@ def test_proxmox_snap_without_argument(capfd):
 
 def test_create_snapshot(mocker):
     set_module_args({
+                "check_mode": True,
                 "hostname": "test-lxc",
                 "api_user": "root@pam",
                 "api_password": "secret",

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -55,9 +55,8 @@ def test_proxmox_snap_without_argument(capfd):
     assert json.loads(out)['failed']
 
 
-def test_create_snapshot(mocker):
-    set_module_args({"check_mode": True,
-                     "hostname": "test-lxc",
+def test_create_snapshot_check_mode(mocker):
+    set_module_args({"hostname": "test-lxc",
                      "api_user": "root@pam",
                      "api_password": "secret",
                      "api_host": "127.0.0.1",
@@ -65,6 +64,7 @@ def test_create_snapshot(mocker):
                      "snapname": "test",
                      "timeout": "1",
                      "force": True})
+    proxmox_snap.check_mode = True
     proxmox_snap.HAS_PROXMOXER = True
     proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
     proxmox_snap.main()

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -12,33 +12,30 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 
 
 def get_resources(type):
-    return [{
-      "diskwrite": 0,
-      "vmid": 100,
-      "node": "localhost",
-      "id": "lxc/100",
-      "maxdisk": 10000,
-      "template": 0,
-      "disk": 10000,
-      "uptime": 10000,
-      "maxmem": 10000,
-      "maxcpu": 1,
-      "netin": 10000,
-      "type": "lxc",
-      "netout": 10000,
-      "mem": 10000,
-      "diskread": 10000,
-      "cpu": 0.01,
-      "name": "test-lxc",
-      "status": "running" }]
+    return [{ "diskwrite": 0,
+              "vmid": 100,
+              "node": "localhost",
+              "id": "lxc/100",
+              "maxdisk": 10000,
+              "template": 0,
+              "disk": 10000,
+              "uptime": 10000,
+              "maxmem": 10000,
+              "maxcpu": 1,
+              "netin": 10000,
+              "type": "lxc",
+              "netout": 10000,
+              "mem": 10000,
+              "diskread": 10000,
+              "cpu": 0.01,
+              "name": "test-lxc",
+              "status": "running" }]
 
 def get_snaps():
-    return [{
-      "running": 0,
-      "name": "test",
-      "digest": "deadbeef",
-      "description": "Test!"
-    }]
+    return [{ "running": 0,
+              "name": "test",
+              "digest": "deadbeef",
+              "description": "Test!" }]
 
 
 def fake_api(api_host, api_user, api_password, validate_certs):

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -5,8 +5,8 @@ __metaclass__ = type
 
 import json
 import pytest
-from unittest.mock import MagicMock
 
+from ansible_collections.community.general.tests.unit.compat.mock import MagicMock
 from ansible_collections.community.general.plugins.modules.cloud.misc import proxmox_snap
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
 
@@ -72,4 +72,24 @@ def test_create_snapshot_check_mode(capfd, mocker):
 
     out, err = capfd.readouterr()
     assert not err
-    assert json.loads(out)['changed']
+    assert not json.loads(out)['changed']
+
+
+def test_remove_snapshot_check_mode(capfd, mocker):
+    set_module_args({"hostname": "test-lxc",
+                     "api_user": "root@pam",
+                     "api_password": "secret",
+                     "api_host": "127.0.0.1",
+                     "state": "absent",
+                     "snapname": "test",
+                     "timeout": "1",
+                     "force": True,
+                     "_ansible_check_mode": True})
+    proxmox_snap.HAS_PROXMOXER = True
+    proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
+    with pytest.raises(SystemExit) as results:
+        proxmox_snap.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    assert not json.loads(out)['changed']

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -12,36 +12,38 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 
 
 def get_resources(type):
-    return [{ "diskwrite": 0,
-              "vmid": 100,
-              "node": "localhost",
-              "id": "lxc/100",
-              "maxdisk": 10000,
-              "template": 0,
-              "disk": 10000,
-              "uptime": 10000,
-              "maxmem": 10000,
-              "maxcpu": 1,
-              "netin": 10000,
-              "type": "lxc",
-              "netout": 10000,
-              "mem": 10000,
-              "diskread": 10000,
-              "cpu": 0.01,
-              "name": "test-lxc",
-              "status": "running" }]
+    return [{"diskwrite": 0,
+             "vmid": 100,
+             "node": "localhost",
+             "id": "lxc/100",
+             "maxdisk": 10000,
+             "template": 0,
+             "disk": 10000,
+             "uptime": 10000,
+             "maxmem": 10000,
+             "maxcpu": 1,
+             "netin": 10000,
+             "type": "lxc",
+             "netout": 10000,
+             "mem": 10000,
+             "diskread": 10000,
+             "cpu": 0.01,
+             "name": "test-lxc",
+             "status": "running" }]
+
 
 def get_snaps():
-    return [{ "running": 0,
-              "name": "test",
-              "digest": "deadbeef",
-              "description": "Test!" }]
+    return [{"running": 0,
+             "name": "test",
+             "digest": "deadbeef",
+             "description": "Test!" }]
 
 
 def fake_api(api_host, api_user, api_password, validate_certs):
     r = MagicMock()
     r.cluster.resources.get = MagicMock(side_effect=get_resources)
     return r
+
 
 def test_proxmox_snap_without_argument(capfd):
     set_module_args({})
@@ -52,17 +54,17 @@ def test_proxmox_snap_without_argument(capfd):
     assert not err
     assert json.loads(out)['failed']
 
+
 def test_create_snapshot(mocker):
-    set_module_args({
-                "check_mode": True,
-                "hostname": "test-lxc",
-                "api_user": "root@pam",
-                "api_password": "secret",
-                "api_host": "127.0.0.1",
-                "state": "present",
-                "snapname": "test",
-                "timeout": "1",
-                "force": True,})
+    set_module_args({"check_mode": True,
+                     "hostname": "test-lxc",
+                     "api_user": "root@pam",
+                     "api_password": "secret",
+                     "api_host": "127.0.0.1",
+                     "state": "present",
+                     "snapname": "test",
+                     "timeout": "1",
+                     "force": True,})
     proxmox_snap.HAS_PROXMOXER = True
     proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
     proxmox_snap.main()

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 from ansible_collections.community.general.plugins.modules.cloud.misc import proxmox_snap
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
 
+
 def get_resources(type):
     return [{
       "diskwrite": 0,
@@ -39,25 +40,28 @@ def get_snaps():
       "description": "Test!"
     }]
 
+
 def task_start(snapname, description, vmstate):
     return str("UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:")
 
+
 def task_status():
-    return {"starttime": 100000,
-    "node": "localhost",
-    "upid": "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:",
-    "pstart": 100001,
-    "exitstatus": "OK",
-    "status": "stopped",
-    "type": "vzsnapshot",
-    "id": "100",
-    "user": "root@pam",
-    "pid": 1001}
+    return {
+      "starttime": 100000,
+      "node": "localhost",
+      "upid": "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:",
+      "pstart": 100001,
+      "exitstatus": "OK",
+      "status": "stopped",
+      "type": "vzsnapshot",
+      "id": "100",
+      "user": "root@pam",
+      "pid": 1001}
 
 
 def fake_api(api_host, api_user, api_password, validate_certs):
-    #vmid = "100"
-    #taskid = "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:"
+    vmid = "100"
+    taskid = "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:"
     r = MagicMock()
     r.cluster.resources.get = MagicMock(side_effect=get_resources)
     r.nodes.localhost.lxc.vmid.snapshot.get = MagicMock(side_effect=get_snaps)
@@ -75,15 +79,15 @@ def test_proxmox_snap_without_argument(capfd):
     assert json.loads(out)['failed']
 
 def test_create_snapshot(mocker):
-    set_module_args({"hostname": "test-lxc",
-        "api_user": "root@pam",
-        "api_password": "secret",
-        "api_host": "127.0.0.1",
-        "state": "present",
-        "snapname": "test",
-        "timeout": "1",
-        "force": True,
-        })
+    set_module_args({
+                "hostname": "test-lxc",
+                "api_user": "root@pam",
+                "api_password": "secret",
+                "api_host": "127.0.0.1",
+                "state": "present",
+                "snapname": "test",
+                "timeout": "1",
+                "force": True,})
     proxmox_snap.HAS_PROXMOXER = True
     proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
     proxmox_snap.main()

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -4,14 +4,66 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-
 import pytest
-
-proxmox = pytest.importorskip('proxmoxer')
+from unittest.mock import MagicMock
 
 from ansible_collections.community.general.plugins.modules.cloud.misc import proxmox_snap
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
 
+def get_resources(type):
+    return [{
+      "diskwrite": 0,
+      "vmid": 100,
+      "node": "localhost",
+      "id": "lxc/100",
+      "maxdisk": 10000,
+      "template": 0,
+      "disk": 10000,
+      "uptime": 10000,
+      "maxmem": 10000,
+      "maxcpu": 1,
+      "netin": 10000,
+      "type": "lxc",
+      "netout": 10000,
+      "mem": 10000,
+      "diskread": 10000,
+      "cpu": 0.01,
+      "name": "test-lxc",
+      "status": "running" }]
+
+def get_snaps():
+    return [{
+      "running": 0,
+      "name": "test",
+      "digest": "deadbeef",
+      "description": "Test!"
+    }]
+
+def task_start(snapname, description, vmstate):
+    return str("UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:")
+
+def task_status():
+    return {"starttime": 100000,
+    "node": "localhost",
+    "upid": "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:",
+    "pstart": 100001,
+    "exitstatus": "OK",
+    "status": "stopped",
+    "type": "vzsnapshot",
+    "id": "100",
+    "user": "root@pam",
+    "pid": 1001}
+
+
+def fake_api(api_host, api_user, api_password, validate_certs):
+    #vmid = "100"
+    #taskid = "UPID:localhost:00007C26:05D37B74:5F90A0B7:vzsnapshot:100:root@pam:"
+    r = MagicMock()
+    r.cluster.resources.get = MagicMock(side_effect=get_resources)
+    r.nodes.localhost.lxc.vmid.snapshot.get = MagicMock(side_effect=get_snaps)
+    r.nodes.localhost.lxc.vmid.snapshot.post = MagicMock(side_effect=task_start)
+    r.nodes.localhost.tasks.taskid.status.get = MagicMock(side_effect=task_status)
+    return r
 
 def test_proxmox_snap_without_argument(capfd):
     set_module_args({})
@@ -21,4 +73,17 @@ def test_proxmox_snap_without_argument(capfd):
     out, err = capfd.readouterr()
     assert not err
     assert json.loads(out)['failed']
-    assert 'project_path' in json.loads(out)['msg']
+
+def test_create_snapshot(mocker):
+    set_module_args({"hostname": "test-lxc",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "api_host": "127.0.0.1",
+        "state": "present",
+        "snapname": "test",
+        "timeout": "1",
+        "force": True,
+        })
+    proxmox_snap.HAS_PROXMOXER = True
+    proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
+    proxmox_snap.main()

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -1,0 +1,24 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+import pytest
+
+proxmox = pytest.importorskip('proxmoxer')
+
+from ansible_collections.community.general.plugins.modules.cloud.misc import proxmox_snap
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args
+
+
+def test_proxmox_snap_without_argument(capfd):
+    set_module_args({})
+    with pytest.raises(SystemExit) as results:
+        proxmox_snap.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    assert json.loads(out)['failed']
+    assert 'project_path' in json.loads(out)['msg']

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -55,7 +55,7 @@ def test_proxmox_snap_without_argument(capfd):
     assert json.loads(out)['failed']
 
 
-def test_create_snapshot_check_mode(mocker):
+def test_create_snapshot_check_mode(capfd, mocker):
     set_module_args({"hostname": "test-lxc",
                      "api_user": "root@pam",
                      "api_password": "secret",
@@ -63,8 +63,13 @@ def test_create_snapshot_check_mode(mocker):
                      "state": "present",
                      "snapname": "test",
                      "timeout": "1",
-                     "force": True})
-    proxmox_snap.check_mode = True
+                     "force": True,
+                     "_ansible_check_mode": True})
     proxmox_snap.HAS_PROXMOXER = True
     proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
-    proxmox_snap.main()
+    with pytest.raises(SystemExit) as results:
+        proxmox_snap.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    assert json.loads(out)['changed']

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -32,13 +32,6 @@ def get_resources(type):
              "status": "running"}]
 
 
-def get_snaps():
-    return [{"running": 0,
-             "name": "test",
-             "digest": "deadbeef",
-             "description": "Test!"}]
-
-
 def fake_api(api_host, api_user, api_password, validate_certs):
     r = MagicMock()
     r.cluster.resources.get = MagicMock(side_effect=get_resources)

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -29,14 +29,14 @@ def get_resources(type):
              "diskread": 10000,
              "cpu": 0.01,
              "name": "test-lxc",
-             "status": "running" }]
+             "status": "running"}]
 
 
 def get_snaps():
     return [{"running": 0,
              "name": "test",
              "digest": "deadbeef",
-             "description": "Test!" }]
+             "description": "Test!"}]
 
 
 def fake_api(api_host, api_user, api_password, validate_certs):
@@ -64,7 +64,7 @@ def test_create_snapshot(mocker):
                      "state": "present",
                      "snapname": "test",
                      "timeout": "1",
-                     "force": True,})
+                     "force": True})
     proxmox_snap.HAS_PROXMOXER = True
     proxmox_snap.setup_api = mocker.MagicMock(side_effect=fake_api)
     proxmox_snap.main()


### PR DESCRIPTION
This commit adds proxmox_snap for snapshot management on PVE, previously worked on in #535 

This is that same module on a new branch (a lot of time passed and I messed up my git checkouts :-) )

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
proxmox_snap: based on 'proxmox', adapted to manage snapshots for LXC/Qemu machines (OpenVZ might work, but I didn't test it as it is no longer supported in PVE)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Status: fully functional, lacks tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_snap
