### PR TITLE
Update gitlab_project_members copyright and author list

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Sergey Mikhaltsov <metanovii@gmail.com>
+# Copyright: (c) 2020, Zainab Alsaffar <Zainab.Alsaffar@mail.rit.edu>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -14,7 +15,9 @@ short_description: Manage project members on GitLab Server
 version_added: 2.2.0
 description:
     - This module allows to add and remove members to/from a project, or change a member's access level in a project on GitLab.
-author: Sergey Mikhaltsov (@metanovii)
+author:
+    - Sergey Mikhaltsov (@metanovii)
+    - Zainab Alsaffar (@zanssa)
 requirements:
     - python-gitlab python module <= 1.15.0
     - owner or maintainer rights to project on the GitLab server


### PR DESCRIPTION
##### SUMMARY
I didn't notice during review that the new gitlab_project_members module (added in #1829) is a slightly adjusted copy of the gitlab_group_members module. Because of that, it needs to keep the copyright notice and `author:` line of the gitlab_group_members module. This updates the module accordingly.

@metanovii please note that you have to include the original copyright and author the next time you adjust an existing module.

@zanssa since you are the author of gitlab_project_members, I copied your copyright header over and added you to the `author:` list. Please approve this PR if this is ok for you! If you don't want to be listed as an author of the new module, I can revert the `author:` change.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
gitlab_project_members
