### PR TITLE
New Filter plugin from_csv

### DIFF
--- a/changelogs/fragments/2037-add-from-csv-filter.yml
+++ b/changelogs/fragments/2037-add-from-csv-filter.yml
@@ -2,3 +2,6 @@
 add plugin.filter:
   - name: from_csv
     description: Converts csv text input into list of dicts
+minor_changes:
+  - csv - adding csv module_utils for shared functions between from_csv filter and read_csv module (https://github.com/ansible-collections/community.general/pull/2037).
+  - read_csv - refactored read_csv module to use shared csv functions from csv module_utils (https://github.com/ansible-collections/community.general/pull/2037).

--- a/changelogs/fragments/2037-add-from-csv-filter.yml
+++ b/changelogs/fragments/2037-add-from-csv-filter.yml
@@ -1,0 +1,4 @@
+---
+add plugin.filter:
+  - name: from_csv
+    description: Converts csv text input into list of dicts

--- a/changelogs/fragments/2037-add-from-csv-filter.yml
+++ b/changelogs/fragments/2037-add-from-csv-filter.yml
@@ -3,5 +3,5 @@ add plugin.filter:
   - name: from_csv
     description: Converts csv text input into list of dicts
 minor_changes:
-  - csv - adding csv module_utils for shared functions between from_csv filter and read_csv module (https://github.com/ansible-collections/community.general/pull/2037).
+  - csv module utils - new module_utils for shared functions between ``from_csv`` filter and ``read_csv`` module (https://github.com/ansible-collections/community.general/pull/2037).
   - read_csv - refactored read_csv module to use shared csv functions from csv module_utils (https://github.com/ansible-collections/community.general/pull/2037).

--- a/changelogs/fragments/2037-add-from-csv-filter.yml
+++ b/changelogs/fragments/2037-add-from-csv-filter.yml
@@ -1,7 +1,7 @@
 ---
 add plugin.filter:
   - name: from_csv
-    description: Converts csv text input into list of dicts
+    description: Converts CSV text input into list of dicts
 minor_changes:
   - csv module utils - new module_utils for shared functions between ``from_csv`` filter and ``read_csv`` module (https://github.com/ansible-collections/community.general/pull/2037).
   - read_csv - refactored read_csv module to use shared csv functions from csv module_utils (https://github.com/ansible-collections/community.general/pull/2037).

--- a/changelogs/fragments/XXXX-add-from-csv-filter.yml
+++ b/changelogs/fragments/XXXX-add-from-csv-filter.yml
@@ -1,4 +1,0 @@
----
-add plugin.filter:
-  - name: from_csv
-    description: Converts csv text input into list of dicts

--- a/changelogs/fragments/XXXX-add-from-csv-filter.yml
+++ b/changelogs/fragments/XXXX-add-from-csv-filter.yml
@@ -1,0 +1,4 @@
+---
+add plugin.filter:
+  - name: from_csv
+    description: Converts csv text input into list of dicts

--- a/plugins/filter/from_csv.py
+++ b/plugins/filter/from_csv.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Andrew Pantuso (@ajpantuso) <ajpantuso@gmail.com>
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import csv
+from io import BytesIO, StringIO
+
+from ansible.errors import AnsibleFilterError
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
+
+
+# Add Unix dialect from Python 3
+class unix_dialect(csv.Dialect):
+    """Describe the usual properties of Unix-generated CSV files."""
+    delimiter = ','
+    quotechar = '"'
+    doublequote = True
+    skipinitialspace = False
+    lineterminator = '\n'
+    quoting = csv.QUOTE_ALL
+
+
+csv.register_dialect("unix", unix_dialect)
+
+
+def from_csv(data, dialect='excel', fieldnames=None, delimiter=None, skipinitialspace=None, strict=None):
+
+    if dialect not in csv.list_dialects():
+        raise AnsibleFilterError("Dialect '%s' is not supported by your version of python." % dialect)
+
+    dialect_options = dict(
+        delimiter=delimiter,
+        skipinitialspace=skipinitialspace,
+        strict=strict,
+    )
+
+    # Create a dictionary from only set options
+    dialect_params = dict((k, v) for k, v in dialect_options.items() if v is not None)
+    if dialect_params:
+        try:
+            csv.register_dialect('custom', dialect, **dialect_params)
+        except TypeError as e:
+            raise AnsibleFilterError("Unable to create custom dialect: %s" % to_native(e))
+        dialect = 'custom'
+
+    data = to_native(data, errors='surrogate_or_strict')
+
+    if PY3:
+        fake_fh = StringIO(data)
+    else:
+        fake_fh = BytesIO(data)
+
+    reader = csv.DictReader(fake_fh, fieldnames=fieldnames, dialect=dialect)
+
+    data_list = []
+
+    try:
+        for row in reader:
+            data_list.append(row)
+    except csv.Error as e:
+        raise AnsibleFilterError("Unable to process file: %s" % to_native(e))
+
+    return data_list
+
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            'from_csv': from_csv
+        }

--- a/plugins/filter/from_csv.py
+++ b/plugins/filter/from_csv.py
@@ -9,7 +9,10 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
-from ansible_collections.community.general.plugins.module_utils.csv import initialize_dialect, read_csv
+
+from ansible_collections.community.general.plugins.module_utils.csv import (initialize_dialect, read_csv, CSVError,
+                                                                            DialectNotAvailableError,
+                                                                            CustomDialectFailureError)
 
 
 def from_csv(data, dialect='excel', fieldnames=None, delimiter=None, skipinitialspace=None, strict=None):
@@ -22,8 +25,8 @@ def from_csv(data, dialect='excel', fieldnames=None, delimiter=None, skipinitial
 
     try:
         dialect = initialize_dialect(dialect, **dialect_params)
-    except Exception as e:
-        raise AnsibleFilterError(e.message)
+    except (CustomDialectFailureError, DialectNotAvailableError) as e:
+        raise AnsibleFilterError(to_native(e))
 
     reader = read_csv(data, dialect, fieldnames)
 
@@ -32,7 +35,7 @@ def from_csv(data, dialect='excel', fieldnames=None, delimiter=None, skipinitial
     try:
         for row in reader:
             data_list.append(row)
-    except Exception as e:
+    except CSVError as e:
         raise AnsibleFilterError("Unable to process file: %s" % to_native(e))
 
     return data_list

--- a/plugins/filter/from_csv.py
+++ b/plugins/filter/from_csv.py
@@ -7,63 +7,32 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import csv
-from io import BytesIO, StringIO
-
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import PY3
-
-
-# Add Unix dialect from Python 3
-class unix_dialect(csv.Dialect):
-    """Describe the usual properties of Unix-generated CSV files."""
-    delimiter = ','
-    quotechar = '"'
-    doublequote = True
-    skipinitialspace = False
-    lineterminator = '\n'
-    quoting = csv.QUOTE_ALL
-
-
-csv.register_dialect("unix", unix_dialect)
+from ansible_collections.community.general.plugins.module_utils.csv import initialize_dialect, read_csv
 
 
 def from_csv(data, dialect='excel', fieldnames=None, delimiter=None, skipinitialspace=None, strict=None):
 
-    if dialect not in csv.list_dialects():
-        raise AnsibleFilterError("Dialect '%s' is not supported by your version of python." % dialect)
+    dialect_params = {
+        "delimiter": delimiter,
+        "skipinitialspace": skipinitialspace,
+        "strict": strict,
+    }
 
-    dialect_options = dict(
-        delimiter=delimiter,
-        skipinitialspace=skipinitialspace,
-        strict=strict,
-    )
+    try:
+        dialect = initialize_dialect(dialect, **dialect_params)
+    except Exception as e:
+        raise AnsibleFilterError(e.message)
 
-    # Create a dictionary from only set options
-    dialect_params = dict((k, v) for k, v in dialect_options.items() if v is not None)
-    if dialect_params:
-        try:
-            csv.register_dialect('custom', dialect, **dialect_params)
-        except TypeError as e:
-            raise AnsibleFilterError("Unable to create custom dialect: %s" % to_native(e))
-        dialect = 'custom'
-
-    data = to_native(data, errors='surrogate_or_strict')
-
-    if PY3:
-        fake_fh = StringIO(data)
-    else:
-        fake_fh = BytesIO(data)
-
-    reader = csv.DictReader(fake_fh, fieldnames=fieldnames, dialect=dialect)
+    reader = read_csv(data, dialect, fieldnames)
 
     data_list = []
 
     try:
         for row in reader:
             data_list.append(row)
-    except csv.Error as e:
+    except Exception as e:
         raise AnsibleFilterError("Unable to process file: %s" % to_native(e))
 
     return data_list

--- a/plugins/module_utils/csv.py
+++ b/plugins/module_utils/csv.py
@@ -14,12 +14,15 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.six import PY3
 
 
+class CustomDialectFailureError(Exception):
+    pass
+
+
 class DialectNotAvailableError(Exception):
     pass
 
 
-class CustomDialectFailureError(Exception):
-    pass
+CSVError = csv.Error
 
 
 def initialize_dialect(dialect, **kwargs):
@@ -36,7 +39,7 @@ def initialize_dialect(dialect, **kwargs):
     csv.register_dialect("unix", unix_dialect)
 
     if dialect not in csv.list_dialects():
-        raise DialectNotAvailableError(dialect)
+        raise DialectNotAvailableError("Dialect '%s' is not supported by your version of python." % dialect)
 
     # Create a dictionary from only set options
     dialect_params = dict((k, v) for k, v in kwargs.items() if v is not None)
@@ -44,7 +47,7 @@ def initialize_dialect(dialect, **kwargs):
         try:
             csv.register_dialect('custom', dialect, **dialect_params)
         except TypeError as e:
-            raise CustomDialectFailureError(to_native(e))
+            raise CustomDialectFailureError("Unable to create custom dialect: %s" % to_native(e))
         dialect = 'custom'
 
     return dialect

--- a/plugins/module_utils/csv.py
+++ b/plugins/module_utils/csv.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Andrew Pantuso (@ajpantuso) <ajpantuso@gmail.com>
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import csv
+from io import BytesIO, StringIO
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
+
+
+class DialectNotAvailableError(Exception):
+    pass
+
+
+class CustomDialectFailureError(Exception):
+    pass
+
+
+def initialize_dialect(dialect, **kwargs):
+    # Add Unix dialect from Python 3
+    class unix_dialect(csv.Dialect):
+        """Describe the usual properties of Unix-generated CSV files."""
+        delimiter = ','
+        quotechar = '"'
+        doublequote = True
+        skipinitialspace = False
+        lineterminator = '\n'
+        quoting = csv.QUOTE_ALL
+
+    csv.register_dialect("unix", unix_dialect)
+
+    if dialect not in csv.list_dialects():
+        raise DialectNotAvailableError(dialect)
+
+    # Create a dictionary from only set options
+    dialect_params = dict((k, v) for k, v in kwargs.items() if v is not None)
+    if dialect_params:
+        try:
+            csv.register_dialect('custom', dialect, **dialect_params)
+        except TypeError as e:
+            raise CustomDialectFailureError(to_native(e))
+        dialect = 'custom'
+
+    return dialect
+
+
+def read_csv(data, dialect, fieldnames=None):
+
+    data = to_native(data, errors='surrogate_or_strict')
+
+    if PY3:
+        fake_fh = StringIO(data)
+    else:
+        fake_fh = BytesIO(data)
+
+    reader = csv.DictReader(fake_fh, fieldnames=fieldnames, dialect=dialect)
+
+    return reader

--- a/tests/integration/targets/filter_from_csv/aliases
+++ b/tests/integration/targets/filter_from_csv/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group2
+skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_from_csv/tasks/main.yml
+++ b/tests/integration/targets/filter_from_csv/tasks/main.yml
@@ -1,0 +1,49 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Parse valid csv input
+  assert:
+    that:
+      - "valid_comma_separated | community.general.from_csv  ==  expected_result"
+
+- name: Parse valid csv input containing spaces with/without skipinitialspace=True
+  assert:
+    that:
+      - "valid_comma_separated_spaces | community.general.from_csv(skipinitialspace=True)  ==  expected_result"
+      - "valid_comma_separated_spaces | community.general.from_csv  !=  expected_result"
+
+- name: Parse valid csv input with no headers with/without specifiying fieldnames
+  assert:
+    that:
+      - "valid_comma_separated_no_headers | community.general.from_csv(fieldnames=['id','name','role'])  ==  expected_result"
+      - "valid_comma_separated_no_headers | community.general.from_csv  !=  expected_result"
+
+- name: Parse valid pipe-delimited csv input with/without delimiter=|
+  assert:
+    that:
+      - "valid_pipe_separated | community.general.from_csv(delimiter='|')  ==  expected_result"
+      - "valid_pipe_separated | community.general.from_csv  !=  expected_result"
+ 
+- name: Register result of invalid csv input when strict=False
+  debug:
+    var: "invalid_comma_separated | community.general.from_csv"
+  register: _invalid_csv_strict_false
+
+- name: Test invalid csv input when strict=False is successful
+  assert:
+    that:
+      - _invalid_csv_strict_false is success
+
+- name: Register result of invalid csv input when strict=True
+  debug:
+    var: "invalid_comma_separated | community.general.from_csv(strict=True)"
+  register: _invalid_csv_strict_true
+  ignore_errors: True
+
+- name: Test invalid csv input when strict=True is failed
+  assert:
+    that:
+      - _invalid_csv_strict_true is failed 
+      - _invalid_csv_strict_true.msg is match('Unable to process file:.*')

--- a/tests/integration/targets/filter_from_csv/tasks/main.yml
+++ b/tests/integration/targets/filter_from_csv/tasks/main.yml
@@ -25,7 +25,7 @@
     that:
       - "valid_pipe_separated | community.general.from_csv(delimiter='|')  ==  expected_result"
       - "valid_pipe_separated | community.general.from_csv  !=  expected_result"
- 
+
 - name: Register result of invalid csv input when strict=False
   debug:
     var: "invalid_comma_separated | community.general.from_csv"
@@ -45,5 +45,5 @@
 - name: Test invalid csv input when strict=True is failed
   assert:
     that:
-      - _invalid_csv_strict_true is failed 
+      - _invalid_csv_strict_true is failed
       - _invalid_csv_strict_true.msg is match('Unable to process file:.*')

--- a/tests/integration/targets/filter_from_csv/vars/main.yml
+++ b/tests/integration/targets/filter_from_csv/vars/main.yml
@@ -22,5 +22,5 @@ expected_result:
     name: foo
     role: bar
   - id: '2'
-    name: bar 
+    name: bar
     role: baz

--- a/tests/integration/targets/filter_from_csv/vars/main.yml
+++ b/tests/integration/targets/filter_from_csv/vars/main.yml
@@ -1,0 +1,26 @@
+valid_comma_separated: |
+  id,name,role
+  1,foo,bar
+  2,bar,baz
+valid_comma_separated_spaces: |
+  id,name,role
+  1, foo, bar
+  2, bar, baz
+valid_comma_separated_no_headers: |
+  1,foo,bar
+  2,bar,baz
+valid_pipe_separated: |
+  id|name|role
+  1|foo|bar
+  2|bar|baz
+invalid_comma_separated: |
+  id,name,role
+  1,foo,bar
+  2,"b"ar",baz
+expected_result:
+  - id: '1'
+    name: foo
+    role: bar
+  - id: '2'
+    name: bar 
+    role: baz

--- a/tests/unit/plugins/module_utils/test_csv.py
+++ b/tests/unit/plugins/module_utils/test_csv.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.community.general.plugins.module_utils import csv
+
+
+VALID_CSV = [
+    (
+        'excel',
+        {},
+        None,
+        "id,name,role\n1,foo,bar\n2,bar,baz",
+        [
+            {
+                "id": "1",
+                "name": "foo",
+                "role": "bar",
+            },
+            {
+                "id": "2",
+                "name": "bar",
+                "role": "baz",
+            },
+        ]
+    ),
+    (
+        'excel',
+        {"skipinitialspace": True},
+        None,
+        "id,name,role\n1, foo, bar\n2, bar, baz",
+        [
+            {
+                "id": "1",
+                "name": "foo",
+                "role": "bar",
+            },
+            {
+                "id": "2",
+                "name": "bar",
+                "role": "baz",
+            },
+        ]
+    ),
+    (
+        'excel',
+        {"delimiter": '|'},
+        None,
+        "id|name|role\n1|foo|bar\n2|bar|baz",
+        [
+            {
+                "id": "1",
+                "name": "foo",
+                "role": "bar",
+            },
+            {
+                "id": "2",
+                "name": "bar",
+                "role": "baz",
+            },
+        ]
+    ),
+    (
+        'unix',
+        {},
+        None,
+        "id,name,role\n1,foo,bar\n2,bar,baz",
+        [
+            {
+                "id": "1",
+                "name": "foo",
+                "role": "bar",
+            },
+            {
+                "id": "2",
+                "name": "bar",
+                "role": "baz",
+            },
+        ]
+    ),
+    (
+        'excel',
+        {},
+        ['id','name','role'],
+        "1,foo,bar\n2,bar,baz",
+        [
+            {
+                "id": "1",
+                "name": "foo",
+                "role": "bar",
+            },
+            {
+                "id": "2",
+                "name": "bar",
+                "role": "baz",
+            },
+        ]
+    ),
+]
+
+INVALID_CSV = [
+    (
+        'excel',
+        {'strict': True},
+        None,
+        'id,name,role\n1,"f"oo",bar\n2,bar,baz',
+    ),
+]
+
+INVALID_DIALECT = [
+    (
+        'invalid',
+        {},
+        None,
+        "id,name,role\n1,foo,bar\n2,bar,baz",
+    ),
+]
+
+@pytest.mark.parametrize("dialect,dialect_params,fieldnames,data,expected", VALID_CSV)
+def test_valid_csv(data, dialect, dialect_params, fieldnames, expected):
+    dialect = csv.initialize_dialect(dialect, **dialect_params)
+    reader = csv.read_csv(data, dialect, fieldnames)
+    result = True
+
+    for idx, row in enumerate(reader):
+        for k,v in row.items():
+            print (k,v,expected[idx][k])
+            if expected[idx][k] != v:
+                result = False
+                break
+
+    assert result
+
+@pytest.mark.parametrize("dialect,dialect_params,fieldnames,data", INVALID_CSV)
+def test_invalid_csv(data, dialect, dialect_params, fieldnames):
+    dialect = csv.initialize_dialect(dialect, **dialect_params)
+    reader = csv.read_csv(data, dialect, fieldnames)
+    result = False
+
+    try:
+        for row in reader:
+            continue
+    except csv.CSVError:
+        result = True
+
+    assert result
+
+@pytest.mark.parametrize("dialect,dialect_params,fieldnames,data", INVALID_DIALECT)
+def test_invalid_dialect(data, dialect, dialect_params, fieldnames):
+    result = False
+
+    try:
+        dialect = csv.initialize_dialect(dialect, **dialect_params)
+    except csv.DialectNotAvailableError:
+        result = True
+
+    assert result

--- a/tests/unit/plugins/module_utils/test_csv.py
+++ b/tests/unit/plugins/module_utils/test_csv.py
@@ -86,7 +86,7 @@ VALID_CSV = [
     (
         'excel',
         {},
-        ['id','name','role'],
+        ['id', 'name', 'role'],
         "1,foo,bar\n2,bar,baz",
         [
             {
@@ -121,6 +121,7 @@ INVALID_DIALECT = [
     ),
 ]
 
+
 @pytest.mark.parametrize("dialect,dialect_params,fieldnames,data,expected", VALID_CSV)
 def test_valid_csv(data, dialect, dialect_params, fieldnames, expected):
     dialect = csv.initialize_dialect(dialect, **dialect_params)
@@ -128,13 +129,13 @@ def test_valid_csv(data, dialect, dialect_params, fieldnames, expected):
     result = True
 
     for idx, row in enumerate(reader):
-        for k,v in row.items():
-            print (k,v,expected[idx][k])
+        for k, v in row.items():
             if expected[idx][k] != v:
                 result = False
                 break
 
     assert result
+
 
 @pytest.mark.parametrize("dialect,dialect_params,fieldnames,data", INVALID_CSV)
 def test_invalid_csv(data, dialect, dialect_params, fieldnames):
@@ -149,6 +150,7 @@ def test_invalid_csv(data, dialect, dialect_params, fieldnames):
         result = True
 
     assert result
+
 
 @pytest.mark.parametrize("dialect,dialect_params,fieldnames,data", INVALID_DIALECT)
 def test_invalid_dialect(data, dialect, dialect_params, fieldnames):


### PR DESCRIPTION
##### SUMMARY
This filter adapts the csv parsing features from the read_csv module to use directly with ansible text/variables

Fixes: #1881 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/filter/from_csv.py
plugins/modules/read_csv.py
plugins/module_utils/csv.py

##### ADDITIONAL INFORMATION
Feature set and core implementation is pulled directly from read_csv and adapted to the filter structure.
Common functions have been refactored into module_utils/csv.py which both read_csv and from_csv utilize

Notable Changes:
- Return of read_csv is a tuple of list and dict with populated result switching to dict if key is provided. For the purposes of a filter I have chosen to make the result a list of anonymous dicts which can be keyed using jinja e.g. some_var | community.general.from_csv | groupby('key') | flatten is equivalent to keyed output of read_csv
- Since keys have been removed there is no need for the unique parameter
- Updated instances of ansible.module_utils._text.to_text to ansible.module_utils._text.to_native

Integration tests were added which cover basic functions, but could be updated for better coverage.

Unit tests also added for csv.py.

Wasn't sure how to properly credit the author of read_csv so I updated copyright as if it was an update to the original module