### PR TITLE
Temporarily disable copr integration tests due to failures with remote repository

### DIFF
--- a/tests/integration/targets/copr/aliases
+++ b/tests/integration/targets/copr/aliases
@@ -3,3 +3,4 @@ needs/root
 skip/macos
 skip/osx
 skip/freebsd
+disabled  # FIXME


### PR DESCRIPTION
##### SUMMARY
```
TASK [copr : enable copr project] **********************************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Chroot centos-stream-x86_64 does not exist in @copr/integration_tests"}
```

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
copr
