### PR TITLE
[stable-1] docker swarm - Add no_log to the signing_ca_key argument

### DIFF
--- a/changelogs/fragments/CVE-2021-20191_no_log_docker.yml
+++ b/changelogs/fragments/CVE-2021-20191_no_log_docker.yml
@@ -1,0 +1,2 @@
+security_fixes:
+  - docker_swarm - enabled ``no_log`` for the option ``signing_ca_key`` to prevent accidental disclosure (CVE-2021-20191, https://github.com/ansible-collections/community.general/pull/1728).

--- a/plugins/modules/cloud/docker/docker_swarm.py
+++ b/plugins/modules/cloud/docker/docker_swarm.py
@@ -616,7 +616,7 @@ def main():
         name=dict(type='str'),
         labels=dict(type='dict'),
         signing_ca_cert=dict(type='str'),
-        signing_ca_key=dict(type='str'),
+        signing_ca_key=dict(type='str', no_log=True),
         ca_force_rotate=dict(type='int'),
         autolock_managers=dict(type='bool'),
         node_id=dict(type='str'),


### PR DESCRIPTION
This will prevent accidental disclosure.

See: CVE-2021-20191

Backport from community.docker: https://github.com/ansible-collections/community.docker/pull/80