### PR TITLE
Add Environment Passthrough to Proxmox Inventory Module

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -30,14 +30,20 @@ DOCUMENTATION = '''
         description: URL to Proxmox cluster.
         default: 'http://localhost:8006'
         type: str
+        env:
+          - name: PROXMOX_URL
       user:
         description: Proxmox authentication user.
         required: yes
         type: str
+        env:
+          - name: PROXMOX_USER
       password:
         description: Proxmox authentication password.
         required: yes
         type: str
+        env:
+          - name: PROXMOX_PASSWORD
       validate_certs:
         description: Verify SSL certificate if using HTTPS.
         type: boolean

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -27,19 +27,25 @@ DOCUMENTATION = '''
         choices: ['community.general.proxmox']
         type: str
       url:
-        description: URL to Proxmox cluster.
+        description:
+          - URL to Proxmox cluster.
+          - If the value is not specified in the task, the value of environment variable C(PROXMOX_URL) will be used instead.
         default: 'http://localhost:8006'
         type: str
         env:
           - name: PROXMOX_URL
       user:
-        description: Proxmox authentication user.
+        description:
+          - Proxmox authentication user.
+          - If the value is not specified in the task, the value of environment variable C(PROXMOX_USER) will be used instead.
         required: yes
         type: str
         env:
           - name: PROXMOX_USER
       password:
-        description: Proxmox authentication password.
+        description:
+          - Proxmox authentication password.
+          - If the value is not specified in the task, the value of environment variable C(PROXMOX_PASSWORD) will be used instead.
         required: yes
         type: str
         env:


### PR DESCRIPTION
##### SUMMARY
Adds environment variable passthrough to the Proxmox inventory module, to allow compatibility with AWX and custom Credential Types.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.proxmox

##### ADDITIONAL INFORMATION
This change enables passthrough of a custom Credential Type from AWX using the following configuration.

Input:
```yaml
fields:
  - id: PROXMOX_URL
    type: string
    label: Proxmox URL

  - id: PROXMOX_USER
    type: string
    label: Username

  - id: PROXMOX_PASSWORD
    type: string
    label: Password
    secret: true

required:
  - PROXMOX_URL
  - PROXMOX_USER
  - PROXMOX_PASSWORD
```

Injector:
```yaml
env:
  PROXMOX_URL: '{{ PROXMOX_URL }}'
  PROXMOX_USER: '{{ PROXMOX_USER }}'
  PROXMOX_PASSWORD: '{{ PROXMOX_PASSWORD }}'
```
