### PR TITLE
Tidy up validate-modules:doc-elements-mismatch

### DIFF
--- a/changelogs/fragments/1399-fixed-wrong-elements-type.yaml
+++ b/changelogs/fragments/1399-fixed-wrong-elements-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- utm_proxy_exception - four parameters had elements types set as 'string' (invalid), changed to 'str'. (https://github.com/ansible-collections/community.general/pull/1399)

--- a/changelogs/fragments/1399-fixed-wrong-elements-type.yaml
+++ b/changelogs/fragments/1399-fixed-wrong-elements-type.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- utm_proxy_exception - four parameters had elements types set as 'string' (invalid), changed to 'str'. (https://github.com/ansible-collections/community.general/pull/1399)
+- utm_proxy_exception - four parameters had elements types set as 'string' (invalid), changed to 'str' (https://github.com/ansible-collections/community.general/pull/1399).

--- a/plugins/modules/cloud/xenserver/xenserver_guest.py
+++ b/plugins/modules/cloud/xenserver/xenserver_guest.py
@@ -122,6 +122,7 @@ options:
     - ' - C(sr) (string): Storage Repository to create disk on. If not specified, will use default SR. Cannot be used for moving disk to other SR.'
     - ' - C(sr_uuid) (string): UUID of a SR to create disk on. Use if SR name is not unique.'
     type: list
+    elements: dict
     aliases: [ disk ]
   cdrom:
     description:
@@ -151,6 +152,7 @@ options:
     - ' - C(ip6) (string): Static IPv6 address (implies C(type6: static)) with prefix in format <IPv6 address>/<prefix>.'
     - ' - C(gateway6) (string): Static IPv6 gateway.'
     type: list
+    elements: dict
     aliases: [ network ]
   home_server:
     description:
@@ -163,6 +165,7 @@ options:
     - Useful for advanced users familiar with managing VM params trough xe CLI.
     - A custom value object takes two fields C(key) and C(value) (see example below).
     type: list
+    elements: dict
   wait_for_ip_address:
     description:
     - Wait until XenServer detects an IP address for the VM. If C(state) is set to C(absent), this parameter is ignored.

--- a/plugins/modules/identity/ipa/ipa_hbacrule.py
+++ b/plugins/modules/identity/ipa/ipa_hbacrule.py
@@ -101,6 +101,7 @@ options:
     - If an empty list if passed all assigned user groups will be removed from the rule.
     - If option is omitted user groups will not be checked or changed.
     type: list
+    elements: str
 extends_documentation_fragment:
 - community.general.ipa.documentation
 

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -299,6 +299,8 @@ options:
               This is 'protocolMappers' in the Keycloak REST API.
         aliases:
             - protocolMappers
+        type: list
+        elements: dict
         suboptions:
             consentRequired:
                 description:

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -68,6 +68,8 @@ options:
         description:
             - a list of dicts defining protocol mappers for this client template.
               This is 'protocolMappers' in the Keycloak REST API.
+        type: list
+        elements: dict
         suboptions:
             consentRequired:
                 description:

--- a/plugins/modules/net_tools/nios/nios_fixed_address.py
+++ b/plugins/modules/net_tools/nios/nios_fixed_address.py
@@ -49,6 +49,8 @@ options:
         the configured network instance.  This argument accepts a list
         of values (see suboptions).  When configuring suboptions at
         least one of C(name) or C(num) must be specified.
+    type: list
+    elements: dict
     suboptions:
       name:
         description:

--- a/plugins/modules/net_tools/nios/nios_host_record.py
+++ b/plugins/modules/net_tools/nios/nios_host_record.py
@@ -50,6 +50,8 @@ options:
         accepts a list of values (see suboptions)
     aliases:
       - ipv4
+    type: list
+    elements: dict
     suboptions:
       ipv4addr:
         description:
@@ -95,6 +97,8 @@ options:
         accepts a list of values (see options)
     aliases:
       - ipv6
+    type: list
+    elements: dict
     suboptions:
       ipv6addr:
         description:

--- a/plugins/modules/net_tools/nios/nios_member.py
+++ b/plugins/modules/net_tools/nios/nios_member.py
@@ -29,6 +29,8 @@ options:
     description:
       - Configures the network settings for the grid member.
     required: true
+    type: list
+    elements: dict
     suboptions:
       address:
         description:
@@ -43,6 +45,8 @@ options:
     description:
       - Configures the IPv6 settings for the grid member.
     required: true
+    type: list
+    elements: dict
     suboptions:
       virtual_ip:
         description:
@@ -77,6 +81,8 @@ options:
   lan2_port_setting:
     description:
       - Settings for the Grid member LAN2 port if 'lan2_enabled' is set to "true".
+    type: list
+    elements: dict
     suboptions:
       enabled:
         description:
@@ -85,6 +91,8 @@ options:
       network_setting:
         description:
           - If the 'enable' field is set to True, this defines IPv4 network settings for LAN2.
+        type: list
+        elements: dict
         suboptions:
           address:
             description:
@@ -98,6 +106,8 @@ options:
       v6_network_setting:
         description:
           - If the 'enable' field is set to True, this defines IPv6 network settings for LAN2.
+        type: list
+        elements: dict
         suboptions:
           virtual_ip:
             description:
@@ -115,10 +125,14 @@ options:
   node_info:
     description:
       - Configures the node information list with detailed status report on the operations of the Grid Member.
+    type: list
+    elements: dict
     suboptions:
       lan2_physical_setting:
         description:
           - Physical port settings for the LAN2 interface.
+        type: list
+        elements: dict
         suboptions:
           auto_port_setting_enabled:
             description:
@@ -133,6 +147,8 @@ options:
       lan_ha_port_setting:
         description:
           - LAN/HA port settings for the node.
+        type: list
+        elements: dict
         suboptions:
           ha_ip_address:
             description:
@@ -140,6 +156,8 @@ options:
           ha_port_setting:
             description:
               - Physical port settings for the HA interface.
+            type: list
+            elements: dict
             suboptions:
               auto_port_setting_enabled:
                 description:
@@ -154,6 +172,8 @@ options:
           lan_port_setting:
             description:
               - Physical port settings for the LAN interface.
+            type: list
+            elements: dict
             suboptions:
               auto_port_setting_enabled:
                 description:
@@ -174,6 +194,8 @@ options:
       mgmt_network_setting:
         description:
           - Network settings for the MGMT port of the node.
+        type: list
+        elements: dict
         suboptions:
           address:
             description:
@@ -187,6 +209,8 @@ options:
       v6_mgmt_network_setting:
         description:
           - The network settings for the IPv6 MGMT port of the node.
+        type: list
+        elements: dict
         suboptions:
           virtual_ip:
             description:
@@ -200,6 +224,8 @@ options:
   mgmt_port_setting:
     description:
       - Settings for the member MGMT port.
+    type: list
+    elements: dict
     suboptions:
       enabled:
         description:
@@ -228,6 +254,8 @@ options:
   syslog_servers:
     description:
       - The list of external syslog servers.
+    type: list
+    elements: dict
     suboptions:
       address:
         description:
@@ -266,10 +294,14 @@ options:
   pre_provisioning:
     description:
       - Pre-provisioning information.
+    type: list
+    elements: dict
     suboptions:
       hardware_info:
         description:
           - An array of structures that describe the hardware being pre-provisioned.
+        type: list
+        elements: dict
         suboptions:
           hwmodel:
             description:

--- a/plugins/modules/net_tools/nios/nios_network.py
+++ b/plugins/modules/net_tools/nios/nios_network.py
@@ -41,6 +41,8 @@ options:
         the configured network instance.  This argument accepts a list
         of values (see suboptions).  When configuring suboptions at
         least one of C(name) or C(num) must be specified.
+    type: list
+    elements: dict
     suboptions:
       name:
         description:

--- a/plugins/modules/net_tools/nios/nios_nsgroup.py
+++ b/plugins/modules/net_tools/nios/nios_nsgroup.py
@@ -31,6 +31,8 @@ options:
     description:
       - This host is to be used as primary server in this nameserver group. It must be a grid member.
         This option is required when setting I(use_external_primaries) to C(false).
+    type: list
+    elements: dict
     suboptions:
       name:
         description:
@@ -56,10 +58,17 @@ options:
           - Configure the external nameserver as stealth server (without NS record) in the zones.
         type: bool
         default: false
+      preferred_primaries:
+        description:
+          - Provide a list of elements like in I(external_primaries) to set the precedence of preferred primary nameservers.
+        type: list
+        elements: dict
   grid_secondaries:
     description:
      - Configures the list of grid member hosts that act as secondary nameservers.
        This option is required when setting I(use_external_primaries) to C(true).
+    type: list
+    elements: dict
     suboptions:
       name:
         description:
@@ -88,6 +97,8 @@ options:
       preferred_primaries:
         description:
           - Provide a list of elements like in I(external_primaries) to set the precedence of preferred primary nameservers.
+        type: list
+        elements: dict
   is_grid_default:
     description:
       - If set to C(True) this nsgroup will become the default nameserver group for new zones.
@@ -105,6 +116,8 @@ options:
     description:
       - Configures a list of external nameservers (non-members of the grid).
         This option is required when setting I(use_external_primaries) to C(true).
+    type: list
+    elements: dict
     suboptions:
       address:
         description:
@@ -134,6 +147,8 @@ options:
   external_secondaries:
     description:
       - Allows to provide a list of external secondary nameservers, that are not members of the grid.
+    type: list
+    elements: dict
     suboptions:
       address:
         description:

--- a/plugins/modules/net_tools/nios/nios_zone.py
+++ b/plugins/modules/net_tools/nios/nios_zone.py
@@ -39,6 +39,8 @@ options:
   grid_primary:
     description:
       - Configures the grid primary servers for this zone.
+    type: list
+    elements: dict
     suboptions:
       name:
         description:
@@ -46,6 +48,8 @@ options:
   grid_secondaries:
     description:
       - Configures the grid secondary servers for this zone.
+    type: list
+    elements: dict
     suboptions:
       name:
         description:

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -72,6 +72,7 @@ options:
       - list of BootOptionReference strings specifying the BootOrder
     default: []
     type: list
+    elements: str
     version_added: '0.2.0'
   network_protocols:
     required: false

--- a/plugins/modules/source_control/github/github_webhook.py
+++ b/plugins/modules/source_control/github/github_webhook.py
@@ -50,6 +50,8 @@ options:
         U(https://developer.github.com/v3/activity/events/types/). Required
         unless C(state) is C(absent)
     required: false
+    type: list
+    elements: str
   active:
     description:
       - Whether or not the hook is active

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py
@@ -216,9 +216,9 @@ def main():
         argument_spec=dict(
             name=dict(type='str', required=True),
             op=dict(type='str', required=False, default='AND', choices=['AND', 'OR']),
-            path=dict(type='list', elements='string', required=False, default=[]),  # @FIXME: str instead of string
-            skip_custom_threats_filters=dict(type='list', elements='string', required=False, default=[]),  # @FIXME: str instead of string
-            skip_threats_filter_categories=dict(type='list', elements='string', required=False, default=[]),  # @FIXME: str instead of string
+            path=dict(type='list', elements='str', required=False, default=[]),
+            skip_custom_threats_filters=dict(type='list', elements='str', required=False, default=[]),
+            skip_threats_filter_categories=dict(type='list', elements='str', required=False, default=[]),
             skipav=dict(type='bool', required=False, default=False),
             skipbadclients=dict(type='bool', required=False, default=False),
             skipcookie=dict(type='bool', required=False, default=False),
@@ -227,7 +227,7 @@ def main():
             skiphtmlrewrite=dict(type='bool', required=False, default=False),
             skiptft=dict(type='bool', required=False, default=False),
             skipurl=dict(type='bool', required=False, default=False),
-            source=dict(type='list', elements='string', required=False, default=[]),  # @FIXME: str instead of string
+            source=dict(type='list', elements='str', required=False, default=[]),
             status=dict(type='bool', required=False, default=True),
         )
     )

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -241,7 +241,6 @@ plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:doc-missing
 plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-elements-mismatch
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-required-mismatch
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:missing-suboption-docs
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:parameter-type-not-in-doc
@@ -289,14 +288,11 @@ plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-p
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/files/xml.py validate-modules:doc-required-mismatch
 plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/ipa/ipa_hbacrule.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
@@ -358,14 +354,12 @@ plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:invalid-ansible
 plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
@@ -374,7 +368,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-li
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_member.py validate-modules:invalid-ansiblemodule-schema
@@ -394,7 +387,6 @@ plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:invalid-ans
 plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_network.py validate-modules:invalid-ansiblemodule-schema
@@ -408,7 +400,6 @@ plugins/modules/net_tools/nios/nios_network_view.py validate-modules:parameter-t
 plugins/modules/net_tools/nios/nios_network_view.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:invalid-ansiblemodule-schema
@@ -434,7 +425,6 @@ plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:invalid-ansib
 plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:invalid-ansiblemodule-schema
@@ -545,7 +535,6 @@ plugins/modules/remote_management/redfish/idrac_redfish_command.py validate-modu
 plugins/modules/remote_management/redfish/idrac_redfish_config.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/idrac_redfish_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/redfish_command.py validate-modules:parameter-list-no-elements
-plugins/modules/remote_management/redfish/redfish_config.py validate-modules:doc-elements-mismatch
 plugins/modules/remote_management/redfish/redfish_config.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/redfish_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-choices-do-not-match-spec
@@ -565,7 +554,6 @@ plugins/modules/source_control/github/github_issue.py validate-modules:parameter
 plugins/modules/source_control/github/github_key.py validate-modules:doc-missing-type
 plugins/modules/source_control/github/github_release.py validate-modules:doc-missing-type
 plugins/modules/source_control/github/github_release.py validate-modules:parameter-type-not-in-doc
-plugins/modules/source_control/github/github_webhook.py validate-modules:doc-elements-mismatch
 plugins/modules/source_control/github/github_webhook.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/gitlab/gitlab_deploy_key.py validate-modules:doc-required-mismatch
@@ -641,7 +629,6 @@ plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
 plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py validate-modules:doc-elements-mismatch
 scripts/inventory/gce.py pylint:blacklisted-name
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -241,7 +241,6 @@ plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:doc-missing
 plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/webfaction/webfaction_site.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-elements-mismatch
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-required-mismatch
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:missing-suboption-docs
 plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:parameter-type-not-in-doc
@@ -289,14 +288,11 @@ plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-p
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/files/xml.py validate-modules:doc-required-mismatch
 plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/ipa/ipa_hbacrule.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-elements-mismatch
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
@@ -358,14 +354,12 @@ plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:invalid-ansible
 plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_dns_view.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_fixed_address.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:invalid-ansiblemodule-schema
@@ -374,7 +368,6 @@ plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-li
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_host_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_member.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_member.py validate-modules:invalid-ansiblemodule-schema
@@ -394,7 +387,6 @@ plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:invalid-ans
 plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_naptr_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_network.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_network.py validate-modules:invalid-ansiblemodule-schema
@@ -408,7 +400,6 @@ plugins/modules/net_tools/nios/nios_network_view.py validate-modules:parameter-t
 plugins/modules/net_tools/nios/nios_network_view.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-choices-do-not-match-spec
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_nsgroup.py validate-modules:invalid-ansiblemodule-schema
@@ -434,7 +425,6 @@ plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:invalid-ansib
 plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_txt_record.py validate-modules:undocumented-parameter
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-elements-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:doc-required-mismatch
 plugins/modules/net_tools/nios/nios_zone.py validate-modules:invalid-ansiblemodule-schema
@@ -545,7 +535,6 @@ plugins/modules/remote_management/redfish/idrac_redfish_command.py validate-modu
 plugins/modules/remote_management/redfish/idrac_redfish_config.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/idrac_redfish_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/redfish_command.py validate-modules:parameter-list-no-elements
-plugins/modules/remote_management/redfish/redfish_config.py validate-modules:doc-elements-mismatch
 plugins/modules/remote_management/redfish/redfish_config.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/redfish/redfish_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-choices-do-not-match-spec
@@ -565,7 +554,6 @@ plugins/modules/source_control/github/github_issue.py validate-modules:parameter
 plugins/modules/source_control/github/github_key.py validate-modules:doc-missing-type
 plugins/modules/source_control/github/github_release.py validate-modules:doc-missing-type
 plugins/modules/source_control/github/github_release.py validate-modules:parameter-type-not-in-doc
-plugins/modules/source_control/github/github_webhook.py validate-modules:doc-elements-mismatch
 plugins/modules/source_control/github/github_webhook.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/gitlab/gitlab_deploy_key.py validate-modules:doc-required-mismatch
@@ -641,7 +629,6 @@ plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
 plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc
-plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py validate-modules:doc-elements-mismatch
 scripts/inventory/gce.py pylint:blacklisted-name
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
Tidy up on sanity tests' ignore files, removing lines with validation-modules for these modules.

The focus was to pass the tests so no code was changed other than adjusting argument_spec for missing types or inconsistencies with the docs. The priority has been not to change any functionality, but to ensure that code and docs are synchronized.

Some lines were added back to the files, but a total of 26 lines were removed (among 2.9, 2.10 and 2.11).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py
plugins/modules/source_control/github/github_webhook.py
plugins/modules/remote_management/redfish/redfish_config.py
plugins/modules/net_tools/nios/nios_nsgroup.py
plugins/modules/net_tools/nios/nios_network.py
plugins/modules/net_tools/nios/nios_member.py
plugins/modules/net_tools/nios/nios_host_record.py
plugins/modules/net_tools/nios/nios_fixed_address.py
plugins/modules/identity/keycloak/keycloak_clienttemplate.py
plugins/modules/identity/keycloak/keycloak_client.py
plugins/modules/identity/ipa/ipa_hbacrule.py
plugins/modules/cloud/xenserver/xenserver_guest.py

##### ADDITIONAL INFORMATION
