### PR TITLE
Adding purge parameter to proxmox for use with lxc delete requests

### DIFF
--- a/changelogs/fragments/2013-proxmox-purge-parameter.yml
+++ b/changelogs/fragments/2013-proxmox-purge-parameter.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- proxmox - added ``purge`` module parameter for use when deleting lxc's with ha options (https://github.com/ansible-collections/community.general/pull/2013).
+- proxmox - added ``purge`` module parameter for use when deleting lxc's with HA options (https://github.com/ansible-collections/community.general/pull/2013).

--- a/changelogs/fragments/2013-proxmox-purge-parameter.yml
+++ b/changelogs/fragments/2013-proxmox-purge-parameter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- proxmox - added ``purge`` module parameter for use when deleting lxc's with ha options (https://github.com/ansible-collections/community.general/pull/2013).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -130,7 +130,8 @@ options:
       - Related ACLs and Firewall entries will always be removed.
       - Used with state C(absent).
     type: bool
-    default: 'no'
+    default: false
+    version_added: 2.3.0
   state:
     description:
      - Indicate desired state of the instance

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -123,6 +123,14 @@ options:
       - with states C(stopped) , C(restarted) allow to force stop instance
     type: bool
     default: 'no'
+  purge:
+    description:
+      - Remove container from all related configurations.
+      - For example backup jobs, replication jobs, or HA.
+      - Related ACLs and Firewall entries will always be removed.
+      - Used with state C(absent).
+    type: bool
+    default: 'no'
   state:
     description:
      - Indicate desired state of the instance
@@ -506,6 +514,7 @@ def main():
             searchdomain=dict(),
             timeout=dict(type='int', default=30),
             force=dict(type='bool', default=False),
+            purge=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
             pubkey=dict(type='str', default=None),
             unprivileged=dict(type='bool', default=False),
@@ -686,7 +695,13 @@ def main():
             if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'mounted':
                 module.exit_json(changed=False, msg="VM %s is mounted. Stop it with force option before deletion." % vmid)
 
-            taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE).delete(vmid)
+            delete_params = {}
+
+            if module.params['purge']:
+                delete_params['purge'] = 1
+
+            taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE).delete(vmid, **delete_params)
+
             while timeout:
                 if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped' and
                         proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):


### PR DESCRIPTION
##### SUMMARY
Adding purge parameter to proxmox module to allow for deletion of containers with HA defined.

Fixes #1488 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox.py

##### ADDITIONAL INFORMATION
Purge can be optionally included with any combination of parameters, but only has meaning when used with state=absent.
If state=absent and purge=true, then the purge parameter will be included as a keyword argument in the delete request.
Given that this is an optional parameter for the PVE API, it has no conflict with other PVE parameters, and is only used for deletion so this should be a low impact change.