### PR TITLE
chroot: clarify disabling of connection chroot tests on macos

### DIFF
--- a/tests/integration/targets/connection_chroot/aliases
+++ b/tests/integration/targets/connection_chroot/aliases
@@ -1,3 +1,3 @@
 needs/root
 shippable/posix/group3
-skip/macos  # FIXME
+skip/macos # Skipped due to limitation of macOS 10.15 SIP, please read https://github.com/ansible-collections/community.general/issues/1017#issuecomment-755088895


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Fixes #1017.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/connection_chroot/aliases
