### PR TITLE
Remove adejoux as maintainer from aix_lvol

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -801,8 +801,6 @@ files:
     maintainers: $team_aix
     labels: aix
     keywords: aix efix lpar wpar
-  $modules/system/aix_lvol.py:
-    maintainers: adejoux
   $modules/system/alternatives.py:
     maintainers: mulby
     labels: alternatives


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/community.general/pull/1330 for details.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
