### PR TITLE
json_query: Handle AnsibleUnicode, AnsibleUnsafeText

### DIFF
--- a/changelogs/fragments/320_unsafe_text.yml
+++ b/changelogs/fragments/320_unsafe_text.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- json_query - handle ``AnsibleUnicode`` and ``AnsibleUnsafeText`` (https://github.com/ansible-collections/community.general/issues/320).

--- a/plugins/filter/json_query.py
+++ b/plugins/filter/json_query.py
@@ -35,6 +35,9 @@ def json_query(data, expr):
         raise AnsibleError('You need to install "jmespath" prior to running '
                            'json_query filter')
 
+    # Hack to handle Ansible String Types
+    # See issue: https://github.com/ansible-collections/community.general/issues/320
+    jmespath.functions.REVERSE_TYPES_MAP['string'] = jmespath.functions.REVERSE_TYPES_MAP['string'] + ('AnsibleUnicode', 'AnsibleUnsafeText', )
     try:
         return jmespath.search(expr, data)
     except jmespath.exceptions.JMESPathError as e:


### PR DESCRIPTION
##### SUMMARY

jmespath library does not undestand custom string types
such as AnsibleUnicode, and AnsibleUnsafeText.
So user need to use ``to_json | from_json`` filter while using
functions like ``starts_with`` and ``contains`` etc.
This hack will allow user to get rid of this filter.

Fixes: #320

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/320_unsafe_text.yml
plugins/filter/json_query.py
