### PR TITLE
deploy_helper: fix a bug when not defining release on state=clean

### DIFF
--- a/plugins/modules/web_infrastructure/deploy_helper.py
+++ b/plugins/modules/web_infrastructure/deploy_helper.py
@@ -228,7 +228,7 @@ EXAMPLES = '''
     release: '{{ deploy_helper.new_release }}'
     state: finalize
 
-# Postponing the cleanup of older builds:
+# Postponing the cleanup of older builds (explicitly setting the release will exclude it from cleanup):
 - community.general.deploy_helper:
     path: /path/to/root
     release: '{{ deploy_helper.new_release }}'
@@ -236,8 +236,9 @@ EXAMPLES = '''
     clean: False
 - community.general.deploy_helper:
     path: /path/to/root
+    release: '{{ deploy_helper.new_release }}'
     state: clean
-# Or running the cleanup ahead of the new deploy
+# Or running the cleanup ahead of the new deploy (not setting release because there is no release yet):
 - community.general.deploy_helper:
     path: /path/to/root
     state: clean
@@ -305,6 +306,9 @@ class DeployHelper(object):
 
         if not self.release and (self.state == 'query' or self.state == 'present'):
             self.release = time.strftime("%Y%m%d%H%M%S")
+
+        if not self.release and (self.state == 'clean'):
+            self.release = "clean_can_be_run_without_setting_a_release_so_this_is_a_default_value_unlikely_to_exists"
 
         if self.release:
             new_release_path = os.path.join(releases_path, self.release)


### PR DESCRIPTION
##### SUMMARY

Fixes #1852 

Set a default value for `release` if the `state=clean`
Clarify the documentation in case of using `state=clean` before or after deployment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/deploy_helper.py

##### ADDITIONAL INFORMATION

The deploy_helper module is useful when doing software deploys in versioned releases. It prepares the folder structure, and also cleans up failed deploys and/or older releases. 

In the case of calling `state=clean`, only the cleanup procedure is called. This procedure is built to _never_ cleanup the release that has just been deployed, but that is optional behaviour since you can use a strategy to cleanup before deploying instead of after.

When there is no relesse specified in `state=clean` the assumption is that cleanup is being called before deployment - and therefore no "current release" can be defined. A default value of `clean_can_be_run_without_setting_a_release_so_this_is_a_default_value_unlikely_to_exists` is set. If a release folder with that name does happen to exist, the side-effect is that this folder is never cleaned up.