### PR TITLE
grove: message -> message_content

### DIFF
--- a/changelogs/fragments/1929-grove-message.yml
+++ b/changelogs/fragments/1929-grove-message.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- "grove - the option ``message`` has been renamed to ``message_content``. The old name ``message`` is kept as an alias and will be removed for community.general 4.0.0. This was done because ``message`` is used internally by Ansible (https://github.com/ansible-collections/community.general/pull/1929)."
+deprecated_features:
+- "grove - the option ``message`` will be removed in community.general 4.0.0. Use the new option ``message_content`` instead (https://github.com/ansible-collections/community.general/pull/1929)."

--- a/plugins/modules/notification/grove.py
+++ b/plugins/modules/notification/grove.py
@@ -27,11 +27,14 @@ options:
       - Name of the service (displayed as the "user" in the message)
     required: false
     default: ansible
-  message:
+  message_content:
     type: str
     description:
-      - Message content
+      - Message content.
+      - The alias I(message) is deprecated and will be removed in community.general 4.0.0.
     required: true
+    aliases:
+      - message
   url:
     type: str
     description:
@@ -92,7 +95,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             channel_token=dict(type='str', required=True, no_log=True),
-            message=dict(type='str', required=True),
+            message_content=dict(type='str', required=True, aliases=['message'],
+                                 deprecated_aliases=[dict(name='message', version='4.0.0',
+                                                          collection_name='community.general')]),
             service=dict(type='str', default='ansible'),
             url=dict(type='str', default=None),
             icon_url=dict(type='str', default=None),
@@ -102,7 +107,7 @@ def main():
 
     channel_token = module.params['channel_token']
     service = module.params['service']
-    message = module.params['message']
+    message = module.params['message_content']
     url = module.params['url']
     icon_url = module.params['icon_url']
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -124,7 +124,6 @@ plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
-plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -123,7 +123,6 @@ plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not
 plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/notification/cisco_webex.py validate-modules:invalid-argument-name
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
-plugins/modules/notification/grove.py validate-modules:nonexistent-parameter-documented
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid


### PR DESCRIPTION
##### SUMMARY
grove still has a `message` option (the option name is also used internally by Ansible). Add a `message_content` option, make `message` its alias, and deprecate `message` for removal in community.general 4.0.0.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
grove
