### PR TITLE
feat(callback): add scalyr callback plugin

### DIFF
--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -66,6 +66,7 @@ import uuid
 from datetime import datetime
 from os.path import basename
 
+from ansible import context
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.parsing.ajson import AnsibleJSONEncoder
@@ -84,6 +85,7 @@ class ScalyrLogSource(object):
         self.host = socket.gethostname()
         self.ip_address = socket.gethostbyname(socket.gethostname())
         self.user = getpass.getuser()
+        self.cli_args = {}
 
     def send_event(self, url, authtoken, state, result, runtime):
         """Send the Ansible task result to the Scalyr API.
@@ -130,7 +132,8 @@ class ScalyrLogSource(object):
                         "ansible_playbook": self.ansible_playbook,
                         "ansible_role": ansible_role,
                         "ansible_task": result._task_fields,
-                        "ansible_result": result._result
+                        "ansible_result": result._result,
+                        "ansible_cli_args": self.cli_args
                     }
                 }
             ]
@@ -207,6 +210,7 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_start(self, playbook):
         self.scalyr.ansible_playbook = basename(playbook._file_name)
+        self.scalyr.cli_args = context.CLIARGS
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.start_datetimes[task._uuid] = datetime.utcnow()

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -212,7 +212,7 @@ class CallbackModule(CallbackBase):
         self.scalyr.ansible_playbook = basename(playbook._file_name)
         self.scalyr.cli_args = context.CLIARGS
 
-    def v2_playbook_on_task_start(self, task, is_conditional):
+    def v2_playbook_on_task_start(self, task, **kwargs):
         self.start_datetimes[task._uuid] = datetime.utcnow()
 
     def v2_playbook_on_handler_task_start(self, task):

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -15,13 +15,13 @@ description:
   - Heavily inspired by splunk and sumologic callbacks
 requirements:
   - Whitelisting this callback plugin.
-  - Create a Log Access Write Key in Scalyr (https://app.eu.scalyr.com/keys)
+  - Create a Log Access Write Key in Scalyr (https://app.scalyr.com/keys)
   - Define the Scalyr API URL and API key as an environment variable, in ansible.cfg or as hostvars.
     - When using the hostvars method the variable(s) need to be present as 'localhost' variables.
 options:
   scalyr_api_url:
     description: URL to the Scalyr API endpoint.
-    default: https://app.eu.scalyr.com/api
+    default: https://app.scalyr.com/api
     env:
       - name: SCALYR_API_URL
     ini:
@@ -45,16 +45,16 @@ examples: |
     callback_whitelist = community.general.scalyr
 
   Set the environment variable
-    export SCALYR_API_URL=https://app.eu.scalyr.com/api
+    export SCALYR_API_URL=https://app.scalyr.com/api
     export SCALYR_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or set the ansible.cfg variable in the callback_scalyr block
     [callback_scalyr]
-    scalry_api_url = https://app.eu.scalyr.com/api
+    scalry_api_url = https://app.scalyr.com/api
     scalyr_api_token = XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or define as hostvars (supports as well Ansible vault)
-    scalry_api_url: https://app.eu.scalyr.com/api
+    scalry_api_url: https://app.scalyr.com/api
     scalyr_api_token: XXXXXXXXXXXXXXXXXXXXXmlQ0-
 '''
 

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -154,7 +154,7 @@ class CallbackModule(CallbackBase):
         return (
             datetime.utcnow() -
             self.start_datetimes[result._task._uuid]
-        ).total_seconds() * 1000 * 1000
+        ).total_seconds()
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -28,13 +28,13 @@ options:
       - section: callback_scalyr
         key: scalyr_api_url
     type: string
-  scalyr_api_authtoken:
+  scalyr_api_token:
     description: Token to authenticate the connection to Scalyr (with write access).
     env:
-      - name: SCALYR_API_AUTHTOKEN
+      - name: SCALYR_API_TOKEN
     ini:
       - section: callback_scalyr
-        key: scalyr_api_authtoken
+        key: scalyr_api_token
     type: string
 '''
 
@@ -46,16 +46,16 @@ examples: |
 
   Set the environment variable
     export SCALYR_API_URL=https://app.eu.scalyr.com/api/addEvents
-    export SCALYR_API_AUTHTOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
+    export SCALYR_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or set the ansible.cfg variable in the callback_scalyr block
     [callback_scalyr]
     scalry_api_url = https://app.eu.scalyr.com/api/addEvents
-    scalyr_api_authtoken = XXXXXXXXXXXXXXXXXXXXXmlQ0-
+    scalyr_api_token = XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or define as hostvars (supports as well Ansible vault)
     scalry_api_url: https://app.eu.scalyr.com/api/addEvents
-    scalyr_api_authtoken: XXXXXXXXXXXXXXXXXXXXXmlQ0-
+    scalyr_api_token: XXXXXXXXXXXXXXXXXXXXXmlQ0-
 '''
 
 import getpass
@@ -181,7 +181,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
         self.url = self.get_option('scalyr_api_url')
-        self.authtoken = self.get_option('scalyr_api_authtoken')
+        self.authtoken = self.get_option('scalyr_api_token')
 
     def v2_playbook_on_play_start(self, play):
         hostvars = play.get_variable_manager()._hostvars
@@ -198,15 +198,15 @@ class CallbackModule(CallbackBase):
                 self.url = hostvars['localhost']['scalyr_api_url']
 
         if self.authtoken is None:
-            if not hostvars or 'scalyr_api_authtoken' not in hostvars['localhost']:
+            if not hostvars or 'scalyr_api_token' not in hostvars['localhost']:
                 self.disabled = True
                 self._display.warning('Scalyr requires a Log Access Write Key'
                                       'token. The Scalyr API key can be '
                                       'provided using the '
-                                      '`SCALYR_API_AUTHTOKEN` environment variable, '
+                                      '`SCALYR_API_TOKEN` environment variable, '
                                       'in the ansible.cfg file or as a hostvar.')
             else:
-                self.authtoken = hostvars['localhost']['scalyr_api_authtoken']
+                self.authtoken = hostvars['localhost']['scalyr_api_token']
 
     def v2_playbook_on_start(self, playbook):
         self.scalyr.ansible_playbook = basename(playbook._file_name)

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -175,7 +175,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_play_start(self, play):
         if self.authtoken is None:
             hostvars = play.get_variable_manager()._hostvars
-            if not hostvars or not hostvars['localhost'].has_key('scalyr_authtoken'):
+            if not hostvars or 'scalyr_authtoken' not in hostvars['localhost']:
                 self.disabled = True
                 self._display.warning('Scalyr requires a Log Access Write Key'
                                       'token. The Scalyr API key can be '

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -99,8 +99,7 @@ class ScalyrLogSource(object):
             "token": str(authtoken),
             "session": str(self.session),
             "sessionInfo": {
-                "serverHost": self.host,
-                "serverIpAddress": self.ip_address,
+                "serverHost": result._host.get_name(),
                 "logfile": "ansible.log",
                 "parser": ""
             },
@@ -114,9 +113,10 @@ class ScalyrLogSource(object):
                         "status": state,
                         "runtime": runtime,
                         "user": self.user,
+                        "ansible_controller_host": self.host,
                         "ansible_version": ansible_version,
                         "ansible_check_mode": self.ansible_check_mode,
-                        "ansible_host": self.host,
+                        "ansible_host": result._host.get_name(),
                         "ansible_playbook": self.ansible_playbook,
                         "ansible_role": ansible_role,
                         "ansible_task": result._task_fields,

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -117,7 +117,6 @@ class ScalyrLogSource(object):
             "events": [
                 {
                     "ts": str(nanoTime()),
-                    "type": 0,
                     "sev": 3,
                     "attrs": {
                         "uuid": result._task._uuid,

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Martin Migasiewicz <migasiew.nk@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+callback: scalyr
+type: aggregate
+short_description: Sends task result events to Scalyr
+author: Martin Migasiewicz (@martinm82)
+version_added: 1.3.0
+description:
+  - This callback plugin will send task results as JSON formatted events to Scalyr.
+requirements:
+  - Whitelisting this callback plugin
+  - 'Create a Log Access Write Key in Scalyr (https://app.eu.scalyr.com/keys)'
+  - 'Define the Scalyr API URL and API key in ansible.cfg'
+  - 'Based on the splunk and sumologic callbacks'
+options:
+  url:
+    description: URL to the Scalyr API endpoint
+    default: https://app.eu.scalyr.com/api/addEvents
+    env:
+      - name: SCALYR_URL
+    ini:
+      - section: callback_scalyr
+        key: url
+    type: string
+  authtoken:
+    description: Token to authenticate the connection to Scalyr.
+    env:
+      - name: SCALYR_AUTHTOKEN
+    ini:
+      - section: callback_scalyr
+        key: authtoken
+    type: string
+'''
+
+EXAMPLES = '''
+examples: >
+  To enable, add this to your ansible.cfg file in the defaults block
+    [defaults]
+    callback_whitelist = community.general.scalyr
+
+  Set the environment variable
+    export SCALYR_URL=https://app.eu.scalyr.com/api/addEvents
+    export SCALYR_AUTHTOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
+
+  Set the ansible.cfg variable in the callback_scalyr block
+    [callback_scalyr]
+    url = https://app.eu.scalyr.com/api/addEvents
+    authtoken = XXXXXXXXXXXXXXXXXXXXXmlQ0-
+'''
+
+import getpass
+import json
+import socket
+import time
+import uuid
+
+from datetime import datetime
+from os.path import basename
+
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.ansible_release import __version__ as ansible_version
+from ansible.parsing.ajson import AnsibleJSONEncoder
+from ansible.plugins.callback import CallbackBase
+
+
+def secondsToNanoSeconds(seconds):
+    return seconds * 1000000000
+
+class ScalyrLogSource(object):
+    def __init__(self):
+        self.ansible_check_mode = False
+        self.ansible_playbook = ""
+        self.session = str(uuid.uuid4())
+        self.host = socket.gethostname()
+        self.ip_address = socket.gethostbyname(socket.gethostname())
+        self.user = getpass.getuser()
+
+    def send_event(self, url, authtoken, state, result, runtime):
+        if result._task_fields['args'].get('_ansible_check_mode') is True:
+            self.ansible_check_mode = True
+
+        if result._task._role:
+            ansible_role = str(result._task._role)
+        else:
+            ansible_role = None
+
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
+        data = {
+            "token": str(authtoken),
+            "session": str(self.session),
+            "sessionInfo": {
+                "serverHost": self.host,
+                "serverIpAddress": self.ip_address,
+                "logfile": "ansible.log",
+                "parser": ""
+            },
+            "events": [
+                {
+                    "ts": str(int(secondsToNanoSeconds(time.time()))) ,
+                    "type": 0,
+                    "sev": 3,
+                    "attrs": {
+                        "uuid": result._task._uuid,
+                        "status": state,
+                        "runtime": runtime,
+                        "user": self.user,
+                        "ansible_version": ansible_version,
+                        "ansible_check_mode": self.ansible_check_mode,
+                        "ansible_host": self.host,
+                        "ansible_playbook": self.ansible_playbook,
+                        "ansible_role": ansible_role,
+                        "ansible_task": result._task_fields,
+                        "ansible_result": result._result
+                    }
+                }
+            ]
+        }
+
+        payload = json.dumps(data, cls=AnsibleJSONEncoder, sort_keys=True)
+        open_url(
+            url,
+            data=payload,
+            headers={
+                'Content-type': 'application/json'
+            },
+            method='POST'
+        )
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'community.general.scalyr'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    def __init__(self, display=None):
+        super(CallbackModule, self).__init__(display=display)
+        self.start_datetimes = {}  # Collect task start times
+        self.url = None
+        self.authtoken = None
+        self.scalyr = ScalyrLogSource()
+
+    def _runtime(self, result):
+        return (
+            datetime.utcnow() -
+            self.start_datetimes[result._task._uuid]
+        ).total_seconds() * 1000 * 1000
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        self.url = self.get_option('url')
+
+        if self.url is None:
+            self.disabled = True
+            self._display.warning('Scalyr API URL was '
+                                  'not provided. The Scalyr API URL '
+                                  'can be provided using the '
+                                  '`SCALYR_URL` environment variable or '
+                                  'in the ansible.cfg file.')
+
+        self.authtoken = self.get_option('authtoken')
+
+        if self.authtoken is None:
+            self.disabled = True
+            self._display.warning('Scalyr requires a Log Access Write Key'
+                                  'token. The Scalyr API key can be '
+                                  'provided using the '
+                                  '`SCALYR_AUTHTOKEN` environment variable or '
+                                  'in the ansible.cfg file.')
+
+    def v2_playbook_on_start(self, playbook):
+        self.scalyr.ansible_playbook = basename(playbook._file_name)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.start_datetimes[task._uuid] = datetime.utcnow()
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.start_datetimes[task._uuid] = datetime.utcnow()
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        self.scalyr.send_event(
+            self.url,
+            self.authtoken,
+            'OK',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_skipped(self, result, **kwargs):
+        self.scalyr.send_event(
+            self.url,
+            self.authtoken,
+            'SKIPPED',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_failed(self, result, **kwargs):
+        self.scalyr.send_event(
+            self.url,
+            self.authtoken,
+            'FAILED',
+            result,
+            self._runtime(result)
+        )
+
+    def runner_on_async_failed(self, result, **kwargs):
+        self.scalyr.send_event(
+            self.url,
+            self.authtoken,
+            'FAILED',
+            result,
+            self._runtime(result)
+        )
+
+    def v2_runner_on_unreachable(self, result, **kwargs):
+        self.scalyr.send_event(
+            self.url,
+            self.authtoken,
+            'UNREACHABLE',
+            result,
+            self._runtime(result)
+        )

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -7,15 +7,15 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 callback: scalyr
 type: aggregate
-short_description: Sends task result events to Scalyr
+short_description: Sends Ansible task results to Scalyr.
 author: Martin Migasiewicz (@martinm82)
 version_added: 1.3.0
 description:
-  - This callback plugin will send task results as JSON formatted events to Scalyr.
-  - Heavily inspired by splunk and sumologic callbacks
+  - This callback plugin will send Ansible task results as JSON formatted events to Scalyr.
+  - Heavily inspired by splunk and sumologic callbacks.
 requirements:
   - Whitelisting this callback plugin.
-  - Create a Log Access Write Key in Scalyr (https://app.scalyr.com/keys)
+  - Create a Log Access Write Key in Scalyr (https://app.scalyr.com/keys).
   - Define the Scalyr API URL and API key as an environment variable, in ansible.cfg or as hostvars.
     - When using the hostvars method the variable(s) need to be present as 'localhost' variables.
 options:

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -12,12 +12,12 @@ author: Martin Migasiewicz (@martinm82)
 version_added: 1.3.0
 description:
   - This callback plugin will send task results as JSON formatted events to Scalyr.
+  - Heavily inspired by splunk and sumologic callbacks
 requirements:
   - Whitelisting this callback plugin.
   - Create a Log Access Write Key in Scalyr (https://app.eu.scalyr.com/keys)
   - Define the Scalyr API URL and API key as an environment variable, in ansible.cfg or as hostvars.
     - When using the hostvars method the variable(s) need to be present as 'localhost' variables.
-  - Heavily inspired by splunk and sumologic callbacks
 options:
   scalyr_api_url:
     description: URL to the Scalyr API endpoint.

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -41,7 +41,7 @@ options:
 '''
 
 EXAMPLES = '''
-examples: >
+examples: |
   To enable, add this to your ansible.cfg file in the defaults block
     [defaults]
     callback_whitelist = community.general.scalyr
@@ -50,10 +50,13 @@ examples: >
     export SCALYR_URL=https://app.eu.scalyr.com/api/addEvents
     export SCALYR_AUTHTOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
-  Set the ansible.cfg variable in the callback_scalyr block
+  Or set the ansible.cfg variable in the callback_scalyr block
     [callback_scalyr]
     url = https://app.eu.scalyr.com/api/addEvents
     authtoken = XXXXXXXXXXXXXXXXXXXXXmlQ0-
+
+  Or define a hostvar (supports as well Ansible vault)
+    scalyr_authtoken: XXXXXXXXXXXXXXXXXXXXXmlQ0-
 '''
 
 import getpass

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -16,7 +16,7 @@ version_added: 1.3.0
 description:
   - This callback plugin will send task results as JSON formatted events to Scalyr.
 requirements:
-  - Whitelisting this callback plugin
+  - Whitelisting this callback plugin.
   - 'Create a Log Access Write Key in Scalyr (https://app.eu.scalyr.com/keys)'
   - 'Define the Scalyr API URL and API key in ansible.cfg'
   - 'Based on the splunk and sumologic callbacks'

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -21,7 +21,7 @@ requirements:
 options:
   scalyr_api_url:
     description: URL to the Scalyr API endpoint.
-    default: https://app.eu.scalyr.com/api/addEvents
+    default: https://app.eu.scalyr.com/api
     env:
       - name: SCALYR_API_URL
     ini:
@@ -45,16 +45,16 @@ examples: |
     callback_whitelist = community.general.scalyr
 
   Set the environment variable
-    export SCALYR_API_URL=https://app.eu.scalyr.com/api/addEvents
+    export SCALYR_API_URL=https://app.eu.scalyr.com/api
     export SCALYR_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or set the ansible.cfg variable in the callback_scalyr block
     [callback_scalyr]
-    scalry_api_url = https://app.eu.scalyr.com/api/addEvents
+    scalry_api_url = https://app.eu.scalyr.com/api
     scalyr_api_token = XXXXXXXXXXXXXXXXXXXXXmlQ0-
 
   Or define as hostvars (supports as well Ansible vault)
-    scalry_api_url: https://app.eu.scalyr.com/api/addEvents
+    scalry_api_url: https://app.eu.scalyr.com/api
     scalyr_api_token: XXXXXXXXXXXXXXXXXXXXXmlQ0-
 '''
 
@@ -67,8 +67,9 @@ from datetime import datetime
 from os.path import basename
 
 from ansible import context
-from ansible.module_utils.urls import open_url
 from ansible.module_utils.ansible_release import __version__ as ansible_version
+from ansible.module_utils.six.moves.urllib.parse import urljoin
+from ansible.module_utils.urls import open_url
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase
 
@@ -141,7 +142,7 @@ class ScalyrLogSource(object):
 
         payload = json.dumps(data, cls=AnsibleJSONEncoder, sort_keys=True)
         open_url(
-            url,
+            urljoin(url, "addEvents"),
             data=payload,
             headers={
                 'Content-type': 'application/json'

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -22,7 +22,7 @@ requirements:
   - 'Based on the splunk and sumologic callbacks'
 options:
   url:
-    description: URL to the Scalyr API endpoint
+    description: URL to the Scalyr API endpoint.
     default: https://app.eu.scalyr.com/api/addEvents
     env:
       - name: SCALYR_URL

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -84,6 +84,15 @@ class ScalyrLogSource(object):
         self.user = getpass.getuser()
 
     def send_event(self, url, authtoken, state, result, runtime):
+        """Send the Ansible task result to the Scalyr API.
+
+        Args:
+            url ([string]): Scalyr API URL to where the event will be sent.
+            authtoken ([string]): Log Access Write Key to authenticate against the Scalyr API.
+            state ([string]): State of the task itself.
+            result ([ansible.executor.task_result.TaskResult]): The Ansible task result.
+            runtime ([int]): Duration of the task.
+        """
         if result._task_fields['args'].get('_ansible_check_mode') is True:
             self.ansible_check_mode = True
 

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-
 # Copyright: (c) 2020, Martin Migasiewicz <migasiew.nk@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -77,6 +74,7 @@ from ansible.plugins.callback import CallbackBase
 def secondsToNanoSeconds(seconds):
     return seconds * 1000000000
 
+
 class ScalyrLogSource(object):
     def __init__(self):
         self.ansible_check_mode = False
@@ -109,7 +107,7 @@ class ScalyrLogSource(object):
             },
             "events": [
                 {
-                    "ts": str(int(secondsToNanoSeconds(time.time()))) ,
+                    "ts": str(int(secondsToNanoSeconds(time.time()))),
                     "type": 0,
                     "sev": 3,
                     "attrs": {
@@ -177,13 +175,13 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_play_start(self, play):
         if self.authtoken is None:
             hostvars = play.get_variable_manager()._hostvars
-            if not hostvars or not 'scalyr_authtoken' in hostvars['localhost']:
+            if not hostvars or not hostvars['localhost'].has_key('scalyr_authtoken'):
                 self.disabled = True
                 self._display.warning('Scalyr requires a Log Access Write Key'
-                                    'token. The Scalyr API key can be '
-                                    'provided using the '
-                                    '`SCALYR_AUTHTOKEN` environment variable, '
-                                    'in the ansible.cfg file or as a hostvar.')
+                                      'token. The Scalyr API key can be '
+                                      'provided using the '
+                                      '`SCALYR_AUTHTOKEN` environment variable, '
+                                      'in the ansible.cfg file or as a hostvar.')
 
             self.authtoken = hostvars['localhost']['scalyr_authtoken']
 

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -59,7 +59,6 @@ examples: |
 import getpass
 import json
 import socket
-import time
 import uuid
 
 from datetime import datetime
@@ -71,8 +70,8 @@ from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase
 
 
-def secondsToNanoSeconds(seconds):
-    return seconds * 1000000000
+def nanoTime():
+    return int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000000000)
 
 
 class ScalyrLogSource(object):
@@ -107,7 +106,7 @@ class ScalyrLogSource(object):
             },
             "events": [
                 {
-                    "ts": str(int(secondsToNanoSeconds(time.time()))),
+                    "ts": str(nanoTime()),
                     "type": 0,
                     "sev": 3,
                     "attrs": {

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -161,10 +161,18 @@ class CallbackModule(CallbackBase):
         self.scalyr = ScalyrLogSource()
 
     def _runtime(self, result):
-        return (
+        """Return duration of task result.
+
+        Args:
+            result ([ansible.executor.TaskResult]): [Task result]
+
+        Returns:
+            [int]: [Duration in ms]
+        """
+        return int((
             datetime.utcnow() -
             self.start_datetimes[result._task._uuid]
-        ).total_seconds()
+        ).total_seconds() * 1000)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -68,7 +68,6 @@ from os.path import basename
 
 from ansible import context
 from ansible.module_utils.ansible_release import __version__ as ansible_version
-from ansible.module_utils.six.moves.urllib.parse import urljoin
 from ansible.module_utils.urls import open_url
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase
@@ -142,7 +141,7 @@ class ScalyrLogSource(object):
 
         payload = json.dumps(data, cls=AnsibleJSONEncoder, sort_keys=True)
         open_url(
-            urljoin(url, "addEvents"),
+            url + "/addEvents",
             data=payload,
             headers={
                 'Content-type': 'application/json'

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -21,7 +21,6 @@ requirements:
 options:
   scalyr_api_url:
     description: URL to the Scalyr API endpoint.
-    default: https://app.scalyr.com/api
     env:
       - name: SCALYR_API_URL
     ini:

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -95,16 +95,16 @@ class ScalyrLogSource(object):
             result ([ansible.executor.task_result.TaskResult]): The Ansible task result.
             runtime ([int]): Duration of the task.
         """
-        if result._task_fields['args'].get('_ansible_check_mode') is True:
-            self.ansible_check_mode = True
+        if 'args' in result._task_fields:
+            if result._task_fields['args'].get('_ansible_check_mode') is True:
+                self.ansible_check_mode = True
+            # Remove uninteresting data
+            del result._task_fields['args']
 
         if result._task._role:
             ansible_role = str(result._task._role)
         else:
             ansible_role = None
-
-        if 'args' in result._task_fields:
-            del result._task_fields['args']
 
         data = {
             "token": str(authtoken),

--- a/plugins/callback/scalyr.py
+++ b/plugins/callback/scalyr.py
@@ -113,7 +113,7 @@ class ScalyrLogSource(object):
             "sessionInfo": {
                 "serverHost": result._host.get_name(),
                 "logfile": "ansible.log",
-                "parser": ""
+                "parser": "json"
             },
             "events": [
                 {


### PR DESCRIPTION
##### SUMMARY
Introducing a new callback plugin to push task/playbook results to Scalyr. The module is heavily inspired by the sumologic and splunk callbacks.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
scalyr

##### ADDITIONAL INFORMATION

TODO:
- [ ] Add unit tests
- [x] Check how API keys could be used in Ansible vault instead in ansible.cfg or as env vars