### PR TITLE
Add default `brew` search path for non-Intel / Apple silicon hardware

### DIFF
--- a/changelogs/fragments/1679-homebrew_search_path.yml
+++ b/changelogs/fragments/1679-homebrew_search_path.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - homebrew - add default search path for `brew` on Apple silicon hardware
+    https://github.com/ansible-collections/community.general/pull/1679
+  - homebrew_cask - add default search path for `brew` on Apple silicon hardware
+    https://github.com/ansible-collections/community.general/pull/1679
+  - homebrew_tap - add default search path for `brew` on Apple silicon hardware
+    https://github.com/ansible-collections/community.general/pull/1679

--- a/changelogs/fragments/1679-homebrew_search_path.yml
+++ b/changelogs/fragments/1679-homebrew_search_path.yml
@@ -1,8 +1,8 @@
 ---
 bugfixes:
-  - homebrew - add default search path for `brew` on Apple silicon hardware
+  - homebrew - add default search path for ``brew`` on Apple silicon hardware
     https://github.com/ansible-collections/community.general/pull/1679
-  - homebrew_cask - add default search path for `brew` on Apple silicon hardware
+  - homebrew_cask - add default search path for ``brew`` on Apple silicon hardware
     https://github.com/ansible-collections/community.general/pull/1679
-  - homebrew_tap - add default search path for `brew` on Apple silicon hardware
+  - homebrew_tap - add default search path for ``brew`` on Apple silicon hardware
     https://github.com/ansible-collections/community.general/pull/1679

--- a/changelogs/fragments/1679-homebrew_search_path.yml
+++ b/changelogs/fragments/1679-homebrew_search_path.yml
@@ -1,8 +1,8 @@
 ---
 bugfixes:
   - homebrew - add default search path for ``brew`` on Apple silicon hardware
-    https://github.com/ansible-collections/community.general/pull/1679
+    (https://github.com/ansible-collections/community.general/pull/1679).
   - homebrew_cask - add default search path for ``brew`` on Apple silicon hardware
-    https://github.com/ansible-collections/community.general/pull/1679
+    (https://github.com/ansible-collections/community.general/pull/1679).
   - homebrew_tap - add default search path for ``brew`` on Apple silicon hardware
-    https://github.com/ansible-collections/community.general/pull/1679
+    (https://github.com/ansible-collections/community.general/pull/1679).

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -38,7 +38,7 @@ options:
             - "A ':' separated list of paths to search for 'brew' executable.
               Since a package (I(formula) in homebrew parlance) location is prefixed relative to the actual path of I(brew) command,
               providing an alternative I(brew) path enables managing different set of packages in an alternative location in the system."
-        default: '/usr/local/bin'
+        default: '/usr/local/bin:/opt/homebrew/bin'
         type: path
     state:
         description:
@@ -76,7 +76,7 @@ notes:
 '''
 
 EXAMPLES = '''
-# Install formula foo with 'brew' in default path (C(/usr/local/bin))
+# Install formula foo with 'brew' in default path
 - community.general.homebrew:
     name: foo
     state: present
@@ -871,7 +871,7 @@ def main():
                 elements='str',
             ),
             path=dict(
-                default="/usr/local/bin",
+                default="/usr/local/bin:/opt/homebrew/bin",
                 required=False,
                 type='path',
             ),

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -32,7 +32,7 @@ options:
   path:
     description:
     - "':' separated list of paths to search for 'brew' executable."
-    default: '/usr/local/bin'
+    default: '/usr/local/bin:/opt/homebrew/bin'
     type: path
   state:
     description:
@@ -779,7 +779,7 @@ def main():
                 elements='str',
             ),
             path=dict(
-                default="/usr/local/bin",
+                default="/usr/local/bin:/opt/homebrew/bin",
                 required=False,
                 type='path',
             ),

--- a/plugins/modules/packaging/os/homebrew_tap.py
+++ b/plugins/modules/packaging/os/homebrew_tap.py
@@ -218,7 +218,7 @@ def main():
     brew_path = module.get_bin_path(
         'brew',
         required=True,
-        opt_dirs=['/usr/local/bin']
+        opt_dirs=['/usr/local/bin', '/opt/homebrew/bin']
     )
 
     taps = module.params['name']


### PR DESCRIPTION
##### SUMMARY
Add default search path for `brew` on Apple silicon hardware per https://docs.brew.sh/Installation

Fixes: #1660


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- homebrew
- homebrew_cask
- homebrew_tap
