### PR TITLE
Bugfix/1457 filesystem is not idempotent when used with resizefs option

### DIFF
--- a/changelogs/fragments/1478-filesystem-fix-1457-resizefs-idempotency.yml
+++ b/changelogs/fragments/1478-filesystem-fix-1457-resizefs-idempotency.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filesystem - do not fail when ``resizefs=yes`` and ``fstype=xfs`` if there is nothing to do, even if
+    the filesystem is not mounted. This only covers systems supporting access to unmounted XFS filesystems.
+    Others will still fail (https://github.com/ansible-collections/community.general/issues/1457, https://github.com/ansible-collections/community.general/pull/1478).

--- a/tests/integration/targets/filesystem/defaults/main.yml
+++ b/tests/integration/targets/filesystem/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 tested_filesystems:
   # key: fstype
   #   fssize: size (Mo)

--- a/tests/integration/targets/filesystem/meta/main.yml
+++ b/tests/integration/targets/filesystem/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies:
   - setup_pkg_mgr
   - setup_remote_tmp_dir

--- a/tests/integration/targets/filesystem/tasks/create_device.yml
+++ b/tests/integration/targets/filesystem/tasks/create_device.yml
@@ -1,3 +1,4 @@
+---
 - name: 'Create a "disk" file'
   command: 'dd if=/dev/zero of={{ image_file }} bs=1M count={{ fssize }}'
 

--- a/tests/integration/targets/filesystem/tasks/create_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/create_fs.yml
@@ -43,40 +43,45 @@
       - 'fs3_result is success'
       - 'uuid.stdout != uuid3.stdout'
 
-- name: increase fake device
-  shell: 'dd if=/dev/zero bs=1M count=1 >> {{ image_file }}'
-
-- when: fstype == 'lvm'
-  block:
-    - name: Resize loop device for LVM
-      command: losetup -c {{ dev }}
 
 - when: 'grow|bool and (fstype != "vfat" or resize_vfat)'
   block:
-  - name: Expand filesystem
-    filesystem:
-      dev: '{{ dev }}'
-      fstype: '{{ fstype }}'
-      resizefs: yes
-    register: fs4_result
+    - name: increase fake device
+      shell: 'dd if=/dev/zero bs=1M count=1 >> {{ image_file }}'
 
-  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-    register: uuid4
+    - name: Resize loop device for LVM
+      command: losetup -c {{ dev }}
+      when: fstype == 'lvm'
 
-  - assert:
-      that:
-        - 'fs4_result is changed'
-        - 'fs4_result is success'
-        - 'uuid3.stdout == uuid4.stdout' # unchanged
+    - name: Expand filesystem
+      filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        resizefs: yes
+      register: fs4_result
 
-  - name: Try to expand filesystem again
-    filesystem:
-      dev: '{{ dev }}'
-      fstype: '{{ fstype }}'
-      resizefs: yes
-    register: fs5_result
+    - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+      register: uuid4
 
-  - assert:
-      that:
-        - 'not (fs5_result is changed)'
-        - 'fs5_result is successful'
+    - assert:
+        that:
+          - 'fs4_result is changed'
+          - 'fs4_result is success'
+          - 'uuid3.stdout == uuid4.stdout' # unchanged
+
+- when:
+    - (grow | bool and (fstype != "vfat" or resize_vfat)) or
+      (fstype == "xfs" and ansible_system == "Linux" and
+      ansible_distribution not in ["CentOS", "Ubuntu"])
+  block:
+    - name: Check that resizefs does nothing if device size is not changed
+      filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        resizefs: yes
+      register: fs5_result
+
+    - assert:
+        that:
+          - 'fs5_result is not changed'
+          - 'fs5_result is succeeded'

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 ####################################################################
 # WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #

--- a/tests/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/tests/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -1,3 +1,4 @@
+---
 - name: 'Recreate "disk" file'
   command: 'dd if=/dev/zero of={{ image_file }} bs=1M count={{ fssize }}'
 

--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -1,3 +1,4 @@
+---
 - name: install filesystem tools
   package:
     name: '{{ item }}'


### PR DESCRIPTION
##### SUMMARY

This PR allows the `filesystem` module to query the size of an XFS filesystem without the need for this fs to be mounted or unmounted, by relying upon `xfs_info` instead of `xfs_growfs`.

`resizefs=yes` needs for idempotency to compare the sizes of the filesystem and its underlying device (or file). For `fstype=xfs`, querying the size of the filesystem was not doable at all without mounting the filesystem first, that means that there was no way to ensure that nothing is done if nothing has to be done when playing the module twice without any action between. There was no way to get filesystem size, and the module failed instead, as reported in #1457 (see also usecase below).

This PR adds some bits of idempotency for systems supporting access to unmounted xfs filesystems (since a few years) when `resizefs=yes` and the filesystem is not mounted yet. It doesn't cover all systems supported by the module, but at least with latest stable versions of major GNU/Linux distros, the module should not fail anymore while querying the size of an XFS filesystem before mounting it.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

filesystem

##### ADDITIONAL INFORMATION

It makes that the following tasks can be broken due to a network issue right before the mount, and replayed without trouble (that is a realistic translation of the more concise testcase described in #1457 )

```yaml
- name: create Logical Volume
  community.general.lvol:
    vg: foo
    lv: bar
    size: 1G
    shrink: no

- name: create XFS filesystem
  community.general.filesystem:
    dev: /dev/mapper/foo-bar
    fstype: xfs
    resizefs: yes                   # <--- module failure here the second time
                                    # <--- network failure here the first time
- name: mount Logical Volume
  ansible.posix.mount:
    path: /srv/foobar
    src: /dev/mapper/foo-bar
    fstype: xfs
    state: mounted
``` 
