### PR TITLE
Updated vdo maintainer to rhawalsh.

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -914,7 +914,7 @@ files:
     maintainers: ahtik ovcharenko pyykkis
     labels: ufw
   $modules/system/vdo.py:
-    maintainers: bgurney-rh
+    maintainers: rhawalsh
   $modules/system/xfconf.py:
     maintainers: russoz jbenden
     labels: xfconf


### PR DESCRIPTION
bgurney-rh does not work with VDO projects anymore.  This change re-points
maintainer pings to rhawalsh instead.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As mentioned.  bgurney-rh does not work with VDO projects any more.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
