### PR TITLE
zfs: avoid errors with creation-only properties

### DIFF
--- a/changelogs/fragments/1833-zfs-creation-only-properties.yaml
+++ b/changelogs/fragments/1833-zfs-creation-only-properties.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zfs - some zfs properties could be passed when the dataset/volume did not exist, but would fail if the dataset already existed, even if the property matched what was specified in the ansible task

--- a/changelogs/fragments/1833-zfs-creation-only-properties.yaml
+++ b/changelogs/fragments/1833-zfs-creation-only-properties.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zfs - some zfs properties could be passed when the dataset/volume did not exist, but would fail if the dataset already existed, even if the property matched what was specified in the ansible task
+  - zfs - some ZFS properties could be passed when the dataset/volume did not exist, but would fail if the dataset already existed, even if the property matched what was specified in the ansible task (https://github.com/ansible-collections/community.general/issues/868, https://github.com/ansible-collections/community.general/pull/1833).

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -203,7 +203,10 @@ class Zfs(object):
         rc, out, err = self.module.run_command(" ".join(cmd))
         properties = dict()
         for prop, value, source in [l.split('\t')[1:4] for l in out.splitlines()]:
-            if source == 'local':
+            # include source '-' so that creation-only properties are not removed
+            # to avoids errors when the dataset already exists and the property is not changed
+            # this scenario is most likely when the same playbook is run more than once
+            if source == 'local' or source == '-':
                 properties[prop] = value
         # Add alias for enhanced sharing properties
         if self.enhanced_sharing:


### PR DESCRIPTION
##### SUMMARY
Fixes #868 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zfs

##### ADDITIONAL INFORMATION
As discussed in the linked issue, there are a few zfs properties that can only be set at creation time. Assuming I haven't missed any, those properties are:
- volblocksize
- encryption
- casesensitivity
- normalization
- utf8only

Additionally, there are two properties that can only be set at creation time or with the `zfs change-key` command:
- keyformat
- pbkdf2iters

For the purpose of this merge request, I don't try to special-case `keyformat` or `pbkdf2iters`, since I would expect that most of the time, users attempting to change these values would be doing so mistakenly. I mention them here in case someone wants to add that feature in.

The problem is that because `zfs list` gives these properties a source of '-' (indicating read-only), they are filtered out. However, by adding read-only properties to the result of `get_current_properties`, the problem can be avoided, since the module only calls `zfs set` if the requested setting differs from the current setting. This means that if the user doesn't try to change the setting, they will get no error, and if they do try to change it, they will get the same error that zfs would provide.

This is also future-proof in case future creation-only properties are added. The other option, which would not be future-proof but some might consider more explicit, would be to make this change instead (inlining the set definition just for exposition here):
``` diff
-            if source == 'local' or source == '-':
+            if source == 'local' or prop in { "volblocksize", "encryption", "casesensitivity", "normalization", "utf8only", "keyformat", "pbkd2fiters" }:
```

Running the command `sudo ansible-playbook add_zvol.yaml` twice with the below playbook fails before this change and  works afterwards:
``` yaml
---
- hosts: localhost
  tasks:
    - community.general.zfs:
        name: rpool/tmpzvol
        state: present
        extra_zfs_properties:
          volsize: 1G
          volblocksize: 1K
```