### PR TITLE
Fix: nmcli - Ensure slave-type for bond-slave

### DIFF
--- a/changelogs/fragments/1882-fix-nmcli-ensure-slave-type-for-bond-slave.yml
+++ b/changelogs/fragments/1882-fix-nmcli-ensure-slave-type-for-bond-slave.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - Ensure slave-type for bond-slave (https://github.com/ansible-collections/community.general/pull/1882).

--- a/changelogs/fragments/1882-fix-nmcli-ensure-slave-type-for-bond-slave.yml
+++ b/changelogs/fragments/1882-fix-nmcli-ensure-slave-type-for-bond-slave.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - Ensure slave-type for bond-slave (https://github.com/ansible-collections/community.general/pull/1882).
+  - nmcli - ensure the ``slave-type`` option is passed to ``nmcli`` for type ``bond-slave`` (https://github.com/ansible-collections/community.general/pull/1882).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -719,6 +719,10 @@ class Nmcli(object):
                 'primary': self.primary,
                 'updelay': self.updelay,
             })
+        elif self.type == 'bond-slave':
+            options.update({
+                'connection.slave-type': 'bond',
+            })
         elif self.type == 'bridge':
             options.update({
                 'bridge.ageing-time': self.ageingtime,


### PR DESCRIPTION
Hello 🙂 

##### SUMMARY
NMCLI module do not work with bond-slave type.

##### ISSUE TYPE
Bug in module

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
When using bond-slave type, by default command sent to nmcli by module is:

`['/usr/bin/nmcli', 'con', 'add', 'type', 'bond-slave', 'con-name', 'enp129s0f0', 'connection.interface-name', 'enp129s0f0', 'connection.autoconnect', 'yes', 'connection.master', 'bond0']`

Which is not enough, nmcli will complain that connection.slave-type is missing. This small fix solve this issue.

If this change is approved, I will add the changelog fragment.

