### PR TITLE
mas : Add example using PATH: /usr/local/bin

### DIFF
--- a/plugins/modules/packaging/os/mas.py
+++ b/plugins/modules/packaging/os/mas.py
@@ -55,6 +55,13 @@ EXAMPLES = '''
     id: 409183694
     state: present
 
+- name: Install Divvy with command mas installed in /usr/local/bin
+  community.general.mas:
+    id: 413857545
+    state: present
+  environment:
+    PATH: /usr/local/bin:{{ ansible_facts.env.PATH }}
+
 - name: Install a list of apps
   community.general.mas:
     id:


### PR DESCRIPTION
##### SUMMARY
I think most people uses homebrew to install mas-cli. In this case, mas is installed in /usr/local/bin but Ansible doesn't find it when ssh connection is used.

Added example shows how to configure environment to workaround the issue.

I've tested with:
 - macOS 10.15.7 (Catalina)
 - macOS 11.0.1 (Big Sur)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mas

##### ADDITIONAL INFORMATION
Without custom environment, error is: 
```yaml
failed: [targethost] (item=413857545) =>
{ ansible_loop_var: item
  changed: false
  item: 413857545
  msg: Required `mas` tool is not installed }
```
