### PR TITLE
Proxmox - add `features` flag

### DIFF
--- a/changelogs/fragments/1413-proxmox-features.yml
+++ b/changelogs/fragments/1413-proxmox-features.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - add features option to LXC (https://github.com/ansible-collections/community.general/issues/816).
+  - proxmox - add ``features`` option to LXC (https://github.com/ansible-collections/community.general/issues/816).

--- a/changelogs/fragments/1413-proxmox-features.yml
+++ b/changelogs/fragments/1413-proxmox-features.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - add features option to LXC (https://github.com/ansible-collections/community.general/pull/1413).

--- a/changelogs/fragments/1413-proxmox-features.yml
+++ b/changelogs/fragments/1413-proxmox-features.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - add features option to LXC (https://github.com/ansible-collections/community.general/pull/1413).
+  - proxmox - add features option to LXC (https://github.com/ansible-collections/community.general/issues/816).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -118,6 +118,7 @@ options:
   features:
     description:
       - Specifies a list of features to be enabled. For valid options, see U(https://pve.proxmox.com/wiki/Linux_Container#pct_options).
+      - Some features can only be turned on privileged or unprivileged containers.
     type: list
     elements: str
     version_added: 2.0.0

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -115,6 +115,12 @@ options:
     description:
       - specifies network interfaces for the container. As a hash/dictionary defining interfaces.
     type: dict
+  features:
+    description:
+      - Specifies a list of features to be enabled. For valid options, see U(https://pve.proxmox.com/wiki/Linux_Container#pct_options).
+    type: list
+    elements: str
+    version_added: 2.0.0
   mounts:
     description:
       - specifies additional mounts (separate disks) for the container. As a hash/dictionary defining mount points
@@ -316,6 +322,21 @@ EXAMPLES = r'''
     hostname: example.org
     ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
     cores: 2
+
+- name: Create a new container with nesting enabled and allows the use of CIFS/NFS inside the container.
+  community.general.proxmox:
+    vmid: 100
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    password: 123456
+    hostname: example.org
+    ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
+    features:
+     - nesting=1
+     - mount=cifs,nfs
+
 
 - name: Start container
   community.general.proxmox:
@@ -526,6 +547,7 @@ def main():
             mounts=dict(type='dict'),
             ip_address=dict(),
             onboot=dict(type='bool'),
+            features=dict(type='list', elements='str'),
             storage=dict(default='local'),
             cpuunits=dict(type='int'),
             nameserver=dict(),
@@ -646,6 +668,7 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
+                            features=",".join(module.params['features']),
                             unprivileged=int(module.params['unprivileged']),
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -668,7 +668,7 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
-                            features=",".join(module.params['features']),
+                            features=",".join(module.params['features'] or []),
                             unprivileged=int(module.params['unprivileged']),
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -118,7 +118,7 @@ options:
   features:
     description:
       - Specifies a list of features to be enabled. For valid options, see U(https://pve.proxmox.com/wiki/Linux_Container#pct_options).
-      - Some features can only be turned on privileged or unprivileged containers.
+      - Some features require the use of a privileged container.
     type: list
     elements: str
     version_added: 2.0.0


### PR DESCRIPTION
##### SUMMARY
Adds the `features` flag to pass to ProxMox LXC

##### ISSUE TYPE
- Fixes #816, proxmox lxc - add features (nesting, nfs, cifs...) 

##### COMPONENT NAME
https://github.com/ansible-collections/community.general/blob/main/plugins/modules/cloud/misc/proxmox.py

##### ADDITIONAL INFORMATION
Containers in Proxmox-LXC has a features string one can set to enable specific things such as container nesting, NFS, CIFS, FUSE, etc. This patch allows the ansible role to pass that feature string to Proxmox in raw form. The user of this role must understand which flags are compatible with each other and how to pass them.