### PR TITLE
proxmox_kvm: 500 error args parameter

### DIFF
--- a/changelogs/fragments/1783-proxmox-kvm-fix-args-500-error.yaml
+++ b/changelogs/fragments/1783-proxmox-kvm-fix-args-500-error.yaml
@@ -1,3 +1,3 @@
 bugfixes:
   - proxmox_kvm - do not add ``args`` if ``proxmox_default_behavior`` is set to no_defaults  (https://github.com/ansible-collections/community.general/issues/1641).
-  - proxmox_kvm - never implicitly add ``force`` equal to False, Proxmox API requires not implemented parameters otherwise, and assumes force to be false by default anyways. 
+  - proxmox_kvm - stop implicitly adding ``force`` equal to ``false``. Proxmox API requires not implemented parameters otherwise, and assumes ``force`` to be ``false`` by default anyways (https://github.com/ansible-collections/community.general/pull/1783).

--- a/changelogs/fragments/1783-proxmox-kvm-fix-args-500-error.yaml
+++ b/changelogs/fragments/1783-proxmox-kvm-fix-args-500-error.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - proxmox_kvm - do not add ``args`` if ``proxmox_default_behavior`` is set to no_defaults  (https://github.com/ansible-collections/community.general/issues/1641).
+  - proxmox_kvm - never implicitly add ``force`` equal to False, Proxmox API requires not implemented parameters otherwise, and assumes force to be false by default anyways. 

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1143,7 +1143,6 @@ def main():
             cores=1,
             cpu='kvm64',
             cpuunits=1000,
-            force=False,
             format='qcow2',
             kvm=True,
             memory=512,

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -32,8 +32,8 @@ options:
       - Pass arbitrary arguments to kvm.
       - This option is for experts only!
       - If I(proxmox_default_behavior) is set to C(compatiblity) (the default value), this
-        option has a default of C(-serial unix:/var/run/qemu-server/<vmid>.serial,server,nowait). 
-        Note that the default value of I(proxmox_default_behavior) changes in community.general 4.0.0.      
+        option has a default of C(-serial unix:/var/run/qemu-server/<vmid>.serial,server,nowait).
+        Note that the default value of I(proxmox_default_behavior) changes in community.general 4.0.0.
     type: str
   autostart:
     description:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -31,6 +31,9 @@ options:
     description:
       - Pass arbitrary arguments to kvm.
       - This option is for experts only!
+      - If I(proxmox_default_behavior) is set to C(compatiblity) (the default value), this
+        option has a default of C(-serial unix:/var/run/qemu-server/<vmid>.serial,server,nowait). 
+        Note that the default value of I(proxmox_default_behavior) changes in community.general 4.0.0.      
     type: str
   autostart:
     description:
@@ -948,9 +951,9 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
         if searchdomains:
             kwargs['searchdomain'] = ' '.join(searchdomains)
 
-    # -args and skiplock require root@pam user
+    # -args and skiplock require root@pam user - but can not use api tokens
     if module.params['api_user'] == "root@pam" and module.params['args'] is None:
-        if not update:
+        if not update and module.params['proxmox_default_behavior'] == 'compatibility':
             kwargs['args'] = vm_args
     elif module.params['api_user'] == "root@pam" and module.params['args'] is not None:
         kwargs['args'] = module.params['args']


### PR DESCRIPTION
##### SUMMARY
vm_args should not be added as 'args' if proxmox_default_behavior is set to no_defaults.

Otherwise the API might always throw 500 - Error because only root@pam is permitted to set 'args'.
This is still tricky, as the Proxmox API does not allow API Tokens to be used when setting "root-only" parameters, even if the user of the token is 'root@pam'. 

Will fix this in a separate issue, as multiple  other parameter are affected by this.

Also we should never add 'force' parameter, even if set to false, the Proxmox API seems to expect the 'archive' parameter if 'force' is submitted. The 'archive' parameter is not implemented at all and will result in a '400 Bad Request: Parameter verification failed'.
In the Proxmox API 'force' is always assumed to be 'false | 0' anyways.

Fixes #1641 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
1. Problem when always supplying force:
```
   - name: "Create VM"
      ignore_errors: yes
      community.general.proxmox_kvm: 
        api_user: root@pam
        api_token_id: "ansible"
        api_token_secret: "38***********0-8e8b-ef63135bbe4d"
        api_host: "****"
        state: present
        validate_certs: no
        node: "******"
        vmid: 9000
      register: exec_result

"msg": "creation of qemu VM None with vmid 9000 failed with exception=400 Bad Request: Parameter verification failed. - b'{\"errors\":{\"archive\":\"missing property - \\'force\\' requires this property\"},\"data\":null}'"
```

2. providing proxmox_default_behavior will prevent 'force' from being added, but results in 500 Error because I'm using API Token for root@pam which is not equivalent to using root@pam with password....
```
   - name: "Create VM"
      ignore_errors: yes
      community.general.proxmox_kvm: 
        api_user: root@pam
        api_token_id: "ansible"
        api_token_secret: "38***********0-8e8b-ef63135bbe4d"
        api_host: "****"
        state: present
        validate_certs: no
        node: "******"
        vmid: 9000
        proxmox_default_behavior: "no_defaults"
      register: exec_result

"msg": "creation of qemu VM None with vmid 9000 failed with exception=500 Internal Server Error: only root can set 'args' config - b'{\"data\":null}'"
```

3. with my fixes, the vm will be created as expected
```
   - name: "Create VM"
      ignore_errors: yes
      community.general.proxmox_kvm: 
        api_user: root@pam
        api_token_id: "ansible"
        api_token_secret: "38***********0-8e8b-ef63135bbe4d"
        api_host: "****"
        state: present
        validate_certs: no
        node: "******"
        vmid: 9000
        proxmox_default_behavior: "no_defaults"
      register: exec_result

"msg": "VM None with vmid 9000 deployed",
```
