### PR TITLE
Adding module_utils/module_helper.py + big revamp in xfconf.py to use it

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -166,6 +166,9 @@ files:
   $module_utils/memset.py:
     maintainers: glitchcrab
     labels: cloud memset
+  $module_utils/module_helper.py:
+    maintainers: russoz
+    labels: module_helper
   $module_utils/net_tools/nios/api.py:
     maintainers: $team_networking sganesh-infoblox
     labels: infoblox networking
@@ -1093,7 +1096,7 @@ macros:
   team_cyberark_conjur: jvanderhoof ryanprior
   team_docker: DBendit WojciechowskiPiotr akshay196 danihodovic dariko felixfontein jwitko kassiansun tbouvet chouseknecht
   team_e_spirit: MatrixCrawler getjack
-  team_flatpak: JayKayy oolongbrothers 
+  team_flatpak: JayKayy oolongbrothers
   team_gitlab: Lunik Shaps dj-wasabi marwatk waheedi zanssa scodeman
   team_google: erjohnso rambleraptor
   team_hpux: bcoca davx8342

--- a/changelogs/fragments/1322-module_helper_and_xfconf.yaml
+++ b/changelogs/fragments/1322-module_helper_and_xfconf.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - module_helper - added ModuleHelper class and a couple of convenience tools for module developers (https://github.com/ansible-collections/community.general/pull/1322).
+bugfixes:
+  - xfconf - xfconf no longer passing the command args as a string, but rather as a list (https://github.com/ansible-collections/community.general/issues/1328).
+  - xfconf - parameter ``value`` no longer required for state ``absent`` (https://github.com/ansible-collections/community.general/issues/1329).

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -70,8 +70,8 @@ class ArgFormat(object):
         elif hasattr(fmt, '__call__'):
             self.arg_format = fmt
         else:
-            raise ValueError('Parameter fmt must be either: a string, a list/tuple of '
-                             'strings or a function: type={0}, value={1}'.format(type(fmt), fmt))
+            raise TypeError('Parameter fmt must be either: a string, a list/tuple of '
+                            'strings or a function: type={0}, value={1}'.format(type(fmt), fmt))
 
         if stars:
             self.arg_format = (self.stars_deco(stars))(self.arg_format)
@@ -126,7 +126,7 @@ class DependencyCtxMgr(object):
         self.exc_type = exc_type
         self.exc_val = exc_val
         self.exc_tb = exc_tb
-        return self.has_it
+        return not self.has_it
 
     @property
     def text(self):

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from functools import partial, wraps
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+class ArgFormat(object):
+    """
+    Argument formatter
+    """
+    BOOLEAN = 0
+    PRINTF = 1
+    FORMAT = 2
+
+    @staticmethod
+    def stars_deco(num):
+        if num == 1:
+            def deco(f):
+                return partial(lambda ff, v: ff(*v), f)
+            return deco
+        elif num == 2:
+            def deco(f):
+                return partial(lambda ff, v: ff(**v), f)
+            return deco
+
+        return lambda f: f
+
+    def __init__(self, name, fmt=None, style=FORMAT, stars=0):
+        """
+        Creates a new formatter
+        :param name: Name of the argument to be formatted
+        :param fmt: Either a str to be formatted (using or not printf-style) or a callable that does that
+        :param style: Whether arg_format (as str) should use printf-style formatting.
+                             Ignored if arg_format is None or not a str (should be callable).
+        :param stars: A int with 0, 1 or 2 value, indicating to formatting the value as: value, *value or **value
+        """
+        _fmts = {
+            ArgFormat.BOOLEAN: lambda _fmt, v: ([_fmt] if bool(v) else []),
+            ArgFormat.PRINTF: lambda _fmt, v: [_fmt % v],
+            ArgFormat.FORMAT: lambda _fmt, v: [_fmt.format(v)],
+        }
+
+        self.name = name
+        self.stars = stars
+
+        if fmt is None:
+            fmt = "{0}"
+            style = ArgFormat.FORMAT
+
+        if isinstance(fmt, str):
+            func = _fmts[style]
+            self.arg_format = partial(func, fmt)
+        elif isinstance(fmt, list) or isinstance(fmt, tuple):
+            self.arg_format = lambda v: [_fmts[style](f, v)[0] for f in fmt]
+        else:
+            self.arg_format = fmt
+
+        if stars:
+            self.arg_format = (self.stars_deco(stars))(self.arg_format)
+
+    def to_text(self, value):
+        func = self.arg_format
+        return [str(p) for p in func(value)]
+
+
+def cause_changes(func, on_success=True, on_failure=False):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            func(*args, **kwargs)
+            if on_success:
+                self.changed = True
+        except Exception as e:
+            if on_failure:
+                self.changed = True
+            raise
+    return wrapper
+
+
+def module_fails_on_exception(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            func(self, *args, **kwargs)
+        except SystemExit:
+            raise
+        except Exception as e:
+            self.vars.msg = "Module failed with exception: {0}".format(str(e).strip())
+            self.vars.exception = traceback.format_exc()
+            self.module.fail_json(changed=False, msg=self.vars.msg, exception=self.vars.exception, output=self.output, vars=self.vars)
+    return wrapper
+
+
+class DependencyCtxMgr(object):
+    def __init__(self, name, msg=None):
+        self.name = name
+        self.msg = msg
+        self.has_it = False
+        self.exc_type = None
+        self.exc_val = None
+        self.exc_tb = None
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.has_it = exc_type is None
+        self.exc_type = exc_type
+        self.exc_val = exc_val
+        self.exc_tb = exc_tb
+        return self.has_it
+
+    @property
+    def text(self):
+        return self.msg or str(self.exc_val)
+
+
+class ModuleHelper(object):
+    _dependencies = []
+    module = {}
+    facts_name = None
+
+    class AttrDict(dict):
+        def __getattr__(self, item):
+            return self[item]
+
+    def __init__(self, module=None):
+        self.vars = ModuleHelper.AttrDict()
+        self.output_dict = dict()
+        self.facts_dict = dict()
+        self._changed = False
+
+        if module:
+            self.module = module
+
+        if not isinstance(module, AnsibleModule):
+            self.module = AnsibleModule(**self.module)
+
+    def update_output(self, **kwargs):
+        if kwargs:
+            self.output_dict.update(kwargs)
+
+    def update_facts(self, **kwargs):
+        if kwargs:
+            self.facts_dict.update(kwargs)
+
+    def __init_module__(self):
+        pass
+
+    def __run__(self):
+        raise NotImplementedError()
+
+    @property
+    def changed(self):
+        return self._changed
+
+    @changed.setter
+    def changed(self, value):
+        self._changed = value
+
+    @property
+    def output(self):
+        result = dict(self.vars)
+        result.update(self.output_dict)
+        if self.facts_name:
+            result['ansible_facts'] = {self.facts_name: self.facts_dict}
+        return result
+
+    @module_fails_on_exception
+    def run(self):
+        self.fail_on_missing_deps()
+        self.__init_module__()
+        self.__run__()
+        self.module.exit_json(changed=self.changed, **self.output_dict)
+
+    @classmethod
+    def dependency(cls, name, msg):
+        cls._dependencies.append(DependencyCtxMgr(name, msg))
+        return cls._dependencies[-1]
+
+    def fail_on_missing_deps(self):
+        for d in self._dependencies:
+            if not d.has_it:
+                self.module.fail_json(changed=False,
+                                      exception=d.exc_val.__traceback__.format_exc(),
+                                      msg=d.text,
+                                      **self.output_dict)
+
+
+class StateMixin(object):
+    state_param = 'state'
+    default_state = None
+
+    def _state(self):
+        state = self.module.params.get(self.state_param)
+        return self.default_state if state is None else state
+
+    def __run__(self):
+        state = self._state()
+        self.vars.state = state
+
+        # resolve aliases
+        if state not in self.module.params:
+            aliased = [name for name, param in self.module.argument_spec.items() if state in param.get('aliases', [])]
+            if aliased:
+                state = aliased[0]
+                self.vars.effective_state = state
+
+        method = "state_{0}".format(state)
+        if not hasattr(self, method):
+            return self.__state_fallback__()
+        func = getattr(self, method)
+        return func()
+
+    def __state_fallback__(self):
+        raise ValueError("Cannot find method for state: {0}".format(self._state()))
+
+
+class CmdMixin(object):
+    """
+    Mixin for mapping module options to running a CLI command with its arguments.
+    """
+    command = None
+    command_args_formats = dict()
+    check_rc = False
+    force_lang = "C"
+
+    @property
+    def module_formats(self):
+        result = {}
+        for param in self.module.params.keys():
+            result[param] = ArgFormat(param)
+        return result
+
+    @property
+    def custom_formats(self):
+        result = {}
+        for param, fmt_spec in self.command_args_formats.items():
+            result[param] = ArgFormat(param, **fmt_spec)
+        return result
+
+    def _calculate_args(self, extra_params=None, params=None):
+        def add_arg_formatted_param(_cmd_args, arg_format, _value):
+            args = [x for x in arg_format.to_text(_value)]
+            return _cmd_args + args
+
+        def find_format(_param):
+            return self.custom_formats.get(_param, self.module_formats.get(_param))
+
+        extra_params = extra_params or dict()
+        cmd_args = [self.module.get_bin_path(self.command)]
+        param_list = params if params else self.module.params.keys()
+
+        for param in param_list:
+            if param in self.module.argument_spec:
+                if param not in self.module.params:
+                    continue
+                fmt = find_format(param)
+                value = self.module.params[param]
+            else:
+                if param not in extra_params:
+                    continue
+                fmt = find_format(param)
+                value = extra_params[param]
+            self.cmd_args = cmd_args
+            cmd_args = add_arg_formatted_param(cmd_args, fmt, value)
+
+        return cmd_args
+
+    def process_command_output(self, rc, out, err):
+        return rc, out, err
+
+    def run_command(self, extra_params=None, params=None, *args, **kwargs):
+        self.vars['cmd_args'] = self._calculate_args(extra_params, params)
+        env_update = kwargs.get('environ_update', {})
+        check_rc = kwargs.get('check_rc', self.check_rc)
+        if self.force_lang:
+            env_update.update({'LANGUAGE': self.force_lang})
+            self.update_output(force_lang=self.force_lang)
+        rc, out, err = self.module.run_command(self.vars['cmd_args'],
+                                               env_update=env_update,
+                                               check_rc=check_rc, *args, **kwargs)
+        self.update_output(rc=rc, stdout=out, stderr=err)
+        return self.process_command_output(rc, out, err)

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -23,11 +23,11 @@ class ArgFormat(object):
     def stars_deco(num):
         if num == 1:
             def deco(f):
-                return partial(lambda ff, v: ff(*v), f)
+                return lambda v: f(*v)
             return deco
         elif num == 2:
             def deco(f):
-                return partial(lambda ff, v: ff(**v), f)
+                return lambda v: f(**v)
             return deco
 
         return lambda f: f

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -296,7 +296,7 @@ class CmdMixin(object):
             env_update.update({'LANGUAGE': self.force_lang})
             self.update_output(force_lang=self.force_lang)
         rc, out, err = self.module.run_command(self.vars['cmd_args'],
-                                               env_update=env_update,
+                                               environ_update=env_update,
                                                check_rc=check_rc, *args, **kwargs)
         self.update_output(rc=rc, stdout=out, stderr=err)
         return self.process_command_output(rc, out, err)

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -191,6 +191,15 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
         return result
 
+    @property
+    def changed(self):
+        if self.vars.previous_value is None:
+            return self.vars.value is not None
+        elif self.vars.value is None:
+            return False
+        else:
+            return set(self.vars.previous_value) != set(self.vars.value)
+
     def _get(self):
         return self.run_command(params=('channel', 'property'))
 
@@ -240,15 +249,6 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
         if not self.vars.is_array:
             self.vars.value = self.vars.value[0]
-
-    @property
-    def changed(self):
-        if self.vars.previous_value is None:
-            return self.vars.value is not None
-        elif self.vars.value is None:
-            return False
-        else:
-            return set(self.vars.previous_value) != set(self.vars.value)
 
 
 def main():

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -139,32 +139,25 @@ class XFConfException(Exception):
 
 
 class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
-    facts_name = "xfconf"
-    SET = "present"
-    GET = "get"
-    RESET = "absent"
-    VALID_STATES = (SET, GET, RESET)
-    VALID_VALUE_TYPES = ('int', 'uint', 'bool', 'float', 'double', 'string')
-
     module = dict(
         argument_spec=dict(
-            state=dict(default=SET,
-                       choices=VALID_STATES,
+            state=dict(default="present",
+                       choices=("present", "get", "absent"),
                        type='str'),
             channel=dict(required=True, type='str'),
             property=dict(required=True, type='str'),
             value_type=dict(required=False, type='list',
-                            elements='str', choices=VALID_VALUE_TYPES),
+                            elements='str', choices=('int', 'uint', 'bool', 'float', 'double', 'string')),
             value=dict(required=False, type='list', elements='raw'),
             force_array=dict(default=False, type='bool', aliases=['array']),
         ),
-        required_if=[('state', SET, ['value', 'value_type'])],
+        required_if=[('state', 'present', ['value', 'value_type'])],
         required_together=[('value', 'value_type')],
         supports_check_mode=True,
     )
 
-    default_state = SET
-
+    facts_name = "xfconf"
+    default_state = 'present'
     command = 'xfconf-query'
     command_args_formats = dict(
         channel=dict(fmt=('--channel', '{0}'),),

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -196,7 +196,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         if self.vars.previous_value is None:
             return self.vars.value is not None
         elif self.vars.value is None:
-            return False
+            return self.vars.previous_value is not None
         else:
             return set(self.vars.previous_value) != set(self.vars.value)
 
@@ -208,7 +208,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
     def state_absent(self):
         self.vars.value = None
-        self.run_command(params=('channel', 'property', 'reset'))
+        self.run_command(params=('channel', 'property', 'reset'), extra_params={"reset": True})
 
     def state_present(self):
         # stringify all values - in the CLI they will all be happy strings anyway

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -211,7 +211,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
     def state_present(self):
         # stringify all values - in the CLI they will all be happy strings anyway
         # and by doing this here the rest of the code can be agnostic to it
-        self.vars.value = list([str(v) for v in self.module.params['value']])
+        self.vars.value = [str(v) for v in self.module.params['value']]
         value_type = self.module.params['value_type']
 
         values_len = len(self.vars.value)
@@ -225,8 +225,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
             raise XFConfException('Number of elements in "value" and "value_type" must be the same')
 
         # fix boolean values
-        self.vars.value = list([fix_bool(v[0]) if v[1] == 'bool' else v[0]
-                                for v in zip(self.vars.value, value_type)])
+        self.vars.value = [fix_bool(v[0]) if v[1] == 'bool' else v[0] for v in zip(self.vars.value, value_type)]
 
         # calculates if it is an array
         self.vars.is_array = \

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -32,7 +32,7 @@ ARG_FORMATS = dict(
                          None, 1, ['a', 'b', 'c'], ["piggies=[a,b,c]"]),
     single_lambda_2star=(single_lambda_2star, None, 2, dict(z='c', x='a', y='b'), ["piggies=[a,b,c]"])
 )
-ARG_FORMATS_IDS = ARG_FORMATS.keys()
+ARG_FORMATS_IDS = sorted(ARG_FORMATS.keys())
 
 
 @pytest.mark.parametrize('fmt, style, stars, value, expected',
@@ -49,7 +49,7 @@ ARG_FORMATS_FAIL = dict(
     int_fmt=(3, None, 0, "", [""]),
     bool_fmt=(True, None, 0, "", [""]),
 )
-ARG_FORMATS_FAIL_IDS = ARG_FORMATS_FAIL.keys()
+ARG_FORMATS_FAIL_IDS = sorted(ARG_FORMATS_FAIL.keys())
 
 
 @pytest.mark.parametrize('fmt, style, stars, value, expected',

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# (c) 2020, Alexei Znamensky <russoz@gmail.com>
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.community.general.plugins.module_utils.module_helper import (
+    ArgFormat, DependencyCtxMgr, ModuleHelper
+)
+
+
+def single_lambda_2star(x, y, z):
+    return ["piggies=[{0},{1},{2}]".format(x, y, z)]
+
+
+ARG_FORMATS = dict(
+    simple_boolean_true=("--superflag", ArgFormat.BOOLEAN, 0, True, ["--superflag"]),
+    simple_boolean_false=("--superflag", ArgFormat.BOOLEAN, 0, False, []),
+    single_printf=("--param=%s", ArgFormat.PRINTF, 0, "potatoes", ["--param=potatoes"]),
+    single_printf_no_substitution=("--param", ArgFormat.PRINTF, 0, "potatoes", ["--param"]),
+    multiple_printf=(["--param", "free-%s"], ArgFormat.PRINTF, 0, "potatoes", ["--param", "free-potatoes"]),
+    single_format=("--param={0}", ArgFormat.FORMAT, 0, "potatoes", ["--param=potatoes"]),
+    single_format_no_substitution=("--param", ArgFormat.FORMAT, 0, "potatoes", ["--param"]),
+    multiple_format=(["--param", "free-{0}"], ArgFormat.FORMAT, 0, "potatoes", ["--param", "free-potatoes"]),
+    single_lambda_0star=((lambda v: ["piggies=[{0},{1},{2}]".format(v[0], v[1], v[2])]),
+                         None, 0, ['a', 'b', 'c'], ["piggies=[a,b,c]"]),
+    single_lambda_1star=((lambda a, b, c: ["piggies=[{0},{1},{2}]".format(a, b, c)]),
+                         None, 1, ['a', 'b', 'c'], ["piggies=[a,b,c]"]),
+    single_lambda_2star=(single_lambda_2star, None, 2, dict(z='c', x='a', y='b'), ["piggies=[a,b,c]"])
+)
+ARG_FORMATS_IDS = ARG_FORMATS.keys()
+
+
+@pytest.mark.parametrize('fmt, style, stars, value, expected',
+                         (ARG_FORMATS[tc] for tc in ARG_FORMATS_IDS),
+                         ids=ARG_FORMATS_IDS)
+def test_arg_format(fmt, style, stars, value, expected):
+    af = ArgFormat('name', fmt, style, stars)
+    actual = af.to_text(value)
+    print("formatted string = {0}".format(actual))
+    assert actual == expected
+
+
+ARG_FORMATS_FAIL = dict(
+    int_fmt=(3, None, 0, "", [""]),
+    bool_fmt=(True, None, 0, "", [""]),
+)
+ARG_FORMATS_FAIL_IDS = ARG_FORMATS_FAIL.keys()
+
+
+@pytest.mark.parametrize('fmt, style, stars, value, expected',
+                         (ARG_FORMATS_FAIL[tc] for tc in ARG_FORMATS_FAIL_IDS),
+                         ids=ARG_FORMATS_FAIL_IDS)
+def test_arg_format_fail(fmt, style, stars, value, expected):
+    with pytest.raises(TypeError):
+        af = ArgFormat('name', fmt, style, stars)
+        actual = af.to_text(value)
+        print("formatted string = {0}".format(actual))
+
+
+def test_dependency_ctxmgr():
+    with DependencyCtxMgr("POTATOES", "Potatoes must be installed") as dep:
+        import potatoes_that_will_never_be_there
+        assert str(dep) == "Potatoes must be installed"

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -63,6 +63,19 @@ def test_arg_format_fail(fmt, style, stars, value, expected):
 
 
 def test_dependency_ctxmgr():
-    with DependencyCtxMgr("POTATOES", "Potatoes must be installed") as dep:
+    ctx = DependencyCtxMgr("POTATOES", "Potatoes must be installed")
+    assert ctx.text == "Potatoes must be installed"
+    with ctx:
         import potatoes_that_will_never_be_there
-        assert str(dep) == "Potatoes must be installed"
+    assert not ctx.has_it
+
+    ctx = DependencyCtxMgr("POTATOES2")
+    with ctx:
+        import potatoes_that_will_never_be_there_again
+    assert not ctx.has_it
+    assert ctx.text == "No module named 'potatoes_that_will_never_be_there_again'"
+
+    ctx = DependencyCtxMgr("TYPING")
+    with ctx:
+        import typing
+    assert ctx.has_it

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -64,18 +64,21 @@ def test_arg_format_fail(fmt, style, stars, value, expected):
 
 def test_dependency_ctxmgr():
     ctx = DependencyCtxMgr("POTATOES", "Potatoes must be installed")
-    assert ctx.text == "Potatoes must be installed"
     with ctx:
         import potatoes_that_will_never_be_there
+    print("POTATOES: ctx.text={0}".format(ctx.text))
+    assert ctx.text == "Potatoes must be installed"
     assert not ctx.has_it
 
     ctx = DependencyCtxMgr("POTATOES2")
     with ctx:
         import potatoes_that_will_never_be_there_again
     assert not ctx.has_it
-    assert ctx.text == "No module named 'potatoes_that_will_never_be_there_again'"
+    print("POTATOES2: ctx.text={0}".format(ctx.text))
+    assert ctx.text.startswith("No module named")
+    assert "potatoes_that_will_never_be_there_again" in ctx.text
 
     ctx = DependencyCtxMgr("TYPING")
     with ctx:
-        import typing
+        import sys
     assert ctx.has_it

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -273,6 +273,38 @@ TEST_CASES = [
             'value': ['A', 'B', 'C'],
         },
     ],
+    [
+        {
+            'channel': 'xfwm4',
+            'property': '/general/workspace_names',
+            'state': 'absent',
+        },
+        {
+            'id': 'test_property_reset_value',
+            'run_command.calls': [
+                (
+                    # Calling of following command will be asserted
+                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
+                    # Was return code checked?
+                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    # Mock of returned code, stdout and stderr
+                    (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
+                ),
+                (
+                    # Calling of following command will be asserted
+                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
+                     '--reset'],
+                    # Was return code checked?
+                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    # Mock of returned code, stdout and stderr
+                    (0, '', '',),
+                ),
+            ],
+            'changed': True,
+            'previous_value': ['A', 'B', 'C'],
+            'value': None,
+        },
+    ],
 ]
 TEST_CASES_IDS = [item[1]['id'] for item in TEST_CASES]
 

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -49,7 +49,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '100\n', '',),
                 ),
@@ -68,7 +68,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/i_dont_exist'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (1, '', 'Property "/general/i_dont_exist" does not exist on channel "xfwm4".\n',),
                 ),
@@ -87,7 +87,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
                 ),
@@ -106,7 +106,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/use_compositing'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'true', '',),
                 ),
@@ -125,7 +125,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/use_compositing'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'false', '',),
                 ),
@@ -150,7 +150,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '100\n', '',),
                 ),
@@ -159,7 +159,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
                      '--create', '--type', 'int', '--set', '90'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -184,7 +184,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '90\n', '',),
                 ),
@@ -193,7 +193,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
                      '--create', '--type', 'int', '--set', '90'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -218,7 +218,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
                 ),
@@ -228,7 +228,7 @@ TEST_CASES = [
                      '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
                      '--type', 'string', '--set', 'C'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -253,7 +253,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
                 ),
@@ -263,7 +263,7 @@ TEST_CASES = [
                      '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
                      '--type', 'string', '--set', 'C'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -286,7 +286,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
                 ),
@@ -295,7 +295,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
                      '--reset'],
                     # Was return code checked?
-                    {'env_update': {'LANGUAGE': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),


### PR DESCRIPTION
##### SUMMARY
After I had worked on xfconf, I became maintainer for the django_manage module as well, and doing that big cleanup work on the ignore files, it wasn't impossible to deny many - most, perhaps - of the modules follow the same patterns. That prompted me to think of a common class that would encompass the standard AnsibleModule and that would provide a scaffolding structure for writing modules. Thus was born `module_helper`.

Right now this is a bit experimental, and I also intend to write unit tests for `module_helper` itself, but right now both `module_helper` and `xfconf` itself are passing sanity tests, and `xfconf` is still passing the tests it passed before (with some adjustments in the internal representation of values, see the big commit message appended below for more details).

I still need to write a changelog frag for it, but will do it tomorrow, let me see how the tests and the comments go here.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
xfconf

##### ADDITIONAL INFORMATION
From the commit:
- added plugin/module_utils/module_helper.py
  - scaffold class for writing modules, beyond standard AnsibleModule
  - automatic capture of exceptions
  - easier dependency testing
  - StateMixin to easily handle different behaviours for 'state' param
  - CmdMixin to easily run external commands
- adapted test_xfconf.py
  - the args for run_command are now lists instead of a string
  - value and previous_value were not being tested before (because xfconf wasn't filling results - see below)
  - added more tests: setting value to previous_value, getting non-existent property
- rewritten xfconf module, keeping the same results
  - original module posted results as ansible_facts, this version still does it for compatibility, but also adds to the module result

