### PR TITLE
Adding another example for tss lookup

### DIFF
--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -85,7 +85,16 @@ EXAMPLES = r"""
             
 - hosts: localhost
   vars:
-      secret: "{{ lookup('community.general.tss', 102, base_url='https://secretserver.domain.com/SecretServer/', username='user.name', password='password') }}"
+      secret: >
+        {{
+            lookup(
+                'community.general.tss',
+                102,
+                base_url='https://secretserver.domain.com/SecretServer/',
+                username='user.name',
+                password='password'
+            )
+        }}
   tasks:
       - ansible.builtin.debug:
           msg: >

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -85,7 +85,7 @@ EXAMPLES = r"""
             
 - hosts: localhost
   vars:
-      secret: "{{ lookup('community.general.tss',102,base_url='https://secretserver.domain.com/SecretServer/',username='user.name',password='password') }}"
+      secret: "{{ lookup('community.general.tss', 102, base_url='https://secretserver.domain.com/SecretServer/', username='user.name', password='password') }}"
   tasks:
       - ansible.builtin.debug:
           msg: >

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -82,6 +82,18 @@ EXAMPLES = r"""
                 | items2dict(key_name='slug',
                              value_name='itemValue'))['password']
             }}
+            
+- hosts: localhost
+  vars:
+      secret: "{{ lookup('community.general.tss',102,base_url='https://secretserver.domain.com/SecretServer/',username='user.name',password='password') }}"
+  tasks:
+      - ansible.builtin.debug:
+          msg: >
+            the password is {{
+              (secret['items']
+                | items2dict(key_name='slug',
+                             value_name='itemValue'))['password']
+            }}
 """
 
 from ansible.errors import AnsibleError, AnsibleOptionsError

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -85,7 +85,7 @@ EXAMPLES = r"""
             
 - hosts: localhost
   vars:
-      secret: >
+      secret: >-
         {{
             lookup(
                 'community.general.tss',

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -82,7 +82,6 @@ EXAMPLES = r"""
                 | items2dict(key_name='slug',
                              value_name='itemValue'))['password']
             }}
-            
 - hosts: localhost
   vars:
       secret: >-

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -82,6 +82,7 @@ EXAMPLES = r"""
                 | items2dict(key_name='slug',
                              value_name='itemValue'))['password']
             }}
+
 - hosts: localhost
   vars:
       secret: >-


### PR DESCRIPTION
A more detailed example using self-hosted secrets server as investigated in #1943

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is only one example in the `tss` module which is very simple. Adding another, slightly more elaborate example which is likely to be used for self-hosted secrets servers.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tss