### PR TITLE
snmp_facts: Hide user sensitive information in console

### DIFF
--- a/changelogs/fragments/snmp_facts.yml
+++ b/changelogs/fragments/snmp_facts.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- 'snmp_facts - **CVE-2021-20178** - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621).'

--- a/plugins/modules/net_tools/snmp_facts.py
+++ b/plugins/modules/net_tools/snmp_facts.py
@@ -269,8 +269,8 @@ def main():
             level=dict(type='str', choices=['authNoPriv', 'authPriv']),
             integrity=dict(type='str', choices=['md5', 'sha']),
             privacy=dict(type='str', choices=['aes', 'des']),
-            authkey=dict(type='str'),
-            privkey=dict(type='str'),
+            authkey=dict(type='str', no_log=True),
+            privkey=dict(type='str', no_log=True),
         ),
         required_together=(
             ['username', 'level', 'integrity', 'authkey'],


### PR DESCRIPTION
##### SUMMARY

**SECURITY** - CVE-2021-20178

Hide user sensitive information like `privkey` and `authkey`
while logging in console.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/snmp_facts.yml
plugins/modules/net_tools/snmp_facts.py
