### PR TITLE
[stable-1] fix docker_container tests

### DIFF
--- a/tests/integration/targets/docker_container/filter_plugins/ipaddr_tools.py
+++ b/tests/integration/targets/docker_container/filter_plugins/ipaddr_tools.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import ipaddress
+from ansible_collections.community.crypto.plugins.module_utils.compat import ipaddress
 
 
 def _normalize_ipaddr(ipaddr):


### PR DESCRIPTION
##### SUMMARY
A filter plugin included in the docker_container test uses ipaddress from ansible.netcommon, which has been removed in the 2.0.0 release yesterday. Switches to the vendored copy in community.crypto.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
docker_container
