### PR TITLE
Previously LXD profiles were overwritten, now these are merged.

### DIFF
--- a/changelogs/fragments/1813-lxd_profile-merge-profiles.yml
+++ b/changelogs/fragments/1813-lxd_profile-merge-profiles.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- lxd_profile - added ``merge_profile`` parameter to merge configurations from the play to an existing profile (https://github.com/ansible-collections/community.general/pull/1748). 

--- a/changelogs/fragments/1813-lxd_profile-merge-profiles.yml
+++ b/changelogs/fragments/1813-lxd_profile-merge-profiles.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- lxd_profile - added ``merge_profile`` parameter to merge configurations from the play to an existing profile (https://github.com/ansible-collections/community.general/pull/1748). 
+- lxd_profile - added ``merge_profile`` parameter to merge configurations from the play to an existing profile (https://github.com/ansible-collections/community.general/pull/1813). 

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2016, Hiroaki Nakamura <hnakamur@gmail.com>
+# Copyright: (c) 2020, Frank Dornheim <dornheim@posteo.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
 
 DOCUMENTATION = '''
 ---
@@ -52,6 +52,14 @@ options:
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-11)
         required: false
         type: str
+    merge_profile:
+        description:
+            - Merge the configuration of the present profile with the new desired configuration,
+              instead of replacing it.
+        required: false
+        default: false
+        type: bool
+        version_added: 2.1.0
     state:
         choices:
           - present
@@ -79,14 +87,14 @@ options:
           - If not specified, it defaults to C($HOME/.config/lxc/client.key).
         required: false
         aliases: [ key_file ]
-        type: path
+        type: str
     client_cert:
         description:
           - The client certificate file path.
           - If not specified, it defaults to C($HOME/.config/lxc/client.crt).
         required: false
         aliases: [ cert_file ]
-        type: path
+        type: str
     trust_password:
         description:
           - The client trusted password.
@@ -142,6 +150,23 @@ EXAMPLES = '''
           parent: br0
           type: nic
 
+# An example for modify/merge a profile
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Merge a profile
+      community.general.lxd_profile:
+        merge_profile: true
+        name: macvlan
+        state: present
+        config: {}
+        description: my macvlan profile
+        devices:
+          eth0:
+            nictype: macvlan
+            parent: br0
+            type: nic
+
 # An example for deleting a profile
 - hosts: localhost
   connection: local
@@ -179,9 +204,7 @@ actions:
   type: list
   sample: '["create"]'
 '''
-
 import os
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.lxd import LXDClient, LXDClientException
 
@@ -266,7 +289,7 @@ class LXDProfileManagement(object):
                     self._create_profile()
                 else:
                     self.module.fail_json(
-                        msg='new_name must not be set when the profile does not exist and the specified state is present',
+                        msg='new_name must not be set when the profile does not exist and the state is present',
                         changed=False)
             else:
                 if self.new_name is not None and self.new_name != self.name:
@@ -307,10 +330,96 @@ class LXDProfileManagement(object):
             self._needs_to_change_profile_config('devices')
         )
 
-    def _apply_profile_configs(self):
-        config = self.old_profile_json.copy()
+    def _merge_dicts(self, source, destination):
+        """Merge Dictionarys
+
+        Get a list of filehandle numbers from logger to be handed to
+        DaemonContext.files_preserve
+
+        Args:
+            dict(source): source dict
+            dict(destination): destination dict
+        Kwargs:
+            None
+        Raises:
+            None
+        Returns:
+            dict(destination): merged dict"""
+        for key, value in source.items():
+            if isinstance(value, dict):
+                # get node or create one
+                node = destination.setdefault(key, {})
+                self._merge_dicts(value, node)
+            else:
+                destination[key] = value
+        return destination
+
+    def _merge_config(self, config):
+        """ merge profile
+
+        Merge Configuration of the present profile and the new desired configitems
+
+        Args:
+            dict(config): Dict with the old config in 'metadata' and new config in 'config'
+        Kwargs:
+            None
+        Raises:
+            None
+        Returns:
+            dict(config): new config"""
+        # merge or copy the sections from the existing profile to 'config'
+        for item in ['config', 'description', 'devices', 'name', 'used_by']:
+            if item in config:
+                config[item] = self._merge_dicts(config['metadata'][item], config[item])
+            else:
+                config[item] = config['metadata'][item]
+        # merge or copy the sections from the ansible-task to 'config'
+        return self._merge_dicts(self.config, config)
+
+    def _generate_new_config(self, config):
+        """ rebuild profile
+
+        Rebuild the Profile by the configuration provided in the play.
+        Existing configurations are discarded.
+
+        This ist the default behavior.
+
+        Args:
+            dict(config): Dict with the old config in 'metadata' and new config in 'config'
+        Kwargs:
+            None
+        Raises:
+            None
+        Returns:
+            dict(config): new config"""
         for k, v in self.config.items():
             config[k] = v
+        return config
+
+    def _apply_profile_configs(self):
+        """ Selection of the procedure: rebuild or merge
+
+        The standard behavior is that all information not contained
+        in the play is discarded.
+
+        If "merge_profile" is provides in the play and "True", then existing
+        configurations from the profile and new ones defined are merged.
+
+        Args:
+            None
+        Kwargs:
+            None
+        Raises:
+            None
+        Returns:
+            None"""
+        config = self.old_profile_json.copy()
+        if self.module.params['merge_profile']:
+            config = self._merge_config(config)
+        else:
+            config = self._generate_new_config(config)
+
+        # upload config to lxd
         self.client.do('PUT', '/1.0/profiles/{0}'.format(self.name), config)
         self.actions.append('apply_profile_configs')
 
@@ -371,6 +480,10 @@ def main():
             devices=dict(
                 type='dict',
             ),
+            merge_profile=dict(
+                type='bool',
+                default=False
+            ),
             state=dict(
                 choices=PROFILES_STATES,
                 default='present'
@@ -384,11 +497,11 @@ def main():
                 default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
             client_key=dict(
-                type='path',
+                type='str',
                 aliases=['key_file']
             ),
             client_cert=dict(
-                type='path',
+                type='str',
                 aliases=['cert_file']
             ),
             trust_password=dict(type='str', no_log=True)

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -87,14 +87,14 @@ options:
           - If not specified, it defaults to C($HOME/.config/lxc/client.key).
         required: false
         aliases: [ key_file ]
-        type: str
+        type: path
     client_cert:
         description:
           - The client certificate file path.
           - If not specified, it defaults to C($HOME/.config/lxc/client.crt).
         required: false
         aliases: [ cert_file ]
-        type: str
+        type: path
     trust_password:
         description:
           - The client trusted password.
@@ -204,6 +204,7 @@ actions:
   type: list
   sample: '["create"]'
 '''
+
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.lxd import LXDClient, LXDClientException
@@ -497,11 +498,11 @@ def main():
                 default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
             client_key=dict(
-                type='str',
+                type='path',
                 aliases=['key_file']
             ),
             client_cert=dict(
-                type='str',
+                type='path',
                 aliases=['cert_file']
             ),
             trust_password=dict(type='str', no_log=True)


### PR DESCRIPTION
##### SUMMARY
Previously LXD profiles were overwritten, now a parameter is added to merge these are merge together.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lxd_profile: Profile Management

##### ADDITIONAL INFORMATION
Previously LXD profiles were overwritten, now, activated by "merge_profile" these are merged.

So far, only configurations that were defined in Ansible have been adopted. Local changes were thus rejected. E.g. a configuration was only made in the config section, then the existing configurations in all other sections disappeared. especially in the default profile that was uncomfortable.