### PR TITLE
proxmox*: add support for API tokens

### DIFF
--- a/changelogs/fragments/1206-proxmox-api-token.yml
+++ b/changelogs/fragments/1206-proxmox-api-token.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - proxmox - add support for API tokens (https://github.com/ansible-collections/community.general/pull/1206).
+  - proxmox_kvm - add support for API tokens (https://github.com/ansible-collections/community.general/pull/1206).
+  - proxmox_template - add support for API tokens (https://github.com/ansible-collections/community.general/pull/1206).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -47,6 +47,16 @@ options:
       - Specify the password to authenticate with.
       - You can use C(PROXMOX_PASSWORD) environment variable.
     type: str
+  api_token_id:
+    description:
+      - Specify the token ID.
+    type: str
+    version_added: 1.3.0
+  api_token_secret:
+    description:
+      - Specify the token secret.
+    type: str
+    version_added: 1.3.0
   autostart:
     description:
       - Specify if the VM should be automatically restarted after crash (currently ignored in PVE API).
@@ -920,8 +930,10 @@ def main():
             agent=dict(type='bool'),
             args=dict(type='str'),
             api_host=dict(required=True),
-            api_user=dict(required=True),
             api_password=dict(no_log=True),
+            api_token_id=dict(no_log=True),
+            api_token_secret=dict(no_log=True),
+            api_user=dict(required=True),
             autostart=dict(type='bool'),
             balloon=dict(type='int'),
             bios=dict(choices=['seabios', 'ovmf']),
@@ -999,9 +1011,11 @@ def main():
     if not HAS_PROXMOXER:
         module.fail_json(msg='proxmoxer required for this module')
 
-    api_user = module.params['api_user']
     api_host = module.params['api_host']
     api_password = module.params['api_password']
+    api_token_id = module.params['api_token_id']
+    api_token_secret = module.params['api_token_secret']
+    api_user = module.params['api_user']
     clone = module.params['clone']
     cpu = module.params['cpu']
     cores = module.params['cores']
@@ -1050,15 +1064,21 @@ def main():
     if module.params['format'] == 'unspecified':
         module.params['format'] = None
 
-    # If password not set get it from PROXMOX_PASSWORD env
-    if not api_password:
-        try:
-            api_password = os.environ['PROXMOX_PASSWORD']
-        except KeyError as e:
-            module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
+    auth_args = {'user': api_user}
+    if not (api_token_id and api_token_secret):
+        # If password not set get it from PROXMOX_PASSWORD env
+        if not api_password:
+            try:
+                api_password = os.environ['PROXMOX_PASSWORD']
+            except KeyError as e:
+                module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
+        auth_args['password'] = api_password
+    else:
+        auth_args['token_name'] = api_token_id
+        auth_args['token_value'] = api_token_secret
 
     try:
-        proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
+        proxmox = ProxmoxAPI(api_host, verify_ssl=validate_certs, **auth_args)
         global PVE_MAJOR_VERSION
         PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY

Provides an alternative authentication method to the password.
The token validity is only tested during the first request after the instantiation of `ProxmoxAPI`, thus the presence of a call to `proxmox.version.get()` in `proxmox_template`.

Fixes #559, idea from @d4vydm.

Require testing for modules `proxmox` and `proxmox_template`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

proxmox_kvm, proxmox_template, proxmox

##### ADDITIONAL INFORMATION

Example of use:

```
- name: Ensure test-vm is created
  proxmox_kvm:
    api_host: prx-test
    api_user: tleguern@pve
    api_token_id: api-pve-test
    api_token_secret: fad3db3d-b335-ee15-9fb0-ea1bf70128db
    node: prx-test-01
    name: test-vm
    ...
```