### PR TITLE
filesystem: fix 355 state absent

### DIFF
--- a/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
+++ b/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filesystem - add option 'state' to remove filesystem signatures when
+    'state=absent'. No breaking changes ('state=present' can be omitted).
+    (https://github.com/ansible-collections/community.general/issues/355).

--- a/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
+++ b/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
@@ -1,5 +1,4 @@
 ---
 bugfixes:
-  - filesystem - add option 'state' to remove filesystem signatures when
-    'state=absent'. No breaking changes ('state=present' can be omitted).
+  - filesystem - add option ``state`` with default ``present``. When set to ``absent``, filesystem signatures are removed
     (https://github.com/ansible-collections/community.general/issues/355).

--- a/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
+++ b/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - filesystem - add option ``state`` with default ``present``. When set to ``absent``, filesystem signatures are removed
+  - filesystem - add option ``state`` with default ``present``. When set to ``absent``, first 128kB of device/file are erased
     (https://github.com/ansible-collections/community.general/issues/355).

--- a/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
+++ b/changelogs/fragments/1149-filesystem-fix-355-state-absent.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - filesystem - add option ``state`` with default ``present``. When set to ``absent``, first 128kB of device/file are erased
+  - filesystem - add option ``state`` with default ``present``. When set to ``absent``, filesystem signatures are removed
     (https://github.com/ansible-collections/community.general/issues/355).

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -24,7 +24,7 @@ options:
       contains a filesystem (as known by C(blkid)).
     - When C(state=absent), all other options but I(dev) are ignored, and the
       module doesn't fail if the device I(dev) doesn't actually exist.
-    - C(state=absent) is not supported and has no effect on FreeBSD systems.
+    - C(state=absent) is not supported and will fail on FreeBSD systems.
     type: str
     choices: [ present, absent ]
     default: present
@@ -171,7 +171,7 @@ class Filesystem(object):
     def wipefs(self, dev):
         if platform.system() == 'FreeBSD':
             msg = "module param state=absent is currently not supported on this OS (FreeBSD)."
-            self.module.exit_json(msg=msg)
+            self.module.fail_json(msg=msg)
 
         if self.module.check_mode:
             return

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -20,7 +20,8 @@ options:
     description:
     - If C(state=present), the filesystem is created if it doesn't already
       exist, that is the default behaviour if I(state) is omitted.
-    - If C(state=absent), all filesystem signatures on I(dev) are wiped.
+    - If C(state=absent), first 128kB of I(dev) are wiped if it contains a
+      filesystem (as known by C(blkid)).
     - When C(state=absent), all other options but I(dev) are ignored, and the
       module doesn't fail if the device I(dev) doesn't actually exist.
     choices: [ present, absent ]
@@ -65,6 +66,7 @@ requirements:
 notes:
   - Potential filesystem on I(dev) are checked using C(blkid), in case C(blkid) isn't able to detect an existing filesystem,
     this filesystem is overwritten even if I(force) is C(no).
+  - This module supports I(check_mode).
 '''
 
 EXAMPLES = '''
@@ -79,7 +81,7 @@ EXAMPLES = '''
     dev: /dev/sdb1
     opts: -cc
 
-- name: Blank filesystem signatures on /dev/sdb1
+- name: Blank filesystem header on /dev/sdb1
   community.general.filesystem:
     dev: /dev/sdb1
     state: absent

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -163,16 +163,10 @@ class Filesystem(object):
         if self.module.check_mode:
             return
 
-        try:
-            # wipefs comes with util-linux package
-            wipefs = self.module.get_bin_path('wipefs', required=True)
-            cmd = [wipefs, "--all", "%s" % dev]
-        except ValueError:
-            # No such 'wipefs' tool on FreeBSD (and more), so we'll blindly
-            # blank the first 128kB, since xfs signature is at offset 0 and
-            # reiserfs & btrfs signatures are near after the first 64kB.
-            dd = self.module.get_bin_path('dd', required=True)
-            cmd = [dd, "if=/dev/zero", "of=%s" % dev, "bs=512", "count=256"]
+        # wipefs comes with util-linux package, and may not work with vfat (at
+        # least on CentOS 6). So we use the good old dd instead, in all cases.
+        dd = self.module.get_bin_path('dd', required=True)
+        cmd = [dd, "if=/dev/zero", "of=%s" % dev, "bs=512", "count=256"]
         self.module.run_command(cmd, check_rc=True)
 
     def grow_cmd(self, dev):

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -167,7 +167,7 @@ class Filesystem(object):
             # wipefs comes with util-linux package
             wipefs = self.module.get_bin_path('wipefs', required=True)
             cmd = [wipefs, "--all", dev]
-        except:
+        except ValueError:
             # No such 'wipefs' tool on FreeBSD (and more), so we'll blindly
             # blank the first 128kB, since xfs signature is at offset 0 and
             # reiserfs & btrfs signatures are near after the first 64kB.

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -161,10 +161,9 @@ class Filesystem(object):
 
     def wipefs(self, dev):
         wipefs = self.module.get_bin_path('wipefs', required=True)
+        cmd = list([wipefs, "--all", dev])
         if self.module.check_mode:
-            cmd = "%s --no-act --all '%s'" % (wipefs, dev)
-        else:
-            cmd = "%s --all '%s'" % (wipefs, dev)
+            cmd.insert(1, "--no-act")
         self.module.run_command(cmd, check_rc=True)
 
     def grow_cmd(self, dev):
@@ -457,12 +456,11 @@ def main():
         filesystem.create(opts, dev)
         changed = True
 
-    else:
+    elif fs:
         # wipe fs signatures
         filesystem = Filesystem(module)
         filesystem.wipefs(dev)
-        if fs:
-            changed = True
+        changed = True
 
     module.exit_json(changed=changed)
 

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -165,6 +165,11 @@ class Filesystem(object):
         if self.module.check_mode:
             return
 
+        mountpoint = dev.get_mountpoint()
+        if mountpoint:
+            msg = "operation forbidden while filesystem %s is mounted (over %s)." % (dev, mountpoint)
+            self.module.fail_json(changed=False, msg=msg)
+
         # wipefs comes with util-linux package, and may not work with vfat (at
         # least on CentOS 6). So we use the good old dd instead, in all cases.
         dd = self.module.get_bin_path('dd', required=True)

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -166,7 +166,7 @@ class Filesystem(object):
         try:
             # wipefs comes with util-linux package
             wipefs = self.module.get_bin_path('wipefs', required=True)
-            cmd = [wipefs, "--all", dev]
+            cmd = [wipefs, "--all", "%s" % dev]
         except ValueError:
             # No such 'wipefs' tool on FreeBSD (and more), so we'll blindly
             # blank the first 128kB, since xfs signature is at offset 0 and

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -166,7 +166,7 @@ class Filesystem(object):
         # wipefs comes with util-linux package, and may not work with vfat (at
         # least on CentOS 6). So we use the good old dd instead, in all cases.
         dd = self.module.get_bin_path('dd', required=True)
-        cmd = [dd, "if=/dev/zero", "of=%s" % dev, "bs=512", "count=256"]
+        cmd = [dd, "if=/dev/zero", "of=%s" % dev, "bs=512", "count=256", "conv=notrunc"]
         self.module.run_command(cmd, check_rc=True)
 
     def grow_cmd(self, dev):

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -28,7 +28,8 @@ options:
   fstype:
     choices: [ btrfs, ext2, ext3, ext4, ext4dev, f2fs, lvm, ocfs2, reiserfs, xfs, vfat, swap ]
     description:
-    - Filesystem type to be created.
+    - Filesystem type to be created. This option is required with
+      C(state=present) (or if I(state) is omitted).
     - reiserfs support was added in 2.2.
     - lvm support was added in 2.5.
     - since 2.5, I(dev) can be an image file.
@@ -36,7 +37,6 @@ options:
     - ocfs2 support was added in 2.6
     - f2fs support was added in 2.7
     - swap support was added in 2.8
-    required: yes
     aliases: [type]
   dev:
     description:

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -25,6 +25,7 @@ options:
     - When C(state=absent), all other options but I(dev) are ignored, and the
       module doesn't fail if the device I(dev) doesn't actually exist.
     - C(state=absent) is not supported and has no effect on FreeBSD systems.
+    type: str
     choices: [ present, absent ]
     default: present
     version_added: 1.3.0
@@ -40,10 +41,12 @@ options:
     - ocfs2 support was added in 2.6
     - f2fs support was added in 2.7
     - swap support was added in 2.8
+    type: str
     aliases: [type]
   dev:
     description:
     - Target path to device or image file.
+    type: path
     required: yes
     aliases: [device]
   force:
@@ -64,6 +67,7 @@ options:
   opts:
     description:
     - List of options to be passed to mkfs command.
+    type: str
 requirements:
   - Uses tools related to the I(fstype) (C(mkfs)) and C(blkid) command. When I(resizefs) is enabled, C(blockdev) command is required too.
 notes:
@@ -405,10 +409,10 @@ def main():
     # There is no "single command" to manipulate filesystems, so we map them all out and their options
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(default='present', choices=['present', 'absent']),
-            fstype=dict(aliases=['type'], choices=list(fstypes)),
-            dev=dict(required=True, aliases=['device']),
-            opts=dict(),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+            fstype=dict(type='str', aliases=['type'], choices=list(fstypes)),
+            dev=dict(type='path', required=True, aliases=['device']),
+            opts=dict(type='str'),
             force=dict(type='bool', default=False),
             resizefs=dict(type='bool', default=False),
         ),

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -25,6 +25,7 @@ options:
       module doesn't fail if the device I(dev) doesn't actually exist.
     choices: [ present, absent ]
     default: present
+    version_added: 1.3.0
   fstype:
     choices: [ btrfs, ext2, ext3, ext4, ext4dev, f2fs, lvm, ocfs2, reiserfs, xfs, vfat, swap ]
     description:

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -43,6 +43,11 @@
     - 'not (item.0.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
     - 'not (item.1 == "overwrite_another_fs" and ansible_system == "FreeBSD")'
 
+    - 'not (item.1 == "remove_fs" and ansible_system == "FreeBSD")' # util-linux not available on FreeBSD
+    # On CentOS 6 shippable containers, wipefs seems unable to remove vfat signatures
+    - 'not (item.1 == "remove_fs" and item.0.key == "vfat" and ansible_distribution == "CentOS" and
+            ansible_distribution_version is version("7.0", "<"))'
+
     # The xfsprogs package on newer versions of OpenSUSE (15+) require Python 3, we skip this on our Python 2 container
     # OpenSUSE 42.3 Python2 and the other py3 containers are not affected so we will continue to run that
     - 'not (item.0.key == "xfs" and ansible_os_family == "Suse" and ansible_python.version.major == 2 and ansible_distribution_major_version|int != 42)'

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -46,4 +46,4 @@
     # The xfsprogs package on newer versions of OpenSUSE (15+) require Python 3, we skip this on our Python 2 container
     # OpenSUSE 42.3 Python2 and the other py3 containers are not affected so we will continue to run that
     - 'not (item.0.key == "xfs" and ansible_os_family == "Suse" and ansible_python.version.major == 2 and ansible_distribution_major_version|int != 42)'
-  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs'])|list }}"
+  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs', 'remove_fs'])|list }}"

--- a/tests/integration/targets/filesystem/tasks/remove_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/remove_fs.yml
@@ -49,6 +49,7 @@
   command:
     cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
   changed_when: false
+  failed_when: false
   register: blkid
 
 - name: Assert that the state changed and the device has no filesystem
@@ -56,6 +57,7 @@
     that:
       - wipefs is changed
       - blkid.stdout | length == 0
+      - blkid.rc == 2
 
 # Do it again
 - name: filesystem removal (idempotency)

--- a/tests/integration/targets/filesystem/tasks/remove_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/remove_fs.yml
@@ -6,17 +6,16 @@
     dev: '{{ dev }}'
     fstype: '{{ fstype }}'
 
-- name: get filesystem TYPE with 'blkid'
+- name: get filesystem UUID with 'blkid'
   command:
-    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+    cmd: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   changed_when: false
-  register: blkid
+  register: blkid_ref
 
-- name: Assert that the filesystem exists with the requested type
+- name: Assert that a filesystem exists on top of the device
   assert:
     that:
-      - ( blkid.stdout == fstype ) or
-        ( blkid.stdout == 'ext4' and fstype == 'ext4dev' )
+      - blkid_ref.stdout | length > 0
 
 
 # Test check_mode first
@@ -27,9 +26,9 @@
   register: wipefs
   check_mode: yes
 
-- name: get filesystem TYPE with 'blkid' (should remain the same)
+- name: get filesystem UUID with 'blkid' (should remain the same)
   command:
-    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+    cmd: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   changed_when: false
   register: blkid
 
@@ -37,8 +36,7 @@
   assert:
     that:
       - wipefs is changed
-      - ( blkid.stdout == fstype ) or
-        ( blkid.stdout == 'ext4' and fstype == 'ext4dev' )
+      - blkid.stdout == blkid_ref.stdout
 
 # Do it
 - name: filesystem removal
@@ -47,9 +45,9 @@
     state: absent
   register: wipefs
 
-- name: get filesystem TYPE with 'blkid' (should be empty)
+- name: get filesystem UUID with 'blkid' (should be empty)
   command:
-    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+    cmd: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   changed_when: false
   failed_when: false
   register: blkid

--- a/tests/integration/targets/filesystem/tasks/remove_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/remove_fs.yml
@@ -1,0 +1,96 @@
+---
+# We assume 'create_fs' tests have passed.
+
+- name: filesystem creation
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+
+- name: get filesystem TYPE with 'blkid'
+  command:
+    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+  changed_when: false
+  register: blkid
+
+- name: Assert that the filesystem exists with the requested type
+  assert:
+    that:
+      - blkid.stdout == fstype
+
+
+# Test check_mode first
+- name: filesystem removal (check mode)
+  filesystem:
+    dev: '{{ dev }}'
+    state: absent
+  register: wipefs
+  check_mode: yes
+
+- name: get filesystem TYPE with 'blkid' (should remain the same)
+  command:
+    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+  changed_when: false
+  register: blkid
+
+- name: Assert that the state changed but the filesystem still exists
+  assert:
+    that:
+      - wipefs is changed
+      - blkid.stdout == fstype
+
+# Do it
+- name: filesystem removal
+  filesystem:
+    dev: '{{ dev }}'
+    state: absent
+  register: wipefs
+
+- name: get filesystem TYPE with 'blkid' (should be empty)
+  command:
+    cmd: 'blkid -c /dev/null -o value -s TYPE {{ dev }}'
+  changed_when: false
+  register: blkid
+
+- name: Assert that the state changed and the device has no filesystem
+  assert:
+    that:
+      - wipefs is changed
+      - blkid.stdout | length == 0
+
+# Do it again
+- name: filesystem removal (idempotency)
+  filesystem:
+    dev: '{{ dev }}'
+    state: absent
+  register: wipefs
+
+- name: Assert that the state did not change
+  assert:
+    that:
+      - wipefs is not changed
+
+# and again
+- name: filesystem removal (idempotency, check mode)
+  filesystem:
+    dev: '{{ dev }}'
+    state: absent
+  register: wipefs
+  check_mode: yes
+
+- name: Assert that the state did not change
+  assert:
+    that:
+      - wipefs is not changed
+
+
+# By the way, test removal of a filesystem on unexistent device
+- name: filesystem removal (unexistent device)
+  filesystem:
+    dev: '/dev/unexistent_device'
+    state: absent
+  register: wipefs
+
+- name: Assert that the state did not change
+  assert:
+    that:
+      - wipefs is not changed

--- a/tests/integration/targets/filesystem/tasks/remove_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/remove_fs.yml
@@ -15,7 +15,8 @@
 - name: Assert that the filesystem exists with the requested type
   assert:
     that:
-      - blkid.stdout == fstype
+      - ( blkid.stdout == fstype ) or
+        ( blkid.stdout == 'ext4' and fstype == 'ext4dev' )
 
 
 # Test check_mode first
@@ -36,7 +37,8 @@
   assert:
     that:
       - wipefs is changed
-      - blkid.stdout == fstype
+      - ( blkid.stdout == fstype ) or
+        ( blkid.stdout == 'ext4' and fstype == 'ext4dev' )
 
 # Do it
 - name: filesystem removal

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1173,7 +1173,6 @@ plugins/modules/system/dconf.py pylint:blacklisted-name
 plugins/modules/system/dconf.py validate-modules:doc-missing-type
 plugins/modules/system/dconf.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/filesystem.py pylint:blacklisted-name
-plugins/modules/system/filesystem.py validate-modules:doc-missing-type
 plugins/modules/system/gconftool2.py pylint:blacklisted-name
 plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/gconftool2.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1173,7 +1173,6 @@ plugins/modules/system/dconf.py pylint:blacklisted-name
 plugins/modules/system/dconf.py validate-modules:doc-missing-type
 plugins/modules/system/dconf.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/filesystem.py pylint:blacklisted-name
-plugins/modules/system/filesystem.py validate-modules:doc-missing-type
 plugins/modules/system/gconftool2.py pylint:blacklisted-name
 plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/gconftool2.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -924,7 +924,6 @@ plugins/modules/system/dconf.py pylint:blacklisted-name
 plugins/modules/system/dconf.py validate-modules:doc-missing-type
 plugins/modules/system/dconf.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/filesystem.py pylint:blacklisted-name
-plugins/modules/system/filesystem.py validate-modules:doc-missing-type
 plugins/modules/system/gconftool2.py pylint:blacklisted-name
 plugins/modules/system/gconftool2.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/interfaces_file.py pylint:blacklisted-name


### PR DESCRIPTION
##### SUMMARY

Add `state` option to the module:
  - `present` is the default value (backward compatibility).
  - When `state=present` or `state` is omitted, the module still behaves as it did before.
  - When `state=absent`, other options are ignored but `dev`: it is still mandatory, but the module doesn't fail if the device/file doesn't exist.
  - When `state=absent`, if the device exists and holds a filesystem, filesystem signatures are wiped.

Fixes #355

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

filesystem

##### ADDITIONAL INFORMATION

This PR also comes with tests matching the new feature.

Possible implementations:
- `wipefs`: comes with util-linux, not implemented on FreeBSD (which is supported by the module); `resizefs` option is also based on util-linux commands (`findmnt`, `blockdev`) and probably not supported too.
- `dd`: much more portable; needs to erase an arbitrary size (128KiB ?); needs to prevent data corruption on mounted filesystems, so needs to know if the filesystem is in use, making things more complicated: module's internal *get_mountpoint()* is based on util-linux too, and not supported on FreeBSD...

Support for `state=absent` is currently a no-way for FreeBSD without some bits of redesign of this module (that initially was not the purpose of this PR).