### PR TITLE
[PR #2125/eb24e336 backport][stable-1] git_config - fixed bug with scope file

### DIFF
--- a/changelogs/fragments/2125-git-config-scope-file.yml
+++ b/changelogs/fragments/2125-git-config-scope-file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - git_config - fixed scope ``file`` behaviour, added integraton test for it, marked integration tests as destructive (https://github.com/ansible-collections/community.general/issues/2117).

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -206,7 +206,10 @@ def main():
     args = [git_path, "config", "--includes"]
     if params['list_all']:
         args.append('-l')
-    if scope:
+    if scope == 'file':
+        args.append('-f')
+        args.append(params['file'])
+    elif scope:
         args.append("--" + scope)
     if name:
         args.append(name)

--- a/tests/integration/targets/git_config/aliases
+++ b/tests/integration/targets/git_config/aliases
@@ -1,2 +1,4 @@
 shippable/posix/group3
 skip/aix
+destructive
+

--- a/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
+++ b/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
@@ -1,0 +1,29 @@
+---
+- import_tasks: setup_no_value.yml
+
+- name: setting value with state=present
+  git_config:
+    name: "{{ option_name }}"
+    value: "{{ option_value }}"
+    scope: "file"
+    file: "{{ output_dir }}/gitconfig_file"
+    state: present
+  register: result
+
+- name: getting value with state=present
+  git_config:
+    name: "{{ option_name }}"
+    scope: "file"
+    file: "{{ output_dir }}/gitconfig_file"
+    state: present
+  register: get_result
+
+- name: assert set changed and value is correct with state=present
+  assert:
+    that:
+      - set_result.changed == true
+      - set_result.diff.before == "\n"
+      - set_result.diff.after == option_value + "\n"
+      - get_result.changed == false
+      - get_result.config_value == option_value
+...

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -16,6 +16,8 @@
     - import_tasks: get_set_no_state.yml
     # testing get/set option with state=present
     - import_tasks: get_set_state_present.yml
+    # testing get/set option with state=present and scope=file
+    - import_tasks: get_set_state_present_file.yml
     # testing state=absent without value to delete
     - import_tasks: unset_no_value.yml
     # testing state=absent with value to delete

--- a/tests/integration/targets/git_config/tasks/setup_no_value.yml
+++ b/tests/integration/targets/git_config/tasks/setup_no_value.yml
@@ -5,4 +5,8 @@
   file:
     path: ~/.gitconfig
     state: absent
+- name: set up without value (file)
+  file:
+    path: "{{ output_dir }}/gitconfig_file"
+    state: absent
 ...

--- a/tests/integration/targets/git_config/tasks/setup_value.yml
+++ b/tests/integration/targets/git_config/tasks/setup_value.yml
@@ -5,4 +5,9 @@
   copy:
     src: gitconfig
     dest: ~/.gitconfig
+
+- name: set up with value (file)
+  copy:
+    src: gitconfig
+    dest: "{{ output_dir }}/gitconfig_file"
 ...


### PR DESCRIPTION
This is a backport of PR #2125 as merged into main (eb24e33).

##### SUMMARY
- scope file was not working
- added test to guarantee that behaviour
- marked integration test as destructive, because it overwrites ~/.gitconfig

Fixes #2117

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git_config
