### PR TITLE
Linode tags as groups

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r'''
       - Luke Murphy (@decentral1se)
     short_description: Ansible dynamic inventory plugin for Linode.
     requirements:
-        - python >= 3.5
+        - python >= 3.6
         - linode_api4 >= 2.0.0
     description:
         - Reads inventories from the Linode API v4.

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -25,8 +25,8 @@ import sys
 
 linode_apiv4 = pytest.importorskip('linode_api4')
 mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason='The linode_api4 dependency requires python2.7 or higher'
+    sys.version_info < (3, 6),
+    reason='The linode_api4 dependency requires python3.6 or higher'
 )
 
 

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -58,18 +58,20 @@ def test_validation_option_bad_option(inventory):
 
 
 def test_empty_config_query_options(inventory):
-    regions, types = inventory._get_query_options({})
-    assert regions == types == []
+    regions, types, tags = inventory._get_query_options({})
+    assert regions == types == tags == []
 
 
 def test_conig_query_options(inventory):
-    regions, types = inventory._get_query_options({
+    regions, types, tags = inventory._get_query_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],
+        'tags': ['web-server'],
     })
 
     assert regions == ['eu-west', 'us-east']
     assert types == ['g5-standard-2', 'g6-standard-2']
+    assert tags == ['web-server']
 
 
 def test_verify_file_bad_config(inventory):


### PR DESCRIPTION
##### SUMMARY
Linode has since deprecated the concept of groups, replacing it fully with tags. The API still has a "group" attribute on the instance, but new instances have no way of assigning group membership.

The `linode` inventory plugin took a hard stance in favor of groups over tags. This reverses that stance, given Ansible allows a single host to be part of multiple groups, much like Linode's concept of tagging.

Without this change, inventory is imported only as ungrouped hosts with Linode API's instance info in host_vars. This restores the grouping feature one would expect.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`linode`

##### ADDITIONAL INFORMATION

_N/a_