### PR TITLE
init_reconfigure fails on module cloud/misc/terraform.py

### DIFF
--- a/changelogs/fragments/1620-terraform_init_reconfigure_fix.yml
+++ b/changelogs/fragments/1620-terraform_init_reconfigure_fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- terraform - fix ``init_reconfigure`` option for proper cli args (https://github.com/ansible-collections/community.general/pull/1620).
+- terraform - fix ``init_reconfigure`` option for proper CLI args (https://github.com/ansible-collections/community.general/pull/1620).

--- a/changelogs/fragments/1620-terraform_init_reconfigure_fix.yml
+++ b/changelogs/fragments/1620-terraform_init_reconfigure_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- terraform - fix ``init_reconfigure`` option for proper cli args (https://github.com/ansible-collections/community.general/pull/1620).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -219,7 +219,7 @@ def init_plugins(bin_path, project_path, backend_config, backend_config_files, i
         for f in backend_config_files:
             command.extend(['-backend-config', f])
     if init_reconfigure:
-        command.extend('-reconfigure')
+        command.extend(['-reconfigure'])
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
         module.fail_json(msg="Failed to initialize Terraform modules:\r\n{0}".format(err))


### PR DESCRIPTION
##### SUMMARY
If parameter `init_reconfigure` is true, the task fails because it runs terraform as:
`terraform init -input=false - r e c o n f i g u r e`

Ansible `module.run_command` expects an array of strings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/terraform.py

##### ADDITIONAL INFORMATION
How to reproduce

```paste below
# file: test.yml
---
- hosts: localhost
  tasks:
  - community.general.terraform:
      project_path: "/tmp/tf-test"
      force_init: true
      init_reconfigure: true

mkdir /tmp/tf-test
ansible-playbook test.yml
```