### PR TITLE
Temporarily disable zypper_repository tests.

### DIFF
--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -5,3 +5,4 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/rhel
+disabled  # FIXME


### PR DESCRIPTION
##### SUMMARY
They are currently failing since ~yesterday: https://app.shippable.com/github/ansible-collections/community.general/runs/5783/45/tests https://app.shippable.com/github/ansible-collections/community.general/runs/5783/46/tests

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zypper_repository
