### PR TITLE
Tidy up validate-modules ignores for remote_management/ipmi modules

### DIFF
--- a/plugins/modules/remote_management/ipmi/ipmi_boot.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_boot.py
@@ -19,18 +19,22 @@ options:
     description:
       - Hostname or ip address of the BMC.
     required: true
+    type: str
   port:
     description:
       - Remote RMCP port.
     default: 623
+    type: int
   user:
     description:
       - Username to use to connect to the BMC.
     required: true
+    type: str
   password:
     description:
       - Password to connect to the BMC.
     required: true
+    type: str
   bootdev:
     description:
       - Set boot device to use on next reboot
@@ -51,6 +55,7 @@ options:
       - optical
       - setup
       - default
+    type: str
   state:
     description:
       - Whether to ensure that boot devices is desired.
@@ -59,6 +64,7 @@ options:
             - absent -- Request system turn on"
     default: present
     choices: [ present, absent ]
+    type: str
   persistent:
     description:
       - If set, ask that system firmware uses this device beyond next boot.

--- a/plugins/modules/remote_management/ipmi/ipmi_power.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_power.py
@@ -19,18 +19,22 @@ options:
     description:
       - Hostname or ip address of the BMC.
     required: true
+    type: str
   port:
     description:
       - Remote RMCP port.
     default: 623
+    type: int
   user:
     description:
       - Username to use to connect to the BMC.
     required: true
+    type: str
   password:
     description:
       - Password to connect to the BMC.
     required: true
+    type: str
   state:
     description:
       - Whether to ensure that the machine in desired state.
@@ -42,10 +46,12 @@ options:
             - boot -- If system is off, then 'on', else 'reset'"
     choices: ['on', 'off', shutdown, reset, boot]
     required: true
+    type: str
   timeout:
     description:
       - Maximum number of seconds before interrupt request.
     default: 300
+    type: int
 requirements:
   - "python >= 2.6"
   - pyghmi

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -241,10 +241,6 @@ plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/imc/imc_rest.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/lxca/lxca_cmms.py validate-modules:doc-missing-type
 plugins/modules/remote_management/lxca/lxca_nodes.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -241,10 +241,6 @@ plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/imc/imc_rest.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/lxca/lxca_cmms.py validate-modules:doc-missing-type
 plugins/modules/remote_management/lxca/lxca_nodes.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -206,10 +206,6 @@ plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/imc/imc_rest.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_boot.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:doc-missing-type
-plugins/modules/remote_management/ipmi/ipmi_power.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/lxca/lxca_cmms.py validate-modules:doc-missing-type
 plugins/modules/remote_management/lxca/lxca_nodes.py validate-modules:doc-missing-type
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec


### PR DESCRIPTION
##### SUMMARY
Tidy up validate-modules ignores for remote_management/ipmi modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/remote_management/ipmi/ipmi_power.py
plugins/modules/remote_management/ipmi/ipmi_boot.py
