### PR TITLE
odbc: adding parameter to disable auto-commit (#1137)

### DIFF
--- a/changelogs/fragments/odbc.yml
+++ b/changelogs/fragments/odbc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "odbc - Added a parameter 'commit' which allows users to subvery the explicit commit after the execute call"

--- a/changelogs/fragments/odbc.yml
+++ b/changelogs/fragments/odbc.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "odbc - Added a parameter 'commit' which allows users to subvery the explicit commit after the execute call"
+- "odbc - Added a parameter 'commit' which allows users to disable the explicit commit after the execute call"

--- a/changelogs/fragments/odbc.yml
+++ b/changelogs/fragments/odbc.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "odbc - Added a parameter 'commit' which allows users to disable the explicit commit after the execute call"
+- "odbc - added a parameter ``commit`` which allows users to disable the explicit commit after the execute call (https://github.com/ansible-collections/community.general/pull/1139)."

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -35,7 +35,7 @@ options:
       description:
         - Perform a commit after the execution of the SQL query.
         - Some databases will allow a commit after a select whereas others will raise an exception.
-        - Default is true to support legacy module behavior.
+        - Default is C(true) to support legacy module behavior.
       type: bool
       default: yes
       version_added: 1.3.0

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
     query: "Select * from table_a where column1 = ?"
     params:
       - "value1"
-    commit: False
+    commit: false
   changed_when: no
 '''
 

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -38,6 +38,7 @@ options:
         - Default is true to support legacy module behavior.
       type: bool
       default: yes
+      version_added: 1.3.0
 requirements:
   - "python >= 2.6"
   - "pyodbc"

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -31,7 +31,13 @@ options:
         - Parameters to pass to the SQL query.
       type: list
       elements: str
-
+    commit:
+      description:
+        - Perform a commit after the execution of the SQL query.
+        - Some databases will allow a commit after a select whereas others will raise an exception.
+        - Default is true to support legacy module behavior.
+      type: bool
+      default: yes
 requirements:
   - "python >= 2.6"
   - "pyodbc"
@@ -49,6 +55,7 @@ EXAMPLES = '''
     query: "Select * from table_a where column1 = ?"
     params:
       - "value1"
+    commit: False
   changed_when: no
 '''
 
@@ -86,12 +93,14 @@ def main():
             dsn=dict(type='str', required=True, no_log=True),
             query=dict(type='str', required=True),
             params=dict(type='list', elements='str'),
+            commit=dict(type='bool', deailt=True),
         ),
     )
 
     dsn = module.params.get('dsn')
     query = module.params.get('query')
     params = module.params.get('params')
+    commit = module.params.get('commit')
 
     if not HAS_PYODBC:
         module.fail_json(msg=missing_required_lib('pyodbc'))
@@ -117,7 +126,8 @@ def main():
             cursor.execute(query, params)
         else:
             cursor.execute(query)
-        cursor.commit()
+        if commit:
+            cursor.commit()
         try:
             # Get the rows out into an 2d array
             for row in cursor.fetchall():

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -94,7 +94,7 @@ def main():
             dsn=dict(type='str', required=True, no_log=True),
             query=dict(type='str', required=True),
             params=dict(type='list', elements='str'),
-            commit=dict(type='bool', deailt=True),
+            commit=dict(type='bool', default=True),
         ),
     )
 

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -34,7 +34,7 @@ options:
     commit:
       description:
         - Perform a commit after the execution of the SQL query.
-        - Some databases will allow a commit after a select whereas others will raise an exception.
+        - Some databases allow a commit after a select whereas others raise an exception.
         - Default is C(true) to support legacy module behavior.
       type: bool
       default: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding a parameter which disables the auto-commit feature within the module.
We had an auto commit in the module incase someone was passing in a DDL statement.
As noted in the referenced bug this commit was causing issues with some databases after trying to perform a select.
This new parameter will prevent the module from auto-committing after the execute statement.

Fixes #1137

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
odbc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
