### PR TITLE
Add fallback url for jenkins plugin

### DIFF
--- a/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
+++ b/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jenkins_plugin - added fallbacks for failure of plugin installation/download (https://github.com/ansible-collections/community.general/pull/1334)       
+  - jenkins_plugin - added fallbacks for failure of plugin installation/download (https://github.com/ansible-collections/community.general/pull/1334).

--- a/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
+++ b/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jenkins_plugin - added fallbacks for failure of plugin installation/download (https://github.com/ansible-collections/community.general/pull/1334)       

--- a/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
+++ b/changelogs/fragments/1334-jenkins-plugin-fallback-urls.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jenkins_plugin - added fallbacks for failure of plugin installation/download (https://github.com/ansible-collections/community.general/pull/1334).
+  - jenkins_plugin - add fallback url(s) for failure of plugin installation/download (https://github.com/ansible-collections/community.general/pull/1334).

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -803,7 +803,7 @@ def main():
         timeout=dict(default=30, type="int"),
         updates_expiration=dict(default=86400, type="int"),
         updates_url=dict(type="list", elements="str", default=['https://updates.jenkins.io',
-                                                               'http://mirrors.jenkins.io/updates']),
+                                                               'http://mirrors.jenkins.io']),
         update_json_url_segment=dict(type="list", elements="str", default=['update-center.json',
                                                                            'updates/update-center.json']),
         latest_plugins_url_segments=dict(type="list", elements="str", default=['latest']),

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -507,8 +507,8 @@ class JenkinsPlugin(object):
             if self.params['version'] in [None, 'latest']:
                 # Take latest version
                 plugin_urls = [("%s/%s.hpi" % (
-                      url,
-                      self.params['name'])) for url in self.params['latest_plugins_url']]
+                    url,
+                    self.params['name'])) for url in self.params['latest_plugins_url']]
             else:
                 # Take specific version
                 plugin_urls = [(

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -72,6 +72,18 @@ options:
       - Used as the base URL to download the plugins and the
         I(update-center.json) JSON file.
     default: https://updates.jenkins.io
+  latest_plugins_url:
+    type: str
+    description:
+      - URL of the latest plugins center.
+      - Used as the base URL to download the latest plugins from.
+    default: https://updates.jenkins.io/latest
+  versioned_plugins_url:
+    type: str
+    description:
+      - URL of the versioned plugins center.
+      - Used as the base URL to download versioned(not latest) plugins from.
+    default: https://updates.jenkins.io/download/plugins
   url:
     type: str
     description:
@@ -450,15 +462,14 @@ class JenkinsPlugin(object):
             if self.params['version'] in [None, 'latest']:
                 # Take latest version
                 plugin_url = (
-                    "%s/latest/%s.hpi" % (
-                        self.params['updates_url'],
-                        self.params['name']))
+                      "%s/%s.hpi" % (
+                          self.params['latest_plugins_url'],
+                          self.params['name']))
             else:
                 # Take specific version
                 plugin_url = (
-                    "{0}/download/plugins/"
-                    "{1}/{2}/{1}.hpi".format(
-                        self.params['updates_url'],
+                    "{0}/{1}/{2}/{1}.hpi".format(
+                        self.params['versioned_plugins_url'],
                         self.params['name'],
                         self.params['version']))
 
@@ -722,6 +733,8 @@ def main():
         timeout=dict(default=30, type="int"),
         updates_expiration=dict(default=86400, type="int"),
         updates_url=dict(default='https://updates.jenkins.io'),
+        latest_plugins_url=dict(default='https://updates.jenkins.io/latest'),
+        versioned_plugins_url=dict(default='https://updates.jenkins.io/download/plugins'),
         url=dict(default='http://localhost:8080'),
         url_password=dict(no_log=True),
         version=dict(),

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -583,29 +583,25 @@ class JenkinsPlugin(object):
         return changed
 
     def _get_latest_plugin_urls(self):
-      urls = []
-      for base_url in self.params['updates_url']:
-        for update_segment in self.params['latest_plugins_url_segments']:
-          urls.append("{0}/{1}/{2}.hpi".format(
-            base_url, update_segment, self.params['name']))
-      return urls
-    
-    def _get_versioned_plugin_urls(self):
-      urls = []
-      for base_url in self.params['updates_url']:
-        for versioned_segment in self.params['versioned_plugins_url_segments']:
-          urls.append("{0}/{1}/{2}/{3}/{2}.hpi".format(
-            base_url, versioned_segment, self.params['name'], self.params['version']))
-      return urls
-    
-    def _get_update_center_urls(self):
-      urls = []
-      for base_url in self.params['updates_url']:
-        for update_json in self.params['update_json_url_segment']:
-          urls.append("{0}/{1}".format(
-            base_url, update_json))
-      return urls
+        urls = []
+        for base_url in self.params['updates_url']:
+            for update_segment in self.params['latest_plugins_url_segments']:
+                urls.append("{0}/{1}/{2}.hpi".format(base_url, update_segment, self.params['name']))
+        return urls
 
+    def _get_versioned_plugin_urls(self):
+        urls = []
+        for base_url in self.params['updates_url']:
+            for versioned_segment in self.params['versioned_plugins_url_segments']:
+                urls.append("{0}/{1}/{2}/{3}/{2}.hpi".format(base_url, versioned_segment, self.params['name'], self.params['version']))
+        return urls
+
+    def _get_update_center_urls(self):
+        urls = []
+        for base_url in self.params['updates_url']:
+            for update_json in self.params['update_json_url_segment']:
+                urls.append("{0}/{1}".format(base_url, update_json))
+        return urls
 
     def _download_updates(self):
         updates_filename = 'jenkins-plugin-cache.json'
@@ -811,7 +807,7 @@ def main():
         update_json_url_segment=dict(type="list", elements="str", default=['update-center.json',
                                                                            'updates/update-center.json']),
         latest_plugins_url_segments=dict(type="list", elements="str", default=['latest']),
-        versioned_plugins_url_segments=dict(type="list", elements="str", default=['download/plugins','plugins']),
+        versioned_plugins_url_segments=dict(type="list", elements="str", default=['download/plugins', 'plugins']),
         url=dict(default='http://localhost:8080'),
         url_password=dict(no_log=True),
         version=dict(),

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -69,29 +69,29 @@ options:
     type: list
     elements: str
     description:
-      - A list of base URLs to retrieve I(update-center.json), and direct plugin files
+      - A list of base URL(s) to retrieve I(update-center.json), and direct plugin files from.
     default: ['https://updates.jenkins.io', 'http://mirrors.jenkins.io']
   update_json_url_segment:
     type: list
     elements: str
     description:
-      - A list of URL segments to retrieve the update center json file from
+      - A list of URL segment(s) to retrieve the update center json file from.
     default: ['update-center.json', 'updates/update-center.json']
-    version_added: 1.3.0
+    version_added: 3.3.0
   latest_plugins_url_segments:
     type: list
     elements: str
     description:
-      - Path inside the updates_url to get latest plugins from
+      - Path inside the I(updates_url) to get latest plugins from.
     default: ['latest']
-    version_added: 1.3.0
+    version_added: 3.3.0
   versioned_plugins_url_segments:
     type: list
     elements: str
     description:
-      - Path inside the updates_url to get specific version of plugins from
+      - Path inside the I(updates_url) to get specific version of plugins from.
     default: ['download/plugins', 'plugins']
-    version_added: 1.3.0
+    version_added: 3.3.0
   url:
     type: str
     description:

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -88,6 +88,7 @@ options:
       - URL of the versioned plugins center.
       - Used as the base URL to download versioned(not latest) plugins from.
     default: ['https://updates.jenkins.io/download/plugins', 'http://mirrors.jenkins.io/plugins']
+    version_added: 1.3.0
   url:
     type: str
     description:

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -70,6 +70,7 @@ options:
     elements: str
     description:
       - A list of base URL(s) to retrieve I(update-center.json), and direct plugin files from.
+      - This can be a list since community.general 3.3.0.
     default: ['https://updates.jenkins.io', 'http://mirrors.jenkins.io']
   update_json_url_segment:
     type: list
@@ -378,7 +379,7 @@ class JenkinsPlugin(object):
                     if info['status'] > 400:  # extend error message
                         err_msg = "%s. response body: %s" % (err_msg, info['body'])
             except Exception as e:
-                err_msg = "%s. fetching url %s failed. error msg: %s" % (msg_status, url, str(e))
+                err_msg = "%s. fetching url %s failed. error msg: %s" % (msg_status, url, to_native(e))
             finally:
                 if err_msg is not None:
                     self.module.debug(err_msg)

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -80,6 +80,7 @@ options:
       - URLs of the latest plugins center.
       - Used as the base URL to download the latest plugins from.
     default: ['https://updates.jenkins.io/latest']
+    version_added: 1.3.0
   versioned_plugins_url:
     type: list
     elements: str

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -72,7 +72,7 @@ options:
       - URLs of the Update Centre.
       - Used as the base URLs to download the I(update-center.json) JSON file.
       - Tries all URLs on failure
-    default: ['https://updates.jenkins.io', 'http://mirrors.jenkins.io/updates/']
+    default: ['https://updates.jenkins.io', 'http://mirrors.jenkins.io/updates']
   latest_plugins_url:
     type: list
     elements: str
@@ -86,7 +86,7 @@ options:
     description:
       - URL of the versioned plugins center.
       - Used as the base URL to download versioned(not latest) plugins from.
-    default: ['https://updates.jenkins.io/download/plugins', 'http://mirrors.jenkins.io/plugins/']
+    default: ['https://updates.jenkins.io/download/plugins', 'http://mirrors.jenkins.io/plugins']
   url:
     type: str
     description:
@@ -298,6 +298,10 @@ import tempfile
 import time
 
 
+class FailedInstallingWithPluginManager(Exception):
+    pass
+
+
 class JenkinsPlugin(object):
     def __init__(self, module):
         # To be able to call fail_json
@@ -444,14 +448,14 @@ class JenkinsPlugin(object):
         if not self.module.check_mode:
             # Install the plugin (with dependencies)
             install_script = (
-                    'd = Jenkins.instance.updateCenter.getPlugin("%s")'
-                    '.deploy(); d.get();' % self.params['name'])
+                'd = Jenkins.instance.updateCenter.getPlugin("%s")'
+                '.deploy(); d.get();' % self.params['name'])
 
             if self.params['with_dependencies']:
                 install_script = (
-                        'Jenkins.instance.updateCenter.getPlugin("%s")'
-                        '.getNeededDependencies().each{it.deploy()}; %s' % (
-                            self.params['name'], install_script))
+                    'Jenkins.instance.updateCenter.getPlugin("%s")'
+                    '.getNeededDependencies().each{it.deploy()}; %s' % (
+                        self.params['name'], install_script))
 
             script_data = {
                 'script': install_script
@@ -503,8 +507,8 @@ class JenkinsPlugin(object):
             if self.params['version'] in [None, 'latest']:
                 # Take latest version
                 plugin_urls = [("%s/%s.hpi" % (
-                          url,
-                          self.params['name'])) for url in self.params['latest_plugins_url']]
+                      url,
+                      self.params['name'])) for url in self.params['latest_plugins_url']]
             else:
                 # Take specific version
                 plugin_urls = [(
@@ -833,7 +837,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-class FailedInstallingWithPluginManager(Exception):
-    pass

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_plugin.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_plugin.py
@@ -151,3 +151,38 @@ def test__get_json_data(mocker):
         'CSRF')
 
     assert isinstance(json_data, Mapping)
+
+def test__new_fallback_urls(mocker):
+  "test generation of new fallback URLs"
+
+  params = {
+    "url": "http://fake.jenkins.server",
+    "timeout": 30,
+    "name": "test-plugin",
+    "version": "1.2.3",
+    "updates_url": ["https://some.base.url"],
+    "latest_plugins_url_segments": ["test_latest"],
+    "versioned_plugins_url_segments": ["ansible", "versioned_plugins"],
+    "update_json_url_segment": ["unreachable", "updates/update-center.json"],
+  }
+  module = mocker.Mock()
+  module.params = params
+
+  JenkinsPlugin._csrf_enabled = pass_function
+  JenkinsPlugin._get_installed_plugins = pass_function
+  
+  jenkins_plugin = JenkinsPlugin(module)
+
+  latest_urls = jenkins_plugin._get_latest_plugin_urls()
+  assert isInList(latest_urls, "https://some.base.url/test_latest/test-plugin.hpi")
+  versioned_urls = jenkins_plugin._get_versioned_plugin_urls()
+  assert isInList(versioned_urls, "https://some.base.url/versioned_plugins/test-plugin/1.2.3/test-plugin.hpi")
+  json_urls = jenkins_plugin._get_update_center_urls()
+  assert isInList(json_urls, "https://some.base.url/updates/update-center.json")
+
+def isInList(l, i):
+  print("checking if %s in %s" % (i, l))
+  for item in l:
+    if item == i:
+      return True
+  return False

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_plugin.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_plugin.py
@@ -152,37 +152,39 @@ def test__get_json_data(mocker):
 
     assert isinstance(json_data, Mapping)
 
+
 def test__new_fallback_urls(mocker):
-  "test generation of new fallback URLs"
+    "test generation of new fallback URLs"
 
-  params = {
-    "url": "http://fake.jenkins.server",
-    "timeout": 30,
-    "name": "test-plugin",
-    "version": "1.2.3",
-    "updates_url": ["https://some.base.url"],
-    "latest_plugins_url_segments": ["test_latest"],
-    "versioned_plugins_url_segments": ["ansible", "versioned_plugins"],
-    "update_json_url_segment": ["unreachable", "updates/update-center.json"],
-  }
-  module = mocker.Mock()
-  module.params = params
+    params = {
+        "url": "http://fake.jenkins.server",
+        "timeout": 30,
+        "name": "test-plugin",
+        "version": "1.2.3",
+        "updates_url": ["https://some.base.url"],
+        "latest_plugins_url_segments": ["test_latest"],
+        "versioned_plugins_url_segments": ["ansible", "versioned_plugins"],
+        "update_json_url_segment": ["unreachable", "updates/update-center.json"],
+    }
+    module = mocker.Mock()
+    module.params = params
 
-  JenkinsPlugin._csrf_enabled = pass_function
-  JenkinsPlugin._get_installed_plugins = pass_function
-  
-  jenkins_plugin = JenkinsPlugin(module)
+    JenkinsPlugin._csrf_enabled = pass_function
+    JenkinsPlugin._get_installed_plugins = pass_function
 
-  latest_urls = jenkins_plugin._get_latest_plugin_urls()
-  assert isInList(latest_urls, "https://some.base.url/test_latest/test-plugin.hpi")
-  versioned_urls = jenkins_plugin._get_versioned_plugin_urls()
-  assert isInList(versioned_urls, "https://some.base.url/versioned_plugins/test-plugin/1.2.3/test-plugin.hpi")
-  json_urls = jenkins_plugin._get_update_center_urls()
-  assert isInList(json_urls, "https://some.base.url/updates/update-center.json")
+    jenkins_plugin = JenkinsPlugin(module)
+
+    latest_urls = jenkins_plugin._get_latest_plugin_urls()
+    assert isInList(latest_urls, "https://some.base.url/test_latest/test-plugin.hpi")
+    versioned_urls = jenkins_plugin._get_versioned_plugin_urls()
+    assert isInList(versioned_urls, "https://some.base.url/versioned_plugins/test-plugin/1.2.3/test-plugin.hpi")
+    json_urls = jenkins_plugin._get_update_center_urls()
+    assert isInList(json_urls, "https://some.base.url/updates/update-center.json")
+
 
 def isInList(l, i):
-  print("checking if %s in %s" % (i, l))
-  for item in l:
-    if item == i:
-      return True
-  return False
+    print("checking if %s in %s" % (i, l))
+    for item in l:
+        if item == i:
+            return True
+    return False


### PR DESCRIPTION
##### SUMMARY
Motivation: Jenkins had down time in their plugin repository for a couple of days ( https://issues.jenkins.io/browse/INFRA-2811 )
The solution proposed in this PR enables several fallback options, which are customable, and do not require active engineer involvement for future down times from Jenkins' side.
What's implemented:
1.  updates_url is now a list of strings, instead of a string. In case of failure, the next items in list are tried. Ansible's input validation automatically converts strings to a list with a single string item, so this is backwards compatible.
2. Two new input variables, latest_plugins_url and versioned_plugins_url, which create separation between the updates json file and downloadable plugin urls. These are list of strings as well, and the fallback behaviour is the same as updates_url
3. Try to download the plugin manually if installation through Jenkins' Plugin Manager fails.
4. Defaults with Jenkins mirrors is given as default values for url variables, when possible.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Jenkins Plugin Module

##### ADDITIONAL INFORMATION