### PR TITLE
Add millisecond data to splunk callback timestamp

### DIFF
--- a/changelogs/fragments/1462-splunk-millisecond.yaml
+++ b/changelogs/fragments/1462-splunk-millisecond.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - splunk - splunk plugin now supports new parameter to add milliseconds to existing timestamp field
+  - splunk - splunk plugin now supports new parameter to add milliseconds to existing timestamp field (https://github.com/ansible-collections/community.general/pull/1462).

--- a/changelogs/fragments/1462-splunk-millisecond.yaml
+++ b/changelogs/fragments/1462-splunk-millisecond.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - splunk - splunk plugin now supports new parameter to add milliseconds to existing timestamp field

--- a/changelogs/fragments/1462-splunk-millisecond.yaml
+++ b/changelogs/fragments/1462-splunk-millisecond.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - splunk - splunk plugin now supports new parameter to add milliseconds to existing timestamp field (https://github.com/ansible-collections/community.general/pull/1462).
+  - splunk callback - new parameter ``include_milliseconds`` to add milliseconds to existing timestamp field (https://github.com/ansible-collections/community.general/pull/1462).

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -127,7 +127,7 @@ class SplunkHTTPCollectorSource(object):
         data['uuid'] = result._task._uuid
         data['session'] = self.session
         data['status'] = state
-        
+
         if include_milliseconds:
             time_format = '%Y-%m-%d %H:%M:%S.%f +0000'
         else:

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -116,7 +116,7 @@ class SplunkHTTPCollectorSource(object):
         data['uuid'] = result._task._uuid
         data['session'] = self.session
         data['status'] = state
-        data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S '
+        data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f '
                                                        '+0000')
         data['host'] = self.host
         data['ip_address'] = self.ip_address

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -127,12 +127,13 @@ class SplunkHTTPCollectorSource(object):
         data['uuid'] = result._task._uuid
         data['session'] = self.session
         data['status'] = state
+        
         if include_milliseconds:
-            data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f '
-                                                       '+0000')
+            time_format = '%Y-%m-%d %H:%M:%S.%f +0000'
         else:
-            data['timestamp'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S '
-                                                       '+0000')
+            time_format = '%Y-%m-%d %H:%M:%S +0000'
+
+        data['timestamp'] = datetime.utcnow().strftime(time_format)
         data['host'] = self.host
         data['ip_address'] = self.ip_address
         data['user'] = self.user

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -67,6 +67,7 @@ DOCUMENTATION = '''
             key: include_milliseconds
         type: bool
         default: false
+        version_added: 2.0.0
 '''
 
 EXAMPLES = '''

--- a/tests/unit/plugins/callback/test_splunk.py
+++ b/tests/unit/plugins/callback/test_splunk.py
@@ -1,0 +1,47 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.executor.task_result import TaskResult
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import patch, call, MagicMock, Mock
+from ansible_collections.community.general.plugins.callback.splunk import SplunkHTTPCollectorSource
+from datetime import datetime
+
+import json
+
+class TestSplunkClient(unittest.TestCase):
+    def setUp(self):
+        self.splunk = SplunkHTTPCollectorSource()
+        self.mock_task = Mock('MockTask')
+        self.mock_task._role = 'myrole'
+        self.mock_task._uuid = 'myuuid'
+        self.task_fields = {'args': {}}
+        self.mock_host = Mock('MockHost')
+        self.mock_host.name = 'myhost'
+      
+    @patch('ansible_collections.community.general.plugins.callback.splunk.datetime')
+    @patch('ansible_collections.community.general.plugins.callback.splunk.open_url')
+    def test_timestamp_with_milliseconds(self, open_url_mock, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2020,12,1)
+        result = TaskResult(host=self.mock_host,task=self.mock_task,return_data={},task_fields=self.task_fields) 
+        
+        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, state='OK', result=result, runtime=100)
+
+        args, kwargs = open_url_mock.call_args
+        sent_data = json.loads(args[1])
+        
+        self.assertEqual(sent_data['event']['timestamp'], '2020-12-01 00:00:00.000000 +0000')

--- a/tests/unit/plugins/callback/test_splunk.py
+++ b/tests/unit/plugins/callback/test_splunk.py
@@ -23,6 +23,7 @@ from datetime import datetime
 
 import json
 
+
 class TestSplunkClient(unittest.TestCase):
     def setUp(self):
         self.splunk = SplunkHTTPCollectorSource()
@@ -32,29 +33,29 @@ class TestSplunkClient(unittest.TestCase):
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')
         self.mock_host.name = 'myhost'
-      
+
     @patch('ansible_collections.community.general.plugins.callback.splunk.datetime')
     @patch('ansible_collections.community.general.plugins.callback.splunk.open_url')
     def test_timestamp_with_milliseconds(self, open_url_mock, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2020,12,1)
-        result = TaskResult(host=self.mock_host,task=self.mock_task,return_data={},task_fields=self.task_fields) 
-        
+        mock_datetime.utcnow.return_value = datetime(2020, 12, 1)
+        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
+
         self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=True, state='OK', result=result, runtime=100)
 
         args, kwargs = open_url_mock.call_args
         sent_data = json.loads(args[1])
-        
+
         self.assertEqual(sent_data['event']['timestamp'], '2020-12-01 00:00:00.000000 +0000')
 
     @patch('ansible_collections.community.general.plugins.callback.splunk.datetime')
     @patch('ansible_collections.community.general.plugins.callback.splunk.open_url')
     def test_timestamp_without_milliseconds(self, open_url_mock, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2020,12,1)
-        result = TaskResult(host=self.mock_host,task=self.mock_task,return_data={},task_fields=self.task_fields) 
-        
+        mock_datetime.utcnow.return_value = datetime(2020, 12, 1)
+        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
+
         self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=False, state='OK', result=result, runtime=100)
 
         args, kwargs = open_url_mock.call_args
         sent_data = json.loads(args[1])
-        
+
         self.assertEqual(sent_data['event']['timestamp'], '2020-12-01 00:00:00 +0000')

--- a/tests/unit/plugins/callback/test_splunk.py
+++ b/tests/unit/plugins/callback/test_splunk.py
@@ -39,9 +39,22 @@ class TestSplunkClient(unittest.TestCase):
         mock_datetime.utcnow.return_value = datetime(2020,12,1)
         result = TaskResult(host=self.mock_host,task=self.mock_task,return_data={},task_fields=self.task_fields) 
         
-        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, state='OK', result=result, runtime=100)
+        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=True, state='OK', result=result, runtime=100)
 
         args, kwargs = open_url_mock.call_args
         sent_data = json.loads(args[1])
         
         self.assertEqual(sent_data['event']['timestamp'], '2020-12-01 00:00:00.000000 +0000')
+
+    @patch('ansible_collections.community.general.plugins.callback.splunk.datetime')
+    @patch('ansible_collections.community.general.plugins.callback.splunk.open_url')
+    def test_timestamp_without_milliseconds(self, open_url_mock, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2020,12,1)
+        result = TaskResult(host=self.mock_host,task=self.mock_task,return_data={},task_fields=self.task_fields) 
+        
+        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=False, state='OK', result=result, runtime=100)
+
+        args, kwargs = open_url_mock.call_args
+        sent_data = json.loads(args[1])
+        
+        self.assertEqual(sent_data['event']['timestamp'], '2020-12-01 00:00:00 +0000')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds millisecond granularity to the timestamp data in the event. Multiple fast-resolving tasks can be executed in the same second and without millisecond granularity Splunk could display these events in an incorrect order, which could lead to some confusion when looking at the events.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Splunk plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
