### PR TITLE
onepassword: find the password field out of the fields list

### DIFF
--- a/changelogs/fragments/1610-bugfix-onepassword-lookup-plugin.yaml
+++ b/changelogs/fragments/1610-bugfix-onepassword-lookup-plugin.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "update onepassword lookup plugin to support password items, which place the password field directly in the payload's `details` attribute."

--- a/changelogs/fragments/1610-bugfix-onepassword-lookup-plugin.yaml
+++ b/changelogs/fragments/1610-bugfix-onepassword-lookup-plugin.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- "update onepassword lookup plugin to support password items, which place the password field directly in the payload's `details` attribute."
+- "onepassword lookup plugin - updated to support password items, which place the password field directly in the payload's ``details`` attribute (https://github.com/ansible-collections/community.general/pull/1610)."

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -187,8 +187,63 @@ class OnePass(object):
         return rc, out, err
 
     def _parse_field(self, data_json, field_name, section_title=None):
+        """
+        Retrieves the desired field from the `op` response payload
+
+        When the item is a `password` type, the password is a key within the `details` key:
+
+        $ op get item 'test item' | jq
+        {
+          [...]
+          "templateUuid": "005",
+          "details": {
+            "notesPlain": "",
+            "password": "foobar",
+            "passwordHistory": [],
+            "sections": [
+              {
+                "name": "linked items",
+                "title": "Related Items"
+              }
+            ]
+          },
+          [...]
+        }
+
+        However, when the item is a `login` type, the password is within a fields array:
+
+        $ op get item 'test item' | jq
+        {
+          [...]
+          "details": {
+            "fields": [
+              {
+                "designation": "username",
+                "name": "username",
+                "type": "T",
+                "value": "foo"
+              },
+              {
+                "designation": "password",
+                "name": "password",
+                "type": "P",
+                "value": "bar"
+              }
+            ],
+            [...]
+          },
+          [...]
+        """
         data = json.loads(data_json)
         if section_title is None:
+            # GitHub PR 1610:
+            # check the details dictionary for `field_name` and return it immediately if it exists
+            # when the entry is a "password" instead of a "login" item, the password field is a key
+            # in the `details` dictionary:
+            if field_name in data['details']:
+                return data['details'][field_name]
+
+            # when the field is not found above, iterate through the fields list in the object details
             for field_data in data['details'].get('fields', []):
                 if field_data.get('name', '').lower() == field_name.lower():
                     return field_data.get('value', '')

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -236,7 +236,7 @@ class OnePass(object):
         """
         data = json.loads(data_json)
         if section_title is None:
-            # GitHub PR 1610:
+            # https://github.com/ansible-collections/community.general/pull/1610:
             # check the details dictionary for `field_name` and return it immediately if it exists
             # when the entry is a "password" instead of a "login" item, the password field is a key
             # in the `details` dictionary:


### PR DESCRIPTION
With the command line utility `op` version 1.8, the password field exists, while the fields list is empty.  This will look for the desired field without it being listed in the fields list.

##### SUMMARY

When using the onepassword lookup plugin, passwords were being sent back as empty even if the record was found.  I found it was because the fields list returned empty, even though the password key existed in the item's details.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

this is for the onepassword lookup plugin

##### ADDITIONAL INFORMATION

In summary the password would return as an empty string instead of the value from 1P.