### PR TITLE
[Fix] fix cobbler_system ssl cert checkwhen validate_certs set to no

### DIFF
--- a/changelogs/fragments/1880-fix_cobbler_system_ssl.yml
+++ b/changelogs/fragments/1880-fix_cobbler_system_ssl.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cobbler_sync, cobbler_system - fix SSL/TLS certificate check when ``validate_certs`` set to ``false`` (https://github.com/ansible-collections/community.general/pull/1880).

--- a/plugins/modules/remote_management/cobbler/cobbler_sync.py
+++ b/plugins/modules/remote_management/cobbler/cobbler_sync.py
@@ -106,12 +106,14 @@ def main():
 
     ssl_context = None
     if not validate_certs:
-        try:  # Python 2.7.9 and newer
-            ssl_context = ssl.create_unverified_context()
-        except AttributeError:  # Legacy Python that doesn't verify HTTPS certificates by default
-            ssl._create_default_context = ssl._create_unverified_context
-        else:  # Python 2.7.8 and older
-            ssl._create_default_https_context = ssl._create_unverified_https_context
+        try:
+            ssl_context = ssl._create_unverified_context()
+        except AttributeError:
+            # Legacy Python that doesn't verify HTTPS certificates by default
+            pass
+        else:
+            # Handle target environment that doesn't support HTTPS verification
+            ssl._create_default_https_context = ssl._create_unverified_context
 
     url = '{proto}://{host}:{port}/cobbler_api'.format(**module.params)
     if ssl_context:

--- a/plugins/modules/remote_management/cobbler/cobbler_system.py
+++ b/plugins/modules/remote_management/cobbler/cobbler_system.py
@@ -229,12 +229,14 @@ def main():
 
     ssl_context = None
     if not validate_certs:
-        try:  # Python 2.7.9 and newer
-            ssl_context = ssl.create_unverified_context()
-        except AttributeError:  # Legacy Python that doesn't verify HTTPS certificates by default
-            ssl._create_default_context = ssl._create_unverified_context
-        else:  # Python 2.7.8 and older
-            ssl._create_default_https_context = ssl._create_unverified_https_context
+        try:
+            ssl_context = ssl._create_unverified_context()
+        except AttributeError:
+            # Legacy Python that doesn't verify HTTPS certificates by default
+            pass
+        else:
+            # Handle target environment that doesn't support HTTPS verification
+            ssl._create_default_https_context = ssl._create_unverified_context
 
     url = '{proto}://{host}:{port}/cobbler_api'.format(**module.params)
     if ssl_context:


### PR DESCRIPTION
##### SUMMARY
Fixes  #1878.
cobbler_system now check self signed certificates correctly. Followed implementation [pep-0476](https://www.python.org/dev/peps/pep-0476/).



##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
cobbler_system
