### PR TITLE
BOTMETA.yml: Add a new maintainer of parted module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -883,7 +883,7 @@ files:
   $modules/system/pamd.py:
     maintainers: kevensen
   $modules/system/parted.py:
-    maintainers: ColOfAbRiX rosowiecki
+    maintainers: ColOfAbRiX rosowiecki jake2184
   $modules/system/pids.py:
     maintainers: saranyasridharan
   $modules/system/puppet.py:


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.general/pull/773

BOTMETA.yml: Add a new maintainer of parted module

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`.github/BOTMETA.yml`