### PR TITLE
use vagrant global-status and use directory name where Vagrantfile li…

### DIFF
--- a/scripts/inventory/vagrant.py
+++ b/scripts/inventory/vagrant.py
@@ -1,14 +1,16 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
-Vagrant external inventory script. Automatically finds the IP of the booted vagrant vm(s), and
-returns it under the host group 'vagrant' with the directory name as ansible hostname.
+Vagrant external inventory script. Automatically finds the IP of the booted
+vagrant vm(s), and returns it under the host group 'vagrant' with the
+directory name as ansible inventory hostname.
 
 # Copyright (C) 2013  Mark Mandel <mark@compoundtheory.com>
 #               2015  Igor Khomyakov <homyakov@gmail.com>
-                2021  Christopher Hornberger github.com/horni23
+#               2021  Christopher Hornberger github.com/horni23
 #
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """
 
 from __future__ import (absolute_import, division, print_function)
@@ -62,16 +64,18 @@ names = []
 mapping = {}
 
 for line in output:
-    matchname = re.search(r"(running.+?)([^\/]+$)",line)
-    matcher   = re.search(r"^\s*([a-zA-Z0-9]+).*running",line)
+    matchname = re.search(r"(running.+?)([^\/]+$)", line)
+    matcher = re.search(r"^\s*([a-zA-Z0-9]+).*running", line)
     if matcher and matchname:
         boxes = str(matcher.group(1))
         boxname = str(matchname.group(2))
         boxname = boxname.strip()
         mapping[boxes] = boxname
 
+
 def get_ssh_config():
     return dict((k, get_a_ssh_config(k)) for k in mapping)
+
 
 # get the ssh config for a single box
 def get_a_ssh_config(box_name):
@@ -92,10 +96,11 @@ def get_a_ssh_config(box_name):
 
     return dict((v, host_config[k]) for k, v in _ssh_to_ansible)
 
+
 # List out servers that vagrant has running
 # ------------------------------
 if options.list:
-    ssh_config   = get_ssh_config()
+    ssh_config = get_ssh_config()
     list_names = []
     meta = defaultdict(dict)
 
@@ -113,7 +118,7 @@ elif options.host:
     host = list(mapping.keys())[list(mapping.values()).index(options.host)]
     host = host.strip("[]")
     host = host.strip("\'")
-    print(json.dumps(get_a_ssh_config(host),indent=4))
+    print(json.dumps(get_a_ssh_config(host), indent=4))
     sys.exit(0)
 
 # Print out help


### PR DESCRIPTION
…es as ansible_host

##### SUMMARY
- the directory name where the Vagrantfile lies is used as ansible_host
- reads vagrant global-status --prune to find running VMs

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
scripts/inventory/vagrant.py

##### ADDITIONAL INFORMATION
`vagrant status` gives information only about one running Vagrant VM, in newer releases `vagrant global-status` is used to list all running VMs.
Also `vagrant global-status --prune` updates the information about the state of running VMs before writing the output.

Additionally, instead of using e.g. `a1b2c3d` (the Vagrant box ID), it might be more human-readable to use the directory name where the Vagrantfile lies as inventory hostname

```
BEFORE:
./vagrant.py --list

A Vagrant environment or target machine is required to run this
command. Run `vagrant init` to create a new Vagrant environment. Or,
get an ID of a target machine from `vagrant global-status` to run
this command on. A final option is to change to a directory with a
Vagrantfile and to try again.
Traceback (most recent call last):
  File "/home/horni/src/community.general/scripts/inventory/./vagrant.py", line 104, in <module>
    ssh_config = get_ssh_config()
  File "/home/horni/src/community.general/scripts/inventory/./vagrant.py", line 64, in get_ssh_config
    return dict((k, get_a_ssh_config(k)) for k in list_running_boxes())
  File "/home/horni/src/community.general/scripts/inventory/./vagrant.py", line 70, in list_running_boxes
    output = to_text(subprocess.check_output(["vagrant", "status"]), errors='surrogate_or_strict').split('\n')
  File "/usr/lib64/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['vagrant', 'status']' returned non-zero exit status 1.

AFTER:
./vagrant.py --list                                   
{
    "vagrant": [
        "CentOS7-1"
    ],
    "_meta": {
        "hostvars": {
            "CentOS7-1": {
                "ansible_user": "vagrant",
                "ansible_host": "127.0.0.1",
                "ansible_private_key_file": "/home/horni/Vagrant/CentOS7-1/.vagrant/machines/default/virtualbox/private_key",
                "ansible_port": "2222"
            }
        }
    }
}

ansible -i vagrant.py -m command -a "uptime" CentOS7-1
CentOS7-1 | CHANGED | rc=0 >>
 18:40:37 up 3 min,  1 user,  load average: 0,19, 0,22, 0,10
```
