### PR TITLE
Fix git_config always changed with space in values

### DIFF
--- a/changelogs/fragments/2028-fix-git_config-false-positives-spaces.yml
+++ b/changelogs/fragments/2028-fix-git_config-false-positives-spaces.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - git_config - When the existing values have spaces, the step will report as changed only if the content changed
+  - git_config - when the existing values have spaces, the step will report as changed only if the content changed (https://github.com/ansible-collections/community.general/pull/2028).

--- a/changelogs/fragments/2028-fix-git_config-false-positives-spaces.yml
+++ b/changelogs/fragments/2028-fix-git_config-false-positives-spaces.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - git_config - When the existing values have spaces, the step will report as changed only if the content changed

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -254,7 +254,7 @@ def main():
     elif unset and not out:
         module.exit_json(changed=False, msg='no setting to unset')
     else:
-        old_value = out.rstrip()
+        old_value = out.rstrip().strip("'")
         if old_value == new_value:
             module.exit_json(changed=False, msg="")
 


### PR DESCRIPTION
When the current configuration item has in a space in it, `git-config`
will wrap the value in single quotes(`'`). This causes Ansible to
always, sometimes falsely, to think that the value is being changed;
however, it really isn't. Stripping the extra quotes allows Ansible to
make a true comparison.
