### PR TITLE
bitbucket: Support Basic Auth

### DIFF
--- a/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
+++ b/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
@@ -1,7 +1,7 @@
 ---
 minor_changes:
-  - bitbucket - Add `user` and `password` options for Basic authentication (https://github.com/ansible-collections/community.general/pull/2045)
+  - bitbucket_* modules - add ``user`` and ``password`` options for Basic authentication (https://github.com/ansible-collections/community.general/pull/2045).
 deprecated_features:
-  - bitbucket - `username` options has been deprecated in favor of `workspace` and will be removed in community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/2045)
+  - bitbucket_* modules - ``username`` options have been deprecated in favor of ``workspace`` and will be removed in community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/2045).
 major_changes:
-  - bitbucket - `client_id` is no longer marked as `no_log=True` (https://github.com/ansible-collections/community.general/pull/2045)
+  - bitbucket_* modules - ``client_id`` is no longer marked as ``no_log=true``. If you relied on its value not showing up in logs and output, please mark the whole tasks with ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/2045).

--- a/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
+++ b/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
@@ -4,4 +4,4 @@ minor_changes:
 deprecated_features:
   - bitbucket_* modules - ``username`` options have been deprecated in favor of ``workspace`` and will be removed in community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/2045).
 major_changes:
-  - bitbucket_* modules - ``client_id`` is no longer marked as ``no_log=true``. If you relied on its value not showing up in logs and output, please mark the whole tasks with ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/2045).
+  - "bitbucket_* modules - ``client_id`` is no longer marked as ``no_log=true``. If you relied on its value not showing up in logs and output, please mark the whole tasks with ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/2045)."

--- a/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
+++ b/changelogs/fragments/2045-bitbucket_support_basic_auth.yaml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - bitbucket - Add `user` and `password` options for Basic authentication (https://github.com/ansible-collections/community.general/pull/2045)
+deprecated_features:
+  - bitbucket - `username` options has been deprecated in favor of `workspace` and will be removed in community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/2045)
+major_changes:
+  - bitbucket - `client_id` is no longer marked as `no_log=True` (https://github.com/ansible-collections/community.general/pull/2045)

--- a/plugins/doc_fragments/bitbucket.py
+++ b/plugins/doc_fragments/bitbucket.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Evgeniy Krysanov <evgeniy.krysanov@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Standard documentation fragment
+    DOCUMENTATION = r'''
+options:
+  client_id:
+    description:
+      - The OAuth consumer key.
+      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
+    type: str
+  client_secret:
+    description:
+      - The OAuth consumer secret.
+      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
+    type: str
+  user:
+    description:
+      - The username.
+      - If not set the environment variable C(BITBUCKET_USERNAME) will be used.
+    type: str
+  password:
+    description:
+      - The App password.
+      - If not set the environment variable C(BITBUCKET_PASSWORD) will be used.
+    type: str
+notes:
+  - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
+  - Bitbucket App password can be created from Bitbucket profile -> Personal Settings -> App passwords
+'''

--- a/plugins/doc_fragments/bitbucket.py
+++ b/plugins/doc_fragments/bitbucket.py
@@ -27,11 +27,13 @@ options:
       - The username.
       - If not set the environment variable C(BITBUCKET_USERNAME) will be used.
     type: str
+    version_added: 4.0.0
   password:
     description:
       - The App password.
       - If not set the environment variable C(BITBUCKET_PASSWORD) will be used.
     type: str
+    version_added: 4.0.0
 notes:
   - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
   - Bitbucket App password can be created from Bitbucket profile -> Personal Settings -> App passwords.

--- a/plugins/doc_fragments/bitbucket.py
+++ b/plugins/doc_fragments/bitbucket.py
@@ -34,5 +34,5 @@ options:
     type: str
 notes:
   - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
-  - Bitbucket App password can be created from Bitbucket profile -> Personal Settings -> App passwords
+  - Bitbucket App password can be created from Bitbucket profile -> Personal Settings -> App passwords.
 '''

--- a/plugins/doc_fragments/bitbucket.py
+++ b/plugins/doc_fragments/bitbucket.py
@@ -35,4 +35,5 @@ options:
 notes:
   - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
   - Bitbucket App password can be created from Bitbucket profile -> Personal Settings -> App passwords.
+  - If both OAuth and Basic Auth credentials are passed, OAuth credentials take precedence.
 '''

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -38,7 +38,7 @@ class BitbucketHelper:
         )
 
     def check_arguments(self):
-        if self.module.params['client_id'] is None and self.module.params['client_secret'] is None or \
+        if self.module.params['client_id'] is None and self.module.params['client_secret'] is None and \
            self.module.params['user'] is None and self.module.params['password'] is None:
             self.module.fail_json(msg=self.error_messages['credentials_required'])
 

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -27,7 +27,7 @@ class BitbucketHelper:
             # TODO:
             # - Rename user to username once current usage of username is removed
             # - Alias user to username and deprecate it
-            user=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_USERNAME'])),
+            user=dict(type='str', fallback=(env_fallback, ['BITBUCKET_USERNAME'])),
             password=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_PASSWORD'])),
         )
 

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -30,6 +30,9 @@ class BitbucketHelper:
         return dict(
             client_id=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_CLIENT_ID'])),
             client_secret=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_CLIENT_SECRET'])),
+            # TODO:
+            # - Rename user to username once current usage of username is removed
+            # - Alias user to username and deprecate it
             user=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_USERNAME'])),
             password=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_PASSWORD'])),
         )

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -40,7 +40,7 @@ class BitbucketHelper:
     def check_arguments(self):
         if self.module.params['client_id'] is None and self.module.params['client_secret'] is None or \
            self.module.params['user'] is None and self.module.params['password'] is None:
-            self.module.fail_json(msg=self.error_messages['required_client_id'])
+            self.module.fail_json(msg=self.error_messages['credentials_required'])
 
     def fetch_access_token(self):
         self.check_arguments()

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -18,8 +18,8 @@ class BitbucketHelper:
     def __init__(self, module):
         self.module = module
         self.access_token = None
-        self.user = None
-        self.password = None
+        self.username = self.module.params['user']
+        self.password = self.module.params['password']
 
     @staticmethod
     def bitbucket_argument_spec():
@@ -66,9 +66,9 @@ class BitbucketHelper:
             headers.update({
                 'Authorization': 'Bearer {0}'.format(self.access_token),
             })
-        elif self.user and self.password:
+        elif self.username and self.password:
             headers.update({
-                'Authorization': basic_auth_header(self.user, self.password)
+                'Authorization': basic_auth_header(self.username, self.password)
             })
 
         if isinstance(data, dict):

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -15,10 +15,6 @@ from ansible.module_utils.urls import fetch_url, basic_auth_header
 class BitbucketHelper:
     BITBUCKET_API_URL = 'https://api.bitbucket.org'
 
-    error_messages = {
-        'credentials_required': '`client_id`/`client_secret` or `user`/`password` must be specified as a parameter',
-    }
-
     def __init__(self, module):
         self.module = module
         self.access_token = None
@@ -37,14 +33,15 @@ class BitbucketHelper:
             password=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_PASSWORD'])),
         )
 
-    def check_arguments(self):
-        if self.module.params['client_id'] is None and self.module.params['client_secret'] is None and \
-           self.module.params['user'] is None and self.module.params['password'] is None:
-            self.module.fail_json(msg=self.error_messages['credentials_required'])
+    @staticmethod
+    def bitbucket_required_one_of():
+        return [['client_id', 'client_secret', 'user', 'password']]
+
+    @staticmethod
+    def bitbucket_required_together():
+        return [['client_id', 'client_secret'], ['user', 'password']]
 
     def fetch_access_token(self):
-        self.check_arguments()
-
         if 'client_id' in self.module.params and 'client_secret' in self.module.params:
             headers = {
                 'Authorization': basic_auth_header(self.module.params['client_id'], self.module.params['client_secret'])

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -42,7 +42,7 @@ class BitbucketHelper:
         return [['client_id', 'client_secret'], ['user', 'password']]
 
     def fetch_access_token(self):
-        if 'client_id' in self.module.params and 'client_secret' in self.module.params:
+        if self.module.params['client_id'] and self.module.params['client_secret']:
             headers = {
                 'Authorization': basic_auth_header(self.module.params['client_id'], self.module.params['client_secret'])
             }

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -66,7 +66,7 @@ class BitbucketHelper:
             })
         elif self.module.params['user'] and self.module.params['password']:
             headers.update({
-                'Authorization': basic_auth_header(self.module.params['user'], self.module.params['password'])
+                'Authorization': basic_auth_header(self.module.params['user'], self.module.params['password']),
             })
 
         if isinstance(data, dict):

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -16,13 +16,13 @@ class BitbucketHelper:
     BITBUCKET_API_URL = 'https://api.bitbucket.org'
 
     error_messages = {
-        'credentials_required': '`client_id`/`client_secret` or `username`/`password` must be specified as a parameter',
+        'credentials_required': '`client_id`/`client_secret` or `user`/`password` must be specified as a parameter',
     }
 
     def __init__(self, module):
         self.module = module
         self.access_token = None
-        self.username = None
+        self.user = None
         self.password = None
 
     @staticmethod
@@ -30,13 +30,13 @@ class BitbucketHelper:
         return dict(
             client_id=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_CLIENT_ID'])),
             client_secret=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_CLIENT_SECRET'])),
-            username=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_USERNAME'])),
+            user=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_USERNAME'])),
             password=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_PASSWORD'])),
         )
 
     def check_arguments(self):
         if self.module.params['client_id'] is None and self.module.params['client_secret'] is None or \
-           self.module.params['username'] is None and self.module.params['password'] is None:
+           self.module.params['user'] is None and self.module.params['password'] is None:
             self.module.fail_json(msg=self.error_messages['required_client_id'])
 
     def fetch_access_token(self):
@@ -66,9 +66,9 @@ class BitbucketHelper:
             headers.update({
                 'Authorization': 'Bearer {0}'.format(self.access_token),
             })
-        elif self.username and self.password:
+        elif self.user and self.password:
             headers.update({
-                'Authorization': basic_auth_header(self.username, self.password)
+                'Authorization': basic_auth_header(self.user, self.password)
             })
 
         if isinstance(data, dict):

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -22,7 +22,7 @@ class BitbucketHelper:
     @staticmethod
     def bitbucket_argument_spec():
         return dict(
-            client_id=dict(type='str', no_log=False, fallback=(env_fallback, ['BITBUCKET_CLIENT_ID'])),
+            client_id=dict(type='str', fallback=(env_fallback, ['BITBUCKET_CLIENT_ID'])),
             client_secret=dict(type='str', no_log=True, fallback=(env_fallback, ['BITBUCKET_CLIENT_SECRET'])),
             # TODO:
             # - Rename user to username once current usage of username is removed

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -18,8 +18,6 @@ class BitbucketHelper:
     def __init__(self, module):
         self.module = module
         self.access_token = None
-        self.username = self.module.params['user']
-        self.password = self.module.params['password']
 
     @staticmethod
     def bitbucket_argument_spec():
@@ -66,9 +64,9 @@ class BitbucketHelper:
             headers.update({
                 'Authorization': 'Bearer {0}'.format(self.access_token),
             })
-        elif self.username and self.password:
+        elif self.module.params['user'] and self.module.params['password']:
             headers.update({
-                'Authorization': basic_auth_header(self.username, self.password)
+                'Authorization': basic_auth_header(self.module.params['user'], self.module.params['password'])
             })
 
         if isinstance(data, dict):

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -42,7 +42,7 @@ class BitbucketHelper:
     def fetch_access_token(self):
         if self.module.params['client_id'] and self.module.params['client_secret']:
             headers = {
-                'Authorization': basic_auth_header(self.module.params['client_id'], self.module.params['client_secret'])
+                'Authorization': basic_auth_header(self.module.params['client_id'], self.module.params['client_secret']),
             }
 
             info, content = self.request(

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -26,6 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
+      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
     type: str
     required: true
     aliases: [ username ]
@@ -215,7 +216,10 @@ def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
         repository=dict(type='str', required=True),
-        workspace=dict(type='str', aliases=['username'], required=True),
+        workspace=dict(
+            type='str', aliases=['username'], required=True,
+            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+        ),
         key=dict(type='str', no_log=False),
         label=dict(type='str', required=True),
         state=dict(type='str', choices=['present', 'absent'], required=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -218,7 +218,7 @@ def main():
         repository=dict(type='str', required=True),
         workspace=dict(
             type='str', aliases=['username'], required=True,
-            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+            deprecated_aliases=[dict(name='username', version='6.0.0', collection_name='community.general')],
         ),
         key=dict(type='str', no_log=False),
         label=dict(type='str', required=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -227,8 +227,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
-        required_together=BitbucketHelper.bitbucket_require_together(),
+        required_one_of=BitbucketHelper.bitbucket_required_one_of(),
+        required_together=BitbucketHelper.bitbucket_required_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -227,6 +227,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
+        required_together=BitbucketHelper.bitbucket_require_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -26,7 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
-      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
+      - Alias I(username) has been deprecated and will become an alias of I(user) in community.general 6.0.0.
     type: str
     required: true
     aliases: [ username ]

--- a/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -15,17 +15,9 @@ description:
   - Manages Bitbucket repository access keys (also called deploy keys).
 author:
   - Evgeniy Krysanov (@catcombo)
+extends_documentation_fragment:
+  - community.general.bitbucket
 options:
-  client_id:
-    description:
-      - The OAuth consumer key.
-      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
-    type: str
-  client_secret:
-    description:
-      - The OAuth consumer secret.
-      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
-    type: str
   repository:
     description:
       - The repository name.
@@ -52,8 +44,7 @@ options:
     required: true
     choices: [ absent, present ]
 notes:
-  - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
-  - Bitbucket OAuth consumer should have permissions to read and administrate account repositories.
+  - Bitbucket OAuth consumer or App password should have permissions to read and administrate account repositories.
   - Check mode is supported.
 '''
 

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -15,17 +15,9 @@ description:
   - Manages Bitbucket pipeline SSH key pair.
 author:
   - Evgeniy Krysanov (@catcombo)
+extends_documentation_fragment:
+  - community.general.bitbucket
 options:
-  client_id:
-    description:
-      - OAuth consumer key.
-      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
-    type: str
-  client_secret:
-    description:
-      - OAuth consumer secret.
-      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
-    type: str
   repository:
     description:
       - The repository name.
@@ -51,7 +43,6 @@ options:
     required: true
     choices: [ absent, present ]
 notes:
-  - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
   - Check mode is supported.
 '''
 

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -155,7 +155,7 @@ def main():
         repository=dict(type='str', required=True),
         workspace=dict(
             type='str', aliases=['username'], required=True,
-            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+            deprecated_aliases=[dict(name='username', version='6.0.0', collection_name='community.general')],
         ),
         public_key=dict(type='str'),
         private_key=dict(type='str', no_log=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -23,11 +23,12 @@ options:
       - The repository name.
     type: str
     required: true
-  username:
+  workspace:
     description:
       - The repository owner.
     type: str
     required: true
+    aliases: [ username ]
   public_key:
     description:
       - The public key.
@@ -50,7 +51,7 @@ EXAMPLES = r'''
 - name: Create or update SSH key pair
   community.general.bitbucket_pipeline_key_pair:
     repository: 'bitbucket-repo'
-    username: bitbucket_username
+    workspace: bitbucket_workspace
     public_key: '{{lookup("file", "bitbucket.pub") }}'
     private_key: '{{lookup("file", "bitbucket") }}'
     state: present
@@ -58,7 +59,7 @@ EXAMPLES = r'''
 - name: Remove SSH key pair
   community.general.bitbucket_pipeline_key_pair:
     repository: bitbucket-repo
-    username: bitbucket_username
+    workspace: bitbucket_workspace
     state: absent
 '''
 
@@ -73,7 +74,7 @@ error_messages = {
 }
 
 BITBUCKET_API_ENDPOINTS = {
-    'ssh-key-pair': '%s/2.0/repositories/{username}/{repo_slug}/pipelines_config/ssh/key_pair' % BitbucketHelper.BITBUCKET_API_URL,
+    'ssh-key-pair': '%s/2.0/repositories/{workspace}/{repo_slug}/pipelines_config/ssh/key_pair' % BitbucketHelper.BITBUCKET_API_URL,
 }
 
 
@@ -95,7 +96,7 @@ def get_existing_ssh_key_pair(module, bitbucket):
         }
     """
     api_url = BITBUCKET_API_ENDPOINTS['ssh-key-pair'].format(
-        username=module.params['username'],
+        workspace=module.params['workspace'],
         repo_slug=module.params['repository'],
     )
 
@@ -114,7 +115,7 @@ def get_existing_ssh_key_pair(module, bitbucket):
 def update_ssh_key_pair(module, bitbucket):
     info, content = bitbucket.request(
         api_url=BITBUCKET_API_ENDPOINTS['ssh-key-pair'].format(
-            username=module.params['username'],
+            workspace=module.params['workspace'],
             repo_slug=module.params['repository'],
         ),
         method='PUT',
@@ -134,7 +135,7 @@ def update_ssh_key_pair(module, bitbucket):
 def delete_ssh_key_pair(module, bitbucket):
     info, content = bitbucket.request(
         api_url=BITBUCKET_API_ENDPOINTS['ssh-key-pair'].format(
-            username=module.params['username'],
+            workspace=module.params['workspace'],
             repo_slug=module.params['repository'],
         ),
         method='DELETE',
@@ -151,7 +152,7 @@ def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
         repository=dict(type='str', required=True),
-        username=dict(type='str', required=True),
+        workspace=dict(type='str', aliases=['username'], required=True),
         public_key=dict(type='str'),
         private_key=dict(type='str', no_log=True),
         state=dict(type='str', choices=['present', 'absent'], required=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -26,7 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
-      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
+      - Alias I(username) has been deprecated and will become an alias of I(user) in community.general 6.0.0.
     type: str
     required: true
     aliases: [ username ]

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -164,6 +164,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
+        required_together=BitbucketHelper.bitbucket_require_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -26,6 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
+      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
     type: str
     required: true
     aliases: [ username ]
@@ -152,7 +153,10 @@ def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
         repository=dict(type='str', required=True),
-        workspace=dict(type='str', aliases=['username'], required=True),
+        workspace=dict(
+            type='str', aliases=['username'], required=True,
+            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+        ),
         public_key=dict(type='str'),
         private_key=dict(type='str', no_log=True),
         state=dict(type='str', choices=['present', 'absent'], required=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_key_pair.py
@@ -164,8 +164,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
-        required_together=BitbucketHelper.bitbucket_require_together(),
+        required_one_of=BitbucketHelper.bitbucket_required_one_of(),
+        required_together=BitbucketHelper.bitbucket_required_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -265,6 +265,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
+        required_together=BitbucketHelper.bitbucket_require_together(),
     )
 
     if (module.params['key'] is None) and (not HAS_PARAMIKO):

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -29,7 +29,7 @@ options:
   workspace:
     description:
       - The repository owner.
-      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
+      - Alias I(username) has been deprecated and will become an alias of I(user) in community.general 6.0.0.
     type: str
     required: true
     aliases: [ username ]

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -29,6 +29,7 @@ options:
   workspace:
     description:
       - The repository owner.
+      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
     type: str
     required: true
     aliases: [ username ]
@@ -253,7 +254,10 @@ def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
         repository=dict(type='str', required=True),
-        workspace=dict(type='str', aliases=['username'], required=True),
+        workspace=dict(
+            type='str', aliases=['username'], required=True,
+            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+        ),
         name=dict(type='str', required=True),
         key=dict(type='str', no_log=False),
         state=dict(type='str', choices=['present', 'absent'], required=True),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -265,8 +265,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
-        required_together=BitbucketHelper.bitbucket_require_together(),
+        required_one_of=BitbucketHelper.bitbucket_required_one_of(),
+        required_together=BitbucketHelper.bitbucket_required_together(),
     )
 
     if (module.params['key'] is None) and (not HAS_PARAMIKO):

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -16,19 +16,11 @@ description:
   - The host fingerprint will be retrieved automatically, but in case of an error, one can use I(key) field to specify it manually.
 author:
   - Evgeniy Krysanov (@catcombo)
+extends_documentation_fragment:
+  - community.general.bitbucket
 requirements:
     - paramiko
 options:
-  client_id:
-    description:
-      - The OAuth consumer key.
-      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
-    type: str
-  client_secret:
-    description:
-      - The OAuth consumer secret.
-      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
-    type: str
   repository:
     description:
       - The repository name.
@@ -55,7 +47,6 @@ options:
     required: true
     choices: [ absent, present ]
 notes:
-  - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
   - Check mode is supported.
 '''
 

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_known_host.py
@@ -256,7 +256,7 @@ def main():
         repository=dict(type='str', required=True),
         workspace=dict(
             type='str', aliases=['username'], required=True,
-            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+            deprecated_aliases=[dict(name='username', version='6.0.0', collection_name='community.general')],
         ),
         name=dict(type='str', required=True),
         key=dict(type='str', no_log=False),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -216,7 +216,7 @@ def main():
         repository=dict(type='str', required=True),
         workspace=dict(
             type='str', aliases=['username'], required=True,
-            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+            deprecated_aliases=[dict(name='username', version='6.0.0', collection_name='community.general')],
         ),
         name=dict(type='str', required=True),
         value=dict(type='str'),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -15,17 +15,9 @@ description:
   - Manages Bitbucket pipeline variables.
 author:
   - Evgeniy Krysanov (@catcombo)
+extends_documentation_fragment:
+  - community.general.bitbucket
 options:
-  client_id:
-    description:
-      - The OAuth consumer key.
-      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
-    type: str
-  client_secret:
-    description:
-      - The OAuth consumer secret.
-      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
-    type: str
   repository:
     description:
       - The repository name.
@@ -57,7 +49,6 @@ options:
     required: true
     choices: [ absent, present ]
 notes:
-  - Bitbucket OAuth consumer key and secret can be obtained from Bitbucket profile -> Settings -> Access Management -> OAuth.
   - Check mode is supported.
   - For secured values return parameter C(changed) is always C(True).
 '''

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -26,6 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
+      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
     type: str
     required: true
     aliases: [ username ]
@@ -213,7 +214,10 @@ def main():
     argument_spec = BitbucketHelper.bitbucket_argument_spec()
     argument_spec.update(
         repository=dict(type='str', required=True),
-        workspace=dict(type='str', aliases=['username'], required=True),
+        workspace=dict(
+            type='str', aliases=['username'], required=True,
+            deprecated_aliases=[dict(name='username', version='5.0.0', collection_name='community.general')],
+        ),
         name=dict(type='str', required=True),
         value=dict(type='str'),
         secured=dict(type='bool', default=False),

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -226,6 +226,8 @@ def main():
     module = BitBucketPipelineVariable(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
+        required_together=BitbucketHelper.bitbucket_require_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -26,7 +26,7 @@ options:
   workspace:
     description:
       - The repository owner.
-      - Alias C(username) has been deprecated and will become an alias of C(user) in community.general 5.0.0.
+      - Alias I(username) has been deprecated and will become an alias of I(user) in community.general 6.0.0.
     type: str
     required: true
     aliases: [ username ]

--- a/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
+++ b/plugins/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
@@ -226,8 +226,8 @@ def main():
     module = BitBucketPipelineVariable(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_one_of=BitbucketHelper.bitbucket_require_one_of(),
-        required_together=BitbucketHelper.bitbucket_require_together(),
+        required_one_of=BitbucketHelper.bitbucket_required_one_of(),
+        required_together=BitbucketHelper.bitbucket_required_together(),
     )
 
     bitbucket = BitbucketHelper(module)

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
@@ -18,9 +18,9 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_missing_key_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
             set_module_args({
-                'client_id': 'ABC',
-                'client_secret': 'XXX',
-                'username': 'name',
+                'user': 'ABC',
+                'password': 'XXX',
+                'workspace': 'name',
                 'repository': 'repo',
                 'label': 'key name',
                 'state': 'present',
@@ -29,7 +29,6 @@ class TestBucketAccessKeyModule(ModuleTestCase):
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_key'])
 
-    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_access_key, 'get_existing_deploy_key', return_value=None)
     def test_create_deploy_key(self, *args):
         with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
@@ -29,6 +29,7 @@ class TestBucketAccessKeyModule(ModuleTestCase):
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_key'])
 
+    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_access_key, 'get_existing_deploy_key', return_value=None)
     def test_create_deploy_key(self, *args):
         with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_access_key.py
@@ -18,9 +18,9 @@ class TestBucketAccessKeyModule(ModuleTestCase):
     def test_missing_key_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
             set_module_args({
-                'user': 'ABC',
-                'password': 'XXX',
-                'workspace': 'name',
+                'client_id': 'ABC',
+                'client_secret': 'XXX',
+                'username': 'name',
                 'repository': 'repo',
                 'label': 'key name',
                 'state': 'present',
@@ -29,15 +29,14 @@ class TestBucketAccessKeyModule(ModuleTestCase):
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_key'])
 
-    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_access_key, 'get_existing_deploy_key', return_value=None)
     def test_create_deploy_key(self, *args):
         with patch.object(self.module, 'create_deploy_key') as create_deploy_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
                 set_module_args({
-                    'client_id': 'ABC',
-                    'client_secret': 'XXX',
-                    'username': 'name',
+                    'user': 'ABC',
+                    'password': 'XXX',
+                    'workspace': 'name',
                     'repository': 'repo',
                     'key': 'public_key',
                     'label': 'key name',

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_key_pair.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_key_pair.py
@@ -28,15 +28,14 @@ class TestBucketPipelineKeyPairModule(ModuleTestCase):
 
         self.assertEqual(exec_info.exception.args[0]['msg'], self.module.error_messages['required_keys'])
 
-    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_pipeline_key_pair, 'get_existing_ssh_key_pair', return_value=None)
     def test_create_keys(self, *args):
         with patch.object(self.module, 'update_ssh_key_pair') as update_ssh_key_pair_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
                 set_module_args({
-                    'client_id': 'ABC',
-                    'client_secret': 'XXX',
-                    'username': 'name',
+                    'user': 'ABC',
+                    'password': 'XXX',
+                    'workspace': 'name',
                     'repository': 'repo',
                     'public_key': 'public',
                     'private_key': 'PRIVATE',

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_known_host.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_known_host.py
@@ -37,16 +37,15 @@ class TestBucketPipelineKnownHostModule(ModuleTestCase):
             self.assertEqual(create_known_host_mock.call_count, 1)
             self.assertEqual(exec_info.exception.args[0]['changed'], True)
 
-    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(BitbucketHelper, 'request', return_value=(dict(status=201), dict()))
     @patch.object(bitbucket_pipeline_known_host, 'get_existing_known_host', return_value=None)
     def test_create_known_host_with_key(self, *args):
         with patch.object(self.module, 'get_host_key') as get_host_key_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
                 set_module_args({
-                    'client_id': 'ABC',
-                    'client_secret': 'XXX',
-                    'username': 'name',
+                    'user': 'ABC',
+                    'password': 'XXX',
+                    'workspace': 'name',
                     'repository': 'repo',
                     'name': 'bitbucket.org',
                     'key': 'ssh-rsa public',

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -25,7 +25,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
             })
             self.module.main()
 
-        self.assertEqual(exec_info.exception.args[0]['Failed'], True)
+        self.assertEqual(exec_info.exception.args[0]['failed'], True)
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -30,9 +30,9 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
             set_module_args({
-                'user': 'ABC',
-                'password': 'XXX',
-                'workspace': 'name',
+                'client_id': 'ABC',
+                'client_secret': 'XXX',
+                'username': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'present',
@@ -72,15 +72,14 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
             })
             self.module.main()
 
-    @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
     def test_create_variable(self, *args):
         with patch.object(self.module, 'create_pipeline_variable') as create_pipeline_variable_mock:
             with self.assertRaises(AnsibleExitJson) as exec_info:
                 set_module_args({
-                    'client_id': 'ABC',
-                    'client_secret': 'XXX',
-                    'username': 'name',
+                    'user': 'ABC',
+                    'password': 'XXX',
+                    'workspace': 'name',
                     'repository': 'repo',
                     'name': 'PIPELINE_VAR_NAME',
                     'value': '42',

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -30,9 +30,9 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:
             set_module_args({
-                'client_id': 'ABC',
-                'client_secret': 'XXX',
-                'username': 'name',
+                'user': 'ABC',
+                'password': 'XXX',
+                'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'present',
@@ -47,10 +47,25 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
     })
     @patch.object(BitbucketHelper, 'fetch_access_token', return_value='token')
     @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
-    def test_env_vars_params(self, *args):
+    def test_oauth_env_vars_params(self, *args):
         with self.assertRaises(AnsibleExitJson):
             set_module_args({
                 'username': 'name',
+                'repository': 'repo',
+                'name': 'PIPELINE_VAR_NAME',
+                'state': 'absent',
+            })
+            self.module.main()
+
+    @patch.dict('os.environ', {
+        'BITBUCKET_USERNAME': 'ABC',
+        'BITBUCKET_PASSWORD': 'XXX',
+    })
+    @patch.object(bitbucket_pipeline_variable, 'get_existing_pipeline_variable', return_value=None)
+    def test_basic_auth_env_vars_params(self, *args):
+        with self.assertRaises(AnsibleExitJson):
+            set_module_args({
+                'workspace': 'name',
                 'repository': 'repo',
                 'name': 'PIPELINE_VAR_NAME',
                 'state': 'absent',

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -25,7 +25,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
             })
             self.module.main()
 
-        self.assertEqual(exec_info.exception.args[0]['msg'], BitbucketHelper.error_messages['required_client_id'])
+        self.assertEqual(exec_info.exception.args[0]['msg'], BitbucketHelper.error_messages['required_credentials'])
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -16,7 +16,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
         self.module = bitbucket_pipeline_variable
 
     def test_without_required_parameters(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(AnsibleFailJson) as exec_info:
             set_module_args({
                 'username': 'name',
                 'repository': 'repo',
@@ -24,6 +24,8 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                 'state': 'absent',
             })
             self.module.main()
+
+        self.assertEqual(exec_info.exception.args[0]['Failed'], True)
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -16,7 +16,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
         self.module = bitbucket_pipeline_variable
 
     def test_without_required_parameters(self):
-        with self.assertRaises(AnsibleFailJson) as exec_info:
+        with self.assertRaises(TypeError):
             set_module_args({
                 'username': 'name',
                 'repository': 'repo',
@@ -24,8 +24,6 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
                 'state': 'absent',
             })
             self.module.main()
-
-        self.assertEqual(exec_info.exception.args[0]['msg'], BitbucketHelper.error_messages['credentials_required'])
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:

--- a/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
+++ b/tests/unit/plugins/modules/source_control/bitbucket/test_bitbucket_pipeline_variable.py
@@ -25,7 +25,7 @@ class TestBucketPipelineVariableModule(ModuleTestCase):
             })
             self.module.main()
 
-        self.assertEqual(exec_info.exception.args[0]['msg'], BitbucketHelper.error_messages['required_credentials'])
+        self.assertEqual(exec_info.exception.args[0]['msg'], BitbucketHelper.error_messages['credentials_required'])
 
     def test_missing_value_with_present_state(self):
         with self.assertRaises(AnsibleFailJson) as exec_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Support Basic Auth

TODO:

- [x] Add support for Basic Auth in module util
- [x] Settle on usage of `username` parameter (and potentially on how migrate/deprecate as needed)
    * ~Option 1. Rename current `username` to `workspace` to follow API semantic (that did confuse me at first as my company is not a username)~
    * Option 2. Use `user` for Basic Auth username (risk to be confusing, deprecate current usage of `username`)
    * ~Option 3. ?~
- [x] Update modules documentation accordingly
- [x] Update tests
- [ ] Anything else?

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Close #2044

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

bitbucket_access_key
bitbucket_pipeline_key_pair
bitbucket_pipeline_known_host
bitbucket_pipeline_variable

##### ADDITIONAL INFORMATION

Bitbucket API - Authentication methods:
https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#app-pw