### PR TITLE
ipa_sudorule add support for setting runasextusers

### DIFF
--- a/changelogs/fragments/2031-ipa_sudorule_add_runasextusers.yml
+++ b/changelogs/fragments/2031-ipa_sudorule_add_runasextusers.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ipa_sudorule - Add support for setting sudo runasuser (https://github.com/ansible-collections/community.general/pull/2031).

--- a/changelogs/fragments/2031-ipa_sudorule_add_runasextusers.yml
+++ b/changelogs/fragments/2031-ipa_sudorule_add_runasextusers.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- ipa_sudorule - Add support for setting sudo runasuser (https://github.com/ansible-collections/community.general/pull/2031).
+- ipa_sudorule - add support for setting sudo runasuser (https://github.com/ansible-collections/community.general/pull/2031).

--- a/plugins/modules/identity/ipa/ipa_sudorule.py
+++ b/plugins/modules/identity/ipa/ipa_sudorule.py
@@ -73,6 +73,7 @@ options:
       - List of external RunAs users
     type: list
     elements: str
+    version_added: 2.3.0
   runasusercategory:
     description:
     - RunAs User category the rule applies to.

--- a/plugins/modules/identity/ipa/ipa_sudorule.py
+++ b/plugins/modules/identity/ipa/ipa_sudorule.py
@@ -68,6 +68,11 @@ options:
     - Option C(hostcategory) must be omitted to assign host groups.
     type: list
     elements: str
+  runasextusers:
+    description:
+      - List of external RunAs users
+    type: list
+    elements: str
   runasusercategory:
     description:
     - RunAs User category the rule applies to.
@@ -143,13 +148,15 @@ EXAMPLES = r'''
     ipa_user: admin
     ipa_pass: topsecret
 
-- name: Ensure user group operations can run any commands that is part of operations-cmdgroup on any host.
+- name: Ensure user group operations can run any commands that is part of operations-cmdgroup on any host as user root.
   community.general.ipa_sudorule:
     name: sudo_operations_all
-    description: Allow operators to run any commands that is part of operations-cmdgroup on any host.
+    description: Allow operators to run any commands that is part of operations-cmdgroup on any host as user root.
     cmdgroup:
     - operations-cmdgroup
     hostcategory: all
+    runasextusers:
+    - root
     sudoopt:
     - '!authenticate'
     usergroup:
@@ -182,6 +189,12 @@ class SudoRuleIPAClient(IPAClient):
 
     def sudorule_add(self, name, item):
         return self._post_json(method='sudorule_add', name=name, item=item)
+
+    def sudorule_add_runasuser(self, name, item):
+        return self._post_json(method='sudorule_add_runasuser', name=name, item={'user': item})
+
+    def sudorule_remove_runasuser(self, name, item):
+        return self._post_json(method='sudorule_remove_runasuser', name=name, item={'user': item})
 
     def sudorule_mod(self, name, item):
         return self._post_json(method='sudorule_mod', name=name, item=item)
@@ -287,6 +300,7 @@ def ensure(module, client):
     hostgroup = module.params['hostgroup']
     runasusercategory = module.params['runasusercategory']
     runasgroupcategory = module.params['runasgroupcategory']
+    runasextusers = module.params['runasextusers']
 
     if state in ['present', 'enabled']:
         ipaenabledflag = 'TRUE'
@@ -371,6 +385,21 @@ def ensure(module, client):
                     for item in diff:
                         client.sudorule_add_option_ipasudoopt(name, item)
 
+        if runasextusers is not None:
+            ipa_sudorule_run_as_user = ipa_sudorule.get('ipasudorunasextuser', [])
+            diff = list(set(ipa_sudorule_run_as_user) - set(runasextusers))
+            if len(diff) > 0:
+                changed = True
+                if not module.check_mode:
+                    for item in diff:
+                        client.sudorule_remove_runasuser(name=name,item=item)
+            diff = list(set(runasextusers) - set(ipa_sudorule_run_as_user))
+            if len(diff) > 0:
+                changed = True
+                if not module.check_mode:
+                    for item in diff:
+                        client.sudorule_add_runasuser(name=name,item=item)
+
         if user is not None:
             changed = category_changed(module, client, 'usercategory', ipa_sudorule) or changed
             changed = client.modify_if_diff(name, ipa_sudorule.get('memberuser_user', []), user,
@@ -406,8 +435,8 @@ def main():
                          state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']),
                          user=dict(type='list', elements='str'),
                          usercategory=dict(type='str', choices=['all']),
-                         usergroup=dict(type='list', elements='str'))
-
+                         usergroup=dict(type='list', elements='str'),
+                         runasextusers=dict(type='list', elements='str'))
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=[['cmdcategory', 'cmd'],
                                                ['cmdcategory', 'cmdgroup'],

--- a/plugins/modules/identity/ipa/ipa_sudorule.py
+++ b/plugins/modules/identity/ipa/ipa_sudorule.py
@@ -392,13 +392,13 @@ def ensure(module, client):
                 changed = True
                 if not module.check_mode:
                     for item in diff:
-                        client.sudorule_remove_runasuser(name=name,item=item)
+                        client.sudorule_remove_runasuser(name=name, item=item)
             diff = list(set(runasextusers) - set(ipa_sudorule_run_as_user))
             if len(diff) > 0:
                 changed = True
                 if not module.check_mode:
                     for item in diff:
-                        client.sudorule_add_runasuser(name=name,item=item)
+                        client.sudorule_add_runasuser(name=name, item=item)
 
         if user is not None:
             changed = category_changed(module, client, 'usercategory', ipa_sudorule) or changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipa_sudorule.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
While moving from bash script to ansible the lack of being able to set sudorule runasuser came up. This pull request is meant to fix that. 

This code allow using ipa_sudorule module to do same as the code below. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ipa sudorule-add-runasuser $SUDONAME --users=root
```
