### PR TITLE
Fix #1435: mas : Fix "invalid literal" when no app

### DIFF
--- a/changelogs/fragments/1436-mas-fix-no-app-installed.yml
+++ b/changelogs/fragments/1436-mas-fix-no-app-installed.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "mas - Fix ``invalid literal`` when no app (https://github.com/ansible-collections/community.general/pull/1436)."
+  - "mas - fix ``invalid literal`` when no app can be found (https://github.com/ansible-collections/community.general/pull/1436)."

--- a/changelogs/fragments/1436-mas-fix-no-app-installed.yml
+++ b/changelogs/fragments/1436-mas-fix-no-app-installed.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "mas - Fix ``invalid literal`` when no app (https://github.com/ansible-collections/community.general/pull/1436)."

--- a/plugins/modules/packaging/os/mas.py
+++ b/plugins/modules/packaging/os/mas.py
@@ -183,6 +183,8 @@ class Mas(object):
 
         rc, raw_apps, err = self.run([command])
         rows = raw_apps.split("\n")
+        if rows[0] == "No installed apps found":
+            rows = []
         apps = []
         for r in rows:
             # Format: "123456789 App Name"


### PR DESCRIPTION
All details are in issue #1435