### PR TITLE
bigpanda: actually use option

### DIFF
--- a/changelogs/fragments/1928-bigpanda-message.yml
+++ b/changelogs/fragments/1928-bigpanda-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "bigpanda - actually use the ``deployment_message`` option (https://github.com/ansible-collections/community.general/pull/1928)."

--- a/plugins/modules/monitoring/bigpanda.py
+++ b/plugins/modules/monitoring/bigpanda.py
@@ -183,7 +183,7 @@ def main():
 
         request_url = url + '/data/events/deployments/start'
     else:
-        message = module.params['message']
+        message = module.params['deployment_message']
         if message is not None:
             body['errorMessage'] = message
 


### PR DESCRIPTION
##### SUMMARY
When `message` was made an alias of `deployment_message`, the code was never adjusted to actually use `deployment_message`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigpanda
