### PR TITLE
Fixed django_manage markup in docs

### DIFF
--- a/changelogs/fragments/1154-django_manage-docs.yml
+++ b/changelogs/fragments/1154-django_manage-docs.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - django_manage - The parameter C(liveserver) relates to a no longer maintained third-party module for django. It is being deprecated now, due to remove in version 3.0.0.
+  - django_manage - the parameter ``liveserver`` relates to a no longer maintained third-party module for django. It is now deprecated, and will be remove in community.general 3.0.0 (https://github.com/ansible-collections/community.general/pull/1154).

--- a/changelogs/fragments/1154-django_manage-docs.yml
+++ b/changelogs/fragments/1154-django_manage-docs.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - django_manage - Fixed a number of inconsistencies and missing details in the documentation. Cleared list of ignored sanity validations.
+deprecated_features:
+  - django_manage - The parameter C(liveserver) relates to a no longer maintained third-party module for django. It is being deprecated now, due to remove in version 3.0.0.

--- a/changelogs/fragments/1154-django_manage-docs.yml
+++ b/changelogs/fragments/1154-django_manage-docs.yml
@@ -1,4 +1,2 @@
-minor_changes:
-  - django_manage - Fixed a number of inconsistencies and missing details in the documentation. Cleared list of ignored sanity validations.
 deprecated_features:
   - django_manage - The parameter C(liveserver) relates to a no longer maintained third-party module for django. It is being deprecated now, due to remove in version 3.0.0.

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -22,7 +22,7 @@ options:
         C(flush), C(loaddata), C(migrate), C(syncdb), C(test), and C(validate).
       - Other commands can be entered, but will fail if they're unknown to Django.  Other commands that may
         prompt for user input should be run with the C(--noinput) flag.
-      - The module will perform some basic parameter validation (when applicable) to the commands C(cleanup)',
+      - The module will perform some basic parameter validation (when applicable) to the commands C(cleanup),
         C(collectstatic), C(createcachetable), C(flush), C(loaddata), C(migrate), C(syncdb), C(test), and C(validate).
     type: str
     required: true

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -17,37 +17,46 @@ description:
       C(virtualenv) parameter, all management commands will be executed by the given C(virtualenv) installation.
 options:
   command:
-    choices: [ 'cleanup', 'collectstatic', 'flush', 'loaddata', 'migrate', 'runfcgi', 'syncdb', 'test', 'validate' ]
     description:
       - The name of the Django management command to run. Built in commands are C(cleanup), C(collectstatic),
-        C(flush), C(loaddata), C(migrate), C(runfcgi), C(syncdb), C(test), and C(validate).
+        C(flush), C(loaddata), C(migrate), C(syncdb), C(test), and C(validate).
       - Other commands can be entered, but will fail if they're unknown to Django.  Other commands that may
         prompt for user input should be run with the C(--noinput) flag.
+      - The module will perform some basic parameter validation (when applicable) to the commands C(cleanup)',
+        C(collectstatic), C(createcachetable), C(flush), C(loaddata), C(migrate), C(syncdb), C(test), and C(validate).
+    type: str
     required: true
   app_path:
     description:
       - The path to the root of the Django application where B(manage.py) lives.
+    type: path
     required: true
   settings:
     description:
       - The Python path to the application's settings module, such as C(myapp.settings).
+    type: path
     required: false
   pythonpath:
     description:
       - A directory to add to the Python path. Typically used to include the settings module if it is located
         external to the application directory.
+    type: path
     required: false
+    aliases: [python_path]
   virtualenv:
     description:
       - An optional path to a I(virtualenv) installation to use while running the manage application.
+    type: path
     aliases: [virtual_env]
   apps:
     description:
       - A list of space-delimited apps to target. Used by the C(test) command.
+    type: str
     required: false
   cache_table:
     description:
       - The name of the table used for database-backed caching. Used by the C(createcachetable) command.
+    type: str
     required: false
   clear:
     description:
@@ -60,16 +69,19 @@ options:
     description:
       - The database to target. Used by the C(createcachetable), C(flush), C(loaddata), C(syncdb),
         and C(migrate) commands.
+    type: str
     required: false
   failfast:
     description:
       - Fail the command immediately if a test fails. Used by the C(test) command.
     required: false
-    default: "no"
+    default: false
     type: bool
+    aliases: [fail_fast]
   fixtures:
     description:
       - A space-delimited list of fixture file names to load in the database. B(Required) by the C(loaddata) command.
+    type: str
     required: false
   skip:
     description:
@@ -88,6 +100,21 @@ options:
        C(collectstatic) command
     required: false
     type: bool
+  liveserver:
+    description:
+      - This parameter was implemented a long time ago in a galaxy far way. It probably relates to the
+        django-liveserver package, which is no longer updated.
+      - Hence, it will be considered DEPRECATED and should be removed in a future release.
+    type: str
+    required: false
+    aliases: [live_server]
+  testrunner:
+    description:
+      - "From the Django docs: Controls the test runner class that is used to execute tests"
+      - This parameter is passed as-is to C(manage.py)
+    type: str
+    required: false
+    aliases: [test_runner]
 notes:
   - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter
     is specified.
@@ -234,20 +261,21 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            command=dict(default=None, required=True),
-            app_path=dict(default=None, required=True, type='path'),
-            settings=dict(default=None, required=False),
-            pythonpath=dict(default=None, required=False, aliases=['python_path']),
+            command=dict(required=True, type='str'),
+            app_path=dict(required=True, type='path'),
+            settings=dict(default=None, required=False, type='path'),
+            pythonpath=dict(default=None, required=False, type='path', aliases=['python_path']),
             virtualenv=dict(default=None, required=False, type='path', aliases=['virtual_env']),
 
             apps=dict(default=None, required=False),
-            cache_table=dict(default=None, required=False),
+            cache_table=dict(default=None, required=False, type='str'),
             clear=dict(default=None, required=False, type='bool'),
-            database=dict(default=None, required=False),
+            database=dict(default=None, required=False, type='str'),
             failfast=dict(default=False, required=False, type='bool', aliases=['fail_fast']),
-            fixtures=dict(default=None, required=False),
-            liveserver=dict(default=None, required=False, aliases=['live_server']),
-            testrunner=dict(default=None, required=False, aliases=['test_runner']),
+            fixtures=dict(default=None, required=False, type='str'),
+            liveserver=dict(default=None, required=False, type='str', aliases=['live_server'],
+                            removed_in_verison='3.0.0'),
+            testrunner=dict(default=None, required=False, type='str', aliases=['test_runner']),
             skip=dict(default=None, required=False, type='bool'),
             merge=dict(default=None, required=False, type='bool'),
             link=dict(default=None, required=False, type='bool'),

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -22,7 +22,7 @@ options:
       - The name of the Django management command to run. Built in commands are C(cleanup), C(collectstatic),
         C(flush), C(loaddata), C(migrate), C(runfcgi), C(syncdb), C(test), and C(validate).
       - Other commands can be entered, but will fail if they're unknown to Django.  Other commands that may
-        prompt for user input should be run with the I(--noinput) flag.
+        prompt for user input should be run with the C(--noinput) flag.
     required: true
   app_path:
     description:

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -125,7 +125,7 @@ notes:
   - To be able to use the C(migrate) command with django versions < 1.7, you must have C(south) installed and added
     as an app in your settings.
   - To be able to use the C(collectstatic) command, you must have enabled staticfiles in your settings.
-  - As of ansible 2.x, your C(manage.py) application must be executable (rwxr-xr-x), and must have a valid I(shebang),
+  - Your C(manage.py) application must be executable (rwxr-xr-x), and must have a valid C(shebang),
     i.e. C(#!/usr/bin/env python), for invoking the appropriate Python interpreter.
 requirements: [ "virtualenv", "django" ]
 author: "Scott Anderson (@tastychutney)"

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -125,7 +125,7 @@ notes:
   - To be able to use the C(migrate) command with django versions < 1.7, you must have C(south) installed and added
     as an app in your settings.
   - To be able to use the C(collectstatic) command, you must have enabled staticfiles in your settings.
-  - Your C(manage.py) application must be executable (rwxr-xr-x), and must have a valid C(shebang),
+  - Your C(manage.py) application must be executable (rwxr-xr-x), and must have a valid shebang,
     i.e. C(#!/usr/bin/env python), for invoking the appropriate Python interpreter.
 requirements: [ "virtualenv", "django" ]
 author: "Scott Anderson (@tastychutney)"

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -97,7 +97,7 @@ options:
   link:
     description:
      - Will create links to the files instead of copying them, you can only use this parameter with
-       C(collectstatic) command
+       C(collectstatic) command.
     required: false
     type: bool
   liveserver:

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -111,7 +111,7 @@ options:
   testrunner:
     description:
       - "From the Django docs: Controls the test runner class that is used to execute tests"
-      - This parameter is passed as-is to C(manage.py)
+      - This parameter is passed as-is to C(manage.py).
     type: str
     required: false
     aliases: [test_runner]

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -110,7 +110,7 @@ options:
     aliases: [live_server]
   testrunner:
     description:
-      - "From the Django docs: Controls the test runner class that is used to execute tests"
+      - "From the Django docs: Controls the test runner class that is used to execute tests."
       - This parameter is passed as-is to C(manage.py).
     type: str
     required: false

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -13,16 +13,16 @@ DOCUMENTATION = '''
 module: django_manage
 short_description: Manages a Django application.
 description:
-    - Manages a Django application using the I(manage.py) application frontend to I(django-admin). With the I(virtualenv) parameter, all
-      management commands will be executed by the given I(virtualenv) installation.
+    - Manages a Django application using the C(manage.py) application frontend to C(django-admin). With the
+      C(virtualenv) parameter, all management commands will be executed by the given C(virtualenv) installation.
 options:
   command:
-    choices: [ 'cleanup', 'collectstatic', 'flush', 'loaddata', 'migrate', 'runfcgi', 'syncdb', 'test', 'validate', ]
+    choices: [ 'cleanup', 'collectstatic', 'flush', 'loaddata', 'migrate', 'runfcgi', 'syncdb', 'test', 'validate' ]
     description:
-      - The name of the Django management command to run. Built in commands are cleanup, collectstatic, flush, loaddata, migrate, runfcgi, syncdb,
-        test, and validate.
-      - Other commands can be entered, but will fail if they're unknown to Django.  Other commands that may prompt for user input should be run
-        with the I(--noinput) flag.
+      - The name of the Django management command to run. Built in commands are C(cleanup), C(collectstatic),
+        C(flush), C(loaddata), C(migrate), C(runfcgi), C(syncdb), C(test), and C(validate).
+      - Other commands can be entered, but will fail if they're unknown to Django.  Other commands that may
+        prompt for user input should be run with the I(--noinput) flag.
     required: true
   app_path:
     description:
@@ -30,23 +30,24 @@ options:
     required: true
   settings:
     description:
-      - The Python path to the application's settings module, such as 'myapp.settings'.
+      - The Python path to the application's settings module, such as C(myapp.settings).
     required: false
   pythonpath:
     description:
-      - A directory to add to the Python path. Typically used to include the settings module if it is located external to the application directory.
+      - A directory to add to the Python path. Typically used to include the settings module if it is located
+        external to the application directory.
     required: false
   virtualenv:
     description:
       - An optional path to a I(virtualenv) installation to use while running the manage application.
-    aliases: [virtualenv]
+    aliases: [virtual_env]
   apps:
     description:
-      - A list of space-delimited apps to target. Used by the 'test' command.
+      - A list of space-delimited apps to target. Used by the C(test) command.
     required: false
   cache_table:
     description:
-      - The name of the table used for database-backed caching. Used by the 'createcachetable' command.
+      - The name of the table used for database-backed caching. Used by the C(createcachetable) command.
     required: false
   clear:
     description:
@@ -57,41 +58,48 @@ options:
     type: bool
   database:
     description:
-      - The database to target. Used by the C(createcachetable), C(flush), C(loaddata), C(syncdb), and C(migrate) I(command).
+      - The database to target. Used by the C(createcachetable), C(flush), C(loaddata), C(syncdb),
+        and C(migrate) commands.
     required: false
   failfast:
     description:
-      - Fail the command immediately if a test fails. Used by the 'test' command.
+      - Fail the command immediately if a test fails. Used by the C(test) command.
     required: false
     default: "no"
     type: bool
   fixtures:
     description:
-      - A space-delimited list of fixture file names to load in the database. B(Required) by the 'loaddata' command.
+      - A space-delimited list of fixture file names to load in the database. B(Required) by the C(loaddata) command.
     required: false
   skip:
     description:
-     - Will skip over out-of-order missing migrations, you can only use this parameter with I(migrate)
+     - Will skip over out-of-order missing migrations, you can only use this parameter with C(migrate) command.
     required: false
     type: bool
   merge:
     description:
-     - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this parameter with 'migrate' command
+     - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this
+       parameter with C(migrate) command
     required: false
     type: bool
   link:
     description:
-     - Will create links to the files instead of copying them, you can only use this parameter with 'collectstatic' command
+     - Will create links to the files instead of copying them, you can only use this parameter with
+       C(collectstatic) command
     required: false
     type: bool
 notes:
-  - I(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter is specified.
-  - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
-  - This module assumes English error messages for the 'createcachetable' command to detect table existence, unfortunately.
-  - To be able to use the migrate command with django versions < 1.7, you must have south installed and added as an app in your settings.
-  - To be able to use the collectstatic command, you must have enabled staticfiles in your settings.
-  - As of ansible 2.x, your I(manage.py) application must be executable (rwxr-xr-x), and must have a valid I(shebang), i.e. "#!/usr/bin/env python",
-    for invoking the appropriate Python interpreter.
+  - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter
+    is specified.
+  - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already
+    exist at the given location.
+  - This module assumes English error messages for the C(createcachetable) command to detect table existence,
+    unfortunately.
+  - To be able to use the C(migrate) command with django versions < 1.7, you must have C(south) installed and added
+    as an app in your settings.
+  - To be able to use the C(collectstatic) command, you must have enabled staticfiles in your settings.
+  - As of ansible 2.x, your C(manage.py) application must be executable (rwxr-xr-x), and must have a valid I(shebang),
+    i.e. C(#!/usr/bin/env python), for invoking the appropriate Python interpreter.
 requirements: [ "virtualenv", "django" ]
 author: "Scott Anderson (@tastychutney)"
 '''
@@ -154,7 +162,6 @@ def _ensure_virtualenv(module):
 
     if not os.path.exists(activate):
         virtualenv = module.get_bin_path('virtualenv', True)
-        vcmd = '%s %s' % (virtualenv, venv_param)
         vcmd = [virtualenv, venv_param]
         rc, out_venv, err_venv = module.run_command(vcmd)
         if rc != 0:
@@ -177,11 +184,14 @@ def loaddata_filter_output(line):
 
 
 def syncdb_filter_output(line):
-    return ("Creating table " in line) or ("Installed" in line and "Installed 0 object" not in line)
+    return ("Creating table " in line) \
+        or ("Installed" in line and "Installed 0 object" not in line)
 
 
 def migrate_filter_output(line):
-    return ("Migrating forwards " in line) or ("Installed" in line and "Installed 0 object" not in line) or ("Applying" in line)
+    return ("Migrating forwards " in line) \
+        or ("Installed" in line and "Installed 0 object" not in line) \
+        or ("Applying" in line)
 
 
 def collectstatic_filter_output(line):

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -274,7 +274,7 @@ def main():
             failfast=dict(default=False, required=False, type='bool', aliases=['fail_fast']),
             fixtures=dict(default=None, required=False, type='str'),
             liveserver=dict(default=None, required=False, type='str', aliases=['live_server'],
-                            removed_in_verison='3.0.0'),
+                            removed_in_version='3.0.0'),
             testrunner=dict(default=None, required=False, type='str', aliases=['test_runner']),
             skip=dict(default=None, required=False, type='bool'),
             merge=dict(default=None, required=False, type='bool'),

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -274,7 +274,7 @@ def main():
             failfast=dict(default=False, required=False, type='bool', aliases=['fail_fast']),
             fixtures=dict(default=None, required=False, type='str'),
             liveserver=dict(default=None, required=False, type='str', aliases=['live_server'],
-                            removed_in_version='3.0.0'),
+                            removed_in_version='3.0.0', removed_from_collection='community.general'),
             testrunner=dict(default=None, required=False, type='str', aliases=['test_runner']),
             skip=dict(default=None, required=False, type='bool'),
             merge=dict(default=None, required=False, type='bool'),

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -91,7 +91,7 @@ options:
   merge:
     description:
      - Will run out-of-order or missing migrations as they are not rollback migrations, you can only use this
-       parameter with C(migrate) command
+       parameter with C(migrate) command.
     required: false
     type: bool
   link:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1235,11 +1235,6 @@ plugins/modules/web_infrastructure/apache2_module.py validate-modules:parameter-
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:parameter-type-not-in-doc
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:undocumented-parameter
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-missing-type
-plugins/modules/web_infrastructure/django_manage.py validate-modules:no-default-for-required-parameter
-plugins/modules/web_infrastructure/django_manage.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/django_manage.py validate-modules:undocumented-parameter
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:doc-required-mismatch
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1235,11 +1235,6 @@ plugins/modules/web_infrastructure/apache2_module.py validate-modules:parameter-
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:parameter-type-not-in-doc
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:undocumented-parameter
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-missing-type
-plugins/modules/web_infrastructure/django_manage.py validate-modules:no-default-for-required-parameter
-plugins/modules/web_infrastructure/django_manage.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/django_manage.py validate-modules:undocumented-parameter
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:doc-required-mismatch
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -965,11 +965,6 @@ plugins/modules/web_infrastructure/apache2_module.py validate-modules:doc-missin
 plugins/modules/web_infrastructure/apache2_module.py validate-modules:parameter-type-not-in-doc
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/deploy_helper.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/web_infrastructure/django_manage.py validate-modules:doc-missing-type
-plugins/modules/web_infrastructure/django_manage.py validate-modules:no-default-for-required-parameter
-plugins/modules/web_infrastructure/django_manage.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/django_manage.py validate-modules:undocumented-parameter
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:doc-missing-type
 plugins/modules/web_infrastructure/ejabberd_user.py validate-modules:parameter-type-not-in-doc
 plugins/modules/web_infrastructure/gunicorn.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
Updates the django_manage documentation: markups and a typo

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/django_manage.py

##### ADDITIONAL INFORMATION
Adjusted the markup for a number of terms, also fixed a typo in the alias for virtualenv.

