### PR TITLE
maven_artifact: use param force_basic_auth

### DIFF
--- a/changelogs/fragments/1979-maven-artifact-force-basic-auth.yml
+++ b/changelogs/fragments/1979-maven-artifact-force-basic-auth.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "maven_artifact - parameter I(force_basic_auth) was being silently ignored by module (... waiting for #215 and #1171 to confirm)."

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -500,7 +500,12 @@ class MavenDownloader:
         self.module.params['url_password'] = self.module.params.get('password', '')
         self.module.params['http_agent'] = self.user_agent
 
-        response, info = fetch_url(self.module, url_to_use, timeout=req_timeout, headers=self.headers)
+        options = dict(
+            timeout=req_timeout,
+            headers=self.headers,
+            force_basic_auth=self.module.params['force_basic_auth']
+        )
+        response, info = fetch_url(self.module, url_to_use, **options)
         if info['status'] == 200:
             return response
         if force:


### PR DESCRIPTION
##### SUMMARY
Per discussion in #215 and #1171 there seems to be some problem with authentication when using `maven_artifact`. While looking at the code, it seems that the well-documented parameter `force_basic_auth` apparently does nothing at all. This PR attempts to change that by adding that parameter to the `fetch_url()` call.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

