### PR TITLE
Allow tags strings containing commas in proxmox inventory plug-in

### DIFF
--- a/1949-proxmox-inventory-tags.yml
+++ b/1949-proxmox-inventory-tags.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- proxmox inventory plugin - enabled support for parsing qemu/lxc tags as list to be returned with facts (https://github.com/ansible-collections/community.general/pull/1949)

--- a/1949-proxmox-inventory-tags.yml
+++ b/1949-proxmox-inventory-tags.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- proxmox inventory plugin - enabled support for parsing qemu/lxc tags as list to be returned with facts (https://github.com/ansible-collections/community.general/pull/1949).

--- a/1949-proxmox-inventory-tags.yml
+++ b/1949-proxmox-inventory-tags.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- proxmox inventory plugin - enabled support for parsing qemu/lxc tags as list to be returned with facts (https://github.com/ansible-collections/community.general/pull/1949)
+- proxmox inventory plugin - enabled support for parsing qemu/lxc tags as list to be returned with facts (https://github.com/ansible-collections/community.general/pull/1949).

--- a/changelogs/fragments/1949-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/1949-proxmox-inventory-tags.yml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
 - proxmox inventory plugin - allowed proxomox tag strng to contain commas when returned as fact (https://github.com/ansible-collections/community.general/pull/1949).
+minor_changes:
+- proxmox inventory plugin - added tags_parsed fact containing tags parsed as a list (https://github.com/ansible-collections/community.general/pull/1949).

--- a/changelogs/fragments/1949-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/1949-proxmox-inventory-tags.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-- proxmox inventory plugin - allowed proxomox tag strng to contain commas when returned as fact (https://github.com/ansible-collections/community.general/pull/1949).
+- proxmox inventory plugin - allowed proxomox tag string to contain commas when returned as fact (https://github.com/ansible-collections/community.general/pull/1949).
 minor_changes:
 - proxmox inventory plugin - added tags_parsed fact containing tags parsed as a list (https://github.com/ansible-collections/community.general/pull/1949).

--- a/changelogs/fragments/1949-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/1949-proxmox-inventory-tags.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- proxmox inventory plugin - allowed proxomox tag strng to contain commas when returned as fact (https://github.com/ansible-collections/community.general/pull/1949).

--- a/changelogs/fragments/1949-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/1949-proxmox-inventory-tags.yml
@@ -2,4 +2,4 @@
 bugfixes:
 - proxmox inventory plugin - allowed proxomox tag string to contain commas when returned as fact (https://github.com/ansible-collections/community.general/pull/1949).
 minor_changes:
-- proxmox inventory plugin - added tags_parsed fact containing tags parsed as a list (https://github.com/ansible-collections/community.general/pull/1949).
+- proxmox inventory plugin - added ``tags_parsed`` fact containing tags parsed as a list (https://github.com/ansible-collections/community.general/pull/1949).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -230,11 +230,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 if config == 'rootfs' or config.startswith(('virtio', 'sata', 'ide', 'scsi')):
                     value = ('disk_image=' + value)
 
-                #Additional field containing parsed tags as list
+                # Additional field containing parsed tags as list
                 if config == 'tags':
                     parsed_key = self.to_safe('%s%s' % (key, "_parsed"))
                     parsed_value = [tag.strip() for tag in value.split(",")]
-                    self.inventory.set_variable(name, parsed_key , parsed_value)
+                    self.inventory.set_variable(name, parsed_key, parsed_value)
 
                 if not (isinstance(value, int) or ',' not in value or config in plaintext_configs):
                     # split off strings with commas to a dict

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -217,6 +217,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         vmtype_key = self.to_safe('%s%s' % (self.get_option('facts_prefix'), vmtype_key.lower()))
         self.inventory.set_variable(name, vmtype_key, vmtype)
 
+        plaintext_configs = [
+            'tags',
+        ]
+
         for config in ret:
             key = config
             key = self.to_safe('%s%s' % (self.get_option('facts_prefix'), key.lower()))
@@ -226,7 +230,13 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 if config == 'rootfs' or config.startswith(('virtio', 'sata', 'ide', 'scsi')):
                     value = ('disk_image=' + value)
 
-                if config != 'tags' and not (isinstance(value, int) or ',' not in value):
+                #Additional field containing parsed tags as list
+                if config == 'tags':
+                    parsed_key = self.to_safe('%s%s' % (key, "_parsed"))
+                    parsed_value = [tag.strip() for tag in value.split(",")]
+                    self.inventory.set_variable(name, parsed_key , parsed_value)
+
+                if not (isinstance(value, int) or ',' not in value or config in plaintext_configs):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed
                     try:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -226,11 +226,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 if config == 'rootfs' or config.startswith(('virtio', 'sata', 'ide', 'scsi')):
                     value = ('disk_image=' + value)
 
-                # Parse Proxmox tag string into list
-                if config == 'tags':
-                    value = [tag.strip() for tag in value.split(",")]
-
-                if not (isinstance(value, int) or ',' not in value):
+                if config != 'tags' and not (isinstance(value, int) or ',' not in value):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed
                     try:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -236,7 +236,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                     parsed_value = [tag.strip() for tag in value.split(",")]
                     self.inventory.set_variable(name, parsed_key, parsed_value)
 
-                if not (isinstance(value, int) or ',' not in value or config in plaintext_configs):
+                if not (isinstance(value, int) or ',' not in value):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed
                     try:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -226,6 +226,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 if config == 'rootfs' or config.startswith(('virtio', 'sata', 'ide', 'scsi')):
                     value = ('disk_image=' + value)
 
+                # Parse Proxmox tag string into list
+                if config == 'tags':
+                    value = [tag.strip() for tag in value.split(",")]
+
                 if not (isinstance(value, int) or ',' not in value):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -71,7 +71,8 @@ def get_json(url):
                  "status": "running",
                  "vmid": "100",
                  "disk": "1000",
-                 "uptime": 1000}]
+                 "uptime": 1000,
+                 "tags": "test, tags, ..."}]
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu":
         # _get_qemu_per_node
         return [{"name": "test-qemu",
@@ -105,7 +106,8 @@ def get_json(url):
                  "vmid": "9001",
                  "uptime": 0,
                  "disk": 0,
-                 "status": "stopped"}]
+                 "status": "stopped",
+                 "tags": "test, tags, ..."}]
     elif url == "https://localhost:8006/api2/json/pools/test":
         # _get_members_per_pool
         return {"members": [{"uptime": 1000,

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -72,7 +72,7 @@ def get_json(url):
                  "vmid": "100",
                  "disk": "1000",
                  "uptime": 1000,
-                 "tags": "test, tags, ..."}]
+                 "tags": "test, tags, here"}]
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu":
         # _get_qemu_per_node
         return [{"name": "test-qemu",
@@ -107,7 +107,7 @@ def get_json(url):
                  "uptime": 0,
                  "disk": 0,
                  "status": "stopped",
-                 "tags": "test, tags, ..."}]
+                 "tags": "test, tags, here"}]
     elif url == "https://localhost:8006/api2/json/pools/test":
         # _get_members_per_pool
         return {"members": [{"uptime": 1000,


### PR DESCRIPTION
##### SUMMARY
Allowing proxmox tags strings containing commas to be passed as facts

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION
The current behavior of the proxmox inventory plugin will attempt to parse values containing commas from the PVE API configs endpoint as dictionaries. However tags strings disallow '=' characters which will always cause parsing to fail for tags strings presented as comma separated list. This change will explicitly allow the 'tags' config to bypass dict parsing.