### PR TITLE
Tidy up validate-modules:parameter-list-no-elements (batch 1)

### DIFF
--- a/changelogs/fragments/1795-list-elements-batch1.yml
+++ b/changelogs/fragments/1795-list-elements-batch1.yml
@@ -23,5 +23,5 @@ minor_changes:
   - redhat_subscription - elements of list parameters ``pool_ids``, ``addons`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
   - gitlab_runner - elements of list parameters ``tag_list`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
   - na_ontap_gather_facts - elements of list parameters ``gather_subset`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-bug_fixes:
+bugfixes:
   - redhat_subscription - ``mutually_exclusive`` was referring to parameter alias instead of name (https://github.com/ansible-collections/community.general/pull/1795).

--- a/changelogs/fragments/1795-list-elements-batch1.yml
+++ b/changelogs/fragments/1795-list-elements-batch1.yml
@@ -1,27 +1,27 @@
 minor_changes:
-  - plugins/module_utils/oracle/oci_utils.py - elements of list parameter ``key_by`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - lxd_container - elements of list parameter ``profiles`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - packet_device - elements of list parameters ``device_ids``, ``hostnames`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - pubnub_blocks - elements of list parameters ``event_handlers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - vmadm - elements of list parameters ``disks``, ``nics``, ``resolvers``, ``filesystems`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - sl_vm - elements of list parameters ``disks``, ``ssh_keys`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - xml - elements of list parameters ``add_children``, ``set_children`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - keycloak_client - elements of list parameters ``default_roles``, ``redirect_uris``, ``web_origins`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - onepassword_info - elements of list parameters ``search_terms`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - librato_annotation - elements of list parameters ``links`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - pagerduty - elements of list parameters ``service`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - statusio_maintenance - elements of list parameters ``components``, ``containers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - dnsimple - elements of list parameters ``record_ids`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - nsupdate - elements of list parameters ``value`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - omapi_host - elements of list parameters ``statements`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - mail - elements of list parameters ``to``, ``cc``, ``bcc``, ``attach``, ``headers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - nexmo - elements of list parameters ``dest`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - rocketchat - elements of list parameters ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - sendgrid - elements of list parameters ``to_addresses``, ``cc``, ``bcc``, ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - slack - elements of list parameters ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - twilio - elements of list parameters ``to_numbers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - redhat_subscription - elements of list parameters ``pool_ids``, ``addons`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - gitlab_runner - elements of list parameters ``tag_list`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
-  - na_ontap_gather_facts - elements of list parameters ``gather_subset`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - plugins/module_utils/oracle/oci_utils.py - elements of list parameter ``key_by`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - lxd_container - elements of list parameter ``profiles`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - packet_device - elements of list parameters ``device_ids``, ``hostnames`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - pubnub_blocks - elements of list parameters ``event_handlers`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - vmadm - elements of list parameters ``disks``, ``nics``, ``resolvers``, ``filesystems`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - sl_vm - elements of list parameters ``disks``, ``ssh_keys`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - xml - elements of list parameters ``add_children``, ``set_children`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - keycloak_client - elements of list parameters ``default_roles``, ``redirect_uris``, ``web_origins`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - onepassword_info - elements of list parameters ``search_terms`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - librato_annotation - elements of list parameters ``links`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - pagerduty - elements of list parameters ``service`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - statusio_maintenance - elements of list parameters ``components``, ``containers`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - dnsimple - elements of list parameters ``record_ids`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - nsupdate - elements of list parameters ``value`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - omapi_host - elements of list parameters ``statements`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - mail - elements of list parameters ``to``, ``cc``, ``bcc``, ``attach``, ``headers`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - nexmo - elements of list parameters ``dest`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - rocketchat - elements of list parameters ``attachments`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - sendgrid - elements of list parameters ``to_addresses``, ``cc``, ``bcc``, ``attachments`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - slack - elements of list parameters ``attachments`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - twilio - elements of list parameters ``to_numbers`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - redhat_subscription - elements of list parameters ``pool_ids``, ``addons`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - gitlab_runner - elements of list parameters ``tag_list`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - na_ontap_gather_facts - elements of list parameters ``gather_subset`` are now validated (https://github.com/ansible-collections/community.general/pull/1795).
 bugfixes:
   - redhat_subscription - ``mutually_exclusive`` was referring to parameter alias instead of name (https://github.com/ansible-collections/community.general/pull/1795).

--- a/changelogs/fragments/1795-list-elements-batch1.yml
+++ b/changelogs/fragments/1795-list-elements-batch1.yml
@@ -1,0 +1,27 @@
+minor_changes:
+  - plugins/module_utils/oracle/oci_utils.py - elements of list parameter ``key_by`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - lxd_container - elements of list parameter ``profiles`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - packet_device - elements of list parameters ``device_ids``, ``hostnames`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - pubnub_blocks - elements of list parameters ``event_handlers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - vmadm - elements of list parameters ``disks``, ``nics``, ``resolvers``, ``filesystems`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - sl_vm - elements of list parameters ``disks``, ``ssh_keys`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - xml - elements of list parameters ``add_children``, ``set_children`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - keycloak_client - elements of list parameters ``default_roles``, ``redirect_uris``, ``web_origins`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - onepassword_info - elements of list parameters ``search_terms`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - librato_annotation - elements of list parameters ``links`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - pagerduty - elements of list parameters ``service`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - statusio_maintenance - elements of list parameters ``components``, ``containers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - dnsimple - elements of list parameters ``record_ids`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - nsupdate - elements of list parameters ``value`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - omapi_host - elements of list parameters ``statements`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - mail - elements of list parameters ``to``, ``cc``, ``bcc``, ``attach``, ``headers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - nexmo - elements of list parameters ``dest`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - rocketchat - elements of list parameters ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - sendgrid - elements of list parameters ``to_addresses``, ``cc``, ``bcc``, ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - slack - elements of list parameters ``attachments`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - twilio - elements of list parameters ``to_numbers`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - redhat_subscription - elements of list parameters ``pool_ids``, ``addons`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - gitlab_runner - elements of list parameters ``tag_list`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+  - na_ontap_gather_facts - elements of list parameters ``gather_subset`` is now validated (https://github.com/ansible-collections/community.general/pull/1795).
+bug_fixes:
+  - redhat_subscription - ``mutually_exclusive`` was referring to parameter alias instead of name (https://github.com/ansible-collections/community.general/pull/1795).

--- a/plugins/doc_fragments/oracle_creatable_resource.py
+++ b/plugins/doc_fragments/oracle_creatable_resource.py
@@ -20,4 +20,5 @@ class ModuleDocFragment(object):
                          identify an instance of the resource. By default, all the attributes of a resource except
                          I(freeform_tags) are used to uniquely identify a resource.
             type: list
+            elements: str
     """

--- a/plugins/module_utils/oracle/oci_utils.py
+++ b/plugins/module_utils/oracle/oci_utils.py
@@ -104,7 +104,7 @@ def get_common_arg_spec(supports_create=False, supports_wait=False):
 
     if supports_create:
         common_args.update(
-            key_by=dict(type="list"),
+            key_by=dict(type="list", elements="str"),
             force_create=dict(type="bool", default=False),
         )
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -45,6 +45,7 @@ options:
         description:
           - Profile to be used by the container
         type: list
+        elements: str
     devices:
         description:
           - 'The devices for the container
@@ -658,6 +659,7 @@ def main():
             ),
             profiles=dict(
                 type='list',
+                elements='str',
             ),
             source=dict(
                 type='dict',

--- a/plugins/modules/cloud/packet/packet_device.py
+++ b/plugins/modules/cloud/packet/packet_device.py
@@ -31,20 +31,25 @@ options:
   auth_token:
     description:
       - Packet API token. You can also supply it in env var C(PACKET_API_TOKEN).
+    type: str
 
   count:
     description:
       - The number of devices to create. Count number can be included in hostname via the %d string formatter.
     default: 1
+    type: int
 
   count_offset:
     description:
       - From which number to start the count.
     default: 1
+    type: int
 
   device_ids:
     description:
       - List of device IDs on which to operate.
+    type: list
+    elements: str
 
   tags:
     description:
@@ -57,10 +62,12 @@ options:
   facility:
     description:
       - Facility slug for device creation. See Packet API for current list - U(https://www.packet.net/developers/api/facilities/).
+    type: str
 
   features:
     description:
       - Dict with "features" for device creation. See Packet API docs for details.
+    type: dict
 
   hostnames:
     description:
@@ -68,6 +75,8 @@ options:
       - If given string or one-item list, you can use the C("%d") Python string format to expand numbers from I(count).
       - If only one hostname, it might be expanded to list if I(count)>1.
     aliases: [name]
+    type: list
+    elements: str
 
   locked:
     description:
@@ -79,15 +88,18 @@ options:
   operating_system:
     description:
       - OS slug for device creation. See Packet API for current list - U(https://www.packet.net/developers/api/operatingsystems/).
+    type: str
 
   plan:
     description:
       - Plan slug for device creation. See Packet API for current list - U(https://www.packet.net/developers/api/plans/).
+    type: str
 
   project_id:
     description:
       - ID of project of the device.
     required: true
+    type: str
 
   state:
     description:
@@ -96,10 +108,12 @@ options:
       - If set to C(active), the module call will block until all the specified devices are in state active due to the Packet API, or until I(wait_timeout).
     choices: [present, absent, active, inactive, rebooted]
     default: present
+    type: str
 
   user_data:
     description:
       - Userdata blob made available to the machine
+    type: str
 
   wait_for_public_IPv:
     description:
@@ -107,16 +121,21 @@ options:
       - If set to 4, it will wait until IPv4 is assigned to the instance.
       - If set to 6, wait until public IPv6 is assigned to the instance.
     choices: [4,6]
+    type: int
 
   wait_timeout:
     description:
       - How long (seconds) to wait either for automatic IP address assignment, or for the device to reach the C(active) I(state).
       - If I(wait_for_public_IPv) is set and I(state) is C(active), the module will wait for both events consequently, applying the timeout twice.
     default: 900
+    type: int
+
   ipxe_script_url:
     description:
       - URL of custom iPXE script for provisioning.
       - More about custom iPXE for Packet devices at U(https://help.packet.net/technical/infrastructure/custom-ipxe).
+    type: str
+
   always_pxe:
     description:
       - Persist PXE as the first boot option.
@@ -601,10 +620,10 @@ def main():
                             no_log=True),
             count=dict(type='int', default=1),
             count_offset=dict(type='int', default=1),
-            device_ids=dict(type='list'),
+            device_ids=dict(type='list', elements='str'),
             facility=dict(),
             features=dict(type='dict'),
-            hostnames=dict(type='list', aliases=['name']),
+            hostnames=dict(type='list', elements='str', aliases=['name']),
             tags=dict(type='list', elements='str'),
             locked=dict(type='bool', default=False, aliases=['lock']),
             operating_system=dict(),

--- a/plugins/modules/cloud/pubnub/pubnub_blocks.py
+++ b/plugins/modules/cloud/pubnub/pubnub_blocks.py
@@ -111,6 +111,7 @@ options:
     required: false
     default: []
     type: list
+    elements: dict
   changes:
     description:
       - "List of fields which should be changed by block itself (doesn't
@@ -552,7 +553,7 @@ def main():
         state=dict(default='present', type='str',
                    choices=['started', 'stopped', 'present', 'absent']),
         name=dict(required=True, type='str'), description=dict(type='str'),
-        event_handlers=dict(default=list(), type='list'),
+        event_handlers=dict(default=list(), type='list', elements='dict'),
         changes=dict(default=dict(), type='dict'),
         cache=dict(default=dict(), type='dict'),
         validate_certs=dict(default=True, type='bool'))

--- a/plugins/modules/cloud/smartos/vmadm.py
+++ b/plugins/modules/cloud/smartos/vmadm.py
@@ -78,6 +78,7 @@ options:
     description:
       - A list of disks to add, valid properties are documented in vmadm(1M).
     type: list
+    elements: dict
   dns_domain:
     required: false
     description:
@@ -93,6 +94,7 @@ options:
     description:
       - Mount additional filesystems into an OS VM.
     type: list
+    elements: dict
   firewall_enabled:
     required: false
     description:
@@ -198,6 +200,7 @@ options:
     description:
       - A list of nics to add, valid properties are documented in vmadm(1M).
     type: list
+    elements: dict
   nowait:
     required: false
     description:
@@ -230,6 +233,7 @@ options:
     description:
       - List of resolvers to be put into C(/etc/resolv.conf).
     type: list
+    elements: dict
   routes:
     required: false
     description:
@@ -670,7 +674,6 @@ def main():
             'zfs_snapshot_limit'
         ],
         'dict': ['customer_metadata', 'internal_metadata', 'routes'],
-        'list': ['disks', 'nics', 'resolvers', 'filesystems']
     }
 
     # Start with the options that are not as trivial as those above.
@@ -697,6 +700,10 @@ def main():
         # Regular strings, however these require additional options.
         spice_password=dict(type='str', no_log=True),
         vnc_password=dict(type='str', no_log=True),
+        disks=dict(type='list', elements='dict'),
+        nics=dict(type='list', elements='dict'),
+        resolvers=dict(type='list', elements='dict'),
+        filesystems=dict(type='list', elements='dict'),
     )
 
     # Add our 'simple' options to options dict.

--- a/plugins/modules/cloud/softlayer/sl_vm.py
+++ b/plugins/modules/cloud/softlayer/sl_vm.py
@@ -115,6 +115,7 @@ options:
       - List of disk sizes to be assigned to new virtual instance.
     default: [ 25 ]
     type: list
+    elements: int
   os_code:
     description:
       - OS Code to be used for new virtual instance.
@@ -140,6 +141,7 @@ options:
     description:
       - List of ssh keys by their Id to be assigned to a virtual instance.
     type: list
+    elements: str
   post_uri:
     description:
       - URL of a post provisioning script to be loaded and executed on virtual instance.
@@ -396,13 +398,13 @@ def main():
             cpus=dict(type='int', choices=CPU_SIZES),
             memory=dict(type='int', choices=MEMORY_SIZES),
             flavor=dict(type='str'),
-            disks=dict(type='list', default=[25]),
+            disks=dict(type='list', elements='int', default=[25]),
             os_code=dict(type='str'),
             image_id=dict(type='str'),
             nic_speed=dict(type='int', choices=NIC_SPEEDS),
             public_vlan=dict(type='str'),
             private_vlan=dict(type='str'),
-            ssh_keys=dict(type='list', default=[]),
+            ssh_keys=dict(type='list', elements='str', default=[]),
             post_uri=dict(type='str'),
             state=dict(type='str', default='present', choices=STATES),
             wait=dict(type='bool', default=True),

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -66,7 +66,7 @@ options:
       or a hash where the key is an element name and the value is the element value.
     - This parameter requires C(xpath) to be set.
     type: list
-    elements: dict
+    elements: raw
   set_children:
     description:
     - Set the child-element(s) of a selected element for a given C(xpath).
@@ -74,7 +74,7 @@ options:
     - Child elements must be specified as in C(add_children).
     - This parameter requires C(xpath) to be set.
     type: list
-    elements: dict
+    elements: raw
   count:
     description:
     - Search for a given C(xpath) and provide the count of any matches.
@@ -811,8 +811,8 @@ def main():
             state=dict(type='str', default='present', choices=['absent', 'present'], aliases=['ensure']),
             value=dict(type='raw'),
             attribute=dict(type='raw'),
-            add_children=dict(type='list', elements='dict'),
-            set_children=dict(type='list', elements='dict'),
+            add_children=dict(type='list', elements='raw'),
+            set_children=dict(type='list', elements='raw'),
             count=dict(type='bool', default=False),
             print_match=dict(type='bool', default=False),
             pretty_print=dict(type='bool', default=False),

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -66,6 +66,7 @@ options:
       or a hash where the key is an element name and the value is the element value.
     - This parameter requires C(xpath) to be set.
     type: list
+    elements: dict
   set_children:
     description:
     - Set the child-element(s) of a selected element for a given C(xpath).
@@ -73,6 +74,7 @@ options:
     - Child elements must be specified as in C(add_children).
     - This parameter requires C(xpath) to be set.
     type: list
+    elements: dict
   count:
     description:
     - Search for a given C(xpath) and provide the count of any matches.
@@ -809,8 +811,8 @@ def main():
             state=dict(type='str', default='present', choices=['absent', 'present'], aliases=['ensure']),
             value=dict(type='raw'),
             attribute=dict(type='raw'),
-            add_children=dict(type='list'),
-            set_children=dict(type='list'),
+            add_children=dict(type='list', elements='dict'),
+            set_children=dict(type='list', elements='dict'),
             count=dict(type='bool', default=False),
             print_match=dict(type='bool', default=False),
             pretty_print=dict(type='bool', default=False),

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -137,6 +137,7 @@ options:
         aliases:
             - defaultRoles
         type: list
+        elements: str
 
     redirect_uris:
         description:
@@ -145,6 +146,7 @@ options:
         aliases:
             - redirectUris
         type: list
+        elements: str
 
     web_origins:
         description:
@@ -153,6 +155,7 @@ options:
         aliases:
             - webOrigins
         type: list
+        elements: str
 
     not_before:
         description:
@@ -708,9 +711,9 @@ def main():
         client_authenticator_type=dict(type='str', choices=['client-secret', 'client-jwt'], aliases=['clientAuthenticatorType']),
         secret=dict(type='str', no_log=True),
         registration_access_token=dict(type='str', aliases=['registrationAccessToken'], no_log=True),
-        default_roles=dict(type='list', aliases=['defaultRoles']),
-        redirect_uris=dict(type='list', aliases=['redirectUris']),
-        web_origins=dict(type='list', aliases=['webOrigins']),
+        default_roles=dict(type='list', elements='str', aliases=['defaultRoles']),
+        redirect_uris=dict(type='list', elements='str', aliases=['redirectUris']),
+        web_origins=dict(type='list', elements='str', aliases=['webOrigins']),
         not_before=dict(type='int', aliases=['notBefore']),
         bearer_only=dict(type='bool', aliases=['bearerOnly']),
         consent_required=dict(type='bool', aliases=['consentRequired']),

--- a/plugins/modules/identity/onepassword_info.py
+++ b/plugins/modules/identity/onepassword_info.py
@@ -34,6 +34,7 @@ description:
 options:
     search_terms:
         type: list
+        elements: dict
         description:
             - A list of one or more search terms.
             - Each search term can either be a simple string or it can be a dictionary for more control.
@@ -372,7 +373,7 @@ def main():
                 master_password=dict(required=True, type='str', no_log=True),
                 secret_key=dict(type='str', no_log=True),
             ), default=None),
-            search_terms=dict(required=True, type='list')
+            search_terms=dict(required=True, type='list', elements='dict'),
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/monitoring/librato_annotation.py
+++ b/plugins/modules/monitoring/librato_annotation.py
@@ -63,6 +63,7 @@ options:
         required: false
     links:
         type: list
+        elements: dict
         description:
             - See examples
 '''
@@ -155,7 +156,7 @@ def main():
             description=dict(required=False),
             start_time=dict(required=False, default=None, type='int'),
             end_time=dict(required=False, default=None, type='int'),
-            links=dict(type='list')
+            links=dict(type='list', elements='dict')
         )
     )
 

--- a/plugins/modules/monitoring/pagerduty.py
+++ b/plugins/modules/monitoring/pagerduty.py
@@ -47,6 +47,7 @@ options:
             - ID of user making the request. Only needed when creating a maintenance_window.
     service:
         type: list
+        elements: str
         description:
             - A comma separated list of PagerDuty service IDs.
         aliases: [ services ]
@@ -233,7 +234,7 @@ def main():
             name=dict(required=False),
             user=dict(required=False),
             token=dict(required=True, no_log=True),
-            service=dict(required=False, type='list', aliases=["services"]),
+            service=dict(required=False, type='list', elements='str', aliases=["services"]),
             window_id=dict(required=False),
             requester_id=dict(required=False),
             hours=dict(default='1', required=False),   # @TODO change to int?

--- a/plugins/modules/monitoring/statusio_maintenance.py
+++ b/plugins/modules/monitoring/statusio_maintenance.py
@@ -59,11 +59,13 @@ options:
         default: "https://api.status.io"
     components:
         type: list
+        elements: str
         description:
             - The given name of your component (server name)
         aliases: ['component']
     containers:
         type: list
+        elements: str
         description:
             - The given name of your container (data center)
         aliases: ['container']
@@ -339,9 +341,9 @@ def main():
             state=dict(required=False, default='present',
                        choices=['present', 'absent']),
             url=dict(default='https://api.status.io', required=False),
-            components=dict(type='list', required=False, default=None,
+            components=dict(type='list', elements='str', required=False, default=None,
                             aliases=['component']),
-            containers=dict(type='list', required=False, default=None,
+            containers=dict(type='list', elements='str', required=False, default=None,
                             aliases=['container']),
             all_infrastructure_affected=dict(type='bool', default=False,
                                              required=False),

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -40,6 +40,7 @@ options:
     description:
       - List of records to ensure they either exist or do not exist.
     type: list
+    elements: str
   type:
     description:
       - The type of DNS record to create.
@@ -167,7 +168,7 @@ def main():
             account_api_token=dict(type='str', no_log=True),
             domain=dict(type='str'),
             record=dict(type='str'),
-            record_ids=dict(type='list'),
+            record_ids=dict(type='list', elements='str'),
             type=dict(type='str', choices=['A', 'ALIAS', 'CNAME', 'MX', 'SPF', 'URL', 'TXT', 'NS', 'SRV', 'NAPTR', 'PTR', 'AAAA', 'SSHFP', 'HINFO',
                                            'POOL']),
             ttl=dict(type='int', default=3600),

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -28,51 +28,64 @@ options:
             - Manage DNS record.
         choices: ['present', 'absent']
         default: 'present'
+        type: str
     server:
         description:
             - Apply DNS modification on this server, specified by IPv4 or IPv6 address.
         required: true
+        type: str
     port:
         description:
             - Use this TCP port when connecting to C(server).
         default: 53
+        type: int
     key_name:
         description:
             - Use TSIG key name to authenticate against DNS C(server)
+        type: str
     key_secret:
         description:
             - Use TSIG key secret, associated with C(key_name), to authenticate against C(server)
+        type: str
     key_algorithm:
         description:
             - Specify key algorithm used by C(key_secret).
         choices: ['HMAC-MD5.SIG-ALG.REG.INT', 'hmac-md5', 'hmac-sha1', 'hmac-sha224', 'hmac-sha256', 'hmac-sha384',
                   'hmac-sha512']
         default: 'hmac-md5'
+        type: str
     zone:
         description:
             - DNS record will be modified on this C(zone).
             - When omitted DNS will be queried to attempt finding the correct zone.
             - Starting with Ansible 2.7 this parameter is optional.
+        type: str
     record:
         description:
             - Sets the DNS record to modify. When zone is omitted this has to be absolute (ending with a dot).
         required: true
+        type: str
     type:
         description:
             - Sets the record type.
         default: 'A'
+        type: str
     ttl:
         description:
             - Sets the record TTL.
         default: 3600
+        type: int
     value:
         description:
             - Sets the record value.
+        type: list
+        elements: str
     protocol:
         description:
             - Sets the transport protocol (TCP or UDP). TCP is the recommended and a more robust option.
         default: 'tcp'
         choices: ['tcp', 'udp']
+        type: str
 '''
 
 EXAMPLES = '''
@@ -432,7 +445,7 @@ def main():
             record=dict(required=True, type='str'),
             type=dict(required=False, default='A', type='str'),
             ttl=dict(required=False, default=3600, type='int'),
-            value=dict(required=False, default=None, type='list'),
+            value=dict(required=False, default=None, type='list', elements='str'),
             protocol=dict(required=False, default='tcp', choices=['tcp', 'udp'], type='str')
         ),
         supports_check_mode=True

--- a/plugins/modules/net_tools/omapi_host.py
+++ b/plugins/modules/net_tools/omapi_host.py
@@ -63,6 +63,7 @@ options:
         description:
             - Attach a list of OMAPI DHCP statements with host lease (without ending semicolon).
         type: list
+        elements: str
         default: []
     ddns:
         description:
@@ -282,7 +283,7 @@ def main():
             hostname=dict(type='str', aliases=['name']),
             ip=dict(type='str'),
             ddns=dict(type='bool', default=False),
-            statements=dict(type='list', default=[]),
+            statements=dict(type='list', elements='str', default=[]),
         ),
         supports_check_mode=False,
     )

--- a/plugins/modules/notification/mail.py
+++ b/plugins/modules/notification/mail.py
@@ -39,6 +39,7 @@ options:
     - The email-address(es) the mail is being sent to.
     - This is a list, which may contain address and phrase portions.
     type: list
+    elements: str
     default: root
     aliases: [ recipients ]
   cc:
@@ -46,11 +47,13 @@ options:
     - The email-address(es) the mail is being copied to.
     - This is a list, which may contain address and phrase portions.
     type: list
+    elements: str
   bcc:
     description:
     - The email-address(es) the mail is being 'blind' copied to.
     - This is a list, which may contain address and phrase portions.
     type: list
+    elements: str
   subject:
     description:
     - The subject of the email being sent.
@@ -85,12 +88,14 @@ options:
     - A list of pathnames of files to attach to the message.
     - Attached files will have their content-type set to C(application/octet-stream).
     type: list
+    elements: path
     default: []
   headers:
     description:
     - A list of headers which should be added to the message.
     - Each individual header is specified as C(header=value) (see example below).
     type: list
+    elements: str
     default: []
   charset:
     description:
@@ -211,13 +216,13 @@ def main():
             host=dict(type='str', default='localhost'),
             port=dict(type='int', default=25),
             sender=dict(type='str', default='root', aliases=['from']),
-            to=dict(type='list', default=['root'], aliases=['recipients']),
-            cc=dict(type='list', default=[]),
-            bcc=dict(type='list', default=[]),
+            to=dict(type='list', elements='str', default=['root'], aliases=['recipients']),
+            cc=dict(type='list', elements='str', default=[]),
+            bcc=dict(type='list', elements='str', default=[]),
             subject=dict(type='str', required=True, aliases=['msg']),
             body=dict(type='str'),
-            attach=dict(type='list', default=[]),
-            headers=dict(type='list', default=[]),
+            attach=dict(type='list', elements='path', default=[]),
+            headers=dict(type='list', elements='str', default=[]),
             charset=dict(type='str', default='utf-8'),
             subtype=dict(type='str', default='plain', choices=['html', 'plain']),
             secure=dict(type='str', default='try', choices=['always', 'never', 'starttls', 'try']),

--- a/plugins/modules/notification/nexmo.py
+++ b/plugins/modules/notification/nexmo.py
@@ -32,6 +32,7 @@ options:
     required: true
   dest:
     type: list
+    elements: int
     description:
       - Phone number(s) to send SMS message to
     required: true
@@ -119,7 +120,7 @@ def main():
             api_key=dict(required=True, no_log=True),
             api_secret=dict(required=True, no_log=True),
             src=dict(required=True, type='int'),
-            dest=dict(required=True, type='list'),
+            dest=dict(required=True, type='list', elements='int'),
             msg=dict(required=True),
         ),
     )

--- a/plugins/modules/notification/office_365_connector_card.py
+++ b/plugins/modules/notification/office_365_connector_card.py
@@ -45,11 +45,13 @@ options:
       - and above any sections or actions present.
   actions:
     type: list
+    elements: dict
     description:
       - This array of objects will power the action links
       - found at the bottom of the card.
   sections:
     type: list
+    elements: dict
     description:
       - Contains a list of sections to display in the card.
       - For more information see https://dev.outlook.com/Connectors/reference.
@@ -264,8 +266,8 @@ def main():
             color=dict(type='str'),
             title=dict(type='str'),
             text=dict(type='str'),
-            actions=dict(type='list'),
-            sections=dict(type='list')
+            actions=dict(type='list', elements='dict'),
+            sections=dict(type='list', elements='dict')
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/notification/rocketchat.py
+++ b/plugins/modules/notification/rocketchat.py
@@ -89,6 +89,7 @@ options:
       - 'danger'
   attachments:
     type: list
+    elements: dict
     description:
       - Define a list of attachments.
 '''
@@ -215,7 +216,7 @@ def main():
             link_names=dict(type='int', default=1, choices=[0, 1]),
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal', choices=['normal', 'good', 'warning', 'danger']),
-            attachments=dict(type='list', required=False)
+            attachments=dict(type='list', elements='dict', required=False)
         )
     )
 

--- a/plugins/modules/notification/sendgrid.py
+++ b/plugins/modules/notification/sendgrid.py
@@ -44,6 +44,7 @@ options:
     required: true
   to_addresses:
     type: list
+    elements: str
     description:
       - A list with one or more recipient email addresses.
     required: true
@@ -58,14 +59,17 @@ options:
       - Sendgrid API key to use instead of username/password.
   cc:
     type: list
+    elements: str
     description:
       - A list of email addresses to cc.
   bcc:
     type: list
+    elements: str
     description:
       - A list of email addresses to bcc.
   attachments:
     type: list
+    elements: path
     description:
       - A list of relative or explicit paths of files you want to attach (7MB limit as per SendGrid docs).
   from_name:
@@ -209,16 +213,16 @@ def main():
             username=dict(required=False),
             password=dict(required=False, no_log=True),
             api_key=dict(required=False, no_log=True),
-            bcc=dict(required=False, type='list'),
-            cc=dict(required=False, type='list'),
+            bcc=dict(required=False, type='list', elements='str'),
+            cc=dict(required=False, type='list', elements='str'),
             headers=dict(required=False, type='dict'),
             from_address=dict(required=True),
             from_name=dict(required=False),
-            to_addresses=dict(required=True, type='list'),
+            to_addresses=dict(required=True, type='list', elements='str'),
             subject=dict(required=True),
             body=dict(required=True),
             html_body=dict(required=False, default=False, type='bool'),
-            attachments=dict(required=False, type='list')
+            attachments=dict(required=False, type='list', elements='path')
         ),
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -116,6 +116,7 @@ options:
     default: 'normal'
   attachments:
     type: list
+    elements: dict
     description:
       - Define a list of attachments. This list mirrors the Slack JSON API.
       - For more information, see U(https://api.slack.com/docs/attachments).
@@ -420,7 +421,7 @@ def main():
             parse=dict(type='str', default=None, choices=['none', 'full']),
             validate_certs=dict(default=True, type='bool'),
             color=dict(type='str', default='normal'),
-            attachments=dict(type='list', required=False, default=None),
+            attachments=dict(type='list', elements='dict', required=False, default=None),
             blocks=dict(type='list', elements='dict'),
             message_id=dict(type='str', default=None),
         ),

--- a/plugins/modules/notification/twilio.py
+++ b/plugins/modules/notification/twilio.py
@@ -37,6 +37,7 @@ options:
     required: true
   to_numbers:
     type: list
+    elements: str
     description:
       one or more phone numbers to send the text message to,
       format +15551112222
@@ -143,7 +144,7 @@ def main():
             auth_token=dict(required=True, no_log=True),
             msg=dict(required=True),
             from_number=dict(required=True),
-            to_numbers=dict(required=True, aliases=['to_number'], type='list'),
+            to_numbers=dict(required=True, aliases=['to_number'], type='list', elements='str'),
             media_url=dict(default=None, required=False),
         ),
         supports_check_mode=True

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -105,6 +105,7 @@ options:
               entitlements from a pool (the pool must support this). Mutually exclusive with I(pool).
         default: []
         type: list
+        elements: raw
     consumer_type:
         description:
             - The type of unit to register, defaults to system
@@ -153,6 +154,7 @@ options:
             addons:
                 description: Syspurpose attribute addons
                 type: list
+                elements: str
             sync:
                 description:
                     - When this option is true, then syspurpose attributes are synchronized with
@@ -787,7 +789,7 @@ def main():
             'org_id': {},
             'environment': {},
             'pool': {'default': '^$'},
-            'pool_ids': {'default': [], 'type': 'list'},
+            'pool_ids': {'default': [], 'type': 'list', 'elements': 'raw'},
             'consumer_type': {},
             'consumer_name': {},
             'consumer_id': {},
@@ -803,7 +805,7 @@ def main():
                     'role': {},
                     'usage': {},
                     'service_level_agreement': {},
-                    'addons': {'type': 'list'},
+                    'addons': {'type': 'list', 'elements': 'str'},
                     'sync': {'type': 'bool', 'default': False}
                 }
             }
@@ -814,7 +816,7 @@ def main():
         mutually_exclusive=[['activationkey', 'username'],
                             ['activationkey', 'consumer_id'],
                             ['activationkey', 'environment'],
-                            ['activationkey', 'autosubscribe'],
+                            ['activationkey', 'auto_attach'],
                             ['pool', 'pool_ids']],
         required_if=[['state', 'present', ['username', 'activationkey'], True]],
     )

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -99,6 +99,7 @@ options:
     required: False
     default: []
     type: list
+    elements: str
 '''
 
 EXAMPLES = '''
@@ -304,7 +305,7 @@ def main():
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
         owned=dict(type='bool', default=False),
-        tag_list=dict(type='list', default=[]),
+        tag_list=dict(type='list', elements='str', default=[]),
         run_untagged=dict(type='bool', default=True),
         locked=dict(type='bool', default=False),
         access_level=dict(type='str', default='ref_protected', choices=["not_protected", "ref_protected"]),

--- a/plugins/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/plugins/modules/storage/netapp/na_ontap_gather_facts.py
@@ -26,25 +26,28 @@ options:
     state:
         description:
             - Returns "info"
-        default: "info"
-        choices: ['info']
+        default: info
+        choices: [info]
+        type: str
     gather_subset:
         description:
             - When supplied, this argument will restrict the facts collected
                 to a given subset.  Possible values for this argument include
-                "aggregate_info", "cluster_node_info", "igroup_info", "lun_info", "net_dns_info",
-                "net_ifgrp_info",
-                "net_interface_info", "net_port_info", "nvme_info", "nvme_interface_info",
-                "nvme_namespace_info", "nvme_subsystem_info", "ontap_version",
-                "qos_adaptive_policy_info", "qos_policy_info", "security_key_manager_key_info",
-                "security_login_account_info", "storage_failover_info", "volume_info",
-                "vserver_info", "vserver_login_banner_info", "vserver_motd_info", "vserver_nfs_info"
+                C(aggregate_info), C(cluster_node_info), C(igroup_info), C(lun_info), C(net_dns_info),
+                C(net_ifgrp_info),
+                C(net_interface_info), C(net_port_info), C(nvme_info), C(nvme_interface_info),
+                C(nvme_namespace_info), C(nvme_subsystem_info), C(ontap_version),
+                C(qos_adaptive_policy_info), C(qos_policy_info), C(security_key_manager_key_info),
+                C(security_login_account_info), C(storage_failover_info), C(volume_info),
+                C(vserver_info), C(vserver_login_banner_info), C(vserver_motd_info), C(vserver_nfs_info)
                 Can specify a list of values to include a larger subset.  Values can also be used
                 with an initial C(M(!)) to specify that a specific subset should
                 not be collected.
             - nvme is supported with ONTAP 9.4 onwards.
-            - use "help" to get a list of supported facts for your system.
-        default: "all"
+            - use C(help) to get a list of supported facts for your system.
+        default: all
+        type: list
+        elements: str
 '''
 
 EXAMPLES = '''
@@ -582,7 +585,7 @@ def main():
     argument_spec = netapp_utils.na_ontap_host_argument_spec()
     argument_spec.update(dict(
         state=dict(default='info', choices=['info']),
-        gather_subset=dict(default=['all'], type='list'),
+        gather_subset=dict(default=['all'], type='list', elements='str'),
     ))
 
     module = AnsibleModule(

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -23,7 +23,6 @@ plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/oneandone/oneandone_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/oneandone/oneandone_load_balancer.py validate-modules:parameter-list-no-elements
@@ -37,7 +36,6 @@ plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-
 plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/oracle/oci_vcn.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_api_facts.py validate-modules:parameter-list-no-elements
@@ -88,9 +86,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-list-no
 plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_device.py validate-modules:doc-missing-type
-plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:doc-missing-type
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
@@ -99,7 +94,6 @@ plugins/modules/cloud/profitbricks/profitbricks.py validate-modules:parameter-li
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:doc-missing-type
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:undocumented-parameter
-plugins/modules/cloud/pubnub/pubnub_blocks.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
 plugins/modules/cloud/rackspace/rax.py validate-modules:parameter-list-no-elements
@@ -127,10 +121,8 @@ plugins/modules/cloud/scaleway/scaleway_snapshot_info.py validate-modules:return
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/smartos_image_info.py validate-modules:doc-missing-type
-plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
-plugins/modules/cloud/softlayer/sl_vm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -183,9 +175,6 @@ plugins/modules/database/vertica/vertica_schema.py validate-modules:undocumented
 plugins/modules/database/vertica/vertica_user.py validate-modules:doc-missing-type
 plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-parameter
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
 plugins/modules/monitoring/bigpanda.py validate-modules:invalid-argument-name
@@ -193,35 +182,21 @@ plugins/modules/monitoring/datadog/datadog_event.py validate-modules:parameter-l
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:invalid-argument-name
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/icinga2_host.py validate-modules:undocumented-parameter
-plugins/modules/monitoring/librato_annotation.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/logstash_plugin.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/monitoring/pagerduty.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_check.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_client.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_handler.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/statusio_maintenance.py pylint:blacklisted-name
-plugins/modules/monitoring/statusio_maintenance.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/dnsimple.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc  # This triggers when a parameter is undocumented
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/nsupdate.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
-plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
-plugins/modules/notification/rocketchat.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/sendgrid.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/slack.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/twilio.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/bundler.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/language/maven_artifact.py validate-modules:parameter-type-not-in-doc
@@ -232,8 +207,6 @@ plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/opkg.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/pacman.py validate-modules:parameter-invalid
-plugins/modules/packaging/os/redhat_subscription.py validate-modules:mutually_exclusive-unknown
-plugins/modules/packaging/os/redhat_subscription.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
 plugins/modules/packaging/os/slackpkg.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/urpmi.py validate-modules:parameter-invalid
@@ -307,7 +280,6 @@ plugins/modules/source_control/github/github_release.py validate-modules:doc-mis
 plugins/modules/source_control/github/github_release.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook_info.py validate-modules:parameter-type-not-in-doc
-plugins/modules/source_control/gitlab/gitlab_runner.py validate-modules:parameter-list-no-elements
 plugins/modules/source_control/hg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:doc-missing-type
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:parameter-type-not-in-doc
@@ -321,10 +293,7 @@ plugins/modules/storage/ibm/ibm_sa_host_ports.py validate-modules:doc-missing-ty
 plugins/modules/storage/ibm/ibm_sa_pool.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol_map.py validate-modules:doc-missing-type
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:doc-missing-type
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-state-invalid-choice
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:doc-required-mismatch
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,6 +1,5 @@
 plugins/callback/hipchat.py pylint:blacklisted-name
 plugins/connection/lxc.py pylint:blacklisted-name
-plugins/module_utils/cloud.py pylint:bad-option-value  # a pylint test that is disabled was modified over time
 plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,5 +1,6 @@
 plugins/callback/hipchat.py pylint:blacklisted-name
 plugins/connection/lxc.py pylint:blacklisted-name
+plugins/module_utils/cloud.py pylint:bad-option-value  # a pylint test that is disabled was modified over time
 plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
@@ -22,7 +23,6 @@ plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_container.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/cloud/lxd/lxd_container.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/oneandone/oneandone_firewall_policy.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/oneandone/oneandone_load_balancer.py validate-modules:parameter-list-no-elements
@@ -36,7 +36,6 @@ plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-
 plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/oracle/oci_vcn.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_api_facts.py validate-modules:parameter-list-no-elements
@@ -87,9 +86,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-list-no
 plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_device.py validate-modules:doc-missing-type
-plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:doc-missing-type
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
@@ -98,7 +94,6 @@ plugins/modules/cloud/profitbricks/profitbricks.py validate-modules:parameter-li
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:doc-missing-type
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/profitbricks/profitbricks_volume.py validate-modules:undocumented-parameter
-plugins/modules/cloud/pubnub/pubnub_blocks.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
 plugins/modules/cloud/rackspace/rax.py validate-modules:parameter-list-no-elements
@@ -126,10 +121,8 @@ plugins/modules/cloud/scaleway/scaleway_snapshot_info.py validate-modules:return
 plugins/modules/cloud/scaleway/scaleway_volume_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_volume_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/smartos_image_info.py validate-modules:doc-missing-type
-plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
-plugins/modules/cloud/softlayer/sl_vm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
@@ -182,9 +175,6 @@ plugins/modules/database/vertica/vertica_schema.py validate-modules:undocumented
 plugins/modules/database/vertica/vertica_user.py validate-modules:doc-missing-type
 plugins/modules/database/vertica/vertica_user.py validate-modules:undocumented-parameter
 plugins/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/files/xml.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-list-no-elements
-plugins/modules/identity/onepassword_info.py validate-modules:parameter-list-no-elements
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 plugins/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
 plugins/modules/monitoring/bigpanda.py validate-modules:invalid-argument-name
@@ -192,35 +182,21 @@ plugins/modules/monitoring/datadog/datadog_event.py validate-modules:parameter-l
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:invalid-argument-name
 plugins/modules/monitoring/datadog/datadog_monitor.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/icinga2_host.py validate-modules:undocumented-parameter
-plugins/modules/monitoring/librato_annotation.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/logstash_plugin.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/monitoring/pagerduty.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_check.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_client.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/sensu/sensu_handler.py validate-modules:parameter-list-no-elements
 plugins/modules/monitoring/statusio_maintenance.py pylint:blacklisted-name
-plugins/modules/monitoring/statusio_maintenance.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/dnsimple.py validate-modules:parameter-list-no-elements
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc  # This triggers when a parameter is undocumented
 plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/nsupdate.py validate-modules:parameter-list-no-elements
-plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/omapi_host.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
-plugins/modules/notification/mail.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/nexmo.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/office_365_connector_card.py validate-modules:parameter-list-no-elements
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
-plugins/modules/notification/rocketchat.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/sendgrid.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/slack.py validate-modules:parameter-list-no-elements
-plugins/modules/notification/twilio.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/bundler.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/language/maven_artifact.py validate-modules:parameter-type-not-in-doc
@@ -231,8 +207,6 @@ plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/opkg.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/pacman.py validate-modules:parameter-invalid
-plugins/modules/packaging/os/redhat_subscription.py validate-modules:mutually_exclusive-unknown
-plugins/modules/packaging/os/redhat_subscription.py validate-modules:parameter-list-no-elements
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
 plugins/modules/packaging/os/slackpkg.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/urpmi.py validate-modules:parameter-invalid
@@ -306,7 +280,6 @@ plugins/modules/source_control/github/github_release.py validate-modules:doc-mis
 plugins/modules/source_control/github/github_release.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook.py validate-modules:parameter-type-not-in-doc
 plugins/modules/source_control/github/github_webhook_info.py validate-modules:parameter-type-not-in-doc
-plugins/modules/source_control/gitlab/gitlab_runner.py validate-modules:parameter-list-no-elements
 plugins/modules/source_control/hg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:doc-missing-type
 plugins/modules/storage/emc/emc_vnx_sg_member.py validate-modules:parameter-type-not-in-doc
@@ -320,10 +293,7 @@ plugins/modules/storage/ibm/ibm_sa_host_ports.py validate-modules:doc-missing-ty
 plugins/modules/storage/ibm/ibm_sa_pool.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol_map.py validate-modules:doc-missing-type
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:doc-missing-type
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-state-invalid-choice
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:doc-required-mismatch
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -96,8 +96,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-no
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:deprecation-mismatch
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:invalid-documentation
-plugins/modules/cloud/packet/packet_device.py validate-modules:doc-missing-type
-plugins/modules/cloud/packet/packet_device.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:doc-missing-type
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/packet/packet_sshkey.py validate-modules:undocumented-parameter
@@ -189,7 +187,6 @@ plugins/modules/net_tools/ldap/ldap_attr.py validate-modules:undocumented-parame
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
-plugins/modules/net_tools/nsupdate.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/notification/pushbullet.py validate-modules:undocumented-parameter
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
@@ -280,9 +277,7 @@ plugins/modules/storage/ibm/ibm_sa_pool.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol.py validate-modules:doc-missing-type
 plugins/modules/storage/ibm/ibm_sa_vol_map.py validate-modules:doc-missing-type
 plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:deprecation-mismatch
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:doc-missing-type
 plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:invalid-documentation
-plugins/modules/storage/netapp/na_ontap_gather_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:deprecation-mismatch
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:invalid-documentation
 plugins/modules/storage/purestorage/purefa_facts.py validate-modules:return-syntax-error


### PR DESCRIPTION
##### SUMMARY
Fixed missing `elements` in both docs and `argument_spec` for a bunch of modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/doc_fragments/oracle_creatable_resource.py
plugins/module_utils/oracle/oci_utils.py
plugins/modules/cloud/lxd/lxd_container.py
plugins/modules/cloud/packet/packet_device.py
plugins/modules/cloud/pubnub/pubnub_blocks.py
plugins/modules/cloud/smartos/vmadm.py
plugins/modules/cloud/softlayer/sl_vm.py
plugins/modules/files/xml.py
plugins/modules/identity/keycloak/keycloak_client.py
plugins/modules/identity/onepassword_info.py
plugins/modules/monitoring/librato_annotation.py
plugins/modules/monitoring/pagerduty.py
plugins/modules/net_tools/dnsimple.py
plugins/modules/net_tools/nsupdate.py
plugins/modules/net_tools/omapi_host.py
plugins/modules/notification/mail.py
plugins/modules/notification/nexmo.py
plugins/modules/notification/office_365_connector_card.py
plugins/modules/notification/rocketchat.py
plugins/modules/notification/sendgrid.py
plugins/modules/notification/slack.py
plugins/modules/notification/twilio.py
plugins/modules/packaging/os/redhat_subscription.py
plugins/modules/source_control/gitlab/gitlab_runner.py
plugins/modules/storage/netapp/na_ontap_gather_facts.py
