### PR TITLE
fix passwordstore.py to be compatible with gopass versions

### DIFF
--- a/changelogs/fragments/1493-fix_passwordstore.py_to_be_compatible_with_gopass_versions.yml
+++ b/changelogs/fragments/1493-fix_passwordstore.py_to_be_compatible_with_gopass_versions.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - passwordstore - `gopass show` is deprecated and executing it will result in a DEPRECATION WARNING  (https://github.com/ansible-collections/community.general/pull/1493).
+  - passwordstore lookup plugin - always use explicit ``show`` command to retrieve password. This ensures compatibility with ``gopass`` and avoids problems when password names equal ``pass`` commands (https://github.com/ansible-collections/community.general/pull/1493).

--- a/changelogs/fragments/1493-fix_passwordstore.py_to_be_compatible_with_gopass_versions.yml
+++ b/changelogs/fragments/1493-fix_passwordstore.py_to_be_compatible_with_gopass_versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - passwordstore - `gopass show` is deprecated and executing it will result in a DEPRECATION WARNING  (https://github.com/ansible-collections/community.general/pull/1493).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -204,7 +204,7 @@ class LookupModule(LookupBase):
     def check_pass(self):
         try:
             self.passoutput = to_text(
-                check_output2(["pass", self.passname], env=self.env),
+                check_output2(["pass", "show", self.passname], env=self.env),
                 errors='surrogate_or_strict'
             ).splitlines()
             self.password = self.passoutput[0]


### PR DESCRIPTION
##### SUMMARY
`gopass show` is deprecated and executing it will result in these messages:
```
gopass mypass
DEPRECATION WARNING: Use gopass show
mysecret
```
The `DEPRECATION WARNING: Use gopass show` will be written to a file looked up by `passwordstore.py`.

This commit fixes it by using `pass show` instead of `pass`.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
passwordstore.py

##### ADDITIONAL INFORMATION
