### PR TITLE
Fix property name typo in get_memory_inventory()

### DIFF
--- a/changelogs/fragments/1484-fix-property-name-in-redfish-memory-inventory.yml
+++ b/changelogs/fragments/1484-fix-property-name-in-redfish-memory-inventory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_info, redfish_utils - Correct PartNumber property name in Redfish GetMemoryInventory command (https://github.com/ansible-collections/community.general/issues/1483)
+  - redfish_info module, redfish_utils module utils - correct ``PartNumber`` property name in Redfish ``GetMemoryInventory`` command (https://github.com/ansible-collections/community.general/issues/1483).

--- a/changelogs/fragments/1484-fix-property-name-in-redfish-memory-inventory.yml
+++ b/changelogs/fragments/1484-fix-property-name-in-redfish-memory-inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_info, redfish_utils - Correct PartNumber property name in Redfish GetMemoryInventory command (https://github.com/ansible-collections/community.general/issues/1483)

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1886,7 +1886,7 @@ class RedfishUtils(object):
         memory_results = []
         key = "Memory"
         # Get these entries, but does not fail if not found
-        properties = ['SerialNumber', 'MemoryDeviceType', 'PartNuber',
+        properties = ['SerialNumber', 'MemoryDeviceType', 'PartNumber',
                       'MemoryLocation', 'RankCount', 'CapacityMiB', 'OperatingMemoryModes', 'Status', 'Manufacturer', 'Name']
 
         # Search for 'key' entry and extract URI from it


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The method `get_memory_inventory()` in redfish_utils.py has a typo in one of the property names: `PartNuber` should be `PartNumber`. With the misspelled property name, the `PartNumber` will not be shown in the memory inventory.

Fixes #1483 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Run a play to issue the `GetMemoryInventory` command. Note that the `PartNumber` property is not shown in the output.

After the fix, the `PartNumber` property is shown in the output.
