### PR TITLE
Tidy up sanity checks ignore lines modules (batch 7) 

### DIFF
--- a/changelogs/fragments/1970-valmod-batch7.yml
+++ b/changelogs/fragments/1970-valmod-batch7.yml
@@ -1,0 +1,17 @@
+minor_changes:
+  - heroku_collaborator - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - linode_v4 - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - one_host - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - one_image_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - one_vm - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - scaleway_compute - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - scaleway_lb - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - manageiq_alert_profiles - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - manageiq_policies - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - manageiq_tags - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - oneview_datacenter_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - oneview_enclosure_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - oneview_ethernet_network_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+  - oneview_network_set_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
+bugfixes:
+  - manageiq_provider - wrapped ``dict.keys()`` with ``list`` for use in ``choices`` setting (https://github.com/ansible-collections/community.general/pull/1970).

--- a/changelogs/fragments/1970-valmod-batch7.yml
+++ b/changelogs/fragments/1970-valmod-batch7.yml
@@ -15,3 +15,4 @@ minor_changes:
   - oneview_network_set_info - elements of list parameters are now validated (https://github.com/ansible-collections/community.general/pull/1970).
 bugfixes:
   - manageiq_provider - wrapped ``dict.keys()`` with ``list`` for use in ``choices`` setting (https://github.com/ansible-collections/community.general/pull/1970).
+  - packet_volume_attachment - removed extraneous ``print`` call - old debug? (https://github.com/ansible-collections/community.general/pull/1970).

--- a/plugins/modules/cloud/heroku/heroku_collaborator.py
+++ b/plugins/modules/cloud/heroku/heroku_collaborator.py
@@ -26,6 +26,7 @@ options:
       - Heroku API key
   apps:
     type: list
+    elements: dict
     description:
       - List of Heroku App names
     required: true
@@ -109,7 +110,7 @@ def main():
     argument_spec = HerokuHelper.heroku_argument_spec()
     argument_spec.update(
         user=dict(required=True, type='str'),
-        apps=dict(required=True, type='list'),
+        apps=dict(required=True, type='list', elements='dict'),
         suppress_invitation=dict(default=False, type='bool'),
         state=dict(default='present', type='str', choices=['present', 'absent']),
     )

--- a/plugins/modules/cloud/heroku/heroku_collaborator.py
+++ b/plugins/modules/cloud/heroku/heroku_collaborator.py
@@ -26,7 +26,7 @@ options:
       - Heroku API key
   apps:
     type: list
-    elements: dict
+    elements: str
     description:
       - List of Heroku App names
     required: true
@@ -110,7 +110,7 @@ def main():
     argument_spec = HerokuHelper.heroku_argument_spec()
     argument_spec.update(
         user=dict(required=True, type='str'),
-        apps=dict(required=True, type='list', elements='dict'),
+        apps=dict(required=True, type='list', elements='str'),
         suppress_invitation=dict(default=False, type='bool'),
         state=dict(default='present', type='str', choices=['present', 'absent']),
     )

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -63,6 +63,7 @@ options:
         U(https://www.linode.com/docs/api/tags/).
     required: false
     type: list
+    elements: str
   root_pass:
     description:
       - The password for the root user. If not specified, one will be
@@ -75,6 +76,7 @@ options:
       - A list of SSH public key parts to deploy for the root user.
     required: false
     type: list
+    elements: str
   state:
     description:
       - The desired instance state.
@@ -240,12 +242,12 @@ def initialise_module():
                 no_log=True,
                 fallback=(env_fallback, ['LINODE_ACCESS_TOKEN']),
             ),
-            authorized_keys=dict(type='list', required=False),
+            authorized_keys=dict(type='list', elements='str', required=False),
             group=dict(type='str', required=False),
             image=dict(type='str', required=False),
             region=dict(type='str', required=False),
             root_pass=dict(type='str', required=False, no_log=True),
-            tags=dict(type='list', required=False),
+            tags=dict(type='list', elements='str', required=False),
             type=dict(type='str', required=False),
             stackscript_id=dict(type='int', required=False),
             stackscript_data=dict(type='dict', required=False),

--- a/plugins/modules/cloud/opennebula/one_host.py
+++ b/plugins/modules/cloud/opennebula/one_host.py
@@ -66,6 +66,7 @@ options:
         description:
             - The labels for this host.
         type: list
+        elements: str
     template:
         description:
             - The template or attribute changes to merge into the host template.
@@ -130,7 +131,7 @@ class HostModule(OpenNebulaModule):
             vmm_mad_name=dict(type='str', default="kvm"),
             cluster_id=dict(type='int', default=0),
             cluster_name=dict(type='str'),
-            labels=dict(type='list'),
+            labels=dict(type='list', elements='str'),
             template=dict(type='dict', aliases=['attributes']),
         )
 

--- a/plugins/modules/cloud/opennebula/one_image_info.py
+++ b/plugins/modules/cloud/opennebula/one_image_info.py
@@ -56,6 +56,7 @@ options:
       - A list of images ids whose facts you want to gather.
     aliases: ['id']
     type: list
+    elements: str
   name:
     description:
       - A C(name) of the image whose facts will be gathered.
@@ -253,7 +254,7 @@ def main():
         "api_url": {"required": False, "type": "str"},
         "api_username": {"required": False, "type": "str"},
         "api_password": {"required": False, "type": "str", "no_log": True},
-        "ids": {"required": False, "aliases": ['id'], "type": "list"},
+        "ids": {"required": False, "aliases": ['id'], "type": "list", "elements": "str"},
         "name": {"required": False, "type": "str"},
     }
 
@@ -273,9 +274,6 @@ def main():
     name = params.get('name')
     client = pyone.OneServer(auth.url, session=auth.username + ':' + auth.password)
 
-    result = {'images': []}
-    images = []
-
     if ids:
         images = get_images_by_ids(module, client, ids)
     elif name:
@@ -283,8 +281,7 @@ def main():
     else:
         images = get_all_images(client).IMAGE
 
-    for image in images:
-        result['images'].append(get_image_info(image))
+    result = [get_image_info(image) for image in images]
 
     module.exit_json(**result)
 

--- a/plugins/modules/cloud/opennebula/one_image_info.py
+++ b/plugins/modules/cloud/opennebula/one_image_info.py
@@ -281,7 +281,9 @@ def main():
     else:
         images = get_all_images(client).IMAGE
 
-    result = [get_image_info(image) for image in images]
+    result = {
+        'images': [get_image_info(image) for image in images],
+    }
 
     module.exit_json(**result)
 

--- a/plugins/modules/cloud/opennebula/one_vm.py
+++ b/plugins/modules/cloud/opennebula/one_vm.py
@@ -72,6 +72,7 @@ options:
       - A list of instance ids used for states':' C(absent), C(running), C(rebooted), C(poweredoff)
     aliases: ['ids']
     type: list
+    elements: str
   state:
     description:
       - C(present) - create instances from a template specified with C(template_id)/C(template_name).
@@ -120,6 +121,7 @@ options:
       - C(state) of instances with these labels.
     default: []
     type: list
+    elements: str
   count_attributes:
     description:
       - A dictionary of key/value attributes that can only be used with
@@ -134,6 +136,7 @@ options:
       - This can be expressed in multiple ways and is shown in the EXAMPLES
       - section.
     type: list
+    elements: str
   count:
     description:
       - Number of instances to launch
@@ -168,6 +171,7 @@ options:
       - NOTE':' If The Template hats Multiple Disks the Order of the Sizes is
       - matched against the order specified in C(template_id)/C(template_name).
     type: list
+    elements: str
   cpu:
     description:
       - Percentage of CPU divided by 100 required for the new instance. Half a
@@ -182,6 +186,7 @@ options:
       - A list of dictionaries with network parameters. See examples for more details.
     default: []
     type: list
+    elements: dict
   disk_saveas:
     description:
       - Creates an image from a VM disk.
@@ -1349,7 +1354,7 @@ def main():
         "api_url": {"required": False, "type": "str"},
         "api_username": {"required": False, "type": "str"},
         "api_password": {"required": False, "type": "str", "no_log": True},
-        "instance_ids": {"required": False, "aliases": ['ids'], "type": "list"},
+        "instance_ids": {"required": False, "aliases": ['ids'], "type": "list", "elements": "str"},
         "template_name": {"required": False, "type": "str"},
         "template_id": {"required": False, "type": "int"},
         "vm_start_on_hold": {"default": False, "type": "bool"},
@@ -1367,16 +1372,16 @@ def main():
         "memory": {"required": False, "type": "str"},
         "cpu": {"required": False, "type": "float"},
         "vcpu": {"required": False, "type": "int"},
-        "disk_size": {"required": False, "type": "list"},
+        "disk_size": {"required": False, "type": "list", "elements": "str"},
         "datastore_name": {"required": False, "type": "str"},
         "datastore_id": {"required": False, "type": "int"},
-        "networks": {"default": [], "type": "list"},
+        "networks": {"default": [], "type": "list", "elements": "dict"},
         "count": {"default": 1, "type": "int"},
         "exact_count": {"required": False, "type": "int"},
         "attributes": {"default": {}, "type": "dict"},
         "count_attributes": {"required": False, "type": "dict"},
-        "labels": {"default": [], "type": "list"},
-        "count_labels": {"required": False, "type": "list"},
+        "labels": {"default": [], "type": "list", "elements": "str"},
+        "count_labels": {"required": False, "type": "list", "elements": "str"},
         "disk_saveas": {"type": "dict"},
         "persistent": {"default": False, "type": "bool"}
     }

--- a/plugins/modules/cloud/opennebula/one_vm.py
+++ b/plugins/modules/cloud/opennebula/one_vm.py
@@ -72,7 +72,7 @@ options:
       - A list of instance ids used for states':' C(absent), C(running), C(rebooted), C(poweredoff)
     aliases: ['ids']
     type: list
-    elements: str
+    elements: int
   state:
     description:
       - C(present) - create instances from a template specified with C(template_id)/C(template_name).
@@ -1354,7 +1354,7 @@ def main():
         "api_url": {"required": False, "type": "str"},
         "api_username": {"required": False, "type": "str"},
         "api_password": {"required": False, "type": "str", "no_log": True},
-        "instance_ids": {"required": False, "aliases": ['ids'], "type": "list", "elements": "str"},
+        "instance_ids": {"required": False, "aliases": ['ids'], "type": "list", "elements": "int"},
         "template_name": {"required": False, "type": "str"},
         "template_id": {"required": False, "type": "int"},
         "vm_start_on_hold": {"default": False, "type": "bool"},

--- a/plugins/modules/cloud/packet/packet_volume_attachment.py
+++ b/plugins/modules/cloud/packet/packet_volume_attachment.py
@@ -181,7 +181,6 @@ def do_detach(packet_conn, vol, dev_id=None):
         return (dev_id is None) or (a['device']['id'] == dev_id)
     for a in vol['attachments']:
         if dev_match(a):
-            print(a['href'])
             packet_conn.call_api(a['href'], type="DELETE")
 
 

--- a/plugins/modules/cloud/scaleway/scaleway_compute.py
+++ b/plugins/modules/cloud/scaleway/scaleway_compute.py
@@ -70,6 +70,7 @@ options:
 
   tags:
     type: list
+    elements: str
     description:
     - List of tags to apply to the instance (5 max)
     required: false
@@ -652,7 +653,7 @@ def main():
         enable_ipv6=dict(default=False, type="bool"),
         public_ip=dict(default="absent"),
         state=dict(choices=list(state_strategy.keys()), default='present'),
-        tags=dict(type="list", default=[]),
+        tags=dict(type="list", elements="str", default=[]),
         organization=dict(required=True),
         wait=dict(type="bool", default=False),
         wait_timeout=dict(type="int", default=300),

--- a/plugins/modules/cloud/scaleway/scaleway_lb.py
+++ b/plugins/modules/cloud/scaleway/scaleway_lb.py
@@ -63,6 +63,7 @@ options:
 
   tags:
     type: list
+    elements: str
     description:
     - List of tags to apply to the load-balancer
 
@@ -338,7 +339,7 @@ def main():
         description=dict(required=True),
         region=dict(required=True, choices=SCALEWAY_REGIONS),
         state=dict(choices=list(state_strategy.keys()), default='present'),
-        tags=dict(type="list", default=[]),
+        tags=dict(type="list", elements="str", default=[]),
         organization_id=dict(required=True),
         wait=dict(type="bool", default=False),
         wait_timeout=dict(type="int", default=300),

--- a/plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py
@@ -40,6 +40,7 @@ options:
               'ExtManagementSystem', 'MiddlewareServer']
   alerts:
     type: list
+    elements: str
     description:
       - List of alert descriptions to assign to this profile.
       - Required if state is "present"
@@ -257,7 +258,7 @@ def main():
                                                 'EmsCluster',
                                                 'ExtManagementSystem',
                                                 'MiddlewareServer']),
-        alerts=dict(type='list'),
+        alerts=dict(type='list', elements='str'),
         notes=dict(type='str'),
         state=dict(default='present', choices=['present', 'absent']),
     )

--- a/plugins/modules/remote_management/manageiq/manageiq_policies.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_policies.py
@@ -31,6 +31,7 @@ options:
     default: 'present'
   policy_profiles:
     type: list
+    elements: dict
     description:
       - list of dictionaries, each includes the policy_profile 'name' key.
       - required if state is present or absent.
@@ -301,7 +302,7 @@ class ManageIQPolicies(object):
 def main():
     actions = {'present': 'assign', 'absent': 'unassign', 'list': 'list'}
     argument_spec = dict(
-        policy_profiles=dict(type='list'),
+        policy_profiles=dict(type='list', elements='dict'),
         resource_id=dict(required=False, type='int'),
         resource_name=dict(required=False, type='str'),
         resource_type=dict(required=True, type='str',

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -829,7 +829,7 @@ def main():
         azure_tenant_id=dict(aliases=['keystone_v3_domain_id']),
         tenant_mapping_enabled=dict(default=False, type='bool'),
         api_version=dict(choices=['v2', 'v3']),
-        type=dict(choices=supported_providers().keys()),
+        type=dict(choices=list(supported_providers().keys())),
     )
     # add the manageiq connection arguments to the arguments
     argument_spec.update(manageiq_argument_spec())

--- a/plugins/modules/remote_management/manageiq/manageiq_tags.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_tags.py
@@ -31,6 +31,7 @@ options:
     default: 'present'
   tags:
     type: list
+    elements: dict
     description:
       - tags - list of dictionaries, each includes 'name' and 'category' keys.
       - required if state is present or absent.
@@ -261,7 +262,7 @@ class ManageIQTags(object):
 def main():
     actions = {'present': 'assign', 'absent': 'unassign', 'list': 'list'}
     argument_spec = dict(
-        tags=dict(type='list'),
+        tags=dict(type='list', elements='dict'),
         resource_id=dict(required=False, type='int'),
         resource_name=dict(required=False, type='str'),
         resource_type=dict(required=True, type='str',

--- a/plugins/modules/remote_management/oneview/oneview_datacenter_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_datacenter_info.py
@@ -27,6 +27,8 @@ options:
     options:
       description:
         - "Retrieve additional information. Options available: 'visualContent'."
+      type: list
+      elements: str
 
 extends_documentation_fragment:
 - community.general.oneview
@@ -108,7 +110,7 @@ from ansible_collections.community.general.plugins.module_utils.oneview import O
 class DatacenterInfoModule(OneViewModuleBase):
     argument_spec = dict(
         name=dict(type='str'),
-        options=dict(type='list'),
+        options=dict(type='list', elements='str'),
         params=dict(type='dict')
     )
 

--- a/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
@@ -29,6 +29,8 @@ options:
         - "List with options to gather additional information about an Enclosure and related resources.
           Options allowed: C(script), C(environmentalConfiguration), and C(utilization). For the option C(utilization),
           you can provide specific parameters."
+      type: list
+      elements: dict
 
 extends_documentation_fragment:
 - community.general.oneview
@@ -153,7 +155,11 @@ from ansible_collections.community.general.plugins.module_utils.oneview import O
 
 
 class EnclosureInfoModule(OneViewModuleBase):
-    argument_spec = dict(name=dict(type='str'), options=dict(type='list'), params=dict(type='dict'))
+    argument_spec = dict(
+        name=dict(type='str'),
+        options=dict(type='list', elements='dict'),
+        params=dict(type='dict')
+    )
 
     def __init__(self):
         super(EnclosureInfoModule, self).__init__(additional_arg_spec=self.argument_spec)

--- a/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_enclosure_info.py
@@ -30,7 +30,7 @@ options:
           Options allowed: C(script), C(environmentalConfiguration), and C(utilization). For the option C(utilization),
           you can provide specific parameters."
       type: list
-      elements: dict
+      elements: raw
 
 extends_documentation_fragment:
 - community.general.oneview
@@ -157,7 +157,7 @@ from ansible_collections.community.general.plugins.module_utils.oneview import O
 class EnclosureInfoModule(OneViewModuleBase):
     argument_spec = dict(
         name=dict(type='str'),
-        options=dict(type='list', elements='dict'),
+        options=dict(type='list', elements='raw'),
         params=dict(type='dict')
     )
 

--- a/plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py
@@ -27,6 +27,8 @@ options:
       description:
         - "List with options to gather additional information about an Ethernet Network and related resources.
           Options allowed: C(associatedProfiles) and C(associatedUplinkGroups)."
+      type: list
+      elements: str
 extends_documentation_fragment:
 - community.general.oneview
 - community.general.oneview.factsparams
@@ -106,7 +108,7 @@ from ansible_collections.community.general.plugins.module_utils.oneview import O
 class EthernetNetworkInfoModule(OneViewModuleBase):
     argument_spec = dict(
         name=dict(type='str'),
-        options=dict(type='list'),
+        options=dict(type='list', elements='str'),
         params=dict(type='dict')
     )
 

--- a/plugins/modules/remote_management/oneview/oneview_network_set_info.py
+++ b/plugins/modules/remote_management/oneview/oneview_network_set_info.py
@@ -29,6 +29,8 @@ options:
         - "List with options to gather information about Network Set.
           Option allowed: C(withoutEthernet).
           The option C(withoutEthernet) retrieves the list of network_sets excluding Ethernet networks."
+      type: list
+      elements: str
 
 extends_documentation_fragment:
 - community.general.oneview
@@ -127,7 +129,7 @@ from ansible_collections.community.general.plugins.module_utils.oneview import O
 class NetworkSetInfoModule(OneViewModuleBase):
     argument_spec = dict(
         name=dict(type='str'),
-        options=dict(type='list'),
+        options=dict(type='list', elements='str'),
         params=dict(type='dict'),
     )
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -62,7 +62,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-list-no
 plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_volume_attachment.py pylint:ansible-bad-function
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
 plugins/modules/cloud/rackspace/rax.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -3,11 +3,8 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/heroku/heroku_collaborator.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/linode/linode.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/linode/linode.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/linode/linode.py validate-modules:undocumented-parameter
-plugins/modules/cloud/linode/linode_v4.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
@@ -15,9 +12,6 @@ plugins/modules/cloud/online/online_server_facts.py validate-modules:return-synt
 plugins/modules/cloud/online/online_server_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_api_facts.py validate-modules:parameter-list-no-elements
@@ -79,12 +73,10 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_mon_notification_plan.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax_scaling_group.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/scaleway/scaleway_compute.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/scaleway/scaleway_image_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_image_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_ip_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_ip_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/scaleway/scaleway_lb.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/scaleway/scaleway_organization_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_security_group_facts.py validate-modules:return-syntax-error
@@ -107,11 +99,11 @@ plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-type
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-required-mismatch
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:missing-suboption-docs
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:undocumented-parameter
+plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-choices-do-not-match-spec  # missing docs on suboptions
+plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:doc-required-mismatch          # missing docs on suboptions
+plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:missing-suboption-docs         # missing docs on suboptions
+plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:parameter-type-not-in-doc      # missing docs on suboptions
+plugins/modules/cloud/xenserver/xenserver_guest.py validate-modules:undocumented-parameter         # missing docs on suboptions
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
@@ -137,25 +129,18 @@ plugins/modules/packaging/os/xbps.py validate-modules:parameter-invalid
 plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-modules:parameter-list-no-elements
-plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-list-no-elements
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-state-invalid-choice
-plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_ethernet_network.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_ethernet_network.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_fc_network.py validate-modules:doc-missing-type
@@ -176,7 +161,6 @@ plugins/modules/remote_management/oneview/oneview_logical_interconnect_group_inf
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:doc-missing-type
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_san_manager.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -3,6 +3,7 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
+plugins/modules/cloud/linode/linode.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/linode/linode.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/linode/linode.py validate-modules:undocumented-parameter
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -2,11 +2,8 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
-plugins/modules/cloud/heroku/heroku_collaborator.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/linode/linode.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/linode/linode.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/linode/linode.py validate-modules:undocumented-parameter
-plugins/modules/cloud/linode/linode_v4.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
@@ -14,9 +11,6 @@ plugins/modules/cloud/online/online_server_facts.py validate-modules:return-synt
 plugins/modules/cloud/online/online_server_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/online/online_user_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/opennebula/one_host.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_image_info.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/opennebula/one_vm.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_affinity_label_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/ovirt/ovirt_api_facts.py validate-modules:parameter-list-no-elements
@@ -78,12 +72,10 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_mon_notification_plan.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax_scaling_group.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/scaleway/scaleway_compute.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/scaleway/scaleway_image_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_image_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_ip_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_ip_info.py validate-modules:return-syntax-error
-plugins/modules/cloud/scaleway/scaleway_lb.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/scaleway/scaleway_organization_facts.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/scaleway/scaleway_security_group_facts.py validate-modules:return-syntax-error
@@ -136,20 +128,14 @@ plugins/modules/packaging/os/xbps.py validate-modules:parameter-invalid
 plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py validate-modules:parameter-list-no-elements
-plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:invalid-ansiblemodule-schema
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-list-no-elements
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-state-invalid-choice
-plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_ethernet_network.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -2,6 +2,7 @@ plugins/module_utils/compat/ipaddress.py no-assert
 plugins/module_utils/compat/ipaddress.py no-unicode-literals
 plugins/module_utils/_mount.py future-import-boilerplate
 plugins/module_utils/_mount.py metaclass-boilerplate
+plugins/modules/cloud/linode/linode.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/linode/linode.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/linode/linode.py validate-modules:undocumented-parameter
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -140,7 +140,6 @@ plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-mod
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_ethernet_network.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_ethernet_network.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_fc_network.py validate-modules:doc-missing-type
@@ -161,7 +160,6 @@ plugins/modules/remote_management/oneview/oneview_logical_interconnect_group_inf
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:doc-missing-type
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_network_set.py validate-modules:undocumented-parameter
-plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:parameter-list-no-elements
 plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_network_set_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_san_manager.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -61,7 +61,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-list-no
 plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
-plugins/modules/cloud/packet/packet_volume_attachment.py pylint:ansible-bad-function
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
 plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
 plugins/modules/cloud/rackspace/rax.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -160,10 +160,10 @@ plugins/modules/packaging/os/xbps.py validate-modules:parameter-invalid
 plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc
-plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
+plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_datacenter_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/oneview/oneview_enclosure_info.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
##### SUMMARY
Tidy up some validation checks - `validate-modules:parameter-list-no-elements` - on a number of modules.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/remote_management/oneview/oneview_enclosure_info.py
plugins/modules/remote_management/oneview/oneview_datacenter_info.py
plugins/modules/remote_management/oneview/oneview_ethernet_network_info.py
plugins/modules/remote_management/oneview/oneview_network_set_info.py
plugins/modules/cloud/scaleway/scaleway_compute.py
plugins/modules/cloud/scaleway/scaleway_lb.py
plugins/modules/cloud/opennebula/one_vm.py
plugins/modules/cloud/opennebula/one_image_info.py
plugins/modules/cloud/opennebula/one_host.py
plugins/modules/remote_management/manageiq/manageiq_tags.py
plugins/modules/remote_management/manageiq/manageiq_alert_profiles.py
plugins/modules/remote_management/manageiq/manageiq_policies.py
plugins/modules/remote_management/manageiq/manageiq_provider.py
plugins/modules/cloud/linode/linode_v4.py
plugins/modules/cloud/heroku/heroku_collaborator.py
