### PR TITLE
Remove redundant aliases from NIOS modules

### DIFF
--- a/changelogs/fragments/1223-nios-remove-redundant-aliases.yml
+++ b/changelogs/fragments/1223-nios-remove-redundant-aliases.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - nios_fixed_address, nios_host_record, nios_zone - removed redundant parameter aliases causing warning messages to incorrectly appear in task output (https://github.com/ansible-collections/community.general/issues/852)
+  - nios_fixed_address, nios_host_record, nios_zone - removed redundant parameter aliases causing warning messages to incorrectly appear in task output (https://github.com/ansible-collections/community.general/issues/852).

--- a/changelogs/fragments/1223-nios-remove-redundant-aliases.yml
+++ b/changelogs/fragments/1223-nios-remove-redundant-aliases.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nios_fixed_address, nios_host_record, nios_zone - removed redundant parameter aliases causing warning messages to incorrectly appear in task output (https://github.com/ansible-collections/community.general/issues/852)

--- a/plugins/modules/net_tools/nios/nios_fixed_address.py
+++ b/plugins/modules/net_tools/nios/nios_fixed_address.py
@@ -37,8 +37,6 @@ options:
   network:
     description:
       - Specifies the network range in which ipaddr exists.
-    aliases:
-      - network
   network_view:
     description:
       - Configures the name of the network view to associate with this
@@ -244,10 +242,10 @@ def main():
 
     ib_spec = dict(
         name=dict(required=True),
-        ipaddr=dict(required=True, aliases=['ipaddr'], ib_req=True),
-        mac=dict(required=True, aliases=['mac'], ib_req=True),
-        network=dict(required=True, aliases=['network']),
-        network_view=dict(default='default', aliases=['network_view']),
+        ipaddr=dict(required=True, ib_req=True),
+        mac=dict(required=True, ib_req=True),
+        network=dict(required=True),
+        network_view=dict(default='default'),
 
         options=dict(type='list', elements='dict', options=option_spec, transform=options),
 

--- a/plugins/modules/net_tools/nios/nios_host_record.py
+++ b/plugins/modules/net_tools/nios/nios_host_record.py
@@ -295,7 +295,7 @@ def main():
 
     ipv6addr_spec = dict(
         ipv6addr=dict(required=True, aliases=['address'], ib_req=True),
-        configure_for_dhcp=dict(type='bool', required=False, aliases=['configure_for_dhcp'], ib_req=True),
+        configure_for_dhcp=dict(type='bool', required=False, ib_req=True),
         mac=dict(required=False, ib_req=True)
     )
 

--- a/plugins/modules/net_tools/nios/nios_host_record.py
+++ b/plugins/modules/net_tools/nios/nios_host_record.py
@@ -73,8 +73,6 @@ options:
           - Configures the hardware MAC address for the host record. If user makes
             DHCP to true, user need to mention MAC address.
         required: false
-        aliases:
-          - mac
       add:
         description:
           - If user wants to add the ipv4 address to an existing host record.
@@ -82,8 +80,6 @@ options:
             as new IP address is allocated to existing host record. See examples.
         type: bool
         required: false
-        aliases:
-          - add
         version_added: '0.2.0'
       remove:
         description:
@@ -92,8 +88,6 @@ options:
             as IP address is de-allocated from an existing host record. See examples.
         type: bool
         required: false
-        aliases:
-          - remove
         version_added: '0.2.0'
   ipv6addrs:
     description:
@@ -294,15 +288,15 @@ def main():
     ipv4addr_spec = dict(
         ipv4addr=dict(required=True, aliases=['address'], ib_req=True),
         configure_for_dhcp=dict(type='bool', required=False, aliases=['dhcp'], ib_req=True),
-        mac=dict(required=False, aliases=['mac'], ib_req=True),
-        add=dict(type='bool', aliases=['add'], required=False),
-        remove=dict(type='bool', aliases=['remove'], required=False)
+        mac=dict(required=False, ib_req=True),
+        add=dict(type='bool', required=False),
+        remove=dict(type='bool', required=False)
     )
 
     ipv6addr_spec = dict(
         ipv6addr=dict(required=True, aliases=['address'], ib_req=True),
         configure_for_dhcp=dict(type='bool', required=False, aliases=['configure_for_dhcp'], ib_req=True),
-        mac=dict(required=False, aliases=['mac'], ib_req=True)
+        mac=dict(required=False, ib_req=True)
     )
 
     ib_spec = dict(

--- a/plugins/modules/net_tools/nios/nios_zone.py
+++ b/plugins/modules/net_tools/nios/nios_zone.py
@@ -184,7 +184,7 @@ def main():
 
     ib_spec = dict(
         fqdn=dict(required=True, aliases=['name'], ib_req=True, update=False),
-        zone_format=dict(default='FORWARD', aliases=['zone_format'], ib_req=False),
+        zone_format=dict(default='FORWARD', ib_req=False),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
 
         grid_primary=dict(type='list', elements='dict', options=grid_spec),

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -766,7 +766,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:nonexistent-parameter-documented
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -758,7 +758,6 @@ plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-elemen
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-default-does-not-match-spec
@@ -836,7 +835,6 @@ plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-elements-mismat
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_zone.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nsupdate.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -766,7 +766,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:nonexistent-parameter-documented
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -758,7 +758,6 @@ plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-elemen
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-default-does-not-match-spec
@@ -836,7 +835,6 @@ plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-elements-mismat
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_zone.py validate-modules:parameter-alias-self
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nsupdate.py validate-modules:parameter-list-no-elements


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #852.
Redundant aliases were present in the argument specs of these modules, causing unnecessary [WARNING] messages on execution.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_fixed_address
nios_host_record
nios_zone

##### ADDITIONAL INFORMATION
See #852 
