### PR TITLE
yum_versionlock: do lock/unlock concurrently

### DIFF
--- a/changelogs/fragments/1912-yum_versionlock-lock_unlock_concurrently.yml
+++ b/changelogs/fragments/1912-yum_versionlock-lock_unlock_concurrently.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - yum_versionlock - Do the lock/unlock concurrently to speed up (https://github.com/ansible-collections/community.general/pull/1912).

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -130,7 +130,8 @@ def main():
                     changed = True
                     continue
                 packages_list.append(single_pkg)
-        changed = yum_v.ensure_state(packages_list, command)
+        if packages_list:
+            changed = yum_v.ensure_state(packages_list, command)
     elif state in ('absent'):
         command = 'delete'
         for single_pkg in packages:
@@ -139,7 +140,8 @@ def main():
                     changed = True
                     continue
                 packages_list.append(single_pkg)
-        changed = yum_v.ensure_state(packages_list, command)
+        if packages_list:
+            changed = yum_v.ensure_state(packages_list, command)
 
     module.exit_json(
         changed=changed,

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -93,9 +93,9 @@ class YumVersionLock:
             self.module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock : " + to_native(err) + to_native(out))
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
 
-    def ensure_state(self, package, command):
+    def ensure_state(self, packages_list, command):
         """ Ensure package state """
-        packages = " ".join(package)
+        packages = " ".join(packages_list)
         cmd = "%s -q versionlock %s %s" % (self.yum_bin, command, packages)
         rc, out, err = self.module.run_command(cmd)
         if rc == 0:

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -93,11 +93,9 @@ class YumVersionLock:
             self.module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock : " + to_native(err) + to_native(out))
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
 
-    def ensure_state(self, packages_list, command):
+    def ensure_state(self, package, command):
         """ Ensure package state """
-        packages = " ".join(packages_list)
-        cmd = "%s -q versionlock %s %s" % (self.yum_bin, command, packages)
-        rc, out, err = self.module.run_command(cmd)
+        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command] + package)
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -128,7 +128,7 @@ def main():
                 if module.check_mode:
                     changed = True
                     continue
-                changed = yum_v.ensure_state(single_pkg, command)
+        changed = yum_v.ensure_state(packages, command)
     elif state in ('absent'):
         command = 'delete'
         for single_pkg in packages:
@@ -136,7 +136,7 @@ def main():
                 if module.check_mode:
                     changed = True
                     continue
-                changed = yum_v.ensure_state(single_pkg, command)
+        changed = yum_v.ensure_state(packages, command)
 
     module.exit_json(
         changed=changed,

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -13,7 +13,7 @@ module: yum_versionlock
 version_added: 2.0.0
 short_description: Locks / unlocks a installed package(s) from being updated by yum package manager
 description:
-     - This module adds installed packages to yum versionlock to prevent the package from being updated.
+     - This module adds installed packages to yum versionlock to prevent the package(s) from being updated.
 options:
   name:
     description:
@@ -93,9 +93,9 @@ class YumVersionLock:
             self.module.fail_json(msg="Error: Please install rpm package yum-plugin-versionlock : " + to_native(err) + to_native(out))
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
 
-    def ensure_state(self, package, command):
-        """ Ensure package state """
-        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command] + package)
+    def ensure_state(self, packages, command):
+        """ Ensure packages state """
+        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command] + packages)
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -95,7 +95,8 @@ class YumVersionLock:
 
     def ensure_state(self, package, command):
         """ Ensure package state """
-        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command, package])
+        packages = " ".join(package)
+        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command, packages])
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -121,22 +121,25 @@ def main():
     versionlock_packages = yum_v.get_versionlock_packages()
 
     # Ensure versionlock state of packages
+    packages_list = []
     if state in ('present'):
         command = 'add'
         for single_pkg in packages:
             if single_pkg not in versionlock_packages:
                 if module.check_mode:
                     changed = True
-        if not module.check_mode:
-            changed = yum_v.ensure_state(packages, command)
+                    continue
+                packages_list.append(single_pkg)
+        changed = yum_v.ensure_state(packages_list, command)
     elif state in ('absent'):
         command = 'delete'
         for single_pkg in packages:
             if single_pkg in versionlock_packages:
                 if module.check_mode:
                     changed = True
-        if not module.check_mode:
-            changed = yum_v.ensure_state(packages, command)
+                    continue
+                packages_list.append(single_pkg)
+        changed = yum_v.ensure_state(packages_list, command)
 
     module.exit_json(
         changed=changed,

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -96,7 +96,8 @@ class YumVersionLock:
     def ensure_state(self, package, command):
         """ Ensure package state """
         packages = " ".join(package)
-        rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command, packages])
+        cmd = "%s -q versionlock %s %s" % (self.yum_bin, command, packages)
+        rc, out, err = self.module.run_command(cmd)
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -129,16 +129,16 @@ def main():
             if single_pkg not in versionlock_packages:
                 if module.check_mode:
                     changed = True
-                    continue
-        changed = yum_v.ensure_state(packages, command)
+        if not module.check_mode:
+            changed = yum_v.ensure_state(packages, command)
     elif state in ('absent'):
         command = 'delete'
         for single_pkg in packages:
             if single_pkg in versionlock_packages:
                 if module.check_mode:
                     changed = True
-                    continue
-        changed = yum_v.ensure_state(packages, command)
+        if not module.check_mode:
+            changed = yum_v.ensure_state(packages, command)
 
     module.exit_json(
         changed=changed,

--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -1,4 +1,3 @@
-disabled  # The tests are way too slow - the locking/unlocking steps need 10 minutes each!
 shippable/posix/group1
 skip/aix
 skip/freebsd


### PR DESCRIPTION
##### SUMMARY
Fixes #1908 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum_versionlock

##### ADDITIONAL INFORMATION
Change module to lock/unlock all packages at once instead of doing it one by one.