### PR TITLE
proxmox_kvm: fix undefined local variable status

### DIFF
--- a/changelogs/fragments/1847-proxmox-kvm-fix-status.yml
+++ b/changelogs/fragments/1847-proxmox-kvm-fix-status.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - Fix undefined local variable `status` when the parameter `state` is either `stopped`, `started`, `restarted` or `absent` (https://github.com/ansible-collections/community.general/pull/1847).

--- a/changelogs/fragments/1847-proxmox-kvm-fix-status.yml
+++ b/changelogs/fragments/1847-proxmox-kvm-fix-status.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_kvm - Fix undefined local variable `status` when the parameter `state` is either `stopped`, `started`, `restarted` or `absent` (https://github.com/ansible-collections/community.general/pull/1847).
+  - proxmox_kvm - fix undefined local variable ``status`` when the parameter ``state`` is either ``stopped``, ``started``, ``restarted`` or ``absent`` (https://github.com/ansible-collections/community.general/pull/1847).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1380,6 +1380,8 @@ def main():
         vm = get_vm(proxmox, vmid)
         if not vm:
             module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+        if not name:
+            name = vm[0]['name']
         current = proxmox.nodes(vm[0]['node']).qemu(vmid).status.current.get()['status']
         status['status'] = current
         if status:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1297,12 +1297,14 @@ def main():
                 module.fail_json(vmid=vmid, msg="creation of qemu VM %s with vmid %s failed with exception=%s" % (name, vmid, e))
 
     elif state == 'started':
+        status = {}
         try:
             if -1 == vmid:
                 module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
             vm = get_vm(proxmox, vmid)
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid <%s> does not exist in cluster' % vmid)
+            status['status'] = vm[0]['status']
             if vm[0]['status'] == 'running':
                 module.exit_json(changed=False, vmid=vmid, msg="VM %s is already running" % vmid, **status)
 
@@ -1312,6 +1314,7 @@ def main():
             module.fail_json(vmid=vmid, msg="starting of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'stopped':
+        status = {}
         try:
             if -1 == vmid:
                 module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
@@ -1320,6 +1323,7 @@ def main():
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid = %s does not exist in cluster' % vmid)
 
+            status['status'] = vm[0]['status']
             if vm[0]['status'] == 'stopped':
                 module.exit_json(changed=False, vmid=vmid, msg="VM %s is already stopped" % vmid, **status)
 
@@ -1329,6 +1333,7 @@ def main():
             module.fail_json(vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'restarted':
+        status = {}
         try:
             if -1 == vmid:
                 module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
@@ -1336,6 +1341,7 @@ def main():
             vm = get_vm(proxmox, vmid)
             if not vm:
                 module.fail_json(vmid=vmid, msg='VM with vmid = %s does not exist in cluster' % vmid)
+            status['status'] = vm[0]['status']
             if vm[0]['status'] == 'stopped':
                 module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid, **status)
 
@@ -1345,12 +1351,14 @@ def main():
             module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e), **status)
 
     elif state == 'absent':
+        status = {}
         try:
             vm = get_vm(proxmox, vmid)
             if not vm:
                 module.exit_json(changed=False, vmid=vmid)
 
             proxmox_node = proxmox.nodes(vm[0]['node'])
+            status['status'] = vm[0]['status']
             if vm[0]['status'] == 'running':
                 if module.params['force']:
                     stop_vm(module, proxmox, vm, True)

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -734,20 +734,20 @@ EXAMPLES = '''
 
 RETURN = '''
 vmid:
-    description: The VM vmid.
-    returned: success
-    type: int
-    sample: 115
+  description: The VM vmid.
+  returned: success
+  type: int
+  sample: 115
 status:
-    description:
-      - The current virtual machine status.
-    returned: success
-    type: dict
-    sample: '{
-      "changed": false,
-      "msg": "VM kropta with vmid = 110 is running",
-      "status": "running"
-    }'
+  description: The current virtual machine status.
+  returned: success, not clone, not absent, not update
+  type: str
+  sample: running
+msg:
+  description: A short message
+  returned: always
+  type: str
+  sample: "VM kropta with vmid = 110 is running"
 '''
 
 import re


### PR DESCRIPTION
##### SUMMARY

PR #1715 introduced a bug in calls to the `proxmox_kvm` module where the parameter `state` is either `stopped`, `started`, `restarted` or `absent` because the local variable `status` passed to `fail_json` was not defined in these branches.

Sorry, I could not run the code earlier :(

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_kvm