### PR TITLE
ease limitation for nios_host_record DNS Bypass

### DIFF
--- a/changelogs/fragments/1788-ease-nios_host_record-dns-bypass-check.yml
+++ b/changelogs/fragments/1788-ease-nios_host_record-dns-bypass-check.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - nios_host_record - allow DNS Bypass for views other than default (https://github.com/ansible-collections/community.general/issues/1786).

--- a/plugins/module_utils/net_tools/nios/api.py
+++ b/plugins/module_utils/net_tools/nios/api.py
@@ -260,13 +260,10 @@ class WapiModule(WapiBase):
                 else:
                     proposed_object[key] = self.module.params[key]
 
-        # If configure_by_dns is set to False, then delete the default dns set in the param else throw exception
+        # If configure_by_dns is set to False and view is 'default', then delete the default dns
         if not proposed_object.get('configure_for_dns') and proposed_object.get('view') == 'default'\
                 and ib_obj_type == NIOS_HOST_RECORD:
             del proposed_object['view']
-        elif not proposed_object.get('configure_for_dns') and proposed_object.get('view') != 'default'\
-                and ib_obj_type == NIOS_HOST_RECORD:
-            self.module.fail_json(msg='DNS Bypass is not allowed if DNS view is set other than \'default\'')
 
         if ib_obj_ref:
             if len(ib_obj_ref) > 1:


### PR DESCRIPTION
DNS bypass should be allowed when `configure_dns` is `false` and `view` is set other than default.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1786 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`community.general.nios_host_record`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Removal of the limiting check.

After removal results are as expected (as opposed to those in the Issue)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
changed: [xxxxx] => changed=true
  invocation:
    module_args:
      aliases: null
      comment: null
      configure_for_dns: false
      dns_view: default.my-custom-view
      extattrs: null
      ipv4:
      - add: null
        address: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        configure_for_dhcp: false
        ipv4addr: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        mac: null
        remove: null
      ipv4addrs:
      - add: null
        address: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        configure_for_dhcp: false
        ipv4addr: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        mac: null
        remove: null
      ipv6addrs: null
      name: testi_vm
      provider:
        host: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        http_pool_connections: 10
        http_pool_maxsize: 10
        http_request_timeout: 10
        max_results: 1000
        max_retries: 3
        password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        silent_ssl_warnings: true
        username: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        wapi_version: '2.10'
      state: present
      ttl: null
      view: default.my-custom-view
```
