### PR TITLE
Fix nios modules to work with ansible-core 2.11

### DIFF
--- a/changelogs/fragments/2057-nios-devel.yml
+++ b/changelogs/fragments/2057-nios-devel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "nios* modules - fix modules to work with ansible-core 2.11 (https://github.com/ansible-collections/community.general/pull/2057)."

--- a/plugins/module_utils/net_tools/nios/api.py
+++ b/plugins/module_utils/net_tools/nios/api.py
@@ -18,6 +18,7 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.common.validation import check_type_dict
 
 try:
     from infoblox_client.connector import Connector
@@ -399,11 +400,11 @@ class WapiModule(WapiBase):
 
         if 'ipv4addrs' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addrs'][0]['ipv4addr']:
-                ip_range = self.module._check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])['nios_next_ip']
+                ip_range = check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])['nios_next_ip']
                 proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
         elif 'ipv4addr' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addr']:
-                ip_range = self.module._check_type_dict(proposed_object['ipv4addr'])['nios_next_ip']
+                ip_range = check_type_dict(proposed_object['ipv4addr'])['nios_next_ip']
                 proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
 
         return proposed_object
@@ -485,7 +486,7 @@ class WapiModule(WapiBase):
         if ('name' in obj_filter):
             # gets and returns the current object based on name/old_name passed
             try:
-                name_obj = self.module._check_type_dict(obj_filter['name'])
+                name_obj = check_type_dict(obj_filter['name'])
                 old_name = name_obj['old_name']
                 new_name = name_obj['new_name']
             except TypeError:
@@ -521,7 +522,7 @@ class WapiModule(WapiBase):
                 test_obj_filter['name'] = test_obj_filter['name'].lower()
                 # resolves issue where multiple a_records with same name and different IP address
                 try:
-                    ipaddr_obj = self.module._check_type_dict(obj_filter['ipv4addr'])
+                    ipaddr_obj = check_type_dict(obj_filter['ipv4addr'])
                     ipaddr = ipaddr_obj['old_ipv4addr']
                 except TypeError:
                     ipaddr = obj_filter['ipv4addr']
@@ -530,7 +531,7 @@ class WapiModule(WapiBase):
                 # resolves issue where multiple txt_records with same name and different text
                 test_obj_filter = obj_filter
                 try:
-                    text_obj = self.module._check_type_dict(obj_filter['text'])
+                    text_obj = check_type_dict(obj_filter['text'])
                     txt = text_obj['old_text']
                 except TypeError:
                     txt = obj_filter['text']
@@ -543,7 +544,7 @@ class WapiModule(WapiBase):
             # resolves issue where multiple a_records with same name and different IP address
             test_obj_filter = obj_filter
             try:
-                ipaddr_obj = self.module._check_type_dict(obj_filter['ipv4addr'])
+                ipaddr_obj = check_type_dict(obj_filter['ipv4addr'])
                 ipaddr = ipaddr_obj['old_ipv4addr']
             except TypeError:
                 ipaddr = obj_filter['ipv4addr']
@@ -553,7 +554,7 @@ class WapiModule(WapiBase):
             # resolves issue where multiple txt_records with same name and different text
             test_obj_filter = obj_filter
             try:
-                text_obj = self.module._check_type_dict(obj_filter['text'])
+                text_obj = check_type_dict(obj_filter['text'])
                 txt = text_obj['old_text']
             except TypeError:
                 txt = obj_filter['text']

--- a/tests/unit/plugins/module_utils/net_tools/nios/test_api.py
+++ b/tests/unit/plugins/module_utils/net_tools/nios/test_api.py
@@ -22,11 +22,14 @@ class TestNiosApi(unittest.TestCase):
 
         self.mock_connector = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.get_connector')
         self.mock_connector.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosApi, self).tearDown()
 
         self.mock_connector.stop()
+        self.mock_check_type_dict.stop()
 
     def test_get_provider_spec(self):
         provider_options = ['host', 'username', 'password', 'validate_certs', 'silent_ssl_warnings',
@@ -55,7 +58,7 @@ class TestNiosApi(unittest.TestCase):
             {
                 "comment": "test comment",
                 "_ref": "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-                "name": self.module._check_type_dict().__getitem__(),
+                "name": self.mock_check_type_dict_obj().__getitem__(),
                 "extattrs": {}
             }
         ]
@@ -143,7 +146,7 @@ class TestNiosApi(unittest.TestCase):
 
         kwargs = copy.deepcopy(test_object[0])
         kwargs['extattrs']['Site']['value'] = 'update'
-        kwargs['name'] = self.module._check_type_dict().__getitem__()
+        kwargs['name'] = self.mock_check_type_dict_obj().__getitem__()
         del kwargs['_ref']
 
         wapi = self._get_wapi(test_object)
@@ -159,7 +162,7 @@ class TestNiosApi(unittest.TestCase):
         test_object = [{
             "comment": "test comment",
             "_ref": "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
-            "name": self.module._check_type_dict().__getitem__(),
+            "name": self.mock_check_type_dict_obj().__getitem__(),
             "extattrs": {'Site': {'value': 'test'}}
         }]
 
@@ -190,7 +193,7 @@ class TestNiosApi(unittest.TestCase):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__()})
 
     def test_wapi_delete(self):
         self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible',
@@ -240,7 +243,7 @@ class TestNiosApi(unittest.TestCase):
         kwargs = test_object[0].copy()
         ref = kwargs.pop('_ref')
         kwargs['comment'] = 'updated comment'
-        kwargs['name'] = self.module._check_type_dict().__getitem__()
+        kwargs['name'] = self.mock_check_type_dict_obj().__getitem__()
         del kwargs['network_view']
         del kwargs['extattrs']
 

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_a_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_a_record.py
@@ -40,11 +40,14 @@ class TestNiosARecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_a_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosARecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -76,7 +79,7 @@ class TestNiosARecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                                   'ipv4': '192.168.10.1'})
 
     def test_nios_a_record_update_comment(self):

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_aaaa_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_aaaa_record.py
@@ -40,11 +40,14 @@ class TestNiosAAAARecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_aaaa_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosAAAARecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -76,7 +79,7 @@ class TestNiosAAAARecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                                   'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334'})
 
     def test_nios_aaaa_record_update_comment(self):

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_cname_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_cname_record.py
@@ -40,11 +40,14 @@ class TestNiosCNameRecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_cname_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosCNameRecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -76,7 +79,7 @@ class TestNiosCNameRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                                   'canonical': 'realhost.ansible.com'})
 
     def test_nios_a_record_update_comment(self):

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_dns_view.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_dns_view.py
@@ -40,11 +40,14 @@ class TestNiosDnsViewModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_dns_view.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosDnsViewModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -75,7 +78,7 @@ class TestNiosDnsViewModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__()})
 
     def test_nios_dns_view_update_comment(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'ansible-dns',

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_host_record.py
@@ -41,10 +41,13 @@ class TestNiosHostRecordModule(TestNiosModule):
         self.mock_wapi_run.start()
 
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosHostRecordModule, self).tearDown()
         self.mock_wapi.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -74,7 +77,7 @@ class TestNiosHostRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__()})
 
     def test_nios_host_record_remove(self):
         self.module.params = {'provider': None, 'state': 'absent', 'name': 'ansible',

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_mx_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_mx_record.py
@@ -40,11 +40,14 @@ class TestNiosMXRecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_mx_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosMXRecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -77,7 +80,7 @@ class TestNiosMXRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                    'mx': 'mailhost.ansible.com', 'preference': 0})
 
     def test_nios_mx_record_update_comment(self):

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_naptr_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_naptr_record.py
@@ -40,11 +40,14 @@ class TestNiosNAPTRRecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_naptr_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosNAPTRRecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -79,7 +82,7 @@ class TestNiosNAPTRRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                                   'order': '1000', 'preference': '10',
                                                                   'replacement': 'replacement1.network.ansiblezone.com'})
 

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_network_view.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_network_view.py
@@ -40,11 +40,14 @@ class TestNiosNetworkViewModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_network_view.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosNetworkViewModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -75,7 +78,7 @@ class TestNiosNetworkViewModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__()})
 
     def test_nios_network_view_update_comment(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'default',

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_nsgroup.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_nsgroup.py
@@ -42,9 +42,13 @@ class TestNiosNSGroupModule(TestNiosModule):
 
         self.load_config = self.mock_wapi_run.start()
 
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
+
     def tearDown(self):
         super(TestNiosNSGroupModule, self).tearDown()
         self.mock_wapi.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -73,7 +77,7 @@ class TestNiosNSGroupModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__()})
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__()})
 
     def test_nios_nsgroup_remove(self):
         self.module.params = {'provider': None, 'state': 'absent', 'name': 'my-simple-group',

--- a/tests/unit/plugins/modules/net_tools/nios/test_nios_srv_record.py
+++ b/tests/unit/plugins/modules/net_tools/nios/test_nios_srv_record.py
@@ -40,11 +40,14 @@ class TestNiosSRVRecordModule(TestNiosModule):
         self.mock_wapi_run = patch('ansible_collections.community.general.plugins.modules.net_tools.nios.nios_srv_record.WapiModule.run')
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible_collections.community.general.plugins.module_utils.net_tools.nios.api.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
 
     def tearDown(self):
         super(TestNiosSRVRecordModule, self).tearDown()
         self.mock_wapi.stop()
         self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
 
     def _get_wapi(self, test_object):
         wapi = api.WapiModule(self.module)
@@ -80,7 +83,7 @@ class TestNiosSRVRecordModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
-        wapi.create_object.assert_called_once_with('testobject', {'name': self.module._check_type_dict().__getitem__(),
+        wapi.create_object.assert_called_once_with('testobject', {'name': self.mock_check_type_dict_obj().__getitem__(),
                                                                   'port': 5080, 'target': 'service1.ansible.com', 'priority': 10, 'weight': 10})
 
     def test_nios_srv_record_update_comment(self):


### PR DESCRIPTION
##### SUMMARY
The module_utils uses a private part of `AnsibleModule` that was removed in ansible/ansible#73703. (See also ansible/ansible#73983.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/net_tools/nios/api.py
