### PR TITLE
Add support for StackScripts to Linode v4 module

### DIFF
--- a/changelogs/fragments/1270-linode-v4-stackscript-support.yaml
+++ b/changelogs/fragments/1270-linode-v4-stackscript-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - linode_v4 - added support for Linode StackScript usage when creating instances (https://github.com/ansible-collections/community.general/issues/723).

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -27,21 +27,21 @@ options:
     description:
       - The region of the instance. This is a required parameter only when
         creating Linode instances. See
-        U(https://developers.linode.com/api/v4#tag/Regions).
+        U(https://www.linode.com/docs/api/regions/).
     required: false
     type: str
   image:
     description:
       - The image of the instance. This is a required parameter only when
         creating Linode instances. See
-        U(https://developers.linode.com/api/v4#tag/Images).
+        U(https://www.linode.com/docs/api/images/).
     type: str
     required: false
   type:
     description:
       - The type of the instance. This is a required parameter only when
         creating Linode instances. See
-        U(https://developers.linode.com/api/v4#tag/Linode-Types).
+        U(https://www.linode.com/docs/api/linode-types/).
     type: str
     required: false
   label:
@@ -60,7 +60,7 @@ options:
   tags:
     description:
       - The tags that the instance should be marked under. See
-        U(https://developers.linode.com/api/v4#tag/Tags).
+        U(https://www.linode.com/docs/api/tags/).
     required: false
     type: list
   root_pass:
@@ -87,8 +87,22 @@ options:
     description:
       - The Linode API v4 access token. It may also be specified by exposing
         the C(LINODE_ACCESS_TOKEN) environment variable. See
-        U(https://developers.linode.com/api/v4#section/Access-and-Authentication).
+        U(https://www.linode.com/docs/api#access-and-authentication).
     required: true
+  stackscript_id:
+    description:
+      - The numeric ID of the StackScript to use when creating the instance.
+        See U(https://www.linode.com/docs/api/stackscripts/).
+    type: int
+    required: false
+  stackscript_data:
+    description:
+      - An object containing arguments to any User Defined Fields present in
+        the StackScript used when creating the instance.
+        Only valid when a stackscript_id is provided.
+        See U(https://www.linode.com/docs/api/stackscripts/).
+    type: dict
+    required: false
 '''
 
 EXAMPLES = """
@@ -229,6 +243,8 @@ def initialise_module():
             root_pass=dict(type='str', required=False, no_log=True),
             tags=dict(type='list', required=False),
             type=dict(type='str', required=False),
+            stackscript_id=dict(type='int', required=False),
+            stackscript_data=dict(type='dict', required=False),
         ),
         supports_check_mode=False,
         required_one_of=(
@@ -272,6 +288,8 @@ def main():
             root_pass=module.params['root_pass'],
             tags=module.params['tags'],
             ltype=module.params['type'],
+            stackscript=module.params['stackscript_id'],
+            stackscript_data=module.params['stackscript_data'],
         )
         module.exit_json(changed=True, instance=instance_json)
 

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -115,6 +115,9 @@ EXAMPLES = """
     root_pass: passw0rd
     authorized_keys:
       - "ssh-rsa ..."
+    stackscript_id: 1337
+    stackscript_data:
+      variable: value
     state: present
 
 - name: Delete that new Linode.

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -94,7 +94,7 @@ options:
       - The numeric ID of the StackScript to use when creating the instance.
         See U(https://www.linode.com/docs/api/stackscripts/).
     type: int
-    required: false
+    version_added: 1.3.0
   stackscript_data:
     description:
       - An object containing arguments to any User Defined Fields present in
@@ -102,7 +102,7 @@ options:
         Only valid when a stackscript_id is provided.
         See U(https://www.linode.com/docs/api/stackscripts/).
     type: dict
-    required: false
+    version_added: 1.3.0
 '''
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY
This adds support for Linode StackScripts when creating instances via the Linode v4 module and hopefully closes https://github.com/ansible-collections/community.general/issues/723. I also fixed some stale documentation links while I was here.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
linode_v4

##### ADDITIONAL INFORMATION
I decided against making an envelope as diagrammed in the issue above. Additionally, I decided to make the ansible argument explicitly `stackscript_id` to be more explicit than Linode's Python wrapper, which accepts `stackscript` as either a numeric parameter _or_ an object.