### PR TITLE
Fix typo in aerospike_migration module

### DIFF
--- a/changelogs/fragments/1740-aerospike_migration.yml
+++ b/changelogs/fragments/1740-aerospike_migration.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "aerospike_migration - fix typo that caused ``migrate_tx_key`` instead of ``migrate_rx_key`` being used (https://github.com/ansible-collections/community.general/pull/1739)."

--- a/plugins/modules/database/aerospike/aerospike_migrations.py
+++ b/plugins/modules/database/aerospike/aerospike_migrations.py
@@ -338,7 +338,7 @@ class Migrations:
             namespace_tx = \
                 int(namespace_stats[self.module.params['migrate_tx_key']])
             namespace_rx = \
-                int(namespace_stats[self.module.params['migrate_tx_key']])
+                int(namespace_stats[self.module.params['migrate_rx_key']])
         except KeyError:
             self.module.fail_json(
                 msg="Did not find partition remaining key:" +


### PR DESCRIPTION
##### SUMMARY
Uses `migrate_tx_key` instead of `migrate_rx_key` when populating `namespace_rx`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aerospike_migration
