### PR TITLE
Remove password requirement when creating lxc containers

### DIFF
--- a/changelogs/fragments/1999-proxmox-fix-issue-1955.yml
+++ b/changelogs/fragments/1999-proxmox-fix-issue-1955.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- proxmox - removed requirement that root password is provided when containter state is present (https://github.com/ansible-collections/community.general/pull/1999).

--- a/changelogs/fragments/1999-proxmox-fix-issue-1955.yml
+++ b/changelogs/fragments/1999-proxmox-fix-issue-1955.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- proxmox - removed requirement that root password is provided when containter state is present (https://github.com/ansible-collections/community.general/pull/1999).
+- proxmox - removed requirement that root password is provided when containter state is ``present`` (https://github.com/ansible-collections/community.general/pull/1999).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -17,7 +17,6 @@ options:
   password:
     description:
       - the instance root password
-      - required only for C(state=present)
     type: str
   hostname:
     description:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -514,7 +514,7 @@ def main():
             hookscript=dict(type='str'),
             proxmox_default_behavior=dict(type='str', choices=['compatibility', 'no_defaults']),
         ),
-        required_if=[('state', 'present', ['node', 'hostname', 'password', 'ostemplate'])],
+        required_if=[('state', 'present', ['node', 'hostname', 'ostemplate'])],
         required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('api_password', 'api_token_id')],
     )


### PR DESCRIPTION
##### SUMMARY
Removing the requirement that the password parameter be required when state = present.
Fixes #1955 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox.py

##### ADDITIONAL INFORMATION
As mentioned in #1955 this proxmox plugin requires that a root password be supplied for an lxc instance which is not consistent with the proxmox API which will happily allow a lxc instance to be created with no root password or ssh public key for the root user.

Removing the module requirement will allow end users to provide either a root password, public key, both, or neither.

Documentation is also updated to reflect that password is no longer required when state=present.

If passwords were explicitly required for earlier versions of PVE (possibly <4.2) then the task will fail because of a 4XX response from the PVE API so this change does not introduce additional side-effects just defers validation.