### PR TITLE
nios_member: fix nios api member_normalize error with python 3

### DIFF
--- a/changelogs/fragments/1527-fix-nios-api-member-normalize.yaml
+++ b/changelogs/fragments/1527-fix-nios-api-member-normalize.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - nios_member - fix python3 compatability with nios api member_normalize function (https://github.com/ansible-collections/community.general/issues/1526).

--- a/changelogs/fragments/1527-fix-nios-api-member-normalize.yaml
+++ b/changelogs/fragments/1527-fix-nios-api-member-normalize.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-    - nios_member - fix python3 compatability with nios api member_normalize function (https://github.com/ansible-collections/community.general/issues/1526).
+    - nios_member - fix Python 3 compatibility with nios api ``member_normalize`` function (https://github.com/ansible-collections/community.general/issues/1526).

--- a/plugins/module_utils/net_tools/nios/api.py
+++ b/plugins/module_utils/net_tools/nios/api.py
@@ -144,7 +144,7 @@ def member_normalize(member_spec):
                        'pre_provisioning', 'network_setting', 'v6_network_setting',
                        'ha_port_setting', 'lan_port_setting', 'lan2_physical_setting',
                        'lan_ha_port_setting', 'mgmt_network_setting', 'v6_mgmt_network_setting']
-    for key in member_spec.keys():
+    for key in list(member_spec.keys()):
         if key in member_elements and member_spec[key] is not None:
             member_spec[key] = member_spec[key][0]
         if isinstance(member_spec[key], dict):


### PR DESCRIPTION
Force a copy of the member_spec dict keys to allow change during iteration.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1526 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_member

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The nios_member module uses a method in `plugins/module_utils/net_tools/nios/api.py` to normalise the request data attributes.  However this method tries to modify the `member_spec` dictionary whilst iterating the same dict.
This is not permitted in Python 3.
This PR changes to use a copy of the dict keys, rather than a iter.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
