### PR TITLE
Supporting scripts for dealing with ignore.txt files

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -484,7 +484,6 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/interfaces_file.py pylint:blacklisted-name
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/java_cert.py pylint:blacklisted-name
-plugins/modules/system/launchd.py use-argspec-type-path  # False positive
 plugins/modules/system/lvg.py pylint:blacklisted-name
 plugins/modules/system/lvol.py pylint:blacklisted-name
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -484,7 +484,6 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/interfaces_file.py pylint:blacklisted-name
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/java_cert.py pylint:blacklisted-name
-plugins/modules/system/launchd.py use-argspec-type-path  # False positive
 plugins/modules/system/lvg.py pylint:blacklisted-name
 plugins/modules/system/lvol.py pylint:blacklisted-name
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -382,7 +382,6 @@ plugins/modules/system/gconftool2.py pylint:blacklisted-name
 plugins/modules/system/interfaces_file.py pylint:blacklisted-name
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/java_cert.py pylint:blacklisted-name
-plugins/modules/system/launchd.py use-argspec-type-path  # False positive
 plugins/modules/system/lvg.py pylint:blacklisted-name
 plugins/modules/system/lvol.py pylint:blacklisted-name
 plugins/modules/system/parted.py pylint:blacklisted-name

--- a/tests/utils/sanity_ignores/count-ignores
+++ b/tests/utils/sanity_ignores/count-ignores
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import sys
 import re

--- a/tests/utils/sanity_ignores/count-ignores
+++ b/tests/utils/sanity_ignores/count-ignores
@@ -1,4 +1,10 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# (c) 2020, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
 
 import sys
 import re

--- a/tests/utils/sanity_ignores/count-ignores
+++ b/tests/utils/sanity_ignores/count-ignores
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+from signal import signal, SIGPIPE, SIG_DFL
+
+
+signal(SIGPIPE,SIG_DFL) 
+result = dict()
+excludes = (
+    #"/cloud/google/",
+    #"/cloud/ovirt/",
+    #"/net_tools/nios/",
+    #"/storage/netapp/",
+)
+assert 2 <= len(sys.argv) <= 4
+filename=sys.argv[1]
+depth=sys.argv[2] if len(sys.argv) == 3 else "f"
+re_filter=re.compile(sys.argv[3]) if len(sys.argv) == 4 else re.compile(".*")
+
+def incr_elem(elem):
+    result[elem] = result.get(elem, 0) + 1
+
+def retrieve_lines(fh):
+    lines = []
+    for line in fh:
+        if not line.startswith("plugins/modules/") or any([e in line for e in excludes]):
+            continue
+        line = line.split()[0]
+        line = "/".join(line.split("/")[2:])
+        lines.append(line)
+    return lines
+
+if filename == '-':
+    lines = retrieve_lines(sys.stdin)
+else:
+    with open(filename) as ifile:
+        lines = retrieve_lines(ifile)
+
+if depth == "f":
+    for line in lines:
+        incr_elem(line)
+elif 0 < int(depth):
+    depth = int(depth)
+    for line in lines:
+        a = line.split("/")
+        term = "/".join([a[x] for x in range(depth) if x < len(a)])
+        incr_elem(term)
+
+for line, count in list(sorted(result.items(), key=lambda item: item[1], reverse=True)):
+    if not re_filter.match(line):
+        continue
+    print(f"{count:6d} {line}")
+        

--- a/tests/utils/sanity_ignores/sort-ignores
+++ b/tests/utils/sanity_ignores/sort-ignores
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sortit() {
+  awk '{ print $2 }' | sort | uniq -c | sort -rn
+}
+
+if [[ -n "$1" ]]; then
+  cat "$@" | sortit
+else
+  sortit
+fi

--- a/tests/utils/sanity_ignores/sort-ignores
+++ b/tests/utils/sanity_ignores/sort-ignores
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sortit() {
   awk '{ print $2 }' | sort | uniq -c | sort -rn

--- a/tests/utils/sanity_ignores/sort-ignores
+++ b/tests/utils/sanity_ignores/sort-ignores
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 sortit() {
   awk '{ print $2 }' | sort | uniq -c | sort -rn

--- a/tests/utils/sanity_ignores/tmp-ansible-test
+++ b/tests/utils/sanity_ignores/tmp-ansible-test
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+self=${0##.*/}
+
+
+msg() {
+  echo "$@" >&2
+}
+
+die() {
+  msg "$@"
+  exit 1
+}
+
+usage() {
+  [[ -n "$1" ]] && msg "$@"
+  cat >&2 <<EOM
+usage: $self [-keep] [<namespace> <collection>] [ansible-test-options]
+EOM
+  exit 1
+}
+
+keep=""
+[[ "$1" == "-keep" ]] && {
+  keep=1
+  shift
+}
+if [[ -r galaxy.yml ]]; then
+  namespace=$(cat galaxy.yml | grep '^namespace:' | awk -F': ' '{ print $2 }')
+  collection=$(cat galaxy.yml | grep '^name:' | awk -F': ' '{ print $2 }')
+else
+  namespace="$1"
+  collection="$2"
+  shift 2
+fi
+[[ -z "$namespace" || -z "$collection" ]] && usage
+
+top_dir=$(mktemp -d /tmp/dev.XXXXX)
+msg top_dir=$top_dir
+collections_dir=$top_dir/ansible_collections
+export COLLECTIONS_PATH=$top_dir:$COLLECTIONS_PATH
+
+coll_dir=$top_dir/ansible_collections/$namespace/$collection
+msg coll_dir=$coll_dir
+
+mkdir -p $coll_dir
+cp -pr * $coll_dir/
+
+cd $coll_dir
+ansible-test "$@"
+rc=$?
+
+[[ -z "$keep" ]] && {
+  msg -e "\nDeleting $top_dir"
+  rm -rf $top_dir
+}
+echo ""
+echo ""
+
+exit $rc
+

--- a/tests/utils/sanity_ignores/tmp-ansible-test
+++ b/tests/utils/sanity_ignores/tmp-ansible-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 self=${0##.*/}
 

--- a/tests/utils/sanity_ignores/tmp-ansible-test
+++ b/tests/utils/sanity_ignores/tmp-ansible-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 self=${0##.*/}
 

--- a/tests/utils/sanity_ignores/tmp-tox
+++ b/tests/utils/sanity_ignores/tmp-tox
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+basedir=${0%/*}
+
+tox_file=${basedir}/tox.ini
+
+export PATH CHDIR
+PATH=${basedir}:$PATH
+CHDIR=$(pwd)
+
+exec tox -c "$tox_file" --workdir "$(pwd)/.tox" "$@"
+

--- a/tests/utils/sanity_ignores/tmp-tox
+++ b/tests/utils/sanity_ignores/tmp-tox
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 basedir=${0%/*}
 

--- a/tests/utils/sanity_ignores/tmp-tox
+++ b/tests/utils/sanity_ignores/tmp-tox
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 basedir=${0%/*}
 

--- a/tests/utils/sanity_ignores/tox.ini
+++ b/tests/utils/sanity_ignores/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+isolated_build = True
+envlist = sanity-ansible{29,210,dev}
+skipdist = true
+
+[base]
+deps =
+  ansible29: ansible>=2.9,<2.10
+  ansible210: ansible>=2.10,<2.11
+  ansibledev: https://github.com/ansible/ansible/archive/devel.tar.gz
+
+[testenv:sanity-ansible{29,210,dev}]
+passenv = PWD HOME
+skip_install = true
+deps = {[base]deps}
+allowlist_externals = tmp-ansible-test
+changedir = {env:CHDIR}
+commands =
+  tmp-ansible-test sanity --docker default -v {posargs}
+
+[testenv:units-ansible{29,210,dev}]
+passenv = PWD HOME
+skip_install = true
+deps = {[base]deps}
+allowlist_externals = tmp-ansible-test
+changedir = {env:CHDIR}
+commands =
+  tmp-ansible-test units --docker default -v {posargs}
+


### PR DESCRIPTION
##### SUMMARY
Scripts to assist removal of lines from the tests/sanity/ignore*.txt files

Brief description:
- ``count-ignores N <ignore-file>`` will count # of ignore files per module/group, N determines how many levels we use for grouping
- ``sort-ignores <ignore-files>`` will sort by the count of how many times a particular validation is ignored
- ``tmp-ansible-test`` will copy the collection structure to a temporary dir and run ansible-test on it
- ``tmp-tox`` will automatically create venvs with ansible 2.9, 2.10 and devel, and run ``tmp-ansible-test`` in each of them

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
Scripts ``count-ignores`` and ``sort-ignores`` should work in any Posix system. Examples:
```bash
$ ./tests/utils/sanity_ignores/sort-ignores tests/sanity/ignore-2.10.txt | head -3
    129 validate-modules:parameter-list-no-elements
     87 validate-modules:parameter-type-not-in-doc
     84 validate-modules:doc-missing-type
```
```bash
$ ./tests/utils/sanity_ignores/count-ignores tests/sanity/ignore-2.9.txt 1 | head -3
   165 cloud
    74 net_tools
    52 remote_management
$ ./tests/utils/sanity_ignores/count-ignores tests/sanity/ignore-2.9.txt 3 | head -3
     6 net_tools/nios/nios_nsgroup.py
     4 cloud/ovirt/ovirt_host_storage_facts.py
     4 cloud/ovirt/ovirt_storage_template_facts.py
```
The script ``tmp-ansible-test`` requires ``ansible-test`` to be in the ``PATH``, and respectively ``tmp-tox`` requires ``tox`` to be in ``PATH``. Example:
```bash
$ ./tests/utils/sanity_ignores/tmp-tox -- --test validate-modules plugins/modules/system/lvol.py
sanity-ansible29 installed: ansible==2.9.15,cffi==1.14.4,cryptography==3.2.1,Jinja2==2.11.2,MarkupSafe==1.1.1,pycparser==2.20,PyYAML==5.3.1,six==1.15.0
sanity-ansible29 run-test-pre: PYTHONHASHSEED='1994142645'
sanity-ansible29 run-test: commands[0] | tmp-ansible-test sanity --docker default -v --test validate-modules plugins/modules/system/lvol.py
top_dir=/tmp/dev.0cJUi
coll_dir=/tmp/dev.0cJUi/ansible_collections/community/general
...
sanity-ansible210 run-test: commands[0] | tmp-ansible-test sanity --docker default -v --test validate-modules plugins/modules/system/lvol.py
...
sanity-ansibledev run-test: commands[0] | tmp-ansible-test sanity --docker default -v --test validate-modules plugins/modules/system/lvol.py
...
_____________________________________________________________ summary ______________________________________________________________
  sanity-ansible29: commands succeeded
  sanity-ansible210: commands succeeded
  sanity-ansibledev: commands succeeded
  congratulations :)
```
