### PR TITLE
Improve docker and hetzner removal announcement fragments

### DIFF
--- a/changelogs/fragments/docker-migration.yml
+++ b/changelogs/fragments/docker-migration.yml
@@ -1,5 +1,5 @@
 major_changes:
-- >
+- |
   For community.general 2.0.0, the ``docker`` modules and plugins will be moved to the `community.docker <https://galaxy.ansible.com/community/docker>`_ collection.
   A redirection will be inserted so that users using ansible-base 2.10 or newer do not have to change anything.
 

--- a/changelogs/fragments/hetzner-migration.yml
+++ b/changelogs/fragments/hetzner-migration.yml
@@ -1,5 +1,5 @@
 major_changes:
-- >
+- |
   For community.general 2.0.0, the Hetzner Robot modules will be moved to the `community.hrobot <https://galaxy.ansible.com/community/hrobot>`_ collection.
   A redirection will be inserted so that users using ansible-base 2.10 or newer do not have to change anything.
 


### PR DESCRIPTION
##### SUMMARY
With `>` instead of `|`, all the text ends up in one paragraph in the changelog.

CC @Andersson007 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
