### PR TITLE
Datadog: Mark notification_message as no_log

### DIFF
--- a/changelogs/fragments/1338-datadog-mark-notification_message-no_log.yml
+++ b/changelogs/fragments/1338-datadog-mark-notification_message-no_log.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - datadog - mark notification_message as no_log (https://github.com/ansible-collections/community.general/pull/1338).
+  - datadog - mark ``notification_message`` as ``no_log`` (https://github.com/ansible-collections/community.general/pull/1338).

--- a/changelogs/fragments/1338-datadog-mark-notification_message-no_log.yml
+++ b/changelogs/fragments/1338-datadog-mark-notification_message-no_log.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - datadog - mark notification_message as no_log (https://github.com/ansible-collections/community.general/pull/1338).

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -209,7 +209,7 @@ def main():
             type=dict(required=False, choices=['metric alert', 'service check', 'event alert', 'process alert', 'log alert']),
             name=dict(required=True),
             query=dict(required=False),
-            notification_message=dict(required=False, default=None, aliases=['message'],
+            notification_message=dict(required=False, no_log=True, default=None, aliases=['message'],
                                       deprecated_aliases=[dict(name='message', version='3.0.0',
                                                                collection_name='community.general')]),  # was Ansible 2.14
             silenced=dict(required=False, default=None, type='dict'),


### PR DESCRIPTION
##### SUMMARY

This message field is often used to page people or teams inside
an organization when a monitor goes off, by using `@` mentions.
If Ansible is configured to use Datadog's callback plugin [1], an
unwanted interaction would happen: 

When a monitor fails to create, the callback sends an error event
to Datadog which contains all the task's loggable fields in it.
If the message field contains `@` mentions, this event would page
the people on them.

[1] https://github.com/DataDog/ansible-datadog-callback

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.general.datadog_monitor`

