### PR TITLE
Added shard_group_duration to influxdb_retention_policy module

### DIFF
--- a/changelogs/fragments/1590-influxdb-shard-group-duration-parameter.yml
+++ b/changelogs/fragments/1590-influxdb-shard-group-duration-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - shard_group_duration - Add shard group duration parameter for influxdb_retention_policy module (https://github.com/ansible-collections/community.general/pull/1590).
+  - influxdb_retention_policy - add shard group duration parameter ``shard_group_duration`` (https://github.com/ansible-collections/community.general/pull/1590).

--- a/changelogs/fragments/1590-influxdb-shard-group-duration-parameter.yml
+++ b/changelogs/fragments/1590-influxdb-shard-group-duration-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - shard_group_duration - Add shard group duration parameter for influxdb_retention_policy module (https://github.com/ansible-collections/community.general/pull/1590).

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -75,15 +75,16 @@ EXAMPLES = r'''
       replication: 1
       shard_group_duration: 1h
 
-- name: Create 1 week retention policy
+- name: Create 1 week retention policy with 1 day shard group duration
   community.general.influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
       policy_name: test
       duration: 1w
       replication: 1
+      shard_group_duration: 1d
 
-- name: Create infinite retention policy
+- name: Create infinite retention policy with 1 week of shard group duration
   community.general.influxdb_retention_policy:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
@@ -92,6 +93,7 @@ EXAMPLES = r'''
       replication: 1
       ssl: no
       validate_certs: no
+      shard_group_duration: 1w
 '''
 
 RETURN = r'''
@@ -204,8 +206,8 @@ def main():
         policy_name=dict(required=True, type='str'),
         duration=dict(required=True, type='str'),
         replication=dict(required=True, type='int'),
-        default=dict(default=False, type='bool'),
-        shard_group_duration=dict(required=False, type='str')
+        shard_group_duration=dict(required=False, type='str'),
+        default=dict(default=False, type='bool')
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -47,6 +47,8 @@ options:
     shard_group_duration:
         description:
             - Determines the size of a shard group.
+            - Value needs to be integer literal followed immediately (with no spaces) by a duration unit.
+              Supported duration units are h,d,w. For example 10d, 1h, 2w.
         type: str
         version_added: '2.0.0'
 extends_documentation_fragment:
@@ -206,8 +208,8 @@ def main():
         policy_name=dict(required=True, type='str'),
         duration=dict(required=True, type='str'),
         replication=dict(required=True, type='int'),
+        default=dict(default=False, type='bool'),
         shard_group_duration=dict(required=False, type='str'),
-        default=dict(default=False, type='bool')
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -48,7 +48,7 @@ options:
         description:
             - Determines the size of a shard group.
             - Value needs to be integer literal followed immediately (with no spaces) by a duration unit.
-              Supported duration units are h,d,w. For example 10d, 1h, 2w.
+              Supported duration units are C(h) for hours, C(d) for days, and C(w) for weeks. For example C(10d), C(1h), C(2w).
         type: str
         version_added: '2.0.0'
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY

For https://github.com/ansible-collections/community.general/issues/529

Adds the shard_group_duration parameter

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
influxdb_retention_policy.py

##### ADDITIONAL INFORMATION
~~~
- name: test influxdb retention policy
  hosts: localhost
  connection: local
  gather_facts: false

  collections:
  - community.general

  tasks:
  - name: create retention policy
    community.general.influxdb_retention_policy:
      hostname: localhost
      password: redhat
      username: ishwar
      port: 8086
      database_name: awx
      policy_name: awx
      replication: 1
      default: true
      duration: 10w
      shard_group_duration: 1d
~~~

With shard_group_duration: 1d

~~~
ansible-playbook 2.10.4
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.8 (default, May 21 2019, 23:51:36) [GCC 8.2.1 20180905 (Red Hat 8.2.1-3)]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: influx.yml **************************************************************************************************
1 plays in influx.yml

PLAY [test influxdb retention policy] *********************************************************************************
META: ran handlers

TASK [create retention policy] ****************************************************************************************
task path: /root/influx.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246 `" && echo ansible-tmp-1609770426.1083753-6937-276418244939246="` echo /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246 `" ) && sleep 0'
Using module file /root/.ansible/collections/ansible_collections/community/general/plugins/modules/influxdb_retention_policy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6931vwtg31qj/tmpfvscr49s TO /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246/AnsiballZ_influxdb_retention_policy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246/ /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3.6 /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1609770426.1083753-6937-276418244939246/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "database_name": "awx",
            "default": true,
            "duration": "10w",
            "hostname": "localhost",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "",
            "policy_name": "awx",
            "port": 8086,
            "proxies": {},
            "replication": 1,
            "retries": 3,
            "shard_group_duration": "1d",
            "ssl": false,
            "timeout": null,
            "udp_port": 4444,
            "use_udp": false,
            "username": "ishwar",
            "validate_certs": true
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
~~~

Rerun of the above playbook without any changes in shard_group_duraiton:

~~~
ansible-playbook 2.10.4
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.8 (default, May 21 2019, 23:51:36) [GCC 8.2.1 20180905 (Red Hat 8.2.1-3)]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: influx.yml **************************************************************************************************
1 plays in influx.yml

PLAY [test influxdb retention policy] *********************************************************************************
META: ran handlers

TASK [create retention policy] ****************************************************************************************
task path: /root/influx.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982 `" && echo ansible-tmp-1609770465.5010128-6960-159901780375982="` echo /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982 `" ) && sleep 0'
Using module file /root/.ansible/collections/ansible_collections/community/general/plugins/modules/influxdb_retention_policy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6954sv586qyg/tmpjkv1egfr TO /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982/AnsiballZ_influxdb_retention_policy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982/ /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3.6 /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1609770465.5010128-6960-159901780375982/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "database_name": "awx",
            "default": true,
            "duration": "10w",
            "hostname": "localhost",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "",
            "policy_name": "awx",
            "port": 8086,
            "proxies": {},
            "replication": 1,
            "retries": 3,
            "shard_group_duration": "1d",
            "ssl": false,
            "timeout": null,
            "udp_port": 4444,
            "use_udp": false,
            "username": "ishwar",
            "validate_certs": true
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
~~~

Changed shard_group_duration to 1w which runs the alter retention policy:

~~~
ansible-playbook 2.10.4
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.8 (default, May 21 2019, 23:51:36) [GCC 8.2.1 20180905 (Red Hat 8.2.1-3)]
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: influx.yml **************************************************************************************************
1 plays in influx.yml

PLAY [test influxdb retention policy] *********************************************************************************
META: ran handlers

TASK [create retention policy] ****************************************************************************************
task path: /root/influx.yml:10
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338 `" && echo ansible-tmp-1609770507.6680102-6993-18580624129338="` echo /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338 `" ) && sleep 0'
Using module file /root/.ansible/collections/ansible_collections/community/general/plugins/modules/influxdb_retention_policy.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6987z5mk1g20/tmp88o0igcd TO /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338/AnsiballZ_influxdb_retention_policy.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338/ /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3.6 /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338/AnsiballZ_influxdb_retention_policy.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1609770507.6680102-6993-18580624129338/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "database_name": "awx",
            "default": true,
            "duration": "10w",
            "hostname": "localhost",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "",
            "policy_name": "awx",
            "port": 8086,
            "proxies": {},
            "replication": 1,
            "retries": 3,
            "shard_group_duration": "1w",
            "ssl": false,
            "timeout": null,
            "udp_port": 4444,
            "use_udp": false,
            "username": "ishwar",
            "validate_certs": true
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
~~~