### PR TITLE
[stable-1] Add missing no_log=True

### DIFF
--- a/changelogs/fragments/missing-no_log-again.yml
+++ b/changelogs/fragments/missing-no_log-again.yml
@@ -1,0 +1,3 @@
+security_fixes:
+- "na_cdot_user - mark the ``set_password`` parameter as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.general/pull/2018)."
+- "sf_account_manager - mark the ``initiator_secret`` and ``target_secret`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.general/pull/2018)."

--- a/plugins/modules/storage/netapp/na_cdot_user.py
+++ b/plugins/modules/storage/netapp/na_cdot_user.py
@@ -127,7 +127,7 @@ class NetAppCDOTUser(object):
                                        choices=['community', 'password',
                                                 'publickey', 'domain',
                                                 'nsswitch', 'usm']),
-            set_password=dict(required=False, type='str', default=None),
+            set_password=dict(required=False, type='str', default=None, no_log=True),
             role_name=dict(required=False, type='str'),
 
             vserver=dict(required=True, type='str'),

--- a/plugins/modules/storage/netapp/sf_account_manager.py
+++ b/plugins/modules/storage/netapp/sf_account_manager.py
@@ -115,8 +115,8 @@ class SolidFireAccount(object):
             account_id=dict(required=False, type='int', default=None),
 
             new_name=dict(required=False, type='str', default=None),
-            initiator_secret=dict(required=False, type='str'),
-            target_secret=dict(required=False, type='str'),
+            initiator_secret=dict(required=False, type='str', no_log=True),
+            target_secret=dict(required=False, type='str', no_log=True),
             attributes=dict(required=False, type='dict'),
             status=dict(required=False, type='str'),
         ))


### PR DESCRIPTION
##### SUMMARY
Adds two missing `no_log=True` in two deprecated modules that were removed in community.general 2.0.0.

In the modules that replace these modules, the issue has already been fixed (https://github.com/ansible-collections/netapp/commit/a2d3b961f9bf7efb89d71e0caca0eef183cc632c#diff-cbb7bcd7441934dc6d76359036460841f01deb56bacce6813ae7935ebacc810cR151) or has never been there in the first place (https://github.com/ansible-collections/netapp/commit/c6018a86fc316b2bf1f27bda893f028e4be1f3e4).

CC @gundalow @relrod

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_cdot_user
sf_account_manager
