### PR TITLE
homebrew_tap: Return error message to user

### DIFF
--- a/changelogs/fragments/1411_homebrew_tap.yml
+++ b/changelogs/fragments/1411_homebrew_tap.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- homebrew_tap - provide error message to user when module fails (https://github.com/ansible-collections/community.general/issues/1411).

--- a/plugins/modules/packaging/os/homebrew_tap.py
+++ b/plugins/modules/packaging/os/homebrew_tap.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Daniel Jaouen <dcj24@cornell.edu>
-# (c) 2016, Indrajit Raychaudhuri <irc+code@indrajit.com>
+# Copyright: (c) 2013, Daniel Jaouen <dcj24@cornell.edu>
+# Copyright: (c) 2016, Indrajit Raychaudhuri <irc+code@indrajit.com>
 #
 # Based on homebrew (Andrew Dunham <andrew@du.nham.ca>)
 #
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: homebrew_tap
 author:
@@ -48,7 +48,7 @@ options:
 requirements: [ homebrew ]
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Tap a Homebrew repository, state present
   community.general.homebrew_tap:
     name: homebrew/dupes
@@ -117,7 +117,7 @@ def add_tap(module, brew_path, tap, url=None):
             msg = 'successfully tapped: %s' % tap
         else:
             failed = True
-            msg = 'failed to tap: %s' % tap
+            msg = 'failed to tap: %s due to %s' % (tap, err)
 
     else:
         msg = 'already tapped: %s' % tap
@@ -172,7 +172,7 @@ def remove_tap(module, brew_path, tap):
             msg = 'successfully untapped: %s' % tap
         else:
             failed = True
-            msg = 'failed to untap: %s' % tap
+            msg = 'failed to untap: %s due to %s' % (tap, err)
 
     else:
         msg = 'already untapped: %s' % tap


### PR DESCRIPTION
##### SUMMARY

* When module fails return meaningful error message to user
  returned by homebrew-tap command.
* Doc update

Fixes: #1411

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/1411_homebrew_tap.yml
plugins/modules/packaging/os/homebrew_tap.py
