### PR TITLE
proxmox_kvm: add integration tests

### DIFF
--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -109,3 +109,170 @@
     - results_userid.proxmox_users[0].domain == "{{ domain }}"
     - results_userid.proxmox_users[0].user == "{{ user }}"
     - results_userid.proxmox_users[0].userid == "{{ user }}@{{ domain }}"
+
+- name: VM creation
+  tags: [ 'create' ]
+  block:
+    - name: Create test vm test-instance
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        storage: "{{ storage }}"
+        vmid: "{{ from_vmid }}"
+        name: test-instance
+        clone: 'yes'
+        state: present
+        timeout: 500
+      register: results_kvm
+
+    - set_fact:
+        vmid: "{{ results_kvm.msg.split(' ')[-7] }}"
+
+    - assert:
+        that:
+        - results_kvm is changed
+        - results_kvm.vmid == from_vmid
+        - results_kvm.msg == "VM test-instance with newid {{ vmid }} cloned from vm with vmid {{ from_vmid }}"
+
+    - pause:
+        seconds: 30
+
+- name: VM start
+  tags: [ 'start' ]
+  block:
+    - name: Start test VM
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: started
+      register: results_action_start
+
+    - assert:
+        that:
+        - results_action_start is changed
+        - results_action_start.status == 'stopped'
+        - results_action_start.vmid == {{ vmid }}
+        - results_action_start.msg == "VM {{ vmid }} started"
+
+    - pause:
+        seconds: 90
+
+    - name: Try to start test VM again
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: started
+      register: results_action_start_again
+
+    - assert:
+        that:
+        - results_action_start_again is not changed
+        - results_action_start_again.status == 'running'
+        - results_action_start_again.vmid == {{ vmid }}
+        - results_action_start_again.msg == "VM {{ vmid }} is already running"
+
+    - name: Check current status
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: current
+      register: results_action_current
+
+    - assert:
+        that:
+        - results_action_current is not changed
+        - results_action_current.status == 'running'
+        - results_action_current.vmid == {{ vmid }}
+        - results_action_current.msg == "VM test-instance with vmid = {{ vmid }} is running"
+
+- name: VM stop
+  tags: [ 'stop' ]
+  block:
+    - name: Stop test VM
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: stopped
+      register: results_action_stop
+
+    - assert:
+        that:
+        - results_action_stop is changed
+        - results_action_stop.status == 'running'
+        - results_action_stop.vmid == {{ vmid }}
+        - results_action_stop.msg == "VM {{ vmid }} is shutting down"
+
+    - pause:
+        seconds: 5
+
+    - name: Check current status again
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: current
+      register: results_action_current
+
+    - assert:
+        that:
+        - results_action_current is not changed
+        - results_action_current.status == 'stopped'
+        - results_action_current.vmid == {{ vmid }}
+        - results_action_current.msg == "VM test-instance with vmid = {{  vmid }} is stopped"
+
+- name: VM destroy
+  tags: [ 'destroy' ]
+  block:
+    - name: Destroy test VM
+      proxmox_kvm:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        proxmox_default_behavior: "no_defaults"
+        node: "{{ node }}"
+        vmid: "{{ vmid }}"
+        state: absent
+      register: results_kvm_destroy
+
+    - assert:
+        that:
+        - results_kvm_destroy is changed
+        - results_kvm_destroy.vmid == {{ vmid }}
+        - results_kvm_destroy.msg == "VM {{ vmid }} removed"


### PR DESCRIPTION
##### SUMMARY

Minimal integration tests for the module `proxmox_kvm`: create, start, stop then destroy.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

proxmox_kvm

##### ADDITIONAL INFORMATION

~~Need PR #1847 and~~ will unlock PR #1422.