### PR TITLE
Add support for keyed_groups, groups, and compose options to linode i…

### DIFF
--- a/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
+++ b/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
@@ -1,4 +1,4 @@
 minor_changes:
-    - community.general.linode - add the standard keyed_groups, groups, and
-      compose options to the linode inventory plugin
+    - linode inventory plugin - add the standard ``keyed_groups``, ``groups``,
+      and ``compose`` options 
       (https://github.com/ansible-collections/community.general/issues/1326)

--- a/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
+++ b/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - community.general.linode - add the standard keyed_groups, groups, and
+      compose options to the linode inventory plugin
+      (https://github.com/ansible-collections/community.general/issues/1326)

--- a/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
+++ b/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
@@ -1,4 +1,4 @@
 minor_changes:
-    - linode inventory plugin - add the standard ``keyed_groups``, ``groups``,
+    - linode inventory plugin - add support for ``keyed_groups``, ``groups``,
       and ``compose`` options 
       (https://github.com/ansible-collections/community.general/issues/1326)

--- a/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
+++ b/changelogs/fragments/1453-add-support-for-keyed_groups-to-linode-inventory-plugin.yml
@@ -1,4 +1,4 @@
 minor_changes:
     - linode inventory plugin - add support for ``keyed_groups``, ``groups``,
       and ``compose`` options 
-      (https://github.com/ansible-collections/community.general/issues/1326)
+      (https://github.com/ansible-collections/community.general/issues/1326).

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -40,6 +40,14 @@ DOCUMENTATION = r'''
           default: []
           type: list
           required: false
+        strict:
+          version_added: 2.0.0
+        compose:
+          version_added: 2.0.0
+        groups:
+          version_added: 2.0.0
+        keyed_groups:
+          version_added: 2.0.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -17,7 +17,7 @@ DOCUMENTATION = r'''
         - Reads inventories from the Linode API v4.
         - Uses a YAML configuration file that ends with linode.(yml|yaml).
         - Linode labels are used by default as the hostnames.
-        - The default inventory groups are built from groups (deprecated by 
+        - The default inventory groups are built from groups (deprecated by
           Linode) and not tags.
     extends_documentation_fragment:
         - constructed

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -219,7 +219,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         self._get_instances_inventory()
 
-        self._strict = self.get_option('strict')
+        strict = self.get_option('strict')
         regions, types = self._get_query_options(config_data)
         self._filter_by_config(regions, types)
 
@@ -232,14 +232,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self.get_option('groups'),
                 variables,
                 instance.label,
-                strict=self._strict)
+                strict=strict)
             self._add_host_to_keyed_groups(
                 self.get_option('keyed_groups'),
                 variables,
                 instance.label,
-                strict=self._strict)
+                strict=strict)
             self._set_composite_vars(
                 self.get_option('compose'),
                 variables,
                 instance.label,
-                strict=self._strict)
+                strict=strict)

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -17,7 +17,8 @@ DOCUMENTATION = r'''
         - Reads inventories from the Linode API v4.
         - Uses a YAML configuration file that ends with linode.(yml|yaml).
         - Linode labels are used by default as the hostnames.
-        - The inventory groups are built from groups and not tags.
+        - The default inventory groups are built from groups (deprecated by 
+          Linode) and not tags.
     extends_documentation_fragment:
         - constructed
     options:

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -73,7 +73,7 @@ import os
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.six import string_types
-from ansible.plugins.inventory import BaseInventoryPlugin,Constructable
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 
 
 try:
@@ -84,7 +84,7 @@ except ImportError:
     HAS_LINODE = False
 
 
-class InventoryModule(BaseInventoryPlugin,Constructable):
+class InventoryModule(BaseInventoryPlugin, Constructable):
 
     NAME = 'community.general.linode'
 
@@ -219,7 +219,7 @@ class InventoryModule(BaseInventoryPlugin,Constructable):
 
         self._get_instances_inventory()
 
-        self._strict=self.get_option('strict')
+        self._strict = self.get_option('strict')
         regions, types = self._get_query_options(config_data)
         self._filter_by_config(regions, types)
 
@@ -227,19 +227,19 @@ class InventoryModule(BaseInventoryPlugin,Constructable):
         self._add_instances_to_groups()
         self._add_hostvars_for_instances()
         for instance in self.instances:
-            variables=self.inventory.get_host(instance,label).get_vars();
+            variables = self.inventory.get_host(instance.label).get_vars()
             self._add_host_to_composed_groups(
-                    self.get_option('groups'),
-                    variables,
-                    instance.label,
-                    strict=self._strict)
+                self.get_option('groups'),
+                variables,
+                instance.label,
+                strict=self._strict)
             self._add_host_to_keyed_groups(
-                    self.get_option('keyed_groups'),
-                    variables,
-                    instance.label,
-                    strict=self._strict)
+                self.get_option('keyed_groups'),
+                variables,
+                instance.label,
+                strict=self._strict)
             self._set_composite_vars(
-                    self.get_option('compose'),
-                    variables,
-                    instance.label,
-                    strict=self._strict)
+                self.get_option('compose'),
+                variables,
+                instance.label,
+                strict=self._strict)


### PR DESCRIPTION
…nventory

plugin

##### SUMMARY
This adds the standard inventory plugin options keyed_groups,groups, and compose to the linode inventory plugin

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/linode.py

