### PR TITLE
[stable-1] Tidy up validate-modules ignores for cloud/centurylink modules

### DIFF
--- a/changelogs/fragments/1771-centurylink-validation-elements.yml
+++ b/changelogs/fragments/1771-centurylink-validation-elements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - clc_* modules - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1771).

--- a/plugins/modules/cloud/centurylink/clc_alert_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_alert_policy.py
@@ -32,6 +32,7 @@ options:
       - A list of recipient email ids to notify the alert.
         This is required for state 'present'
     type: list
+    elements: str
   metric:
     description:
       - The metric on which to measure the condition that will trigger the alert.
@@ -220,7 +221,7 @@ class ClcAlertPolicy:
             name=dict(),
             id=dict(),
             alias=dict(required=True),
-            alert_recipients=dict(type='list'),
+            alert_recipients=dict(type='list', elements='str'),
             metric=dict(
                 choices=[
                     'cpu',

--- a/plugins/modules/cloud/centurylink/clc_blueprint_package.py
+++ b/plugins/modules/cloud/centurylink/clc_blueprint_package.py
@@ -18,6 +18,7 @@ options:
       - A list of server Ids to deploy the blue print package.
     type: list
     required: True
+    elements: str
   package_id:
     description:
       - The package id of the blue print.
@@ -164,7 +165,7 @@ class ClcBlueprintPackage:
         :return: the package dictionary object
         """
         argument_spec = dict(
-            server_ids=dict(type='list', required=True),
+            server_ids=dict(type='list', elements='str', required=True),
             package_id=dict(required=True),
             package_params=dict(type='dict', default={}),
             wait=dict(default=True),   # @FIXME should be bool?

--- a/plugins/modules/cloud/centurylink/clc_firewall_policy.py
+++ b/plugins/modules/cloud/centurylink/clc_firewall_policy.py
@@ -29,17 +29,20 @@ options:
       - The list  of source addresses for traffic on the originating firewall.
         This is required when state is 'present'
     type: list
+    elements: str
   destination:
     description:
       - The list of destination addresses for traffic on the terminating firewall.
         This is required when state is 'present'
     type: list
+    elements: str
   ports:
     description:
       - The list of ports associated with the policy.
         TCP and UDP can take in single ports or port ranges.
       - "Example: C(['any', 'icmp', 'TCP/123', 'UDP/123', 'TCP/123-456', 'UDP/123-456'])."
     type: list
+    elements: str
   firewall_policy_id:
     description:
       - Id of the firewall policy. This is required to update or delete an existing firewall policy
@@ -217,9 +220,9 @@ class ClcFirewallPolicy:
             source_account_alias=dict(required=True),
             destination_account_alias=dict(),
             firewall_policy_id=dict(),
-            ports=dict(type='list'),
-            source=dict(type='list'),
-            destination=dict(type='list'),
+            ports=dict(type='list', elements='str'),
+            source=dict(type='list', elements='str'),
+            destination=dict(type='list', elements='str'),
             wait=dict(default=True),   # @FIXME type=bool
             state=dict(default='present', choices=['present', 'absent']),
             enabled=dict(default=True, choices=[True, False])

--- a/plugins/modules/cloud/centurylink/clc_loadbalancer.py
+++ b/plugins/modules/cloud/centurylink/clc_loadbalancer.py
@@ -53,6 +53,7 @@ options:
       - A list of nodes that needs to be added to the load balancer pool
     type: list
     default: []
+    elements: dict
   status:
     description:
       - The status of the loadbalancer
@@ -869,7 +870,7 @@ class ClcLoadBalancer:
             port=dict(choices=[80, 443]),
             method=dict(choices=['leastConnection', 'roundRobin']),
             persistence=dict(choices=['standard', 'sticky']),
-            nodes=dict(type='list', default=[]),
+            nodes=dict(type='list', default=[], elements='dict'),
             status=dict(default='enabled', choices=['enabled', 'disabled']),
             state=dict(
                 default='present',

--- a/plugins/modules/cloud/centurylink/clc_modify_server.py
+++ b/plugins/modules/cloud/centurylink/clc_modify_server.py
@@ -18,6 +18,7 @@ options:
       - A list of server Ids to modify.
     type: list
     required: True
+    elements: str
   cpu:
     description:
       - How many CPUs to update on the server
@@ -396,7 +397,7 @@ class ClcModifyServer:
         :return: argument spec dictionary
         """
         argument_spec = dict(
-            server_ids=dict(type='list', required=True),
+            server_ids=dict(type='list', required=True, elements='str'),
             state=dict(default='present', choices=['present', 'absent']),
             cpu=dict(),
             memory=dict(),

--- a/plugins/modules/cloud/centurylink/clc_publicip.py
+++ b/plugins/modules/cloud/centurylink/clc_publicip.py
@@ -23,11 +23,13 @@ options:
     description:
       - A list of ports to expose. This is required when state is 'present'
     type: list
+    elements: int
   server_ids:
     description:
       - A list of servers to create public ips on.
     type: list
     required: True
+    elements: str
   state:
     description:
       - Determine whether to create or delete public IPs. If present module will not create a second public ip if one
@@ -193,9 +195,9 @@ class ClcPublicIp(object):
         :return: argument spec dictionary
         """
         argument_spec = dict(
-            server_ids=dict(type='list', required=True),
+            server_ids=dict(type='list', required=True, elements='str'),
             protocol=dict(default='TCP', choices=['TCP', 'UDP', 'ICMP']),
-            ports=dict(type='list'),
+            ports=dict(type='list', elements='int'),
             wait=dict(type='bool', default=True),
             state=dict(default='present', choices=['present', 'absent']),
         )

--- a/plugins/modules/cloud/centurylink/clc_server.py
+++ b/plugins/modules/cloud/centurylink/clc_server.py
@@ -17,6 +17,7 @@ options:
     description:
       - The list of additional disks for the server
     type: list
+    elements: dict
     default: []
   add_public_ip:
     description:
@@ -66,6 +67,7 @@ options:
       - The list of custom fields to set on the server.
     type: list
     default: []
+    elements: dict
   description:
     description:
       - The description to set for the server.
@@ -111,6 +113,7 @@ options:
     description:
       - The list of blue print packages to run on the server after its created.
     type: list
+    elements: dict
     default: []
   password:
     description:
@@ -130,6 +133,7 @@ options:
     description:
       - A list of ports to allow on the firewall to the servers public ip, if add_public_ip is set to True.
     type: list
+    elements: dict
     default: []
   secondary_dns:
     description:
@@ -141,6 +145,7 @@ options:
         A list of server Ids to insure are started, stopped, or absent.
     type: list
     default: []
+    elements: str
   source_server_password:
     description:
       - The password for the source server if a clone is specified.
@@ -575,8 +580,8 @@ class ClcServer:
             type=dict(default='standard', choices=['standard', 'hyperscale', 'bareMetal']),
             primary_dns=dict(default=None),
             secondary_dns=dict(default=None),
-            additional_disks=dict(type='list', default=[]),
-            custom_fields=dict(type='list', default=[]),
+            additional_disks=dict(type='list', default=[], elements='dict'),
+            custom_fields=dict(type='list', default=[], elements='dict'),
             ttl=dict(default=None),
             managed_os=dict(type='bool', default=False),
             description=dict(default=None),
@@ -586,7 +591,7 @@ class ClcServer:
             anti_affinity_policy_name=dict(default=None),
             alert_policy_id=dict(default=None),
             alert_policy_name=dict(default=None),
-            packages=dict(type='list', default=[]),
+            packages=dict(type='list', default=[], elements='dict'),
             state=dict(
                 default='present',
                 choices=[
@@ -597,7 +602,7 @@ class ClcServer:
             count=dict(type='int', default=1),
             exact_count=dict(type='int', default=None),
             count_group=dict(),
-            server_ids=dict(type='list', default=[]),
+            server_ids=dict(type='list', default=[], elements='str'),
             add_public_ip=dict(type='bool', default=False),
             public_ip_protocol=dict(
                 default='TCP',
@@ -605,7 +610,7 @@ class ClcServer:
                     'TCP',
                     'UDP',
                     'ICMP']),
-            public_ip_ports=dict(type='list', default=[]),
+            public_ip_ports=dict(type='list', default=[], elements='dict'),
             configuration_id=dict(default=None),
             os_type=dict(default=None,
                          choices=[

--- a/plugins/modules/cloud/centurylink/clc_server_snapshot.py
+++ b/plugins/modules/cloud/centurylink/clc_server_snapshot.py
@@ -18,6 +18,7 @@ options:
       - The list of CLC server Ids.
     type: list
     required: True
+    elements: str
   expiration_days:
     description:
       - The number of days to keep the server snapshot before it expires.
@@ -330,7 +331,7 @@ class ClcSnapshot:
         :return: the package dictionary object
         """
         argument_spec = dict(
-            server_ids=dict(type='list', required=True),
+            server_ids=dict(type='list', required=True, elements='str'),
             expiration_days=dict(default=7, type='int'),
             wait=dict(default=True),
             state=dict(

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -5,14 +5,6 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_blueprint_package.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_loadbalancer.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_modify_server.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_publicip.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_server.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_server_snapshot.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/docker/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path
 plugins/modules/cloud/google/gcdns_record.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/google/gce.py pylint:blacklisted-name

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,14 +4,6 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/centurylink/clc_alert_policy.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_blueprint_package.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_firewall_policy.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_loadbalancer.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_modify_server.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_publicip.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_server.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/centurylink/clc_server_snapshot.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/docker/docker_container.py use-argspec-type-path # uses colon-separated paths, can't use type=path
 plugins/modules/cloud/google/gcdns_record.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/google/gce.py validate-modules:parameter-list-no-elements


### PR DESCRIPTION
##### SUMMARY
Backport of #1771 to stable-1.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/centurylink/clc_server.py
plugins/modules/cloud/centurylink/clc_server_snapshot.py
plugins/modules/cloud/centurylink/clc_publicip.py
plugins/modules/cloud/centurylink/clc_modify_server.py
plugins/modules/cloud/centurylink/clc_loadbalancer.py
plugins/modules/cloud/centurylink/clc_firewall_policy.py
plugins/modules/cloud/centurylink/clc_blueprint_package.py
plugins/modules/cloud/centurylink/clc_alert_policy.py
