### PR TITLE
updated deprecated homebrew cask commands

### DIFF
--- a/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
+++ b/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Homebrew will be deprecating use of `brew cask` commands as of version 2.6.0 https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using `brew cask` for brew version >= 2.6.0

--- a/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
+++ b/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Homebrew will be deprecating use of `brew cask` commands as of version 2.6.0 https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using `brew cask` for brew version >= 2.6.0
+  - homebrew_cask - Homebrew will be deprecating use of `brew cask` commands as of version 2.6.0 https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using `brew cask` for brew version >= 2.6.0 (https://github.com/ansible-collections/community.general/pull/1481)

--- a/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
+++ b/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew_cask - Homebrew will be deprecating use of `brew cask` commands as of version 2.6.0 https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using `brew cask` for brew version >= 2.6.0 (https://github.com/ansible-collections/community.general/pull/1481)
+  - homebrew_cask - Homebrew will be deprecating use of ``brew cask`` commands as of version 2.6.0, see https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using ``brew cask`` for brew version >= 2.6.0 (https://github.com/ansible-collections/community.general/pull/1481)

--- a/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
+++ b/changelogs/fragments/1481-deprecated-brew-cask-command.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew_cask - Homebrew will be deprecating use of ``brew cask`` commands as of version 2.6.0, see https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using ``brew cask`` for brew version >= 2.6.0 (https://github.com/ansible-collections/community.general/pull/1481)
+  - homebrew_cask - Homebrew will be deprecating use of ``brew cask`` commands as of version 2.6.0, see https://brew.sh/2020/12/01/homebrew-2.6.0/. Added logic to stop using ``brew cask`` for brew version >= 2.6.0 (https://github.com/ansible-collections/community.general/pull/1481).

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -504,11 +504,8 @@ class HomebrewCask(object):
         return self.brew_version
 
     def _brew_cask_command_is_deprecated(self):
-        latest_version_with_brew_cask_command = version.LooseVersion('2.5.0')
-
-        current_version = version.LooseVersion(self._get_brew_version())
-
-        return current_version > latest_version_with_brew_cask_command
+        # The `brew cask` replacements were fully available in 2.6.0 (https://brew.sh/2020/12/01/homebrew-2.6.0/)
+        return version.LooseVersion(self._get_brew_version()) >= version.LooseVersion('2.6.0')
     # /checks ------------------------------------------------------ }}}
 
     # commands ----------------------------------------------------- {{{

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -367,7 +367,7 @@ class HomebrewCask(object):
             return None
 
     @brew_version.setter
-    def params(self, brew_version):
+    def brew_version(self, brew_version):
         self._brew_version = brew_version
 
     # /class properties -------------------------------------------- }}}

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -358,6 +358,18 @@ class HomebrewCask(object):
         else:
             self._current_cask = cask
             return cask
+
+    @property
+    def brew_version(self):
+        try:
+            return self._brew_version
+        except AttributeError:
+            return None
+
+    @brew_version.setter
+    def params(self, brew_version):
+        self._brew_version = brew_version
+
     # /class properties -------------------------------------------- }}}
 
     def __init__(self, module, path=path, casks=None, state=None,
@@ -475,6 +487,9 @@ class HomebrewCask(object):
             return False
 
     def _get_brew_version(self):
+        if self.brew_version:
+            return self.brew_version
+
         cmd = [self.brew_path, '--version']
 
         process = subprocess.run(cmd, stdout=subprocess.PIPE)
@@ -484,7 +499,9 @@ class HomebrewCask(object):
         # get version string from first line of "brew --version" output
         version = process_output.split('\n')[0].split(' ')[1]
 
-        return version
+        self.brew_version = version
+
+        return self.brew_version
 
     def _brew_cask_command_is_deprecated(self):
         latest_version_with_brew_cask_command = version.LooseVersion('2.5.0')

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -484,14 +484,17 @@ class HomebrewCask(object):
 
         cmd = [self.brew_path, '--version']
 
-        process_output = subprocess.check_output(cmd)
+        rc, out, err = self.module.run_command(cmd, check_rc=True)
 
-        # get version string from first line of "brew --version" output
-        version = process_output.decode('utf-8').split('\n')[0].split(' ')[1]
-
-        self.brew_version = version
-
-        return self.brew_version
+        if rc == 0:
+            # get version string from first line of "brew --version" output
+            version = out.split('\n')[0].split(' ')[1]
+            self.brew_version = version
+            return self.brew_version
+        else:
+            self.failed = True
+            self.message = err.strip()
+            raise HomebrewCaskException(self.message)
 
     def _brew_cask_command_is_deprecated(self):
         # The `brew cask` replacements were fully available in 2.6.0 (https://brew.sh/2020/12/01/homebrew-2.6.0/)

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -466,17 +466,9 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            base_opts = [
-                "{brew_path}".format(brew_path=self.brew_path),
-                "list",
-                "--cask",
-            ]
+            base_opts = [self.brew_path, "list", "--cask"]
         else:
-            base_opts = [
-                "{brew_path}".format(brew_path=self.brew_path),
-                "cask",
-                "list",
-            ]
+            base_opts = [self.brew_path, "cask", "list"]
 
         cmd = base_opts + [self.current_cask]
         rc, out, err = self.module.run_command(cmd)

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -437,8 +437,8 @@ class HomebrewCask(object):
         cask_is_outdated_command = (
             [
                 self.brew_path,
-                'cask',
                 'outdated',
+                '--cask',
             ]
             + (['--greedy'] if self.greedy else [])
             + [self.current_cask]
@@ -456,8 +456,8 @@ class HomebrewCask(object):
 
         cmd = [
             "{brew_path}".format(brew_path=self.brew_path),
-            "cask",
             "list",
+            "--cask",
             self.current_cask
         ]
         rc, out, err = self.module.run_command(cmd)
@@ -538,7 +538,7 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         opts = (
-            [self.brew_path, 'cask', 'upgrade']
+            [self.brew_path, 'upgrade', '--cask']
         )
 
         cmd = [opt for opt in opts if opt]
@@ -587,7 +587,7 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         opts = (
-            [self.brew_path, 'cask', 'install', self.current_cask]
+            [self.brew_path, 'install', '--cask', self.current_cask]
             + self.install_options
         )
 
@@ -651,7 +651,7 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         opts = (
-            [self.brew_path, 'cask', command]
+            [self.brew_path, command, '--cask']
             + self.install_options
             + [self.current_cask]
         )
@@ -704,7 +704,7 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         opts = (
-            [self.brew_path, 'cask', 'uninstall', self.current_cask]
+            [self.brew_path, 'uninstall', '--cask', self.current_cask]
             + self.install_options
         )
 

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -140,6 +140,7 @@ import os
 import re
 import tempfile
 import subprocess
+from distutils import version
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.basic import AnsibleModule
@@ -488,30 +489,6 @@ class HomebrewCask(object):
         else:
             return False
 
-    def _compare_version(self, version1, version2):
-        # convert version string into array of numbers (e.g '1.2.3' => [1,2,3])
-        v1_int_arr = [int(i) for i in version1.split('.')]
-        v2_int_arr = [int(i) for i in version2.split('.')]
-
-        v1_len = len(v1_int_arr)
-        v2_len = len(v2_int_arr)
-
-        # pad array with 0s if version arrays are different length (e.g '1.2.3' vs '1.2' => [1,2,3] vs [1,2,0])
-        if v1_len > v2_len:
-            for i in range(v2_len, v1_len):
-                v2_int_arr.append(0)
-        elif v2_len > v1_len:
-            for i in range(v1_len, v2_len):
-                v1_int_arr.append(0)
-
-        # compare each version number in array
-        for i in range(len(v1_int_arr)):
-            if v1_int_arr[i] > v2_int_arr[i]:
-                return 1
-            elif v2_int_arr[i] > v1_int_arr[i]:
-                return -1
-        return 0
-
     def _get_brew_version(self):
         opts = (
             [self.brew_path, '--version']
@@ -529,13 +506,11 @@ class HomebrewCask(object):
         return version
 
     def _brew_cask_command_is_deprecated(self):
-        latest_version_with_brew_cask_command = '2.5.0'
+        latest_version_with_brew_cask_command = version.LooseVersion('2.5.0')
 
-        current_version = self._get_brew_version()
+        current_version = version.LooseVersion(self._get_brew_version())
 
-        comparison_result = self._compare_version(current_version, latest_version_with_brew_cask_command)
-
-        return comparison_result > 0
+        return current_version > latest_version_with_brew_cask_command
     # /checks ------------------------------------------------------ }}}
 
     # commands ----------------------------------------------------- {{{

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -437,25 +437,11 @@ class HomebrewCask(object):
             return False
 
         if self._brew_cask_command_is_deprecated():
-            cask_is_outdated_command = (
-                [
-                    self.brew_path,
-                    'outdated',
-                    '--cask',
-                ]
-                + (['--greedy'] if self.greedy else [])
-                + [self.current_cask]
-            )
+            base_opts = [self.brew_path, 'outdated', '--cask']
         else:
-            cask_is_outdated_command = (
-                [
-                    self.brew_path,
-                    'cask',
-                    'outdated',
-                ]
-                + (['--greedy'] if self.greedy else [])
-                + [self.current_cask]
-            )
+            base_opts = [self.brew_path, 'cask', 'outdated']
+
+        cask_is_outdated_command = base_opts + (['--greedy'] if self.greedy else []) + [self.current_cask]
 
         rc, out, err = self.module.run_command(cask_is_outdated_command)
 
@@ -468,20 +454,19 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            cmd = [
+            base_opts = [
                 "{brew_path}".format(brew_path=self.brew_path),
                 "list",
                 "--cask",
-                self.current_cask
             ]
         else:
-            cmd = [
+            base_opts = [
                 "{brew_path}".format(brew_path=self.brew_path),
                 "cask",
                 "list",
-                self.current_cask
             ]
 
+        cmd = base_opts + [self.current_cask]
         rc, out, err = self.module.run_command(cmd)
 
         if rc == 0:
@@ -490,11 +475,7 @@ class HomebrewCask(object):
             return False
 
     def _get_brew_version(self):
-        opts = (
-            [self.brew_path, '--version']
-        )
-
-        cmd = [opt for opt in opts if opt]
+        cmd = [self.brew_path, '--version']
 
         process = subprocess.run(cmd, stdout=subprocess.PIPE)
 
@@ -583,15 +564,9 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            opts = (
-                [self.brew_path, 'upgrade', '--cask']
-            )
+            cmd = [self.brew_path, 'upgrade', '--cask']
         else:
-            opts = (
-                [self.brew_path, 'cask', 'upgrade']
-            )
-
-        cmd = [opt for opt in opts if opt]
+            cmd = [self.brew_path, 'cask', 'upgrade']
 
         rc, out, err = '', '', ''
 
@@ -637,15 +612,11 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            opts = (
-                [self.brew_path, 'install', '--cask', self.current_cask]
-                + self.install_options
-            )
+            base_opts = [self.brew_path, 'install', '--cask']
         else:
-            opts = (
-                [self.brew_path, 'cask', 'install', self.current_cask]
-                + self.install_options
-            )
+            base_opts = [self.brew_path, 'cask', 'install']
+
+        opts = base_opts + [self.current_cask] + self.install_options
 
         cmd = [opt for opt in opts if opt]
 
@@ -707,17 +678,11 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            opts = (
-                [self.brew_path, command, '--cask']
-                + self.install_options
-                + [self.current_cask]
-            )
+            base_opts = [self.brew_path, command, '--cask']
         else:
-            opts = (
-                [self.brew_path, 'cask', command]
-                + self.install_options
-                + [self.current_cask]
-            )
+            base_opts = [self.brew_path, 'cask', command]
+
+        opts = base_opts + self.install_options + [self.current_cask]
 
         cmd = [opt for opt in opts if opt]
 
@@ -768,15 +733,11 @@ class HomebrewCask(object):
             raise HomebrewCaskException(self.message)
 
         if self._brew_cask_command_is_deprecated():
-            opts = (
-                [self.brew_path, 'uninstall', '--cask', self.current_cask]
-                + self.install_options
-            )
+            base_opts = [self.brew_path, 'uninstall', '--cask']
         else:
-            opts = (
-                [self.brew_path, 'cask', 'uninstall', self.current_cask]
-                + self.install_options
-            )
+            base_opts = [self.brew_path, 'cask', 'uninstall']
+
+        opts = base_opts + [self.current_cask] + self.install_options
 
         cmd = [opt for opt in opts if opt]
 

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -139,7 +139,6 @@ EXAMPLES = '''
 import os
 import re
 import tempfile
-import subprocess
 from distutils import version
 
 from ansible.module_utils._text import to_bytes

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -485,15 +485,10 @@ class HomebrewCask(object):
 
         rc, out, err = self.module.run_command(cmd, check_rc=True)
 
-        if rc == 0:
-            # get version string from first line of "brew --version" output
-            version = out.split('\n')[0].split(' ')[1]
-            self.brew_version = version
-            return self.brew_version
-        else:
-            self.failed = True
-            self.message = err.strip()
-            raise HomebrewCaskException(self.message)
+        # get version string from first line of "brew --version" output
+        version = out.split('\n')[0].split(' ')[1]
+        self.brew_version = version
+        return self.brew_version
 
     def _brew_cask_command_is_deprecated(self):
         # The `brew cask` replacements were fully available in 2.6.0 (https://brew.sh/2020/12/01/homebrew-2.6.0/)

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -484,12 +484,10 @@ class HomebrewCask(object):
 
         cmd = [self.brew_path, '--version']
 
-        process = subprocess.run(cmd, stdout=subprocess.PIPE)
-
-        process_output = process.stdout.decode()
+        process_output = subprocess.check_output(cmd)
 
         # get version string from first line of "brew --version" output
-        version = process_output.split('\n')[0].split(' ')[1]
+        version = process_output.decode('utf-8').split('\n')[0].split(' ')[1]
 
         self.brew_version = version
 

--- a/tests/unit/plugins/modules/packaging/os/test_homebrew_cask.py
+++ b/tests/unit/plugins/modules/packaging/os/test_homebrew_cask.py
@@ -19,3 +19,23 @@ class TestHomebrewCaskModule(unittest.TestCase):
     def test_valid_cask_names(self):
         for name in self.brew_cask_names:
             self.assertTrue(HomebrewCask.valid_cask(name))
+
+    def test_version_comparison(self):
+        mock_brew_version_1 = '2.4.0'
+        mock_brew_version_2 = '2.8.0'
+
+        comparison_result_1 = HomebrewCask._compare_version(mock_brew_version_1, mock_brew_version_2)
+
+        mock_brew_version_3 = '2.8.0'
+        mock_brew_version_4 = '2.4.0'
+
+        comparison_result_2 = HomebrewCask._compare_version(mock_brew_version_3, mock_brew_version_4)
+
+        mock_brew_version_5 = '2.4.0'
+        mock_brew_version_6 = '2.4.0'
+
+        comparison_result_3 = HomebrewCask._compare_version(mock_brew_version_5, mock_brew_version_6)
+
+        self.assertEqual(comparison_result_1, -1)
+        self.assertEqual(comparison_result_1, 1)
+        self.assertEqual(comparison_result_1, 0)

--- a/tests/unit/plugins/modules/packaging/os/test_homebrew_cask.py
+++ b/tests/unit/plugins/modules/packaging/os/test_homebrew_cask.py
@@ -19,23 +19,3 @@ class TestHomebrewCaskModule(unittest.TestCase):
     def test_valid_cask_names(self):
         for name in self.brew_cask_names:
             self.assertTrue(HomebrewCask.valid_cask(name))
-
-    def test_version_comparison(self):
-        mock_brew_version_1 = '2.4.0'
-        mock_brew_version_2 = '2.8.0'
-
-        comparison_result_1 = HomebrewCask._compare_version(mock_brew_version_1, mock_brew_version_2)
-
-        mock_brew_version_3 = '2.8.0'
-        mock_brew_version_4 = '2.4.0'
-
-        comparison_result_2 = HomebrewCask._compare_version(mock_brew_version_3, mock_brew_version_4)
-
-        mock_brew_version_5 = '2.4.0'
-        mock_brew_version_6 = '2.4.0'
-
-        comparison_result_3 = HomebrewCask._compare_version(mock_brew_version_5, mock_brew_version_6)
-
-        self.assertEqual(comparison_result_1, -1)
-        self.assertEqual(comparison_result_1, 1)
-        self.assertEqual(comparison_result_1, 0)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replaced deprecated `brew cask` commands with `--cask` (e.g `brew install --cask <app>`)

See https://brew.sh/2020/12/01/homebrew-2.6.0/ & https://github.com/Homebrew/brew/pull/8899
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #1524.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/homebrew_cask.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
