### PR TITLE
[stable-1] docker.py: allow docker versions beginning with 'v'

### DIFF
--- a/changelogs/fragments/community.docker-76-leading-v-support-in-docker-version.yml
+++ b/changelogs/fragments/community.docker-76-leading-v-support-in-docker-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker connection plugin - fix Docker version parsing, as some docker versions have a leading ``v`` in the output of the command ``docker version --format "{{.Server.Version}}"`` (https://github.com/ansible-collections/community.docker/pull/76).

--- a/plugins/connection/docker.py
+++ b/plugins/connection/docker.py
@@ -116,7 +116,9 @@ class Connection(ConnectionBase):
 
     @staticmethod
     def _sanitize_version(version):
-        return re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub(u'[^0-9a-zA-Z.]', u'', version)
+        version = re.sub(u'^v', u'', version)
+        return version
 
     def _old_docker_version(self):
         cmd_args = []


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.docker/pull/76 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/docker.py
