### PR TITLE
docker.py: allow docker versions beginning with 'v'

### DIFF
--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -116,7 +116,9 @@ class Connection(ConnectionBase):
 
     @staticmethod
     def _sanitize_version(version):
-        return re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub('^v', '', version)
+        return version
 
     def _old_docker_version(self):
         cmd_args = []


### PR DESCRIPTION
I don't know why, but here, the docker version output begins with a 'v':
```
$ docker version --format "{{.Server.Version}}"
v20.10.1
```
which trigger this error:
```
Traceback (most recent call last):
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 158, in run
    res = self._execute()
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 613, in _execute
    self._connection = self._get_connection(cvars, templar)
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 908, in _get_connection
    connection, plugin_load_context = self._shared_loader_obj.connection_loader.get_with_context(
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible/plugins/loader.py", line 826, in get_with_context
    obj.__init__(instance, *args, **kwargs)
  File "/home/romain/pro/aubonticket/.venv/lib/python3.8/site-packages/ansible_collections/community/general/plugins/connection/docker.py", line 93, in __init__
    if docker_version != u'dev' and LooseVersion(docker_version) < LooseVersion(u'1.3'):
  File "/usr/host/lib/python3.8/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/host/lib/python3.8/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
fatal: [server]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
