### PR TITLE
Remove bridge-slave from list of IP based connections

### DIFF
--- a/changelogs/fragments/1517-bridge-slave-from-list-of-ip-based-connections.yml
+++ b/changelogs/fragments/1517-bridge-slave-from-list-of-ip-based-connections.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - remove bridge-slave from list of ip based connectons ((https://github.com/ansible-collections/community.general/issues/1500).

--- a/changelogs/fragments/1517-bridge-slave-from-list-of-ip-based-connections.yml
+++ b/changelogs/fragments/1517-bridge-slave-from-list-of-ip-based-connections.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - remove bridge-slave from list of ip based connectons ((https://github.com/ansible-collections/community.general/issues/1500).
+  - nmcli - remove ``bridge-slave`` from list of IP based connections ((https://github.com/ansible-collections/community.general/issues/1500).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -781,7 +781,6 @@ class Nmcli(object):
         return self.type in (
             'bond',
             'bridge',
-            'bridge-slave',
             'ethernet',
             'generic',
             'infiniband',


### PR DESCRIPTION
…since nmcli does not accept IP options for bridge-slave connections.

##### SUMMARY
The nmcli does not accept IP based options that automatically get injected for bridge-slave connection type. 

Fixes #1500.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION