### PR TITLE
Implemented fix pointed in issue

### DIFF
--- a/changelogs/fragments/1714-gitlab_runner-required-reg-token.yml
+++ b/changelogs/fragments/1714-gitlab_runner-required-reg-token.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_runner - parameter ``registration_token`` was required but is used only when ``state`` is ``present`` (https://github.com/ansible-collections/community.general/issues/1714).

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -55,7 +55,7 @@ options:
   registration_token:
     description:
       - The registration token is used to register new runners.
-    required: True
+      - Required if I(state) is C(present).
     type: str
   owned:
     description:
@@ -309,7 +309,7 @@ def main():
         locked=dict(type='bool', default=False),
         access_level=dict(type='str', default='ref_protected', choices=["not_protected", "ref_protected"]),
         maximum_timeout=dict(type='int', default=3600),
-        registration_token=dict(type='str', required=True, no_log=True),
+        registration_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
     ))
 
@@ -324,6 +324,9 @@ def main():
         ],
         required_one_of=[
             ['api_username', 'api_token'],
+        ],
+        required_if=[
+            ('state', 'present', ['registration_token']),
         ],
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY
registration_token is no longer required

Fixes #1714 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner

##### ADDITIONAL INFORMATION
