### PR TITLE
xfconf: add return values and expand test coverage

### DIFF
--- a/changelogs/fragments/1419-xfconf-return-values.yaml
+++ b/changelogs/fragments/1419-xfconf-return-values.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- xfconf - add in missing return values that are specified in te documentation (https://github.com/ansible-collections/community.general/issues/1418).

--- a/changelogs/fragments/1419-xfconf-return-values.yaml
+++ b/changelogs/fragments/1419-xfconf-return-values.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- xfconf - add in missing return values that are specified in te documentation (https://github.com/ansible-collections/community.general/issues/1418).
+- xfconf - add in missing return values that are specified in the documentation (https://github.com/ansible-collections/community.general/issues/1418).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -86,12 +86,12 @@ EXAMPLES = """
 RETURN = '''
   channel:
     description: The channel specified in the module parameters
-    returned: always
+    returned: success
     type: str
     sample: "xsettings"
   property:
     description: The property specified in the module parameters
-    returned: always
+    returned: success
     type: str
     sample: "/Xft/DPI"
   value_type:

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -97,28 +97,26 @@ RETURN = '''
   value_type:
     description:
     - The type of the value that was changed (C(none) for C(get) and C(reset)
-      state). Either a single string value or a list of strings for array
+      state). Either a single string value or a list of strings for array.
+      Deprecated.
       types.
     returned: success
-    type: list
-    elements: str
+    type: string or list of strings
     sample: '"int" or ["str", "str", "str"]'
   value:
     description:
     - The value of the preference key after executing the module. Either a
-      single string value or a list of strings for array types.
+      single string value or a list of strings for array types. Deprecated.
     returned: success
-    type: list
-    elements: str
+    type: string or list of strings
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
     description:
     - The value of the preference key before executing the module (C(none) for
       C(get) state). Either a single string value or a list of strings for array
-      types.
+      types. Deprecated.
     returned: success
-    type: list
-    elements: str
+    type: string or list of strings
     sample: '"96" or ["red", "blue", "green"]'
 '''
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -188,14 +188,6 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
                                   channel=self.module.params['channel'],
                                   previous_value=None)
 
-        deprecation_messages = [
-            {
-                'msg': 'xfconf: Seeting of facts is deprecated. Please use return values going forwad.',
-                'version': '',
-            },
-        ]
-        self.update_output(deprecations=deprecation_messages)
-
     def process_command_output(self, rc, out, err):
         if err.rstrip() == self.does_not:
             return None

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -95,7 +95,7 @@ RETURN = '''
     type: str
     sample: "/Xft/DPI"
   value_type:
-    description: The type of the value that was changed (None for "get" and "reset" state)
+    description: The type of the value that was changed (C(none) for C(get) and C(reset) state)
     returned: success
     type: list
     elements: str

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -16,7 +16,6 @@ short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
     xfconf-query.  Please see the xfconf-query(1) man pages for more details.
-    The setting of facts by this module is deprecated.
 options:
   channel:
     description:

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -107,7 +107,7 @@ RETURN = '''
     type: raw
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
-    description: The value of the preference key before executing the module (None for "get" state). Either a single string value or a list of strings for array types.
+    description: The value of the preference key before executing the module (C(none) for C(get) state). Either a single string value or a list of strings for array types.
     returned: success
     type: raw
     sample: '"96" or ["red", "blue", "green"]'

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -95,22 +95,21 @@ RETURN = '''
     type: str
     sample: "/Xft/DPI"
   value_type:
-    description: The type of the value that was changed (C(none) for C(get) and C(reset) state)
+    description: The type of the value that was changed (C(none) for C(get) and C(reset) state). Either a single string value or a list of strings for array types.
     returned: success
-    type: list
-    elements: str
+    type: raw
+    returned: success
+    type: raw
     sample: '"int" or ["str", "str", "str"]'
   value:
-    description: The value of the preference key after executing the module
+    description: The value of the preference key after executing the module. Either a single string value or a list of strings for array types.
     returned: success
-    type: list
-    elements: str
+    type: raw
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
-    description: The value of the preference key before executing the module (None for "get" state)
+    description: The value of the preference key before executing the module (None for "get" state). Either a single string value or a list of strings for array types.
     returned: success
-    type: list
-    elements: str
+    type: raw
     sample: '"96" or ["red", "blue", "green"]'
 '''
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -97,19 +97,19 @@ RETURN = '''
   value_type:
     description: The type of the value that was changed (None for "get" and "reset" state)
     returned: success
-    type: 'str|list'
+    type: list
     elements: str
     sample: '"int" or ["str", "str", "str"]'
   value:
     description: The value of the preference key after executing the module
     returned: success
-    type: 'str|list'
+    type: list
     elements: str
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
     description: The value of the preference key before executing the module (None for "get" state)
     returned: success
-    type: 'str|list'
+    type: list
     elements: str
     sample: '"96" or ["red", "blue", "green"]'
 '''

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -95,24 +95,27 @@ RETURN = '''
     type: str
     sample: "/Xft/DPI"
   value_type:
-    description: The type of the value that was changed (C(none) for C(get) and C(reset) state). Either a single string value or a list of strings for array
-                 types.
-    returned: success
-    type: list
-    elem
+    description:
+    - The type of the value that was changed (C(none) for C(get) and C(reset)
+      state). Either a single string value or a list of strings for array
+      types.
     returned: success
     type: list
     elements: str
     sample: '"int" or ["str", "str", "str"]'
   value:
-    description: The value of the preference key after executing the module. Either a single string value or a list of strings for array types.
+    description:
+    - The value of the preference key after executing the module. Either a
+      single string value or a list of strings for array types.
     returned: success
     type: list
     elements: str
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
-    description: The value of the preference key before executing the module (C(none) for C(get) state). Either a single string value or a list of strings for
-                 array types.
+    description:
+    - The value of the preference key before executing the module (C(none) for
+      C(get) state). Either a single string value or a list of strings for array
+      types.
     returned: success
     type: list
     elements: str

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -16,7 +16,7 @@ short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
     xfconf-query.  Please see the xfconf-query(1) man pages for more details.
-    Note: The setting of facts by this module is deprecated.
+    The setting of facts by this module is deprecated.
 options:
   channel:
     description:
@@ -189,6 +189,18 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.update_xfconf_output(property=self.module.params['property'],
                                   channel=self.module.params['channel'],
                                   previous_value=None)
+
+        deprecation_messages = [
+            {
+                'msg': 'xfconf: Seeting of facts is deprecated. Please use return values going forwad.',
+                'version': '',
+            },
+            {
+                'msg': 'xfconf: The format of return values is deprecated and will change to a new format in a future version.',
+                'version': '',
+            },
+        ]
+        self.update_output(deprecations=deprecation_messages)
 
     def process_command_output(self, rc, out, err):
         if err.rstrip() == self.does_not:

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -99,8 +99,6 @@ RETURN = '''
                  types.
     returned: success
     type: raw
-    returned: success
-    type: raw
     sample: '"int" or ["str", "str", "str"]'
   value:
     description: The value of the preference key after executing the module. Either a single string value or a list of strings for array types.

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -95,7 +95,8 @@ RETURN = '''
     type: str
     sample: "/Xft/DPI"
   value_type:
-    description: The type of the value that was changed (C(none) for C(get) and C(reset) state). Either a single string value or a list of strings for array types.
+    description: The type of the value that was changed (C(none) for C(get) and C(reset) state). Either a single string value or a list of strings for array
+                 types.
     returned: success
     type: raw
     returned: success
@@ -107,7 +108,8 @@ RETURN = '''
     type: raw
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
-    description: The value of the preference key before executing the module (C(none) for C(get) state). Either a single string value or a list of strings for array types.
+    description: The value of the preference key before executing the module (C(none) for C(get) state). Either a single string value or a list of strings for
+                 array types.
     returned: success
     type: raw
     sample: '"96" or ["red", "blue", "green"]'

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -97,21 +97,21 @@ RETURN = '''
   value_type:
     description: The type of the value that was changed (None for "get" and "reset" state)
     returned: success
-    type: str|list
+    type: 'str|list'
     elements: str
-    sample: "int" or ["str", "str", "str"]
+    sample: '"int" or ["str", "str", "str"]'
   value:
     description: The value of the preference key after executing the module
     returned: success
-    type: str|list
+    type: 'str|list'
     elements: str
-    sample: "192" or ["orange", "yellow", "violet"]
+    sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
     description: The value of the preference key before executing the module (None for "get" state)
     returned: success
-    type: str|list
+    type: 'str|list'
     elements: str
-    sample: "96" or ["red", "blue", "green"]
+    sample: '"96" or ["red", "blue", "green"]'
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -98,18 +98,24 @@ RETURN = '''
     description: The type of the value that was changed (C(none) for C(get) and C(reset) state). Either a single string value or a list of strings for array
                  types.
     returned: success
-    type: raw
+    type: list
+    elem
+    returned: success
+    type: list
+    elements: str
     sample: '"int" or ["str", "str", "str"]'
   value:
     description: The value of the preference key after executing the module. Either a single string value or a list of strings for array types.
     returned: success
-    type: raw
+    type: list
+    elements: str
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
     description: The value of the preference key before executing the module (C(none) for C(get) state). Either a single string value or a list of strings for
                  array types.
     returned: success
-    type: raw
+    type: list
+    elements: str
     sample: '"96" or ["red", "blue", "green"]'
 '''
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -86,29 +86,32 @@ EXAMPLES = """
 RETURN = '''
   channel:
     description: The channel specified in the module parameters
-    returned: success
+    returned: always
     type: str
     sample: "xsettings"
   property:
     description: The property specified in the module parameters
-    returned: success
+    returned: always
     type: str
     sample: "/Xft/DPI"
   value_type:
-    description: The type of the value that was changed
+    description: The type of the value that was changed (None for "get" and "reset" state)
     returned: success
-    type: str
-    sample: "int"
+    type: str|list
+    elements: str
+    sample: "int" or ["str", "str", "str"]
   value:
     description: The value of the preference key after executing the module
     returned: success
-    type: str
-    sample: "192"
+    type: str|list
+    elements: str
+    sample: "192" or ["orange", "yellow", "violet"]
   previous_value:
-    description: The value of the preference key before executing the module (None for "get" state).
+    description: The value of the preference key before executing the module (None for "get" state)
     returned: success
-    type: str
-    sample: "96"
+    type: str|list
+    elements: str
+    sample: "96" or ["red", "blue", "green"]
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
@@ -176,6 +179,9 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.does_not = 'Property "{0}" does not exist on channel "{1}".'.format(self.module.params['property'],
                                                                                  self.module.params['channel'])
         self.vars.previous_value = self._get()
+        self.update_xfconf_output(property=self.module.params['property'],
+                                  channel=self.module.params['channel'],
+                                  previous_value=None)
 
     def process_command_output(self, rc, out, err):
         if err.rstrip() == self.does_not:
@@ -205,10 +211,13 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
     def state_get(self):
         self.vars.value = self.vars.previous_value
+        self.update_xfconf_output(value=self.vars.value)
 
     def state_absent(self):
         self.vars.value = None
         self.run_command(params=('channel', 'property', 'reset'), extra_params={"reset": True})
+        self.update_xfconf_output(previous_value=self.vars.previous_value,
+                                  value=None)
 
     def state_present(self):
         # stringify all values - in the CLI they will all be happy strings anyway
@@ -249,6 +258,11 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
         if not self.vars.is_array:
             self.vars.value = self.vars.value[0]
+            value_type = value_type[0]
+
+        self.update_xfconf_output(previous_value=self.vars.previous_value,
+                                  value=self.vars.value,
+                                  type=value_type)
 
 
 def main():

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -16,6 +16,7 @@ short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
     xfconf-query.  Please see the xfconf-query(1) man pages for more details.
+    Note: The setting of facts by this module is deprecated.
 options:
   channel:
     description:

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -98,8 +98,7 @@ RETURN = '''
   value_type:
     description:
     - The type of the value that was changed (C(none) for C(get) and C(reset)
-      state). Either a single string value or a list of strings for array.
-      Deprecated.
+      state). Either a single string value or a list of strings for array
       types.
     returned: success
     type: string or list of strings
@@ -107,7 +106,7 @@ RETURN = '''
   value:
     description:
     - The value of the preference key after executing the module. Either a
-      single string value or a list of strings for array types. Deprecated.
+      single string value or a list of strings for array types.
     returned: success
     type: string or list of strings
     sample: '"192" or ["orange", "yellow", "violet"]'
@@ -115,7 +114,7 @@ RETURN = '''
     description:
     - The value of the preference key before executing the module (C(none) for
       C(get) state). Either a single string value or a list of strings for array
-      types. Deprecated.
+      types.
     returned: success
     type: string or list of strings
     sample: '"96" or ["red", "blue", "green"]'
@@ -193,10 +192,6 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         deprecation_messages = [
             {
                 'msg': 'xfconf: Seeting of facts is deprecated. Please use return values going forwad.',
-                'version': '',
-            },
-            {
-                'msg': 'xfconf: The format of return values is deprecated and will change to a new format in a future version.',
                 'version': '',
             },
         ]

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -542,6 +542,7 @@ plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:undocumented-parameter
 plugins/modules/system/timezone.py pylint:blacklisted-name
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
 plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -542,6 +542,7 @@ plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:undocumented-parameter
 plugins/modules/system/timezone.py pylint:blacklisted-name
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
 plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -437,6 +437,7 @@ plugins/modules/system/runit.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:undocumented-parameter
 plugins/modules/system/timezone.py pylint:blacklisted-name
+plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:deprecation-mismatch
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:invalid-documentation

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -349,12 +349,14 @@ def test_xfconf(mocker, capfd, patch_xfconf, testcase):
 
     for test_result in ('channel', 'property'):
         assert test_result in results, "'{}' not found in {}".format(test_result, results)
-        assert results[test_result] == results['invocation']['module_args'][test_result], "'{}': '{}' != '{}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
+        assert results[test_result] == results['invocation']['module_args'][test_result], \
+            "'{}': '{}' != '{}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
 
     for conditional_test_result in ('msg', 'value', 'previous_value'):
         if conditional_test_result in testcase:
             assert conditional_test_result in results, "'{}' not found in {}".format(conditional_test_result, results)
-            assert results[conditional_test_result] == testcase[conditional_test_result], "'{}': '{}' != '{}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
+            assert results[conditional_test_result] == testcase[conditional_test_result], \
+                "'{}': '{}' != '{}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
 
     assert mock_run_command.call_count == len(testcase['run_command.calls'])
     if mock_run_command.call_count:

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -348,15 +348,15 @@ def test_xfconf(mocker, capfd, patch_xfconf, testcase):
     assert results['changed'] == testcase['changed']
 
     for test_result in ('channel', 'property'):
-        assert test_result in results, "'{}' not found in {}".format(test_result, results)
+        assert test_result in results, "'{0}' not found in {1}".format(test_result, results)
         assert results[test_result] == results['invocation']['module_args'][test_result], \
-            "'{}': '{}' != '{}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
+            "'{0}': '{1}' != '{2}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
 
     for conditional_test_result in ('msg', 'value', 'previous_value'):
         if conditional_test_result in testcase:
-            assert conditional_test_result in results, "'{}' not found in {}".format(conditional_test_result, results)
+            assert conditional_test_result in results, "'{0}' not found in {1}".format(conditional_test_result, results)
             assert results[conditional_test_result] == testcase[conditional_test_result], \
-                "'{}': '{}' != '{}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
+                "'{0}': '{1}' != '{2}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
 
     assert mock_run_command.call_count == len(testcase['run_command.calls'])
     if mock_run_command.call_count:

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -55,7 +55,8 @@ TEST_CASES = [
                 ),
             ],
             'changed': False,
-            'previous_value': '100',
+            'previous_value': None,
+            'value_type': None,
             'value': '100',
         }
     ],
@@ -75,6 +76,7 @@ TEST_CASES = [
             ],
             'changed': False,
             'previous_value': None,
+            'value_type': None,
             'value': None,
         }
     ],
@@ -93,7 +95,8 @@ TEST_CASES = [
                 ),
             ],
             'changed': False,
-            'previous_value': ['Main', 'Work', 'Tmp'],
+            'previous_value': None,
+            'value_type': None,
             'value': ['Main', 'Work', 'Tmp'],
         },
     ],
@@ -112,7 +115,8 @@ TEST_CASES = [
                 ),
             ],
             'changed': False,
-            'previous_value': 'true',
+            'previous_value': None,
+            'value_type': None,
             'value': 'true',
         },
     ],
@@ -131,7 +135,8 @@ TEST_CASES = [
                 ),
             ],
             'changed': False,
-            'previous_value': 'false',
+            'previous_value': None,
+            'value_type': None,
             'value': 'false',
         },
     ],
@@ -166,6 +171,7 @@ TEST_CASES = [
             ],
             'changed': True,
             'previous_value': '100',
+            'value_type': 'int',
             'value': '90',
         },
     ],
@@ -200,6 +206,7 @@ TEST_CASES = [
             ],
             'changed': False,
             'previous_value': '90',
+            'value_type': 'int',
             'value': '90',
         },
     ],
@@ -235,6 +242,7 @@ TEST_CASES = [
             ],
             'changed': True,
             'previous_value': ['Main', 'Work', 'Tmp'],
+            'value_type': ['str', 'str', 'str'],
             'value': ['A', 'B', 'C'],
         },
     ],
@@ -270,6 +278,7 @@ TEST_CASES = [
             ],
             'changed': False,
             'previous_value': ['A', 'B', 'C'],
+            'value_type': ['str', 'str', 'str'],
             'value': ['A', 'B', 'C'],
         },
     ],
@@ -302,6 +311,7 @@ TEST_CASES = [
             ],
             'changed': True,
             'previous_value': ['A', 'B', 'C'],
+            'value_type': None,
             'value': None,
         },
     ],
@@ -333,14 +343,18 @@ def test_xfconf(mocker, capfd, patch_xfconf, testcase):
     results = json.loads(out)
     print("testcase =\n%s" % testcase)
     print("results =\n%s" % results)
+
     assert 'changed' in results
     assert results['changed'] == testcase['changed']
-    if 'msg' in results:
-        assert results.get('msg') == testcase['msg']
-    if 'value' in results:
-        assert results['value'] == testcase['value']
-    if 'previous_value' in results:
-        assert results['previous_value'] == testcase['previous_value']
+
+    for test_result in ('channel', 'property'):
+        assert test_result in results, "'{}' not found in {}".format(test_result, results)
+        assert results[test_result] == results['invocation']['module_args'][test_result], "'{}': '{}' != '{}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
+
+    for conditional_test_result in ('msg', 'value', 'previous_value'):
+        if conditional_test_result in testcase:
+            assert conditional_test_result in results, "'{}' not found in {}".format(conditional_test_result, results)
+            assert results[conditional_test_result] == testcase[conditional_test_result], "'{}': '{}' != '{}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
 
     assert mock_run_command.call_count == len(testcase['run_command.calls'])
     if mock_run_command.call_count:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In #1322 #1305 it looks like we long returning values that are called out in the documentation. Also, the test coverage has a logic bug that would cause this case to not get exercised in the tests.

Changes:
* Add return values by calling `update_xfconf_output()` at appropriate times to match documentation
* Update `RETURNS` documentation to reflect returning either scalar `str` or `list(str)` in `value` and `value_type`
* Fix logical bug in test to cover `value`, `msg`, and `previous_value` in the case where they are not in `result` but should be
* Add coverage for return values of `value_type`.
* Fix test data to match documentation of returning `previous_value = None` in some cases.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1418 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/system/xfconf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Using the following task:
```yaml
- name: Get current panel layout
  xfconf:
    channel: xfce4-panel
    property: /panels/panel-0/plugin-ids
    state: get
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
ok: [localhost] => {
    "changed": false,
    "force_lang": "C",
    "invocation": {
        "module_args": {
            "channel": "xfce4-panel",
            "force_array": false,
            "property": "/panels/panel-0/plugin-ids",
            "state": "get",
            "value": null,
            "value_type": null
        }
    },
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Value is an array with 13 items:\n\n1\n2\n3\n4\n15\n5\n6\n7\n8\n9\n10\n11\n12\n",
    "stdout_lines": [
        "Value is an array with 13 items:",
        "",
        "1",
        "2",
        "3",
        "4",
        "15",
        "5",
        "6",
        "7",
        "8",
        "9",
        "10",
        "11",
        "12"
    ]
}
```

After:
```
ok: [localhost] => {
    "changed": false,
    "channel": "xfce4-panel",
    "force_lang": "C",
    "invocation": {
        "module_args": {
            "channel": "xfce4-panel",
            "force_array": false,
            "property": "/panels/panel-0/plugin-ids",
            "state": "get",
            "value": null,
            "value_type": null
        }
    },
    "previous_value": null,
    "property": "/panels/panel-0/plugin-ids",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Value is an array with 13 items:\n\n1\n2\n3\n4\n15\n5\n6\n7\n8\n9\n10\n11\n12\n",
    "stdout_lines": [
        "Value is an array with 13 items:",
        "",
        "1",
        "2",
        "3",
        "4",
        "15",
        "5",
        "6",
        "7",
        "8",
        "9",
        "10",
        "11",
        "12"
    ],
    "value": [
        "1",
        "2",
        "3",
        "4",
        "15",
        "5",
        "6",
        "7",
        "8",
        "9",
        "10",
        "11",
        "12"
    ]
}
```
