### PR TITLE
[WIP] Investigation: Argument Specs from Doc String

### DIFF
--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -11,6 +11,7 @@ import traceback
 
 import sys
 from ansible.module_utils.basic import AnsibleModule
+from ansible.parsing.plugin_docs import read_docstring
 
 
 class ModuleHelperException(Exception):
@@ -174,8 +175,7 @@ class ModuleHelper(object):
         return result
 
     def load_argspec_from_docs(self):
-        import ansible.parsing.plugin_docs as pdocs
-        ds = pdocs.read_docstring(sys.modules[self.python_module_name].__file__)
+        ds = read_docstring(sys.modules[self.python_module_name].__file__)
         options = ds['doc']['options']
         return self.filter_options(options)
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -155,19 +155,8 @@ class XFConfException(Exception):
 
 
 class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
+    python_module_name = __name__
     module = dict(
-        argument_spec=dict(
-            state=dict(default="present",
-                       choices=("present", "get", "absent"),
-                       type='str'),
-            channel=dict(required=True, type='str'),
-            property=dict(required=True, type='str'),
-            value_type=dict(required=False, type='list',
-                            elements='str', choices=('int', 'uint', 'bool', 'float', 'double', 'string')),
-            value=dict(required=False, type='list', elements='raw'),
-            force_array=dict(default=False, type='bool', aliases=['array']),
-            disable_facts=dict(type='bool', default=False),
-        ),
         required_if=[('state', 'present', ['value', 'value_type'])],
         required_together=[('value', 'value_type')],
         supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY
This is an investigation more than anything else. I don't expect this PR to be merged at all, but I would like to foster the discussion on the topic.

A while ago I suggested in the IRC channel that we generated the plugin docs from the code. That idea was quickly bashed by others, the main argument (as I recall it) being the fact that we have modules not written in python, and more than that even the python modules fall in the "old module" or "new module" category. So, I thought of inverting that relationship: why couldn't we - in the specific case of python "new modules" generate the _code_ from the docstrings?

This PR shows the results of my testing in that direction: it does work beautifully. I have added that functionality to `ModuleHelper` and removed `argument_spec` from the `xfconf` module. Unit tests worked perfectly, however sanity tests gave me:
```
ERROR: Found 2 import issue(s) on python 3.6 which need to be resolved:
ERROR: plugins/module_utils/module_helper.py:14:0: traceback: ImportError: import of "ansible.parsing" is not allowed in this context
ERROR: plugins/modules/system/xfconf.py:130:0: traceback: ImportError: import of "ansible.parsing" is not allowed in this context (at plugins/module_utils/module_helper.py:14:0)
See documentation for help: https://docs.ansible.com/ansible/2.10/dev_guide/testing/sanity/import.html
```
Having the arg spec straight out of the documentation is likely to improve the quality of docs and code.

The custom module loader complains about loading ansible internals. Would this be something we could consider bringing into `AnsibleModule` itself? 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_helper
xfconf