### PR TITLE
proxmox: ignore QEMU templates altogether

### DIFF
--- a/changelogs/fragments/1185-proxmox-ignore-qemu-templates.yml
+++ b/changelogs/fragments/1185-proxmox-ignore-qemu-templates.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox - ignore QEMU templates altogether instead of skipping the creation of the host in the inventory

--- a/changelogs/fragments/1185-proxmox-ignore-qemu-templates.yml
+++ b/changelogs/fragments/1185-proxmox-ignore-qemu-templates.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - proxmox - ignore QEMU templates altogether instead of skipping the creation of the host in the inventory
+  - proxmox inventory plugin - ignore QEMU templates altogether instead of skipping the creation of the host in the inventory (https://github.com/ansible-collections/community.general/pull/1185).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -300,10 +300,12 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 node_qemu_group = self.to_safe('%s%s' % (self.get_option('group_prefix'), ('%s_qemu' % node['node']).lower()))
                 self.inventory.add_group(node_qemu_group)
                 for qemu in self._get_qemu_per_node(node['node']):
-                    if not qemu['template']:
-                        self.inventory.add_host(qemu['name'])
-                        self.inventory.add_child(qemu_group, qemu['name'])
-                        self.inventory.add_child(node_qemu_group, qemu['name'])
+                    if qemu['template']:
+                        continue
+
+                    self.inventory.add_host(qemu['name'])
+                    self.inventory.add_child(qemu_group, qemu['name'])
+                    self.inventory.add_child(node_qemu_group, qemu['name'])
 
                     # get QEMU status
                     self._get_vm_status(node['node'], qemu['vmid'], 'qemu', qemu['name'])

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -75,7 +75,7 @@ def get_json(url):
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu":
         # _get_qemu_per_node
         return [{"name": "test-qemu",
-                "cpus": 1,
+                 "cpus": 1,
                  "mem": 1000,
                  "template": "",
                  "diskread": 0,
@@ -89,7 +89,23 @@ def get_json(url):
                  "vmid": "101",
                  "uptime": 1000,
                  "disk": 0,
-                 "status": "running"}]
+                 "status": "running"},
+                {"name": "test-qemu-template",
+                 "cpus": 1,
+                 "mem": 0,
+                 "template": 1,
+                 "diskread": 0,
+                 "cpu": 0,
+                 "maxmem": 1000,
+                 "diskwrite": 0,
+                 "netout": 0,
+                 "pid": "1001",
+                 "netin": 0,
+                 "maxdisk": 1000,
+                 "vmid": "9001",
+                 "uptime": 0,
+                 "disk": 0,
+                 "status": "stopped"}]
     elif url == "https://localhost:8006/api2/json/pools/test":
         # _get_members_per_pool
         return {"members": [{"uptime": 1000,
@@ -174,6 +190,7 @@ def test_populate(inventory, mocker):
 
     # get different hosts
     host_qemu = inventory.inventory.get_host('test-qemu')
+    host_qemu_template = inventory.inventory.get_host('test-qemu-template')
     host_lxc = inventory.inventory.get_host('test-lxc')
     host_node = inventory.inventory.get_host('testnode')
 
@@ -185,3 +202,6 @@ def test_populate(inventory, mocker):
     # check if lxc-test has been discovered correctly
     group_lxc = inventory.inventory.groups['proxmox_all_lxc']
     assert group_lxc.hosts == [host_lxc]
+
+    # check if qemu template is not present
+    assert host_qemu_template is None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current implementation caused `_get_vm_status method` to fail, as the host has not been created in inventory at line [304](https://github.com/ansible-collections/community.general/blob/master/plugins/inventory/proxmox.py#L304-L306). This patch changes the condition to ignore templates altogether instead of skipping the creation of the host in the inventory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[WARNING]:  * Failed to parse inventory.proxmox.yml with auto plugin: Could not identify group or host named Ubuntu20.04
  File "/usr/local/lib/python3.8/dist-packages/ansible/inventory/manager.py", line 289, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/local/lib/python3.8/dist-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/root/.ansible/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 348, in parse
    self._populate()
  File "/root/.ansible/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 309, in _populate
    self._get_vm_status(node['node'], qemu['vmid'], 'qemu', qemu['name'])
  File "/root/.ansible/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 235, in _get_vm_status
    self.inventory.set_variable(name, status_key, status)
  File "/usr/local/lib/python3.8/dist-packages/ansible/inventory/data.py", line 250, in set_variable
    raise AnsibleError("Could not identify group or host named %s" % entity)
```
