### PR TITLE
added description parameter to create request

### DIFF
--- a/changelogs/fragments/1196-use_description-in-gitlab-group-creation.yml
+++ b/changelogs/fragments/1196-use_description-in-gitlab-group-creation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - added description parameter to `createGroup()` call. (https://github.com/ansible-collections/community.general/issues/138)
+  - gitlab_group - added description parameter to ``createGroup()`` call (https://github.com/ansible-collections/community.general/issues/138).

--- a/changelogs/fragments/1196-use_description-in-gitlab-group-creation.yml
+++ b/changelogs/fragments/1196-use_description-in-gitlab-group-creation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - added description parameter to `createGroup()` call. (https://github.com/ansible-collections/community.general/issues/138)

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -162,12 +162,16 @@ class GitLabGroup(object):
         if self.groupObject is None:
             parent_id = self.getGroupId(parent)
 
-            group = self.createGroup({
+            payload = {
                 'name': name,
                 'path': options['path'],
                 'parent_id': parent_id,
                 'description': options['description'],
-                'visibility': options['visibility']})
+                'visibility': options['visibility']
+            }
+            if options.get('description'):
+                payload['description'] = options['description']
+            group = self.createGroup(payload)
             changed = True
         else:
             changed, group = self.updateGroup(self.groupObject, {

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -166,7 +166,6 @@ class GitLabGroup(object):
                 'name': name,
                 'path': options['path'],
                 'parent_id': parent_id,
-                'description': options['description'],
                 'visibility': options['visibility']
             }
             if options.get('description'):

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -166,6 +166,7 @@ class GitLabGroup(object):
                 'name': name,
                 'path': options['path'],
                 'parent_id': parent_id,
+                'description': options['description'],
                 'visibility': options['visibility']})
             changed = True
         else:

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -10,18 +10,18 @@
 
 - name: Cleanup GitLab Group
   gitlab_group:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     name: ansible_test_group
     path: ansible_test_group
     state: absent
 
 - name: Create GitLab Group
   gitlab_group:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     name: ansible_test_group
     path: ansible_test_group
     state: present
@@ -35,9 +35,9 @@
 
 - name: Create GitLab Group ( Idempotency test )
   gitlab_group:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     name: ansible_test_group
     path: ansible_test_group
     state: present
@@ -50,18 +50,18 @@
 
 - name: Cleanup GitLab Group for Description Test
   gitlab_group:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     name: ansible_test_group
     path: ansible_test_group
     state: absent
 
 - name: Create GitLab Group for Description Test
   gitlab_group:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     name: ansible_test_group
     path: ansible_test_group
     description: My Test Group

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -25,14 +25,12 @@
     name: ansible_test_group
     path: ansible_test_group
     state: present
-    description: My Test Group
   register: gitlab_group_state
 
 - name: Test group created
   assert:
     that:
       - gitlab_group_state is changed
-      - gitlab_group_state.group.description == "My Test Group"
 
 
 - name: Create GitLab Group ( Idempotency test )
@@ -49,3 +47,28 @@
   assert:
     that:
       - gitlab_group_state_again is not changed
+
+- name: Cleanup GitLab Group for Description Test
+  gitlab_group:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    state: absent
+
+- name: Create GitLab Group for Description Test
+  gitlab_group:
+    server_url: "{{ gitlab_host }}"
+    validate_certs: false
+    login_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    description: My Test Group
+    state: present
+  register: gitlab_group_state_desc
+
+- name: Test group created with Description
+  assert:
+    that:
+      - gitlab_group_state_desc.group.description == "My Test Group"

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -25,12 +25,14 @@
     name: ansible_test_group
     path: ansible_test_group
     state: present
+    description: My Test Group
   register: gitlab_group_state
 
 - name: Test group created
   assert:
     that:
       - gitlab_group_state is changed
+      - gitlab_group_state.group.description == "My Test Group"
 
 
 - name: Create GitLab Group ( Idempotency test )

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -66,11 +66,14 @@ class TestGitlabGroup(GitlabModuleTestCase):
 
     @with_httmock(resp_create_group)
     def test_create_group(self):
-        group = self.moduleUtil.createGroup({'name': "Foobar Group", 'path': "foo-bar"})
+        group = self.moduleUtil.createGroup({'name': "Foobar Group",
+                                             'path': "foo-bar",
+                                             'description': "An interesting group"})
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "Foobar Group")
         self.assertEqual(group.path, "foo-bar")
+        self.assertEqual(group.description, "An interesting group")
         self.assertEqual(group.id, 1)
 
     @with_httmock(resp_create_subgroup)


### PR DESCRIPTION
##### SUMMARY
Adds the description parameter to the creation request.

Fixes #138 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_group

##### ADDITIONAL INFORMATION
Issue #138 is a couple of months old and a lot has changed since then. Nonetheless, the `description` parameter is still not used in the creation of groups.

The **Steps to Reproduce** should change a bit, from:
```
- name: "Create GitLab Group"
  gitlab_group:
    server_url: https://gitlab.example.com/
    validate_certs: True
    api_username: dj-wasabi
    api_password: "MySecretPassword"
    name: my_first_group
    path: my_first_group
    description: My First Group
    state: present
```
to 
```
- name: "Create GitLab Group"
  gitlab_group:
    api_url: https://gitlab.example.com/
    validate_certs: True
    api_username: dj-wasabi
    api_password: "MySecretPassword"
    name: my_first_group
    path: my_first_group
    description: My First Group
    state: present
```
