### PR TITLE
Improved ModuleHelper.run_command()

### DIFF
--- a/changelogs/fragments/1867-modhelper-cmdmixin-dict-params.yml
+++ b/changelogs/fragments/1867-modhelper-cmdmixin-dict-params.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_helper - ``CmdMixin.run_command()`` now accepts ``dict`` command arguments, providing the parameter and its value (https://github.com/ansible-collections/community.general/pull/1867).
+  - module_helper module utils - ``CmdMixin.run_command()`` now accepts ``dict`` command arguments, providing the parameter and its value (https://github.com/ansible-collections/community.general/pull/1867).

--- a/changelogs/fragments/1867-modhelper-cmdmixin-dict-params.yml
+++ b/changelogs/fragments/1867-modhelper-cmdmixin-dict-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper - ``CmdMixin.run_command()`` now accepts ``dict`` command arguments, providing the parameter and its value (https://github.com/ansible-collections/community.general/pull/1867).

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -312,7 +312,7 @@ class CmdMixin(object):
                     value = extra_params[param]
                 else:
                     self.module.deprecate("Cannot determine value for parameter: {0}. "
-                                          "From version 4.0.0 onwards this will generate an exception.".format(param),
+                                          "From version 4.0.0 onwards this will generate an exception".format(param),
                                           version="4.0.0", collection_name="community.general")
                     continue
 

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -297,7 +297,7 @@ class CmdMixin(object):
 
         for param in param_list:
             if isinstance(param, dict):
-                if len(param.keys()) != 1:
+                if len(param) != 1:
                     raise ModuleHelperException("run_command parameter as a dict must "
                                                 "contain only one key: {0}".format(param))
                 _param = list(param.keys())[0]

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -311,7 +311,10 @@ class CmdMixin(object):
                     fmt = find_format(param)
                     value = extra_params[param]
                 else:
-                    raise ModuleHelperException("Cannot determine value for parameter: {0}".format(param))
+                    self.module.deprecate("Cannot determine value for parameter: {0}. "
+                                          "From version 4.0.0 onwards this will generate an exception.".format(param),
+                                          version="4.0.0", collection_name="community.general")
+                    continue
 
             else:
                 raise ModuleHelperException("run_command parameter must be either a str or a dict: {0}".format(param))

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -238,7 +238,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
     def state_absent(self):
         self.vars.value = None
-        self.run_command(params=('channel', 'property', 'reset'), extra_params={"reset": True})
+        self.run_command(params=('channel', 'property', {'reset': True}))
         self.update_xfconf_output(previous_value=self.vars.previous_value,
                                   value=None)
 
@@ -267,17 +267,13 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
             isinstance(self.vars.previous_value, list) or \
             values_len > 1
 
-        params = ['channel', 'property', 'create']
+        params = ['channel', 'property', {'create': True}]
         if self.vars.is_array:
-            params.append('is_array')
-        params.append('values_and_types')
-
-        extra_params = dict(values_and_types=(self.vars.value, value_type))
-        extra_params['create'] = True
-        extra_params['is_array'] = self.vars.is_array
+            params.append({'is_array': True})
+        params.append({'values_and_types': (self.vars.value, value_type)})
 
         if not self.module.check_mode:
-            self.run_command(params=params, extra_params=extra_params)
+            self.run_command(params=params)
 
         if not self.vars.is_array:
             self.vars.value = self.vars.value[0]


### PR DESCRIPTION
##### SUMMARY
Improved run_command signature and behaviour
- extra_params has been removed from the signature
- params now can be either str or dict (containing the param value)

The purpose is to simplify passing custom values to parameters (either parameters declared in the module's `argument_spec` or custom ones)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/module_helper.py
plugins/modules/system/xfconf.py
