### PR TITLE
deploy_helper: fix a bug when not defining release on state=clean

### DIFF
--- a/changelogs/fragments/1852-deploy-helper-fix-state-is-clean-without-release.yaml
+++ b/changelogs/fragments/1852-deploy-helper-fix-state-is-clean-without-release.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - deploy_helper - allow ``state=clean`` to be used without defining a ``release`` (https://github.com/ansible-collections/community.general/issues/1852).

--- a/plugins/modules/web_infrastructure/deploy_helper.py
+++ b/plugins/modules/web_infrastructure/deploy_helper.py
@@ -408,6 +408,9 @@ class DeployHelper(object):
     def remove_unfinished_link(self, path):
         changed = False
 
+        if not self.release:
+            return changed
+
         tmp_link_name = os.path.join(path, self.release + '.' + self.unfinished_filename)
         if not self.module.check_mode and os.path.exists(tmp_link_name):
             changed = True


### PR DESCRIPTION
##### SUMMARY

Fixes #1852 

Do not try to `remove_unfinished_link` if no release was specifed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/deploy_helper.py

##### ADDITIONAL INFORMATION

The deploy_helper module is useful when doing software deploys in versioned releases. It prepares the folder structure, and also cleans up failed deploys and/or older releases. 

In the case of calling `state=clean`, only the cleanup procedure is called. Specifying a release is optional in that case.

In my opinion, this bug stems from the fact that we are accessing `self.release` in the function `remove_unfinished_link` without passing that value as a parameter. So `self.release` is a hidden dependency of this method.

The current solution is to return early from within the `remove_unfinished_link` method - but a better solution would be to not depend on optional global state inside the module functions at all. `self.unfinished_filename` is also referenced a lot from within different methods (but since that has a default value in all cases, it does not cause problems currently).

I did not want to make this change larger than needed.