### PR TITLE
proxmox_kvm: pool parameter not supported by qemu/<vmid>/config API endpoint

### DIFF
--- a/changelogs/fragments/1258-proxmox_kvm-ignore-pool-on-update.yaml
+++ b/changelogs/fragments/1258-proxmox_kvm-ignore-pool-on-update.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_kvm - ignore unsupported pool parameter on update
+  - proxmox_kvm - ignore unsupported ``pool`` parameter on update (https://github.com/ansible-collections/community.general/pull/1258).

--- a/changelogs/fragments/1258-proxmox_kvm-ignore-pool-on-update.yaml
+++ b/changelogs/fragments/1258-proxmox_kvm-ignore-pool-on-update.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - ignore unsupported pool parameter on update

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -414,6 +414,7 @@ options:
       - If C(yes), the VM will be updated with new value.
       - Cause of the operations of the API and security reasons, I have disabled the update of the following parameters
       - C(net, virtio, ide, sata, scsi). Per example updating C(net) update the MAC address and C(virtio) create always new disk...
+      - Update of C(pool) is disabled. It needs an additional API endpoint not covered by this module.
     type: bool
     default: 'no'
   validate_certs:
@@ -828,6 +829,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
                 del kwargs[p]
 
     # If update, don't update disk (virtio, ide, sata, scsi) and network interface
+    # pool parameter not supported by qemu/<vmid>/config endpoint on "update" (PVE 6.2) - only with "create"
     if update:
         if 'virtio' in kwargs:
             del kwargs['virtio']
@@ -841,6 +843,8 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             del kwargs['net']
         if 'force' in kwargs:
             del kwargs['force']
+        if 'pool' in kwargs:
+            del kwargs['pool']
 
     # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
     for k in list(kwargs.keys()):


### PR DESCRIPTION
##### SUMMARY
Updating a VM with `pool` parameter set fails with a 400 status code, since it's not in the parameter list of the `qemu/<vmid>/config` endpoint. I only found the API docs of PVE 6.2, so I don't know if it ever worked. Would have added a version check otherwise.
The correct way to update it should be using the /pools endpoint. But I think that's be something for another module or a feature of the API itself (like with the disks).

Like for `virtio`, ... I added the removal of the key for `update` and mentioned it at the same place in the docs. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
It's my first contribution to any ansible related code, so I had some issues with the dev environment... I tried the tests, but kubevirt fails. The doc generation also failed, so I couldn't check if the formatting is correct.
But I could test the code with the forked collection repo installed.