### PR TITLE
Adding xmadsen and renxulei as Redfish maintainers

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1015,7 +1015,7 @@ macros:
   team_opennebula: ilicmilan meerkampdvv rsmontero xorel
   team_oracle: manojmeda mross22 nalsaber
   team_purestorage: bannaych dnix101 genegr lionmax opslounge raekins sdodsley sile16
-  team_redfish: billdodd mraineri tomasg2012
+  team_redfish: billdodd mraineri tomasg2012 xmadsen renxulei
   team_rhn: FlossWare alikins barnabycourt vritant
   team_scaleway: QuentinBrosse abarbare jerome-quere kindermoumoute remyleone sieben
   team_solaris: bcoca fishman jasperla jpdasma mator scathatheworm troy2914 xen0l


### PR DESCRIPTION
##### SUMMARY

Adding xmadsen and renxulei from Lenovo as Redfish maintainers to help manage the module.

##### ISSUE TYPE

- Other

##### COMPONENT NAME

ansibullbot configuration

##### ADDITIONAL INFORMATION

