### PR TITLE
Add optional header_value parameter to hashi_vault lookup

### DIFF
--- a/changelogs/fragments/1485-add-hashi_vault-header_value-param.yml
+++ b/changelogs/fragments/1485-add-hashi_vault-header_value-param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hashi_vault - parse optional header_value parameter as the X-Vault-AWS-IAM-Server-ID header (https://github.com/ansible-collections/community.general/pull/1485).

--- a/plugins/lookup/hashi_vault.py
+++ b/plugins/lookup/hashi_vault.py
@@ -178,6 +178,11 @@ DOCUMENTATION = """
         - name: EC2_REGION
         - name: AWS_REGION
         version_added: '0.2.0'
+    header_value:
+      description: If specificed, will send the value in this field as the X-Vault-AWS-IAM-Server-ID header as part of GetCallerIdentity request.
+      env:
+        - name: VAULT_HEADER_VALUE
+      required: False
 """
 
 EXAMPLES = """
@@ -620,6 +625,9 @@ class LookupModule(LookupBase):
 
         if self.get_option('region'):
             params['region'] = self.get_option('region')
+
+        if self.get_option('header_value'):
+            params['header_value'] = self.get_option('header_value')
 
         if not (params['access_key'] and params['secret_key']):
             profile = self.get_option('aws_profile')


### PR DESCRIPTION
Add optional header_value parameter to hashi_vault lookup to support X-Vault-AWS-IAM-Server-ID

##### SUMMARY
Add support for the parameter `header_value` to support Vault policies that require X-Vault-AWS-IAM-Server-ID
as part of the GetCallerIdentity request.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hashi_vault

##### ADDITIONAL INFORMATION
Without this feature the following would fail when the Hashi Vault policy requires the `X-Vault-AWS-IAM-Server-ID` header.

```
- name: Authenticate with a Vault app role
  ansible.builtin.debug:
    msg: "{{ lookup('community.general.hashi_vault', 'secret=secret/data/test:hello auth_method=aws_iam_login role_id=ec2-instance url=https://vault-url region=us-west-2') }}"
```

Including the parameter `header_value` will pass the value along to the HVAC library, which then sends it along as the header.  This would return the secret.

```
- name: Authenticate with a Vault app role
  ansible.builtin.debug:
    msg: "{{ lookup('community.general.hashi_vault', 'secret=secret/data/test:hello auth_method=aws_iam_login role_id=ec2-instance url=https://vault-url region=us-west-2 header_value=https://vault-url') }}"
```
