### PR TITLE
allow passing the --allow-root flag to kibana_plugin module

### DIFF
--- a/changelogs/fragments/2014-allow-root-for-kibana-plugin.yaml
+++ b/changelogs/fragments/2014-allow-root-for-kibana-plugin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - kibana_plugin - add parameter for passing ``--allow-root`` flag to kibana and kibana-plugin commands (https://github.com/ansible-collections/community.general/pull/2014).

--- a/plugins/modules/database/misc/kibana_plugin.py
+++ b/plugins/modules/database/misc/kibana_plugin.py
@@ -58,7 +58,7 @@ options:
       description:
       - Delete and re-install the plugin. Can be useful for plugins update.
       type: bool
-      default: 'no'
+      default: false
 '''
 
 EXAMPLES = '''
@@ -222,7 +222,7 @@ def main():
             plugin_bin=dict(default="/opt/kibana/bin/kibana", type="path"),
             plugin_dir=dict(default="/opt/kibana/installedPlugins/", type="path"),
             version=dict(default=None),
-            force=dict(default="no", type="bool")
+            force=dict(default=False, type="bool")
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow specifying an `allow_root` option to pass the `--allow-root` flag to the `kibana` and `kibana-plugin` commands. 

The Kibana RPM from Elasticsearch by default installs everything as `root`, so this module fails when trying to 

1. Run `kibana --version` since it cannot read `/etc/kibana/kibana.yml`
2. Modify `/usr/share/kibana/plugins` since it is only writeable by `root`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kibana-plugin

##### ADDITIONAL INFORMATION

Please let me know if I can provide any more information or need to make any further changes.

Thank you
