### PR TITLE
Proxmox inventory: Add some sanitization to url parameter

### DIFF
--- a/changelogs/fragments/1914-add-sanitization-to-url.yml
+++ b/changelogs/fragments/1914-add-sanitization-to-url.yml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - proxmox inventory - Added handling of extra trailing slashes in the url (https://github.com/ansible-collections/community.general/pull/1914)
-

--- a/changelogs/fragments/1914-add-sanitization-to-url.yml
+++ b/changelogs/fragments/1914-add-sanitization-to-url.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox inventory - Added handling of extra trailing slashes in the url (https://github.com/ansible-collections/community.general/pull/1914)
+

--- a/changelogs/fragments/1914-add-sanitization-to-url.yml
+++ b/changelogs/fragments/1914-add-sanitization-to-url.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox inventory - Added handling of extra trailing slashes in the url (https://github.com/ansible-collections/community.general/pull/1914)
+  - proxmox inventory - added handling of extra trailing slashes in the url (https://github.com/ansible-collections/community.general/pull/1914).

--- a/changelogs/fragments/1914-add-sanitization-to-url.yml
+++ b/changelogs/fragments/1914-add-sanitization-to-url.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox inventory - added handling of extra trailing slashes in the url (https://github.com/ansible-collections/community.general/pull/1914).
+  - proxmox inventory - added handling of extra trailing slashes in the URL (https://github.com/ansible-collections/community.general/pull/1914).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -352,7 +352,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         self._read_config_data(path)
 
         # get connection host
-        self.proxmox_url = self.get_option('url')
+        self.proxmox_url = self.get_option('url').rstrip('/')
         self.proxmox_user = self.get_option('user')
         self.proxmox_password = self.get_option('password')
         self.cache_key = self.get_cache_key(path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I received an email a few days ago about an interesting issue with this module. A user configured this module with a trailing / for the Proxmox URL, which breaks the Proxmox API.

I added a small patch to strip any and all trailing slashes from the url field, so this will no longer occur.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Before this patch, running the inventory with a trailing slash resulted in the error below
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[WARNING]:  * Failed to parse /root/projects/playground/inventory/carrier.proxmox.yml with
ansible_collections.community.general.plugins.inventory.proxmox plugin: Expecting value: line 1 column 1 (char 0)
```