### PR TITLE
improve force_archive parameter documentation of archive module

### DIFF
--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -46,7 +46,7 @@ options:
     description:
       - Allows you to force the module to treat this as an archive even if only a single file is specified.
       - By default when a single file is specified it is compressed only (not archived).
-      - Enable this if you want to use the unarchive ansible module on an archive of a single file created with this module.
+      - Enable this if you want to use M(ansible.builtin.unarchive) on an archive of a single file created with this module.
     type: bool
     default: false
   remove:

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -44,8 +44,9 @@ options:
     elements: path
   force_archive:
     description:
-      - Allow you to force the module to treat this as an archive even if only a single file is specified.
-      - By default behaviour is maintained. i.e A when a single file is specified it is compressed only (not archived).
+      - Allows you to force the module to treat this as an archive even if only a single file is specified.
+      - By default when a single file is specified it is compressed only (not archived).
+      - Enable this if you want to use the unarchive ansible module on an archive of a single file created with this module.
     type: bool
     default: false
   remove:


### PR DESCRIPTION
##### SUMMARY
"ansible.builtin.unarchive" module does not work on a file created by the "community.general.archive" module if this is an archive of a single file unless "force_archive" parameter is enabled

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.general.archive

##### ADDITIONAL INFORMATION
I believe it is important to note that this parameter should be enabled for single file "archives" to be compatible with unarchive module.

"ansible.builtin.unarchive" module says in the docs :

"It will not unpack a compressed file that does not contain an archive."

This was tested with .tar and .tar.gz files and failed when this parameter was left at the default value. The only solution for this was to enable this parameter.
