### PR TITLE
proxmox_kvm: trivial patch for github issue #1875

### DIFF
--- a/changelogs/fragments/1895-proxmox-kvm-fix-issue-1875.yml
+++ b/changelogs/fragments/1895-proxmox-kvm-fix-issue-1875.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox_kvm - fix parameter ``vmid`` passed twice to ``exit_json`` while creating a virtual machine without cloning, https://github.com/ansible-collections/community.general/pull/1895
+  - proxmox_kvm - fix parameter ``vmid`` passed twice to ``exit_json`` while creating a virtual machine without cloning (https://github.com/ansible-collections/community.general/issues/1875, https://github.com/ansible-collections/community.general/pull/1895).

--- a/changelogs/fragments/1895-proxmox-kvm-fix-issue-1875.yml
+++ b/changelogs/fragments/1895-proxmox-kvm-fix-issue-1875.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_kvm - fix parameter ``vmid`` passed twice to ``exit_json`` while creating a virtual machine without cloning, https://github.com/ansible-collections/community.general/pull/1895

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1287,7 +1287,7 @@ def main():
             elif clone is not None:
                 module.exit_json(changed=True, vmid=vmid, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
             else:
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
+                module.exit_json(changed=True, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
         except Exception as e:
             if update:
                 module.fail_json(vmid=vmid, msg="Unable to update vm {0} with vmid {1}=".format(name, vmid) + str(e))


### PR DESCRIPTION
##### SUMMARY

Fixes issue #1875: parameter `vmid` passed twice to `exit_json()`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_kvm