### PR TITLE
postgresql modules: Fix documentation of trust_input parameter

### DIFF
--- a/plugins/modules/database/postgresql/postgresql_copy.py
+++ b/plugins/modules/database/postgresql/postgresql_copy.py
@@ -72,7 +72,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether values of parameters are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections are possible.
+    - It makes sense to use C(no) only when SQL injections are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_db.py
+++ b/plugins/modules/database/postgresql/postgresql_db.py
@@ -107,7 +107,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(owner), I(conn_limit), I(encoding),
       I(db), I(template), I(tablespace), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_ext.py
+++ b/plugins/modules/database/postgresql/postgresql_ext.py
@@ -80,7 +80,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(ext), I(schema),
       I(version), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_idx.py
+++ b/plugins/modules/database/postgresql/postgresql_idx.py
@@ -114,7 +114,7 @@ options:
     - If C(no), check whether values of parameters I(idxname), I(session_role),
       I(schema), I(table), I(columns), I(tablespace), I(storage_params),
       I(cond) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_info.py
+++ b/plugins/modules/database/postgresql/postgresql_info.py
@@ -43,7 +43,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether a value of I(session_role) is potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via I(session_role) are possible.
+    - It makes sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_lang.py
+++ b/plugins/modules/database/postgresql/postgresql_lang.py
@@ -106,7 +106,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(lang), I(session_role),
       I(owner) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_membership.py
+++ b/plugins/modules/database/postgresql/postgresql_membership.py
@@ -70,7 +70,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(groups),
       I(target_roles), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_owner.py
+++ b/plugins/modules/database/postgresql/postgresql_owner.py
@@ -68,7 +68,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(new_owner), I(obj_name),
       I(reassign_owned_by), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_ping.py
+++ b/plugins/modules/database/postgresql/postgresql_ping.py
@@ -31,7 +31,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether a value of I(session_role) is potentially dangerous.
-    - It does make sense to use C(yes) only when SQL injections via I(session_role) are possible.
+    - It does make sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_ping.py
+++ b/plugins/modules/database/postgresql/postgresql_ping.py
@@ -31,7 +31,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether a value of I(session_role) is potentially dangerous.
-    - It does make sense to use C(no) only when SQL injections via I(session_role) are possible.
+    - It makes sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_privs.py
+++ b/plugins/modules/database/postgresql/postgresql_privs.py
@@ -159,7 +159,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(roles), I(target_roles), I(session_role),
       I(schema) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_publication.py
+++ b/plugins/modules/database/postgresql/postgresql_publication.py
@@ -69,7 +69,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(name), I(tables), I(owner),
       I(session_role), I(params) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_query.py
+++ b/plugins/modules/database/postgresql/postgresql_query.py
@@ -71,7 +71,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether a value of I(session_role) is potentially dangerous.
-    - It does make sense to use C(no) only when SQL injections via I(session_role) are possible.
+    - It makes sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_query.py
+++ b/plugins/modules/database/postgresql/postgresql_query.py
@@ -71,7 +71,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether a value of I(session_role) is potentially dangerous.
-    - It does make sense to use C(yes) only when SQL injections via I(session_role) are possible.
+    - It does make sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_schema.py
+++ b/plugins/modules/database/postgresql/postgresql_schema.py
@@ -68,7 +68,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether values of parameters I(schema), I(owner), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_sequence.py
+++ b/plugins/modules/database/postgresql/postgresql_sequence.py
@@ -133,7 +133,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(sequence), I(schema), I(rename_to),
       I(owner), I(newschema), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -56,7 +56,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether values of parameters are potentially dangerous.
-    - It does make sense to use C(yes) only when SQL injections are possible.
+    - It does make sense to use C(no) only when SQL injections are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_set.py
+++ b/plugins/modules/database/postgresql/postgresql_set.py
@@ -56,7 +56,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether values of parameters are potentially dangerous.
-    - It does make sense to use C(no) only when SQL injections are possible.
+    - It makes sense to use C(no) only when SQL injections are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_slot.py
+++ b/plugins/modules/database/postgresql/postgresql_slot.py
@@ -69,7 +69,7 @@ options:
   trust_input:
     description:
     - If C(no), check the value of I(session_role) is potentially dangerous.
-    - It sense to use C(no) only when SQL injections via I(session_role) are possible.
+    - It makes sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_table.py
+++ b/plugins/modules/database/postgresql/postgresql_table.py
@@ -96,7 +96,7 @@ options:
   trust_input:
     description:
     - If C(no), check whether values of parameters are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections are possible.
+    - It makes sense to use C(no) only when SQL injections are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_tablespace.py
+++ b/plugins/modules/database/postgresql/postgresql_tablespace.py
@@ -73,7 +73,7 @@ options:
     description:
     - If C(no), check whether values of parameters I(tablespace), I(location), I(owner),
       I(rename_to), I(session_role), I(settings_list) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections via the parameters are possible.
+    - It makes sense to use C(no) only when SQL injections via the parameters are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_user.py
+++ b/plugins/modules/database/postgresql/postgresql_user.py
@@ -143,7 +143,7 @@ options:
     description:
     - If C(no), checks whether values of options I(name), I(password), I(privs), I(expires),
       I(role_attr_flags), I(groups), I(comment), I(session_role) are potentially dangerous.
-    - It makes sense to use C(yes) only when SQL injections through the options are possible.
+    - It makes sense to use C(no) only when SQL injections through the options are possible.
     type: bool
     default: yes
     version_added: '0.2.0'

--- a/plugins/modules/database/postgresql/postgresql_user_obj_stat_info.py
+++ b/plugins/modules/database/postgresql/postgresql_user_obj_stat_info.py
@@ -43,7 +43,7 @@ options:
   trust_input:
     description:
     - If C(no), check the value of I(session_role) is potentially dangerous.
-    - It only makes sense to use C(no) only when SQL injections via I(session_role) are possible.
+    - It makes sense to use C(no) only when SQL injections via I(session_role) are possible.
     type: bool
     default: yes
     version_added: '0.2.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed that the postgresql_db module's [documentation](https://docs.ansible.com/ansible/latest/collections/community/general/postgresql_db_module.html) on `trust_input` says that

> It makes sense to use `yes` only when SQL injections via the parameters are possible.

I think this is a typo, and it should say 'use `no`' instead of 'use `yes`'. My understanding is that the input should not be trusted by the Ansible script when injection attacks are possible.

This PR fixes the relevant documentation, as well as the documentation of other modules that have the `trust_input` parameter.

Related to ansible-collections/community.general#309.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- postgresql_copy
- postgresql_db
- postgresql_ext
- postgresql_idx
- postgresql_info
- postgresql_lang
- postgresql_membership
- postgresql_owner
- postgrsql_ping
- postgrsql_privs
- postgrsql_publication
- postgrsql_query
- postgrsql_schema
- postgrsql_sequence
- postgrsql_set
- postgrsql_slot
- postgrsql_table
- postgrsql_tablespace
- postgrsql_user
- postgrsql_user_obj_stat_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have not tested or built the documentation locally (because the change is so minor).
