### PR TITLE
BOTMETA.yml: add a maintainer for pagerduty_user module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -412,6 +412,8 @@ files:
     maintainers: ApsOps
   $modules/monitoring/pagerduty_change.py:
     maintainers: adamvaughan
+  $modules/monitoring/pagerduty_user.py:
+    maintainers: zanssa
   $modules/monitoring/pingdom.py:
     maintainers: thaumos
   $modules/monitoring/rollbar_deployment.py:


### PR DESCRIPTION
##### SUMMARY
BOTMETA.yml: add a maintainer for pagerduty_user module

Relates to https://github.com/ansible-collections/community.general/pull/1025

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
BOTMETA.yml