### PR TITLE
dnsmadeeasy: Fix HTTP 400 errors when creating a TXT record

### DIFF
--- a/changelogs/fragments/1654-dnsmadeeasy-http-400-fixes.yaml
+++ b/changelogs/fragments/1654-dnsmadeeasy-http-400-fixes.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dnsmadeeasy - fix http 400 errors when creating a txt record (https://github.com/ansible-collections/community.general/issues/1237).
+  - dnsmadeeasy - fix HTTP 400 errors when creating a TXT record (https://github.com/ansible-collections/community.general/issues/1237).

--- a/changelogs/fragments/1654-dnsmadeeasy-http-400-fixes.yaml
+++ b/changelogs/fragments/1654-dnsmadeeasy-http-400-fixes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnsmadeeasy - fix http 400 errors when creating a txt record (https://github.com/ansible-collections/community.general/issues/1237).

--- a/plugins/modules/net_tools/dnsmadeeasy.py
+++ b/plugins/modules/net_tools/dnsmadeeasy.py
@@ -678,7 +678,7 @@ def main():
         # create record and monitor as the record does not exist
         if not current_record:
             record = DME.createRecord(DME.prepareRecord(new_record))
-            if new_monitor['monitor'] and record_type == "A":
+            if new_monitor.get('monitor') and record_type == "A":
                 monitor = DME.updateMonitor(record['id'], DME.prepareMonitor(new_monitor))
                 module.exit_json(changed=True, result=dict(record=record, monitor=monitor))
             else:

--- a/plugins/modules/net_tools/dnsmadeeasy.py
+++ b/plugins/modules/net_tools/dnsmadeeasy.py
@@ -469,7 +469,7 @@ class DME2(object):
                     value = record_value.split(" ")[1]
                 # Note that TXT records are surrounded by quotes in the API response.
                 elif record_type == "TXT":
-                    value = '"{}"'.format(record_value)
+                    value = '"{0}"'.format(record_value)
                 elif record_type == "SRV":
                     value = record_value.split(" ")[3]
                 else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

* When creating a record the module fails on monitor API call
* TXT records are surrounded by quotes in the API response

Fixes: #1237

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnsmadeeasy
