### PR TITLE
fix so module `nios_host_record` can remove aliases

### DIFF
--- a/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
+++ b/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - nios_host_record - fix to remove ``aliases`` for configuration comparison (https://github.com/ansible-collections/community.general/issues/1335).
+  - nios_host_record - fix to remove ``aliases`` (CNAMES) for configuration comparison (https://github.com/ansible-collections/community.general/issues/1335).

--- a/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
+++ b/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nios_host_record - fix to remove aliases (https://github.com/ansible-collections/community.general/issues/1335).

--- a/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
+++ b/changelogs/fragments/nios_host_record-fix-aliases-removal.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - nios_host_record - fix to remove aliases (https://github.com/ansible-collections/community.general/issues/1335).
+  - nios_host_record - fix to remove ``aliases`` for configuration comparison (https://github.com/ansible-collections/community.general/issues/1335).

--- a/plugins/module_utils/net_tools/nios/api.py
+++ b/plugins/module_utils/net_tools/nios/api.py
@@ -455,6 +455,9 @@ class WapiModule(WapiBase):
                 return False
 
             elif isinstance(proposed_item, list):
+                if key == 'aliases':
+                    if set(current_item) != set(proposed_item):
+                        return False
                 for subitem in proposed_item:
                     if not self.issubset(subitem, current_item):
                         return False


### PR DESCRIPTION
##### SUMMARY
fix so module `nios_host_record` can remove aliases

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nios_host_record

##### ADDITIONAL INFORMATION
Fix for https://github.com/ansible-collections/community.general/issues/1335

I couldn't find any other module in https://github.com/ansible-collections/community.general/tree/main/plugins/modules/net_tools/nios with another argument named `aliases` so this change should only affect module `nios_host_record` 