### PR TITLE
fix: scaleway inventory pagination

### DIFF
--- a/changelogs/fragments/2036-scaleway-inventory.yml
+++ b/changelogs/fragments/2036-scaleway-inventory.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - scaleway-inventory - fix pagination on scaleway inventory plugin
+  - scaleway inventory plugin - fix pagination on scaleway inventory plugin (https://github.com/ansible-collections/community.general/pull/2036).

--- a/changelogs/fragments/2036-scaleway-inventory.yml
+++ b/changelogs/fragments/2036-scaleway-inventory.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - scaleway-inventory - fix pagination on scaleway inventory plugin

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -39,7 +39,7 @@ class ScalewayException(Exception):
 R_LINK_HEADER = r'''<[^>]+>;\srel="(first|previous|next|last)"
     (,<[^>]+>;\srel="(first|previous|next|last)")*'''
 # Specify a single relation, for iteration and string extraction purposes
-R_RELATION = r'<(?P<target_IRI>[^>]+)>; rel="(?P<relation>first|previous|next|last)"'
+R_RELATION = r'</?(?P<target_IRI>[^>]+)>; rel="(?P<relation>first|previous|next|last)"'
 
 
 def parse_pagination_link(header):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`scaleway-inventory.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Scaleway inventory got a pagination issue which leads to redirect paginated call without taken in account the region specified in the base URL.  

Scaleway inventory parse the header returned from the API see https://github.com/ansible-collections/community.general/blob/main/plugins/inventory/scaleway.py#L120 and construct a new url with the page return by the `parse_pagination_link` function. 

Previously, the `parse_pagination_link` returned absolute URL like `/servers?page=2&per_page=50&` as we use the `urljoin` function, the new constructed URL is not regionified anymore see urljoin doc https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin

```
>>> import ansible.module_utils.six.moves.urllib.parse as urllib_parse
>>> print(urllib_parse.urljoin('https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers', '/servers?page=2&per_page=50&'))
https://api.scaleway.com/servers?page=2&per_page=50&
```

This PR change the way the `parse_pagination_link`  returns its result by trailing the first `/` from the header result. 

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To be reproduced, you need to have at least more than 50 servers in a regions and try to list the inventory 

```
ansible-inventory --list -i inventory/scaleway_inventory.yml
```

You should see hosts from multiple regions even if you specified a single region in your configuration file