### PR TITLE
Fix IndexError in SetManagerNic

### DIFF
--- a/changelogs/fragments/2040-fix-index-error-in-redfish-set-manager-nic.yml
+++ b/changelogs/fragments/2040-fix-index-error-in-redfish-set-manager-nic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_config module, redfish_utils module utils - fix IndexError in ``SetManagerNic`` command (https://github.com/ansible-collections/community.general/issues/1692).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2672,6 +2672,10 @@ class RedfishUtils(object):
                         need_change = True
             # type is list
             if isinstance(set_value, list):
+                if len(set_value) != len(cur_value):
+                    # if arrays are not the same len, no need to check each element
+                    need_change = True
+                    continue
                 for i in range(len(set_value)):
                     for subprop in payload[property][i].keys():
                         if subprop not in target_ethernet_current_setting[property][i]:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If an array property is passed to the `SetManagerNic` command and the new array is longer than the current array, an IndexError will occur during the checks to see if the new properties are the same or different from the existing properties. The reason for checking if the arrays are different is to avoid making the change if the existing values already match the new values.

In the case where the new array is a different length than the existing array, there is no need to try to compare individual elements to see if any have changed. If the lengths are different, the arrays are different and we should attempt to make the change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1692 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_config.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Given a play like this:

```
---
- hosts: myhosts
  connection: local
  name: Set Manager NIC
  gather_facts: False

  tasks:

  - name: Set Manager NIC
    redfish_config:
      category: Manager
      command: SetManagerNic
      nic_addr: 192.168.0.10
      nic_config:
        DHCPv4:
          DHCPEnabled: False
        IPv4StaticAddresses:
          Address: 192.168.1.3
          Gateway: 192.168.1.1
          SubnetMask: 255.255.255.0
      resource_id: "1"
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
    register: result
```
Assume the existing IPv4StaticAddresses property looks like this in the resource:

```
    ...
    "DHCPv6": {
        "OperatingMode": "Stateful",
        "UseDNSServers": true,
        "UseDomainName": false,
        "UseNTPServers": false,
        "UseRapidCommit": false
    },
    "IPv4StaticAddresses": [],
    ...
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Results **before** the change:
```paste below
$ ansible-playbook -i myinventory.yml  playbooks/manager/set_manager_nic.yml

PLAY [Set Manager NIC] *********************************************************

TASK [Set Manager NIC] *********************************************************

fatal: [mockup-devel]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "module_stderr": "[...] File  \"/var/folders/26/d5906nfx0rv7mgclxymgp5rw0000gn/T/ansible_redfish_config_payload_cwElbf/ansible_redfish_config_payload.zip/ansible_collections/community/general/plugins/module_utils/redfish_utils.py\", line 2677, in set_manager_nic\nIndexError: list index out of range\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *********************************************************************
mockup-devel               : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```

Results **after** the change:
```
$ ansible-playbook -i myinventory.yml  playbooks/manager/set_manager_nic.yml

PLAY [Set Manager NIC] *********************************************************

TASK [Set Manager NIC] *********************************************************

changed: [mockup-devel]

PLAY RECAP *********************************************************************
mockup-devel               : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```

See issue #1692 for additional info.
