### PR TITLE
Improve infoblox inventory script dependencies

### DIFF
--- a/changelogs/fragments/1871-infoblox-inventory.yml
+++ b/changelogs/fragments/1871-infoblox-inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "infoblox inventory script - make sure that the script also works with Ansible 2.9, and returns a more helpful error when community.general is not installed as part of Ansible 2.10/3 (https://github.com/ansible-collections/community.general/pull/1871)."

--- a/scripts/inventory/infoblox.py
+++ b/scripts/inventory/infoblox.py
@@ -13,10 +13,22 @@ import json
 import argparse
 
 from ansible.parsing.dataloader import DataLoader
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.six import iteritems, raise_from
 from ansible.module_utils._text import to_text
-from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import WapiInventory
-from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import normalize_extattrs, flatten_extattrs
+try:
+    from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import WapiInventory
+    from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import normalize_extattrs, flatten_extattrs
+except ImportError as exc:
+    try:
+        # Fallback for Ansible 2.9
+        from ansible.module_utils.net_tools.nios.api import WapiInventory
+        from ansible.module_utils.net_tools.nios.api import normalize_extattrs, flatten_extattrs
+    except ImportError:
+        raise_from(
+            Exception(
+                'This inventory plugin only works with Ansible 2.9, 2.10, or 3, or when community.general is installed correctly in PYTHONPATH.'
+                ' Try using the inventory plugin from infoblox.nios_modules instead.'),
+            exc)
 
 
 CONFIG_FILES = [


### PR DESCRIPTION
##### SUMMARY
The infoblox inventory script does not work out of the box: it imports from `ansible_collections.community.general.plugins.module_utils.net_tools.nios.api`, which is only importable in a regular Python script when community.general is installed as part of Ansible 2.10/3, or has somehow otherwise been installed in PYTHONPATH.

This PR also makes the script work when Ansible 2.9 is installed, and provides a more helpful error in case neither 2.9, 2.10 or 3 are installed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
infoblox inventory script
