### PR TITLE
redfish module_utils: case insesitive search for situations where the hostname/FQDN on iLO is in caps

### DIFF
--- a/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
+++ b/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_config - redfish module_utils case insesitive search for situations where the hostname/FQDN case on iLO doesn't match variable's case (https://github.com/ansible-collections/community.general/pull/1744).
+  - redfish_config - case insensitive search for situations where the hostname/FQDN case on iLO doesn't match variable's case (https://github.com/ansible-collections/community.general/pull/1744).

--- a/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
+++ b/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_config - redfish module_utils: case insesitive search for situations where the hostname/FQDN case on iLO doesn't match variable's case (https://github.com/ansible-collections/community.general/pull/1744).
+  - redfish_config - redfish module_utils case insesitive search for situations where the hostname/FQDN case on iLO doesn't match variable's case (https://github.com/ansible-collections/community.general/pull/1744).

--- a/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
+++ b/changelogs/fragments/1744-case-insensitive-hostname-fqdn-matching.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_config - redfish module_utils: case insesitive search for situations where the hostname/FQDN case on iLO doesn't match variable's case (https://github.com/ansible-collections/community.general/pull/1744).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2625,14 +2625,14 @@ class RedfishUtils(object):
         target_ethernet_current_setting = None
         if nic_addr == 'null':
             # Find root_uri matched EthernetInterface when nic_addr is not specified
-            nic_addr = (self.root_uri).lower().split('/')[-1]
+            nic_addr = (self.root_uri).split('/')[-1]
             nic_addr = nic_addr.split(':')[0]  # split port if existing
         for uri in uris:
             response = self.get_request(self.root_uri + uri)
             if response['ret'] is False:
                 return response
             data = response['data']
-            if '"' + nic_addr + '"' in str(data).lower() or "'" + nic_addr + "'" in str(data).lower():
+            if '"' + nic_addr.lower() + '"' in str(data).lower() or "'" + nic_addr.lower() + "'" in str(data).lower():
                 target_ethernet_uri = uri
                 target_ethernet_current_setting = data
                 break

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2625,14 +2625,14 @@ class RedfishUtils(object):
         target_ethernet_current_setting = None
         if nic_addr == 'null':
             # Find root_uri matched EthernetInterface when nic_addr is not specified
-            nic_addr = (self.root_uri).split('/')[-1]
+            nic_addr = (self.root_uri).lower().split('/')[-1]
             nic_addr = nic_addr.split(':')[0]  # split port if existing
         for uri in uris:
             response = self.get_request(self.root_uri + uri)
             if response['ret'] is False:
                 return response
             data = response['data']
-            if '"' + nic_addr + '"' in str(data) or "'" + nic_addr + "'" in str(data):
+            if '"' + nic_addr + '"' in str(data).lower() or "'" + nic_addr + "'" in str(data).lower():
                 target_ethernet_uri = uri
                 target_ethernet_current_setting = data
                 break


### PR DESCRIPTION
##### SUMMARY
If instead of an IP one wants to use FQDN and the case on iLO doesn't match Ansible's {{ baseuri }} case the task will fail.
This PR implements basic case insensitive comparison.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/redfish_utils.py

##### ANSIBLE TASK
```
  - name: Set Manager NIC
    community.general.redfish_config:
      category: Manager
      command: SetManagerNic
      nic_config:
        DHCPv4:
          DHCPEnabled: False
        IPv4StaticAddresses:
          Address: "{{ ilo.address }}"
          Gateway: "{{ ilo.gateway }}"
          SubnetMask: "{{ ilo.netmask }}"
      baseuri: "{{ ilo.baseuri }}"
      username: "{{ username }}"

```
