### PR TITLE
fix passwordstore.py to be compatible with gopass.

### DIFF
--- a/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
+++ b/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
@@ -2,4 +2,4 @@ bugfixes:
   - passwordstore lookup plugin - fix compatibility with gopass when used with
     ``create=true``. While pass returns 1 on a non-existent password, gopass
     returns 10, or 11, depending on whether a similar named password was stored.
-    We know just check stdout and that the return code != 0.
+    We now just check standard output and that the return code is not zero (https://github.com/ansible-collections/community.general/pull/1589).

--- a/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
+++ b/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
@@ -1,5 +1,5 @@
 bugfixes:
   - passwordstore lookup plugin - fix compatibility with gopass when used with
-    create=true. Wut while pass returns 1 on a non-existent password, gopass
+    ``create=true``. While pass returns 1 on a non-existent password, gopass
     returns 10, or 11, depending on whether a similar named password was stored.
     We know just check stdout and that the return code != 0.

--- a/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
+++ b/changelogs/fragments/1589-passwordstore-fix-passwordstore.py-to-be-compatible-with-gopass.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - passwordstore lookup plugin - fix compatibility with gopass when used with
+    create=true. Wut while pass returns 1 on a non-existent password, gopass
+    returns 10, or 11, depending on whether a similar named password was stored.
+    We know just check stdout and that the return code != 0.

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -214,7 +214,7 @@ class LookupModule(LookupBase):
                     name, value = line.split(':', 1)
                     self.passdict[name.strip()] = value.strip()
         except (subprocess.CalledProcessError) as e:
-            if e.returncode =! 0 and 'not in the password store' in e.output:
+            if e.returncode != 0 and 'not in the password store' in e.output:
                 # if pass returns 1 and return string contains 'is not in the password store.'
                 # We need to determine if this is valid or Error.
                 if not self.paramvals['create']:

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -214,7 +214,7 @@ class LookupModule(LookupBase):
                     name, value = line.split(':', 1)
                     self.passdict[name.strip()] = value.strip()
         except (subprocess.CalledProcessError) as e:
-            if e.returncode == 1 and 'not in the password store' in e.output:
+            if e.returncode =! 0 and 'not in the password store' in e.output:
                 # if pass returns 1 and return string contains 'is not in the password store.'
                 # We need to determine if this is valid or Error.
                 if not self.paramvals['create']:


### PR DESCRIPTION

##### SUMMARY

...even when used with create=true.

The same output snippet matches for both, `pass` and `gopass`, but while `pass` returns `1` on a non-existant password, `gopass` returns `10`, or `11`, depending on whether a similar named password was stored.

So I'd propose to change `e.returncode == 1` to `e.returncode != 0` to cover both cases here.

What do you think?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

./plugins/lookup/passwordstore.py

##### ADDITIONAL INFORMATION

In a module fall like the following:

```yaml
- debug:
        msg: "{{ lookup('passwordstore', 'test create=true nosymbols=true') }}"
```

Everything works with pass, but with gopass the new password is created but the ansible module call fails because it's return code is unexpected