### PR TITLE
stacki_host - configured params to use fallback instead of default

### DIFF
--- a/changelogs/fragments/2072-stacki-host-params-fallback.yml
+++ b/changelogs/fragments/2072-stacki-host-params-fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - stacki_host - replaced ``default`` to environment variables with ``fallback`` to them (https://github.com/ansible-collections/community.general/pull/2072).

--- a/plugins/modules/remote_management/stacki/stacki_host.py
+++ b/plugins/modules/remote_management/stacki/stacki_host.py
@@ -53,6 +53,7 @@ options:
     description:
      - Set value to True to force node into install state if it already exists in stacki.
     type: bool
+    default: no
   state:
     description:
       - Set value to the desired state for the specified host.
@@ -103,9 +104,8 @@ stdout_lines:
 '''
 
 import json
-import os
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 
@@ -235,9 +235,9 @@ def main():
             prim_intf_ip=dict(type='str'),
             network=dict(type='str', default='private'),
             prim_intf_mac=dict(type='str'),
-            stacki_user=dict(type='str', required=True, default=os.environ.get('stacki_user')),
-            stacki_password=dict(type='str', required=True, default=os.environ.get('stacki_password'), no_log=True),
-            stacki_endpoint=dict(type='str', required=True, default=os.environ.get('stacki_endpoint')),
+            stacki_user=dict(type='str', required=True, fallback=(env_fallback, ['stacki_user'])),
+            stacki_password=dict(type='str', required=True, fallback=(env_fallback, ['stacki_password']), no_log=True),
+            stacki_endpoint=dict(type='str', required=True, fallback=(env_fallback, ['stacki_endpoint'])),
             force_install=dict(type='bool', default=False),
         ),
         supports_check_mode=False,

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -159,7 +159,6 @@ plugins/modules/remote_management/oneview/oneview_san_manager.py validate-module
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -158,7 +158,6 @@ plugins/modules/remote_management/oneview/oneview_san_manager.py validate-module
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -194,7 +194,6 @@ plugins/modules/remote_management/oneview/oneview_san_manager.py validate-module
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/oneview/oneview_san_manager_info.py validate-modules:undocumented-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-default-does-not-match-spec
-plugins/modules/remote_management/stacki/stacki_host.py validate-modules:no-default-for-required-parameter
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid


### PR DESCRIPTION
##### SUMMARY
Some parameters were set with `default=os.environ.get(...)`, while the recommended way for doing that is to use `fallback=(env_fallback, ...)`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
stacki_host

##### ADDITIONAL INFORMATION
