### PR TITLE
Fixing return code not showing the command that fails in terraform.

### DIFF
--- a/changelogs/fragments/1632-using_check_rc_in_terraform.yml
+++ b/changelogs/fragments/1632-using_check_rc_in_terraform.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- terraform - adding ``check_rc`` option for commands in terraform.py (https://github.com/ansible-collections/community.general/pull/1632).
+- terraform - improve result code checking when executing terraform commands (https://github.com/ansible-collections/community.general/pull/1632).

--- a/changelogs/fragments/1632-using_check_rc_in_terraform.yml
+++ b/changelogs/fragments/1632-using_check_rc_in_terraform.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- terraform - adding ``check_rc`` option for commands in terraform.py (https://github.com/ansible-collections/community.general/pull/1632).


### PR DESCRIPTION
##### SUMMARY
The terraform module has code which just checks if the return code has failed. Then prints just the error message. Though this doesn't show the format of the command that was run. See https://github.com/ansible-collections/community.general/pull/1629 as an example of an issue that can occur with the format of the command.

This PR uses the underlying ansible module's run_command to check the rc which will print the command that was run when a failure occurs.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/terraform.py

