### PR TITLE
Raises error for non-existent repo path

### DIFF
--- a/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
+++ b/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- git_config - actually raises an error for non-existent repo paths, for ansible-base versions greater or equal to 2.10.4 (https://github.com/ansible-collections/community.general/issues/630).
+- git_config - now raises an error for non-existent repository paths (https://github.com/ansible-collections/community.general/issues/630).

--- a/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
+++ b/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- git_config - actually raises an error for non-existent repo paths, for Ansible versions greater or equal to 2.10.4 (https://github.com/ansible-collections/community.general/issues/630).

--- a/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
+++ b/changelogs/fragments/630-git_config-handling-invalid-dir.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- git_config - actually raises an error for non-existent repo paths, for Ansible versions greater or equal to 2.10.4 (https://github.com/ansible-collections/community.general/issues/630).
+- git_config - actually raises an error for non-existent repo paths, for ansible-base versions greater or equal to 2.10.4 (https://github.com/ansible-collections/community.general/issues/630).

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -245,7 +245,13 @@ def main():
         else:
             new_value_quoted = shlex_quote(new_value)
             cmd = ' '.join(args + [new_value_quoted])
-        (rc, out, err) = module.run_command(cmd, cwd=dir)
+        try:  # extra parameter from Ansible 2.10.4 onwards
+            (rc, out, err) = module.run_command(cmd, cwd=dir, ignore_invalid_cwd=False)
+        except TypeError:
+            # @TODO remove try/except when community.general drop support for 2.10.x
+            module.warn('If "repo" is not an invalid directory, "git_config" will not raise an error and will run '
+                        '"git" from the current working dir. Use Ansible 2.10.4 or newer to prevent that.')
+            (rc, out, err) = module.run_command(cmd, cwd=dir)
         if err:
             module.fail_json(rc=rc, msg=err, cmd=cmd)
 

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -245,12 +245,12 @@ def main():
         else:
             new_value_quoted = shlex_quote(new_value)
             cmd = ' '.join(args + [new_value_quoted])
-        try:  # extra parameter from Ansible 2.10.4 onwards
+        try:  # extra parameter from ansible-base 2.10.4 onwards
             (rc, out, err) = module.run_command(cmd, cwd=dir, ignore_invalid_cwd=False)
         except TypeError:
             # @TODO remove try/except when community.general drop support for 2.10.x
-            module.warn('If "repo" is not an invalid directory, "git_config" will not raise an error and will run '
-                        '"git" from the current working dir. Use Ansible 2.10.4 or newer to prevent that.')
+            module.warn('If "repo" is an invalid directory, "git_config" will not raise an error and will run '
+                        '"git" from the current working dir. Use ansible-base 2.10.4 or newer to prevent that.')
             (rc, out, err) = module.run_command(cmd, cwd=dir)
         if err:
             module.fail_json(rc=rc, msg=err, cmd=cmd)

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -148,6 +148,8 @@ config_values:
     alias.diffc: "diff --cached"
     alias.remotev: "remote -v"
 '''
+import os
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
@@ -245,12 +247,12 @@ def main():
         else:
             new_value_quoted = shlex_quote(new_value)
             cmd = ' '.join(args + [new_value_quoted])
-        try:  # extra parameter from ansible-base 2.10.4 onwards
+        try:  # try using extra parameter from ansible-base 2.10.4 onwards
             (rc, out, err) = module.run_command(cmd, cwd=dir, ignore_invalid_cwd=False)
         except TypeError:
             # @TODO remove try/except when community.general drop support for 2.10.x
-            module.warn('If "repo" is an invalid directory, "git_config" will not raise an error and will run '
-                        '"git" from the current working dir. Use ansible-base 2.10.4 or newer to prevent that.')
+            if not os.path.isdir(dir):
+                module.fail_json(msg="Cannot find directory '{0}'".format(dir))
             (rc, out, err) = module.run_command(cmd, cwd=dir)
         if err:
             module.fail_json(rc=rc, msg=err, cmd=cmd)


### PR DESCRIPTION
##### SUMMARY
Try to use the parameter ``ignore_invalid_cwd=True`` on the call to ``module.run_command()``, available from ansible base 2.10.4 onwards.

Fixes #630 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/source_control/git_config.py

##### ADDITIONAL INFORMATION
