### PR TITLE
changed make parameter from --question to -q

### DIFF
--- a/changelogs/fragments/1574-make-question.yaml
+++ b/changelogs/fragments/1574-make-question.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - make - Fixed ``make`` parameter used for check mode when running a non-GNU ``make`` (https://github.com/ansible-collections/community.general/pull/1574).

--- a/changelogs/fragments/1574-make-question.yaml
+++ b/changelogs/fragments/1574-make-question.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - make - Fixed ``make`` parameter used for check mode when running a non-GNU ``make`` (https://github.com/ansible-collections/community.general/pull/1574).
+  - make - fixed ``make`` parameter used for check mode when running a non-GNU ``make`` (https://github.com/ansible-collections/community.general/pull/1574).

--- a/plugins/modules/system/make.py
+++ b/plugins/modules/system/make.py
@@ -136,7 +136,7 @@ def main():
     base_command.extend(make_parameters)
 
     # Check if the target is already up to date
-    rc, out, err = run_command(base_command + ['--question'], module, check_rc=False)
+    rc, out, err = run_command(base_command + ['-q'], module, check_rc=False)
     if module.check_mode:
         # If we've been asked to do a dry run, we only need
         # to report whether or not the target is up to date


### PR DESCRIPTION
##### SUMMARY
Platforms that do not use GNU ``make`` (why oh why) will not recognize the long option ``--question`` for check mode. Must use ``-q`` instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/make.py

##### ADDITIONAL INFORMATION
