### PR TITLE
Various fixes for updating existing gitlab users

### DIFF
--- a/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
+++ b/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  -  gitlab_user - make updates to following attributes of an existing gitlab user work: ``isadmin``, ``password``, ``confirm`` (https://github.com/ansible-collections/community.general/pull/1724).
+  - gitlab_user - make updates to following attributes of an existing gitlab user work: isadmin, password, confirm (https://github.com/ansible-collections/community.general/pull/1724).

--- a/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
+++ b/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_user - make updates to following attributes of an existing gitlab user work: isadmin, password, confirm (https://github.com/ansible-collections/community.general/pull/1724).
+  - gitlab_user - make updates to following attributes of an existing gitlab user work => isadmin, password, confirm (https://github.com/ansible-collections/community.general/pull/1724).

--- a/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
+++ b/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  -  gitlab_user - make updates to following attributes of an existing gitlab user work: ``isadmin``, ``password``, ``confirm`` (https://github.com/ansible-collections/community.general/pull/1724).

--- a/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
+++ b/changelogs/fragments/1724-various-fixes-for-updating-existing-gitlab-user.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_user - make updates to following attributes of an existing gitlab user work => isadmin, password, confirm (https://github.com/ansible-collections/community.general/pull/1724).
+  - gitlab_user - make updates to the ``isadmin``, ``password`` and ``confirm`` options of an already existing GitLab user work (https://github.com/ansible-collections/community.general/pull/1724).

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -220,30 +220,30 @@ class GitLabUser(object):
             changed = True
         else:
             changed, user = self.updateUser(self.userObject, {
-                  # add "normal" parameters here, put uncheckable
-                  # params in the dict below
-                  'name': { 'value': options['name'] },
-                  'email': { 'value': options['email'] },
+                # add "normal" parameters here, put uncheckable
+                # params in the dict below
+                'name': {'value': options['name']},
+                'email': {'value': options['email']},
 
-                  # note: for some attributes like this one the key 
-                  #   from reading back from server is unfortunately 
-                  #   different to the one needed for pushing/writing, 
-                  #   in that case use the optional setter key
-                  'is_admin': { 
-                     'value': options['isadmin'], 'setter': 'admin' 
-                  },
-                  'external': { 'value': options['external'] },
+                # note: for some attributes like this one the key
+                #   from reading back from server is unfortunately
+                #   different to the one needed for pushing/writing,
+                #   in that case use the optional setter key
+                'is_admin': {
+                   'value': options['isadmin'], 'setter': 'admin'
+                },
+                'external': {'value': options['external']},
                 }, {
-                  # put "uncheckable" params here, this means params 
-                  # which the gitlab does accept for setting but does 
-                  # not return any information about it
-                  'skip_reconfirmation': { 'value': not options['confirm'] },
-                  'password': { 'value': options['password'] },
+                # put "uncheckable" params here, this means params
+                # which the gitlab does accept for setting but does
+                # not return any information about it
+                'skip_reconfirmation': {'value': not options['confirm']},
+                'password': {'value': options['password']},
                 })
 
-            # note: as we unfortunately have some uncheckable parameters 
-            #   where it is not possible to determine if the update 
-            #   changed something or not, we must assume here that a 
+            # note: as we unfortunately have some uncheckable parameters
+            #   where it is not possible to determine if the update
+            #   changed something or not, we must assume here that a
             #   changed happend and that an user object update is needed
             potentionally_changed = True
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -220,28 +220,28 @@ class GitLabUser(object):
             changed = True
         else:
             changed, user = self.updateUser(
-              self.userObject, {
-              # add "normal" parameters here, put uncheckable
-              # params in the dict below
-              'name': {'value': options['name']},
-              'email': {'value': options['email']},
+                self.userObject, {
+                    # add "normal" parameters here, put uncheckable
+                    # params in the dict below
+                    'name': {'value': options['name']},
+                    'email': {'value': options['email']},
 
-              # note: for some attributes like this one the key
-              #   from reading back from server is unfortunately
-              #   different to the one needed for pushing/writing,
-              #   in that case use the optional setter key
-              'is_admin': {
-                  'value': options['isadmin'], 'setter': 'admin'
-              },
-              'external': {'value': options['external']},
-              },
-              {
-              # put "uncheckable" params here, this means params
-              # which the gitlab does accept for setting but does
-              # not return any information about it
-              'skip_reconfirmation': {'value': not options['confirm']},
-              'password': {'value': options['password']},
-              }
+                    # note: for some attributes like this one the key
+                    #   from reading back from server is unfortunately
+                    #   different to the one needed for pushing/writing,
+                    #   in that case use the optional setter key
+                    'is_admin': {
+                        'value': options['isadmin'], 'setter': 'admin'
+                    },
+                    'external': {'value': options['external']},
+                },
+                {
+                    # put "uncheckable" params here, this means params
+                    # which the gitlab does accept for setting but does
+                    # not return any information about it
+                    'skip_reconfirmation': {'value': not options['confirm']},
+                    'password': {'value': options['password']},
+                }
             )
 
             # note: as we unfortunately have some uncheckable parameters

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -230,10 +230,11 @@ class GitLabUser(object):
                 #   different to the one needed for pushing/writing,
                 #   in that case use the optional setter key
                 'is_admin': {
-                   'value': options['isadmin'], 'setter': 'admin'
+                    'value': options['isadmin'], 'setter': 'admin'
                 },
                 'external': {'value': options['external']},
-                }, {
+                }, 
+                {
                 # put "uncheckable" params here, this means params
                 # which the gitlab does accept for setting but does
                 # not return any information about it

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -219,28 +219,30 @@ class GitLabUser(object):
                 'external': options['external']})
             changed = True
         else:
-            changed, user = self.updateUser(self.userObject, {
-                # add "normal" parameters here, put uncheckable
-                # params in the dict below
-                'name': {'value': options['name']},
-                'email': {'value': options['email']},
+            changed, user = self.updateUser(
+              self.userObject, {
+              # add "normal" parameters here, put uncheckable
+              # params in the dict below
+              'name': {'value': options['name']},
+              'email': {'value': options['email']},
 
-                # note: for some attributes like this one the key
-                #   from reading back from server is unfortunately
-                #   different to the one needed for pushing/writing,
-                #   in that case use the optional setter key
-                'is_admin': {
-                    'value': options['isadmin'], 'setter': 'admin'
-                },
-                'external': {'value': options['external']},
-                }, 
-                {
-                # put "uncheckable" params here, this means params
-                # which the gitlab does accept for setting but does
-                # not return any information about it
-                'skip_reconfirmation': {'value': not options['confirm']},
-                'password': {'value': options['password']},
-                })
+              # note: for some attributes like this one the key
+              #   from reading back from server is unfortunately
+              #   different to the one needed for pushing/writing,
+              #   in that case use the optional setter key
+              'is_admin': {
+                  'value': options['isadmin'], 'setter': 'admin'
+              },
+              'external': {'value': options['external']},
+              },
+              {
+              # put "uncheckable" params here, this means params
+              # which the gitlab does accept for setting but does
+              # not return any information about it
+              'skip_reconfirmation': {'value': not options['confirm']},
+              'password': {'value': options['password']},
+              }
+            )
 
             # note: as we unfortunately have some uncheckable parameters
             #   where it is not possible to determine if the update

--- a/tests/integration/targets/gitlab_user/tasks/main.yml
+++ b/tests/integration/targets/gitlab_user/tasks/main.yml
@@ -248,4 +248,3 @@
   assert:
     that:
       - gitlab_user_state is not changed
-

--- a/tests/integration/targets/gitlab_user/tasks/main.yml
+++ b/tests/integration/targets/gitlab_user/tasks/main.yml
@@ -10,25 +10,25 @@
 
 - name: Clean up gitlab user
   gitlab_user:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     name: ansible_test_user
     username: ansible_test_user
     password: Secr3tPassw00rd
     email: root@localhost
     validate_certs: false
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     state: absent
 
 
 - name: Create gitlab user
   gitlab_user:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     email: "{{ gitlab_user_email }}"
     name: "{{ gitlab_user }}"
     username: "{{ gitlab_user }}"
     password: "{{ gitlab_user_pass }}"
     validate_certs: False
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     state: present
   register: gitlab_user_state
 
@@ -39,13 +39,13 @@
 
 - name: Create gitlab user again
   gitlab_user:
-    server_url: "{{ gitlab_host }}"
+    api_url: "{{ gitlab_host }}"
     email: root@localhost
     name: ansible_test_user
     username: ansible_test_user
     password: Secr3tPassw00rd
     validate_certs: False
-    login_token: "{{ gitlab_login_token }}"
+    api_token: "{{ gitlab_login_token }}"
     state: present
   register: gitlab_user_state_again
 
@@ -53,3 +53,199 @@
   assert:
     that:
       - gitlab_user_state_again is not changed
+      - gitlab_user_state_again.user.is_admin == False
+
+
+- name: Update User Test => Make User Admin 
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    isadmin: true
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check if user is admin now
+  assert:
+    that:
+      - gitlab_user_state is changed
+      - gitlab_user_state.user.is_admin == True
+
+- name: Update User Test => Make User Admin (Again)
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    isadmin: true
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check state is not changed
+  assert:
+    that:
+      - gitlab_user_state is not changed
+      - gitlab_user_state.user.is_admin == True
+
+- name: Update User Test => Remove Admin Rights
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    isadmin: false
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check if user is not admin anymore
+  assert:
+    that:
+      - gitlab_user_state is changed
+      - gitlab_user_state.user.is_admin == False
+
+
+- name: Update User Test => Try Changing Mail without Confirmation Skipping
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: foo@bar.baz
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    confirm: True
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check that eMail is unchanged (Only works with confirmation skipping)
+  assert:
+    that:
+      - gitlab_user_state is changed
+      - gitlab_user_state.user.email == gitlab_user_email
+
+- name: Update User Test => Change Mail with Confirmation Skip
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: foo@bar.baz
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    confirm: false
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check that mail has changed now
+  assert:
+    that:
+      - gitlab_user_state is changed
+      - gitlab_user_state.user.email == 'foo@bar.baz'
+
+- name: Update User Test => Change Mail with Confirmation Skip (Again)
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: foo@bar.baz
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    confirm: false
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check state is not changed
+  assert:
+    that:
+      - gitlab_user_state is not changed
+      - gitlab_user_state.user.email == 'foo@bar.baz'
+
+- name: Update User Test => Revert to original Mail Address
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    confirm: false
+    validate_certs: False
+    api_token: "{{ gitlab_login_token }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check that reverting mail back to original has worked
+  assert:
+    that:
+      - gitlab_user_state is changed
+      - gitlab_user_state.user.email == gitlab_user_email
+
+
+- name: Update User Test => Change User Password
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: False
+
+    # note: the only way to check if a password really is what it is expected 
+    #   to be is to use it for login, so we use it here instead of the 
+    #   default token assuming that a user can always change its own password
+    api_username: "{{ gitlab_user }}"
+    api_password: "{{ gitlab_user_pass }}"
+
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    password: new-super-password
+    state: present
+  register: gitlab_user_state
+
+- name: Check PW setting return state
+  assert:
+    that:
+        # note: there is no way to determine if a password has changed or 
+        #   not, so it can only be always yellow or always green, we 
+        #   decided for always green for now
+      - gitlab_user_state is not changed
+
+- name: Update User Test => Reset User Password
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: False
+
+    api_username: "{{ gitlab_user }}"
+    api_password: new-super-password
+
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    password: "{{ gitlab_user_pass }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check PW setting return state (Again)
+  assert:
+    that:
+      - gitlab_user_state is not changed
+
+- name: Update User Test => Check that password was reset
+  gitlab_user:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: False
+
+    api_username: "{{ gitlab_user }}"
+    api_password: "{{ gitlab_user_pass }}"
+
+    email: "{{ gitlab_user_email }}"
+    name: "{{ gitlab_user }}"
+    username: "{{ gitlab_user }}"
+    state: present
+  register: gitlab_user_state
+
+- name: Check PW setting return state (Reset)
+  assert:
+    that:
+      - gitlab_user_state is not changed
+

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -83,14 +83,11 @@ class TestGitlabUser(GitlabModuleTestCase):
                                            'username': 'john_smith', 'name': 'John Smith'})
         self.assertEqual(type(user), User)
         self.assertEqual(user.name, "John Smith")
-        self.assertEqual(user.email, 'john@example.com')
         self.assertEqual(user.id, 1)
 
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
-
-        ##assert False, "\n\n{}\n\n{}".format(user.__dict__["_updated_attrs"], user.__dict__["_attrs"])
 
         changed, newUser = self.moduleUtil.updateUser(
             user,
@@ -107,15 +104,14 @@ class TestGitlabUser(GitlabModuleTestCase):
 
         changed, newUser = self.moduleUtil.updateUser(
             user,
-            ##{'email': {'value': "foo@bar.baz"}}, {
             {}, {
                 'skip_reconfirmation': {'value': True},
                 'password': {'value': 'super_secret-super_secret'},
             }
         )
 
-        self.assertEqual(changed, True)
-        ##self.assertEqual(newUser.email, "foo@bar.baz")
+        # note: uncheckable parameters dont set changed state
+        self.assertEqual(changed, False)
         self.assertEqual(newUser.skip_reconfirmation, True)
         self.assertEqual(newUser.password, 'super_secret-super_secret')
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -89,8 +89,8 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
         changed, newUser = self.moduleUtil.updateUser(
-          user,
-          {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
+            user,
+            {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
         )
 
         self.assertEqual(changed, True)
@@ -102,11 +102,11 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(changed, False)
 
         changed, newUser = self.moduleUtil.updateUser(
-          user,
-          {'email': {'value': "foo@bar.baz"}}, {
-              'skip_reconfirmation': {'value': True},
-              'password': {'value': 'super_secret-super_secret'},
-          }
+            user,
+            {'email': {'value': "foo@bar.baz"}}, {
+                'skip_reconfirmation': {'value': True},
+                'password': {'value': 'super_secret-super_secret'},
+            }
         )
 
         self.assertEqual(changed, True)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -89,7 +89,7 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
         changed, newUser = self.moduleUtil.updateUser(user,
-          {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
+            {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
         )
 
         self.assertEqual(changed, True)
@@ -101,10 +101,10 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(changed, False)
 
         changed, newUser = self.moduleUtil.updateUser(user,
-          {'email': {'value': "foo@bar.baz"}}, {
-             'skip_reconfirmation': {'value': True},
-             'password': {'value': 'super_secret-super_secret'},
-          }
+            {'email': {'value': "foo@bar.baz"}}, {
+                'skip_reconfirmation': {'value': True},
+                'password': {'value': 'super_secret-super_secret'},
+            }
         )
 
         self.assertEqual(changed, True)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -88,13 +88,31 @@ class TestGitlabUser(GitlabModuleTestCase):
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
-        changed, newUser = self.moduleUtil.updateUser(user, {'name': "Jack Smith", "is_admin": "true"})
+        changed, newUser = self.moduleUtil.updateUser(user, 
+          {'name': { 'value': "Jack Smith"}, "is_admin": { 'value': "true", 'setter': 'admin' }}, {}
+        )
 
         self.assertEqual(changed, True)
         self.assertEqual(newUser.name, "Jack Smith")
-        self.assertEqual(newUser.is_admin, "true")
+        self.assertEqual(newUser.admin, "true")
 
-        changed, newUser = self.moduleUtil.updateUser(user, {'name': "Jack Smith"})
+        changed, newUser = self.moduleUtil.updateUser(user, {'name': { 'value': "Jack Smith" }}, {})
+
+        self.assertEqual(changed, False)
+
+        changed, newUser = self.moduleUtil.updateUser(user, 
+          {'email': { 'value': "foo@bar.baz"}}, {
+             'skip_reconfirmation': { 'value': True },
+             'password': { 'value': 'super_secret-super_secret' },
+          }
+        )
+
+        self.assertEqual(changed, True)
+        self.assertEqual(newUser.email, "foo@bar.baz")
+        self.assertEqual(newUser.skip_reconfirmation, True)
+        self.assertEqual(newUser.password, 'super_secret-super_secret')
+
+        changed, newUser = self.moduleUtil.updateUser(user, {'email': { 'value': "foo@bar.baz" }}, {})
 
         self.assertEqual(changed, False)
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -83,13 +83,14 @@ class TestGitlabUser(GitlabModuleTestCase):
                                            'username': 'john_smith', 'name': 'John Smith'})
         self.assertEqual(type(user), User)
         self.assertEqual(user.name, "John Smith")
+        self.assertEqual(user.email, 'john@example.com')
         self.assertEqual(user.id, 1)
 
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
 
-        assert False, "\n\n{}\n\n{}".format(user.__dict__["_updated_attrs"], user.__dict__["_attrs"])
+        ##assert False, "\n\n{}\n\n{}".format(user.__dict__["_updated_attrs"], user.__dict__["_attrs"])
 
         changed, newUser = self.moduleUtil.updateUser(
             user,
@@ -106,14 +107,15 @@ class TestGitlabUser(GitlabModuleTestCase):
 
         changed, newUser = self.moduleUtil.updateUser(
             user,
-            {'email': {'value': "foo@bar.baz"}}, {
+            ##{'email': {'value': "foo@bar.baz"}}, {
+            {}, {
                 'skip_reconfirmation': {'value': True},
                 'password': {'value': 'super_secret-super_secret'},
             }
         )
 
         self.assertEqual(changed, True)
-        self.assertEqual(newUser.email, "foo@bar.baz")
+        ##self.assertEqual(newUser.email, "foo@bar.baz")
         self.assertEqual(newUser.skip_reconfirmation, True)
         self.assertEqual(newUser.password, 'super_secret-super_secret')
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -88,6 +88,9 @@ class TestGitlabUser(GitlabModuleTestCase):
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
+
+        assert False, "\n\n{}\n\n{}".format(user.__dict__["_updated_attrs"], user.__dict__["_attrs"])
+
         changed, newUser = self.moduleUtil.updateUser(
             user,
             {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -115,10 +115,6 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(newUser.skip_reconfirmation, True)
         self.assertEqual(newUser.password, 'super_secret-super_secret')
 
-        changed, newUser = self.moduleUtil.updateUser(user, {'email': {'value': "foo@bar.baz"}}, {})
-
-        self.assertEqual(changed, False)
-
     @with_httmock(resp_find_user)
     @with_httmock(resp_delete_user)
     def test_delete_user(self):

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -88,8 +88,9 @@ class TestGitlabUser(GitlabModuleTestCase):
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
-        changed, newUser = self.moduleUtil.updateUser(user,
-            {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
+        changed, newUser = self.moduleUtil.updateUser(
+          user,
+          {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
         )
 
         self.assertEqual(changed, True)
@@ -100,11 +101,12 @@ class TestGitlabUser(GitlabModuleTestCase):
 
         self.assertEqual(changed, False)
 
-        changed, newUser = self.moduleUtil.updateUser(user,
-            {'email': {'value': "foo@bar.baz"}}, {
-                'skip_reconfirmation': {'value': True},
-                'password': {'value': 'super_secret-super_secret'},
-            }
+        changed, newUser = self.moduleUtil.updateUser(
+          user,
+          {'email': {'value': "foo@bar.baz"}}, {
+              'skip_reconfirmation': {'value': True},
+              'password': {'value': 'super_secret-super_secret'},
+          }
         )
 
         self.assertEqual(changed, True)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -88,22 +88,22 @@ class TestGitlabUser(GitlabModuleTestCase):
     @with_httmock(resp_get_user)
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
-        changed, newUser = self.moduleUtil.updateUser(user, 
-          {'name': { 'value': "Jack Smith"}, "is_admin": { 'value': "true", 'setter': 'admin' }}, {}
+        changed, newUser = self.moduleUtil.updateUser(user,
+          {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
         )
 
         self.assertEqual(changed, True)
         self.assertEqual(newUser.name, "Jack Smith")
         self.assertEqual(newUser.admin, "true")
 
-        changed, newUser = self.moduleUtil.updateUser(user, {'name': { 'value': "Jack Smith" }}, {})
+        changed, newUser = self.moduleUtil.updateUser(user, {'name': {'value': "Jack Smith"}}, {})
 
         self.assertEqual(changed, False)
 
-        changed, newUser = self.moduleUtil.updateUser(user, 
-          {'email': { 'value': "foo@bar.baz"}}, {
-             'skip_reconfirmation': { 'value': True },
-             'password': { 'value': 'super_secret-super_secret' },
+        changed, newUser = self.moduleUtil.updateUser(user,
+          {'email': {'value': "foo@bar.baz"}}, {
+             'skip_reconfirmation': {'value': True},
+             'password': {'value': 'super_secret-super_secret'},
           }
         )
 
@@ -112,7 +112,7 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(newUser.skip_reconfirmation, True)
         self.assertEqual(newUser.password, 'super_secret-super_secret')
 
-        changed, newUser = self.moduleUtil.updateUser(user, {'email': { 'value': "foo@bar.baz" }}, {})
+        changed, newUser = self.moduleUtil.updateUser(user, {'email': {'value': "foo@bar.baz"}}, {})
 
         self.assertEqual(changed, False)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR packs together various bug fixes all related to updating an existing gitlab user. In detail:

1. Makes changes to admin state of user working, which failed before because the attribute key when querying the user object `is_admin` is different from the json payload key needed for setting `admin`
2. Makes user password changes working which were simply ignored before
3. Supports confirmation skipping or more preciesly reconfirmation skipping also for user updates (before it only worked for new users), which according to my experiments is essential when trying to change the user email address

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
All these changes made some substantial upgrades necessary for the internal process which handles gitlab user updates. For 1) we needed the possibility to specify different "getter" and "setter" keys when comparing old and new value and triggering an object update.

For 2) and 3) it must be possible to trigger a gitlab update without checking the old value first, because it is simply not provided by the gitlab "read" query. This also raises a fundamental question concerning the external / module API behaviour. As we never know the old password and the gitlab server also does not signal if it did change the password or not it is imho inpossible
to decide if the state should be yellow / changed or green.
Is there a general project guideline how to handle such situations? I personally see three possible solutions:

A. Map undecidable cases to green (Ever-Green) [currently implemented]
B. Map undecidable cases to yellow (Ever-Yellow)
C. Check if the critical parameter (e.g. password) is set by the module user or not, map to B) in the first case and A) in the 2nd case

I did A) because I prefer my plays to be green eventually if run two or three times in sequence without any code changes, but one could totally argue that B) is the safer option (signaling the user "there-might-be-changes-but-we-dont-know-for-sure instead of "hiding" some potential changes). An user could than still opt to work with `changed_when` to avoid ever-yellow situations.

For the 3rd option to work it must be possible to decide inside the module if the corresponding parameter was explicity set by caller or not, which should work fine for something like a password, but not so much for a bool like `skip_reconfirmation`. But in this special case it seems actually to be pretty ok to ignore any influence of `skip_reconfirmation` on module changed status, as I'm pretty sure it does not really change any real permanent status inside the gitlab server, it only changes how the server reacts to a changed mail address for a single update process.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
