### PR TITLE
yum_versionlock: new module

### DIFF
--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -68,7 +68,7 @@ packages:
     sample: [ 'httpd' ]
 state:
     description: State of package(s).
-    returned: everytime
+    returned: always
     type: str
     sample: present
 '''

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -7,12 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
-
 DOCUMENTATION = r'''
 ---
 module: yum_versionlock

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -27,7 +27,7 @@ options:
     - If state is C(absent) or C(unlocked), package(s) will be removed from yum versionlock list.
     choices: [ 'absent', 'locked', 'present', 'unlocked' ]
     type: str
-    default: present
+    default: locked
 notes:
     - Requires yum-plugin-versionlock package on the remote node.
     - Supports C(check_mode).
@@ -41,12 +41,12 @@ author:
 EXAMPLES = r'''
 - name: Prevent Apache / httpd from being updated
   community.general.yum_versionlock:
-    state: present
+    state: locked
     name: httpd
 
 - name: Prevent multiple packages from being updated
   community.general.yum_versionlock:
-    state: present
+    state: locked
     name:
     - httpd
     - nginx
@@ -55,7 +55,7 @@ EXAMPLES = r'''
 
 - name: Unlock Apache / httpd to be updated again
   community.general.yum_versionlock:
-    state: absent
+    state: unlocked
     package: httpd
 '''
 
@@ -70,7 +70,7 @@ state:
     description: State of package(s).
     returned: success
     type: str
-    sample: present
+    sample: locked
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -104,7 +104,7 @@ def main():
     """ start main program to add/remove a package to yum versionlock"""
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(default='present', choices=['present', 'locked', 'unlocked', 'absent']),
+            state=dict(default='locked', choices=['present', 'locked', 'unlocked', 'absent']),
             name=dict(required=True, type='list', elements='str'),
         ),
         supports_check_mode=True

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -19,7 +19,7 @@ options:
     description:
       - Package name or a list of packages.
     type: list
-    required: True
+    required: true
     elements: str
   state:
     description:
@@ -62,8 +62,9 @@ EXAMPLES = r'''
 RETURN = r'''
 packages:
     description: A list of package(s) in versionlock list.
-    returned: everytime
+    returned: always
     type: list
+    elements: str
     sample: [ 'httpd' ]
 state:
     description: State of package(s).
@@ -84,7 +85,7 @@ class YumVersionLock:
 
     def get_versionlock_packages(self):
         """ Get an overview of all packages on yum versionlock """
-        rc, out, err = self.module.run_command("%s versionlock list" % self.yum_bin)
+        rc, out, err = self.module.run_command([self.yum_bin, "versionlock", "list"])
         if rc == 0:
             return out
         elif rc == 1 and 'o such command:' in err:

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: yum_versionlock
-version_added: 2.10
+version_added: 2.0.0
 short_description: Locks / Unlocks an installed package(s) from being updates by yum package manager
 description:
      - This module adds installed packages to yum versionlock to prevent the package from being updated.

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r'''
 ---
 module: yum_versionlock
 version_added: 2.0.0
-short_description: Locks / Unlocks an installed package(s) from being updates by yum package manager
+short_description: Locks / Unlocks an installed package(s) from being updated by yum package manager.
 description:
      - This module adds installed packages to yum versionlock to prevent the package from being updated.
      - Please install yum-plugin-versionlock before using this module.
@@ -59,13 +59,12 @@ EXAMPLES = r'''
 
 RETURN = r'''
 packages:
-    description: A list of package in versionlock list.
+    description: A list of package(s) in versionlock list.
     returned: everytime
     type: list
     sample: [ 'httpd' ]
 state:
-    description: State of used package.
-``
+    description: State of package(s).
     returned: everytime
     type: str
     sample: present

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -59,7 +59,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 packages:
-    description: A list of package in versionlock list
+    description: A list of package in versionlock list.
     returned: everytime
     type: list
     sample: [ 'httpd' ]

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -62,13 +62,13 @@ EXAMPLES = r'''
 RETURN = r'''
 packages:
     description: A list of package(s) in versionlock list.
-    returned: always
+    returned: success
     type: list
     elements: str
     sample: [ 'httpd' ]
 state:
     description: State of package(s).
-    returned: always
+    returned: success
     type: str
     sample: present
 '''

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -30,7 +30,7 @@ options:
     default: present
 notes:
     - Requires yum-plugin-versionlock package on the remote node.
-    - Currently C(check_mode) is not supported.
+    - C(check_mode) is supported.
 requirements:
 - yum
 - yum-versionlock

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -84,7 +84,7 @@ class YumVersionLock:
 
     def get_versionlock_packages(self):
         """ Get an overview of all packages on yum versionlock """
-        rc, out, err = self.module.run_command("%s -q versionlock list" % self.yum_bin)
+        rc, out, err = self.module.run_command("%s versionlock list" % self.yum_bin)
         if rc == 0:
             return out
         elif rc == 1 and 'o such command:' in err:

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -30,7 +30,7 @@ options:
     default: present
 notes:
     - Requires yum-plugin-versionlock package on the remote node.
-    - C(check_mode) is supported.
+    - Supports C(check_mode).
 requirements:
 - yum
 - yum-versionlock

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -94,7 +94,7 @@ class YumVersionLock:
 
     def ensure_state(self, package, command):
         """ Ensure package state """
-        rc, out, err = self.module.run_command("%s -q versionlock %s %s" % (self.yum_bin, command, package))
+        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command, package])
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -15,7 +15,7 @@ short_description: Locks / Unlocks an installed package(s) from being updated by
 description:
      - This module adds installed packages to yum versionlock to prevent the package from being updated.
 options:
-  pkg:
+  name:
     description:
       - Package name or a list of packages.
     type: list
@@ -42,12 +42,12 @@ EXAMPLES = r'''
 - name: Prevent Apache / httpd from being updated
   community.general.yum_versionlock:
     state: present
-    pkg: httpd
+    name: httpd
 
 - name: Prevent multiple packages from being updated
   community.general.yum_versionlock:
     state: present
-    pkg:
+    name:
     - httpd
     - nginx
     - haproxy
@@ -104,13 +104,13 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'locked', 'unlocked', 'absent']),
-            pkg=dict(required=True, type='list', elements='str'),
+            name=dict(required=True, type='list', elements='str'),
         ),
         supports_check_mode=True
     )
 
     state = module.params['state']
-    packages = module.params['pkg']
+    packages = module.params['name']
     changed = False
 
     yum_v = YumVersionLock(module)

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -36,6 +36,7 @@ requirements:
 - yum-versionlock
 author:
     - Florian Paul Hoberg (@florianpaulhoberg)
+    - Amin Vakil (@aminvakil)
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Florian Paul Hoberg <florian.hoberg@credativ.de>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: yum_versionlock
+version_added: 2.10
+short_description: Locks / Unlocks an installed package(s) from being updates by yum package manager
+description:
+     - This module adds installed packages to yum versionlock to prevent the package from being updated.
+     - Please install yum-plugin-versionlock before using this module.
+options:
+  pkg:
+    description:
+      - Package name or a list of packages.
+    type: list
+    required: True
+    elements: str
+  state:
+    description:
+    - If state is C(present) or C(locked), package(s) will be added to yum versionlock list.
+    - If state is C(absent) or C(unlocked), package(s) will be removed from yum versionlock list.
+    choices: [ 'absent', 'locked', 'present', 'unlocked' ]
+    type: str
+    default: present
+requirements:
+- yum
+- yum-versionlock
+author:
+    - Florian Paul Hoberg (@florianpaulhoberg)
+'''
+
+EXAMPLES = r'''
+- name: Prevent Apache / httpd from being updated
+  community.general.yum_versionlock:
+    state: present
+    pkg: httpd
+
+- name: Prevent multiple packages from being updated
+  community.general.yum_versionlock:
+    state: present
+    pkg:
+    - httpd
+    - nginx
+    - haproxy
+    - curl
+
+- name: Unlock Apache / httpd to be updated again
+  community.general.yum_versionlock:
+    state: absent
+    package: httpd
+'''
+
+RETURN = r'''
+packages:
+    description: A list of package in versionlock list
+    returned: everytime
+    type: list
+    sample: [ 'httpd' ]
+state:
+    description: state of used package
+    returned: everytime
+    type: str
+    sample: present
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+class YumVersionLock:
+    def __init__(self, module):
+        self.module = module
+        self.params = module.params
+        self.yum_bin = module.get_bin_path('yum', required=True)
+
+    def get_versionlock_packages(self):
+        """ Get an overview of all packages on yum versionlock """
+        rc, out, err = self.module.run_command("%s -q versionlock list" % self.yum_bin)
+        if rc == 0:
+            return out
+        elif rc == 1 and 'o such command:' in err:
+            self.module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock : " + to_native(err) + to_native(out))
+        self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
+
+    def ensure_state(self, package, command):
+        """ Ensure package state """
+        rc, out, err = self.module.run_command("%s -q versionlock %s %s" % (self.yum_bin, command, package))
+        if rc == 0:
+            return True
+        self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
+
+
+def main():
+    """ start main program to add/remove a package to yum versionlock"""
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(default='present', choices=['present', 'locked', 'unlocked', 'absent']),
+            pkg=dict(required=True, type='list', elements='str'),
+        ),
+        supports_check_mode=True
+    )
+
+    state = module.params['state']
+    packages = module.params['pkg']
+    changed = False
+
+    yum_v = YumVersionLock(module)
+
+    # Get an overview of all packages that have a version lock
+    versionlock_packages = yum_v.get_versionlock_packages()
+
+    # Ensure versionlock state of packages
+    if state in ('present', 'locked'):
+        command = 'add'
+        for single_pkg in packages:
+            if single_pkg not in versionlock_packages:
+                if module.check_mode:
+                    changed = True
+                    continue
+                changed = yum_v.ensure_state(single_pkg, command)
+    elif state in ('absent', 'unlocked'):
+        command = 'delete'
+        for single_pkg in packages:
+            if single_pkg in versionlock_packages:
+                if module.check_mode:
+                    changed = True
+                    continue
+                changed = yum_v.ensure_state(single_pkg, command)
+
+    module.exit_json(
+        changed=changed,
+        meta={
+            "packages": packages,
+            "state": state
+        }
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r'''
 ---
 module: yum_versionlock
 version_added: 2.0.0
-short_description: Locks / Unlocks an installed package(s) from being updated by yum package manager.
+short_description: Locks / unlocks a installed package(s) from being updated by yum package manager
 description:
      - This module adds installed packages to yum versionlock to prevent the package from being updated.
 options:

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -64,7 +64,8 @@ packages:
     type: list
     sample: [ 'httpd' ]
 state:
-    description: state of used package
+    description: State of used package.
+``
     returned: everytime
     type: str
     sample: present

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -14,7 +14,6 @@ version_added: 2.0.0
 short_description: Locks / Unlocks an installed package(s) from being updated by yum package manager.
 description:
      - This module adds installed packages to yum versionlock to prevent the package from being updated.
-     - Please install yum-plugin-versionlock before using this module.
 options:
   pkg:
     description:
@@ -29,6 +28,9 @@ options:
     choices: [ 'absent', 'locked', 'present', 'unlocked' ]
     type: str
     default: present
+notes:
+    - Requires yum-plugin-versionlock package on the remote node.
+    - Currently C(check_mode) is not supported.
 requirements:
 - yum
 - yum-versionlock

--- a/plugins/modules/yum_versionlock.py
+++ b/plugins/modules/yum_versionlock.py
@@ -1,1 +1,1 @@
-plugins/modules/packaging/os/yum_versionlock.py
+./packaging/os/yum_versionlock.py

--- a/plugins/modules/yum_versionlock.py
+++ b/plugins/modules/yum_versionlock.py
@@ -1,0 +1,1 @@
+plugins/modules/packaging/os/yum_versionlock.py

--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -1,0 +1,5 @@
+shippable/posix/group1
+skip/aix
+skip/freebsd
+skip/osx
+skip/macos

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -59,4 +59,5 @@
         name: yum-plugin-versionlock
         state: absent
       when: yum_versionlock_install is changed
-  when: ansible_distribution in ['CentOS', 'RedHat', 'Fedora']
+  when: (ansible_distribution in ['CentOS', 'RedHat'] and ansible_distribution_major_version is version('7', '>=')) or
+        (ansible_distribution == 'Fedora')

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -21,21 +21,21 @@
         name: "{{ yum_updates.results | map(attribute='name') | list }}"
         state: locked
       register: lock_all_packages
-      when: yum_updates.results | list != 0
+      when: yum_updates.results | length != 0
 
     - name: update all packages
       yum:
         name: '*'
         state: latest
       register: update_all_locked_packages
-      when: yum_updates.results | list != 0
+      when: yum_updates.results | length != 0
 
     - name: unlock all packages
       community.general.yum_versionlock:
         name: "{{ yum_updates.results | map(attribute='name') | list }}"
         state: unlocked
       register: unlock_all_packages
-      when: yum_updates.results | list != 0
+      when: yum_updates.results | length != 0
 
     - name: update all packages
       yum:
@@ -43,7 +43,7 @@
         state: latest
       check_mode: yes
       register: update_all_packages
-      when: yum_updates.results | list != 0
+      when: yum_updates.results | length != 0
 
     - name: assert everything is fine
       assert:
@@ -52,7 +52,7 @@
           - "{{ not update_all_locked_packages.changed }}"
           - "{{ unlock_all_packages.changed }}"
           - "{{ update_all_packages.changed }}"
-      when: yum_updates.results | list != 0
+      when: yum_updates.results | length != 0
 
     - name: Remove installed packages in case it was not installed
       yum:

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -21,18 +21,21 @@
         name: "{{ yum_updates.results | map(attribute='name') | list }}"
         state: locked
       register: lock_all_packages
+      when: yum_updates.results | list != 0
 
     - name: update all packages
       yum:
         name: '*'
         state: latest
       register: update_all_locked_packages
+      when: yum_updates.results | list != 0
 
     - name: unlock all packages
       community.general.yum_versionlock:
         name: "{{ yum_updates.results | map(attribute='name') | list }}"
         state: unlocked
       register: unlock_all_packages
+      when: yum_updates.results | list != 0
 
     - name: update all packages
       yum:
@@ -40,6 +43,7 @@
         state: latest
       check_mode: yes
       register: update_all_packages
+      when: yum_updates.results | list != 0
 
     - name: assert everything is fine
       assert:
@@ -48,6 +52,7 @@
           - "{{ not update_all_locked_packages.changed }}"
           - "{{ unlock_all_packages.changed }}"
           - "{{ update_all_packages.changed }}"
+      when: yum_updates.results | list != 0
 
     - name: Remove installed packages in case it was not installed
       yum:

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -16,42 +16,41 @@
         list: updates
       register: yum_updates
 
-    - name: lock all packages
-      community.general.yum_versionlock:
-        name: "{{ yum_updates.results | map(attribute='name') | list }}"
-        state: locked
-      register: lock_all_packages
-      when: yum_updates.results | length != 0
+    - block:
+        - name: lock all packages
+          community.general.yum_versionlock:
+            name: "{{ yum_updates.results | map(attribute='name') | list }}"
+            state: locked
+          register: lock_all_packages
 
-    - name: update all packages
-      yum:
-        name: '*'
-        state: latest
-      register: update_all_locked_packages
-      when: yum_updates.results | length != 0
+        - name: update all packages
+          command: yum update --setopt=obsoletes=0
+          register: update_all_locked_packages
+          changed_when:
+            - '"No packages marked for update" not in update_all_locked_packages.stdout'
+            - '"Nothing to do" not in update_all_locked_packages.stdout'
 
-    - name: unlock all packages
-      community.general.yum_versionlock:
-        name: "{{ yum_updates.results | map(attribute='name') | list }}"
-        state: unlocked
-      register: unlock_all_packages
-      when: yum_updates.results | length != 0
+        - name: unlock all packages
+          community.general.yum_versionlock:
+            name: "{{ yum_updates.results | map(attribute='name') | list }}"
+            state: unlocked
+          register: unlock_all_packages
 
-    - name: update all packages
-      yum:
-        name: '*'
-        state: latest
-      check_mode: yes
-      register: update_all_packages
-      when: yum_updates.results | length != 0
+        - name: update all packages
+          yum:
+            name: '*'
+            state: latest
+          check_mode: yes
+          register: update_all_packages
+          when: yum_updates.results | length != 0
 
-    - name: assert everything is fine
-      assert:
-        that:
-          - "{{ lock_all_packages.changed }}"
-          - "{{ not update_all_locked_packages.changed }}"
-          - "{{ unlock_all_packages.changed }}"
-          - "{{ update_all_packages.changed }}"
+        - name: assert everything is fine
+          assert:
+            that:
+              - "{{ lock_all_packages.changed }}"
+              - "{{ not update_all_locked_packages.changed }}"
+              - "{{ unlock_all_packages.changed }}"
+              - "{{ update_all_packages.changed }}"
       when: yum_updates.results | length != 0
 
     - name: Remove installed packages in case it was not installed

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -20,7 +20,7 @@
         - name: Lock all packages
           community.general.yum_versionlock:
             name: "{{ yum_updates.results | map(attribute='name') | list }}"
-            state: locked
+            state: present
           register: lock_all_packages
 
         - name: Update all packages
@@ -33,7 +33,7 @@
         - name: Unlock all packages
           community.general.yum_versionlock:
             name: "{{ yum_updates.results | map(attribute='name') | list }}"
-            state: unlocked
+            state: absent
           register: unlock_all_packages
 
         - name: Update all packages

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- block:
+    - name: Install necessary packages to test yum_versionlock
+      yum:
+        name: yum-plugin-versionlock
+        state: present
+      register: yum_versionlock_install
+
+    - name: yum checkupdate
+      yum:
+        list: updates
+      register: yum_updates
+
+    - name: lock all packages
+      community.general.yum_versionlock:
+        name: "{{ yum_updates.results | map(attribute='name') | list }}"
+        state: locked
+      register: lock_all_packages
+
+    - name: update all packages
+      yum:
+        name: '*'
+        state: latest
+      register: update_all_locked_packages
+
+    - name: unlock all packages
+      community.general.yum_versionlock:
+        name: "{{ yum_updates.results | map(attribute='name') | list }}"
+        state: unlocked
+      register: unlock_all_packages
+
+    - name: update all packages
+      yum:
+        name: '*'
+        state: latest
+      check_mode: yes
+      register: update_all_packages
+
+    - name: assert everything is fine
+      assert:
+        that:
+          - "{{ lock_all_packages.changed }}"
+          - "{{ not update_all_locked_packages.changed }}"
+          - "{{ unlock_all_packages.changed }}"
+          - "{{ update_all_packages.changed }}"
+
+    - name: Remove installed packages in case it was not installed
+      yum:
+        name: yum-plugin-versionlock
+        state: absent
+      when: yum_versionlock_install is changed
+  when: ansible_distribution in ['CentOS', 'RedHat', 'Fedora']

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -11,32 +11,32 @@
         state: present
       register: yum_versionlock_install
 
-    - name: yum checkupdate
+    - name: Yum checkupdate
       yum:
         list: updates
       register: yum_updates
 
     - block:
-        - name: lock all packages
+        - name: Lock all packages
           community.general.yum_versionlock:
             name: "{{ yum_updates.results | map(attribute='name') | list }}"
             state: locked
           register: lock_all_packages
 
-        - name: update all packages
+        - name: Update all packages
           command: yum update --setopt=obsoletes=0
           register: update_all_locked_packages
           changed_when:
             - '"No packages marked for update" not in update_all_locked_packages.stdout'
             - '"Nothing to do" not in update_all_locked_packages.stdout'
 
-        - name: unlock all packages
+        - name: Unlock all packages
           community.general.yum_versionlock:
             name: "{{ yum_updates.results | map(attribute='name') | list }}"
             state: unlocked
           register: unlock_all_packages
 
-        - name: update all packages
+        - name: Update all packages
           yum:
             name: '*'
             state: latest
@@ -44,7 +44,7 @@
           register: update_all_packages
           when: yum_updates.results | length != 0
 
-        - name: assert everything is fine
+        - name: Assert everything is fine
           assert:
             that:
               - "{{ lock_all_packages.changed }}"


### PR DESCRIPTION
##### SUMMARY
This module adds support to lock packages in their version to prevent these from updating by yum.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
yum_versionlock

##### ADDITIONAL INFORMATION
This has been first implemented by @florianpaulhoberg in https://github.com/ansible/ansible/pull/41778 and then copied to https://github.com/ansible-collections/community.general/pull/324, but didn't finish there.

I'm going to add some integration tests to this and hopefully this time the module will get merged :)