### PR TITLE
Mark non-secret leaking module options with no_log=False

### DIFF
--- a/changelogs/fragments/2001-no_log-false.yml
+++ b/changelogs/fragments/2001-no_log-false.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Mark various module options with ``no_log=False`` which have a name that potentially could leak secrets, but which do not (https://github.com/ansible-collections/community.general/pull/2001)."

--- a/plugins/module_utils/oracle/oci_utils.py
+++ b/plugins/module_utils/oracle/oci_utils.py
@@ -104,7 +104,7 @@ def get_common_arg_spec(supports_create=False, supports_wait=False):
 
     if supports_create:
         common_args.update(
-            key_by=dict(type="list", elements="str"),
+            key_by=dict(type="list", elements="str", no_log=False),
             force_create=dict(type="bool", default=False),
         )
 

--- a/plugins/modules/cloud/pubnub/pubnub_blocks.py
+++ b/plugins/modules/cloud/pubnub/pubnub_blocks.py
@@ -549,7 +549,7 @@ def main():
         password=dict(default='', required=False, type='str', no_log=True),
         account=dict(default='', required=False, type='str'),
         application=dict(required=True, type='str'),
-        keyset=dict(required=True, type='str'),
+        keyset=dict(required=True, type='str', no_log=False),
         state=dict(default='present', type='str',
                    choices=['started', 'stopped', 'present', 'absent']),
         name=dict(required=True, type='str'), description=dict(type='str'),

--- a/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
+++ b/plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py
@@ -1448,7 +1448,7 @@ def main():
         iam_role_arn=dict(type='str'),
         iam_role_name=dict(type='str'),
         image_id=dict(type='str', required=True),
-        key_pair=dict(type='str'),
+        key_pair=dict(type='str', no_log=False),
         kubernetes=dict(type='dict'),
         lifetime_period=dict(type='int'),
         load_balancers=dict(type='list'),

--- a/plugins/modules/cloud/xenserver/xenserver_guest.py
+++ b/plugins/modules/cloud/xenserver/xenserver_guest.py
@@ -1839,7 +1839,7 @@ def main():
             type='list',
             elements='dict',
             options=dict(
-                key=dict(type='str', required=True),
+                key=dict(type='str', required=True, no_log=False),
                 value=dict(type='raw', required=True),
             ),
         ),

--- a/plugins/modules/clustering/consul/consul_acl.py
+++ b/plugins/modules/clustering/consul/consul_acl.py
@@ -229,7 +229,7 @@ _ARGUMENT_SPEC = {
     PORT_PARAMETER_NAME: dict(default=8500, type='int'),
     RULES_PARAMETER_NAME: dict(type='list', elements='dict'),
     STATE_PARAMETER_NAME: dict(default=PRESENT_STATE_VALUE, choices=[PRESENT_STATE_VALUE, ABSENT_STATE_VALUE]),
-    TOKEN_PARAMETER_NAME: dict(),
+    TOKEN_PARAMETER_NAME: dict(no_log=False),
     TOKEN_TYPE_PARAMETER_NAME: dict(choices=[CLIENT_TOKEN_TYPE_VALUE, MANAGEMENT_TOKEN_TYPE_VALUE],
                                     default=CLIENT_TOKEN_TYPE_VALUE)
 }

--- a/plugins/modules/clustering/consul/consul_kv.py
+++ b/plugins/modules/clustering/consul/consul_kv.py
@@ -297,7 +297,7 @@ def main():
         argument_spec=dict(
             cas=dict(type='str'),
             flags=dict(type='str'),
-            key=dict(type='str', required=True),
+            key=dict(type='str', required=True, no_log=False),
             host=dict(type='str', default='localhost'),
             scheme=dict(type='str', default='http'),
             validate_certs=dict(type='bool', default=True),

--- a/plugins/modules/clustering/etcd3.py
+++ b/plugins/modules/clustering/etcd3.py
@@ -134,7 +134,7 @@ def run_module():
     # define the available arguments/parameters that a user can pass to
     # the module
     module_args = dict(
-        key=dict(type='str', required=True),
+        key=dict(type='str', required=True, no_log=False),
         value=dict(type='str', required=True),
         host=dict(type='str', default='localhost'),
         port=dict(type='int', default=2379),

--- a/plugins/modules/files/read_csv.py
+++ b/plugins/modules/files/read_csv.py
@@ -164,7 +164,7 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['filename']),
             dialect=dict(type='str', default='excel'),
-            key=dict(type='str'),
+            key=dict(type='str', no_log=False),
             fieldnames=dict(type='list', elements='str'),
             unique=dict(type='bool', default=True),
             delimiter=dict(type='str'),

--- a/plugins/modules/files/xattr.py
+++ b/plugins/modules/files/xattr.py
@@ -172,7 +172,7 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['name']),
             namespace=dict(type='str', default='user'),
-            key=dict(type='str'),
+            key=dict(type='str', no_log=False),
             value=dict(type='str'),
             state=dict(type='str', default='read', choices=['absent', 'all', 'keys', 'present', 'read']),
             follow=dict(type='bool', default=True),

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -800,7 +800,7 @@ def main():
             algorithm=dict(type='int'),
             cert_usage=dict(type='int', choices=[0, 1, 2, 3]),
             hash_type=dict(type='int', choices=[1, 2]),
-            key_tag=dict(type='int'),
+            key_tag=dict(type='int', no_log=False),
             port=dict(type='int'),
             priority=dict(type='int', default=1),
             proto=dict(type='str'),

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -224,7 +224,7 @@ def main():
     argument_spec.update(
         repository=dict(type='str', required=True),
         username=dict(type='str', required=True),
-        key=dict(type='str'),
+        key=dict(type='str', no_log=False),
         label=dict(type='str', required=True),
         state=dict(type='str', choices=['present', 'absent'], required=True),
     )

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -263,7 +263,7 @@ def main():
         repository=dict(type='str', required=True),
         username=dict(type='str', required=True),
         name=dict(type='str', required=True),
-        key=dict(type='str'),
+        key=dict(type='str', no_log=False),
         state=dict(type='str', choices=['present', 'absent'], required=True),
     )
     module = AnsibleModule(

--- a/plugins/modules/source_control/github/github_deploy_key.py
+++ b/plugins/modules/source_control/github/github_deploy_key.py
@@ -292,7 +292,7 @@ def main():
             owner=dict(required=True, type='str', aliases=['account', 'organization']),
             repo=dict(required=True, type='str', aliases=['repository']),
             name=dict(required=True, type='str', aliases=['title', 'label']),
-            key=dict(required=True, type='str'),
+            key=dict(required=True, type='str', no_log=False),
             read_only=dict(required=False, type='bool', default=True),
             state=dict(default='present', choices=['present', 'absent']),
             force=dict(required=False, type='bool', default=False),

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -241,7 +241,7 @@ def main():
         api_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
-        key=dict(type='str', required=True),
+        key=dict(type='str', required=True, no_log=False),
         can_push=dict(type='bool', default=False),
         title=dict(type='str', required=True)
     ))

--- a/plugins/modules/system/dconf.py
+++ b/plugins/modules/system/dconf.py
@@ -352,7 +352,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent', 'read']),
-            key=dict(required=True, type='str'),
+            key=dict(required=True, type='str', no_log=False),
             value=dict(required=False, default=None, type='str'),
         ),
         supports_check_mode=True

--- a/plugins/modules/system/gconftool2.py
+++ b/plugins/modules/system/gconftool2.py
@@ -151,7 +151,7 @@ def main():
     # Setup the Ansible module
     module = AnsibleModule(
         argument_spec=dict(
-            key=dict(type='str', required=True),
+            key=dict(type='str', required=True, no_log=False),
             value_type=dict(type='str', choices=['bool', 'float', 'int', 'string']),
             value=dict(type='str'),
             state=dict(type='str', required=True, choices=['absent', 'get', 'present']),

--- a/plugins/modules/system/osx_defaults.py
+++ b/plugins/modules/system/osx_defaults.py
@@ -369,7 +369,7 @@ def main():
         argument_spec=dict(
             domain=dict(type='str', default='NSGlobalDomain'),
             host=dict(type='str'),
-            key=dict(type='str'),
+            key=dict(type='str', no_log=False),
             type=dict(type='str', default='string', choices=['array', 'bool', 'boolean', 'date', 'float', 'int', 'integer', 'string']),
             array_add=dict(type='bool', default=False),
             value=dict(type='raw'),


### PR DESCRIPTION
##### SUMMARY
Fixes current `devel` sanity errors; see https://github.com/ansible/ansible/pull/73508.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
oci_utils
pubnub_blocks
spotinst_aws_elastigroup
xenserver_guest
consul_acl
consul_kv
etcd3
read_csv
xattr
cloudflare_dns
bitbucket_access_key
bitbucket_pipeline_known_host
github_deploy_key
gitlab_deploy_key
dconf
gconftool2
osx_defaults
