### PR TITLE
parted: fix regex for version match and partition size output

### DIFF
--- a/changelogs/fragments/1695-parted-updatedregex.yaml
+++ b/changelogs/fragments/1695-parted-updatedregex.yaml
@@ -1,4 +1,4 @@
 bugfixes:
   - parted - change the regex that decodes the partition size to better support different formats that parted uses.
-    Change the regex that validate parted's version string.
+    Change the regex that validates parted's version string
     (https://github.com/ansible-collections/community.general/pull/1695).

--- a/changelogs/fragments/1695-parted-updatedregex.yaml
+++ b/changelogs/fragments/1695-parted-updatedregex.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - parted - change the regex that decodes the partition size to better support different formats that parted uses.
+    Change the regex that validate parted's version string.
+    (https://github.com/ansible-collections/community.general/pull/1695).

--- a/changelogs/fragments/813-parted-updatedregex.yaml
+++ b/changelogs/fragments/813-parted-updatedregex.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - parted - change the regex that decodes the partition size to better support different formats that parted uses. Change the regex that validate parted's version string (https://github.com/ansible-collections/community.general/pull/817).

--- a/changelogs/fragments/813-parted-updatedregex.yaml
+++ b/changelogs/fragments/813-parted-updatedregex.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - parted.py - Change the regex that decodes the partition size  to better support different formats that parted uses. Change the regex that validate partted's version string.

--- a/changelogs/fragments/813-parted-updatedregex.yaml
+++ b/changelogs/fragments/813-parted-updatedregex.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - parted.py - Change the regex that decodes the partition size  to better support different formats that parted uses. Change the regex that validate partted's version string.
+  - parted - change the regex that decodes the partition size to better support different formats that parted uses. Change the regex that validate parted's version string (https://github.com/ansible-collections/community.general/pull/817).

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -516,7 +516,7 @@ def parted_version():
     if len(lines) == 0:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 
-    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.+$', lines[0])
+    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.?$', lines[0])
     if matches is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -502,7 +502,7 @@ def check_parted_label(device):
 
 def parted_fetch_version(out):
     """
-    returns version string from the output of "parted --version" command
+    returns version tupple from the output of "parted --version" command
     """
     lines = [x for x in out.split('\n') if x.strip() != '']
     if len(lines) == 0:

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -502,7 +502,7 @@ def check_parted_label(device):
 
 def parse_parted_version(out):
     """
-    returns version tupple from the output of "parted --version" command
+    Returns version tuple from the output of "parted --version" command
     """
     lines = [x for x in out.split('\n') if x.strip() != '']
     if len(lines) == 0:

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -516,7 +516,12 @@ def parted_version():
     if len(lines) == 0:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 
-    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.?$', lines[0])
+    # failed to write a test unit, so sample versions in here:
+    # parted (GNU parted) 3.3
+    # parted (GNU parted) 3.4.5
+    # parted (GNU parted) 3.3.14-dfc61
+    matches = re.search(r'^parted .*(\d+)\.(\d+)(?:\.(\d+))?', lines[0])
+
     if matches is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -506,7 +506,7 @@ def parted_fetch_version(out):
     """
     lines = [x for x in out.split('\n') if x.strip() != '']
     if len(lines) == 0:
-        return
+        return None, None, None
 
     # failed to write a test unit, so sample versions in here:
     # parted (GNU parted) 3.3
@@ -515,7 +515,7 @@ def parted_fetch_version(out):
     matches = re.search(r'^parted.+\s(\d+)\.(\d+)(?:\.(\d+))?', lines[0].strip())
 
     if matches is None:
-        return
+        return None, None, None
 
     # Convert version to numbers
     major = int(matches.group(1))

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -241,7 +241,7 @@ def parse_unit(size_str, unit=''):
     """
     Parses a string containing a size or boundary information
     """
-    matches = re.search(r'^(-?[\d.]+)([\w%]+)?$', size_str)
+    matches = re.search(r'^(-?[\d.]+) *([\w%]+)?$', size_str)
     if matches is None:
         # "<cylinder>,<head>,<sector>" format
         matches = re.search(r'^(\d+),(\d+),(\d+)$', size_str)
@@ -516,7 +516,7 @@ def parted_version():
     if len(lines) == 0:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 
-    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?$', lines[0])
+    matches = re.search(r'^parted.+(\d+)\.(\d+)(?:\.(\d+))?.+$', lines[0])
     if matches is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -500,7 +500,7 @@ def check_parted_label(device):
     return False
 
 
-def parted_fetch_version(out):
+def parse_parted_version(out):
     """
     returns version tupple from the output of "parted --version" command
     """
@@ -539,7 +539,7 @@ def parted_version():
             msg="Failed to get parted version.", rc=rc, out=out, err=err
         )
 
-    (major, minor, rev) = parted_fetch_version(out)
+    (major, minor, rev) = parse_parted_version(out)
     if major is None:
         module.fail_json(msg="Failed to get parted version.", rc=0, out=out)
 

--- a/plugins/modules/system/parted.py
+++ b/plugins/modules/system/parted.py
@@ -508,7 +508,7 @@ def parse_parted_version(out):
     if len(lines) == 0:
         return None, None, None
 
-    # failed to write a test unit, so sample versions in here:
+    # Sample parted versions (see as well test unit):
     # parted (GNU parted) 3.3
     # parted (GNU parted) 3.4.5
     # parted (GNU parted) 3.3.14-dfc61

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -6,8 +6,8 @@ __metaclass__ = type
 
 from ansible_collections.community.general.tests.unit.compat.mock import patch, call
 from ansible_collections.community.general.plugins.modules.system import parted as parted_module
+from ansible_collections.community.general.plugins.modules.system.parted import parse_parted_version
 from ansible_collections.community.general.plugins.modules.system.parted import parse_partition_info
-from ansible_collections.community.general.plugins.modules.system.parted import parted_fetch_version
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 
 # Example of output : parted -s -m /dev/sdb -- unit 'MB' print
@@ -340,6 +340,6 @@ class TestParted(ModuleTestCase):
             self.execute_module(changed=True)
 
     def test_version_info(self):
-        """Test that the parted_fetch_version returns the expected tuple"""
+        """Test that the parse_parted_version returns the expected tuple"""
         for key, value in parted_version_info.items():
-            self.assertEqual(parted_fetch_version(key), value)
+            self.assertEqual(parse_parted_version(key), value)

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 from ansible_collections.community.general.tests.unit.compat.mock import patch, call
 from ansible_collections.community.general.plugins.modules.system import parted as parted_module
 from ansible_collections.community.general.plugins.modules.system.parted import parse_partition_info
+from ansible_collections.community.general.plugins.modules.system.parted import parted_fetch_version
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 
 # Example of output : parted -s -m /dev/sdb -- unit 'MB' print
@@ -16,6 +17,34 @@ BYT;
 1:1.05MB:106MB:105MB:fat32::esp;
 2:106MB:368MB:262MB:ext2::;
 3:368MB:256061MB:255692MB:::;"""
+
+parted_version_info = { """
+        parted (GNU parted) 3.3
+        Copyright (C) 2019 Free Software Foundation, Inc.
+        License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+        This is free software: you are free to change and redistribute it.
+        There is NO WARRANTY, to the extent permitted by law.
+
+        Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
+        """: (3,3,0),
+        """
+        parted (GNU parted) 3.4.5
+        Copyright (C) 2019 Free Software Foundation, Inc.
+        License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+        This is free software: you are free to change and redistribute it.
+        There is NO WARRANTY, to the extent permitted by law.
+
+        Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
+        """: (3,4,5),
+        """
+        parted (GNU parted) 3.3.14-dfc61
+        Copyright (C) 2019 Free Software Foundation, Inc.
+        License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
+        This is free software: you are free to change and redistribute it.
+        There is NO WARRANTY, to the extent permitted by law.
+
+        Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
+        """: (3,3,14) }
 
 # corresponding dictionary after parsing by parse_partition_info
 parted_dict1 = {
@@ -311,3 +340,8 @@ class TestParted(ModuleTestCase):
         })
         with patch('ansible_collections.community.general.plugins.modules.system.parted.get_device_info', return_value=parted_dict3):
             self.execute_module(changed=True)
+
+    def test_version_info(self):
+        """Test that the parted_version returns the expected tuple"""
+        for key, value in parted_version_info.items():
+            self.assertEqual(parted_fetch_version(key), value)

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -340,6 +340,6 @@ class TestParted(ModuleTestCase):
             self.execute_module(changed=True)
 
     def test_version_info(self):
-        """Test that the parted_version returns the expected tuple"""
+        """Test that the parted_fetch_version returns the expected tuple"""
         for key, value in parted_version_info.items():
             self.assertEqual(parted_fetch_version(key), value)

--- a/tests/unit/plugins/modules/system/test_parted.py
+++ b/tests/unit/plugins/modules/system/test_parted.py
@@ -18,7 +18,7 @@ BYT;
 2:106MB:368MB:262MB:ext2::;
 3:368MB:256061MB:255692MB:::;"""
 
-parted_version_info = { """
+parted_version_info = {"""
         parted (GNU parted) 3.3
         Copyright (C) 2019 Free Software Foundation, Inc.
         License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
@@ -26,8 +26,7 @@ parted_version_info = { """
         There is NO WARRANTY, to the extent permitted by law.
 
         Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
-        """: (3,3,0),
-        """
+        """: (3, 3, 0), """
         parted (GNU parted) 3.4.5
         Copyright (C) 2019 Free Software Foundation, Inc.
         License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
@@ -35,8 +34,7 @@ parted_version_info = { """
         There is NO WARRANTY, to the extent permitted by law.
 
         Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
-        """: (3,4,5),
-        """
+        """: (3, 4, 5), """
         parted (GNU parted) 3.3.14-dfc61
         Copyright (C) 2019 Free Software Foundation, Inc.
         License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
@@ -44,7 +42,7 @@ parted_version_info = { """
         There is NO WARRANTY, to the extent permitted by law.
 
         Written by <http://git.debian.org/?p=parted/parted.git;a=blob_plain;f=AUTHORS>.
-        """: (3,3,14) }
+        """: (3, 3, 14)}
 
 # corresponding dictionary after parsing by parse_partition_info
 parted_dict1 = {


### PR DESCRIPTION
##### SUMMARY

Rewrite/extends PR #817 with corrected regex for parted version.

Original PR - Modify 2 regex expressions to support:
1 - Different version strings
2 - Support optional white space between numeral and unit designator in partition size output from parted

Fixes #812
Fixes #813
  
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/parted.py

##### ADDITIONAL INFORMATION
Please see original PR #817 for the discussion. 
Thanks.

PS: someone could help me with a test unit, if it even possible for this module