### PR TITLE
Previously LXD profiles were overwritten, now these are merged.

### DIFF
--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -310,10 +310,10 @@ class LXDProfileManagement(object):
 
     def _merge_dicts(self, source: dict, destination: dict) -> dict:
         """Merge Dictionary
-        
+
         Get a list of filehandle numbers from logger to be handed to
         DaemonContext.files_preserve
-        
+
         Args:
             source: source dict
             destination: destination dict

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2016, Hiroaki Nakamura <hnakamur@gmail.com>
-# Copyright: (c) 2020, Frnak Dornheim <dornheim@posteo.de>
+# Copyright: (c) 2020, Frank Dornheim <dornheim@posteo.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -316,7 +316,7 @@ class LXDProfileManagement(object):
 
         Args:
             dict(source): source dict
-            dicht(destination): destination dict
+            dict(destination): destination dict
         Kwargs:
             None
         Raises:

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -308,21 +308,21 @@ class LXDProfileManagement(object):
             self._needs_to_change_profile_config('devices')
         )
 
-    def _merge_dicts(self, source: dict, destination: dict) -> dict:
+    def _merge_dicts(self, source, destination):
         """Merge Dictionary
 
         Get a list of filehandle numbers from logger to be handed to
         DaemonContext.files_preserve
 
         Args:
-            source: source dict
-            destination: destination dict
+            dict(source): source dict
+            dicht(destination): destination dict
         Kwargs:
             None
         Raises:
             None
         Returns:
-            destination: merged dict"""
+            dict(destination): merged dict"""
         for key, value in source.items():
             if isinstance(value, dict):
                 # get node or create one


### PR DESCRIPTION
##### SUMMARY
Previously LXD profiles were overwritten, now these are merged.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Previously LXD profiles were overwritten, now these are merged.

So far, only configurations that were defined in Ansible have been adopted. Local changes were thus rejected. E.g. a configuration was only made in the config section, then the existing configurations in all other sections disappeared. especially in the default profile that was uncomfortable.
```
