### PR TITLE
Deprecation of parameters triggering the parameter-invalid sanity-check

### DIFF
--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - puppet - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - puppet - deprecated parameter ``show_diff``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use `--diff` or the task attribute `diff: true` instead (https://github.com/ansible-collections/community.general/pull/1927).
+  - "puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use `--diff` or the task attribute `diff: true` instead (https://github.com/ansible-collections/community.general/pull/1927)."

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -1,13 +1,12 @@
 deprecated_features:
-  - composer - deprecated invalid parameter aliases, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - composer - deprecated invalid parameter aliases ``working-dir``, ``global-command``, ``prefer-source``, ``prefer-dist``, ``no-dev``, ``no-scripts``, ``no-plugins``, ``optimize-autoloader``, ``classmap-authoritative``, ``apcu-autoloader``, ``ignore-platform-reqs``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - apt_rpm - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - homebrew - deprecated invalid parameter alias ``update-brew``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - homebrew_cask - deprecated invalid parameter alias ``update-brew``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - opkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - pacman - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - opkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - slackpkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - xbps - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - github_deploy_key - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - puppet - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - puppet - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - puppet - deprecated parameter ``show_diff``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use `--diff` or the task attribute `diff: true` instead (https://github.com/ansible-collections/community.general/pull/1927).

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - "puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use ``--diff`` or the task attribute ``diff: true`` instead (https://github.com/ansible-collections/community.general/pull/1927)."
+  - puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. (https://github.com/ansible-collections/community.general/pull/1927).

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -1,0 +1,13 @@
+deprecated_features:
+  - composer - deprecated invalid parameter aliases, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - apt_rpm - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - homebrew - deprecated invalid parameter alias ``update-brew``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - homebrew_cask - deprecated invalid parameter alias ``update-brew``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - opkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - pacman - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - opkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - slackpkg - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - xbps - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - github_deploy_key - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
+  - puppet - deprecated invalid parameter aliases ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - "puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use `--diff` or the task attribute `diff: true` instead (https://github.com/ansible-collections/community.general/pull/1927)."
+  - "puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. Use ``--diff`` or the task attribute ``diff: true`` instead (https://github.com/ansible-collections/community.general/pull/1927)."

--- a/changelogs/fragments/1927-removed-parameter-invalid.yml
+++ b/changelogs/fragments/1927-removed-parameter-invalid.yml
@@ -9,4 +9,4 @@ deprecated_features:
   - urmpi - deprecated invalid parameter aliases ``update-cache`` and ``no-recommends``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - xbps - deprecated invalid parameter alias ``update-cache``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
   - github_deploy_key - deprecated invalid parameter alias ``2fa_token``, will be removed in 5.0.0 (https://github.com/ansible-collections/community.general/pull/1927).
-  - puppet - deprecated undocumented parameter ``show_diff``, will be removed in 5.0.0. (https://github.com/ansible-collections/community.general/pull/1927).
+  - puppet - deprecated undocumented parameter ``show_diff``, will be removed in 7.0.0. (https://github.com/ansible-collections/community.general/pull/1927).

--- a/plugins/modules/packaging/language/composer.py
+++ b/plugins/modules/packaging/language/composer.py
@@ -41,40 +41,47 @@ options:
             - Directory of your project (see --working-dir). This is required when
               the command is not run globally.
             - Will be ignored if C(global_command=true).
+            - Alias C(working-dir) has been deprecated and will be removed in community.general 5.0.0.
         aliases: [ working-dir ]
     global_command:
         description:
             - Runs the specified command globally.
+            - Alias C(global-command) has been deprecated and will be removed in community.general 5.0.0.
         type: bool
         default: false
         aliases: [ global-command ]
     prefer_source:
         description:
             - Forces installation from package sources when possible (see --prefer-source).
+            - Alias C(prefer-source) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ prefer-source ]
     prefer_dist:
         description:
             - Forces installation from package dist even for dev versions (see --prefer-dist).
+            - Alias C(prefer-dist) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ prefer-dist ]
     no_dev:
         description:
             - Disables installation of require-dev packages (see --no-dev).
+            - Alias C(no-dev) has been deprecated and will be removed in community.general 5.0.0.
         default: true
         type: bool
         aliases: [ no-dev ]
     no_scripts:
         description:
             - Skips the execution of all scripts defined in composer.json (see --no-scripts).
+            - Alias C(no-scripts) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ no-scripts ]
     no_plugins:
         description:
             - Disables all plugins ( see --no-plugins ).
+            - Alias C(no-plugins) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ no-plugins ]
@@ -83,6 +90,7 @@ options:
             - Optimize autoloader during autoloader dump (see --optimize-autoloader).
             - Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
             - Recommended especially for production, but can take a bit of time to run.
+            - Alias C(optimize-autoloader) has been deprecated and will be removed in community.general 5.0.0.
         default: true
         type: bool
         aliases: [ optimize-autoloader ]
@@ -91,18 +99,21 @@ options:
             - Autoload classes from classmap only.
             - Implicitely enable optimize_autoloader.
             - Recommended especially for production, but can take a bit of time to run.
+            - Alias C(classmap-authoritative) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ classmap-authoritative ]
     apcu_autoloader:
         description:
             - Uses APCu to cache found/not-found classes
+            - Alias C(apcu-autoloader) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ apcu-autoloader ]
     ignore_platform_reqs:
         description:
             - Ignore php, hhvm, lib-* and ext-* requirements and force the installation even if the local machine does not fulfill these.
+            - Alias C(ignore-platform-reqs) has been deprecated and will be removed in community.general 5.0.0.
         default: false
         type: bool
         aliases: [ ignore-platform-reqs ]
@@ -187,17 +198,39 @@ def main():
             command=dict(default="install", type="str"),
             arguments=dict(default="", type="str"),
             executable=dict(type="path", aliases=["php_path"]),
-            working_dir=dict(type="path", aliases=["working-dir"]),
-            global_command=dict(default=False, type="bool", aliases=["global-command"]),
-            prefer_source=dict(default=False, type="bool", aliases=["prefer-source"]),
-            prefer_dist=dict(default=False, type="bool", aliases=["prefer-dist"]),
-            no_dev=dict(default=True, type="bool", aliases=["no-dev"]),
-            no_scripts=dict(default=False, type="bool", aliases=["no-scripts"]),
-            no_plugins=dict(default=False, type="bool", aliases=["no-plugins"]),
-            apcu_autoloader=dict(default=False, type="bool", aliases=["apcu-autoloader"]),
-            optimize_autoloader=dict(default=True, type="bool", aliases=["optimize-autoloader"]),
-            classmap_authoritative=dict(default=False, type="bool", aliases=["classmap-authoritative"]),
-            ignore_platform_reqs=dict(default=False, type="bool", aliases=["ignore-platform-reqs"]),
+            working_dir=dict(
+                type="path", aliases=["working-dir"],
+                deprecated_aliases=[dict(name='working-dir', version='5.0.0', collection_name='community.general')]),
+            global_command=dict(
+                default=False, type="bool", aliases=["global-command"],
+                deprecated_aliases=[dict(name='global-command', version='5.0.0', collection_name='community.general')]),
+            prefer_source=dict(
+                default=False, type="bool", aliases=["prefer-source"],
+                deprecated_aliases=[dict(name='prefer-source', version='5.0.0', collection_name='community.general')]),
+            prefer_dist=dict(
+                default=False, type="bool", aliases=["prefer-dist"],
+                deprecated_aliases=[dict(name='prefer-dist', version='5.0.0', collection_name='community.general')]),
+            no_dev=dict(
+                default=True, type="bool", aliases=["no-dev"],
+                deprecated_aliases=[dict(name='no-dev', version='5.0.0', collection_name='community.general')]),
+            no_scripts=dict(
+                default=False, type="bool", aliases=["no-scripts"],
+                deprecated_aliases=[dict(name='no-scripts', version='5.0.0', collection_name='community.general')]),
+            no_plugins=dict(
+                default=False, type="bool", aliases=["no-plugins"],
+                deprecated_aliases=[dict(name='no-plugins', version='5.0.0', collection_name='community.general')]),
+            apcu_autoloader=dict(
+                default=False, type="bool", aliases=["apcu-autoloader"],
+                deprecated_aliases=[dict(name='apcu-autoloader', version='5.0.0', collection_name='community.general')]),
+            optimize_autoloader=dict(
+                default=True, type="bool", aliases=["optimize-autoloader"],
+                deprecated_aliases=[dict(name='optimize-autoloader', version='5.0.0', collection_name='community.general')]),
+            classmap_authoritative=dict(
+                default=False, type="bool", aliases=["classmap-authoritative"],
+                deprecated_aliases=[dict(name='classmap-authoritative', version='5.0.0', collection_name='community.general')]),
+            ignore_platform_reqs=dict(
+                default=False, type="bool", aliases=["ignore-platform-reqs"],
+                deprecated_aliases=[dict(name='ignore-platform-reqs', version='5.0.0', collection_name='community.general')]),
         ),
         required_if=[('global_command', False, ['working_dir'])],
         supports_check_mode=True

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -33,6 +33,7 @@ options:
   update_cache:
     description:
       - update the package database first C(apt-get update).
+      - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
     aliases: [ 'update-cache' ]
     type: bool
     default: no
@@ -157,7 +158,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'installed', 'present', 'removed']),
-            update_cache=dict(type='bool', default=False, aliases=['update-cache']),
+            update_cache=dict(
+                type='bool', default=False, aliases=['update-cache'],
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
             package=dict(type='list', elements='str', required=True, aliases=['name', 'pkg']),
         ),
     )

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -49,6 +49,7 @@ options:
     update_homebrew:
         description:
             - update homebrew itself first.
+            - Alias C(update-brew) has been deprecated and will be removed in community.general 5.0.0.
         type: bool
         default: no
         aliases: ['update-brew']
@@ -888,6 +889,7 @@ def main():
                 default=False,
                 aliases=["update-brew"],
                 type='bool',
+                deprecated_aliases=[dict(name='update-brew', version='5.0.0', collection_name='community.general')],
             ),
             upgrade_all=dict(
                 default=False,

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -49,6 +49,7 @@ options:
     description:
     - Update homebrew itself first.
     - Note that C(brew cask update) is a synonym for C(brew update).
+    - Alias C(update-brew) has been deprecated and will be removed in community.general 5.0.0.
     type: bool
     default: no
     aliases: [ 'update-brew' ]
@@ -800,6 +801,7 @@ def main():
                 default=False,
                 aliases=["update-brew"],
                 type='bool',
+                deprecated_aliases=[dict(name='update-brew', version='5.0.0', collection_name='community.general')],
             ),
             install_options=dict(
                 default=None,

--- a/plugins/modules/packaging/os/opkg.py
+++ b/plugins/modules/packaging/os/opkg.py
@@ -49,6 +49,7 @@ options:
     update_cache:
         description:
             - update the package db first
+            - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
         aliases: ['update-cache']
         default: "no"
         type: bool
@@ -173,7 +174,9 @@ def main():
             state=dict(default="present", choices=["present", "installed", "absent", "removed"]),
             force=dict(default="", choices=["", "depends", "maintainer", "reinstall", "overwrite", "downgrade", "space", "postinstall", "remove",
                                             "checksum", "removal-of-dependent-packages"]),
-            update_cache=dict(default="no", aliases=["update-cache"], type='bool')
+            update_cache=dict(
+                default="no", aliases=["update-cache"], type='bool',
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
         )
     )
 

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -54,6 +54,7 @@ options:
         description:
             - Whether or not to refresh the master package lists.
             - This can be run as part of a package installation or as a separate step.
+            - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
         default: no
         type: bool
         aliases: [ update-cache ]
@@ -421,7 +422,9 @@ def main():
             extra_args=dict(type='str', default=''),
             upgrade=dict(type='bool', default=False),
             upgrade_extra_args=dict(type='str', default=''),
-            update_cache=dict(type='bool', default=False, aliases=['update-cache']),
+            update_cache=dict(
+                type='bool', default=False, aliases=['update-cache'],
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
             update_cache_extra_args=dict(type='str', default=''),
         ),
         required_one_of=[['name', 'update_cache', 'upgrade']],

--- a/plugins/modules/packaging/os/slackpkg.py
+++ b/plugins/modules/packaging/os/slackpkg.py
@@ -41,6 +41,7 @@ options:
     update_cache:
         description:
             - update the package database first
+            - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
         required: false
         default: false
         type: bool
@@ -177,8 +178,9 @@ def main():
         argument_spec=dict(
             state=dict(default="present", choices=['installed', 'removed', 'absent', 'present', 'latest']),
             name=dict(aliases=["pkg"], required=True, type='list', elements='str'),
-            update_cache=dict(default=False, aliases=["update-cache"],
-                              type='bool'),
+            update_cache=dict(
+                default=False, aliases=["update-cache"], type='bool',
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
         ),
         supports_check_mode=True)
 

--- a/plugins/modules/packaging/os/urpmi.py
+++ b/plugins/modules/packaging/os/urpmi.py
@@ -33,12 +33,14 @@ options:
   update_cache:
     description:
       - Update the package database first C(urpmi.update -a).
+      - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
     type: bool
     default: no
     aliases: ['update-cache']
   no_recommends:
     description:
       - Corresponds to the C(--no-recommends) option for I(urpmi).
+      - Alias C(no-recommends) has been deprecated and will be removed in community.general 5.0.0.
     type: bool
     default: yes
     aliases: ['no-recommends']
@@ -195,9 +197,13 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present',
                        choices=['absent', 'installed', 'present', 'removed']),
-            update_cache=dict(type='bool', default=False, aliases=['update-cache']),
+            update_cache=dict(
+                type='bool', default=False, aliases=['update-cache'],
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
             force=dict(type='bool', default=True),
-            no_recommends=dict(type='bool', default=True, aliases=['no-recommends']),
+            no_recommends=dict(
+                type='bool', default=True, aliases=['no-recommends'],
+                deprecated_aliases=[dict(name='no-recommends', version='5.0.0', collection_name='community.general')]),
             name=dict(type='list', elements='str', required=True, aliases=['package', 'pkg']),
             root=dict(type='str', aliases=['installroot']),
         ),

--- a/plugins/modules/packaging/os/xbps.py
+++ b/plugins/modules/packaging/os/xbps.py
@@ -42,6 +42,7 @@ options:
         description:
             - Whether or not to refresh the master package lists. This can be
               run as part of a package installation or as a separate step.
+            - Alias C(update-cache) has been deprecated and will be removed in community.general 5.0.0.
         aliases: ['update-cache']
         type: bool
         default: yes
@@ -290,8 +291,9 @@ def main():
             recurse=dict(default=False, type='bool'),
             force=dict(default=False, type='bool', removed_in_version='3.0.0', removed_from_collection='community.general'),
             upgrade=dict(default=False, type='bool'),
-            update_cache=dict(default=True, aliases=['update-cache'],
-                              type='bool'),
+            update_cache=dict(
+                default=True, aliases=['update-cache'], type='bool',
+                deprecated_aliases=[dict(name='update-cache', version='5.0.0', collection_name='community.general')]),
             upgrade_xbps=dict(default=True, type='bool')
         ),
         required_one_of=[['name', 'update_cache', 'upgrade']],

--- a/plugins/modules/source_control/github/github_deploy_key.py
+++ b/plugins/modules/source_control/github/github_deploy_key.py
@@ -78,6 +78,7 @@ options:
   otp:
     description:
       - The 6 digit One Time Password for 2-Factor Authentication. Required together with I(username) and I(password).
+      - Alias C(2fa_token) has been deprecated and will be removed in community.general 5.0.0.
     aliases: ['2fa_token']
     type: int
 notes:
@@ -297,7 +298,9 @@ def main():
             force=dict(required=False, type='bool', default=False),
             username=dict(required=False, type='str'),
             password=dict(required=False, type='str', no_log=True),
-            otp=dict(required=False, type='int', aliases=['2fa_token'], no_log=True),
+            otp=dict(
+                required=False, type='int', aliases=['2fa_token'], no_log=True,
+                deprecated_aliases=[dict(name='2fa_token', version='5.0.0', collection_name='community.general')]),
             token=dict(required=False, type='str', no_log=True)
         ),
         mutually_exclusive=[

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -244,9 +244,8 @@ def main():
                " --detailed-exitcodes --verbose --color 0") % dict(base_cmd=base_cmd)
         if p['puppetmaster']:
             cmd += " --server %s" % shlex_quote(p['puppetmaster'])
-        if p['show_diff'] or module._diff:
-            module.deprecate("The 'show_diff' parameter is deprecated, use module diff instead ",
-                             version='4.0.0', collection_name='community.general')
+        if p['show_diff']:
+            cmd += " --show_diff"
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
         if p['tags']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -171,14 +171,11 @@ def main():
             puppetmaster=dict(type='str'),
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
-            noop=dict(required=False, type='bool'),
-            logdest=dict(type='str', default='stdout', choices=['all',
-                                                                'stdout',
-                                                                'syslog']),
-            # internal code to work with --diff, do not use
+            noop=dict(type='bool'),
+            logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
-                deprecated_aliases=[dict(name='show-diff', version='5.0.0', collection_name='community.general')]),
+                removed_in_version='4.0.0', removed_from_collection='community.general'),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),
@@ -248,7 +245,8 @@ def main():
         if p['puppetmaster']:
             cmd += " --server %s" % shlex_quote(p['puppetmaster'])
         if p['show_diff']:
-            cmd += " --show_diff"
+            module.deprecate("The 'show_diff' parameter is deprecated, use module diff instead ",
+                             version='4.0.0', collection_name='community.general')
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
         if p['tags']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -176,7 +176,9 @@ def main():
                                                                 'stdout',
                                                                 'syslog']),
             # internal code to work with --diff, do not use
-            show_diff=dict(type='bool', default=False, aliases=['show-diff']),
+            show_diff=dict(
+                type='bool', default=False, aliases=['show-diff'],
+                deprecated_aliases=[dict(name='show-diff', version='5.0.0', collection_name='community.general')]),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -244,7 +244,7 @@ def main():
                " --detailed-exitcodes --verbose --color 0") % dict(base_cmd=base_cmd)
         if p['puppetmaster']:
             cmd += " --server %s" % shlex_quote(p['puppetmaster'])
-        if p['show_diff']:
+        if p['show_diff'] or module._diff:
             module.deprecate("The 'show_diff' parameter is deprecated, use module diff instead ",
                              version='4.0.0', collection_name='community.general')
         if p['environment']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -175,7 +175,7 @@ def main():
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
-                removed_in_version='5.0.0', removed_from_collection='community.general'),
+                removed_in_version='7.0.0', removed_from_collection='community.general'),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -175,7 +175,7 @@ def main():
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
-                removed_in_version='4.0.0', removed_from_collection='community.general'),
+                removed_in_version='5.0.0', removed_from_collection='community.general'),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -206,9 +206,7 @@ plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-invalid
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
-plugins/modules/system/puppet.py validate-modules:undocumented-parameter
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -205,9 +205,7 @@ plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-invalid
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
-plugins/modules/system/puppet.py validate-modules:undocumented-parameter
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -220,9 +220,7 @@ plugins/modules/storage/purestorage/purefb_facts.py validate-modules:return-synt
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/launchd.py use-argspec-type-path  # False positive
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:parameter-invalid
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
-plugins/modules/system/puppet.py validate-modules:undocumented-parameter
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error


### PR DESCRIPTION
##### SUMMARY
Deprecating the parameters, removal on version 5.0.0.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/puppet.py
plugins/modules/source_control/github/github_deploy_key.py
plugins/modules/packaging/os/xbps.py
plugins/modules/packaging/os/urpmi.py
plugins/modules/packaging/os/slackpkg.py
plugins/modules/packaging/os/pacman.py
plugins/modules/packaging/os/opkg.py
plugins/modules/packaging/os/homebrew_cask.py
plugins/modules/packaging/os/homebrew.py
plugins/modules/packaging/os/apt_rpm.py
plugins/modules/packaging/language/composer.py
