### PR TITLE
Allow gitlab_runner to function for non-admin users

### DIFF
--- a/changelogs/fragments/1491-gitlab-runner-owned-parameter.yml
+++ b/changelogs/fragments/1491-gitlab-runner-owned-parameter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gitlab_runner - add ``owned`` param to allow non-admin use (https://github.com/ansible-collections/community.general/pull/1491)."

--- a/changelogs/fragments/1491-gitlab-runner-owned-parameter.yml
+++ b/changelogs/fragments/1491-gitlab-runner-owned-parameter.yml
@@ -1,3 +1,5 @@
 ---
 minor_changes:
-  - gitlab_runner - add ``owned`` param to allow non-admin use (https://github.com/ansible-collections/community.general/pull/1491)."
+  - gitlab_runner - add ``owned`` option to allow non-admin use (https://github.com/ansible-collections/community.general/pull/1491).
+bugfixes:
+  - gitlab_runner - fix compatiblity with some versions of python-gitlab (https://github.com/ansible-collections/community.general/pull/1491).

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -62,7 +62,7 @@ options:
       - Searches only owned runners when searching for existing, when false admin token required.
     default: no
     type: bool
-    since: 2.0.0
+    version_added: 2.0.0
   active:
     description:
       - Define if the runners is immediately active after creation.

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -121,7 +121,7 @@ EXAMPLES = '''
     description: Docker Machine t1
     state: absent
 
-- name: "Delete an owned runner as a non-admin"
+- name: Delete an owned runner as a non-admin
   community.general.gitlab_runner:
     api_url: https://gitlab.example.com/
     api_token: "{{ access_token }}"

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -268,7 +268,7 @@ class GitLabRunner(object):
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner
-            # object, so we need to handle both, getattr allows that
+            # object, so we need to handle both, hasattr allows that
             if hasattr(runner, "description"):
                 if (runner.description == description):
                     return self._gitlab.runners.get(runner.id)

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -59,10 +59,10 @@ options:
     type: str
   owned:
     description:
-      - Will search only owned runners when searching for existing, when false admin token required
-    required: False
+      - Searches only owned runners when searching for existing, when false admin token required.
     default: no
     type: bool
+    since: 2.0.0
   active:
     description:
       - Define if the runners is immediately active after creation.
@@ -119,6 +119,14 @@ EXAMPLES = '''
     api_url: https://gitlab.example.com/
     api_token: "{{ access_token }}"
     description: Docker Machine t1
+    state: absent
+
+- name: "Delete an owned runner as a non-admin"
+  community.general.gitlab_runner:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ access_token }}"
+    description: Docker Machine t1
+    owned: yes
     state: absent
 '''
 

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -57,6 +57,12 @@ options:
       - The registration token is used to register new runners.
     required: True
     type: str
+  owned:
+    description:
+      - Will search only owned runners when searching for existing, when false admin token required
+    required: False
+    default: no
+    type: bool
   active:
     description:
       - Define if the runners is immediately active after creation.
@@ -246,18 +252,28 @@ class GitLabRunner(object):
     '''
     @param description Description of the runner
     '''
-    def findRunner(self, description):
-        runners = self._gitlab.runners.all(as_list=False)
+    def findRunner(self, description, owned=False):
+        if owned:
+            runners = self._gitlab.runners.list(as_list=False)
+        else:
+            runners = self._gitlab.runners.all(as_list=False)
+
         for runner in runners:
-            if (runner['description'] == description):
-                return self._gitlab.runners.get(runner['id'])
+            # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner
+            # object, so we need to handle both, getattr allows that
+            if hasattr(runner, "description"):
+                if (runner.description == description):
+                    return self._gitlab.runners.get(runner.id)
+            else:
+                if (runner['description'] == description):
+                    return self._gitlab.runners.get(runner['id'])
 
     '''
     @param description Description of the runner
     '''
-    def existsRunner(self, description):
+    def existsRunner(self, description, owned=False):
         # When runner exists, object will be stored in self.runnerObject.
-        runner = self.findRunner(description)
+        runner = self.findRunner(description, owned)
 
         if runner:
             self.runnerObject = runner
@@ -279,6 +295,7 @@ def main():
         api_token=dict(type='str', no_log=True),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
+        owned=dict(type='bool', default=False),
         tag_list=dict(type='list', default=[]),
         run_untagged=dict(type='bool', default=True),
         locked=dict(type='bool', default=False),
@@ -304,6 +321,7 @@ def main():
     )
 
     state = module.params['state']
+    owned = module.params['owned']
     runner_description = module.params['description']
     runner_active = module.params['active']
     tag_list = module.params['tag_list']
@@ -319,7 +337,7 @@ def main():
     gitlab_instance = gitlabAuthentication(module)
 
     gitlab_runner = GitLabRunner(module, gitlab_instance)
-    runner_exists = gitlab_runner.existsRunner(runner_description)
+    runner_exists = gitlab_runner.existsRunner(runner_description, owned)
 
     if state == 'absent':
         if runner_exists:

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -59,7 +59,7 @@ options:
     type: str
   owned:
     description:
-      - Searches only owned runners when searching for existing, when false admin token required.
+      - Searches only owned runners (i.e. specific and group runners) when searching for existing runners, when false admin token required, but also returns shared runners.
     default: no
     type: bool
     version_added: 2.0.0

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -59,7 +59,7 @@ options:
     type: str
   owned:
     description:
-      - Searches only owned runners (i.e. specific and group runners) when searching for existing runners, when false admin token required, but also returns shared runners.
+      - Searches only owned runners when searching for existing runners, when false admin token required.
     default: no
     type: bool
     version_added: 2.0.0

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -268,7 +268,7 @@ class GitLabRunner(object):
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner
-            # object, so we need to handle both, getattr allows that
+            # object, so we need to handle both
             if hasattr(runner, "description"):
                 if (runner.description == description):
                     return self._gitlab.runners.get(runner.id)

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -59,7 +59,7 @@ options:
     type: str
   owned:
     description:
-      - Searches only owned runners when searching for existing runners, when false admin token required.
+      - Searches only runners available to the user when searching for existing, when false admin token required.
     default: no
     type: bool
     version_added: 2.0.0
@@ -268,7 +268,7 @@ class GitLabRunner(object):
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner
-            # object, so we need to handle both, hasattr allows that
+            # object, so we need to handle both, getattr allows that
             if hasattr(runner, "description"):
                 if (runner.description == description):
                     return self._gitlab.runners.get(runner.id)

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -587,7 +587,6 @@ def resp_get_runner(url, request):
 
 @urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners$', method="post")
 def resp_create_runner(url, request):
-    
     headers = {'content-type': 'application/json'}
     content = ('{"active": true,"description": "test-1-20150125","id": 1,'
                '"is_shared": false,"ip_address": "127.0.0.1","name": null,'

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -524,20 +524,8 @@ RUNNER API
 '''
 
 
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners/all", method="get")
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners/all$', method="get")
 def resp_find_runners_all(url, request):
-    headers = {'content-type': 'application/json'}
-    content = ('[{"active": true,"description": "test-1-20150125","id": 1,'
-               '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
-               '"online": true,"status": "online"},{"active": true,'
-               '"description": "test-2-20150125","id": 2,"ip_address": "127.0.0.1",'
-               '"is_shared": false,"name": null,"online": false,"status": "offline"}]')
-    content = content.encode("utf-8")
-    return response(200, content, headers, None, 5, request)
-
-
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners", method="get")
-def resp_find_runners_list(url, request):
     headers = {'content-type': 'application/json',
                "X-Page": 1,
                "X-Next-Page": 2,
@@ -553,7 +541,41 @@ def resp_find_runners_list(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners/1", method="get")
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners$', method="get")
+def resp_find_runners_list(url, request):
+    headers = {'content-type': 'application/json',
+               "X-Page": 1,
+               "X-Next-Page": 2,
+               "X-Per-Page": 1,
+               "X-Total-Pages": 1,
+               "X-Total": 2}
+    content = ('[{"active": true,"description": "test-1-20201214","id": 1,'
+               '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
+               '"online": true,"status": "online"},{"active": true,'
+               '"description": "test-2-20201214","id": 2,"ip_address": "127.0.0.1",'
+               '"is_shared": false,"name": null,"online": false,"status": "offline"}]')
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners/1$', method="put")
+def resp_update_runner(url, request):
+    headers = {'content-type': 'application/json',
+               "X-Page": 1,
+               "X-Next-Page": 2,
+               "X-Per-Page": 1,
+               "X-Total-Pages": 1,
+               "X-Total": 2}
+    content = ('[{"active": true,"description": "test-1-20201214","id": 1,'
+               '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
+               '"online": true,"status": "online"},{"active": true,'
+               '"description": "test-2-20201214","id": 2,"ip_address": "127.0.0.1",'
+               '"is_shared": false,"name": null,"online": false,"status": "offline"}]')
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners/1$', method="get")
 def resp_get_runner(url, request):
     headers = {'content-type': 'application/json'}
     content = ('{"active": true,"description": "test-1-20150125","id": 1,'
@@ -563,8 +585,9 @@ def resp_get_runner(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners", method="post")
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners$', method="post")
 def resp_create_runner(url, request):
+    
     headers = {'content-type': 'application/json'}
     content = ('{"active": true,"description": "test-1-20150125","id": 1,'
                '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
@@ -573,7 +596,7 @@ def resp_create_runner(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners/1", method="delete")
+@urlmatch(scheme="http", netloc="localhost", path=r'/api/v4/runners/1$', method="delete")
 def resp_delete_runner(url, request):
     headers = {'content-type': 'application/json'}
     content = ('{}')

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
@@ -21,6 +21,7 @@ pytestmark = []
 try:
     from .gitlab import (GitlabModuleTestCase,
                          python_version_match_requirement,
+                         resp_find_runners_all,
                          resp_find_runners_list, resp_get_runner,
                          resp_create_runner, resp_delete_runner)
 
@@ -50,14 +51,25 @@ class TestGitlabRunner(GitlabModuleTestCase):
 
         self.moduleUtil = GitLabRunner(module=self.mock_module, gitlab_instance=self.gitlab_instance)
 
-    @with_httmock(resp_find_runners_list)
+    @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
-    def test_runner_exist(self):
+    def test_runner_exist_all(self):
         rvalue = self.moduleUtil.existsRunner("test-1-20150125")
 
         self.assertEqual(rvalue, True)
 
         rvalue = self.moduleUtil.existsRunner("test-3-00000000")
+
+        self.assertEqual(rvalue, False)
+
+    @with_httmock(resp_find_runners_list)
+    @with_httmock(resp_get_runner)
+    def test_runner_exist_owned(self):
+        rvalue = self.moduleUtil.existsRunner("test-1-20201214", True)
+
+        self.assertEqual(rvalue, True)
+
+        rvalue = self.moduleUtil.existsRunner("test-3-00000000", True)
 
         self.assertEqual(rvalue, False)
 
@@ -68,7 +80,7 @@ class TestGitlabRunner(GitlabModuleTestCase):
         self.assertEqual(type(runner), Runner)
         self.assertEqual(runner.description, "test-1-20150125")
 
-    @with_httmock(resp_find_runners_list)
+    @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     def test_update_runner(self):
         runner = self.moduleUtil.findRunner("test-1-20150125")
@@ -84,7 +96,7 @@ class TestGitlabRunner(GitlabModuleTestCase):
         self.assertEqual(changed, False)
         self.assertEqual(newRunner.description, "Runner description")
 
-    @with_httmock(resp_find_runners_list)
+    @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     @with_httmock(resp_delete_runner)
     def test_delete_runner(self):

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -12,7 +12,7 @@ linode-python  # APIv3
 linode_api4 ; python_version > '2.6'  # APIv4
 
 # requirement for the gitlab module
-python-gitlab < 2.3.0  # version 2.3.0 makes gitlab_runner tests fail
+python-gitlab
 httmock
 
 # requirement for kubevirt modules


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This change adds an 'owned' option to gitlab_runner to toggle between the `runners/` and `runners/all` API methods and allow non-admins to use it. It also cleans up the runner tests which were hitting the wrong mocks. Fixes #440, #484

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_runner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #440 for a description of the problem
