### PR TITLE
iptables_state: fix race condition between module and its action plugin

### DIFF
--- a/changelogs/fragments/1140-iptables_state-fix-race-condition.yml
+++ b/changelogs/fragments/1140-iptables_state-fix-race-condition.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - iptables_state - fix race condition between module and its action plugin
+    (https://github.com/ansible-collections/community.general/issues/1136).

--- a/plugins/modules/system/iptables_state.py
+++ b/plugins/modules/system/iptables_state.py
@@ -551,6 +551,17 @@ def main():
             restored_state = state_to_restore
 
     else:
+        # Let time enough to the plugin to retrieve async status of the module
+        # in case of bad option type/value and the like.
+        b_starter = to_bytes('%s.starter' % _back, errors='surrogate_or_strict')
+        while True:
+            if os.path.exists(b_starter):
+                os.remove(b_starter)
+                break
+            else:
+                time.sleep(0.01)
+                continue
+
         (rc, stdout, stderr) = module.run_command(MAINCOMMAND)
         if 'Another app is currently holding the xtables lock' in stderr:
             module.fail_json(

--- a/plugins/modules/system/iptables_state.py
+++ b/plugins/modules/system/iptables_state.py
@@ -553,14 +553,15 @@ def main():
     else:
         # Let time enough to the plugin to retrieve async status of the module
         # in case of bad option type/value and the like.
-        b_starter = to_bytes('%s.starter' % _back, errors='surrogate_or_strict')
-        while True:
-            if os.path.exists(b_starter):
-                os.remove(b_starter)
-                break
-            else:
-                time.sleep(0.01)
-                continue
+        if _back is not None:
+            b_starter = to_bytes('%s.starter' % _back, errors='surrogate_or_strict')
+            while True:
+                if os.path.exists(b_starter):
+                    os.remove(b_starter)
+                    break
+                else:
+                    time.sleep(0.01)
+                    continue
 
         (rc, stdout, stderr) = module.run_command(MAINCOMMAND)
         if 'Another app is currently holding the xtables lock' in stderr:


### PR DESCRIPTION
##### SUMMARY
Fixes #1136

Also remove irrelevant/unneeded display.v() and display.warning() around connection reset, by the way.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iptables_state

##### ADDITIONAL INFORMATION

For the rationale, see the issue description. This PR applies the solution 3 as found at the end of this description:
https://github.com/ansible-collections/community.general/issues/1136