### PR TITLE
[stable-2] Also mention plugins/modules added in 1.1.0, 1.2.0 and 1.3.0 in 2.0.0 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -611,6 +611,15 @@ Bugfixes
 - zfs - fixed ``invalid character '@' in pool name"`` error when working with snapshots on a root zvol (https://github.com/ansible-collections/community.general/issues/932).
 - zypper - force ``LANG=C`` to as zypper is looking in XML output where attribute could be translated (https://github.com/ansible-collections/community.general/issues/1175).
 
+New Plugins
+-----------
+
+Inventory
+~~~~~~~~~
+
+- proxmox - Proxmox inventory source
+- stackpath_compute - StackPath Edge Computing inventory source
+
 New Modules
 -----------
 
@@ -620,7 +629,24 @@ Cloud
 misc
 ^^^^
 
+- proxmox_domain_info - Retrieve information about one or more Proxmox VE domains
+- proxmox_group_info - Retrieve information about one or more Proxmox VE groups
 - proxmox_snap - Snapshot management of instances in Proxmox VE cluster
+- proxmox_user_info - Retrieve information about one or more Proxmox VE users
+
+scaleway
+^^^^^^^^
+
+- scaleway_database_backup - Scaleway database backups management module
+
+Clustering
+~~~~~~~~~~
+
+nomad
+^^^^^
+
+- nomad_job - Launch a Nomad Job
+- nomad_job_info - Get Nomad Jobs info
 
 Identity
 ~~~~~~~~
@@ -632,6 +658,9 @@ ipa
 
 Monitoring
 ~~~~~~~~~~
+
+- pagerduty_change - Track a code or infrastructure change as a PagerDuty change event
+- pagerduty_user - Manage a user account on PagerDuty
 
 datadog
 ^^^^^^^
@@ -648,8 +677,20 @@ os
 - rpm_ostree_pkg - Install or uninstall overlay additional packages
 - yum_versionlock - Locks / unlocks a installed package(s) from being updated by yum package manager
 
+Source Control
+~~~~~~~~~~~~~~
+
+gitlab
+^^^^^^
+
+- gitlab_group_members - Manage group members on GitLab Server
+- gitlab_group_variable - Creates, updates, or deletes GitLab groups variables
+
 System
 ~~~~~~
 
+- iptables_state - Save iptables state into a file or restore it from a file
+- shutdown - Shut down a machine
 - ssh_config - Manage SSH config for user
 - sysrc - Manage FreeBSD using sysrc
+- sysupgrade - Manage OpenBSD system upgrades

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -980,25 +980,72 @@ releases:
     - description: Manages Datadog downtimes
       name: datadog_downtime
       namespace: monitoring.datadog
+    - description: Manage group members on GitLab Server
+      name: gitlab_group_members
+      namespace: source_control.gitlab
+    - description: Creates, updates, or deletes GitLab groups variables
+      name: gitlab_group_variable
+      namespace: source_control.gitlab
     - description: Manage FreeIPA password policies
       name: ipa_pwpolicy
       namespace: identity.ipa
+    - description: Save iptables state into a file or restore it from a file
+      name: iptables_state
+      namespace: system
+    - description: Launch a Nomad Job
+      name: nomad_job
+      namespace: clustering.nomad
+    - description: Get Nomad Jobs info
+      name: nomad_job_info
+      namespace: clustering.nomad
+    - description: Track a code or infrastructure change as a PagerDuty change event
+      name: pagerduty_change
+      namespace: monitoring
+    - description: Manage a user account on PagerDuty
+      name: pagerduty_user
+      namespace: monitoring
+    - description: Retrieve information about one or more Proxmox VE domains
+      name: proxmox_domain_info
+      namespace: cloud.misc
+    - description: Retrieve information about one or more Proxmox VE groups
+      name: proxmox_group_info
+      namespace: cloud.misc
     - description: Snapshot management of instances in Proxmox VE cluster
       name: proxmox_snap
+      namespace: cloud.misc
+    - description: Retrieve information about one or more Proxmox VE users
+      name: proxmox_user_info
       namespace: cloud.misc
     - description: Install or uninstall overlay additional packages
       name: rpm_ostree_pkg
       namespace: packaging.os
+    - description: Scaleway database backups management module
+      name: scaleway_database_backup
+      namespace: cloud.scaleway
+    - description: Shut down a machine
+      name: shutdown
+      namespace: system
     - description: Manage SSH config for user
       name: ssh_config
       namespace: system
     - description: Manage FreeBSD using sysrc
       name: sysrc
       namespace: system
+    - description: Manage OpenBSD system upgrades
+      name: sysupgrade
+      namespace: system
     - description: Locks / unlocks a installed package(s) from being updated by yum
         package manager
       name: yum_versionlock
       namespace: packaging.os
+    plugins:
+      inventory:
+      - description: Proxmox inventory source
+        name: proxmox
+        namespace: null
+      - description: StackPath Edge Computing inventory source
+        name: stackpath_compute
+        namespace: null
     release_date: '2021-01-28'
   2.0.1:
     changes:


### PR DESCRIPTION
##### SUMMARY
The 2.0.0 changelog claims to contain all changes since 1.0.0. It does, except the modules/plugins added in 1.1.0, 1.2.0 and 1.3.0.

Fixes #1933. (Fixed by using ansible-community/antsibull-changelog#52.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
