### PR TITLE
Add tags filter to linode inventory plugin

### DIFF
--- a/changelogs/fragments/1549-add-tag-filter-to-linode-inventory.yml
+++ b/changelogs/fragments/1549-add-tag-filter-to-linode-inventory.yml
@@ -1,4 +1,4 @@
 minor_changes:
         - linode inventory plugin - add support for ``tags`` option to filter
           instances by tag
-          (https://github.com/ansible-collections/community.general/issues/1549)
+          (https://github.com/ansible-collections/community.general/issues/1549).

--- a/changelogs/fragments/1549-add-tag-filter-to-linode-inventory.yml
+++ b/changelogs/fragments/1549-add-tag-filter-to-linode-inventory.yml
@@ -1,0 +1,4 @@
+minor_changes:
+        - linode inventory plugin - add support for ``tags`` option to filter
+          instances by tag
+          (https://github.com/ansible-collections/community.general/issues/1549)

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -37,7 +37,8 @@ DOCUMENTATION = r'''
           type: list
           required: false
         tags:
-          description: Populate inventory with instances with this tag.
+          description: Populate inventory only with instances which have at
+          least one of the tags listed here.
           default: []
           type: list
           reqired: false

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -37,8 +37,7 @@ DOCUMENTATION = r'''
           type: list
           required: false
         tags:
-          description: Populate inventory only with instances which have at
-          least one of the tags listed here.
+          description: Populate inventory only with instances which have at least one of the tags listed here.
           default: []
           type: list
           reqired: false

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -36,6 +36,12 @@ DOCUMENTATION = r'''
           default: []
           type: list
           required: false
+        tags:
+          description: Populate inventory with instances with this tag.
+          default: []
+          type: list
+          reqired: false
+          version_added: 2.0.0
         types:
           description: Populate inventory with instances with this type.
           default: []
@@ -136,7 +142,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for linode_group in self.linode_groups:
             self.inventory.add_group(linode_group)
 
-    def _filter_by_config(self, regions, types):
+    def _filter_by_config(self, regions, types, tags):
         """Filter instances by user specified configuration."""
         if regions:
             self.instances = [
@@ -148,6 +154,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.instances = [
                 instance for instance in self.instances
                 if instance.type.id in types
+            ]
+
+        if tags:
+            self.instances = [
+                instance for instance in self.instances
+                for tag in instance.tags if tag in tags
             ]
 
     def _add_instances_to_groups(self):
@@ -194,6 +206,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 'type_to_be': list,
                 'value': config_data.get('types', [])
             },
+            'tags': {
+                'type_to_be': list,
+                'value': config_data.get('tags', [])
+            },
         }
 
         for name in options:
@@ -205,8 +221,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         regions = options['regions']['value']
         types = options['types']['value']
+        tags = options['tags']['value']
 
-        return regions, types
+        return regions, types, tags
 
     def verify_file(self, path):
         """Verify the Linode configuration file."""
@@ -229,8 +246,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._get_instances_inventory()
 
         strict = self.get_option('strict')
-        regions, types = self._get_query_options(config_data)
-        self._filter_by_config(regions, types)
+        regions, types, tags = self._get_query_options(config_data)
+        self._filter_by_config(regions, types, tags)
 
         self._add_groups()
         self._add_instances_to_groups()

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -159,7 +159,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if tags:
             self.instances = [
                 instance for instance in self.instances
-                for tag in instance.tags if tag in tags
+                if any(tag in instance.tags for tag in tags)
             ]
 
     def _add_instances_to_groups(self):

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -58,18 +58,20 @@ def test_validation_option_bad_option(inventory):
 
 
 def test_empty_config_query_options(inventory):
-    regions, types = inventory._get_query_options({})
-    assert regions == types == []
+    regions, types, tags = inventory._get_query_options({})
+    assert regions == types == tags == []
 
 
 def test_conig_query_options(inventory):
     regions, types = inventory._get_query_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],
+        'tags': ['web-server'],
     })
 
     assert regions == ['eu-west', 'us-east']
     assert types == ['g5-standard-2', 'g6-standard-2']
+    assert tags == ['web-server']
 
 
 def test_verify_file_bad_config(inventory):

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -63,7 +63,7 @@ def test_empty_config_query_options(inventory):
 
 
 def test_conig_query_options(inventory):
-    regions, types = inventory._get_query_options({
+    regions, types, tags = inventory._get_query_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],
         'tags': ['web-server'],


### PR DESCRIPTION
##### SUMMARY
This adds a ``tags`` option to the linode inventory plugin to filter instances
Fixes #1549 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
inventory plugin linode

##### ADDITIONAL INFORMATION

Use the tags option like the regions or types option to filter the returned nodes
