### PR TITLE
Prevented the expansion of parameters in run_command()

### DIFF
--- a/changelogs/fragments/1776-git_config-tilde_value.yml
+++ b/changelogs/fragments/1776-git_config-tilde_value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - git_config - prevent ``run_command`` from expanding values (https://github.com/ansible-collections/community.general/issues/1776).

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -157,7 +157,6 @@ config_values:
 import os
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves import shlex_quote
 
 
 def main():
@@ -230,7 +229,7 @@ def main():
         # Run from root directory to avoid accidentally picking up any local config settings
         dir = "/"
 
-    (rc, out, err) = module.run_command(' '.join(args), cwd=dir)
+    (rc, out, err) = module.run_command(args, cwd=dir, expand_user_and_vars=False)
     if params['list_all'] and scope and rc == 128 and 'unable to read config file' in err:
         # This just means nothing has been set at the given scope
         module.exit_json(changed=False, msg='', config_values={})
@@ -259,15 +258,14 @@ def main():
             args.insert(len(args) - 1, "--" + unset)
             cmd = args
         else:
-            new_value_quoted = shlex_quote(new_value)
-            cmd = args + [new_value_quoted]
+            cmd = args + [new_value]
         try:  # try using extra parameter from ansible-base 2.10.4 onwards
-            (rc, out, err) = module.run_command(cmd, cwd=dir, ignore_invalid_cwd=False)
+            (rc, out, err) = module.run_command(cmd, cwd=dir, ignore_invalid_cwd=False, expand_user_and_vars=False)
         except TypeError:
             # @TODO remove try/except when community.general drop support for 2.10.x
             if not os.path.isdir(dir):
                 module.fail_json(msg="Cannot find directory '{0}'".format(dir))
-            (rc, out, err) = module.run_command(cmd, cwd=dir)
+            (rc, out, err) = module.run_command(cmd, cwd=dir, expand_user_and_vars=False)
         if err:
             module.fail_json(rc=rc, msg=err, cmd=cmd)
 

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -24,5 +24,7 @@
     - import_tasks: precedence_between_unset_and_value.yml
     # testing state=absent with check mode
     - import_tasks: unset_check_mode.yml
+    # testing for case in issue #1776
+    - import_tasks: set_value_with_tilde.yml
   when: git_installed is succeeded and git_version.stdout is version(git_version_supporting_includes, ">=")
 ...

--- a/tests/integration/targets/git_config/tasks/set_value_with_tilde.yml
+++ b/tests/integration/targets/git_config/tasks/set_value_with_tilde.yml
@@ -1,0 +1,33 @@
+---
+#- import_tasks: setup_no_value.yml
+
+- name: setting value
+  git_config:
+    name: core.hooksPath
+    value: '~/foo/bar'
+    state: present
+    scope: global
+  register: set_result
+
+- name: setting value again
+  git_config:
+    name: core.hooksPath
+    value: '~/foo/bar'
+    state: present
+    scope: global
+  register: set_result2
+
+- name: getting value
+  git_config:
+    name: core.hooksPath
+    scope: global
+  register: get_result
+
+- name: assert set changed and value is correct
+  assert:
+    that:
+      - set_result is changed
+      - set_result2 is not changed
+      - get_result is not changed
+      - get_result.config_value == '~/foo/bar'
+...


### PR DESCRIPTION
##### SUMMARY
Prevents `run_command()` from expanding all arguments.

Fixes #1776 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git_config
