### PR TITLE
added jobs parameter to make module

### DIFF
--- a/changelogs/fragments/1550-add-jobs-parameter-to-make.yml
+++ b/changelogs/fragments/1550-add-jobs-parameter-to-make.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- make - add jobs parameter to allow specification of number of simultaneous jobs for make to run

--- a/changelogs/fragments/1550-add-jobs-parameter-to-make.yml
+++ b/changelogs/fragments/1550-add-jobs-parameter-to-make.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- make - add jobs parameter to allow specification of number of simultaneous jobs for make to run
+- make - add ``jobs`` parameter to allow specification of number of simultaneous jobs for make to run (https://github.com/ansible-collections/community.general/pull/1550).

--- a/plugins/modules/system/make.py
+++ b/plugins/modules/system/make.py
@@ -40,6 +40,11 @@ options:
       - Use a specific make binary.
     type: path
     version_added: '0.2.0'
+  jobs:
+    description:
+      - Set the number of make jobs to run concurrently.
+    type: int
+    version_added: 'not yet'
 '''
 
 EXAMPLES = r'''
@@ -111,6 +116,7 @@ def main():
             chdir=dict(type='path', required=True),
             file=dict(type='path'),
             make=dict(type='path'),
+            jobs=dict(type='int')
         ),
         supports_check_mode=True,
     )
@@ -129,10 +135,19 @@ def main():
     else:
         make_parameters = []
 
+    # build command:
+    # handle any make specific arguments included in params
+    base_command = [make_path]
+    if module.params['jobs'] is not None:
+        jobs = str(module.params['jobs'])
+        base_command.extend(["-j", jobs])
     if module.params['file'] is not None:
-        base_command = [make_path, "-f", module.params['file'], make_target]
-    else:
-        base_command = [make_path, make_target]
+        base_command.extend(["-f", module.params['file']])
+
+    # add make target
+    base_command.append(make_target)
+
+    # add makefile parameters
     base_command.extend(make_parameters)
 
     # Check if the target is already up to date
@@ -165,7 +180,8 @@ def main():
         target=module.params['target'],
         params=module.params['params'],
         chdir=module.params['chdir'],
-        file=module.params['file']
+        file=module.params['file'],
+        jobs=module.params['jobs'],
     )
 
 

--- a/plugins/modules/system/make.py
+++ b/plugins/modules/system/make.py
@@ -43,8 +43,8 @@ options:
   jobs:
     description:
       - Set the number of make jobs to run concurrently.
+      - Typically if set, this would be the number of processors and/or threads available to the machine
     type: int
-    version_added: 'not yet'
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/system/make.py
+++ b/plugins/modules/system/make.py
@@ -43,8 +43,10 @@ options:
   jobs:
     description:
       - Set the number of make jobs to run concurrently.
-      - Typically if set, this would be the number of processors and/or threads available to the machine
+      - Typically if set, this would be the number of processors and/or threads available to the machine.
+      - This is not supported by all make implementations.
     type: int
+    version_added: 2.0.0
 '''
 
 EXAMPLES = r'''
@@ -116,7 +118,7 @@ def main():
             chdir=dict(type='path', required=True),
             file=dict(type='path'),
             make=dict(type='path'),
-            jobs=dict(type='int')
+            jobs=dict(type='int'),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY
I added this to allow use of the -j or --jobs argument for make/gmake. If hardware supports multiple jobs this significantly speeds up compile time

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.make

##### ADDITIONAL INFORMATION
I kept my changes to a minimum focused only on adding and documenting the new parameter. I refactored the existing file parameter since it was also a commandline argument to make/gmake. I tried to add appropriate comments to the code as well.