### PR TITLE
[stable-1] Tidy up validate-modules:no-default-for-required-parameter and other cases

### DIFF
--- a/changelogs/fragments/1423-valmod_multiple_cases.yml
+++ b/changelogs/fragments/1423-valmod_multiple_cases.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - utm_network_interface_address - changed param type from invalid 'boolean' to valid 'bool' (https://github.com/ansible-collections/community.general/pull/1423).
+  - bigpanda - removed the dynamic default for ``host`` param (https://github.com/ansible-collections/community.general/pull/1423).
+  - udm_user - removed the dynamic default for ``userexpiry`` param (https://github.com/ansible-collections/community.general/pull/1423).
+  - profitbricks_nic - removed the dynamic default for ``name`` param (https://github.com/ansible-collections/community.general/pull/1423).
+  - profitbricks_nic - replaced code with ``required`` and ``required_if`` (https://github.com/ansible-collections/community.general/pull/1423).

--- a/plugins/modules/cloud/centurylink/clc_alert_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_alert_policy.py
@@ -217,18 +217,18 @@ class ClcAlertPolicy:
         :return: argument spec dictionary
         """
         argument_spec = dict(
-            name=dict(default=None),  # @FIXME default=None is redundant - remove all
-            id=dict(default=None),
-            alias=dict(required=True, default=None),
-            alert_recipients=dict(type='list', default=None),
+            name=dict(),
+            id=dict(),
+            alias=dict(required=True),
+            alert_recipients=dict(type='list'),
             metric=dict(
                 choices=[
                     'cpu',
                     'memory',
                     'disk'],
                 default=None),
-            duration=dict(type='str', default=None),
-            threshold=dict(type='int', default=None),
+            duration=dict(type='str'),
+            threshold=dict(type='int'),
             state=dict(default='present', choices=['present', 'absent'])
         )
         mutually_exclusive = [

--- a/plugins/modules/cloud/centurylink/clc_firewall_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_firewall_policy.py
@@ -214,12 +214,12 @@ class ClcFirewallPolicy:
         """
         argument_spec = dict(
             location=dict(required=True),
-            source_account_alias=dict(required=True, default=None),   # @FIXME remove default=None
-            destination_account_alias=dict(default=None),
-            firewall_policy_id=dict(default=None),
-            ports=dict(default=None, type='list'),
-            source=dict(default=None, type='list'),
-            destination=dict(default=None, type='list'),
+            source_account_alias=dict(required=True),
+            destination_account_alias=dict(),
+            firewall_policy_id=dict(),
+            ports=dict(type='list'),
+            source=dict(type='list'),
+            destination=dict(type='list'),
             wait=dict(default=True),   # @FIXME type=bool
             state=dict(default='present', choices=['present', 'absent']),
             enabled=dict(default=True, choices=[True, False])

--- a/plugins/modules/cloud/opennebula/one_host.py
+++ b/plugins/modules/cloud/opennebula/one_host.py
@@ -26,6 +26,7 @@ options:
         description:
             - Hostname of the machine to manage.
         required: true
+        type: str
     state:
         description:
             - Takes the host to the desired lifecycle state.
@@ -41,29 +42,36 @@ options:
             - disabled
             - offline
         default: present
+        type: str
     im_mad_name:
         description:
             - The name of the information manager, this values are taken from the oned.conf with the tag name IM_MAD (name)
         default: kvm
+        type: str
     vmm_mad_name:
         description:
             - The name of the virtual machine manager mad name, this values are taken from the oned.conf with the tag name VM_MAD (name)
         default: kvm
+        type: str
     cluster_id:
         description:
             - The cluster ID.
         default: 0
+        type: int
     cluster_name:
         description:
             - The cluster specified by name.
+        type: str
     labels:
         description:
             - The labels for this host.
+        type: list
     template:
         description:
             - The template or attribute changes to merge into the host template.
         aliases:
             - attributes
+        type: dict
 
 extends_documentation_fragment:
 - community.general.opennebula

--- a/plugins/modules/cloud/opennebula/one_image.py
+++ b/plugins/modules/cloud/opennebula/one_image.py
@@ -39,20 +39,25 @@ options:
       - It is recommended to use HTTPS so that the username/password are not
       - transferred over the network unencrypted.
       - If not set then the value of the C(ONE_URL) environment variable is used.
+    type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula RPC server. If not set
       - then the value of the C(ONE_USERNAME) environment variable is used.
+    type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula RPC server. If not set
       - then the value of the C(ONE_PASSWORD) environment variable is used.
+    type: str
   id:
     description:
       - A C(id) of the image you would like to manage.
+    type: int
   name:
     description:
       - A C(name) of the image you would like to manage.
+    type: str
   state:
     description:
       - C(present) - state that is used to manage the image
@@ -61,6 +66,7 @@ options:
       - C(renamed) - rename the image to the C(new_name)
     choices: ["present", "absent", "cloned", "renamed"]
     default: present
+    type: str
   enabled:
     description:
       - Whether the image should be enabled or disabled.
@@ -69,6 +75,7 @@ options:
     description:
       - A name that will be assigned to the existing or new image.
       - In the case of cloning, by default C(new_name) will take the name of the origin image with the prefix 'Copy of'.
+    type: str
 author:
     - "Milan Ilic (@ilicmilan)"
 '''

--- a/plugins/modules/cloud/opennebula/one_image_info.py
+++ b/plugins/modules/cloud/opennebula/one_image_info.py
@@ -40,18 +40,22 @@ options:
       - It is recommended to use HTTPS so that the username/password are not
       - transferred over the network unencrypted.
       - If not set then the value of the C(ONE_URL) environment variable is used.
+    type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula RPC server. If not set
       - then the value of the C(ONE_USERNAME) environment variable is used.
+    type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula RPC server. If not set
       - then the value of the C(ONE_PASSWORD) environment variable is used.
+    type: str
   ids:
     description:
       - A list of images ids whose facts you want to gather.
     aliases: ['id']
+    type: list
   name:
     description:
       - A C(name) of the image whose facts will be gathered.
@@ -59,6 +63,7 @@ options:
       - which restricts the list of images (whose facts will be returned) whose names match specified regex.
       - Also, if the C(name) begins with '~*' case-insensitive matching will be performed.
       - See examples for more details.
+    type: str
 author:
     - "Milan Ilic (@ilicmilan)"
     - "Jan Meerkamp (@meerkampdvv)"

--- a/plugins/modules/cloud/opennebula/one_service.py
+++ b/plugins/modules/cloud/opennebula/one_service.py
@@ -36,24 +36,31 @@ options:
       - URL of the OpenNebula OneFlow API server.
       - It is recommended to use HTTPS so that the username/password are not transferred over the network unencrypted.
       - If not set then the value of the ONEFLOW_URL environment variable is used.
+    type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula OneFlow API server. If not set then the value of the C(ONEFLOW_USERNAME) environment variable is used.
+    type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula OneFlow API server. If not set then the value of the C(ONEFLOW_PASSWORD) environment variable is used.
+    type: str
   template_name:
     description:
       - Name of service template to use to create a new instance of a service
+    type: str
   template_id:
     description:
       - ID of a service template to use to create a new instance of a service
+    type: int
   service_id:
     description:
       - ID of a service instance that you would like to manage
+    type: int
   service_name:
     description:
       - Name of a service instance that you would like to manage
+    type: str
   unique:
     description:
       - Setting C(unique=yes) will make sure that there is only one service instance running with a name set with C(service_name) when
@@ -66,15 +73,19 @@ options:
       - C(absent) - terminate an instance of a service specified with C(service_id)/C(service_name).
     choices: ["present", "absent"]
     default: present
+    type: str
   mode:
     description:
       - Set permission mode of a service instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+    type: str
   owner_id:
     description:
       - ID of the user which will be set as the owner of the service
+    type: int
   group_id:
     description:
       - ID of the group which will be set as the group of the service
+    type: int
   wait:
     description:
       - Wait for the instance to reach RUNNING state after DEPLOYING or COOLDOWN state after SCALING
@@ -84,16 +95,20 @@ options:
     description:
       - How long before wait gives up, in seconds
     default: 300
+    type: int
   custom_attrs:
     description:
       - Dictionary of key/value custom attributes which will be used when instantiating a new service.
     default: {}
+    type: dict
   role:
     description:
       - Name of the role whose cardinality should be changed
+    type: str
   cardinality:
     description:
       - Number of VMs for the specified role
+    type: int
   force:
     description:
       - Force the new cardinality even if it is outside the limits

--- a/plugins/modules/cloud/opennebula/one_vm.py
+++ b/plugins/modules/cloud/opennebula/one_vm.py
@@ -40,10 +40,12 @@ options:
       - It is recommended to use HTTPS so that the username/password are not
       - transferred over the network unencrypted.
       - If not set then the value of the C(ONE_URL) environment variable is used.
+    type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula RPC server. If not set
       - then the value of the C(ONE_USERNAME) environment variable is used.
+    type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula RPC server. If not set
@@ -51,20 +53,25 @@ options:
       - if both I(api_username) or I(api_password) are not set, then it will try
       - authenticate with ONE auth file. Default path is "~/.one/one_auth".
       - Set environment variable C(ONE_AUTH) to override this path.
+    type: str
   template_name:
     description:
       - Name of VM template to use to create a new instace
+    type: str
   template_id:
     description:
       - ID of a VM template to use to create a new instance
+    type: int
   vm_start_on_hold:
     description:
       - Set to true to put vm on hold while creating
     default: False
+    type: bool
   instance_ids:
     description:
       - A list of instance ids used for states':' C(absent), C(running), C(rebooted), C(poweredoff)
     aliases: ['ids']
+    type: list
   state:
     description:
       - C(present) - create instances from a template specified with C(template_id)/C(template_name).
@@ -74,6 +81,7 @@ options:
       - C(absent) - terminate instances
     choices: ["present", "absent", "running", "rebooted", "poweredoff"]
     default: present
+    type: str
   hard:
     description:
       - Reboot, power-off or terminate instances C(hard)
@@ -92,6 +100,7 @@ options:
     description:
       - How long before wait gives up, in seconds
     default: 300
+    type: int
   attributes:
     description:
       - A dictionary of key/value attributes to add to new instances, or for
@@ -104,61 +113,75 @@ options:
       - When used with C(count_attributes) and C(exact_count) the module will
       - match the base name without the index part.
     default: {}
+    type: dict
   labels:
     description:
       - A list of labels to associate with new instances, or for setting
       - C(state) of instances with these labels.
     default: []
+    type: list
   count_attributes:
     description:
       - A dictionary of key/value attributes that can only be used with
       - C(exact_count) to determine how many nodes based on a specific
       - attributes criteria should be deployed. This can be expressed in
       - multiple ways and is shown in the EXAMPLES section.
+    type: dict
   count_labels:
     description:
       - A list of labels that can only be used with C(exact_count) to determine
       - how many nodes based on a specific labels criteria should be deployed.
       - This can be expressed in multiple ways and is shown in the EXAMPLES
       - section.
+    type: list
   count:
     description:
       - Number of instances to launch
     default: 1
+    type: int
   exact_count:
     description:
       - Indicates how many instances that match C(count_attributes) and
       - C(count_labels) parameters should be deployed. Instances are either
       - created or terminated based on this value.
       - NOTE':' Instances with the least IDs will be terminated first.
+    type: int
   mode:
     description:
       - Set permission mode of the instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+    type: str
   owner_id:
     description:
       - ID of the user which will be set as the owner of the instance
+    type: int
   group_id:
     description:
       - ID of the group which will be set as the group of the instance
+    type: int
   memory:
     description:
       - The size of the memory for new instances (in MB, GB, ...)
+    type: str
   disk_size:
     description:
       - The size of the disk created for new instances (in MB, GB, TB,...).
       - NOTE':' If The Template hats Multiple Disks the Order of the Sizes is
       - matched against the order specified in C(template_id)/C(template_name).
+    type: list
   cpu:
     description:
       - Percentage of CPU divided by 100 required for the new instance. Half a
       - processor is written 0.5.
+    type: float
   vcpu:
     description:
       - Number of CPUs (cores) new VM will have.
+    type: int
   networks:
     description:
       - A list of dictionaries with network parameters. See examples for more details.
     default: []
+    type: list
   disk_saveas:
     description:
       - Creates an image from a VM disk.
@@ -167,6 +190,7 @@ options:
       - I(NOTE)':' This operation will only be performed on the first VM (if more than one VM ID is passed)
       - and the VM has to be in the C(poweredoff) state.
       - Also this operation will fail if an image with specified C(name) already exists.
+    type: dict
   persistent:
     description:
       - Create a private persistent copy of the template plus any image defined in DISK, and instantiate that copy.
@@ -177,10 +201,12 @@ options:
     description:
       - Name of Datastore to use to create a new instace
     version_added: '0.2.0'
+    type: int
   datastore_name:
     description:
       - Name of Datastore to use to create a new instace
     version_added: '0.2.0'
+    type: str
 author:
     - "Milan Ilic (@ilicmilan)"
     - "Jan Meerkamp (@meerkampdvv)"

--- a/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
+++ b/plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
@@ -43,9 +43,11 @@ options:
             - "Type of the external provider."
         choices: ['os_image', 'os_network', 'os_volume', 'foreman']
         required: true
+        type: str
     name:
         description:
             - "Name of the external provider, can be used as glob expression."
+        type: str
 extends_documentation_fragment:
 - community.general.ovirt_facts
 
@@ -110,11 +112,8 @@ def main():
     argument_spec = ovirt_info_full_argument_spec(
         name=dict(default=None, required=False),
         type=dict(
-            default=None,
             required=True,
-            choices=[
-                'os_image', 'os_network', 'os_volume', 'foreman',
-            ],
+            choices=['os_image', 'os_network', 'os_volume', 'foreman'],
             aliases=['provider'],
         ),
     )

--- a/plugins/modules/cloud/smartos/imgadm.py
+++ b/plugins/modules/cloud/smartos/imgadm.py
@@ -26,10 +26,12 @@ options:
         default: zones
         description:
           - zpool to import to or delete images from.
+        type: str
     source:
         required: false
         description:
           - URI for the image source.
+        type: str
     state:
         required: true
         choices: [ present, absent, deleted, imported, updated, vacuumed ]
@@ -37,16 +39,22 @@ options:
           - State the object operated on should be in. C(imported) is an alias for
             for C(present) and C(deleted) for C(absent). When set to C(vacuumed)
             and C(uuid) to C(*), it will remove all unused images.
+        type: str
+
     type:
         required: false
         choices: [ imgapi, docker, dsapi ]
         default: imgapi
         description:
           - Type for image sources.
+        type: str
+
     uuid:
         required: false
         description:
           - Image UUID. Can either be a full UUID or C(*) for all images.
+        type: str
+
 requirements:
     - python >= 2.6
 '''
@@ -260,12 +268,12 @@ class Imgadm(object):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            force=dict(default=None, type='bool'),
+            force=dict(type='bool'),
             pool=dict(default='zones'),
-            source=dict(default=None),
-            state=dict(default=None, required=True, choices=['present', 'absent', 'deleted', 'imported', 'updated', 'vacuumed']),
+            source=dict(),
+            state=dict(required=True, choices=['present', 'absent', 'deleted', 'imported', 'updated', 'vacuumed']),
             type=dict(default='imgapi', choices=['imgapi', 'docker', 'dsapi']),
-            uuid=dict(default=None)
+            uuid=dict()
         ),
         # This module relies largely on imgadm(1M) to enforce idempotency, which does not
         # provide a "noop" (or equivalent) mode to do a dry-run.

--- a/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -23,19 +23,22 @@ options:
 
   credentials_path:
     description:
-      - (String) Optional parameter that allows to set a non-default credentials path.
-       Default is ~/.spotinst/credentials
+      - (Path) Optional parameter that allows to set a non-default credentials path.
+    default: ~/.spotinst/credentials
+    type: path
 
   account_id:
     description:
       - (String) Optional parameter that allows to set an account-id inside the module configuration
        By default this is retrieved from the credentials path
+    type: str
 
   availability_vs_cost:
     description:
       - (String) The strategy orientation.
       - "The choices available are: C(availabilityOriented), C(costOriented), C(balanced)."
     required: true
+    type: str
 
   availability_zones:
     description:
@@ -46,6 +49,7 @@ options:
         subnet_id (String),
         placement_group_name (String),
     required: true
+    type: list
 
   block_device_mappings:
     description:
@@ -63,6 +67,7 @@ options:
         snapshot_id(Integer),
         volume_type(String),
         volume_size(Integer))
+    type: list
 
   chef:
     description:
@@ -72,10 +77,12 @@ options:
         user (String),
         pem_key (String),
         chef_version (String)
+    type: dict
 
   draining_timeout:
     description:
       - (Integer) Time for instance to be drained from incoming requests and deregistered from ELB before termination.
+    type: int
 
   ebs_optimized:
     description:
@@ -90,61 +97,72 @@ options:
         keys allowed are -
         volume_ids (List of Strings),
         device_name (String)
+    type: list
 
   ecs:
     description:
       - (Object) The ECS integration configuration.;
         Expects the following key -
         cluster_name (String)
-
+    type: dict
 
   elastic_ips:
     description:
       - (List of Strings) List of ElasticIps Allocation Ids (Example C(eipalloc-9d4e16f8)) to associate to the group instances
+    type: list
 
   fallback_to_od:
     description:
       - (Boolean) In case of no spots available, Elastigroup will launch an On-demand instance instead
     type: bool
+
   health_check_grace_period:
     description:
       - (Integer) The amount of time, in seconds, after the instance has launched to start and check its health.
-    default: 300
+      - If not specified, it defaults to C(300).
+    type: int
 
   health_check_unhealthy_duration_before_replacement:
     description:
       - (Integer) Minimal mount of time instance should be unhealthy for us to consider it unhealthy.
+    type: int
 
   health_check_type:
     description:
       - (String) The service to use for the health check.
       - "The choices available are: C(ELB), C(HCS), C(TARGET_GROUP), C(MLB), C(EC2)."
+    type: str
 
   iam_role_name:
     description:
       - (String) The instance profile iamRole name
       - Only use iam_role_arn, or iam_role_name
+    type: str
 
   iam_role_arn:
     description:
       - (String) The instance profile iamRole arn
       - Only use iam_role_arn, or iam_role_name
+    type: str
 
   id:
     description:
       - (String) The group id if it already exists and you want to update, or delete it.
         This will not work unless the uniqueness_by field is set to id.
         When this is set, and the uniqueness_by field is set, the group will either be updated or deleted, but not created.
+    type: str
 
   image_id:
     description:
       - (String) The image Id used to launch the instance.;
         In case of conflict between Instance type and image type, an error will be returned
     required: true
+    type: str
 
   key_pair:
     description:
       - (String) Specify a Key Pair to attach to the instances
+    type: str
 
   kubernetes:
     description:
@@ -152,39 +170,47 @@ options:
         Expects the following keys -
         api_server (String),
         token (String)
+    type: dict
 
   lifetime_period:
     description:
-      - (String) lifetime period
+      - (Integer) lifetime period
+    type: int
 
   load_balancers:
     description:
       - (List of Strings) List of classic ELB names
+    type: list
 
   max_size:
     description:
       - (Integer) The upper limit number of instances that you can scale up to
     required: true
+    type: int
 
   mesosphere:
     description:
       - (Object) The Mesosphere integration configuration.
         Expects the following key -
         api_server (String)
+    type: dict
 
   min_size:
     description:
       - (Integer) The lower limit number of instances that you can scale down to
     required: true
+    type: int
 
   monitoring:
     description:
-      - (Boolean) Describes whether instance Enhanced Monitoring is enabled
+      - (String) Describes whether instance Enhanced Monitoring is enabled
+    type: str
 
   name:
     description:
       - (String) Unique name for elastigroup to be created, updated or deleted
     required: true
+    type: str
 
   network_interfaces:
     description:
@@ -202,22 +228,26 @@ options:
         subnet_id (String),
         associate_ipv6_address (Boolean),
         private_ip_addresses (List of Objects, Keys are privateIpAddress (String, required) and primary (Boolean))
+    type: list
 
   on_demand_count:
     description:
       - (Integer) Required if risk is not set
       - Number of on demand instances to launch. All other instances will be spot instances.;
         Either set this parameter or the risk parameter
+    type: int
 
   on_demand_instance_type:
     description:
       - (String) On-demand instance type that will be provisioned
+    type: str
 
   opsworks:
     description:
       - (Object) The elastigroup OpsWorks integration configration.;
         Expects the following key -
         layer_id (String)
+    type: dict
 
   persistence:
     description:
@@ -226,12 +256,14 @@ options:
         should_persist_root_device (Boolean),
         should_persist_block_devices (Boolean),
         should_persist_private_ip (Boolean)
+    type: dict
 
   product:
     description:
       - (String) Operation system type.
       - "Available choices are: C(Linux/UNIX), C(SUSE Linux), C(Windows), C(Linux/UNIX (Amazon VPC)), C(SUSE Linux (Amazon VPC))."
     required: true
+    type: str
 
   rancher:
     description:
@@ -241,6 +273,7 @@ options:
         access_key (String),
         secret_key (String),
         master_host (String)
+    type: dict
 
   right_scale:
     description:
@@ -248,10 +281,12 @@ options:
         Expects the following keys -
         account_id (String),
         refresh_token (String)
+    type: dict
 
   risk:
     description:
       - (Integer) required if on demand is not set. The percentage of Spot instances to launch (0 - 100).
+    type: int
 
   roll_config:
     description:
@@ -261,6 +296,7 @@ options:
         batch_size_percentage(Integer, Required),
         grace_period - (Integer, Required),
         health_check_type(String, Optional)
+    type: dict
 
   scheduled_tasks:
     description:
@@ -278,17 +314,20 @@ options:
         grace_period (Integer),
         task_type (String, required),
         is_enabled (Boolean)
+    type: list
 
   security_group_ids:
     description:
       - (List of Strings) One or more security group IDs. ;
         In case of update it will override the existing Security Group with the new given array
     required: true
+    type: list
 
   shutdown_script:
     description:
       - (String) The Base64-encoded shutdown script that executes prior to instance termination.
         Encode before setting.
+    type: str
 
   signals:
     description:
@@ -296,15 +335,18 @@ options:
         keys allowed are -
         name (String, required),
         timeout (Integer)
+    type: list
 
   spin_up_time:
     description:
       - (Integer) spin up time, in seconds, for the instance
+    type: int
 
   spot_instance_types:
     description:
       - (List of Strings) Spot instance type that will be provisioned.
     required: true
+    type: list
 
   state:
     choices:
@@ -312,33 +354,41 @@ options:
       - absent
     description:
       - (String) create or delete the elastigroup
+    default: present
+    type: str
 
   tags:
     description:
-      - (List of tagKey:tagValue paris) a list of tags to configure in the elastigroup. Please specify list of keys and values (key colon value);
+      - (List of tagKey:tagValue pairs) a list of tags to configure in the elastigroup. Please specify list of keys and values (key colon value);
+    type: list
 
   target:
     description:
       - (Integer) The number of instances to launch
     required: true
+    type: int
 
   target_group_arns:
     description:
       - (List of Strings) List of target group arns instances should be registered to
+    type: list
 
   tenancy:
     description:
       - (String) dedicated vs shared tenancy.
       - "The available choices are: C(default), C(dedicated)."
+    type: str
 
   terminate_at_end_of_billing_hour:
     description:
       - (Boolean) terminate at the end of billing hour
     type: bool
+
   unit:
     description:
       - (String) The capacity unit to launch instances by.
       - "The available choices are: C(instance), C(weight)."
+    type: str
 
   up_scaling_policies:
     description:
@@ -362,7 +412,7 @@ options:
         target (String),
         maximum (String),
         minimum (String)
-
+    type: list
 
   down_scaling_policies:
     description:
@@ -386,6 +436,7 @@ options:
         target (String),
         maximum (String),
         minimum (String)
+    type: list
 
   target_tracking_policies:
     description:
@@ -400,6 +451,7 @@ options:
         unit (String, required),
         cooldown (String, required),
         target (String, required)
+    type: list
 
   uniqueness_by:
     choices:
@@ -408,12 +460,13 @@ options:
     description:
       - (String) If your group names are not unique, you may use this feature to update or delete a specific group.
         Whenever this property is set, you must set a group_id in order to update or delete a group, otherwise a group will be created.
-
+    default: name
+    type: str
 
   user_data:
     description:
       - (String) Base64-encoded MIME user data. Encode before setting the value.
-
+    type: str
 
   utilize_reserved_instances:
     description:
@@ -430,6 +483,7 @@ options:
     description:
       - (Integer) How long the module should wait for instances before failing the action.;
         Only works if wait_for_instances is True.
+    type: int
 
 '''
 EXAMPLES = '''
@@ -877,7 +931,6 @@ multai_fields = ('multai_token',)
 
 def handle_elastigroup(client, module):
     has_changed = False
-    should_create = False
     group_id = None
     message = 'None'
 
@@ -970,7 +1023,7 @@ def retrieve_group_instances(client, module, group_id):
                 healthy_instances = client.get_instance_healthiness(group_id=group_id)
 
                 for healthy_instance in healthy_instances:
-                    if(healthy_instance.get('healthStatus') == 'HEALTHY'):
+                    if healthy_instance.get('healthStatus') == 'HEALTHY':
                         amount_of_fulfilled_instances += 1
                         instances.append(healthy_instance)
 

--- a/plugins/modules/cloud/univention/udm_group.py
+++ b/plugins/modules/cloud/univention/udm_group.py
@@ -27,27 +27,34 @@ options:
         choices: [ present, absent ]
         description:
             - Whether the group is present or not.
+        type: str
     name:
         required: true
         description:
             - Name of the posix group.
+        type: str
     description:
         required: false
         description:
             - Group description.
+        type: str
     position:
         required: false
         description:
             - define the whole ldap position of the group, e.g.
               C(cn=g123m-1A,cn=classes,cn=schueler,cn=groups,ou=schule,dc=example,dc=com).
+        type: str
     ou:
         required: false
         description:
             - LDAP OU, e.g. school for LDAP OU C(ou=school,dc=example,dc=com).
+        type: str
     subpath:
         required: false
         description:
             - Subpath inside the OU, e.g. C(cn=classes,cn=students,cn=groups).
+        type: str
+        default: "cn=groups"
 '''
 
 

--- a/plugins/modules/cloud/univention/udm_user.py
+++ b/plugins/modules/cloud/univention/udm_user.py
@@ -27,203 +27,250 @@ options:
         choices: [ present, absent ]
         description:
             - Whether the user is present or not.
+        type: str
     username:
         required: true
         description:
             - User name
         aliases: ['name']
+        type: str
     firstname:
         description:
             - First name. Required if C(state=present).
+        type: str
     lastname:
         description:
             - Last name. Required if C(state=present).
+        type: str
     password:
         description:
             - Password. Required if C(state=present).
+        type: str
     birthday:
         description:
             - Birthday
+        type: str
     city:
         description:
             - City of users business address.
+        type: str
     country:
         description:
             - Country of users business address.
+        type: str
     department_number:
         description:
             - Department number of users business address.
         aliases: [ departmentNumber ]
+        type: str
     description:
         description:
             - Description (not gecos)
+        type: str
     display_name:
         description:
             - Display name (not gecos)
         aliases: [ displayName ]
+        type: str
     email:
-        default: []
+        default: ['']
         description:
             - A list of e-mail addresses.
+        type: list
     employee_number:
         description:
             - Employee number
         aliases: [ employeeNumber ]
+        type: str
     employee_type:
         description:
             - Employee type
         aliases: [ employeeType ]
+        type: str
     gecos:
         description:
             - GECOS
+        type: str
     groups:
         default: []
         description:
             - "POSIX groups, the LDAP DNs of the groups will be found with the
                LDAP filter for each group as $GROUP:
                C((&(objectClass=posixGroup)(cn=$GROUP)))."
+        type: list
     home_share:
         description:
             - "Home NFS share. Must be a LDAP DN, e.g.
                C(cn=home,cn=shares,ou=school,dc=example,dc=com)."
         aliases: [ homeShare ]
+        type: str
     home_share_path:
         description:
             - Path to home NFS share, inside the homeShare.
         aliases: [ homeSharePath ]
+        type: str
     home_telephone_number:
         default: []
         description:
             - List of private telephone numbers.
         aliases: [ homeTelephoneNumber ]
+        type: list
     homedrive:
         description:
             - Windows home drive, e.g. C("H:").
+        type: str
     mail_alternative_address:
         default: []
         description:
             - List of alternative e-mail addresses.
         aliases: [ mailAlternativeAddress ]
+        type: list
     mail_home_server:
         description:
             - FQDN of mail server
         aliases: [ mailHomeServer ]
+        type: str
     mail_primary_address:
         description:
             - Primary e-mail address
         aliases: [ mailPrimaryAddress ]
+        type: str
     mobile_telephone_number:
         default: []
         description:
             - Mobile phone number
         aliases: [ mobileTelephoneNumber ]
+        type: list
     organisation:
         description:
             - Organisation
         aliases: [ organization ]
-    override_pw_history:
+        type: str
+    overridePWHistory:
         type: bool
         default: 'no'
         description:
             - Override password history
-        aliases: [ overridePWHistory ]
-    override_pw_length:
+        aliases: [ override_pw_history ]
+    overridePWLength:
         type: bool
         default: 'no'
         description:
             - Override password check
-        aliases: [ overridePWLength ]
+        aliases: [ override_pw_length ]
     pager_telephonenumber:
         default: []
         description:
             - List of pager telephone numbers.
         aliases: [ pagerTelephonenumber ]
+        type: list
     phone:
         description:
             - List of telephone numbers.
+        type: list
     postcode:
         description:
             - Postal code of users business address.
+        type: str
     primary_group:
-        default: cn=Domain Users,cn=groups,$LDAP_BASE_DN
         description:
             - Primary group. This must be the group LDAP DN.
+            - If not specified, it defaults to C(cn=Domain Users,cn=groups,$LDAP_BASE_DN).
         aliases: [ primaryGroup ]
+        type: str
     profilepath:
         description:
             - Windows profile directory
+        type: str
     pwd_change_next_login:
         choices: [ '0', '1' ]
         description:
             - Change password on next login.
         aliases: [ pwdChangeNextLogin ]
+        type: str
     room_number:
         description:
             - Room number of users business address.
         aliases: [ roomNumber ]
+        type: str
     samba_privileges:
         description:
             - "Samba privilege, like allow printer administration, do domain
                join."
         aliases: [ sambaPrivileges ]
+        type: list
     samba_user_workstations:
         description:
             - Allow the authentication only on this Microsoft Windows host.
         aliases: [ sambaUserWorkstations ]
+        type: list
     sambahome:
         description:
             - Windows home path, e.g. C('\\$FQDN\$USERNAME').
+        type: str
     scriptpath:
         description:
             - Windows logon script.
+        type: str
     secretary:
         default: []
         description:
             - A list of superiors as LDAP DNs.
+        type: list
     serviceprovider:
-        default: []
+        default: ['']
         description:
             - Enable user for the following service providers.
+        type: list
     shell:
         default: '/bin/bash'
         description:
             - Login shell
+        type: str
     street:
         description:
             - Street of users business address.
+        type: str
     title:
         description:
             - Title, e.g. C(Prof.).
+        type: str
     unixhome:
-        default: '/home/$USERNAME'
         description:
             - Unix home directory
+            - If not specified, it defaults to C(/home/$USERNAME).
+        type: str
     userexpiry:
-        default: Today + 1 year
         description:
             - Account expiry date, e.g. C(1999-12-31).
+            - If not specified, it defaults to the current day plus one year.
+        type: str
     position:
         default: ''
         description:
             - "Define the whole position of users object inside the LDAP tree,
                e.g. C(cn=employee,cn=users,ou=school,dc=example,dc=com)."
+        type: str
     update_password:
         default: always
         choices: [ always, on_create ]
         description:
             - "C(always) will update passwords if they differ.
                C(on_create) will only set the password for newly created users."
+        type: str
     ou:
         default: ''
         description:
             - "Organizational Unit inside the LDAP Base DN, e.g. C(school) for
                LDAP OU C(ou=school,dc=example,dc=com)."
+        type: str
     subpath:
         default: 'cn=users'
         description:
             - "LDAP subpath inside the organizational unit, e.g.
                C(cn=teachers,cn=users) for LDAP container
                C(cn=teachers,cn=users,dc=example,dc=com)."
+        type: str
 '''
 
 
@@ -273,61 +320,44 @@ def main():
     expiry = date.strftime(date.today() + timedelta(days=365), "%Y-%m-%d")
     module = AnsibleModule(
         argument_spec=dict(
-            birthday=dict(default=None,
-                          type='str'),
-            city=dict(default=None,
-                      type='str'),
-            country=dict(default=None,
-                         type='str'),
-            department_number=dict(default=None,
-                                   type='str',
+            birthday=dict(type='str'),
+            city=dict(type='str'),
+            country=dict(type='str'),
+            department_number=dict(type='str',
                                    aliases=['departmentNumber']),
-            description=dict(default=None,
-                             type='str'),
-            display_name=dict(default=None,
-                              type='str',
+            description=dict(type='str'),
+            display_name=dict(type='str',
                               aliases=['displayName']),
             email=dict(default=[''],
                        type='list'),
-            employee_number=dict(default=None,
-                                 type='str',
+            employee_number=dict(type='str',
                                  aliases=['employeeNumber']),
-            employee_type=dict(default=None,
-                               type='str',
+            employee_type=dict(type='str',
                                aliases=['employeeType']),
-            firstname=dict(default=None,
-                           type='str'),
-            gecos=dict(default=None,
-                       type='str'),
+            firstname=dict(type='str'),
+            gecos=dict(type='str'),
             groups=dict(default=[],
                         type='list'),
-            home_share=dict(default=None,
-                            type='str',
+            home_share=dict(type='str',
                             aliases=['homeShare']),
-            home_share_path=dict(default=None,
-                                 type='str',
+            home_share_path=dict(type='str',
                                  aliases=['homeSharePath']),
             home_telephone_number=dict(default=[],
                                        type='list',
                                        aliases=['homeTelephoneNumber']),
-            homedrive=dict(default=None,
-                           type='str'),
-            lastname=dict(default=None,
-                          type='str'),
+            homedrive=dict(type='str'),
+            lastname=dict(type='str'),
             mail_alternative_address=dict(default=[],
                                           type='list',
                                           aliases=['mailAlternativeAddress']),
-            mail_home_server=dict(default=None,
-                                  type='str',
+            mail_home_server=dict(type='str',
                                   aliases=['mailHomeServer']),
-            mail_primary_address=dict(default=None,
-                                      type='str',
+            mail_primary_address=dict(type='str',
                                       aliases=['mailPrimaryAddress']),
             mobile_telephone_number=dict(default=[],
                                          type='list',
                                          aliases=['mobileTelephoneNumber']),
-            organisation=dict(default=None,
-                              type='str',
+            organisation=dict(type='str',
                               aliases=['organization']),
             overridePWHistory=dict(default=False,
                                    type='bool',
@@ -338,24 +368,18 @@ def main():
             pager_telephonenumber=dict(default=[],
                                        type='list',
                                        aliases=['pagerTelephonenumber']),
-            password=dict(default=None,
-                          type='str',
+            password=dict(type='str',
                           no_log=True),
             phone=dict(default=[],
                        type='list'),
-            postcode=dict(default=None,
-                          type='str'),
-            primary_group=dict(default=None,
-                               type='str',
+            postcode=dict(type='str'),
+            primary_group=dict(type='str',
                                aliases=['primaryGroup']),
-            profilepath=dict(default=None,
-                             type='str'),
-            pwd_change_next_login=dict(default=None,
-                                       type='str',
+            profilepath=dict(type='str'),
+            pwd_change_next_login=dict(type='str',
                                        choices=['0', '1'],
                                        aliases=['pwdChangeNextLogin']),
-            room_number=dict(default=None,
-                             type='str',
+            room_number=dict(type='str',
                              aliases=['roomNumber']),
             samba_privileges=dict(default=[],
                                   type='list',
@@ -363,24 +387,18 @@ def main():
             samba_user_workstations=dict(default=[],
                                          type='list',
                                          aliases=['sambaUserWorkstations']),
-            sambahome=dict(default=None,
-                           type='str'),
-            scriptpath=dict(default=None,
-                            type='str'),
+            sambahome=dict(type='str'),
+            scriptpath=dict(type='str'),
             secretary=dict(default=[],
                            type='list'),
             serviceprovider=dict(default=[''],
                                  type='list'),
             shell=dict(default='/bin/bash',
                        type='str'),
-            street=dict(default=None,
-                        type='str'),
-            title=dict(default=None,
-                       type='str'),
-            unixhome=dict(default=None,
-                          type='str'),
-            userexpiry=dict(default=expiry,
-                            type='str'),
+            street=dict(type='str'),
+            title=dict(type='str'),
+            unixhome=dict(type='str'),
+            userexpiry=dict(type='str'),
             username=dict(required=True,
                           aliases=['name'],
                           type='str'),
@@ -451,6 +469,8 @@ def main():
                     obj[k] = module.params[k]
             # handle some special values
             obj['e-mail'] = module.params['email']
+            if 'userexpiry' in obj and obj.get('userexpiry') is None:
+                obj['userexpiry'] = expiry
             password = module.params['password']
             if obj['password'] is None:
                 obj['password'] = password

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -37,10 +37,13 @@ options:
             - On C(absent), the client will be removed if it exists
         choices: ['present', 'absent']
         default: 'present'
+        type: str
 
     realm:
         description:
             - The realm to create the client in.
+        type: str
+        default: master
 
     client_id:
         description:
@@ -49,19 +52,23 @@ options:
               This is 'clientId' in the Keycloak REST API.
         aliases:
             - clientId
+        type: str
 
     id:
         description:
             - Id of client to be worked on. This is usually an UUID. Either this or I(client_id)
               is required. If you specify both, this takes precedence.
+        type: str
 
     name:
         description:
             - Name of the client (this is not the same as I(client_id))
+        type: str
 
     description:
         description:
             - Description of the client in Keycloak
+        type: str
 
     root_url:
         description:
@@ -69,6 +76,7 @@ options:
               This is 'rootUrl' in the Keycloak REST API.
         aliases:
             - rootUrl
+        type: str
 
     admin_url:
         description:
@@ -76,6 +84,7 @@ options:
               This is 'adminUrl' in the Keycloak REST API.
         aliases:
             - adminUrl
+        type: str
 
     base_url:
         description:
@@ -83,6 +92,7 @@ options:
               This is 'baseUrl' in the Keycloak REST API.
         aliases:
             - baseUrl
+        type: str
 
     enabled:
         description:
@@ -100,6 +110,7 @@ options:
         choices: ['client-secret', 'client-jwt']
         aliases:
             - clientAuthenticatorType
+        type: str
 
     secret:
         description:
@@ -107,6 +118,7 @@ options:
               specify a secret here (otherwise one will be generated if it does not exit). If
               changing this secret, the module will not register a change currently (but the
               changed secret will be saved).
+        type: str
 
     registration_access_token:
         description:
@@ -115,6 +127,7 @@ options:
               This is 'registrationAccessToken' in the Keycloak REST API.
         aliases:
             - registrationAccessToken
+        type: str
 
     default_roles:
         description:
@@ -123,6 +136,7 @@ options:
               This is 'defaultRoles' in the Keycloak REST API.
         aliases:
             - defaultRoles
+        type: list
 
     redirect_uris:
         description:
@@ -130,6 +144,7 @@ options:
               This is 'redirectUris' in the Keycloak REST API.
         aliases:
             - redirectUris
+        type: list
 
     web_origins:
         description:
@@ -137,11 +152,13 @@ options:
               This is 'webOrigins' in the Keycloak REST API.
         aliases:
             - webOrigins
+        type: list
 
     not_before:
         description:
             - Revoke any tokens issued before this date for this client (this is a UNIX timestamp).
               This is 'notBefore' in the Keycloak REST API.
+        type: int
         aliases:
             - notBefore
 
@@ -220,6 +237,7 @@ options:
     protocol:
         description:
             - Type of client (either C(openid-connect) or C(saml).
+        type: str
         choices: ['openid-connect', 'saml']
 
     full_scope_allowed:
@@ -234,6 +252,7 @@ options:
         description:
             - Cluster node re-registration timeout for this client.
               This is 'nodeReRegistrationTimeout' in the Keycloak REST API.
+        type: int
         aliases:
             - nodeReRegistrationTimeout
 
@@ -242,6 +261,7 @@ options:
             - dict of registered cluster nodes (with C(nodename) as the key and last registration
               time as the value).
               This is 'registeredNodes' in the Keycloak REST API.
+        type: dict
         aliases:
             - registeredNodes
 
@@ -250,6 +270,7 @@ options:
             - Client template to use for this client. If it does not exist this field will silently
               be dropped.
               This is 'clientTemplate' in the Keycloak REST API.
+        type: str
         aliases:
             - clientTemplate
 
@@ -290,6 +311,7 @@ options:
             - a data structure defining the authorization settings for this client. For reference,
               please see the Keycloak API docs at U(https://www.keycloak.org/docs-api/8.0/rest-api/index.html#_resourceserverrepresentation).
               This is 'authorizationSettings' in the Keycloak REST API.
+        type: dict
         aliases:
             - authorizationSettings
 
@@ -305,24 +327,29 @@ options:
             consentRequired:
                 description:
                     - Specifies whether a user needs to provide consent to a client for this mapper to be active.
+                type: bool
 
             consentText:
                 description:
                     - The human-readable name of the consent the user is presented to accept.
+                type: str
 
             id:
                 description:
                     - Usually a UUID specifying the internal ID of this protocol mapper instance.
+                type: str
 
             name:
                 description:
                     - The name of this protocol mapper.
+                type: str
 
             protocol:
                 description:
                     - This is either C(openid-connect) or C(saml), this specifies for which protocol this protocol mapper
                       is active.
                 choices: ['openid-connect', 'saml']
+                type: str
 
             protocolMapper:
                 description:
@@ -354,6 +381,7 @@ options:
                     - An exhaustive list of available mappers on your installation can be obtained on
                       the admin console by going to Server Info -> Providers and looking under
                       'protocol-mapper'.
+                type: str
 
             config:
                 description:
@@ -362,6 +390,7 @@ options:
                       other than by the source of the mappers and its parent class(es). An example is given
                       below. It is easiest to obtain valid config values by dumping an already-existing
                       protocol mapper configuration through check-mode in the I(existing) field.
+                type: dict
 
     attributes:
         description:
@@ -370,6 +399,7 @@ options:
               permissible options is not available; possible options as of Keycloak 3.4 are listed below. The Keycloak
               API does not validate whether a given option is appropriate for the protocol used; if specified
               anyway, Keycloak will simply not use it.
+        type: dict
         suboptions:
             saml.authnstatement:
                 description:

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -36,27 +36,34 @@ options:
             - On C(absent), the client template will be removed if it exists
         choices: ['present', 'absent']
         default: 'present'
+        type: str
 
     id:
         description:
             - Id of client template to be worked on. This is usually a UUID.
+        type: str
 
     realm:
         description:
             - Realm this client template is found in.
+        type: str
+        default: master
 
     name:
         description:
             - Name of the client template
+        type: str
 
     description:
         description:
             - Description of the client template in Keycloak
+        type: str
 
     protocol:
         description:
             - Type of client template (either C(openid-connect) or C(saml).
         choices: ['openid-connect', 'saml']
+        type: str
 
     full_scope_allowed:
         description:
@@ -74,24 +81,29 @@ options:
             consentRequired:
                 description:
                     - Specifies whether a user needs to provide consent to a client for this mapper to be active.
+                type: bool
 
             consentText:
                 description:
                     - The human-readable name of the consent the user is presented to accept.
+                type: str
 
             id:
                 description:
                     - Usually a UUID specifying the internal ID of this protocol mapper instance.
+                type: str
 
             name:
                 description:
                     - The name of this protocol mapper.
+                type: str
 
             protocol:
                 description:
                     - is either 'openid-connect' or 'saml', this specifies for which protocol this protocol mapper
                       is active.
                 choices: ['openid-connect', 'saml']
+                type: str
 
             protocolMapper:
                 description:
@@ -123,6 +135,7 @@ options:
                     - An exhaustive list of available mappers on your installation can be obtained on
                       the admin console by going to Server Info -> Providers and looking under
                       'protocol-mapper'.
+                type: str
 
             config:
                 description:
@@ -131,12 +144,14 @@ options:
                       other than by the source of the mappers and its parent class(es). An example is given
                       below. It is easiest to obtain valid config values by dumping an already-existing
                       protocol mapper configuration through check-mode in the "existing" field.
+                type: dict
 
     attributes:
         description:
             - A dict of further attributes for this client template. This can contain various
               configuration settings, though in the default installation of Keycloak as of 3.4, none
               are documented or known, so this is usually empty.
+        type: dict
 
 notes:
 - The Keycloak REST API defines further fields (namely I(bearerOnly), I(consentRequired), I(standardFlowEnabled),

--- a/plugins/modules/monitoring/bigpanda.py
+++ b/plugins/modules/monitoring/bigpanda.py
@@ -41,8 +41,8 @@ options:
     type: str
     description:
       - Name of affected host name. Can be a list.
+      - If not specified, it defaults to the remote system's hostname.
     required: false
-    default: machine's hostname
     aliases: ['host']
   env:
     type: str
@@ -144,7 +144,7 @@ def main():
             version=dict(required=True),
             token=dict(required=True, no_log=True),
             state=dict(required=True, choices=['started', 'finished', 'failed']),
-            hosts=dict(required=False, default=[socket.gethostname()], aliases=['host']),  # @FIXME
+            hosts=dict(required=False, aliases=['host']),
             env=dict(required=False),
             owner=dict(required=False),
             description=dict(required=False),
@@ -168,6 +168,8 @@ def main():
         v = module.params[k]
         if v is not None:
             body[k] = v
+    if body.get('hosts') is None:
+        body['hosts'] = [socket.gethostname()]
 
     if not isinstance(body['hosts'], list):
         body['hosts'] = [body['hosts']]

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -71,6 +71,7 @@ options:
     - Record priority.
     - Required for C(type=MX) and C(type=SRV)
     default: 1
+    type: int
   proto:
     description:
     - Service protocol. Required for C(type=SRV) and C(type=TLSA).
@@ -100,6 +101,7 @@ options:
     description:
     - Record service.
     - Required for C(type=SRV)
+    type: str
   solo:
     description:
     - Whether the record should be the only one for that record type and record name.

--- a/plugins/modules/net_tools/ip_netns.py
+++ b/plugins/modules/net_tools/ip_netns.py
@@ -31,12 +31,14 @@ options:
         required: false
         description:
             - Name of the namespace
+        type: str
     state:
         required: false
         default: "present"
         choices: [ present, absent ]
         description:
             - Whether the namespace should exist
+        type: str
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/net_tools/ipinfoio_facts.py
+++ b/plugins/modules/net_tools/ipinfoio_facts.py
@@ -21,11 +21,13 @@ options:
       - HTTP connection timeout in seconds
     required: false
     default: 10
+    type: int
   http_agent:
     description:
       - Set http user agent
     required: false
     default: "ansible-ipinfoio-module/0.0.1"
+    type: str
 notes:
   - "Check http://ipinfo.io/ for more information"
 '''

--- a/plugins/modules/net_tools/ldap/ldap_passwd.py
+++ b/plugins/modules/net_tools/ldap/ldap_passwd.py
@@ -31,6 +31,7 @@ options:
   passwd:
     description:
       - The (plaintext) password to be set for I(dn).
+    type: str
 extends_documentation_fragment:
 - community.general.ldap.documentation
 

--- a/plugins/modules/net_tools/netcup_dns.py
+++ b/plugins/modules/net_tools/netcup_dns.py
@@ -20,32 +20,39 @@ options:
     description:
       - API key for authentication, must be obtained via the netcup CCP (U(https://ccp.netcup.net))
     required: True
+    type: str
   api_password:
     description:
       - API password for authentication, must be obtained via the netcup CCP (https://ccp.netcup.net)
     required: True
+    type: str
   customer_id:
     description:
       - Netcup customer id
     required: True
+    type: int
   domain:
     description:
       - Domainname the records should be added / removed
     required: True
+    type: str
   record:
     description:
       - Record to add or delete, supports wildcard (*). Default is C(@) (e.g. the zone name)
     default: "@"
     aliases: [ name ]
+    type: str
   type:
     description:
       - Record type
     choices: ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS']
     required: True
+    type: str
   value:
     description:
       - Record value
     required: true
+    type: str
   solo:
     type: bool
     default: False
@@ -56,12 +63,14 @@ options:
     description:
       - Record priority. Required for C(type=MX)
     required: False
+    type: int
   state:
     description:
       - Whether the record should exist or not
     required: False
     default: present
     choices: [ 'present', 'absent' ]
+    type: str
 requirements:
   - "nc-dnsapi >= 0.1.3"
 author: "Nicolai Buchwitz (@nbuchwitz)"

--- a/plugins/modules/notification/rocketchat.py
+++ b/plugins/modules/notification/rocketchat.py
@@ -204,18 +204,18 @@ def do_notify_rocketchat(module, domain, token, protocol, payload):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            domain=dict(type='str', required=True, default=None),
+            domain=dict(type='str', required=True),
             token=dict(type='str', required=True, no_log=True),
             protocol=dict(type='str', default='https', choices=['http', 'https']),
-            msg=dict(type='str', required=False, default=None),
-            channel=dict(type='str', default=None),
+            msg=dict(type='str', required=False),
+            channel=dict(type='str'),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),
-            icon_emoji=dict(type='str', default=None),
+            icon_emoji=dict(type='str'),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal', choices=['normal', 'good', 'warning', 'danger']),
-            attachments=dict(type='list', required=False, default=None)
+            attachments=dict(type='list', required=False)
         )
     )
 

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -815,7 +815,6 @@ def main():
                             ['activationkey', 'consumer_id'],
                             ['activationkey', 'environment'],
                             ['activationkey', 'autosubscribe'],
-                            ['force', 'consumer_id'],
                             ['pool', 'pool_ids']],
         required_if=[['state', 'present', ['username', 'activationkey'], True]],
     )

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -128,8 +128,7 @@ options:
         description: The CA bundle string with custom certificates. defaults to None.
       path:
         type: str
-        description: Database name for oVirt metrics. Defaults to ovirt_engine_history.
-        default: ovirt_engine_history
+        description: Database name for oVirt metrics. Defaults to C(ovirt_engine_history).
 
   alerts:
     description: Alerts endpoint connection information.
@@ -175,6 +174,12 @@ options:
       auth_key:
         type: str
         description: SSH private key.
+      validate_certs:
+        description:
+          - Whether certificates should be verified for connections.
+        type: bool
+        default: yes
+        aliases: [ verify_ssl ]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/remote_management/stacki/stacki_host.py
+++ b/plugins/modules/remote_management/stacki/stacki_host.py
@@ -19,29 +19,36 @@ options:
     description:
      - Name of the host to be added to Stacki.
     required: True
+    type: str
   stacki_user:
     description:
      - Username for authenticating with Stacki API, but if not
        specified, the environment variable C(stacki_user) is used instead.
     required: True
+    type: str
   stacki_password:
     description:
      - Password for authenticating with Stacki API, but if not
        specified, the environment variable C(stacki_password) is used instead.
     required: True
+    type: str
   stacki_endpoint:
     description:
      - URL for the Stacki API Endpoint.
     required: True
+    type: str
   prim_intf_mac:
     description:
      - MAC Address for the primary PXE boot network interface.
+    type: str
   prim_intf_ip:
     description:
      - IP Address for the primary network interface.
+    type: str
   prim_intf:
     description:
      - Name of the primary network interface.
+    type: str
   force_install:
     description:
      - Set value to True to force node into install state if it already exists in stacki.

--- a/plugins/modules/remote_management/wakeonlan.py
+++ b/plugins/modules/remote_management/wakeonlan.py
@@ -19,14 +19,17 @@ options:
     description:
     - MAC address to send Wake-on-LAN broadcast packet for.
     required: true
+    type: str
   broadcast:
     description:
     - Network broadcast address to use for broadcasting magic Wake-on-LAN packet.
     default: 255.255.255.255
+    type: str
   port:
     description:
     - UDP port to use for magic Wake-on-LAN packet.
     default: 7
+    type: int
 todo:
   - Add arping support to check whether the system is up (before and after)
   - Enable check-mode support (when we have arping support)

--- a/plugins/modules/system/runit.py
+++ b/plugins/modules/system/runit.py
@@ -87,7 +87,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 
-def _load_dist_subclass(cls, *args, **kwargs):
+def _load_dist_subclass(cls, *args, **kwargs):  # @FIXME remove unused function?
     '''
     Used for derivative implementations
     '''
@@ -239,7 +239,7 @@ def main():
             name=dict(type='str', required=True),
             state=dict(type='str', choices=['killed', 'once', 'reloaded', 'restarted', 'started', 'stopped']),
             enabled=dict(type='bool'),
-            dist=dict(type='str', default='runit'),
+            dist=dict(type='str', default='runit'),  # @FIXME unused param?
             service_dir=dict(type='str', default='/var/service'),
             service_src=dict(type='str', default='/etc/sv'),
         ),

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
@@ -41,9 +41,11 @@ options:
         description:
           - An optional comment to add to the object
     resolved:
+        type: bool
         description:
           - Whether or not the object is resolved
     resolved6:
+        type: bool
         description:
           - Whether or not the object is resolved
 
@@ -118,8 +120,8 @@ def main():
             address=dict(type='str', required=True),
             comment=dict(type='str', required=False, default=""),
             address6=dict(type='str', required=False),
-            resolved=dict(type='boolean', required=False),  # @FIXME bool instead of boolean
-            resolved6=dict(type='boolean', required=False),  # @FIXME bool instead of boolean
+            resolved=dict(type='bool', required=False),
+            resolved6=dict(type='bool', required=False),
         )
     )
     try:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -4,10 +4,8 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_blueprint_package.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_loadbalancer.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_modify_server.py validate-modules:parameter-list-no-elements
@@ -76,15 +74,8 @@ plugins/modules/cloud/lxc/lxc_container.py pylint:blacklisted-name
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-missing-type
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:undocumented-parameter
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-missing-type
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/oneandone/oneandone_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/oneandone/oneandone_load_balancer.py validate-modules:parameter-list-no-elements
@@ -95,15 +86,9 @@ plugins/modules/cloud/online/online_server_facts.py validate-modules:return-synt
 plugins/modules/cloud/online/online_server_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/opennebula/one_host.py validate-modules:doc-missing-type
 plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_image.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_service.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/oracle/oci_vcn.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
@@ -115,8 +100,6 @@ plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py validate-modules:parameter
 plugins/modules/cloud/ovirt/ovirt_disk_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_disk_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_event_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:doc-missing-type
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:undocumented-parameter
 plugins/modules/cloud/ovirt/ovirt_group_facts.py validate-modules:doc-missing-type
@@ -165,7 +148,6 @@ plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-no
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
 plugins/modules/cloud/packet/packet_volume_attachment.py pylint:ansible-bad-function
 plugins/modules/cloud/profitbricks/profitbricks.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/profitbricks/profitbricks_nic.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:doc-missing-type
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:undocumented-parameter
@@ -196,15 +178,11 @@ plugins/modules/cloud/scaleway/scaleway_snapshot_facts.py validate-modules:retur
 plugins/modules/cloud/scaleway/scaleway_snapshot_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/smartos/imgadm.py validate-modules:doc-missing-type
-plugins/modules/cloud/smartos/imgadm.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/smartos/smartos_image_info.py validate-modules:doc-missing-type
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/softlayer/sl_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -212,12 +190,8 @@ plugins/modules/cloud/univention/udm_dns_record.py validate-modules:parameter-ty
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:undocumented-parameter
-plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/webfaction/webfaction_app.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_db.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_domain.py validate-modules:doc-missing-type
@@ -267,17 +241,10 @@ plugins/modules/database/vertica/vertica_user.py validate-modules:doc-missing-ty
 plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-parameter
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
-plugins/modules/monitoring/bigpanda.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/monitoring/bigpanda.py validate-modules:invalid-argument-name
 plugins/modules/monitoring/datadog/datadog_event.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:invalid-argument-name
@@ -291,19 +258,12 @@ plugins/modules/monitoring/sensu/sensu_client.py validate-modules:parameter-list
 plugins/modules/monitoring/sensu/sensu_handler.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/statusio_maintenance.py pylint:blacklisted-name
 plugins/modules/monitoring/statusio_maintenance.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/cloudflare_dns.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/dnsimple.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/ip_netns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc  # This triggers when a parameter is undocumented
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/ldap/ldap_passwd.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:invalid-ansiblemodule-schema
@@ -401,7 +361,6 @@ plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-element
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
-plugins/modules/notification/rocketchat.py validate-modules:no-default-for-required-parameter
 plugins/modules/notification/rocketchat.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/sendgrid.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/slack.py validate-modules:parameter-list-no-elements
@@ -442,7 +401,6 @@ plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-m
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
@@ -495,7 +453,6 @@ plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-def
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/wakeonlan.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/bzr.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/git_config.py validate-modules:doc-missing-type
 plugins/modules/source_control/git_config.py validate-modules:parameter-type-not-in-doc
@@ -596,7 +553,6 @@ plugins/modules/system/timezone.py pylint:blacklisted-name
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc
 scripts/inventory/gce.py pylint:blacklisted-name
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py future-import-boilerplate
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py metaclass-boilerplate

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,10 +4,8 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_blueprint_package.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_loadbalancer.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/centurylink/clc_modify_server.py validate-modules:parameter-list-no-elements
@@ -76,15 +74,8 @@ plugins/modules/cloud/lxc/lxc_container.py pylint:blacklisted-name
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-missing-type
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:undocumented-parameter
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-missing-type
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/oneandone/oneandone_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/oneandone/oneandone_load_balancer.py validate-modules:parameter-list-no-elements
@@ -95,15 +86,9 @@ plugins/modules/cloud/online/online_server_facts.py validate-modules:return-synt
 plugins/modules/cloud/online/online_server_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/opennebula/one_host.py validate-modules:doc-missing-type
 plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_image.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_service.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/oracle/oci_vcn.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
@@ -115,8 +100,6 @@ plugins/modules/cloud/ovirt/ovirt_datacenter_facts.py validate-modules:parameter
 plugins/modules/cloud/ovirt/ovirt_disk_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_disk_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_event_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:doc-missing-type
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:undocumented-parameter
 plugins/modules/cloud/ovirt/ovirt_group_facts.py validate-modules:doc-missing-type
@@ -165,7 +148,6 @@ plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-no
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
 plugins/modules/cloud/packet/packet_volume_attachment.py pylint:ansible-bad-function
 plugins/modules/cloud/profitbricks/profitbricks.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/profitbricks/profitbricks_nic.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:doc-missing-type
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:undocumented-parameter
@@ -196,15 +178,11 @@ plugins/modules/cloud/scaleway/scaleway_snapshot_facts.py validate-modules:retur
 plugins/modules/cloud/scaleway/scaleway_snapshot_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/smartos/imgadm.py validate-modules:doc-missing-type
-plugins/modules/cloud/smartos/imgadm.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/smartos/smartos_image_info.py validate-modules:doc-missing-type
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/softlayer/sl_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -212,12 +190,8 @@ plugins/modules/cloud/univention/udm_dns_record.py validate-modules:parameter-ty
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:undocumented-parameter
-plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/webfaction/webfaction_app.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_db.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_domain.py validate-modules:doc-missing-type
@@ -267,17 +241,10 @@ plugins/modules/database/vertica/vertica_user.py validate-modules:doc-missing-ty
 plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-parameter
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
 plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
-plugins/modules/monitoring/bigpanda.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/monitoring/bigpanda.py validate-modules:invalid-argument-name
 plugins/modules/monitoring/datadog/datadog_event.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:invalid-argument-name
@@ -291,19 +258,12 @@ plugins/modules/monitoring/sensu/sensu_client.py validate-modules:parameter-list
 plugins/modules/monitoring/sensu/sensu_handler.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/statusio_maintenance.py pylint:blacklisted-name
 plugins/modules/monitoring/statusio_maintenance.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/cloudflare_dns.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/dnsimple.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/ip_netns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc  # This triggers when a parameter is undocumented
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/ldap/ldap_passwd.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:invalid-ansiblemodule-schema
@@ -401,7 +361,6 @@ plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-element
 plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
-plugins/modules/notification/rocketchat.py validate-modules:no-default-for-required-parameter
 plugins/modules/notification/rocketchat.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/sendgrid.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/slack.py validate-modules:parameter-list-no-elements
@@ -442,7 +401,6 @@ plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-m
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
@@ -495,7 +453,6 @@ plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-def
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/wakeonlan.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/bzr.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/git_config.py validate-modules:doc-missing-type
 plugins/modules/source_control/git_config.py validate-modules:parameter-type-not-in-doc
@@ -596,7 +553,6 @@ plugins/modules/system/timezone.py pylint:blacklisted-name
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc
 scripts/inventory/gce.py pylint:blacklisted-name
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py future-import-boilerplate
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py metaclass-boilerplate

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -4,8 +4,6 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:no-default-for-required-parameter
-plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/docker/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path
 plugins/modules/cloud/google/gcdns_record.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/google/gcdns_record.py validate-modules:invalid-documentation
@@ -57,13 +55,6 @@ plugins/modules/cloud/linode/linode.py validate-modules:undocumented-parameter
 plugins/modules/cloud/lxc/lxc_container.py pylint:blacklisted-name
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:doc-missing-type
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:undocumented-parameter
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:doc-missing-type
-plugins/modules/cloud/lxd/lxd_profile.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/misc/helm.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/misc/helm.py validate-modules:invalid-documentation
 plugins/modules/cloud/misc/ovirt.py validate-modules:deprecation-mismatch
@@ -76,12 +67,6 @@ plugins/modules/cloud/online/online_user_facts.py validate-modules:deprecation-m
 plugins/modules/cloud/online/online_user_facts.py validate-modules:invalid-documentation
 plugins/modules/cloud/online/online_user_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/opennebula/one_host.py validate-modules:doc-missing-type
-plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_image.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_service.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:invalid-documentation
@@ -99,9 +84,7 @@ plugins/modules/cloud/ovirt/ovirt_disk_facts.py validate-modules:invalid-documen
 plugins/modules/cloud/ovirt/ovirt_event_facts.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/ovirt/ovirt_event_facts.py validate-modules:invalid-documentation
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:deprecation-mismatch
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:invalid-documentation
-plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py validate-modules:undocumented-parameter
 plugins/modules/cloud/ovirt/ovirt_group_facts.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/ovirt/ovirt_group_facts.py validate-modules:doc-missing-type
@@ -163,7 +146,6 @@ plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-type-no
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:doc-missing-type
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
-plugins/modules/cloud/profitbricks/profitbricks_nic.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:doc-missing-type
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:undocumented-parameter
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path
@@ -199,22 +181,14 @@ plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:depreca
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:invalid-documentation
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/smartos/imgadm.py validate-modules:doc-missing-type
-plugins/modules/cloud/smartos/imgadm.py validate-modules:no-default-for-required-parameter
 plugins/modules/cloud/smartos/smartos_image_info.py validate-modules:doc-missing-type
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:doc-missing-type
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_dns_record.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:undocumented-parameter
-plugins/modules/cloud/univention/udm_group.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_group.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/univention/udm_user.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/webfaction/webfaction_app.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_db.py validate-modules:doc-missing-type
 plugins/modules/cloud/webfaction/webfaction_domain.py validate-modules:doc-missing-type
@@ -256,21 +230,10 @@ plugins/modules/database/vertica/vertica_schema.py validate-modules:undocumented
 plugins/modules/database/vertica/vertica_user.py validate-modules:doc-missing-type
 plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-parameter
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
-plugins/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
-plugins/modules/monitoring/bigpanda.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/monitoring/icinga2_host.py validate-modules:undocumented-parameter
 plugins/modules/monitoring/statusio_maintenance.py pylint:blacklisted-name
-plugins/modules/net_tools/cloudflare_dns.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/ip_netns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ipinfoio_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:deprecation-mismatch
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:invalid-documentation
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc
@@ -278,9 +241,6 @@ plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parame
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/ldap/ldap_passwd.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:doc-missing-type
-plugins/modules/net_tools/netcup_dns.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:doc-missing-type
 plugins/modules/net_tools/nios/nios_a_record.py validate-modules:parameter-type-not-in-doc
@@ -350,7 +310,6 @@ plugins/modules/net_tools/nios/nios_zone.py validate-modules:undocumented-parame
 plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
-plugins/modules/notification/rocketchat.py validate-modules:no-default-for-required-parameter
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/language/maven_artifact.py validate-modules:parameter-type-not-in-doc
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid
@@ -381,7 +340,6 @@ plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:parameter-
 plugins/modules/remote_management/lxca/lxca_cmms.py validate-modules:doc-missing-type
 plugins/modules/remote_management/lxca/lxca_nodes.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter
@@ -421,7 +379,6 @@ plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-def
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/wakeonlan.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/bzr.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/git_config.py validate-modules:doc-missing-type
 plugins/modules/source_control/git_config.py validate-modules:parameter-type-not-in-doc
@@ -527,7 +484,6 @@ plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:deprecation-mismatch
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:invalid-documentation
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py validate-modules:parameter-type-not-in-doc
 scripts/inventory/gce.py pylint:blacklisted-name
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py future-import-boilerplate
 tests/unit/plugins/modules/cloud/google/test_gcp_forwarding_rule.py metaclass-boilerplate


### PR DESCRIPTION
##### SUMMARY
Backport of #1423 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/cloud/ovirt/ovirt_external_provider_facts.py
plugins/modules/cloud/profitbricks/profitbricks_nic.py
plugins/modules/cloud/smartos/imgadm.py
plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
plugins/modules/cloud/univention/udm_group.py
plugins/modules/cloud/univention/udm_user.py
plugins/modules/identity/keycloak/keycloak_clienttemplate.py
plugins/modules/identity/keycloak/keycloak_client.py
plugins/modules/monitoring/bigpanda.py
plugins/modules/notification/rocketchat.py
plugins/modules/remote_management/manageiq/manageiq_provider.py
plugins/modules/remote_management/stacki/stacki_host.py
plugins/modules/remote_management/wakeonlan.py
plugins/modules/net_tools/netcup_dns.py
plugins/modules/net_tools/ipinfoio_facts.py
plugins/modules/net_tools/ip_netns.py
plugins/modules/net_tools/cloudflare_dns.py
plugins/modules/cloud/opennebula/one_vm.py
plugins/modules/cloud/opennebula/one_service.py
plugins/modules/cloud/opennebula/one_image.py
plugins/modules/cloud/opennebula/one_image_info.py
plugins/modules/cloud/opennebula/one_host.py
plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
plugins/modules/cloud/lxd/lxd_container.py
plugins/modules/packaging/os/redhat_subscription.py
