### PR TITLE
Add Name and/or Id properties to resource inventory output

### DIFF
--- a/changelogs/fragments/1691-add-name-and-id-props-to-redfish-inventory-output.yml
+++ b/changelogs/fragments/1691-add-name-and-id-props-to-redfish-inventory-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_info module, redfish_utils module utils - add ``Name`` and ``Id`` properties to output of Redfish inventory commands (https://github.com/ansible-collections/community.general/issues/1650).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -469,7 +469,7 @@ class RedfishUtils(object):
         controller_results = []
         # Get these entries, but does not fail if not found
         properties = ['CacheSummary', 'FirmwareVersion', 'Identifiers',
-                      'Location', 'Manufacturer', 'Model', 'Name',
+                      'Location', 'Manufacturer', 'Model', 'Name', 'Id',
                       'PartNumber', 'SerialNumber', 'SpeedGbps', 'Status']
         key = "StorageControllers"
 
@@ -1700,7 +1700,7 @@ class RedfishUtils(object):
         chassis_results = []
 
         # Get these entries, but does not fail if not found
-        properties = ['ChassisType', 'PartNumber', 'AssetTag',
+        properties = ['Name', 'Id', 'ChassisType', 'PartNumber', 'AssetTag',
                       'Manufacturer', 'IndicatorLED', 'SerialNumber', 'Model']
 
         # Go through list
@@ -1724,7 +1724,7 @@ class RedfishUtils(object):
         fan_results = []
         key = "Thermal"
         # Get these entries, but does not fail if not found
-        properties = ['FanName', 'Reading', 'ReadingUnits', 'Status']
+        properties = ['Name', 'FanName', 'Reading', 'ReadingUnits', 'Status']
 
         # Go through list
         for chassis_uri in self.chassis_uris:
@@ -1836,8 +1836,8 @@ class RedfishUtils(object):
         cpu_results = []
         key = "Processors"
         # Get these entries, but does not fail if not found
-        properties = ['Id', 'Manufacturer', 'Model', 'MaxSpeedMHz', 'TotalCores',
-                      'TotalThreads', 'Status']
+        properties = ['Id', 'Name', 'Manufacturer', 'Model', 'MaxSpeedMHz',
+                      'TotalCores', 'TotalThreads', 'Status']
 
         # Search for 'key' entry and extract URI from it
         response = self.get_request(self.root_uri + systems_uri)
@@ -1886,7 +1886,7 @@ class RedfishUtils(object):
         memory_results = []
         key = "Memory"
         # Get these entries, but does not fail if not found
-        properties = ['SerialNumber', 'MemoryDeviceType', 'PartNumber',
+        properties = ['Id', 'SerialNumber', 'MemoryDeviceType', 'PartNumber',
                       'MemoryLocation', 'RankCount', 'CapacityMiB', 'OperatingMemoryModes', 'Status', 'Manufacturer', 'Name']
 
         # Search for 'key' entry and extract URI from it
@@ -1943,7 +1943,7 @@ class RedfishUtils(object):
         nic_results = []
         key = "EthernetInterfaces"
         # Get these entries, but does not fail if not found
-        properties = ['Description', 'FQDN', 'IPv4Addresses', 'IPv6Addresses',
+        properties = ['Name', 'Id', 'Description', 'FQDN', 'IPv4Addresses', 'IPv6Addresses',
                       'NameServers', 'MACAddress', 'PermanentMACAddress',
                       'SpeedMbps', 'MTUSize', 'AutoNeg', 'Status']
 
@@ -2368,7 +2368,7 @@ class RedfishUtils(object):
         properties = ['Status', 'HostName', 'PowerState', 'Model', 'Manufacturer',
                       'PartNumber', 'SystemType', 'AssetTag', 'ServiceTag',
                       'SerialNumber', 'SKU', 'BiosVersion', 'MemorySummary',
-                      'ProcessorSummary', 'TrustedModules']
+                      'ProcessorSummary', 'TrustedModules', 'Name', 'Id']
 
         response = self.get_request(self.root_uri + systems_uri)
         if response['ret'] is False:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Most of the resource inventory commands show the standard `Id` and `Name` properties in the output. But a few of the commands did not (`GetSystemInventory`, `GetNicInventory`, etc.).

This fix updates the commands to include the `Name` and/or `Id` properties in the output, if appropriate.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1650 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Run a play like this:

```
  community.general.redfish_info:
    category: Systems
    command: GetNicInventory
```

Notice that the output does not include the `Name` or `Id` properties.

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```paste below
{
    "ansible_facts": {
        "redfish_facts": {
            "nic": {
                "entries": [
                    [
                        {
                            "resource_uri": "/redfish/v1/Systems/437XR1138R2"
                        },
                        [
                            {
                                "Description": "System NIC 1",
                                "FQDN": "web483.contoso.com",
                                "IPv4Addresses": [
                                    {
                                        "Address": "192.168.0.10",
                                        "AddressOrigin": "Static",
                                        "Gateway": "192.168.0.1",
                                        "SubnetMask": "255.255.252.0"
                                    }
                                ],
                                "IPv6Addresses": [
                                    {
                                        "Address": "fe80::1ec1:deff:fe6f:1e24",
                                        "AddressOrigin": "Static",
                                        "AddressState": "Preferred",
                                        "PrefixLength": 64
                                    }
                                ],
                                "MACAddress": "12:44:6A:3B:04:11",
                                "NameServers": [
                                    "names.contoso.com"
                                ],
                                ...
```

**After:**
```
{
    "ansible_facts": {
        "redfish_facts": {
            "nic": {
                "entries": [
                    [
                        {
                            "resource_uri": "/redfish/v1/Systems/437XR1138R2"
                        },
                        [
                            {
                                "Description": "System NIC 1",
                                "FQDN": "web483.contoso.com",
                                "Id": "1",
                                "IPv4Addresses": [
                                    {
                                        "Address": "192.168.0.10",
                                        "AddressOrigin": "Static",
                                        "Gateway": "192.168.0.1",
                                        "SubnetMask": "255.255.252.0"
                                    }
                                ],
                                "IPv6Addresses": [
                                    {
                                        "Address": "fe80::1ec1:deff:fe6f:1e24",
                                        "AddressOrigin": "Static",
                                        "AddressState": "Preferred",
                                        "PrefixLength": 64
                                    }
                                ],
                                "MACAddress": "12:44:6A:3B:04:11",
                                "Name": "Ethernet Interface",
                                "NameServers": [
                                    "names.contoso.com"
                                ],
                                ...
```