### PR TITLE
Added support for remote project in the LXD connection plugin

### DIFF
--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -26,6 +26,18 @@ DOCUMENTATION = '''
         vars:
             - name: ansible_executable
             - name: ansible_lxd_executable
+      remote:
+        description:
+            - Name of the LXD remote to use
+        default: local
+        vars:
+            - name: ansible_lxd_remote
+      project:
+        description:
+            - Name of the LXD project to use
+        default: default
+        vars:
+            - name: ansible_lxd_project
 '''
 
 import os
@@ -70,7 +82,13 @@ class Connection(ConnectionBase):
 
         self._display.vvv(u"EXEC {0}".format(cmd), host=self._host)
 
-        local_cmd = [self._lxc_cmd, "exec", self._host, "--", self._play_context.executable, "-c", cmd]
+        local_cmd = [
+            self._lxc_cmd,
+            "--project", self.get_option("project"),
+            "exec",
+            "%s:%s" % (self.get_option("remote"), self._host),
+            "--",
+            self._play_context.executable, "-c", cmd]
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         in_data = to_bytes(in_data, errors='surrogate_or_strict', nonstring='passthru')
@@ -98,7 +116,12 @@ class Connection(ConnectionBase):
         if not os.path.isfile(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("input path is not a file: %s" % in_path)
 
-        local_cmd = [self._lxc_cmd, "file", "push", in_path, self._host + "/" + out_path]
+        local_cmd = [
+            self._lxc_cmd,
+            "--project", self.get_option("project"),
+            "file", "push",
+            in_path,
+            "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)]
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
@@ -111,7 +134,12 @@ class Connection(ConnectionBase):
 
         self._display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._host)
 
-        local_cmd = [self._lxc_cmd, "file", "pull", self._host + "/" + in_path, out_path]
+        local_cmd = [
+            self._lxc_cmd,
+            "--project", self.get_option("project"),
+            "file", "pull",
+            "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
+            out_path]
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -83,21 +83,15 @@ class Connection(ConnectionBase):
 
         self._display.vvv(u"EXEC {0}".format(cmd), host=self._host)
 
+        local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
-            local_cmd = [
-                self._lxc_cmd,
-                "--project", self.get_option("project"),
+            local_cmd.extend(["--project", self.get_option("project")])
+        local_cmd.extend([
                 "exec",
                 "%s:%s" % (self.get_option("remote"), self._host),
                 "--",
-                self._play_context.executable, "-c", cmd]
-        else:
-            local_cmd = [
-                self._lxc_cmd,
-                "exec",
-                "%s:%s" % (self.get_option("remote"), self._host),
-                "--",
-                self._play_context.executable, "-c", cmd]
+                self._play_context.executable, "-c", cmd
+        ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         in_data = to_bytes(in_data, errors='surrogate_or_strict', nonstring='passthru')
@@ -125,19 +119,14 @@ class Connection(ConnectionBase):
         if not os.path.isfile(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("input path is not a file: %s" % in_path)
 
+        local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
-            local_cmd = [
-                self._lxc_cmd,
-                "--project", self.get_option("project"),
+            local_cmd.extend(["--project", self.get_option("project")])
+        local_cmd.extend([
                 "file", "push",
                 in_path,
-                "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)]
-        else:
-            local_cmd = [
-                self._lxc_cmd,
-                "file", "push",
-                in_path,
-                "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)]
+                "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)
+        ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
@@ -150,19 +139,14 @@ class Connection(ConnectionBase):
 
         self._display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._host)
 
+        local_cmd = [self._lxc_cmd]
         if self.get_option("project"):
-            local_cmd = [
-                self._lxc_cmd,
-                "--project", self.get_option("project"),
+            local_cmd.extend(["--project", self.get_option("project")])
+        local_cmd.extend([
                 "file", "pull",
                 "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
-                out_path]
-        else:
-            local_cmd = [
-                self._lxc_cmd,
-                "file", "pull",
-                "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
-                out_path]
+                out_path
+        ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -87,10 +87,10 @@ class Connection(ConnectionBase):
         if self.get_option("project"):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
-                "exec",
-                "%s:%s" % (self.get_option("remote"), self._host),
-                "--",
-                self._play_context.executable, "-c", cmd
+            "exec",
+            "%s:%s" % (self.get_option("remote"), self._host),
+            "--",
+            self._play_context.executable, "-c", cmd
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
@@ -123,9 +123,9 @@ class Connection(ConnectionBase):
         if self.get_option("project"):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
-                "file", "push",
-                in_path,
-                "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)
+            "file", "push",
+            in_path,
+            "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
@@ -143,9 +143,9 @@ class Connection(ConnectionBase):
         if self.get_option("project"):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
-                "file", "pull",
-                "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
-                out_path
+            "file", "pull",
+            "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
+            out_path
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]


### PR DESCRIPTION
… plugin

##### SUMMARY
For https://github.com/ansible-collections/community.general/issues/1441
Add support for specifying remote and project in the LXD connection plugin.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
community.general.lxd

##### ADDITIONAL INFORMATION
Tested the PR as below:

~~~
root@lxd:~# lxc --version
4.0.4

root@lxd:~# lxc remote list
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
|      NAME       |                   URL                    |   PROTOCOL    |  AUTH TYPE  | PUBLIC | STATIC |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
| images          | https://images.linuxcontainers.org       | simplestreams | none        | YES    | NO     |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
| local (default) | unix://                                  | lxd           | file access | NO     | YES    |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
| myhost          | https://172.16.33.55:8443                | lxd           | tls         | NO     | NO     |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
| ubuntu          | https://cloud-images.ubuntu.com/releases | simplestreams | none        | YES    | YES    |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+
| ubuntu-daily    | https://cloud-images.ubuntu.com/daily    | simplestreams | none        | YES    | YES    |
+-----------------+------------------------------------------+---------------+-------------+--------+--------+


root@lxd:~# lxc list myhost: --project=testproject
+-------+---------+------+------+-----------+-----------+
| NAME  |  STATE  | IPV4 | IPV6 |   TYPE    | SNAPSHOTS |
+-------+---------+------+------+-----------+-----------+
| test2 | RUNNING |      |      | CONTAINER | 0         |
+-------+---------+------+------+-----------+-----------+

root@lxd:~# cat inventory 
test2

[all:vars]
ansible_connection = community.general.lxd
ansible_lxd_remote = myhost
ansible_lxd_project = testproject

root@lxd:~# cat main.yml 
- hosts: all
  gather_facts: false

  collections:
  - community.general

  tasks:
    - name: Check the container hostname
      shell: hostname


root@lxd:~# ansible-playbook -i inventory main.yml -vvvv
ansible-playbook 2.10.4
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.8/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.8.5 (default, Jul 28 2020, 12:59:40) [GCC 9.3.0]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /root/inventory as it did not pass its verify_file() method
script declined parsing /root/inventory as it did not pass its verify_file() method
auto declined parsing /root/inventory as it did not pass its verify_file() method
Parsed /root/inventory inventory source with ini plugin
Loading collection community.general from /root/.ansible/collections/ansible_collections/community/general
Loading callback plugin default of type stdout, v2.0 from /usr/local/lib/python3.8/dist-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: main.yml ****************************************************************************************************
Positional arguments: main.yml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('all',)
inventory: ('/root/inventory',)
forks: 5
1 plays in main.yml

PLAY [all] ************************************************************************************************************
META: ran handlers

TASK [Check the container hostname] ********************************************************************************************
task path: /root/main.yml:8
<test2> ESTABLISH LXD CONNECTION FOR USER: root
<test2> EXEC /bin/sh -c 'echo ~root && sleep 0'
<test2> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467 `" && echo ansible-tmp-1608443005.4742098-25659-4163528023467="` echo /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467 `" ) && sleep 0'
<test2> Attempting python interpreter discovery
<test2> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<test2> EXEC /bin/sh -c '/usr/bin/python3.5 && sleep 0'
Using module file /usr/local/lib/python3.8/dist-packages/ansible/modules/command.py
<test2> PUT /root/.ansible/tmp/ansible-local-25655pd7tvfk1/tmp0d8zlxqz TO /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467/AnsiballZ_command.py
<test2> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467/ /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467/AnsiballZ_command.py && sleep 0'
<test2> EXEC /bin/sh -c '/usr/bin/python3 /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467/AnsiballZ_command.py && sleep 0'
<test2> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1608443005.4742098-25659-4163528023467/ > /dev/null 2>&1 && sleep 0'
changed: [test2] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": true,
    "cmd": "hostname",
    "delta": "0:00:00.002845",
    "end": "2020-12-20 05:43:28.811535",
    "invocation": {
        "module_args": {
            "_raw_params": "hostname",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "rc": 0,
    "start": "2020-12-20 05:43:28.808690",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "test2",
    "stdout_lines": [
        "test2"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************
test2                      : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
~~~
