### PR TITLE
dnsimple: Add support for CAA records

### DIFF
--- a/changelogs/fragments/1814-dnsimple-add-support-for-caa-records.yml
+++ b/changelogs/fragments/1814-dnsimple-add-support-for-caa-records.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnsimple - add CAA records to the whitelist of valid record types (https://github.com/ansible-collections/community.general/pull/1814).

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -43,7 +43,7 @@ options:
   type:
     description:
       - The type of DNS record to create.
-    choices: [ 'A', 'ALIAS', 'CNAME', 'MX', 'SPF', 'URL', 'TXT', 'NS', 'SRV', 'NAPTR', 'PTR', 'AAAA', 'SSHFP', 'HINFO', 'POOL' ]
+    choices: [ 'A', 'ALIAS', 'CNAME', 'MX', 'SPF', 'URL', 'TXT', 'NS', 'SRV', 'NAPTR', 'PTR', 'AAAA', 'SSHFP', 'HINFO', 'POOL', 'CAA' ]
     type: str
   ttl:
     description:
@@ -169,7 +169,7 @@ def main():
             record=dict(type='str'),
             record_ids=dict(type='list'),
             type=dict(type='str', choices=['A', 'ALIAS', 'CNAME', 'MX', 'SPF', 'URL', 'TXT', 'NS', 'SRV', 'NAPTR', 'PTR', 'AAAA', 'SSHFP', 'HINFO',
-                                           'POOL']),
+                                           'POOL', 'CAA']),
             ttl=dict(type='int', default=3600),
             value=dict(type='str'),
             priority=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
I've been using the dnsimple functionality, and found out the whitelist of valid record types doesn't include `CAA` records.

My personal feeling is probably that it shouldn't whitelist them at all, and instead capture errors from the upstream API, so these PR's aren't necessary - but I want this merged so I can use it ;)

So: this adds `CAA` to the valid record types.

I couldn't find tests specific to this module, unless I'm mistaken.

First PR to the Ansible project; do advise if anything else is required. Hopefully this is small enough to just merge.

**Edit:** Oh, and I've checked this against https://support.dnsimple.com/articles/supported-dns-records/ - this is the only record type missing to make it "complete".

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dnsimple

##### ADDITIONAL INFORMATION
N/A