### PR TITLE
Add a warning when ansible_key label is not found on a secret. (#31)

### DIFF
--- a/changelogs/fragments/community.docker-31-docker-secret.yml
+++ b/changelogs/fragments/community.docker-31-docker-secret.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "docker_secret - add a warning when the secret does not have an ``ansible_key`` label but the ``force`` parameter is not set (https://github.com/ansible-collections/community.docker/issues/30, https://github.com/ansible-collections/community.docker/pull/31)."

--- a/plugins/modules/cloud/docker/docker_secret.py
+++ b/plugins/modules/cloud/docker/docker_secret.py
@@ -236,6 +236,9 @@ class SecretManager(DockerBaseClass):
             if attrs.get('Labels', {}).get('ansible_key'):
                 if attrs['Labels']['ansible_key'] != self.data_key:
                     data_changed = True
+            else:
+                if not self.force:
+                    self.client.module.warn("'ansible_key' label not found. Secret will not be changed unless the force parameter is set to 'yes'")
             labels_changed = not compare_generic(self.labels, attrs.get('Labels'), 'allow_more_present', 'dict')
             if data_changed or labels_changed or self.force:
                 # if something changed or force, delete and re-create the secret


### PR DESCRIPTION
##### SUMMARY
Backport of ansible-collections/community.docker#31.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_secret
