### PR TITLE
Add filter dict_kv

### DIFF
--- a/changelogs/fragments/1264-dict_kv-new-filter.yaml
+++ b/changelogs/fragments/1264-dict_kv-new-filter.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Add new filter plugin ``dict_kv`` which returns a single key-value pair from two arguments. Useful for generating complex dictionaries without using loops. For example ``'value' | community.general.dict_kv('key'))`` evaluates to ``{'key': 'value'}`` (https://github.com/ansible-collections/community.general/pull/1264)."

--- a/plugins/filter/dict_kv.py
+++ b/plugins/filter/dict_kv.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2020 Stanislav German-Evtushenko (@giner) <ginermail@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def dict_kv(value, key):
+    '''Return a dictionary with a single key-value pair
+
+    Example:
+
+        - hosts: localhost
+          gather_facts: false
+          vars:
+            myvar: myvalue
+          tasks:
+          - debug:
+              msg: "{{ myvar | dict_kv('thatsmyvar') }}"
+
+        produces:
+
+        ok: [localhost] => {
+            "msg": {
+                "thatsmyvar": "myvalue"
+            }
+        }
+
+    Example 2:
+
+        - hosts: localhost
+          gather_facts: false
+          vars:
+            common_config:
+              type: host
+              database: all
+            myservers:
+            - server1
+            - server2
+          tasks:
+          - debug:
+              msg: "{{ myservers | map('dict_kv', 'server') | map('combine', common_config) }}"
+
+        produces:
+
+        ok: [localhost] => {
+            "msg": [
+                {
+                    "database": "all",
+                    "server": "server1",
+                    "type": "host"
+                },
+                {
+                    "database": "all",
+                    "server": "server2",
+                    "type": "host"
+                }
+            ]
+        }
+    '''
+    return {key: value}
+
+
+class FilterModule(object):
+    ''' Query filter '''
+
+    def filters(self):
+        return {
+            'dict_kv': dict_kv
+        }

--- a/tests/integration/targets/filter_dict_kv/aliases
+++ b/tests/integration/targets/filter_dict_kv/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group2
+skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict_kv/tasks/main.yml
+++ b/tests/integration/targets/filter_dict_kv/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: test dict_kv filter
+  assert:
+    that:
+      - "('value' | community.general.dict_kv('key')) == {'key': 'value'}"


### PR DESCRIPTION
Add dict_kv filter which returns a single key-value pair from two arguments. Useful for generating complex dictionaries without using loops.

Example 1

```
- hosts: localhost
  gather_facts: false
  vars:
    myvar: myvalue
  tasks:
  - debug:
      msg: "{{ myvar | dict_kv('thatsmyvar') }}" 

OUTPUT:
ok: [localhost] => {
    "msg": {
        "thatsmyvar": "myvalue"
    }   
}
```

Example 2

```
- hosts: localhost
  gather_facts: false
  vars:
    common_config:
      type: host
      database: all 
    myservers:
    - server1
    - server2
  tasks:
  - debug:
      msg: "{{ myservers | map('dict_kv', 'server') | map('combine', common_config) }}" 

OUTPUT:
ok: [localhost] => {
    "msg": [
        {
            "database": "all",
            "server": "server1",
            "type": "host"
        },  
        {   
            "database": "all",
            "server": "server2",
            "type": "host"
        }   
    ]   
}
``` 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin/filter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
