### PR TITLE
Adding tags as module parameter to proxmox_kvm

### DIFF
--- a/changelogs/fragments/2000-proxmox_kvm-tag-support.yml
+++ b/changelogs/fragments/2000-proxmox_kvm-tag-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- proxmox_kvm - added new module paramter ``tags`` for use with PVE 6+ (https://github.com/ansible-collections/community.general/pull/2000).

--- a/changelogs/fragments/2000-proxmox_kvm-tag-support.yml
+++ b/changelogs/fragments/2000-proxmox_kvm-tag-support.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- proxmox_kvm - added new module paramter ``tags`` for use with PVE 6+ (https://github.com/ansible-collections/community.general/pull/2000).
+- proxmox_kvm - added new module parameter ``tags`` for use with PVE 6+ (https://github.com/ansible-collections/community.general/pull/2000).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -427,9 +427,9 @@ options:
     type: bool
   tags:
     description:
-      - List of tags to apply to the VM instance
-      - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.]
-      - Tags are only available in Proxmox 6+
+      - List of tags to apply to the VM instance.
+      - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.].
+      - Tags are only available in Proxmox 6+.
     type: list
     elements: str
   target:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -428,7 +428,7 @@ options:
   tags:
     description:
       - List of tags to apply to the VM instance.
-      - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.].
+      - Tags must start with C([a-z0-9_]) followed by zero or more of the following characters C([a-z0-9_-+.]).
       - Tags are only available in Proxmox 6+.
     type: list
     elements: str

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -431,7 +431,6 @@ options:
       - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.].
       - Tags are only available in Proxmox 6+.
     type: list
-    default: [""]
     elements: str
     version_added: 2.3.0
   target:
@@ -939,17 +938,10 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
 
     # VM tags are expected to be valid and presented as a comma/semi-colon delimited string
     if 'tags' in kwargs:
-        # Set tags to null if empty list
-        if not kwargs['tags']:
-            kwargs['tags'] = ""
-        # Do nothing if tags contains a single empty element
-        elif len(kwargs['tags']) == 1 and not kwargs['tags'][0]:
-            del kwargs['tags']
-        else:
-            for tag in kwargs['tags']:
-                if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
-                    module.fail_json(msg='%s is not a valid tag' % tag)
-            kwargs['tags'] = ",".join(kwargs['tags'])
+        for tag in kwargs['tags']:
+            if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
+                module.fail_json(msg='%s is not a valid tag' % tag)
+        kwargs['tags'] = ",".join(kwargs['tags'])
 
     # -args and skiplock require root@pam user - but can not use api tokens
     if module.params['api_user'] == "root@pam" and module.params['args'] is None:
@@ -1086,7 +1078,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),
             storage=dict(type='str'),
             tablet=dict(type='bool'),
-            tags=dict(type='list', default=[""], elements='str'),
+            tags=dict(type='list', elements='str'),
             target=dict(type='str'),
             tdf=dict(type='bool'),
             template=dict(type='bool'),

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -937,7 +937,7 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             kwargs['searchdomain'] = ' '.join(searchdomains)
 
     # VM tags are expected to be valid and presented as a comma/semi-colon delimited string
-    if 'tags' in module.params:
+    if module.params['tags']:
         for tag in module.params['tags']:
             if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
                 module.fail_json(msg='%s is not a valid tag' % tag)

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -431,6 +431,7 @@ options:
       - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.].
       - Tags are only available in Proxmox 6+.
     type: list
+    default: [""]
     elements: str
     version_added: 2.3.0
   target:
@@ -937,11 +938,18 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             kwargs['searchdomain'] = ' '.join(searchdomains)
 
     # VM tags are expected to be valid and presented as a comma/semi-colon delimited string
-    if module.params['tags']:
-        for tag in module.params['tags']:
-            if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
-                module.fail_json(msg='%s is not a valid tag' % tag)
-        kwargs['tags'] = ",".join(module.params['tags'])
+    if 'tags' in kwargs:
+        # Set tags to null if empty list
+        if not kwargs['tags']:
+            kwargs['tags'] = ""
+        # Do nothing if tags contains a single empty element
+        elif len(kwargs['tags']) == 1 and not kwargs['tags'][0]:
+            del kwargs['tags']
+        else:
+            for tag in kwargs['tags']:
+                if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
+                    module.fail_json(msg='%s is not a valid tag' % tag)
+            kwargs['tags'] = ",".join(kwargs['tags'])
 
     # -args and skiplock require root@pam user - but can not use api tokens
     if module.params['api_user'] == "root@pam" and module.params['args'] is None:
@@ -1078,7 +1086,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),
             storage=dict(type='str'),
             tablet=dict(type='bool'),
-            tags=dict(type='list', elements='str'),
+            tags=dict(type='list', default=[""], elements='str'),
             target=dict(type='str'),
             tdf=dict(type='bool'),
             template=dict(type='bool'),
@@ -1283,6 +1291,7 @@ def main():
                       startdate=module.params['startdate'],
                       startup=module.params['startup'],
                       tablet=module.params['tablet'],
+                      tags=module.params['tags'],
                       target=module.params['target'],
                       tdf=module.params['tdf'],
                       template=module.params['template'],

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -432,6 +432,7 @@ options:
       - Tags are only available in Proxmox 6+.
     type: list
     elements: str
+    version_added: 2.3.0
   target:
     description:
       - Target node. Only allowed if the original VM is on shared storage.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -425,6 +425,13 @@ options:
         option has a default of C(no). Note that the default value of I(proxmox_default_behavior)
         changes in community.general 4.0.0.
     type: bool
+  tags:
+    description:
+      - List of tags to apply to the VM instance
+      - Tags must start with [a-z0-9_] followed by zero or more of the following characters [a-z0-9_-+.]
+      - Tags are only available in Proxmox 6+
+    type: list
+    elements: str
   target:
     description:
       - Target node. Only allowed if the original VM is on shared storage.
@@ -858,7 +865,7 @@ def wait_for_task(module, proxmox, node, taskid):
 def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sockets, update, **kwargs):
     # Available only in PVE 4
     only_v4 = ['force', 'protection', 'skiplock']
-    only_v6 = ['ciuser', 'cipassword', 'sshkeys', 'ipconfig']
+    only_v6 = ['ciuser', 'cipassword', 'sshkeys', 'ipconfig', 'tags']
 
     # valide clone parameters
     valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target']
@@ -927,6 +934,13 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
         searchdomains = module.params.pop('searchdomains')
         if searchdomains:
             kwargs['searchdomain'] = ' '.join(searchdomains)
+
+    # VM tags are expected to be valid and presented as a comma/semi-colon delimited string
+    if 'tags' in module.params:
+        for tag in module.params['tags']:
+            if not re.match(r'^[a-z0-9_][a-z0-9_\-\+\.]*$', tag):
+                module.fail_json(msg='%s is not a valid tag' % tag)
+        kwargs['tags'] = ",".join(module.params['tags'])
 
     # -args and skiplock require root@pam user - but can not use api tokens
     if module.params['api_user'] == "root@pam" and module.params['args'] is None:
@@ -1063,6 +1077,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),
             storage=dict(type='str'),
             tablet=dict(type='bool'),
+            tags=dict(type='list', elements='str'),
             target=dict(type='str'),
             tdf=dict(type='bool'),
             template=dict(type='bool'),


### PR DESCRIPTION
##### SUMMARY
New feature in proxmox_kvm plugin to allow VM tags to be passed as module parameters.

Fixes #1989 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox_kvm.py

##### ADDITIONAL INFORMATION
Tags are supplied as a yaml list of strings to the tags parameter.
Within the module tags are restricted to only Proxmox version >=6.
Tags are validated against the format provided by the proxmox devs and failed validation will fail the module indicating which tag is at fault.
Tags are joined with commas and then passed to proxmoxer as a tag-list-string,
CRUD operations function as expected for tags as well.