### PR TITLE
simple inventory with groups from simple apt-dater/hosts.xml with FQD…

### DIFF
--- a/plugins/inventory/apt-dater.sh
+++ b/plugins/inventory/apt-dater.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+xsltproc <(cat <<EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="text" encoding="UTF-8" omit-xml-declaration="yes" indent="no" media-type="application/json" />
+<xsl:strip-space elements="*" />
+  <xsl:template match="/">
+    <xsl:text>{</xsl:text>
+      <xsl:for-each select="hosts/group">
+        "<xsl:value-of select="@name"/>": [ 
+          <xsl:for-each select="host">
+          "<xsl:value-of select="@name"/>"
+            <xsl:if test="position() != last()"> 
+              <xsl:text>,</xsl:text> 
+            </xsl:if> 
+          </xsl:for-each> ]
+        <xsl:if test="position() != last()"> 
+        <xsl:text>,</xsl:text> 
+        </xsl:if>
+      </xsl:for-each>
+    <xsl:text>}</xsl:text>
+</xsl:template>
+</xsl:stylesheet>
+EOF
+) ~/.config/apt-dater/hosts.xml


### PR DESCRIPTION
Hello,

it's just new dynamic inventory for apt-dater with simple hosts.xml with FQDN in name attributes.
ISSUE TYPE

    Feature Pull Request

I hope it's right here: look https://github.com/ansible/ansible/pull/67567

Best Regards,
Juri Grabowski
