### PR TITLE
Adjusted django_manage integration test files to reduce ignore lines in sanity tests

### DIFF
--- a/tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py
+++ b/tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py
@@ -1,12 +1,18 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 # single_app_project/manage.py
 import os
 import sys
+
 
 def main():
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'single_app_project.core.settings')
     from django.core.management import execute_from_command_line
     execute_from_command_line(sys.argv)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py
+++ b/tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 """Django's command-line utility for administrative tasks."""
 import os
 import sys

--- a/tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py
+++ b/tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 """
 Django settings for p1 project.
 

--- a/tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py
+++ b/tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 """p1 URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -365,18 +365,7 @@ plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py metaclass-boilerplate      # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py future-import-boilerplate  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E302  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E305  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py shebang    # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.7   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py future-import-boilerplate   # django generated code
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -364,18 +364,7 @@ plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py metaclass-boilerplate      # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py future-import-boilerplate  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E302  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E305  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py shebang    # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.7   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py future-import-boilerplate   # django generated code
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -320,18 +320,7 @@ plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:deprecation-mismatch
 plugins/modules/web_infrastructure/nginx_status_facts.py validate-modules:invalid-documentation
 plugins/modules/web_infrastructure/rundeck_acl_policy.py pylint:blacklisted-name
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py metaclass-boilerplate      # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py future-import-boilerplate  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E302  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py pep8:E305  # django generated code
-tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py shebang    # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.7   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py future-import-boilerplate   # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py metaclass-boilerplate       # django generated code
-tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py future-import-boilerplate   # django generated code
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
Adjusted the tests files to ansible standards.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/django_manage/files/base_test/1045-single-app-project/single_app_project/manage.py
tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py
tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/settings.py
tests/integration/targets/django_manage/files/base_test/simple_project/p1/p1/urls.py
