### PR TITLE
only set param features when variable is not empty

### DIFF
--- a/changelogs/fragments/816-only-invocate-feature-when-variable-is-set.yml
+++ b/changelogs/fragments/816-only-invocate-feature-when-variable-is-set.yml
@@ -1,4 +1,2 @@
 bugfixes:
-  - proxmox lxc - only invocate feature flag, when variable is set, 
-  - proxmox lxc - an empty feature variable breaks proxmox pct list 
-  - proxmox lxc - feature invocation forces to use root@pam for module execution  
+  - proxmox lxc - only add the features flag when module parameter ``features`` is set. Before an empty string was send to proxmox in case the parameter was not used, which required to use ``root@pam`` for module execution (https://github.com/ansible-collections/community.general/pull/1763).

--- a/changelogs/fragments/816-only-invocate-feature-when-variable-is-set.yml
+++ b/changelogs/fragments/816-only-invocate-feature-when-variable-is-set.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - proxmox lxc - only invocate feature flag, when variable is set, 
+  - proxmox lxc - an empty feature variable breaks proxmox pct list 
+  - proxmox lxc - feature invocation forces to use root@pam for module execution  

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -622,7 +622,7 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
-                            features=",".join(module.params['features'] or []),
+                            features=",".join(module.params['features']) if module.params['features'] is not None else None,
                             unprivileged=int(module.params['unprivileged']),
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- only invoke param feature when variable is set
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #816 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- proxmox
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
- the param requires root@pam permissions on Proxmox PVE side
- so, it makes only sense to provide this param, when the variable is set, and the user explicitly wants to use this param
- btw.  if feature param is provided with "none", `pct` creates the container but `pct list` on Proxmox PVE side fails. 

> pct list
> vm 103 - unable to parse config: features:
> vm 104 - unable to parse config: features:
> vm 105 - unable to parse config: features:
> 
