### PR TITLE
xfconf: feature flag to disable facts and deprecation warning

### DIFF
--- a/changelogs/fragments/1475-xfconf-facts.yml
+++ b/changelogs/fragments/1475-xfconf-facts.yml
@@ -1,2 +1,4 @@
 minor_changes:
-  - xfconf - added feature flag to disable facts and its associated deprecation warning (https://github.com/ansible-collections/community.general/issues/1475).
+  - xfconf - added option ``disable_facts`` to disable facts and its associated deprecation warning (https://github.com/ansible-collections/community.general/issues/1475).
+deprecated_features:
+  - xfconf - returning output as facts is deprecated, should be removed by version 4.0.0

--- a/changelogs/fragments/1475-xfconf-facts.yml
+++ b/changelogs/fragments/1475-xfconf-facts.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - xfconf - added option ``disable_facts`` to disable facts and its associated deprecation warning (https://github.com/ansible-collections/community.general/issues/1475).
 deprecated_features:
-  - xfconf - returning output as facts is deprecated, should be removed by version 4.0.0
+  - xfconf - returning output as facts is deprecated, this will be removed in community.general 4.0.0. Please register the task output in a variable and use it instead. You can already switch to the new behavior now by using the new ``disable_facts`` option (https://github.com/ansible-collections/community.general/pull/1747).

--- a/changelogs/fragments/1475-xfconf-facts.yml
+++ b/changelogs/fragments/1475-xfconf-facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xfconf - added feature flag to disable facts and its associated deprecation warning (https://github.com/ansible-collections/community.general/issues/1475).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -198,7 +198,8 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         if not self.module.params['disable_facts']:
             self.facts_name = "xfconf"
             self.module.deprecate(
-                msg="Returning results as facts is deprecated. Please register the module output to a variable instead",
+                msg="Returning results as facts is deprecated. Please register the module output to a variable instead."
+                    " You can use the disable_facts option to switch to the new behavior already now and disable this warning"
                 version="4.0.0", collection_name="community.general"
             )
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -198,8 +198,10 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         if not self.module.params['disable_facts']:
             self.facts_name = "xfconf"
             self.module.deprecate(
-                msg="Returning results as facts is deprecated. Please register the module output to a variable instead."
-                    " You can use the disable_facts option to switch to the new behavior already now and disable this warning"
+                msg="Returning results as facts is deprecated. "
+                    "Please register the module output to a variable instead."
+                    " You can use the disable_facts option to switch to the "
+                    "new behavior already now and disable this warning",
                 version="4.0.0", collection_name="community.general"
             )
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -64,6 +64,7 @@ options:
     - This flag disables the output as facts and also disables the deprecation warning.
     type: bool
     default: no
+    version_added: 2.1.0
 '''
 
 EXAMPLES = """

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -59,7 +59,8 @@ options:
     version_added: 1.0.0
   disable_facts:
     description:
-    - For backward compatibility, output results are also returned as ansible facts, but this behaviour is deprecated.
+    - For backward compatibility, output results are also returned as C(ansible_facts), but this behaviour is deprecated
+      and will be removed in community.general 4.0.0.
     - This flag disables the output as facts and also disables the deprecation warning.
     type: bool
     default: no

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -164,7 +164,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
                             elements='str', choices=('int', 'uint', 'bool', 'float', 'double', 'string')),
             value=dict(required=False, type='list', elements='raw'),
             force_array=dict(default=False, type='bool', aliases=['array']),
-            disable_facts=dict(type=bool, default=False),
+            disable_facts=dict(type='bool', default=False),
         ),
         required_if=[('state', 'present', ['value', 'value_type'])],
         required_together=[('value', 'value_type')],


### PR DESCRIPTION
##### SUMMARY
Added feature flag to disable facts and its associated deprecation warning.

Fixes: #1475 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/xfconf.py

##### ADDITIONAL INFORMATION
