### PR TITLE
lldp - use get_bin_path to locate the lldpctl executable

### DIFF
--- a/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
+++ b/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lldp - use get_bin_path to locate the lldpctl executable
+  - lldp - use ``get_bin_path`` to locate the ``lldpctl`` executable (https://github.com/ansible-collections/community.general/pull/1643).

--- a/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
+++ b/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - lldp - use ``get_bin_path`` to locate the ``lldpctl`` executable (https://github.com/ansible-collections/community.general/pull/1643).

--- a/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
+++ b/changelogs/fragments/lldp-use-get_bin_path-to-locate-the-lldpctl-executable.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lldp - use get_bin_path to locate the lldpctl executable

--- a/plugins/modules/net_tools/lldp.py
+++ b/plugins/modules/net_tools/lldp.py
@@ -41,7 +41,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def gather_lldp(module):
-    cmd = ['lldpctl', '-f', 'keyvalue']
+    cmd = [module.get_bin_path('lldpctl'), '-f', 'keyvalue']
     rc, output, err = module.run_command(cmd)
     if output:
         output_dict = {}


### PR DESCRIPTION
##### SUMMARY
Use get_bin_path to locate the lldpctl executable.

This prevents failures [1] on hosts that have lldpd installed and running but
where the PATH directories haven't been hashed recently. With this patch
the full pathname of the lldpctl will be used to avoid potential hashing issues
(typically /sbin/lldpctl will be used).

References:
1 - Failures seen:
   FAILED! => {"changed": false, "cmd": "lldpctl -f keyvalue",
               "msg": "[Errno 2] No such file or directory", "rc": 2}

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lldp

##### ADDITIONAL INFORMATION
Tested against:
 * Linux servers running CentOS 7 and 8, and
 * Mellanox switch running Cumulus Linux 4.2
