### PR TITLE
Added fields to the ipa_config module

### DIFF
--- a/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
+++ b/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Add support new fields in ipa_config module for ipaconfigstrong, ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipabrkauthzdata, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, and ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)
+  - ipa_config - add new options ``ipaconfigstring``, ``ipadefaultprimarygroup``, ``ipagroupsearchfields``, ``ipahomesrootdir``, ``ipabrkauthzdata``, ``ipamaxusernamelength``, ``ipapwdexpadvnotify``, ``ipasearchrecordslimit``, ``ipasearchtimelimit``, ``ipauserauthtype``, and ``ipausersearchfields`` (https://github.com/ansible-collections/community.general/pull/2116).

--- a/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
+++ b/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Add support for new fields in ipa_config module: ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)
+  - Add support new fields in ipa_config module for ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, and ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)

--- a/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
+++ b/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Add support new fields in ipa_config module for ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, and ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)
+  - Add support new fields in ipa_config module for ipaconfigstrong, ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipabrkauthzdata, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, and ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)

--- a/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
+++ b/changelogs/fragments/2116-add-fields-to-ipa-config-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support for new fields in ipa_config module: ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, ipausersearchfields.  (https://github.com/ansible-collections/community.general/pull/2116)

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -74,84 +74,84 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Ensure the default login shell is bash.
+- name: Ensure the default login shell is bash
   community.general.ipa_config:
     ipadefaultloginshell: /bin/bash
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default e-mail domain is ansible.com.
+- name: Ensure the default e-mail domain is ansible.com
   community.general.ipa_config:
     ipadefaultemaildomain: ansible.com
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default e-mail domain is ansible.com.
+- name: Ensure the default e-mail domain is ansible.com
   community.general.ipa_config:
     ipadefaultemaildomain: ansible.com
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default primary group is set to ipausers.
+- name: Ensure the default primary group is set to ipausers
   community.general.ipa_config:
     ipadefaultprimarygroup: ipausers
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the group search fields are set to 'cn,description'.
+- name: Ensure the group search fields are set to 'cn,description'
   community.general.ipa_config:
     ipagroupsearchfields: cn,description
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the home directory location is set to /home.
+- name: Ensure the home directory location is set to /home
   community.general.ipa_config:
     ipahomesrootdir: /home
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the maximum user name length is set to 32.
+- name: Ensure the maximum user name length is set to 32
   community.general.ipa_config:
     ipamaxusernamelength: '32'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the password expiration notice is set to 4 days.
+- name: Ensure the password expiration notice is set to 4 days
   community.general.ipa_config:
     ipapwdexpadvnotify: '4'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the search record limit is set to 100.
+- name: Ensure the search record limit is set to 100
   community.general.ipa_config:
     ipasearchrecordslimit: '100'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the search time limit is set to 2 seconds.
+- name: Ensure the search time limit is set to 2 seconds
   community.general.ipa_config:
     ipasearchtimelimit: '2'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default user auth type is password.
+- name: Ensure the default user auth type is password
   community.general.ipa_config:
     ipauserauthtype: password
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'.
+- name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'
   community.general.ipa_config:
     ipausersearchfields: uid,givenname,sn,ou,title
     ipa_host: localhost

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -31,6 +31,7 @@ options:
     description: A comma-separated list of fields to search in when searching for groups.
     aliases: ["groupsearchfields"]
     type: str
+    version_added: '2.4.0'
   ipahomesrootdir:
     description: Default location of home directories.
     aliases: ["homesrootdir"]

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -88,7 +88,7 @@ EXAMPLES = r'''
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default e-mail domain is ansible.com.
+- name: Ensure the default e-mail domain is ansible.com
   community.general.ipa_config:
     ipadefaultemaildomain: ansible.com
     ipa_host: localhost

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -43,12 +43,12 @@ options:
     version_added: '2.4.0'
   ipapwdexpadvnotify:
     description: Notice of impending password expiration, in days.
-    aliases: ["pwexpadvnotify"]
+    aliases: ["pwdexpadvnotify"]
     type: str
     version_added: '2.4.0'
   ipasearchrecordslimit:
     description: Maximum number of records to search (-1 or 0 is unlimited).
-    aliases: ["searchrecordlimit"]
+    aliases: ["searchrecordslimit"]
     type: str
     version_added: '2.4.0'
   ipasearchtimelimit:
@@ -57,8 +57,8 @@ options:
     type: str
     version_added: '2.4.0'
   ipauserauthtype:
-    description:
-    - The authentication type to use for the user.
+    description: The authentication type to use by default.
+    aliases: ["userauthtype"]
     choices: ["password", "radius", "otp", "pkinit", "hardened", "disabled"]
     type: str
     version_added: '2.4.0'

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -35,7 +35,7 @@ options:
     type: str
     version_added: '2.5.0'
   ipagroupsearchfields:
-    description: A comma-separated list of fields to search in when searching for groups.
+    description: A list of fields to search in when searching for groups.
     aliases: ["groupsearchfields"]
     type: list
     elements: str

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -80,7 +80,7 @@ options:
     elements: str
     version_added: '2.5.0'
   ipausersearchfields:
-    description: A comma-separated list of fields to search in when searching for users.
+    description: A list of fields to search in when searching for users.
     aliases: ["usersearchfields"]
     type: list
     elements: str

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -88,70 +88,70 @@ EXAMPLES = r'''
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default e-mail domain is ansible.com
+- name: Ensure the default e-mail domain is ansible.com.
   community.general.ipa_config:
     ipadefaultemaildomain: ansible.com
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default primary group is set to ipausers
+- name: Ensure the default primary group is set to ipausers.
   community.general.ipa_config:
     ipadefaultprimarygroup: ipausers
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the group search fields are set to 'cn,description'
+- name: Ensure the group search fields are set to 'cn,description'.
   community.general.ipa_config:
     ipagroupsearchfields: cn,description
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the home directory location is set to /home
+- name: Ensure the home directory location is set to /home.
   community.general.ipa_config:
     ipahomesrootdir: /home
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the maximum user name length is set to 32
+- name: Ensure the maximum user name length is set to 32.
   community.general.ipa_config:
     ipamaxusernamelength: '32'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the password expiration notice is set to 4 days
+- name: Ensure the password expiration notice is set to 4 days.
   community.general.ipa_config:
     ipapwdexpadvnotify: '4'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the search record limit is set to 100
+- name: Ensure the search record limit is set to 100.
   community.general.ipa_config:
     ipasearchrecordslimit: '100'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the search time limit is set to 2 seconds
+- name: Ensure the search time limit is set to 2 seconds.
   community.general.ipa_config:
     ipasearchtimelimit: '2'
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the default user auth type is password
+- name: Ensure the default user auth type is password.
   community.general.ipa_config:
     ipauserauthtype: password
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
-- name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'
+- name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'.
   community.general.ipa_config:
     ipausersearchfields: uid,givenname,sn,ou,title
     ipa_host: localhost

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -40,22 +40,22 @@ options:
   ipamaxusernamelength:
     description: Maximum length of usernames.
     aliases: ["maxusernamelength"]
-    type: str
+    type: int
     version_added: '2.4.0'
   ipapwdexpadvnotify:
     description: Notice of impending password expiration, in days.
     aliases: ["pwdexpadvnotify"]
-    type: str
+    type: int
     version_added: '2.4.0'
   ipasearchrecordslimit:
     description: Maximum number of records to search (-1 or 0 is unlimited).
     aliases: ["searchrecordslimit"]
-    type: str
+    type: int
     version_added: '2.4.0'
   ipasearchtimelimit:
     description: Maximum amount of time (seconds) for a search (-1 or 0 is unlimited).
     aliases: ["searchtimelimit"]
-    type: str
+    type: int
     version_added: '2.4.0'
   ipauserauthtype:
     description: The authentication type to use by default.
@@ -77,13 +77,6 @@ EXAMPLES = r'''
 - name: Ensure the default login shell is bash
   community.general.ipa_config:
     ipadefaultloginshell: /bin/bash
-    ipa_host: localhost
-    ipa_user: admin
-    ipa_pass: supersecret
-
-- name: Ensure the default e-mail domain is ansible.com
-  community.general.ipa_config:
-    ipadefaultemaildomain: ansible.com
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -118,28 +111,28 @@ EXAMPLES = r'''
 
 - name: Ensure the maximum user name length is set to 32
   community.general.ipa_config:
-    ipamaxusernamelength: '32'
+    ipamaxusernamelength: 32
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
 - name: Ensure the password expiration notice is set to 4 days
   community.general.ipa_config:
-    ipapwdexpadvnotify: '4'
+    ipapwdexpadvnotify: 4
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
 - name: Ensure the search record limit is set to 100
   community.general.ipa_config:
-    ipasearchrecordslimit: '100'
+    ipasearchrecordslimit: 100
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
 
 - name: Ensure the search time limit is set to 2 seconds
   community.general.ipa_config:
-    ipasearchtimelimit: '2'
+    ipasearchtimelimit: 2
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -202,13 +195,13 @@ def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None,
     if ipahomesrootdir is not None:
         config['ipahomesrootdir'] = ipahomesrootdir
     if ipamaxusernamelength is not None:
-        config['ipamaxusernamelength'] = ipamaxusernamelength
+        config['ipamaxusernamelength'] = str(ipamaxusernamelength)
     if ipapwdexpadvnotify is not None:
-        config['ipapwdexpadvnotify'] = ipapwdexpadvnotify
+        config['ipapwdexpadvnotify'] = str(ipapwdexpadvnotify)
     if ipasearchrecordslimit is not None:
-        config['ipasearchrecordslimit'] = ipasearchrecordslimit
+        config['ipasearchrecordslimit'] = str(ipasearchrecordslimit)
     if ipasearchtimelimit is not None:
-        config['ipasearchtimelimit'] = ipasearchtimelimit
+        config['ipasearchtimelimit'] = str(ipasearchtimelimit)
     if ipauserauthtype is not None:
         config['ipauserauthtype'] = ipauserauthtype
     if ipausersearchfields is not None:
@@ -259,10 +252,10 @@ def main():
         ipadefaultprimarygroup=dict(type='str', aliases=['primarygroup']),
         ipagroupsearchfields=dict(type='str', aliases=['groupsearchfields']),
         ipahomesrootdir=dict(type='str', aliases=['homesrootdir']),
-        ipamaxusernamelength=dict(type='str', aliases=['maxusernamelength']),
-        ipapwdexpadvnotify=dict(type='str', aliases=['pwdexpadvnotify']),
-        ipasearchrecordslimit=dict(type='str', aliases=['searchrecordslimit']),
-        ipasearchtimelimit=dict(type='str', aliases=['searchtimelimit']),
+        ipamaxusernamelength=dict(type='int', aliases=['maxusernamelength']),
+        ipapwdexpadvnotify=dict(type='int', aliases=['pwdexpadvnotify']),
+        ipasearchrecordslimit=dict(type='int', aliases=['searchrecordslimit']),
+        ipasearchtimelimit=dict(type='int', aliases=['searchtimelimit']),
         ipauserauthtype=dict(type='str', aliases=['userauthtype'],
                              choices=["password", "radius", "otp", "pkinit",
                                       "hardened", "disabled"]),

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -37,7 +37,8 @@ options:
   ipagroupsearchfields:
     description: A comma-separated list of fields to search in when searching for groups.
     aliases: ["groupsearchfields"]
-    type: str
+    type: list
+    elements: str
     version_added: '2.5.0'
   ipahomesrootdir:
     description: Default location of home directories.
@@ -81,7 +82,8 @@ options:
   ipausersearchfields:
     description: A comma-separated list of fields to search in when searching for users.
     aliases: ["usersearchfields"]
-    type: str
+    type: list
+    elements: str
     version_added: '2.5.0'
 extends_documentation_fragment:
 - community.general.ipa.documentation
@@ -119,7 +121,7 @@ EXAMPLES = r'''
 
 - name: Ensure the group search fields are set to 'cn,description'
   community.general.ipa_config:
-    ipagroupsearchfields: cn,description
+    ipagroupsearchfields: ['cn', 'description']
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -175,7 +177,7 @@ EXAMPLES = r'''
 
 - name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'
   community.general.ipa_config:
-    ipausersearchfields: uid,givenname,sn,ou,title
+    ipausersearchfields: ['uid', 'givenname', 'sn', 'ou', 'title']
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -223,7 +225,7 @@ def get_config_dict(ipaconfigstring=None, ipadefaultloginshell=None,
     if ipadefaultprimarygroup is not None:
         config['ipadefaultprimarygroup'] = ipadefaultprimarygroup
     if ipagroupsearchfields is not None:
-        config['ipagroupsearchfields'] = ipagroupsearchfields
+        config['ipagroupsearchfields'] = ','.join(ipagroupsearchfields)
     if ipahomesrootdir is not None:
         config['ipahomesrootdir'] = ipahomesrootdir
     if ipakrbauthzdata is not None:
@@ -239,7 +241,7 @@ def get_config_dict(ipaconfigstring=None, ipadefaultloginshell=None,
     if ipauserauthtype is not None:
         config['ipauserauthtype'] = ipauserauthtype
     if ipausersearchfields is not None:
-        config['ipausersearchfields'] = ipausersearchfields
+        config['ipausersearchfields'] = ','.join(ipausersearchfields)
 
     return config
 
@@ -292,7 +294,8 @@ def main():
         ipadefaultloginshell=dict(type='str', aliases=['loginshell']),
         ipadefaultemaildomain=dict(type='str', aliases=['emaildomain']),
         ipadefaultprimarygroup=dict(type='str', aliases=['primarygroup']),
-        ipagroupsearchfields=dict(type='str', aliases=['groupsearchfields']),
+        ipagroupsearchfields=dict(type='list', elements='str',
+                                  aliases=['groupsearchfields']),
         ipahomesrootdir=dict(type='str', aliases=['homesrootdir']),
         ipakrbauthzdata=dict(type='list', elements='str',
                              choices=['MS-PAC', 'PAD', 'nfs:NONE'],
@@ -305,7 +308,8 @@ def main():
                              aliases=['userauthtype'],
                              choices=["password", "radius", "otp", "pkinit",
                                       "hardened", "disabled"]),
-        ipausersearchfields=dict(type='str', aliases=['usersearchfields']),
+        ipausersearchfields=dict(type='list', elements='str',
+                                 aliases=['usersearchfields']),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -45,7 +45,7 @@ options:
     type: str
     version_added: '2.5.0'
   ipakrbauthzdata:
-    description: Default types of PAC supported for services
+    description: Default types of PAC supported for services.
     aliases: ["krbauthzdata"]
     type: list
     elements: str

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -22,6 +22,51 @@ options:
     description: Default e-mail domain for new users.
     aliases: ["emaildomain"]
     type: str
+  ipadefaultprimarygroup:
+    description: Default group for new users.
+    aliases: ["primarygroup"]
+    type: str
+    version_added: '2.4.0'
+  ipagroupsearchfields:
+    description: A comma-separated list of fields to search in when searching for groups.
+    aliases: ["groupsearchfields"]
+    type: str
+  ipahomesrootdir:
+    description: Default location of home directories.
+    aliases: ["homesrootdir"]
+    type: str
+    version_added: '2.4.0'
+  ipamaxusernamelength:
+    description: Maximum length of usernames.
+    aliases: ["maxusernamelength"]
+    type: str
+    version_added: '2.4.0'
+  ipapwdexpadvnotify:
+    description: Notice of impending password expiration, in days.
+    aliases: ["pwexpadvnotify"]
+    type: str
+    version_added: '2.4.0'
+  ipasearchrecordslimit:
+    description: Maximum number of records to search (-1 or 0 is unlimited).
+    aliases: ["searchrecordlimit"]
+    type: str
+    version_added: '2.4.0'
+  ipasearchtimelimit:
+    description: Maximum amount of time (seconds) for a search (-1 or 0 is unlimited).
+    aliases: ["searchtimelimit"]
+    type: str
+    version_added: '2.4.0'
+  ipauserauthtype:
+    description:
+    - The authentication type to use for the user.
+    choices: ["password", "radius", "otp", "pkinit", "hardened", "disabled"]
+    type: str
+    version_added: '2.4.0'
+  ipausersearchfields:
+    description: A comma-separated list of fields to search in when searching for users.
+    aliases: ["usersearchfields"]
+    type: str
+    version_added: '2.4.0'
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -38,6 +83,76 @@ EXAMPLES = r'''
 - name: Ensure the default e-mail domain is ansible.com.
   community.general.ipa_config:
     ipadefaultemaildomain: ansible.com
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the default e-mail domain is ansible.com.
+  community.general.ipa_config:
+    ipadefaultemaildomain: ansible.com
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the default primary group is set to ipausers
+  community.general.ipa_config:
+    ipadefaultprimarygroup: ipausers
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the group search fields are set to 'cn,description'
+  community.general.ipa_config:
+    ipagroupsearchfields: cn,description
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the home directory location is set to /home
+  community.general.ipa_config:
+    ipahomesrootdir: /home
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the maximum user name length is set to 32
+  community.general.ipa_config:
+    ipamaxusernamelength: '32'
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the password expiration notice is set to 4 days
+  community.general.ipa_config:
+    ipapwdexpadvnotify: '4'
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the search record limit is set to 100
+  community.general.ipa_config:
+    ipasearchrecordslimit: '100'
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the search time limit is set to 2 seconds
+  community.general.ipa_config:
+    ipasearchtimelimit: '2'
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the default user auth type is password
+  community.general.ipa_config:
+    ipauserauthtype: password
+    ipa_host: localhost
+    ipa_user: admin
+    ipa_pass: supersecret
+
+- name: Ensure the user search fields is set to 'uid,givenname,sn,ou,title'
+  community.general.ipa_config:
+    ipausersearchfields: uid,givenname,sn,ou,title
     ipa_host: localhost
     ipa_user: admin
     ipa_pass: supersecret
@@ -68,12 +183,35 @@ class ConfigIPAClient(IPAClient):
         return self._post_json(method='config_mod', name=name, item=item)
 
 
-def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None):
+def get_config_dict(ipadefaultloginshell=None, ipadefaultemaildomain=None,
+                    ipadefaultprimarygroup=None, ipagroupsearchfields=None,
+                    ipahomesrootdir=None, ipamaxusernamelength=None,
+                    ipapwdexpadvnotify=None, ipasearchrecordslimit=None,
+                    ipasearchtimelimit=None, ipauserauthtype=None,
+                    ipausersearchfields=None):
     config = {}
     if ipadefaultloginshell is not None:
         config['ipadefaultloginshell'] = ipadefaultloginshell
     if ipadefaultemaildomain is not None:
         config['ipadefaultemaildomain'] = ipadefaultemaildomain
+    if ipadefaultprimarygroup is not None:
+        config['ipadefaultprimarygroup'] = ipadefaultprimarygroup
+    if ipagroupsearchfields is not None:
+        config['ipagroupsearchfields'] = ipagroupsearchfields
+    if ipahomesrootdir is not None:
+        config['ipahomesrootdir'] = ipahomesrootdir
+    if ipamaxusernamelength is not None:
+        config['ipamaxusernamelength'] = ipamaxusernamelength
+    if ipapwdexpadvnotify is not None:
+        config['ipapwdexpadvnotify'] = ipapwdexpadvnotify
+    if ipasearchrecordslimit is not None:
+        config['ipasearchrecordslimit'] = ipasearchrecordslimit
+    if ipasearchtimelimit is not None:
+        config['ipasearchtimelimit'] = ipasearchtimelimit
+    if ipauserauthtype is not None:
+        config['ipauserauthtype'] = ipauserauthtype
+    if ipausersearchfields is not None:
+        config['ipausersearchfields'] = ipausersearchfields
 
     return config
 
@@ -86,6 +224,15 @@ def ensure(module, client):
     module_config = get_config_dict(
         ipadefaultloginshell=module.params.get('ipadefaultloginshell'),
         ipadefaultemaildomain=module.params.get('ipadefaultemaildomain'),
+        ipadefaultprimarygroup=module.params.get('ipadefaultprimarygroup'),
+        ipagroupsearchfields=module.params.get('ipagroupsearchfields'),
+        ipahomesrootdir=module.params.get('ipahomesrootdir'),
+        ipamaxusernamelength=module.params.get('ipamaxusernamelength'),
+        ipapwdexpadvnotify=module.params.get('ipapwdexpadvnotify'),
+        ipasearchrecordslimit=module.params.get('ipasearchrecordslimit'),
+        ipasearchtimelimit=module.params.get('ipasearchtimelimit'),
+        ipauserauthtype=module.params.get('ipauserauthtype'),
+        ipausersearchfields=module.params.get('ipausersearchfields'),
     )
     ipa_config = client.config_show()
     diff = get_config_diff(client, ipa_config, module_config)
@@ -108,6 +255,17 @@ def main():
     argument_spec.update(
         ipadefaultloginshell=dict(type='str', aliases=['loginshell']),
         ipadefaultemaildomain=dict(type='str', aliases=['emaildomain']),
+        ipadefaultprimarygroup=dict(type='str', aliases=['primarygroup']),
+        ipagroupsearchfields=dict(type='str', aliases=['groupsearchfields']),
+        ipahomesrootdir=dict(type='str', aliases=['homesrootdir']),
+        ipamaxusernamelength=dict(type='str', aliases=['maxusernamelength']),
+        ipapwdexpadvnotify=dict(type='str', aliases=['pwdexpadvnotify']),
+        ipasearchrecordslimit=dict(type='str', aliases=['searchrecordslimit']),
+        ipasearchtimelimit=dict(type='str', aliases=['searchtimelimit']),
+        ipauserauthtype=dict(type='str', aliases=['userauthtype'],
+                             choices=["password", "radius", "otp", "pkinit",
+                                      "hardened", "disabled"]),
+        ipausersearchfields=dict(type='str', aliases=['usersearchfields']),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -15,7 +15,7 @@ description:
 - Modify global configuration settings of a FreeIPA Server.
 options:
   ipaconfigstring:
-    description: Extra hashes to generate in password plug-in
+    description: Extra hashes to generate in password plug-in.
     aliases: ["configstring"]
     type: list
     elements: str


### PR DESCRIPTION
##### SUMMARY
Added fields to the ipa_config module: ipaconfistring, ipadefaultprimarygroup, ipagroupsearchfields, ipahomesrootdir, ipakrbauthzdata, ipamaxusernamelength, ipapwdexpadvnotify, ipasearchrecordslimit, ipasearchtimelimit, ipauserauthtype, ipausersearchfields

Fixes #2115 
Fixes #498

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_config
