### PR TITLE
Bugfix: Respect PATH env variable in zypper modules

### DIFF
--- a/changelogs/fragments/2094-bugfix-respect-PATH-env-variable-in-zypper-modules.yaml
+++ b/changelogs/fragments/2094-bugfix-respect-PATH-env-variable-in-zypper-modules.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - zypper_repository - respect PATH environment variable when resolving zypper executable path.
-  - zypper - respect PATH environment variable when resolving zypper executable path.
+  - zypper, zypper_repository - respect ``PATH`` environment variable when resolving zypper executable path (https://github.com/ansible-collections/community.general/pull/2094).

--- a/changelogs/fragments/2094-bugfix-respect-PATH-env-variable-in-zypper-modules.yaml
+++ b/changelogs/fragments/2094-bugfix-respect-PATH-env-variable-in-zypper-modules.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zypper_repository - respect PATH environment variable when resolving zypper executable path.
+  - zypper - respect PATH environment variable when resolving zypper executable path.

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -336,7 +336,7 @@ def get_cmd(m, subcommand):
     "puts together the basic zypper command arguments with those passed to the module"
     is_install = subcommand in ['install', 'update', 'patch', 'dist-upgrade']
     is_refresh = subcommand == 'refresh'
-    cmd = ['/usr/bin/zypper', '--quiet', '--non-interactive', '--xmlout']
+    cmd = [m.get_bin_path('zypper', required=True), '--quiet', '--non-interactive', '--xmlout']
     if m.params['extra_args_precommand']:
         args_list = m.params['extra_args_precommand'].split()
         cmd.extend(args_list)


### PR DESCRIPTION
##### SUMMARY
Currently the zypper modules use the hard-coded path `/usr/bin/zypper` for the zypper executable. So, in case of other locations the modules are not able to handle zypper actions correctly.

This Pull Request fixes this issue. Now, the zypper modules respect the PATH environment variable to find the zypper exceutable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- community.general.zypper
- community.general.zypper_repository
