### PR TITLE
jenkins_plugin: fix "'encoding' is an invalid keyword arg" on python 2

### DIFF
--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -280,6 +280,7 @@ import json
 import os
 import tempfile
 import time
+from io import open
 
 
 class JenkinsPlugin(object):


### PR DESCRIPTION
##### SUMMARY
When the remote Python interpreter is python 2, the use of the `encoding` keyword arg fails when called on the default `open`. Importing `open` from `io` fixes this issue so the `jenkins_plugin` module will work on machines running python 2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jenkins_plugin

##### ADDITIONAL INFORMATION
Here is example output from before this change: 

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: 'encoding' is an invalid keyword argument for this function
failed: [10.0.64.20] (item=configuration-as-code) => {"ansible_loop_var": "item", "attempts": 3, "changed": false, "item": "configuration-as-code", "module_stderr": "Shared connection to 10.0.64.20 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/ec2-user/.ansible/tmp/ansible-tmp-1614404884.5692868-86253-195158584335708/AnsiballZ_jenkins_plugin.py\", line 102, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/ec2-user/.ansible/tmp/ansible-tmp-1614404884.5692868-86253-195158584335708/AnsiballZ_jenkins_plugin.py\", line 94, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/ec2-user/.ansible/tmp/ansible-tmp-1614404884.5692868-86253-195158584335708/AnsiballZ_jenkins_plugin.py\", line 40, in invoke_module\r\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.jenkins_plugin', init_globals=None, run_name='__main__', alter_sys=True)\r\n  File \"/usr/lib64/python2.7/runpy.py\", line 188, in run_module\r\n    fname, loader, pkg_name)\r\n  File \"/usr/lib64/python2.7/runpy.py\", line 82, in _run_module_code\r\n    mod_name, mod_fname, mod_loader, pkg_name)\r\n  File \"/usr/lib64/python2.7/runpy.py\", line 72, in _run_code\r\n    exec code in run_globals\r\n  File \"/tmp/ansible_jenkins_plugin_payload_Ltu2dZ/ansible_jenkins_plugin_payload.zip/ansible_collections/community/general/plugins/modules/jenkins_plugin.py\", line 780, in <module>\r\n  File \"/tmp/ansible_jenkins_plugin_payload_Ltu2dZ/ansible_jenkins_plugin_payload.zip/ansible_collections/community/general/plugins/modules/jenkins_plugin.py\", line 763, in main\r\n  File \"/tmp/ansible_jenkins_plugin_payload_Ltu2dZ/ansible_jenkins_plugin_payload.zip/ansible_collections/community/general/plugins/modules/jenkins_plugin.py\", line 495, in install\r\n  File \"/tmp/ansible_jenkins_plugin_payload_Ltu2dZ/ansible_jenkins_plugin_payload.zip/ansible_collections/community/general/plugins/modules/jenkins_plugin.py\", line 563, in _download_updates\r\nTypeError: 'encoding' is an invalid keyword argument for this function\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After this change, the module succeeds. Thanks for reviewing!
