### PR TITLE
Fix undeclared result for nomad_job_info module

### DIFF
--- a/changelogs/fragments/1721-fix-nomad_job_info-no-jobs-failure.yml
+++ b/changelogs/fragments/1721-fix-nomad_job_info-no-jobs-failure.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nomad_job_info module - fix module failure when nomad client returns no jobs. (https://github.com/ansible-collections/community.general/pull/1721).

--- a/changelogs/fragments/1721-fix-nomad_job_info-no-jobs-failure.yml
+++ b/changelogs/fragments/1721-fix-nomad_job_info-no-jobs-failure.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nomad_job_info module - fix module failure when nomad client returns no jobs. (https://github.com/ansible-collections/community.general/pull/1721).
+  - nomad_job_info - fix module failure when nomad client returns no jobs (https://github.com/ansible-collections/community.general/pull/1721).

--- a/plugins/modules/clustering/nomad/nomad_job_info.py
+++ b/plugins/modules/clustering/nomad/nomad_job_info.py
@@ -312,13 +312,11 @@ def run():
     )
 
     changed = False
-    nomad_jobs = list()
     result = list()
     try:
         job_list = nomad_client.jobs.get_jobs()
         for job in job_list:
-            nomad_jobs.append(nomad_client.job.get_job(job.get('ID')))
-            result = nomad_jobs
+            result.append(nomad_client.job.get_job(job.get('ID')))
     except Exception as e:
         module.fail_json(msg=to_native(e))
 

--- a/plugins/modules/clustering/nomad/nomad_job_info.py
+++ b/plugins/modules/clustering/nomad/nomad_job_info.py
@@ -313,6 +313,7 @@ def run():
 
     changed = False
     nomad_jobs = list()
+    result = list()
     try:
         job_list = nomad_client.jobs.get_jobs()
         for job in job_list:


### PR DESCRIPTION
##### SUMMARY
If a nomad cluster has no jobs and we try to list its jobs the module crashes because the returned value of `nomad_client.jobs.get_jobs()` and thus it will be no iteration and result will never be initialized/declared, however the module will try to use it later on.

Result not being declared outside loop:
https://github.com/ansible-collections/community.general/blob/2297f2f802f286abdc76bbae0c9d3aae44255554/plugins/modules/clustering/nomad/nomad_job_info.py#L317-L320

Trying to return result even when it's not declared.
https://github.com/ansible-collections/community.general/blob/2297f2f802f286abdc76bbae0c9d3aae44255554/plugins/modules/clustering/nomad/nomad_job_info.py#L336
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/clustering/nomad/nomad_job_info.py

##### ADDITIONAL INFORMATION
The change is just to initialize the result list  outside the loop .

###### Steps to reproduce
Sample playbook
```yaml
- name: Sample playbook
  hosts: nomad_servers
  gather_facts: false
  tasks:
    - name: List jobs
      community.general.nomad_job_info:
        host: localhost
        use_ssl: false
      register: job_list
```
Output
```
    PLAY RECAP *********************************************************************
      File "/tmp/ansible_community.general.nomad_job_info_payload_qWNjiN/ansible_community.general.nomad_job_info_payload.zip/ansible_collections/community/general/plugins/modules/nomad_job_info.py", line 336, in run
    UnboundLocalError: local variable 'result' referenced before assignment
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
