### PR TITLE
[pkgng] present the 'ignore_osver' option to pkg

### DIFF
--- a/changelogs/fragments/1243-pkgng-present-ignoreosver.yaml
+++ b/changelogs/fragments/1243-pkgng-present-ignoreosver.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pkgng - present the ignore_osver option to pkg (https://github.com/ansible-collections/community.general/pull/1243)

--- a/changelogs/fragments/1243-pkgng-present-ignoreosver.yaml
+++ b/changelogs/fragments/1243-pkgng-present-ignoreosver.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pkgng - present the ignore_osver option to pkg (https://github.com/ansible-collections/community.general/pull/1243)
+  - pkgng - present the ``ignore_osver`` option to pkg (https://github.com/ansible-collections/community.general/pull/1243).

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -142,6 +142,8 @@ def query_package(module, pkgng_path, name, dir_arg):
 
 def query_update(module, pkgng_path, name, dir_arg, old_pkgng, pkgsite):
 
+    ignoreosver_var = "env IGNORE_OSVERSION=yes"
+
     # Check to see if a package upgrade is available.
     # rc = 0, no updates available or package not installed
     # rc = 1, updates available

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -97,6 +97,7 @@ options:
         required: false
         type: bool
         default: no
+        version_added: 1.3.0
 author: "bleader (@bleader)"
 notes:
   - When using pkgsite, be careful that already in cache packages won't be downloaded again.

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -144,7 +144,7 @@ def query_update(module, pkgng_path, name, dir_arg, old_pkgng, pkgsite):
 
     # Ignore FreeBSD OS version check,
     #   useful on -STABLE and -CURRENT branches.
-    ignoreosver_var = "env IGNORE_OSVERSION=yes"
+    ignoreosver_var = 'env IGNORE_OSVERSION=yes'
 
     # Check to see if a package upgrade is available.
     # rc = 0, no updates available or package not installed

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -217,7 +217,7 @@ def remove_packages(module, pkgng_path, packages, dir_arg):
     return (False, "package(s) already absent", stdout, stderr)
 
 
-def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, state):
+def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, state, ignoreosver):
     install_c = 0
     stdout = ""
     stderr = ""
@@ -443,7 +443,9 @@ def main():
     # Operate on named packages
     named_packages = [pkg for pkg in pkgs if pkg != '*']
     if p["state"] in ("present", "latest") and named_packages:
-        _changed, _msg, _out, _err = install_packages(module, pkgng_path, named_packages, p["cached"], p["pkgsite"], dir_arg, p["state"])
+        _changed, _msg, _out, _err = install_packages(module, pkgng_path, named_packages, \
+                                                      p["cached"], p["pkgsite"], dir_arg, \
+                                                      p["state"], p["ignoreosver"])
         stdout += _out
         stderr += _err
         changed = changed or _changed

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -90,7 +90,7 @@ options:
         required: false
         type: bool
         default: no
-    ignoreosver:
+    ignore_osver:
         description:
             - Ignore FreeBSD OS version check, useful on -STABLE and -CURRENT branches.
             - Defines the C(IGNORE_OSVERSION) environment variable.
@@ -400,7 +400,7 @@ def main():
             state=dict(default="present", choices=["present", "latest", "absent"], required=False),
             name=dict(aliases=["pkg"], required=True, type='list', elements='str'),
             cached=dict(default=False, type='bool'),
-            ignoreosver=dict(default=False, required=False, type='bool'),
+            ignore_osver=dict(default=False, required=False, type='bool'),
             annotation=dict(default="", required=False),
             pkgsite=dict(default="", required=False),
             rootdir=dict(default="", required=False, type='path'),
@@ -429,10 +429,10 @@ def main():
         else:
             dir_arg = "--rootdir %s" % (p["rootdir"])
 
-    if p["ignoreosver"]:
+    if p["ignore_osver"]:
         old_pkgng = pkgng_older_than(module, pkgng_path, [1, 11, 0])
         if old_pkgng:
-            module.fail_json(msg="To use option 'ignoreosver' pkg version must be 1.11 or greater")
+            module.fail_json(msg="To use option 'ignore_osver' pkg version must be 1.11 or greater")
 
     if p["chroot"] != "":
         dir_arg = '--chroot %s' % (p["chroot"])
@@ -453,7 +453,7 @@ def main():
     if p["state"] in ("present", "latest") and named_packages:
         _changed, _msg, _out, _err = install_packages(module, pkgng_path, named_packages, \
                                                       p["cached"], p["pkgsite"], dir_arg, \
-                                                      p["state"], p["ignoreosver"])
+                                                      p["state"], p["ignore_osver"])
         stdout += _out
         stderr += _err
         changed = changed or _changed

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -391,6 +391,7 @@ def main():
             state=dict(default="present", choices=["present", "latest", "absent"], required=False),
             name=dict(aliases=["pkg"], required=True, type='list', elements='str'),
             cached=dict(default=False, type='bool'),
+            ignoreosver=dict(default=False, type='bool'),
             annotation=dict(default="", required=False),
             pkgsite=dict(default="", required=False),
             rootdir=dict(default="", required=False, type='path'),

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -90,6 +90,12 @@ options:
         required: false
         type: bool
         default: no
+    ignoreosver:
+        description:
+            - Ignore FreeBSD OS version check, useful on -STABLE and -CURRENT branches.
+        required: false
+        type: bool
+        default: no
 author: "bleader (@bleader)"
 notes:
   - When using pkgsite, be careful that already in cache packages won't be downloaded again.

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -142,10 +142,6 @@ def query_package(module, pkgng_path, name, dir_arg):
 
 def query_update(module, pkgng_path, name, dir_arg, old_pkgng, pkgsite):
 
-    # Ignore FreeBSD OS version check,
-    #   useful on -STABLE and -CURRENT branches.
-    ignoreosver_var = 'env IGNORE_OSVERSION=yes'
-
     # Check to see if a package upgrade is available.
     # rc = 0, no updates available or package not installed
     # rc = 1, updates available
@@ -238,6 +234,11 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, sta
     # This environment variable skips mid-install prompts,
     # setting them to their default values.
     batch_var = 'env BATCH=yes'
+
+    if ignoreosver:
+        # Ignore FreeBSD OS version check,
+        #   useful on -STABLE and -CURRENT branches.
+        batch_var = batch_var + ' IGNORE_OSVERSION=yes'
 
     if not module.check_mode and not cached:
         if old_pkgng:

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -142,6 +142,8 @@ def query_package(module, pkgng_path, name, dir_arg):
 
 def query_update(module, pkgng_path, name, dir_arg, old_pkgng, pkgsite):
 
+    # Ignore FreeBSD OS version check,
+    #   useful on -STABLE and -CURRENT branches.
     ignoreosver_var = "env IGNORE_OSVERSION=yes"
 
     # Check to see if a package upgrade is available.

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -250,7 +250,7 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, dir_arg, sta
         if old_pkgng:
             rc, out, err = module.run_command("%s %s update" % (pkgsite, pkgng_path))
         else:
-            rc, out, err = module.run_command("%s %s update" % (pkgng_path, dir_arg))
+            rc, out, err = module.run_command("%s %s %s update" % (batch_var, pkgng_path, dir_arg))
         stdout += out
         stderr += err
         if rc != 0:

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -451,8 +451,8 @@ def main():
     # Operate on named packages
     named_packages = [pkg for pkg in pkgs if pkg != '*']
     if p["state"] in ("present", "latest") and named_packages:
-        _changed, _msg, _out, _err = install_packages(module, pkgng_path, named_packages, \
-                                                      p["cached"], p["pkgsite"], dir_arg, \
+        _changed, _msg, _out, _err = install_packages(module, pkgng_path, named_packages,
+                                                      p["cached"], p["pkgsite"], dir_arg,
                                                       p["state"], p["ignore_osver"])
         stdout += _out
         stderr += _err

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -93,6 +93,7 @@ options:
     ignoreosver:
         description:
             - Ignore FreeBSD OS version check, useful on -STABLE and -CURRENT branches.
+            - Defines the C(IGNORE_OSVERSION) environment variable.
         required: false
         type: bool
         default: no

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -421,6 +421,11 @@ def main():
         else:
             dir_arg = "--rootdir %s" % (p["rootdir"])
 
+    if p["ignoreosver"]:
+        old_pkgng = pkgng_older_than(module, pkgng_path, [1, 11, 0])
+        if old_pkgng:
+            module.fail_json(msg="To use option 'ignoreosver' pkg version must be 1.11 or greater")
+
     if p["chroot"] != "":
         dir_arg = '--chroot %s' % (p["chroot"])
 

--- a/plugins/modules/packaging/os/pkgng.py
+++ b/plugins/modules/packaging/os/pkgng.py
@@ -391,7 +391,7 @@ def main():
             state=dict(default="present", choices=["present", "latest", "absent"], required=False),
             name=dict(aliases=["pkg"], required=True, type='list', elements='str'),
             cached=dict(default=False, type='bool'),
-            ignoreosver=dict(default=False, type='bool'),
+            ignoreosver=dict(default=False, required=False, type='bool'),
             annotation=dict(default="", required=False),
             pkgsite=dict(default="", required=False),
             rootdir=dict(default="", required=False, type='path'),


### PR DESCRIPTION
##### SUMMARY
By applying this merge request we would be able to:

  - use "_ignore_osver_" as option to define `IGNORE_OSVERSION` as environment variable;
  - make possible to ignore **FreeBSD** OS version check on `pkg` versions _>= 1.11_;
  - be able to freely use `pkg` on systems running _-STABLE_ and _-CURRENT_ branches.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```
plugins/modules/packaging/os/pkgng.py
```

##### ADDITIONAL INFORMATION

  - `pkg`'s config manpage: [pkg.conf(5)](https://www.freebsd.org/cgi/man.cgi?query=pkg.conf&sektion=5)
  - [Changes from pkg 1.10.99.7 to 1.10.99.8](https://github.com/freebsd/pkg/blob/release-1.11/NEWS#L51)
 -  Reddit thread: [Fix pkg mismatch after updating](https://www.reddit.com/r/freebsd/comments/f360r2/fix_pkg_mismatch_after_updating/)