### PR TITLE
Remove ansible.netcommon dependency

### DIFF
--- a/changelogs/fragments/remove-ansible.netcommon-dependency.yml
+++ b/changelogs/fragments/remove-ansible.netcommon-dependency.yml
@@ -1,0 +1,4 @@
+major_changes:
+- "The community.general collection no longer depends on the ansible.netcommon collection (https://github.com/ansible-collections/community.general/pull/1561)."
+minor_changes:
+- "nios_network - no longer requires the ansible.netcommon collection (https://github.com/ansible-collections/community.general/pull/1561)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,6 @@ license_file: COPYING
 tags: [community]
 # NOTE: No more dependencies can be added to this list
 dependencies:
-  ansible.netcommon: '>=1.0.0'
   community.kubernetes: '>=1.0.0'
 repository: https://github.com/ansible-collections/community.general
 documentation: https://docs.ansible.com/ansible/latest/collections/community/general/

--- a/plugins/modules/net_tools/nios/nios_network.py
+++ b/plugins/modules/net_tools/nios/nios_network.py
@@ -173,12 +173,37 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
+import socket
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import WapiModule
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import validate_ip_address, validate_ip_v6_address
 from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK
 from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER
+
+
+# The following function validate_ip_address has been taken from
+# https://github.com/ansible-collections/ansible.netcommon/blob/20124ecbb420daa0f5bb9cdaa865a952657aa0e7/plugins/module_utils/network/common/utils.py#L496
+# The code there is licensed under BSD 2-clause.
+# Copyright (c) 2016 Red Hat Inc.
+def validate_ip_address(address):
+    try:
+        socket.inet_aton(address)
+    except socket.error:
+        return False
+    return address.count(".") == 3
+
+
+# The following function validate_ip_v6_address has been taken from
+# https://github.com/ansible-collections/ansible.netcommon/blob/20124ecbb420daa0f5bb9cdaa865a952657aa0e7/plugins/module_utils/network/common/utils.py#L504
+# The code there is licensed under BSD 2-clause.
+# Copyright (c) 2016 Red Hat Inc.
+def validate_ip_v6_address(address):
+    try:
+        socket.inet_pton(socket.AF_INET6, address)
+    except socket.error:
+        return False
+    return True
 
 
 def options(module):

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,9 +1,7 @@
 integration_tests_dependencies:
-- ansible.netcommon
 - ansible.posix
 - community.crypto
 - community.kubernetes
 unit_tests_dependencies:
-- ansible.netcommon
 - community.internal_test_tools
 - community.kubernetes

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -74,7 +74,6 @@ else
 fi
 
 # START: HACK install dependencies
-retry ansible-galaxy -vvv collection install ansible.netcommon
 retry ansible-galaxy -vvv collection install community.kubernetes
 
 if [ "${script}" != "sanity" ] || [ "${test}" == "sanity/extra" ]; then


### PR DESCRIPTION
##### SUMMARY
Since it is not clear whether the nios modules are actually removed before 2.0.0 is released, I've created this small PR which vendors the two ansible.netcommon functions used in the nios_network module.

The functions are pretty simple and the module itself will hopefully be removed in the near future anyway, so I don't see much problem with replicating the code in this collection.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
collection
nios_network
