### PR TITLE
keycloak: Provide meaningful error message to user

### DIFF
--- a/changelogs/fragments/331_keycloak.yml
+++ b/changelogs/fragments/331_keycloak.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- keycloak module_utils - provide meaningful error message to user when auth URL does not start with http or https (https://github.com/ansible-collections/community.general/issues/331).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -75,6 +75,8 @@ class KeycloakError(Exception):
 
 def get_token(base_url, validate_certs, auth_realm, client_id,
               auth_username, auth_password, client_secret):
+    if not base_url.lower().startswith(('http', 'https')):
+        raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
     auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
     temp_payload = {
         'grant_type': 'password',


### PR DESCRIPTION
##### SUMMARY

When user provides auth URL value which does not startswith
http or https protocol schema, provide a meaningful error message
stating so.

Fixes: #331

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/331_keycloak.yml
plugins/module_utils/identity/keycloak/keycloak.py
