### PR TITLE
document what filesystem types are supported by 'resizefs' option

### DIFF
--- a/changelogs/fragments/1753-document-fstypes-supported-by-resizefs.yml
+++ b/changelogs/fragments/1753-document-fstypes-supported-by-resizefs.yml
@@ -1,5 +1,3 @@
 ---
 bugfixes:
   - filesystem - remove ``swap`` from list of FS supported by ``resizefs=yes`` (https://github.com/ansible-collections/community.general/issues/790).
-minor_changes:
-  - lvol - list filesystems supported by ``resizefs=yes``.

--- a/changelogs/fragments/1753-document-fstypes-supported-by-resizefs.yml
+++ b/changelogs/fragments/1753-document-fstypes-supported-by-resizefs.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filesystem - remove ``swap`` from list of FS supported by ``resizefs=yes`` (https://github.com/ansible-collections/community.general/issues/790).
+minor_changes:
+  - lvol - list filesystems supported by ``resizefs=yes``.

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -57,7 +57,8 @@ options:
   resizefs:
     description:
     - If C(yes), if the block device and filesystem size differ, grow the filesystem into the space.
-    - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(f2fs), C(lvm), C(xfs), C(vfat), C(swap) filesystems.
+    - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(f2fs), C(lvm), C(xfs) and C(vfat) filesystems.
+      Attempts to resize other filesystem types will fail.
     - XFS Will only grow if mounted. Currently, the module is based on commands
       from C(util-linux) package to perform operations, so resizing of XFS is
       not supported on FreeBSD systems.

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -76,6 +76,8 @@ options:
   resizefs:
     description:
     - Resize the underlying filesystem together with the logical volume.
+    - Supported for C(ext2), C(ext3), C(ext4), C(reiserfs) and C(XFS) filesystems.
+      Attempts to resize other filesystem types will fail.
     type: bool
     default: 'no'
 notes:


### PR DESCRIPTION
##### SUMMARY

Document which filesystem types are supported by the `resizefs` param of the `lvol` and `filesystem` modules.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- lvol
- filesystem

##### ADDITIONAL INFORMATION

- Fix `filesystem` documentation claiming that `resizefs` param supports swap filesystem, although this is not the case.
- List filesystem types supported by `resizefs` param in `lvol` module, that differs from `filesystem`'s list.

See also #790 