### PR TITLE
bitbucket_pipeline_variable: Hide secured values in console log

### DIFF
--- a/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
+++ b/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- 'bitbucket_pipeline_variable - **CVE-2021-20180** - hide user sensitive information which are marked as ``secured`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1635).'

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -85,7 +85,7 @@ EXAMPLES = r'''
 
 RETURN = r''' # '''
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, _load_params
 from ansible_collections.community.general.plugins.module_utils.source_control.bitbucket import BitbucketHelper
 
 error_messages = {
@@ -211,6 +211,14 @@ def delete_pipeline_variable(module, bitbucket, variable_uuid):
         ))
 
 
+class BitBucketPipelineVariable(AnsibleModule):
+    def __init__(self, *args, **kwargs):
+        params = _load_params() or {}
+        if params.get('secured'):
+            kwargs['argument_spec']['value'].update({'no_log': True})
+        super(BitBucketPipelineVariable, self).__init__(*args, **kwargs)
+
+
 def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
@@ -221,7 +229,7 @@ def main():
         secured=dict(type='bool', default=False),
         state=dict(type='str', choices=['present', 'absent'], required=True),
     )
-    module = AnsibleModule(
+    module = BitBucketPipelineVariable(
         argument_spec=argument_spec,
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY

**SECURITY** - CVE-2021-20180

Hide user sensitive information which is marked as ``secured``
while logging in console.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/cve_bitbucket_pipeline_variable.yml
plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
