### PR TITLE
timezone: add gentoo and alpine linux support

### DIFF
--- a/changelogs/fragments/1722_timezone.yml
+++ b/changelogs/fragments/1722_timezone.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- timezone - add Alpine Linux support (https://github.com/ansible-collections/community.general/issues/781).
+- timezone - add Gentoo and Alpine Linux support (https://github.com/ansible-collections/community.general/issues/781).

--- a/changelogs/fragments/1722_timezone.yml
+++ b/changelogs/fragments/1722_timezone.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- timezone - add Alpine Linux support (https://github.com/ansible-collections/community.general/issues/781).

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -371,12 +371,13 @@ class NosystemdTimezone(Timezone):
             self.conf_files['hwclock'] = '/etc/default/rcS'
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
             self.tzline_format = '%s\n'
-        elif distribution == 'Alpine':
+        elif distribution == 'Alpine' or distribution == 'Gentoo':
             self.conf_files['name'] = '/etc/timezone'
             self.conf_files['hwclock'] = '/etc/conf.d/hwclock'
             self.tzline_format = '%s\n'
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
-            self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), planned_tz)]
+            if distribution == 'Alpine':
+                self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), planned_tz)]
         else:
             # RHEL/CentOS/SUSE
             if self.module.get_bin_path('tzdata-update') is not None:

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -316,7 +316,7 @@ class NosystemdTimezone(Timezone):
 
     For timezone setting, it edits the following file and reflect changes:
         - /etc/sysconfig/clock  ... RHEL/CentOS
-        - /etc/timezone         ... Debian/Ubuntu/Alpine
+        - /etc/timezone         ... Debian/Ubuntu
     For hwclock setting, it executes `hwclock --systohc` command with the
     '--utc' or '--localtime' option.
     """
@@ -370,10 +370,12 @@ class NosystemdTimezone(Timezone):
             self.conf_files['hwclock'] = '/etc/default/rcS'
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
             self.tzline_format = '%s\n'
-        else if distribution == 'Alpine':
+        elif distribution == 'Alpine':
             self.conf_files['name'] = '/etc/timezone'
             self.conf_files['hwclock'] = '/etc/conf.d/hwclock'
             self.tzline_format = '%s\n'
+            self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
+            self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), tzfile)]
         else:
             # RHEL/CentOS/SUSE
             if self.module.get_bin_path('tzdata-update') is not None:

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -316,7 +316,7 @@ class NosystemdTimezone(Timezone):
 
     For timezone setting, it edits the following file and reflect changes:
         - /etc/sysconfig/clock  ... RHEL/CentOS
-        - /etc/timezone         ... Debian/Ubuntu
+        - /etc/timezone         ... Debian/Ubuntu/Alpine
     For hwclock setting, it executes `hwclock --systohc` command with the
     '--utc' or '--localtime' option.
     """
@@ -360,6 +360,7 @@ class NosystemdTimezone(Timezone):
             self.update_timezone = ['%s --remove-destination %s /etc/localtime' % (self.module.get_bin_path('cp', required=True), tzfile)]
         self.update_hwclock = self.module.get_bin_path('hwclock', required=True)
         # Distribution-specific configurations
+        distribution = get_distribution()
         if self.module.get_bin_path('dpkg-reconfigure') is not None:
             # Debian/Ubuntu
             if 'name' in self.value:
@@ -368,6 +369,10 @@ class NosystemdTimezone(Timezone):
             self.conf_files['name'] = '/etc/timezone'
             self.conf_files['hwclock'] = '/etc/default/rcS'
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
+            self.tzline_format = '%s\n'
+        else if distribution == 'Alpine':
+            self.conf_files['name'] = '/etc/timezone'
+            self.conf_files['hwclock'] = '/etc/conf.d/hwclock'
             self.tzline_format = '%s\n'
         else:
             # RHEL/CentOS/SUSE
@@ -386,7 +391,6 @@ class NosystemdTimezone(Timezone):
             except IOError as err:
                 if self._allow_ioerror(err, 'name'):
                     # If the config file doesn't exist detect the distribution and set regexps.
-                    distribution = get_distribution()
                     if distribution == 'SuSE':
                         # For SUSE
                         self.regexps['name'] = self.dist_regexps['SuSE']

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -543,7 +543,9 @@ class NosystemdTimezone(Timezone):
                         # to other zone files, so it's hard to get which TZ is actually set
                         # if we follow the symlink.
                         path = os.readlink('/etc/localtime')
-                        linktz = re.search(r'/usr/share/zoneinfo/(.*)', path, re.MULTILINE)
+                        # most linuxes has it in /usr/share/zoneinfo
+                        # alpine linux links under /etc/zoneinfo
+                        linktz = re.search(r'(?:/(?:usr/share|etc)/zoneinfo/)(.*)', path, re.MULTILINE)
                         if linktz:
                             valuelink = linktz.group(1)
                             if valuelink != planned:

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -360,22 +360,19 @@ class NosystemdTimezone(Timezone):
             # that it overwrites it instead of following it.
             self.update_timezone = ['%s --remove-destination %s /etc/localtime' % (self.module.get_bin_path('cp', required=True), tzfile)]
         self.update_hwclock = self.module.get_bin_path('hwclock', required=True)
-        # Distribution-specific configurations
         distribution = get_distribution()
+        self.conf_files['name'] = '/etc/timezone'
+        self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
+        self.tzline_format = '%s\n'
+        # Distribution-specific configurations
         if self.module.get_bin_path('dpkg-reconfigure') is not None:
             # Debian/Ubuntu
             if 'name' in self.value:
                 self.update_timezone = ['%s -sf %s /etc/localtime' % (self.module.get_bin_path('ln', required=True), tzfile),
                                         '%s --frontend noninteractive tzdata' % self.module.get_bin_path('dpkg-reconfigure', required=True)]
-            self.conf_files['name'] = '/etc/timezone'
             self.conf_files['hwclock'] = '/etc/default/rcS'
-            self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
-            self.tzline_format = '%s\n'
         elif distribution == 'Alpine' or distribution == 'Gentoo':
-            self.conf_files['name'] = '/etc/timezone'
             self.conf_files['hwclock'] = '/etc/conf.d/hwclock'
-            self.tzline_format = '%s\n'
-            self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
             if distribution == 'Alpine':
                 self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), planned_tz)]
         else:

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -355,6 +355,7 @@ class NosystemdTimezone(Timezone):
         # Validate given timezone
         if 'name' in self.value:
             tzfile = self._verify_timezone()
+            planned_tz = self.value['name']['planned']
             # `--remove-destination` is needed if /etc/localtime is a symlink so
             # that it overwrites it instead of following it.
             self.update_timezone = ['%s --remove-destination %s /etc/localtime' % (self.module.get_bin_path('cp', required=True), tzfile)]
@@ -375,7 +376,7 @@ class NosystemdTimezone(Timezone):
             self.conf_files['hwclock'] = '/etc/conf.d/hwclock'
             self.tzline_format = '%s\n'
             self.regexps['name'] = re.compile(r'^([^\s]+)', re.MULTILINE)
-            self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), tzfile)]
+            self.update_timezone = ['%s -z %s' % (self.module.get_bin_path('setup-timezone', required=True), planned_tz)]
         else:
             # RHEL/CentOS/SUSE
             if self.module.get_bin_path('tzdata-update') is not None:


### PR DESCRIPTION
##### SUMMARY
Fix `timezone` module to work with Alpine and Gentoo linux.

Fixes #781

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
timezone

##### ADDITIONAL INFORMATION
Tested with alpine:
```
alpine:~# cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.13.1
PRETTY_NAME="Alpine Linux v3.13"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```
and Gentoo in a docker container...

PS: completely untested code path with `hwclock` on Gentoo/Alpine