### PR TITLE
Fix macports package present/active detection

### DIFF
--- a/changelogs/fragments/1307-macports-fix-status-check.yml
+++ b/changelogs/fragments/1307-macports-fix-status-check.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - macports - fix failure to install a package whose name is contained within an already installed package's name or variant (https://github.com/ansible-collections/community.general/issues/1307)
+  - macports - fix failure to install a package whose name is contained within an already installed package's name or variant (https://github.com/ansible-collections/community.general/issues/1307).

--- a/changelogs/fragments/1307-macports-fix-status-check.yml
+++ b/changelogs/fragments/1307-macports-fix-status-check.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - macports - fix failure to install a package whose name is contained within an already installed package's name or variant (https://github.com/ansible-collections/community.general/issues/1307)

--- a/plugins/modules/packaging/os/macports.py
+++ b/plugins/modules/packaging/os/macports.py
@@ -157,9 +157,9 @@ def query_port(module, port_path, name, state="present"):
 
     elif state == "active":
 
-        rc, out, err = module.run_command("%s installed %s | grep -q active" % (shlex_quote(port_path), shlex_quote(name)), use_unsafe_shell=True)
+        rc, out, err = module.run_command([port_path, "-q", "installed", name])
 
-        if rc == 0:
+        if rc == 0 and "(active)" in out:
             return True
 
         return False

--- a/plugins/modules/packaging/os/macports.py
+++ b/plugins/modules/packaging/os/macports.py
@@ -148,8 +148,9 @@ def query_port(module, port_path, name, state="present"):
 
     if state == "present":
 
-        rc, out, err = module.run_command("%s installed | grep -q ^.*%s" % (shlex_quote(port_path), shlex_quote(name)), use_unsafe_shell=True)
-        if rc == 0:
+        rc, out, err = module.run_command([port_path, "-q", "installed", name])
+
+        if rc == 0 and out.strip().startswith(name + " "):
             return True
 
         return False

--- a/tests/unit/plugins/modules/packaging/os/test_macports.py
+++ b/tests/unit/plugins/modules/packaging/os/test_macports.py
@@ -27,7 +27,7 @@ QUERY_PORT_TEST_CASES = [
 def test_macports_query_port(mocker, run_cmd_return_val, present_expected, active_expected):
     module = mocker.Mock()
     run_command = mocker.Mock()
-    run_command.return_value=(0, run_cmd_return_val, '')
+    run_command.return_value = (0, run_cmd_return_val, '')
     module.run_command = run_command
 
     assert macports.query_port(module, 'port', 'git', state="present") == present_expected

--- a/tests/unit/plugins/modules/packaging/os/test_macports.py
+++ b/tests/unit/plugins/modules/packaging/os/test_macports.py
@@ -1,0 +1,37 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils import basic
+from ansible_collections.community.general.plugins.modules.packaging.os import macports
+
+import pytest
+
+TESTED_MODULE = macports.__name__
+
+QUERY_PORT_TEST_CASES = [
+	pytest.param('', False, False, id='Not installed'),
+	pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28', True, False, id='Installed but not active'),
+	pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)', True, True, id='Installed and active'),
+	pytest.param('''
+  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
+  git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
+''', True, False, id='2 versions installed, neither active'),
+	pytest.param('''
+  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)
+  git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
+''', True, True, id='2 versions installed, one active'),
+]
+
+@pytest.mark.parameterize("run_cmd_return_val, present_expected, active_expected", QUERY_PORT_TEST_CASES)
+def test_macports_query_port(mocker, run_cmd_return_val, present_expected, active_expected):
+	module = mocker.patch.object(
+		basic.AnsibleModule,
+		'run_command',
+		return_value=(0, run_cmd_return_val, '')
+	)
+
+	assert query_port(module, 'port', 'git', state="present") == present_expected
+	assert query_port(module, 'port', 'git', state="active") == active_expected
+

--- a/tests/unit/plugins/modules/packaging/os/test_macports.py
+++ b/tests/unit/plugins/modules/packaging/os/test_macports.py
@@ -11,15 +11,13 @@ import pytest
 TESTED_MODULE = macports.__name__
 
 QUERY_PORT_TEST_CASES = [
-  pytest.param('', False, False, id='Not installed'),
-  pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28', True, False, id='Installed but not active'),
-  pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)', True, True, id='Installed and active'),
-  pytest.param('''
-  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
+    pytest.param('', False, False, id='Not installed'),
+    pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28', True, False, id='Installed but not active'),
+    pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)', True, True, id='Installed and active'),
+    pytest.param('''  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
   git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
-    ''', True, False, id='2 versions installed, neither active'),
-  pytest.param('''
-  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)
+''', True, False, id='2 versions installed, neither active'),
+    pytest.param('''  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)
   git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
 ''', True, True, id='2 versions installed, one active'),
 ]
@@ -27,11 +25,10 @@ QUERY_PORT_TEST_CASES = [
 
 @pytest.mark.parametrize("run_cmd_return_val, present_expected, active_expected", QUERY_PORT_TEST_CASES)
 def test_macports_query_port(mocker, run_cmd_return_val, present_expected, active_expected):
-    module = mocker.patch.object(
-        basic.AnsibleModule,
-        'run_command',
-        return_value=(0, run_cmd_return_val, '')
-    )
+    module = mocker.Mock()
+    run_command = mocker.Mock()
+    run_command.return_value=(0, run_cmd_return_val, '')
+    module.run_command = run_command
 
     assert macports.query_port(module, 'port', 'git', state="present") == present_expected
     assert macports.query_port(module, 'port', 'git', state="active") == active_expected

--- a/tests/unit/plugins/modules/packaging/os/test_macports.py
+++ b/tests/unit/plugins/modules/packaging/os/test_macports.py
@@ -11,27 +11,27 @@ import pytest
 TESTED_MODULE = macports.__name__
 
 QUERY_PORT_TEST_CASES = [
-	pytest.param('', False, False, id='Not installed'),
-	pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28', True, False, id='Installed but not active'),
-	pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)', True, True, id='Installed and active'),
-	pytest.param('''
+  pytest.param('', False, False, id='Not installed'),
+  pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28', True, False, id='Installed but not active'),
+  pytest.param('  git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)', True, True, id='Installed and active'),
+  pytest.param('''
   git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
   git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
-''', True, False, id='2 versions installed, neither active'),
-	pytest.param('''
+    ''', True, False, id='2 versions installed, neither active'),
+  pytest.param('''
   git @2.29.2_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28 (active)
   git @2.28.1_0+credential_osxkeychain+diff_highlight+doc+pcre+perl5_28
 ''', True, True, id='2 versions installed, one active'),
 ]
 
-@pytest.mark.parameterize("run_cmd_return_val, present_expected, active_expected", QUERY_PORT_TEST_CASES)
+
+@pytest.mark.parametrize("run_cmd_return_val, present_expected, active_expected", QUERY_PORT_TEST_CASES)
 def test_macports_query_port(mocker, run_cmd_return_val, present_expected, active_expected):
-	module = mocker.patch.object(
-		basic.AnsibleModule,
-		'run_command',
-		return_value=(0, run_cmd_return_val, '')
-	)
+    module = mocker.patch.object(
+        basic.AnsibleModule,
+        'run_command',
+        return_value=(0, run_cmd_return_val, '')
+    )
 
-	assert query_port(module, 'port', 'git', state="present") == present_expected
-	assert query_port(module, 'port', 'git', state="active") == active_expected
-
+    assert macports.query_port(module, 'port', 'git', state="present") == present_expected
+    assert macports.query_port(module, 'port', 'git', state="active") == active_expected

--- a/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
@@ -18,7 +18,7 @@ TESTED_MODULE = redhat_subscription.__name__
 @pytest.fixture
 def patch_redhat_subscription(mocker):
     """
-    Function used for mocking some parts of redhat_subscribtion module
+    Function used for mocking some parts of redhat_subscription module
     """
     mocker.patch('ansible_collections.community.general.plugins.modules.packaging.os.redhat_subscription.RegistrationBase.REDHAT_REPO')
     mocker.patch('ansible_collections.community.general.plugins.modules.packaging.os.redhat_subscription.isfile', return_value=False)
@@ -817,7 +817,7 @@ TEST_CASES_IDS = [item[1]['id'] for item in TEST_CASES]
 
 @pytest.mark.parametrize('patch_ansible_module, testcase', TEST_CASES, ids=TEST_CASES_IDS, indirect=['patch_ansible_module'])
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_redhat_subscribtion(mocker, capfd, patch_redhat_subscription, testcase):
+def test_redhat_subscription(mocker, capfd, patch_redhat_subscription, testcase):
     """
     Run unit tests for test cases listen in TEST_CASES
     """
@@ -1173,7 +1173,7 @@ SYSPURPOSE_TEST_CASES_IDS = [item[1]['id'] for item in SYSPURPOSE_TEST_CASES]
 
 @pytest.mark.parametrize('patch_ansible_module, testcase', SYSPURPOSE_TEST_CASES, ids=SYSPURPOSE_TEST_CASES_IDS, indirect=['patch_ansible_module'])
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_redhat_subscribtion_syspurpose(mocker, capfd, patch_redhat_subscription, patch_ansible_module, testcase, tmpdir):
+def test_redhat_subscription_syspurpose(mocker, capfd, patch_redhat_subscription, patch_ansible_module, testcase, tmpdir):
     """
     Run unit tests for test cases listen in SYSPURPOSE_TEST_CASES (syspurpose specific cases)
     """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1307: MacPorts fails to install package whose name is contained within already installed package

Instead of using `grep` on full list of installed packages, have macports filter to only the requested package and then use native python to search the output for a match.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/packaging/os/macports.py

##### ADDITIONAL INFORMATION
See #1307 for more info about the problem. Here's more info about suggested solution:

The macports output format looks really stable. According to github blame, it hasn't changed in over a decade:
https://github.com/macports/macports-base/blob/ec8a2bc682c7afbde198aee23a1920557721b508/src/port/port.tcl#L3320-L3323

Instead of this approach, I considered just changing the `grep` pattern. I think it is preferable to eliminate the `use_unsafe_shell=True` flag, and search the output using python. As far as I can tell, the main benefit of using `grep` was that it meant the return code alone could be used for success/failure.

As far as I can tell, my chosen approach also makes it easier to write unit tests. The previous implementation relied on `run_command` executing a shell & relied passing output through `grep`, which I couldn't figure out an reasonable method to test.

This code assumes the following about `port -q installed <name>` output:

- If output is empty, `name` is not installed
- If one or more versions of `name` are installed, the output will start with some (optional) whitespace, the `name` string, followed by a space. The `-q` flag is important for this behavior.
- If the output contains `(active)`, one of the installed versions of the package is active.
  - This assumption could be wrong, if the package name, variants, or other information printed contains that string. This PR makes it slightly less likely to be a false positive.


##### Output

With `gh` **not** installed:

###### Before
```
❯ ansible-playbook -l liberty -K repro.yml -vv
ansible-playbook 2.10.2
  config file = /Users/daniel/Developer/home-ansible/ansible.cfg
  configured module search path = ['/Users/daniel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/daniel/Library/Python/3.8/lib/python/site-packages/ansible
  executable location = /Users/daniel/Library/Python/3.8/bin/ansible-playbook
  python version = 3.8.2 (default, Oct  2 2020, 10:45:42) [Clang 12.0.0 (clang-1200.0.32.27)]
Using /Users/daniel/Developer/home-ansible/ansible.cfg as config file
BECOME password:

PLAYBOOK: repro.yml ******************************************************************************************************************************************************************************************************************************
1 plays in repro.yml

PLAY [all] ***************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************************
task path: /Users/daniel/Developer/home-ansible/repro.yml:1
ok: [liberty]
META: ran handlers

TASK [Install git and gh] ************************************************************************************************************************************************************************************************************************
task path: /Users/daniel/Developer/home-ansible/repro.yml:3
ok: [liberty] => (item=git) => {"ansible_loop_var": "item", "changed": false, "item": "git", "msg": "Port(s) already present"}
ok: [liberty] => (item=gh) => {"ansible_loop_var": "item", "changed": false, "item": "gh", "msg": "Port(s) already present"}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
liberty                    : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
###### After
```
❯ ansible-playbook -l liberty -K repro.yml -vv
ansible-playbook 2.10.2
  config file = /Users/daniel/Developer/home-ansible/ansible.cfg
  configured module search path = ['/Users/daniel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/daniel/Library/Python/3.8/lib/python/site-packages/ansible
  executable location = /Users/daniel/Library/Python/3.8/bin/ansible-playbook
  python version = 3.8.2 (default, Oct  2 2020, 10:45:42) [Clang 12.0.0 (clang-1200.0.32.27)]
Using /Users/daniel/Developer/home-ansible/ansible.cfg as config file
BECOME password:

PLAYBOOK: repro.yml ******************************************************************************************************************************************************************************************************************************
1 plays in repro.yml

PLAY [all] ***************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************************
task path: /Users/daniel/Developer/home-ansible/repro.yml:1
ok: [liberty]
META: ran handlers

TASK [Install git and gh] ************************************************************************************************************************************************************************************************************************
task path: /Users/daniel/Developer/home-ansible/repro.yml:3
ok: [liberty] => (item=git) => {"ansible_loop_var": "item", "changed": false, "item": "git", "msg": "Port(s) already present"}
changed: [liberty] => (item=gh) => {"ansible_loop_var": "item", "changed": true, "item": "gh", "msg": "Installed 1 port(s)"}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
liberty                    : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

##### Testing

I've done manual, ad-hoc testing of `state=present` and `state=active` with macOS 11.0.1 and macports v2.6.4.

I've attempted to write a reasonable unit test. I haven't figured out how to run it locally though... so I'm hoping the github PR will do that for me. (I tried venv, and it's failing to install cffi with an Arm64-related error).
