### PR TITLE
saltstack: fix put_file to preserve checksum

### DIFF
--- a/changelogs/fragments/1472-saltstack-fix-put_file-to-preserve-checksum.yml
+++ b/changelogs/fragments/1472-saltstack-fix-put_file-to-preserve-checksum.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - saltstack - Use hashutil.base64_decodefile to ensure that the file checksum is preserved (https://github.com/ansible-collections/community.general/pull/1472).
+  - saltstack connection plugin - use ``hashutil.base64_decodefile`` to ensure that the file checksum is preserved (https://github.com/ansible-collections/community.general/pull/1472).

--- a/changelogs/fragments/1472-saltstack-fix-put_file-to-preserve-checksum.yml
+++ b/changelogs/fragments/1472-saltstack-fix-put_file-to-preserve-checksum.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - saltstack - Use hashutil.base64_decodefile to ensure that the file checksum is preserved (https://github.com/ansible-collections/community.general/pull/1472).

--- a/plugins/connection/saltstack.py
+++ b/plugins/connection/saltstack.py
@@ -19,6 +19,7 @@ DOCUMENTATION = '''
 import re
 import os
 import pty
+import codecs
 import subprocess
 
 from ansible.module_utils._text import to_bytes, to_text
@@ -85,9 +86,9 @@ class Connection(ConnectionBase):
 
         out_path = self._normalize_path(out_path, '/')
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.host)
-        with open(in_path) as in_fh:
+        with open(in_path, 'rb') as in_fh:
             content = in_fh.read()
-        self.client.cmd(self.host, 'file.write', [out_path, content])
+        self.client.cmd(self.host, 'hashutil.base64_decodefile', [codecs.encode(content, 'base64'), out_path])
 
     # TODO test it
     def fetch_file(self, in_path, out_path):


### PR DESCRIPTION
##### SUMMARY
Use hashutil.base64_decodefile to ensure that the file checksum
is preserved, since file.write only supports text files. This solves
ansible copy module failure triggered when the checksum is not
preserved. For example, if the content parameter is an empty
string, then the checksum fails to match because the file.write
function always appends a newline.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
saltstack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```json
$ ansible myhost -c saltstack -m ansible.builtin.copy -a "content= dest=/tmp/empty-file.txt"
myhost | FAILED! => {
    "changed": false,
    "checksum": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
    "expected_checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
    "msg": "Copied file does not match the expected checksum. Transfer failed."
}

```
