### PR TITLE
Wire token param into consul_api #2124

### DIFF
--- a/changelogs/fragments/2124-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2124-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - plugins/lookup/consul_kv.py - use self.get_option and
-    wire the exsisting token attribute into consul_api call.
-    (https://github.com/ansible-collections/community.general/issues/2124)
+  - consul_kv lookup - use ``self.get_option`` and
+    wire the existing ``token`` attribute into consul_api call
+    (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2124-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2124-consul_kv-pass-token.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - plugins/lookup/consul_kv.py - use self.get_option and
+    wire the exsisting token attribute into consul_api call.
+    (https://github.com/ansible-collections/community.general/issues/2124)

--- a/changelogs/fragments/2124-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2124-consul_kv-pass-token.yml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - plugins/lookup/consul_kv.py - use self.get_option and
-    wire the exsisting token attribute into consul_api call.
-    (https://github.com/ansible-collections/community.general/issues/2124)

--- a/changelogs/fragments/2124-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2124-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - consul_kv lookup - use ``self.get_option`` and
-    wire the existing ``token`` attribute into consul_api call
-    (https://github.com/ansible-collections/community.general/issues/2124).
+  - plugins/lookup/consul_kv.py - use self.get_option and
+    wire the exsisting token attribute into consul_api call.
+    (https://github.com/ansible-collections/community.general/issues/2124)

--- a/changelogs/fragments/2124-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2124-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    remove the function parse_params all together with its for loop
+    wire the existing ``token`` attribute into consul_api call
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    remove the function parse_params all together with its for loop
+    remove the function parse_params get key form self.terms
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    wire the existing ``token`` attribute into consul_api call
+    remove the function parse_params all together with its for loop
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - consul_kv lookup plugin - allow to set ``recurse``, ``index``, ``datacenter`` and 
+    ``token`` as keyword arguments
+    (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    remove the function parse_params get key form self.terms
+    remove the function ``parse_params()`` get key form ``self.terms``
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,4 @@
 ---
 bugfixes:
-  - consul_kv lookup plugin - allow to set ``recurse``, ``index``, ``datacenter`` and 
-    ``token`` as keyword arguments
+  - consul_kv lookup plugin - allow to set ``recurse``, ``index``, ``datacenter`` and ``token`` as keyword arguments
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    remove the function parse_params get key form self.terms
+    remove the function parse_params all together with its for loop
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/changelogs/fragments/2126-consul_kv-pass-token.yml
+++ b/changelogs/fragments/2126-consul_kv-pass-token.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
   - consul_kv lookup - use ``self.get_option`` and
-    remove the function ``parse_params()`` get key form ``self.terms``
+    remove the function parse_params get key form self.terms
     (https://github.com/ansible-collections/community.general/issues/2124).

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -150,7 +150,7 @@ class LookupModule(LookupBase):
             for term in terms:
                 key = term.split(' ')[0]
                 consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token,
-                                dc=datacenter, verify=validate_certs, cert=client_cert)
+                                           dc=datacenter, verify=validate_certs, cert=client_cert)
 
                 results = consul_api.kv.get(key,
                                             index=index,

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -126,7 +126,6 @@ class LookupModule(LookupBase):
 
         # get options
         self.set_options(direct=kwargs)
-        key = terms[0].split(' ')[0]
         scheme = self.get_option('scheme')
         host = self.get_option('host')
         port = self.get_option('port')
@@ -148,20 +147,22 @@ class LookupModule(LookupBase):
 
         values = []
         try:
-          consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, dc=datacenter,
-                                        verify=validate_certs, cert=client_cert)
+              for term in terms:
+                  key = term.split(' ')[0]
+                  consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, 
+                  dc=datacenter,verify=validate_certs, cert=client_cert)
 
-          results = consul_api.kv.get(key,
-                                      index=index,
-                                      recurse=recurse,
-                                      )
-          if results[1]:
-              # responds with a single or list of result maps
-              if isinstance(results[1], list):
-                  for r in results[1]:
-                      values.append(to_text(r['Value']))
-              else:
-                  values.append(to_text(results[1]['Value']))
+                  results = consul_api.kv.get(key,
+                                              index=index,
+                                              recurse=recurse,
+                                              )
+                  if results[1]:
+                      # responds with a single or list of result maps
+                      if isinstance(results[1], list):
+                          for r in results[1]:
+                              values.append(to_text(r['Value']))
+                      else:
+                          values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
                 "Error locating '%s' in kv store. Error was %s" % (key, e))

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -138,31 +138,31 @@ class LookupModule(LookupBase):
             if u.port is not None:
                 port = u.port
         token = self.get_option('token')
-        datacenter=self.get_option('datacenter')
-        recurse=self.get_option('recurse')
-        index=self.get_option('index')
+        datacenter = self.get_option('datacenter')
+        recurse = self.get_option('recurse')
+        index = self.get_option('index')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
 
         values = []
         try:
-              for term in terms:
-                  key = term.split(' ')[0]
-                  consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, 
-                  dc=datacenter,verify=validate_certs, cert=client_cert)
+            for term in terms:
+                key = term.split(' ')[0]
+                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token,
+                                dc=datacenter, verify=validate_certs, cert=client_cert)
 
-                  results = consul_api.kv.get(key,
-                                              index=index,
-                                              recurse=recurse,
-                                              )
-                  if results[1]:
-                      # responds with a single or list of result maps
-                      if isinstance(results[1], list):
-                          for r in results[1]:
-                              values.append(to_text(r['Value']))
-                      else:
-                          values.append(to_text(results[1]['Value']))
+                results = consul_api.kv.get(key,
+                                            index=index,
+                                            recurse=recurse,
+                                            )
+                if results[1]:
+                    # responds with a single or list of result maps
+                    if isinstance(results[1], list):
+                        for r in results[1]:
+                            values.append(to_text(r['Value']))
+                    else:
+                        values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
                 "Error locating '%s' in kv store. Error was %s" % (key, e))

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -171,10 +171,10 @@ class LookupModule(LookupBase):
 
         paramvals = {
             'key': params[0],
-            'token': None,
-            'recurse': False,
-            'index': None,
-            'datacenter': None
+            'token': self.get_option('token'),
+            'recurse': self.get_option('recurse'),
+            'index': self.get_option('index'),
+            'datacenter': self.get_option('datacenter')
         }
 
         # parameters specified?

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -138,6 +138,7 @@ class LookupModule(LookupBase):
             host = u.hostname
             if u.port is not None:
                 port = u.port
+        token = self.get_option('token')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
@@ -146,7 +147,7 @@ class LookupModule(LookupBase):
         try:
             for term in terms:
                 params = self.parse_params(term)
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs, cert=client_cert)
+                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, verify=validate_certs, cert=client_cert)
 
                 results = consul_api.kv.get(params['key'],
                                             token=params['token'],

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -126,7 +126,7 @@ class LookupModule(LookupBase):
 
         # get options
         self.set_options(direct=kwargs)
-        key = terms[0].split(' ')[0]
+
         scheme = self.get_option('scheme')
         host = self.get_option('host')
         port = self.get_option('port')
@@ -139,31 +139,54 @@ class LookupModule(LookupBase):
             if u.port is not None:
                 port = u.port
         token = self.get_option('token')
-        datacenter=self.get_option('datacenter')
-        recurse=self.get_option('recurse')
-        index=self.get_option('index')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
 
         values = []
         try:
-          consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, dc=datacenter,
-                                        verify=validate_certs, cert=client_cert)
+            for term in terms:
+                params = self.parse_params(term)
+                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, verify=validate_certs, cert=client_cert)
 
-          results = consul_api.kv.get(key,
-                                      index=index,
-                                      recurse=recurse,
-                                      )
-          if results[1]:
-              # responds with a single or list of result maps
-              if isinstance(results[1], list):
-                  for r in results[1]:
-                      values.append(to_text(r['Value']))
-              else:
-                  values.append(to_text(results[1]['Value']))
+                results = consul_api.kv.get(params['key'],
+                                            token=params['token'],
+                                            index=params['index'],
+                                            recurse=params['recurse'],
+                                            dc=params['datacenter'])
+                if results[1]:
+                    # responds with a single or list of result maps
+                    if isinstance(results[1], list):
+                        for r in results[1]:
+                            values.append(to_text(r['Value']))
+                    else:
+                        values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
-                "Error locating '%s' in kv store. Error was %s" % (key, e))
+                "Error locating '%s' in kv store. Error was %s" % (term, e))
 
         return values
+
+    def parse_params(self, term):
+        params = term.split(' ')
+
+        paramvals = {
+            'key': params[0],
+            'token': None,
+            'recurse': False,
+            'index': None,
+            'datacenter': None
+        }
+
+        # parameters specified?
+        try:
+            for param in params[1:]:
+                if param and len(param) > 0:
+                    name, value = param.split('=')
+                    if name not in paramvals:
+                        raise AnsibleAssertionError("%s not a valid consul lookup parameter" % name)
+                    paramvals[name] = value
+        except (ValueError, AssertionError) as e:
+            raise AnsibleError(e)
+
+        return paramvals

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -126,6 +126,7 @@ class LookupModule(LookupBase):
 
         # get options
         self.set_options(direct=kwargs)
+        key = terms[0].split(' ')[0]
         scheme = self.get_option('scheme')
         host = self.get_option('host')
         port = self.get_option('port')
@@ -147,22 +148,20 @@ class LookupModule(LookupBase):
 
         values = []
         try:
-              for term in terms:
-                  key = term.split(' ')[0]
-                  consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, 
-                  dc=datacenter,verify=validate_certs, cert=client_cert)
+          consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, dc=datacenter,
+                                        verify=validate_certs, cert=client_cert)
 
-                  results = consul_api.kv.get(key,
-                                              index=index,
-                                              recurse=recurse,
-                                              )
-                  if results[1]:
-                      # responds with a single or list of result maps
-                      if isinstance(results[1], list):
-                          for r in results[1]:
-                              values.append(to_text(r['Value']))
-                      else:
-                          values.append(to_text(results[1]['Value']))
+          results = consul_api.kv.get(key,
+                                      index=index,
+                                      recurse=recurse,
+                                      )
+          if results[1]:
+              # responds with a single or list of result maps
+              if isinstance(results[1], list):
+                  for r in results[1]:
+                      values.append(to_text(r['Value']))
+              else:
+                  values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
                 "Error locating '%s' in kv store. Error was %s" % (key, e))

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -150,7 +150,7 @@ class LookupModule(LookupBase):
             for term in terms:
                 key = term.split(' ')[0]
                 consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token,
-                                           dc=datacenter, verify=validate_certs, cert=client_cert)
+                                dc=datacenter, verify=validate_certs, cert=client_cert)
 
                 results = consul_api.kv.get(key,
                                             index=index,

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -138,7 +138,6 @@ class LookupModule(LookupBase):
             host = u.hostname
             if u.port is not None:
                 port = u.port
-        token = self.get_option('token')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
@@ -147,7 +146,7 @@ class LookupModule(LookupBase):
         try:
             for term in terms:
                 params = self.parse_params(term)
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, verify=validate_certs, cert=client_cert)
+                consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs, cert=client_cert)
 
                 results = consul_api.kv.get(params['key'],
                                             token=params['token'],

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -2,6 +2,11 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
+from ansible.module_utils._text import to_text
+from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError, AnsibleAssertionError
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+import os
 
 __metaclass__ = type
 
@@ -102,11 +107,6 @@ RETURN = """
     type: dict
 """
 
-import os
-from ansible.module_utils.six.moves.urllib.parse import urlparse
-from ansible.errors import AnsibleError, AnsibleAssertionError
-from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
 
 try:
     import consul
@@ -126,6 +126,7 @@ class LookupModule(LookupBase):
 
         # get options
         self.set_options(direct=kwargs)
+
         scheme = self.get_option('scheme')
         host = self.get_option('host')
         port = self.get_option('port')
@@ -137,10 +138,6 @@ class LookupModule(LookupBase):
             host = u.hostname
             if u.port is not None:
                 port = u.port
-        token = self.get_option('token')
-        datacenter = self.get_option('datacenter')
-        recurse = self.get_option('recurse')
-        index = self.get_option('index')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
@@ -148,14 +145,15 @@ class LookupModule(LookupBase):
         values = []
         try:
             for term in terms:
-                key = term.split(' ')[0]
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token,
-                                           dc=datacenter, verify=validate_certs, cert=client_cert)
+                params = self.parse_params(term)
+                consul_api = consul.Consul(
+                    host=host, port=port, scheme=scheme, verify=validate_certs, cert=client_cert)
 
-                results = consul_api.kv.get(key,
-                                            index=index,
-                                            recurse=recurse,
-                                            )
+                results = consul_api.kv.get(params['key'],
+                                            token=params['token'],
+                                            index=params['index'],
+                                            recurse=params['recurse'],
+                                            dc=params['datacenter'])
                 if results[1]:
                     # responds with a single or list of result maps
                     if isinstance(results[1], list):
@@ -165,6 +163,31 @@ class LookupModule(LookupBase):
                         values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
-                "Error locating '%s' in kv store. Error was %s" % (key, e))
+                "Error locating '%s' in kv store. Error was %s" % (term, e))
 
         return values
+
+    def parse_params(self, term):
+        params = term.split(' ')
+
+        paramvals = {
+            'key': params[0],
+            'token': self.get_option('token'),
+            'recurse': self.get_option('recurse'),
+            'index': self.get_option('index'),
+            'datacenter': self.get_option('datacenter')
+        }
+
+        # parameters specified?
+        try:
+            for param in params[1:]:
+                if param and len(param) > 0:
+                    name, value = param.split('=')
+                    if name not in paramvals:
+                        raise AnsibleAssertionError(
+                            "%s not a valid consul lookup parameter" % name)
+                    paramvals[name] = value
+        except (ValueError, AssertionError) as e:
+            raise AnsibleError(e)
+
+        return paramvals

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -138,31 +138,31 @@ class LookupModule(LookupBase):
             if u.port is not None:
                 port = u.port
         token = self.get_option('token')
-        datacenter = self.get_option('datacenter')
-        recurse = self.get_option('recurse')
-        index = self.get_option('index')
+        datacenter=self.get_option('datacenter')
+        recurse=self.get_option('recurse')
+        index=self.get_option('index')
 
         validate_certs = self.get_option('validate_certs')
         client_cert = self.get_option('client_cert')
 
         values = []
         try:
-            for term in terms:
-                key = term.split(' ')[0]
-                consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token,
-                                dc=datacenter, verify=validate_certs, cert=client_cert)
+              for term in terms:
+                  key = term.split(' ')[0]
+                  consul_api = consul.Consul(host=host, port=port, scheme=scheme, token=token, 
+                  dc=datacenter,verify=validate_certs, cert=client_cert)
 
-                results = consul_api.kv.get(key,
-                                            index=index,
-                                            recurse=recurse,
-                                            )
-                if results[1]:
-                    # responds with a single or list of result maps
-                    if isinstance(results[1], list):
-                        for r in results[1]:
-                            values.append(to_text(r['Value']))
-                    else:
-                        values.append(to_text(results[1]['Value']))
+                  results = consul_api.kv.get(key,
+                                              index=index,
+                                              recurse=recurse,
+                                              )
+                  if results[1]:
+                      # responds with a single or list of result maps
+                      if isinstance(results[1], list):
+                          for r in results[1]:
+                              values.append(to_text(r['Value']))
+                      else:
+                          values.append(to_text(results[1]['Value']))
         except Exception as e:
             raise AnsibleError(
                 "Error locating '%s' in kv store. Error was %s" % (key, e))


### PR DESCRIPTION
##### SUMMARY
a first contribution attempt: 
/lookup/consul_kv.py should now use it's exsistent parameter token,
if provided. 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup/consul_kv.py

##### ADDITIONAL INFORMATION
see [issue comment](https://github.com/ansible-collections/community.general/issues/2124#issuecomment-808799307)
