### PR TITLE
Tidy up validate-modules nonexistent-parameter-documented

### DIFF
--- a/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -144,13 +144,6 @@ options:
         This will not work unless the uniqueness_by field is set to id.
         When this is set, and the uniqueness_by field is set, the group will either be updated or deleted, but not created.
 
-  ignore_changes:
-    choices:
-      - image_id
-      - target
-    description:
-      - (List of Strings) list of fields on which changes should be ignored when updating
-
   image_id:
     description:
       - (String) The image Id used to launch the instance.;

--- a/plugins/modules/cloud/univention/udm_share.py
+++ b/plugins/modules/cloud/univention/udm_share.py
@@ -90,12 +90,6 @@ options:
         description:
             - Blocking locks.
         aliases: [ sambaBlockingLocks ]
-    samba_browseable:
-        default: '1'
-        choices: [ '0', '1' ]
-        description:
-            - Show in Windows network environment.
-        aliases: [ sambaBrowseable ]
     samba_create_mode:
         default: '0744'
         description:

--- a/plugins/modules/cloud/univention/udm_share.py
+++ b/plugins/modules/cloud/univention/udm_share.py
@@ -90,6 +90,12 @@ options:
         description:
             - Blocking locks.
         aliases: [ sambaBlockingLocks ]
+    sambaBrowseable:
+        description:
+        - Show in Windows network environment.
+        type: bool
+        default: True
+        aliases: [ samba_browsable ]
     samba_create_mode:
         default: '0744'
         description:

--- a/plugins/modules/net_tools/nios/nios_host_record.py
+++ b/plugins/modules/net_tools/nios/nios_host_record.py
@@ -107,8 +107,6 @@ options:
           - Configure the host_record over DHCP instead of DNS, if user
             changes it to true, user need to mention MAC address to configure
         required: false
-        aliases:
-          - dhcp
   aliases:
     description:
       - Configures an optional list of additional aliases to add to the host

--- a/plugins/modules/storage/zfs/zfs_facts.py
+++ b/plugins/modules/storage/zfs/zfs_facts.py
@@ -38,7 +38,6 @@ options:
             - Specifies which dataset properties should be queried in comma-separated format.
               For more information about dataset properties, check zfs(1M) man page.
         default: all
-        aliases: [ "props" ]
     type:
         description:
             - Specifies which datasets types to display. Multiple values have to be

--- a/plugins/modules/storage/zfs/zpool_facts.py
+++ b/plugins/modules/storage/zfs/zpool_facts.py
@@ -32,7 +32,6 @@ options:
         description:
             - Specifies which dataset properties should be queried in comma-separated format.
               For more information about dataset properties, check zpool(1M) man page.
-        aliases: [ "props" ]
         default: all
         required: false
 '''

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -230,7 +230,6 @@ plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-required-mismatch
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -244,7 +243,6 @@ plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-
 plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_share.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
@@ -390,7 +388,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:nonexistent-parameter-documented
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter
@@ -466,7 +463,6 @@ plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
-plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
@@ -628,9 +624,7 @@ plugins/modules/storage/zfs/zfs.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:doc-required-mismatch
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zfs_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zfs_facts.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zpool_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zpool_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/aix_devices.py validate-modules:doc-required-mismatch
 plugins/modules/system/alternatives.py pylint:blacklisted-name

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -245,7 +245,6 @@ plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-no
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -463,6 +463,7 @@ plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
+plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -230,7 +230,6 @@ plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-required-mismatch
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -244,7 +243,6 @@ plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-
 plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_share.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
@@ -390,7 +388,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:nonexistent-parameter-documented
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter
@@ -466,7 +463,6 @@ plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
-plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
@@ -628,9 +624,7 @@ plugins/modules/storage/zfs/zfs.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:doc-required-mismatch
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zfs_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zfs_facts.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zpool_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zpool_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/aix_devices.py validate-modules:doc-required-mismatch
 plugins/modules/system/alternatives.py pylint:blacklisted-name

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -245,7 +245,6 @@ plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-no
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -463,6 +463,7 @@ plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
+plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -210,7 +210,6 @@ plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-no
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -198,7 +198,6 @@ plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_dns_record.py validate-modules:doc-choices-do-not-match-spec
@@ -210,7 +209,6 @@ plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-
 plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/cloud/univention/udm_share.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_share.py validate-modules:nonexistent-parameter-documented
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_user.py validate-modules:doc-choices-do-not-match-spec
@@ -304,7 +302,6 @@ plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-type
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:nonexistent-parameter-documented
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-default-does-not-match-spec
@@ -461,9 +458,7 @@ plugins/modules/storage/purestorage/purefb_facts.py validate-modules:invalid-doc
 plugins/modules/storage/purestorage/purefb_facts.py validate-modules:return-syntax-error
 plugins/modules/storage/zfs/zfs.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/zfs/zfs_delegate_admin.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zfs_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zfs_facts.py validate-modules:parameter-type-not-in-doc
-plugins/modules/storage/zfs/zpool_facts.py validate-modules:nonexistent-parameter-documented
 plugins/modules/storage/zfs/zpool_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/alternatives.py pylint:blacklisted-name
 plugins/modules/system/beadm.py pylint:blacklisted-name


### PR DESCRIPTION
##### SUMMARY
Tidy up on sanity tests' ignore files, removing lines with validation-modules for these modules.

The focus was to pass the tests so no code was changed other than adjusting argument_spec for missing types or inconsistencies with the docs. The priority has been not to change any functionality, but to ensure that code and docs are synchronized.

Some lines were added back to the files, but a total of 17 lines were removed (among 2.9, 2.10 and 2.11).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/storage/zfs/zpool_facts.py
plugins/modules/storage/zfs/zfs_facts.py
plugins/modules/net_tools/nios/nios_host_record.py
plugins/modules/cloud/univention/udm_share.py
plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py

##### ADDITIONAL INFORMATION
