### PR TITLE
Added VMID to all returns

### DIFF
--- a/changelogs/fragments/1715-proxmox_kvm-add-vmid-to-returns.yml
+++ b/changelogs/fragments/1715-proxmox_kvm-add-vmid-to-returns.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm module - Added VMID and status returns to returns. Updated docs to reflect current situation.
+  - proxmox_kvm module - actually implemented ``vmid`` and ``status`` return values. Updated documentation to reflect current situation (https://github.com/ansible-collections/community.general/issues/1410, https://github.com/ansible-collections/community.general/pull/1715).

--- a/changelogs/fragments/1715-proxmox_kvm-add-vmid-to-returns.yml
+++ b/changelogs/fragments/1715-proxmox_kvm-add-vmid-to-returns.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm module - Added VMID and status returns to returns. Updated docs to reflect current situation.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -730,31 +730,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-devices:
-    description:
-      - The list of devices created or used.
-      - Returned only when C(state=current)
-    returned: success
-    type: dict
-    sample: '
-      {
-        "ide0": "VMS_LVM:vm-115-disk-1",
-        "ide1": "VMs:115/vm-115-disk-3.raw",
-        "virtio0": "VMS_LVM:vm-115-disk-2",
-        "virtio1": "VMs:115/vm-115-disk-1.qcow2",
-        "virtio2": "VMs:115/vm-115-disk-2.raw"
-      }'
-mac:
-    description:
-      - List of mac address created and net[n] attached. Useful when you want to use provision systems like Foreman via PXE.
-      - Returned only when C(state=current)
-    returned: success
-    type: dict
-    sample: '
-      {
-        "net0": "3E:6E:97:D2:31:9F",
-        "net1": "B6:A1:FC:EF:78:A4"
-      }'
 vmid:
     description: The VM vmid.
     returned: success
@@ -763,7 +738,6 @@ vmid:
 status:
     description:
       - The current virtual machine status.
-      - Returned only when C(state=current)
     returned: success
     type: dict
     sample: '{

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1405,7 +1405,7 @@ def main():
         current = proxmox.nodes(vm[0]['node']).qemu(vmid).status.current.get()['status']
         status['status'] = current
         if status:
-            module.exit_json(changed=False, vmid=vmid, devices=devices, mac=mac, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
+            module.exit_json(changed=False, vmid=vmid, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1181,7 +1181,7 @@ def main():
 
         # Ensure source VM name exists when cloning
         if -1 == vmid:
-            module.fail_json(vmid=vmid, msg='VM with name = %s does not exist in cluster' % clone)
+            module.fail_json(msg='VM with name = %s does not exist in cluster' % clone)
 
         # Ensure source VM id exists when cloning
         if not get_vm(proxmox, vmid):
@@ -1303,7 +1303,7 @@ def main():
     elif state == 'started':
         try:
             if -1 == vmid:
-                module.fail_json(vmid=vmid, msg='VM with name = %s does not exist in cluster' % name)
+                module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
             vm = get_vm(proxmox, vmid)
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid <%s> does not exist in cluster' % vmid)
@@ -1318,7 +1318,7 @@ def main():
     elif state == 'stopped':
         try:
             if -1 == vmid:
-                module.fail_json(vmid=vmid, msg='VM with name = %s does not exist in cluster' % name)
+                module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
 
             vm = get_vm(proxmox, vmid)
             if not vm:
@@ -1335,7 +1335,7 @@ def main():
     elif state == 'restarted':
         try:
             if -1 == vmid:
-                module.fail_json(vmid=vmid, msg='VM with name = %s does not exist in cluster' % name)
+                module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
 
             vm = get_vm(proxmox, vmid)
             if not vm:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1334,12 +1334,12 @@ def main():
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid <%s> does not exist in cluster' % vmid)
             if vm[0]['status'] == 'running':
-                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already running" % vmid)
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already running" % vmid, **status)
 
             if start_vm(module, proxmox, vm):
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s started" % vmid)
+                module.exit_json(changed=True, vmid=vmid, msg="VM %s started" % vmid, **status)
         except Exception as e:
-            module.fail_json(vmid=vmid, msg="starting of VM %s failed with exception: %s" % (vmid, e))
+            module.fail_json(vmid=vmid, msg="starting of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'stopped':
         try:
@@ -1351,12 +1351,12 @@ def main():
                 module.fail_json(vmid=vmid, msg='VM with vmid = %s does not exist in cluster' % vmid)
 
             if vm[0]['status'] == 'stopped':
-                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already stopped" % vmid)
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is already stopped" % vmid, **status)
 
             if stop_vm(module, proxmox, vm, force=module.params['force']):
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid)
+                module.exit_json(changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid, **status)
         except Exception as e:
-            module.fail_json(vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e))
+            module.fail_json(vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'restarted':
         try:
@@ -1367,12 +1367,12 @@ def main():
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid = %s does not exist in cluster' % vmid)
             if vm[0]['status'] == 'stopped':
-                module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid)
+                module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid, **status)
 
             if stop_vm(module, proxmox, vm, force=module.params['force']) and start_vm(module, proxmox, vm):
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid)
+                module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid, **status)
         except Exception as e:
-            module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e))
+            module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'absent':
         try:


### PR DESCRIPTION
Also added in the docs promised return of MAC and devices when state ==
current.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the requested return values to the module.

Fixes: #1410 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Get vm] ********************************************************************************************************
task path: /root/projects/playground/playbooks/proxmox_kvm.yml:6
[DEPRECATION WARNING]: The proxmox_default_behavior option will change its default value from "compatibility" to 
"no_defaults" in community.general 4.0.0. To remove this warning, please specify an explicit value for it now. This 
feature will be removed from community.general in version 4.0.0. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
ok: [localhost] => changed=false 
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  msg: VM test with vmid = 104 is stopped
  status: stopped
  vmid: 104
```
