### PR TITLE
Disable way too slow yum_versionlock tests

### DIFF
--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -1,3 +1,4 @@
+disabled  # The tests are way too slow - the locking/unlocking steps need 10 minutes each!
 shippable/posix/group1
 skip/aix
 skip/freebsd


### PR DESCRIPTION
##### SUMMARY
The yum_versionlock tests are **extremely** slow: the locking and unlocking operation both take up to 10 minutes!

See for example:
- https://dev.azure.com/ansible/b24bf3ca-6168-45d7-99e2-bf8029e67c87/_apis/build/builds/7679/logs/1194
- https://dev.azure.com/ansible/b24bf3ca-6168-45d7-99e2-bf8029e67c87/_apis/build/builds/7679/logs/1187

Timestamps of interest:
- RHEL 8.2 on Ansible 2.10:
  ```
  2021-02-26T09:31:35.8642168Z 06:52 TASK [yum_versionlock : Lock all packages] *************************************
  2021-02-26T09:41:41.5695147Z 16:58 changed: [testhost] => {"changed": true, "meta": {"packages": ["epel-release", "rh-amazon-rhui-client", ..., "microcode_ctl"], "state": "present"}}
  ```
  for locking and
  ```
  2021-02-26T09:41:45.1511543Z 17:02 TASK [yum_versionlock : Unlock all packages] ***********************************
  2021-02-26T09:51:19.0732524Z 26:36 changed: [testhost] => {"changed": true, "meta": {"packages": ["epel-release", ..., "microcode_ctl"], "state": "absent"}}
  ```
  for unlocking: this is a total of 20 minutes!
- RHEL 8.2 on Ansible 2.9:
  ```
  2021-02-26T09:31:58.4566170Z 06:50 TASK [yum_versionlock : Lock all packages] *************************************
  2021-02-26T09:41:06.3081782Z 15:58 changed: [testhost] => {"changed": true, "meta": {"packages": ["epel-release", ..., "microcode_ctl"], "state": "present"}}
  ```
  for locking and
  ```
  2021-02-26T09:41:08.7250532Z 16:00 TASK [yum_versionlock : Unlock all packages] ***********************************
  2021-02-26T09:49:53.0925833Z 24:45 changed: [testhost] => {"changed": true, "meta": {"packages": ["epel-release", ..., "microcode_ctl"], "state": "absent"}}
  ```
  for unlocking: this is a total of 18 minutes!

(For some reason, the tests are NOT run on RHEL 8.3 with ansible-core's devel branch.)

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
yum_versionlock
