### PR TITLE
monit: add support for all monit services when checking process state

### DIFF
--- a/changelogs/fragments/1532-monit-support-all-services.yaml
+++ b/changelogs/fragments/1532-monit-support-all-services.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - monit - add support for all monit service checks (https://github.com/ansible-collections/community.general/pull/1532).

--- a/plugins/modules/monitoring/monit.py
+++ b/plugins/modules/monitoring/monit.py
@@ -62,6 +62,9 @@ STATE_COMMAND_MAP = {
     'restarted': 'restart'
 }
 
+MONIT_SERVICES = ['Process', 'File', 'Fifo', 'Filesystem', 'Directory', 'Remote host', 'System', 'Program',
+                  'Network']
+
 
 @python_2_unicode_compatible
 class StatusValue(namedtuple("Status", "value, is_pending")):
@@ -151,7 +154,8 @@ class Monit(object):
         return self._parse_status(out, err)
 
     def _parse_status(self, output, err):
-        if "Process '%s'" % self.process_name not in output:
+        pattern = "(%s) '%s'" % ('|'.join(MONIT_SERVICES), self.process_name)
+        if not re.search(pattern, output):
             return Status.MISSING
 
         status_val = re.findall(r"^\s*status\s*([\w\- ]+)", output, re.MULTILINE)

--- a/plugins/modules/monitoring/monit.py
+++ b/plugins/modules/monitoring/monit.py
@@ -154,7 +154,7 @@ class Monit(object):
         return self._parse_status(out, err)
 
     def _parse_status(self, output, err):
-        pattern = "(%s) '%s'" % ('|'.join(MONIT_SERVICES), self.process_name)
+        pattern = "(%s) '%s'" % ('|'.join(re.escape(MONIT_SERVICES)), re.escape(self.process_name))
         if not re.search(pattern, output, re.IGNORECASE):
             return Status.MISSING
 

--- a/plugins/modules/monitoring/monit.py
+++ b/plugins/modules/monitoring/monit.py
@@ -154,7 +154,8 @@ class Monit(object):
         return self._parse_status(out, err)
 
     def _parse_status(self, output, err):
-        pattern = "(%s) '%s'" % ('|'.join(re.escape(MONIT_SERVICES)), re.escape(self.process_name))
+        escaped_monit_services = '|'.join([re.escape(x) for x in MONIT_SERVICES])
+        pattern = "(%s) '%s'" % (escaped_monit_services, re.escape(self.process_name))
         if not re.search(pattern, output, re.IGNORECASE):
             return Status.MISSING
 

--- a/plugins/modules/monitoring/monit.py
+++ b/plugins/modules/monitoring/monit.py
@@ -155,7 +155,7 @@ class Monit(object):
 
     def _parse_status(self, output, err):
         pattern = "(%s) '%s'" % ('|'.join(MONIT_SERVICES), self.process_name)
-        if not re.search(pattern, output):
+        if not re.search(pattern, output, re.IGNORECASE):
             return Status.MISSING
 
         status_val = re.findall(r"^\s*status\s*([\w\- ]+)", output, re.MULTILINE)

--- a/tests/unit/plugins/modules/monitoring/test_monit.py
+++ b/tests/unit/plugins/modules/monitoring/test_monit.py
@@ -12,7 +12,7 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 
 
 TEST_OUTPUT = """
-Process '%s'
+%s '%s'
   status                       %s
   monitoring status            Not monitored
   monitoring mode              active
@@ -106,24 +106,41 @@ def test_status_value(status_name):
 
 
 BASIC_OUTPUT_CASES = [
-    (TEST_OUTPUT % ('processX', name), getattr(monit.Status, name.upper()))
+    (TEST_OUTPUT % ('Process', 'processX', name), getattr(monit.Status, name.upper()))
     for name in monit.StatusValue.ALL_STATUS
 ]
 
 
 @pytest.mark.parametrize('output, expected', BASIC_OUTPUT_CASES + [
     ('', monit.Status.MISSING),
-    (TEST_OUTPUT % ('processY', 'OK'), monit.Status.MISSING),
-    (TEST_OUTPUT % ('processX', 'Not Monitored - start pending'), monit.Status.OK),
-    (TEST_OUTPUT % ('processX', 'Monitored - stop pending'), monit.Status.NOT_MONITORED),
-    (TEST_OUTPUT % ('processX', 'Monitored - restart pending'), monit.Status.OK),
-    (TEST_OUTPUT % ('processX', 'Not Monitored - monitor pending'), monit.Status.OK),
-    (TEST_OUTPUT % ('processX', 'Does not exist'), monit.Status.DOES_NOT_EXIST),
-    (TEST_OUTPUT % ('processX', 'Not monitored'), monit.Status.NOT_MONITORED),
-    (TEST_OUTPUT % ('processX', 'Running'), monit.Status.OK),
-    (TEST_OUTPUT % ('processX', 'Execution failed | Does not exist'), monit.Status.EXECUTION_FAILED),
+    (TEST_OUTPUT % ('Process', 'processY', 'OK'), monit.Status.MISSING),
+    (TEST_OUTPUT % ('Process', 'processX', 'Not Monitored - start pending'), monit.Status.OK),
+    (TEST_OUTPUT % ('Process', 'processX', 'Monitored - stop pending'), monit.Status.NOT_MONITORED),
+    (TEST_OUTPUT % ('Process', 'processX', 'Monitored - restart pending'), monit.Status.OK),
+    (TEST_OUTPUT % ('Process', 'processX', 'Not Monitored - monitor pending'), monit.Status.OK),
+    (TEST_OUTPUT % ('Process', 'processX', 'Does not exist'), monit.Status.DOES_NOT_EXIST),
+    (TEST_OUTPUT % ('Process', 'processX', 'Not monitored'), monit.Status.NOT_MONITORED),
+    (TEST_OUTPUT % ('Process', 'processX', 'Running'), monit.Status.OK),
+    (TEST_OUTPUT % ('Process', 'processX', 'Execution failed | Does not exist'), monit.Status.EXECUTION_FAILED),
 ])
 def test_parse_status(output, expected):
+    status = monit.Monit(None, '', 'processX', 0)._parse_status(output, '')
+    assert status == expected
+
+
+@pytest.mark.parametrize('output, expected', BASIC_OUTPUT_CASES + [
+    (TEST_OUTPUT % ('Process', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('File', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Fifo', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Filesystem', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Directory', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Remote host', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('System', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Program', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Network', 'processX', 'OK'), monit.Status.OK),
+    (TEST_OUTPUT % ('Unsupported', 'processX', 'OK'), monit.Status.MISSING),
+])
+def test_parse_status_supports_all_services(output, expected):
     status = monit.Monit(None, '', 'processX', 0)._parse_status(output, '')
     assert status == expected
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The changes introduced by @snopoke [here](https://github.com/ansible-collections/community.general/pull/1107) did not include support for other [monit service checks](https://mmonit.com/monit/documentation/monit.html#Service-checks) besides "Process". Other service checks return a process status of "missing".

This change checks the output of `monit validate <name>` or `monit status <name>` for all of the potential monit service checks. I've tested this locally when running the "File" service check and it works as expected. The "File" service check is also how I noticed the issue in the first place. 

The unit test assumes the text returned from other service checks based on the pattern observed in the "Process" and "File" service checks. To be safe, this was my reasoning for ignoring case in the check (specifically for the "Remote host" service).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
monit
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->

