### PR TITLE
rax - removed service parameter

### DIFF
--- a/changelogs/fragments/2020-remove-unused-param-in-rax.yml
+++ b/changelogs/fragments/2020-remove-unused-param-in-rax.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - rax - unused parameter ``service`` removed (https://github.com/ansible-collections/community.general/pull/2020).

--- a/plugins/modules/cloud/rackspace/rax.py
+++ b/plugins/modules/cloud/rackspace/rax.py
@@ -817,7 +817,6 @@ def main():
             meta=dict(type='dict', default={}),
             name=dict(),
             networks=dict(type='list', elements='str', default=['public', 'private']),
-            service=dict(),
             state=dict(default='present', choices=['present', 'absent']),
             user_data=dict(no_log=True),
             wait=dict(default=False, type='bool'),
@@ -832,13 +831,6 @@ def main():
 
     if not HAS_PYRAX:
         module.fail_json(msg='pyrax is required for this module')
-
-    service = module.params.get('service')
-
-    if service is not None:
-        module.fail_json(msg='The "service" attribute has been deprecated, '
-                             'please remove "service: cloudservers" from your '
-                             'playbook pertaining to the "rax" module')
 
     auto_increment = module.params.get('auto_increment')
     boot_from_volume = module.params.get('boot_from_volume')

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -64,8 +64,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-no
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
-plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
-plugins/modules/cloud/rackspace/rax.py validate-modules:undocumented-parameter
 plugins/modules/cloud/rackspace/rax_files.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_mon_notification_plan.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -63,8 +63,6 @@ plugins/modules/cloud/ovirt/ovirt_vm_facts.py validate-modules:parameter-type-no
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path # fix needed
-plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
-plugins/modules/cloud/rackspace/rax.py validate-modules:undocumented-parameter
 plugins/modules/cloud/rackspace/rax_files.py validate-modules:parameter-state-invalid-choice
 plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_mon_notification_plan.py validate-modules:parameter-list-no-elements

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -94,8 +94,6 @@ plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:deprecation-m
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:doc-missing-type
 plugins/modules/cloud/ovirt/ovirt_vmpool_facts.py validate-modules:invalid-documentation
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path
-plugins/modules/cloud/rackspace/rax.py validate-modules:doc-missing-type
-plugins/modules/cloud/rackspace/rax.py validate-modules:undocumented-parameter
 plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_image_facts.py validate-modules:deprecation-mismatch


### PR DESCRIPTION
##### SUMMARY
Parameter `service` in module `rax` is not being used since Ansible 2.3.0, but not using any of the (now) standard deprecation methods. If that paremeter receives a value, the module will call `module.fail_json()`.

This PR removes that parameter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rax
