### PR TITLE
[stable-1] no_log: more false-positives (not flagged by sanity tests yet)

### DIFF
--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -55,7 +55,7 @@ def keycloak_argument_spec():
     :return: argument_spec dict
     """
     return dict(
-        auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
+        auth_keycloak_url=dict(type='str', aliases=['url'], required=True, no_log=False),
         auth_client_id=dict(type='str', default='admin-cli'),
         auth_realm=dict(type='str', required=True),
         auth_client_secret=dict(type='str', default=None, no_log=True),

--- a/plugins/modules/cloud/docker/docker_swarm_service.py
+++ b/plugins/modules/cloud/docker/docker_swarm_service.py
@@ -2730,8 +2730,8 @@ def main():
             mode=dict(type='int'),
         )),
         secrets=dict(type='list', elements='dict', no_log=False, options=dict(
-            secret_id=dict(type='str'),
-            secret_name=dict(type='str', required=True),
+            secret_id=dict(type='str', no_log=False),
+            secret_name=dict(type='str', required=True, no_log=False),
             filename=dict(type='str'),
             uid=dict(type='str'),
             gid=dict(type='str'),

--- a/plugins/modules/cloud/google/gc_storage.py
+++ b/plugins/modules/cloud/google/gc_storage.py
@@ -421,7 +421,7 @@ def main():
             permission=dict(choices=['private', 'public-read', 'authenticated-read'], default='private'),
             headers=dict(type='dict', default={}),
             gs_secret_key=dict(no_log=True, required=True),
-            gs_access_key=dict(required=True),
+            gs_access_key=dict(required=True, no_log=False),
             overwrite=dict(default=True, type='bool', aliases=['force']),
             region=dict(default='US', type='str'),
             versioning=dict(default=False, type='bool')

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -240,7 +240,7 @@ def initialise_module():
                 no_log=True,
                 fallback=(env_fallback, ['LINODE_ACCESS_TOKEN']),
             ),
-            authorized_keys=dict(type='list', required=False),
+            authorized_keys=dict(type='list', required=False, no_log=False),
             group=dict(type='str', required=False),
             image=dict(type='str', required=False),
             region=dict(type='str', required=False),

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -693,7 +693,8 @@ def main():
             ),
             client_key=dict(
                 type='str',
-                aliases=['key_file']
+                aliases=['key_file'],
+                no_log=False,
             ),
             client_cert=dict(
                 type='str',

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -385,7 +385,8 @@ def main():
             ),
             client_key=dict(
                 type='str',
-                aliases=['key_file']
+                aliases=['key_file'],
+                no_log=False,
             ),
             client_cert=dict(
                 type='str',

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1101,7 +1101,7 @@ def main():
             smbios=dict(type='str'),
             snapname=dict(type='str'),
             sockets=dict(type='int'),
-            sshkeys=dict(type='str'),
+            sshkeys=dict(type='str', no_log=False),
             startdate=dict(type='str'),
             startup=dict(),
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),

--- a/plugins/modules/cloud/oneandone/oneandone_server.py
+++ b/plugins/modules/cloud/oneandone/oneandone_server.py
@@ -630,7 +630,7 @@ def main():
             ram=dict(type='float'),
             hdds=dict(type='list', elements='dict'),
             count=dict(type='int', default=1),
-            ssh_key=dict(type='raw'),
+            ssh_key=dict(type='raw', no_log=False),
             auto_increment=dict(type='bool', default=True),
             server=dict(type='str'),
             datacenter=dict(

--- a/plugins/modules/cloud/profitbricks/profitbricks.py
+++ b/plugins/modules/cloud/profitbricks/profitbricks.py
@@ -583,7 +583,7 @@ def main():
             volume_size=dict(type='int', default=10),
             disk_type=dict(choices=['HDD', 'SSD'], default='HDD'),
             image_password=dict(default=None, no_log=True),
-            ssh_keys=dict(type='list', elements='str', default=[]),
+            ssh_keys=dict(type='list', elements='str', default=[], no_log=False),
             bus=dict(choices=['VIRTIO', 'IDE'], default='VIRTIO'),
             lan=dict(type='int', default=1),
             count=dict(type='int', default=1),

--- a/plugins/modules/cloud/profitbricks/profitbricks_volume.py
+++ b/plugins/modules/cloud/profitbricks/profitbricks_volume.py
@@ -376,7 +376,7 @@ def main():
             bus=dict(choices=['VIRTIO', 'IDE'], default='VIRTIO'),
             image=dict(),
             image_password=dict(no_log=True),
-            ssh_keys=dict(type='list', elements='str', default=[]),
+            ssh_keys=dict(type='list', elements='str', default=[], no_log=False),
             disk_type=dict(choices=['HDD', 'SSD'], default='HDD'),
             licence_type=dict(default='UNKNOWN'),
             count=dict(type='int', default=1),

--- a/plugins/modules/cloud/softlayer/sl_vm.py
+++ b/plugins/modules/cloud/softlayer/sl_vm.py
@@ -404,7 +404,7 @@ def main():
             nic_speed=dict(type='int', choices=NIC_SPEEDS),
             public_vlan=dict(type='str'),
             private_vlan=dict(type='str'),
-            ssh_keys=dict(type='list', elements='str', default=[]),
+            ssh_keys=dict(type='list', elements='str', default=[], no_log=False),
             post_uri=dict(type='str'),
             state=dict(type='str', default='present', choices=STATES),
             wait=dict(type='bool', default=True),

--- a/plugins/modules/database/aerospike/aerospike_migrations.py
+++ b/plugins/modules/database/aerospike/aerospike_migrations.py
@@ -190,9 +190,9 @@ def run_module():
         min_cluster_size=dict(type='int', required=False, default=1),
         target_cluster_size=dict(type='int', required=False, default=None),
         fail_on_cluster_change=dict(type='bool', required=False, default=True),
-        migrate_tx_key=dict(type='str', required=False,
+        migrate_tx_key=dict(type='str', required=False, no_log=False,
                             default="migrate_tx_partitions_remaining"),
-        migrate_rx_key=dict(type='str', required=False,
+        migrate_rx_key=dict(type='str', required=False, no_log=False,
                             default="migrate_rx_partitions_remaining")
     )
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -120,7 +120,7 @@ def main():
             host=dict(),
             tags=dict(type='list', elements='str'),
             alert_type=dict(default='info', choices=['error', 'warning', 'info', 'success']),
-            aggregation_key=dict(),
+            aggregation_key=dict(no_log=False),
             validate_certs=dict(default=True, type='bool'),
         )
     )

--- a/plugins/modules/monitoring/pagerduty_alert.py
+++ b/plugins/modules/monitoring/pagerduty_alert.py
@@ -205,7 +205,7 @@ def main():
             client=dict(required=False, default=None),
             client_url=dict(required=False, default=None),
             desc=dict(required=False, default='Created via Ansible'),
-            incident_key=dict(required=False, default=None)
+            incident_key=dict(required=False, default=None, no_log=False)
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/remote_management/manageiq/manageiq_provider.py
+++ b/plugins/modules/remote_management/manageiq/manageiq_provider.py
@@ -569,7 +569,7 @@ def endpoint_list_spec():
         provider=dict(type='dict', options=endpoint_argument_spec()),
         metrics=dict(type='dict', options=endpoint_argument_spec()),
         alerts=dict(type='dict', options=endpoint_argument_spec()),
-        ssh_keypair=dict(type='dict', options=endpoint_argument_spec()),
+        ssh_keypair=dict(type='dict', options=endpoint_argument_spec(), no_log=False),
     )
 
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -470,7 +470,7 @@ def main():
         password=dict(type='str', no_log=True),
         email=dict(type='str'),
         sshkey_name=dict(type='str'),
-        sshkey_file=dict(type='str'),
+        sshkey_file=dict(type='str', no_log=False),
         group=dict(type='str'),
         access_level=dict(type='str', default="guest", choices=["developer", "guest", "maintainer", "master", "owner", "reporter"]),
         confirm=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY
Backport of #2010 to stable-1. Includes https://github.com/ansible-collections/community.docker/pull/102 and new changes to the modules `gc_storage`, `lxd_container`, `lxd_profile` which have been removed/updated in 2.0.0.

(`gc_storage` was moved to community.google, and in both `lxd_container` and `lxd_profile` the option was changed to type `path` since it is actually a path and not the value of the private key.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
gc_storage
lxd_container
lxd_profile
keycloak
linode_v4
proxmox_kvm
oneandone_server
profitbricks
profitbricks_volume
sl_vm
aerospike_migrations
datadog_event
pagerduty_alert
manageiq_provider
gitlab_user
