### PR TITLE
datadog_monitor: Add missing monitor types query alert, trace-analytics alert, rum alert

### DIFF
--- a/changelogs/fragments/1723-datadog_monitor-add-missing-monitor-types.yml
+++ b/changelogs/fragments/1723-datadog_monitor-add-missing-monitor-types.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - datadog_monitor - add missing monitor types query alert, trace-analytics alert, rum alert
+  - datadog_monitor - add missing monitor types ``query alert``, ``trace-analytics alert``, ``rum alert`` (https://github.com/ansible-collections/community.general/pull/1723).

--- a/changelogs/fragments/1723-datadog_monitor-add-missing-monitor-types.yml
+++ b/changelogs/fragments/1723-datadog_monitor-add-missing-monitor-types.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - datadog_monitor - add missing monitor types query alert, trace-analytics alert, rum alert

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -49,7 +49,7 @@ options:
     type:
         description:
           - The type of the monitor.
-        choices: ['metric alert', 'service check', 'event alert', 'process alert', 'log alert']
+        choices: ['metric alert', 'service check', 'event alert', 'process alert', 'log alert', 'query alert', 'trace-analytics alert', 'rum alert']
         type: str
     query:
         description:
@@ -208,7 +208,9 @@ def main():
             api_host=dict(required=False),
             app_key=dict(required=True, no_log=True),
             state=dict(required=True, choices=['present', 'absent', 'mute', 'unmute']),
-            type=dict(required=False, choices=['metric alert', 'service check', 'event alert', 'process alert', 'log alert']),
+            type=dict(required=False, choices=['metric alert', 'service check', 'event alert',
+                                               'process alert', 'log alert', 'query alert',
+                                               'trace-analytics alert', 'rum alert']),
             name=dict(required=True),
             query=dict(required=False),
             notification_message=dict(required=False, no_log=True, default=None, aliases=['message'],
@@ -348,7 +350,7 @@ def install_monitor(module):
 
     if module.params['type'] == "service check":
         options["thresholds"] = module.params['thresholds'] or {'ok': 1, 'critical': 1, 'warning': 1}
-    if module.params['type'] in ["metric alert", "log alert"] and module.params['thresholds'] is not None:
+    if module.params['type'] in ["metric alert", "log alert", "query alert", "trace-analytics alert", "rum alert"] and module.params['thresholds'] is not None:
         options["thresholds"] = module.params['thresholds']
 
     monitor = _get_monitor(module)

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -49,6 +49,7 @@ options:
     type:
         description:
           - The type of the monitor.
+          - The types C(query alert), C(trace-analytics alert) and C(rum alert) were added in community.general 2.1.0.
         choices: ['metric alert', 'service check', 'event alert', 'process alert', 'log alert', 'query alert', 'trace-analytics alert', 'rum alert']
         type: str
     query:


### PR DESCRIPTION
##### SUMMARY
This PR adds additional Datadog monitor types that were missing from the module: `query alert`, `trace-analytics alert`, `rum alert`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
datadog_monitor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Tested against Datadog
```yaml
      - name: Create query Monitors
        community.general.datadog_monitor:
          api_key: "{{ dd_api_key }}"
          app_key: "{{ dd_app_key }}"
          type: "query alert"
          name: "Ansible Service frontend has a high error rate on env:ruby-shop"
          state: "present"
          query: "sum(last_10m):( sum:trace.rack.request.errors{env:ruby-shop,service:frontend}.as_count() / sum:trace.rack.request.hits{env:ruby-shop,service:frontend}.as_count() ) > 0.02"
          notification_message: "Service frontend on env:ruby-shop has a high error rate."
          tags:
            - "env:ruby-shop"
            - "service:frontend"
          thresholds:
            warning: "0.01"
            critical: "0.02"

      - name: Create trace Monitor
        community.general.datadog_monitor:
          api_key: "{{ dd_api_key }}"
          app_key: "{{ dd_app_key }}"
          type: "trace-analytics alert"
          name: "Ansible trace test"
          state: "present"
          query: 'trace-analytics("*").rollup("count").last("5m") > 5'
          notification_message: "Ansible test"
          tags:
            - "env:ruby-shop"
          thresholds:
            warning: "1"
            critical: "5"

      - name: Create rum Monitor
        community.general.datadog_monitor:
          api_key: "{{ dd_api_key }}"
          app_key: "{{ dd_app_key }}"
          type: "rum alert"
          name: "Ansible rum test"
          state: "present"
          query: 'rum("*").rollup("count").last("5m") > 6'
          notification_message: "Ansible test"
          tags:
            - "env:ruby-shop"
          thresholds:
            warning: "2"
            critical: "6"
```
            
