### PR TITLE
Deprecate gluster_* modules

### DIFF
--- a/changelogs/fragments/gluster-deprecation.yaml
+++ b/changelogs/fragments/gluster-deprecation.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+- The ``gluster_heal_info``, ``gluster_peer`` and ``gluster_volume`` modules have migrated to the `gluster.gluster <https://galaxy.ansible.com/gluster/gluster>`_ collection. Ansible-base 2.10.1 adjusted the routing target to point to the modules in that collection, so we will remove these modules in community.general 3.0.0. If you use Ansible 2.9, or use FQCNs ``community.general.gluster_*`` in your playbooks and/or roles, please update them to use the modules from ``gluster.gluster`` instead.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -146,6 +146,18 @@ plugin_routing:
       tombstone:
         removal_version: 2.0.0
         warning_text: Use community.general.github_webhook and community.general.github_webhook_info instead.
+    gluster_heal_info:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: The gluster modules have migrated to the gluster.gluster collection. Use gluster.gluster.gluster_heal_info instead.
+    gluster_peer:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: The gluster modules have migrated to the gluster.gluster collection. Use gluster.gluster.gluster_peer instead.
+    gluster_volume:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: The gluster modules have migrated to the gluster.gluster collection. Use gluster.gluster.gluster_volume instead.
     helm:
       deprecation:
         removal_version: 3.0.0

--- a/plugins/modules/storage/glusterfs/gluster_heal_info.py
+++ b/plugins/modules/storage/glusterfs/gluster_heal_info.py
@@ -11,6 +11,10 @@ DOCUMENTATION = '''
 ---
 module: gluster_heal_info
 short_description: Gather information on self-heal or rebalance status
+deprecated:
+    removed_in: 3.0.0
+    why: The gluster modules have migrated to the gluster.gluster collection.
+    alternative: Use M(gluster.gluster.gluster_heal_info) instead.
 author: "Devyani Kota (@devyanikota)"
 description:
   - Gather facts about either self-heal or rebalance status.

--- a/plugins/modules/storage/glusterfs/gluster_peer.py
+++ b/plugins/modules/storage/glusterfs/gluster_peer.py
@@ -14,6 +14,10 @@ DOCUMENTATION = '''
 ---
 module: gluster_peer
 short_description: Attach/Detach peers to/from the cluster
+deprecated:
+    removed_in: 3.0.0
+    why: The gluster modules have migrated to the gluster.gluster collection.
+    alternative: Use M(gluster.gluster.gluster_peer) instead.
 description:
   - Create or diminish a GlusterFS trusted storage pool. A set of nodes can be
     added into an existing trusted storage pool or a new storage pool can be

--- a/plugins/modules/storage/glusterfs/gluster_volume.py
+++ b/plugins/modules/storage/glusterfs/gluster_volume.py
@@ -10,6 +10,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
 module: gluster_volume
 short_description: Manage GlusterFS volumes
+deprecated:
+    removed_in: 3.0.0
+    why: The gluster modules have migrated to the gluster.gluster collection.
+    alternative: Use M(gluster.gluster.gluster_volume) instead.
 description:
   - Create, remove, start, stop and tune GlusterFS volumes
 options:

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -351,7 +351,13 @@ plugins/modules/source_control/github/github_webhook_info.py validate-modules:pa
 plugins/modules/source_control/hg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:doc-missing-type
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:parameter-type-not-in-doc
+plugins/modules/storage/glusterfs/gluster_heal_info.py validate-modules:deprecation-mismatch
+plugins/modules/storage/glusterfs/gluster_heal_info.py validate-modules:invalid-documentation
 plugins/modules/storage/glusterfs/gluster_heal_info.py validate-modules:parameter-type-not-in-doc
+plugins/modules/storage/glusterfs/gluster_peer.py validate-modules:deprecation-mismatch
+plugins/modules/storage/glusterfs/gluster_peer.py validate-modules:invalid-documentation
+plugins/modules/storage/glusterfs/gluster_volume.py validate-modules:deprecation-mismatch
+plugins/modules/storage/glusterfs/gluster_volume.py validate-modules:invalid-documentation
 plugins/modules/storage/glusterfs/gluster_volume.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/ibm/ibm_sa_domain.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_host.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
The gluster_* modules have been in gluster.gluster for some time (https://github.com/ansible-collections/community.general/issues/761), that collection has been included since Ansible 2.10.0 (https://github.com/ansible-community/ansible-build-data/commit/f73bb171fc3eb2ee6cf61d0d337e5ece4a8ca4e8#diff-d4908359527020805b8e055ee817d68b049157109fc2516d2a9f76c32384b58d), and since ansible-base 2.10.1 the short names redirect to gluster.gluster (https://github.com/ansible/ansible/pull/71240, https://github.com/ansible/ansible/pull/71264). So it's time to deprecate the modules here (for community.general 2.0.0), with removal for 3.0.0 (a bit shorter than our usual deprecation period, but I think it's ok since it mostly affects Ansible 2.9 users), and redirect users to the gluster.gluster collection.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
gluster_* modules
