### PR TITLE
Excluded qemu templates in pools

### DIFF
--- a/changelogs/fragments/1991-proxmox-inventory-fix-template-in-pool.yml
+++ b/changelogs/fragments/1991-proxmox-inventory-fix-template-in-pool.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox inventory - exclude qemu templates from inclusion to the inventory via pools (https://github.com/ansible-collections/community.general/issues/1986, https://github.com/ansible-collections/community.general/pull/1991).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -339,7 +339,8 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
                 for member in self._get_members_per_pool(pool['poolid']):
                     if member.get('name'):
-                        self.inventory.add_child(pool_group, member['name'])
+                        if not member['template']:
+                            self.inventory.add_child(pool_group, member['name'])
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_REQUESTS:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -339,7 +339,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
                 for member in self._get_members_per_pool(pool['poolid']):
                     if member.get('name'):
-                        if not member['template']:
+                        if not member.get('template'):
                             self.inventory.add_child(pool_group, member['name'])
 
     def parse(self, inventory, loader, path, cache=True):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Exclude qemu templates from inclusion to the inventory via pools

Fixes #1986 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/proxmox.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
