### PR TITLE
Changed parameter name, added aliases for compatibility.

### DIFF
--- a/changelogs/fragments/1244-renamed-parameter.yaml
+++ b/changelogs/fragments/1244-renamed-parameter.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - django_manage - renamed parameter app_path to project_path, adding app_path and chdir as aliases (https://github.com/ansible-collections/community.general/issues/1044).

--- a/changelogs/fragments/1244-renamed-parameter.yaml
+++ b/changelogs/fragments/1244-renamed-parameter.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - django_manage - renamed parameter app_path to project_path, adding app_path and chdir as aliases (https://github.com/ansible-collections/community.general/issues/1044).
+  - django_manage - renamed parameter ``app_path`` to ``project_path``, adding ``app_path`` and ``chdir`` as aliases (https://github.com/ansible-collections/community.general/issues/1044).


### PR DESCRIPTION
##### SUMMARY
Per issue #1044 it was concluded that neither `app_path` nor `chdir` are the best names for the parameter, so changing it to `project_path` and adding those other terms as aliases.

Fixes #1044 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/django_manage.py

##### ADDITIONAL INFORMATION
Module users should be able to continue using it as-is, but the name of the parameter is now `project_path`. 
