### PR TITLE
zypper_repository: fix broken tests

### DIFF
--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -5,4 +5,3 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/rhel
-disabled  # FIXME

--- a/tests/integration/targets/zypper_repository/tasks/test.yml
+++ b/tests/integration/targets/zypper_repository/tasks/test.yml
@@ -18,7 +18,7 @@
         - test
         - testrefresh
         - testprio
-        - Apache_Modules
+        - Apache_PHP_Modules
 
     - name: collect repo configuration after test
       shell: "grep . /etc/zypp/repos.d/*"

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -120,8 +120,8 @@
 
 - name: "Test adding a repo with custom GPG key"
   community.general.zypper_repository:
-    name: "Apache_Modules"
-    repo: "http://download.opensuse.org/repositories/Apache:/Modules/openSUSE_Tumbleweed/"
+    name: "Apache_PHP_Modules"
+    repo: "http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/"
     priority: 100
     auto_import_keys: true
     state: "present"


### PR DESCRIPTION
##### SUMMARY
Fixes #1446

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository

##### ADDITIONAL INFORMATION
It seems that https://en.opensuse.org/Additional_package_repositories#Apache_modules Tumbleweed version is missing.
Maybe it's temporary but I guess this change is OK to test the module.