### PR TITLE
sensu-silence: fix json parsing of sensu API response

### DIFF
--- a/changelogs/fragments/1703-sensu_silence-fix_json_parsing.yml
+++ b/changelogs/fragments/1703-sensu_silence-fix_json_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sensu-silence module - fix json parsing of sensu API responses on Python 3.5

--- a/changelogs/fragments/1703-sensu_silence-fix_json_parsing.yml
+++ b/changelogs/fragments/1703-sensu_silence-fix_json_parsing.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - sensu-silence module - fix json parsing of sensu API responses on Python 3.5
+  - sensu-silence module - fix json parsing of sensu API responses on Python 3.5 (https://github.com/ansible-collections/community.general/pull/1703).

--- a/plugins/modules/monitoring/sensu/sensu_silence.py
+++ b/plugins/modules/monitoring/sensu/sensu_silence.py
@@ -181,7 +181,7 @@ def clear(module, url, check, subscription):
             )
 
         try:
-            json_out = json.loads(response.read())
+            json_out = json.loads(response.read().decode('utf-8'))
         except Exception:
             json_out = ""
 

--- a/plugins/modules/monitoring/sensu/sensu_silence.py
+++ b/plugins/modules/monitoring/sensu/sensu_silence.py
@@ -97,6 +97,7 @@ RETURN = '''
 
 import json
 
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 
@@ -129,7 +130,7 @@ def query(module, url, check, subscription):
         )
 
     try:
-        json_out = json.loads(response.read())
+        json_out = json.loads(to_native(response.read()))
     except Exception:
         json_out = ""
 
@@ -181,7 +182,7 @@ def clear(module, url, check, subscription):
             )
 
         try:
-            json_out = json.loads(response.read().decode('utf-8'))
+            json_out = json.loads(to_native(response.read()))
         except Exception:
             json_out = ""
 
@@ -246,7 +247,7 @@ def create(
             )
 
         try:
-            json_out = json.loads(response.read())
+            json_out = json.loads(to_native(response.read()))
         except Exception:
             json_out = ""
 


### PR DESCRIPTION
##### SUMMARY

`sensu_silence` is broken on Python3 and shows unexpected behavior on silencing, as well as on unsilencing. This is caused by a missing cast from bytestream to string. JSON parser is failing in consequence, resulting in errors when comparing target state with current state.

In consequence, on `state: present` states gets changed on every Ansible run and checks gets always silenced (again). On `state: absent` checks gets never unsilenced.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.general.sensu_silence`

##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
{"changed": true, "invocation": {"module_args": {"creator": "account-admin-ansible", "check": null, "reason": "running deployment", "expire": null, "url": "http://127.0.01:4567", "expire_on_resolve": null, "subscription": "client:accountadmin-staging-app-00", "state": "present"}}, "result": "", "msg": "success"}
```

After:
```
{"changed": false, "msg": "success", "invocation": {"module_args": {"expire_on_resolve": null, "check": null, "expire": null, "state": "present", "url": "http://127.0.01:4567", "creator": "account-admin-ansible", "reason": "running deployment", "subscription": "client:accountadmin-staging-app-00"}}, "result": [{"id": "client:accountadmin-staging-backend-00:*", "timestamp": 1611933599, "reason": "running deployment", "check": null, "subscription": "client:accountadmin-staging-backend-00", "expire_on_resolve": false, "creator": "account-admin-ansible", "begin": null, "expire": -1}, {"id": "client:accountadmin-staging-proxy-01:*", "timestamp": 1611933599, "reason": "running deployment", "check": null, "subscription": "client:accountadmin-staging-proxy-01", "expire_on_resolve": false, "creator": "account-admin-ansible", "begin": null, "expire": -1}, {"id": "client:accountadmin-staging-db-00:*", "timestamp": 1611933599, "reason": "running deployment", "check": null, "subscription": "client:accountadmin-staging-db-00", "expire_on_resolve": false, "creator": "account-admin-ansible", "begin": null, "expire": -1}, {"id": "client:accountadmin-staging-proxy-00:*", "timestamp": 1611933599, "reason": "running deployment", "check": null, "subscription": "client:accountadmin-staging-proxy-00", "expire_on_resolve": false, "creator": "account-admin-ansible", "begin": null, "expire": -1}, {"id": "client:accountadmin-staging-app-00:*", "timestamp": 1611936117, "reason": "running deployment", "check": null, "subscription": "client:accountadmin-staging-app-00", "expire_on_resolve": false, "creator": "account-admin-ansible", "begin": null, "expire": -1}]}
```
