### PR TITLE
BOTMETA.yml - setting aix modules for team_aix

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -880,26 +880,12 @@ files:
   $modules/system/python_requirements_facts.py:
     maintainers: willthames
     ignore: ryansb
-  $modules/system/aix_devices.py:
+  $modules/system/aix:
     maintainers: $team_aix
     labels: aix
     keywords: aix efix lpar wpar
-  $modules/system/aix_filesystem.py:
-    maintainers: $team_aix
-    labels: aix
-    keywords: aix jfs
-  $modules/system/aix_inittab.py:
-    maintainers: $team_aix
-    labels: aix
-    keywords: aix inittab
-  $modules/system/aix_lvg.py:
-    maintainers: $team_aix
-    labels: aix
-    keywords: aix lvm
   $modules/system/aix_lvol.py:
-    maintainers: $team_aix
-    labels: aix
-    keywords: aix lvm
+    maintainers: adejoux
   $modules/system/alternatives.py:
     maintainers: mulby
     labels: alternatives

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -880,12 +880,26 @@ files:
   $modules/system/python_requirements_facts.py:
     maintainers: willthames
     ignore: ryansb
-  $modules/system/:
+  $modules/system/aix_devices.py:
     maintainers: $team_aix
     labels: aix
     keywords: aix efix lpar wpar
+  $modules/system/aix_filesystem.py:
+    maintainers: $team_aix
+    labels: aix
+    keywords: aix jfs
+  $modules/system/aix_inittab.py:
+    maintainers: $team_aix
+    labels: aix
+    keywords: aix inittab
+  $modules/system/aix_lvg.py:
+    maintainers: $team_aix
+    labels: aix
+    keywords: aix lvm
   $modules/system/aix_lvol.py:
-    maintainers: adejoux
+    maintainers: $team_aix
+    labels: aix
+    keywords: aix lvm
   $modules/system/alternatives.py:
     maintainers: mulby
     labels: alternatives
@@ -1093,7 +1107,7 @@ macros:
   team_cyberark_conjur: jvanderhoof ryanprior
   team_docker: DBendit WojciechowskiPiotr akshay196 danihodovic dariko felixfontein jwitko kassiansun tbouvet chouseknecht
   team_e_spirit: MatrixCrawler getjack
-  team_flatpak: JayKayy oolongbrothers 
+  team_flatpak: JayKayy oolongbrothers
   team_gitlab: Lunik Shaps dj-wasabi marwatk waheedi zanssa scodeman
   team_google: erjohnso rambleraptor
   team_hpux: bcoca davx8342


### PR DESCRIPTION
##### SUMMARY
In the `BOTMETA.yml` file now, `$team_aix` is responsible for all modules under `system` which does not seem to make sense - given the variety range of modules in that directory. On top of that, the `aix_lvol.py` module has its maintainer set to this one single user, **adejoux**. In the `ansible` repository, this user last commit was in 2017, so it does not look like it is someone actively working on these modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ADDITIONAL INFORMATION
Modules with maintainer set to team_aix:
aix_devices.py
aix_filesystem.py
aix_inittab.py
aix_lvg.py
aix_lvol.py
