### PR TITLE
jira - changing the logic for transition

### DIFF
--- a/changelogs/fragments/1978-jira-transition-logic.yml
+++ b/changelogs/fragments/1978-jira-transition-logic.yml
@@ -1,2 +1,4 @@
 bugfixes:
   - jira - fixed fields' update in ticket transitions (https://github.com/ansible-collections/community.general/issues/818).
+minor_changes:
+  - jira - added parameter ``accountId`` for compatibility with recent versions of JIRA (https://github.com/ansible-collections/community.general/issues/818).

--- a/changelogs/fragments/1978-jira-transition-logic.yml
+++ b/changelogs/fragments/1978-jira-transition-logic.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - jira - fixed fields' update in ticket transitions (https://github.com/ansible-collections/community.general/issues/818).
 minor_changes:
-  - jira - added parameter ``accountId`` for compatibility with recent versions of JIRA (https://github.com/ansible-collections/community.general/issues/818).
+  - jira - added parameter ``accountId`` for compatibility with recent versions of JIRA (https://github.com/ansible-collections/community.general/issues/818, https://github.com/ansible-collections/community.general/pull/1978).

--- a/changelogs/fragments/1978-jira-transition-logic.yml
+++ b/changelogs/fragments/1978-jira-transition-logic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - jira - fixed fields' update in ticket transitions (https://github.com/ansible-collections/community.general/issues/818).

--- a/changelogs/fragments/1978-jira-transition-logic.yml
+++ b/changelogs/fragments/1978-jira-transition-logic.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - jira - fixed fields' update in ticket transitions (https://github.com/ansible-collections/community.general/issues/818).
 minor_changes:
-  - jira - added parameter ``accountId`` for compatibility with recent versions of JIRA (https://github.com/ansible-collections/community.general/issues/818, https://github.com/ansible-collections/community.general/pull/1978).
+  - jira - added parameter ``account_id`` for compatibility with recent versions of JIRA (https://github.com/ansible-collections/community.general/issues/818, https://github.com/ansible-collections/community.general/pull/1978).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -96,14 +96,15 @@ options:
     required: false
     description:
      - Sets the the assignee when C(operation) is I(create), I(transition) or I(edit).
-     - Recent versions of JIRA no longer accept an user name as an user identifier. In that case, use C(accountId) instead.
+     - Recent versions of JIRA no longer accept an user name as an user identifier. In that case, use C(account_id) instead.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 
-  accountId:
+  account_id:
     type: str
     description:
      - Sets the account identifier for the assignee when C(operation) is I(create), I(transition) or I(edit).
      - Note that JIRA may not allow changing field values on specific transitions or states.
+    version_added: 2.5.0
 
   linktype:
     type: str
@@ -295,8 +296,8 @@ EXAMPLES = r"""
     inwardissue: HSP-1
     outwardissue: MKY-1
 
-# Transition an issue by target status
-- name: Close the issue
+# Transition an issue
+- name: Resolve the issue
   community.general.jira:
     uri: '{{ server }}'
     username: '{{ user }}'
@@ -304,6 +305,7 @@ EXAMPLES = r"""
     issue: '{{ issue.meta.key }}'
     operation: transition
     status: Resolve Issue
+    account_id: 112233445566778899aabbcc
     fields:
       resolution:
         name: Done
@@ -510,7 +512,7 @@ def main():
             maxresults=dict(type='int'),
             timeout=dict(type='float', default=10),
             validate_certs=dict(default=True, type='bool'),
-            accountId=dict(type='str'),
+            account_id=dict(type='str'),
         ),
         required_if=(
             ('operation', 'create', ['project', 'issuetype', 'summary']),
@@ -520,7 +522,7 @@ def main():
             ('operation', 'link', ['linktype', 'inwardissue', 'outwardissue']),
             ('operation', 'search', ['jql']),
         ),
-        mutually_exclusive=[('assignee', 'accountId')],
+        mutually_exclusive=[('assignee', 'account_id')],
         supports_check_mode=False
     )
 
@@ -532,8 +534,8 @@ def main():
     passwd = module.params['password']
     if module.params['assignee']:
         module.params['fields']['assignee'] = {'name': module.params['assignee']}
-    if module.params['accountId']:
-        module.params['fields']['assignee'] = {'accountId': module.params['accountId']}
+    if module.params['account_id']:
+        module.params['fields']['assignee'] = {'account_id': module.params['accountId']}
 
     if not uri.endswith('/'):
         uri = uri + '/'

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -535,7 +535,7 @@ def main():
     if module.params['assignee']:
         module.params['fields']['assignee'] = {'name': module.params['assignee']}
     if module.params['account_id']:
-        module.params['fields']['assignee'] = {'account_id': module.params['accountId']}
+        module.params['fields']['assignee'] = {'accountId': module.params['account_id']}
 
     if not uri.endswith('/'):
         uri = uri + '/'

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -450,7 +450,7 @@ def transition(restbase, user, passwd, params):
     if params['comment'] is not None:
         data.update({"update": {
             "comment": [{
-                "add": {"body": "Bug has been fixed."}
+                "add": {"body": params['comment']}
             }],
         }})
 

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -96,7 +96,7 @@ options:
     required: false
     description:
      - Sets the the assignee when I(operation) is C(create), C(transition) or C(edit).
-     - Recent versions of JIRA no longer accept an user name as an user identifier. In that case, use C(account_id) instead.
+     - Recent versions of JIRA no longer accept a user name as a user identifier. In that case, use I(account_id) instead.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 
   account_id:

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -89,7 +89,7 @@ options:
     type: str
     required: false
     description:
-     - Only used when C(operation) is I(transition), and a bit of aa misnomer, it actually refers to the transition name.
+     - Only used when I(operation) is C(transition), and a bit of a misnomer, it actually refers to the transition name.
 
   assignee:
     type: str

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -443,10 +443,13 @@ def transition(restbase, user, passwd, params):
     fields = dict(params['fields'])
     if params['summary'] is not None:
         fields.update({'summary': params['summary']})
+    if params['description'] is not None:
+        fields.update({'description': params['description']})
+
     # Perform it
     url = restbase + '/issue/' + params['issue'] + "/transitions"
     data = {'transition': {"id": tid},
-            'fields': params['fields']}
+            'fields': fields}
     if params['comment'] is not None:
         data.update({"update": {
             "comment": [{

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -164,7 +164,7 @@ options:
 
 notes:
   - "Currently this only works with basic-auth."
-  - "To use with JIRA Cloud, pass the login e-mail as the C(username) and the API token as C(password)."
+  - "To use with JIRA Cloud, pass the login e-mail as the I(username) and the API token as I(password)."
 
 author:
 - "Steve Smith (@tarka)"

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -440,10 +440,19 @@ def transition(restbase, user, passwd, params):
     if not tid:
         raise ValueError("Failed find valid transition for '%s'" % target)
 
+    fields = dict(params['fields'])
+    if params['summary'] is not None:
+        fields.update({'summary': params['summary']})
     # Perform it
     url = restbase + '/issue/' + params['issue'] + "/transitions"
     data = {'transition': {"id": tid},
-            'update': params['fields']}
+            'fields': params['fields']}
+    if params['comment'] is not None:
+        data.update({"update": {
+            "comment": [{
+                "add": {"body": "Bug has been fixed."}
+            }],
+        }})
 
     return True, post(url, user, passwd, params['timeout'], data)
 

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -102,7 +102,7 @@ options:
   account_id:
     type: str
     description:
-     - Sets the account identifier for the assignee when C(operation) is I(create), I(transition) or I(edit).
+     - Sets the account identifier for the assignee when I(operation) is C(create), C(transition) or C(edit).
      - Note that JIRA may not allow changing field values on specific transitions or states.
     version_added: 2.5.0
 

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -95,7 +95,7 @@ options:
     type: str
     required: false
     description:
-     - Sets the the assignee when C(operation) is I(create), I(transition) or I(edit).
+     - Sets the the assignee when I(operation) is C(create), C(transition) or C(edit).
      - Recent versions of JIRA no longer accept an user name as an user identifier. In that case, use C(account_id) instead.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 

--- a/tests/integration/targets/jira/aliases
+++ b/tests/integration/targets/jira/aliases
@@ -1,0 +1,2 @@
+unsupported
+shippable/posix/group3

--- a/tests/integration/targets/jira/tasks/main.yml
+++ b/tests/integration/targets/jira/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- community.general.jira:
+    uri: "{{ uri }}"
+    username: "{{ user }}"
+    password: "{{ pasw }}"
+    project: "{{ proj }}"
+    operation: create
+    summary: test ticket
+    description: bla bla bla
+    issuetype: Task
+  register: issue
+
+- debug:
+    msg: Issue={{ issue }}
+- name: Add comment bleep bleep
+  community.general.jira:
+    uri: "{{ uri }}"
+    username: "{{ user }}"
+    password: "{{ pasw }}"
+    issue: "{{ issue.meta.key }}"
+    operation: comment
+    comment: bleep bleep!
+- name: Transition -> In Progress with comment
+  community.general.jira:
+    uri: "{{ uri }}"
+    username: "{{ user }}"
+    password: "{{ pasw }}"
+    issue: "{{ issue.meta.key }}"
+    operation: transition
+    status: Start Progress
+    comment: -> in progress
+- name: Change assignee
+  community.general.jira:
+    uri: "{{ uri }}"
+    username: "{{ user }}"
+    password: "{{ pasw }}"
+    issue: "{{ issue.meta.key }}"
+    operation: edit
+    accountId: "{{ user2 }}"
+- name: Transition -> Resolved with comment
+  community.general.jira:
+    uri: "{{ uri }}"
+    username: "{{ user }}"
+    password: "{{ pasw }}"
+    issue: "{{ issue.meta.key }}"
+    operation: transition
+    status: Resolve Issue
+    comment: -> resolved
+    accountId: "{{ user1 }}"
+    fields:
+      resolution:
+        name: Done
+      description: wakawakawakawaka
+
+- debug:
+    msg:
+      - Issue = {{ issue.meta.key }}
+      - URL = {{ issue.meta.self }}

--- a/tests/integration/targets/jira/vars/main.yml
+++ b/tests/integration/targets/jira/vars/main.yml
@@ -1,0 +1,7 @@
+---
+uri: https://xxxx.atlassian.net/
+user: xxx@xxxx.xxx
+pasw: supersecret
+proj: ABC
+user1: 6574474636373822y7338
+user2: 6574474636373822y73959696


### PR DESCRIPTION
##### SUMMARY
Per discussion in #818 trying to send the `fields` (ansible module) under the `fields` key in JIRA APIv2, while adjusting for `summary`, `assignee` and `comment` (this last one goes into the `update` key in JIRA APIv2.

Fixes: #818 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/jira.py
