### PR TITLE
fix type information for vmadm.resolvers

### DIFF
--- a/changelogs/fragments/2135-vmadm-resolvers-type-fix.yml
+++ b/changelogs/fragments/2135-vmadm-resolvers-type-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmadm - correct type of list in resolvers parameter
+  - vmadm - correct type of list elements in ``resolvers`` parameter (https://github.com/ansible-collections/community.general/issues/2135).

--- a/changelogs/fragments/2135-vmadm-resolvers-type-fix.yml
+++ b/changelogs/fragments/2135-vmadm-resolvers-type-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmadm - correct type of list in resolvers parameter

--- a/plugins/modules/cloud/smartos/vmadm.py
+++ b/plugins/modules/cloud/smartos/vmadm.py
@@ -233,7 +233,7 @@ options:
     description:
       - List of resolvers to be put into C(/etc/resolv.conf).
     type: list
-    elements: dict
+    elements: str
   routes:
     required: false
     description:
@@ -702,7 +702,7 @@ def main():
         vnc_password=dict(type='str', no_log=True),
         disks=dict(type='list', elements='dict'),
         nics=dict(type='list', elements='dict'),
-        resolvers=dict(type='list', elements='dict'),
+        resolvers=dict(type='list', elements='str'),
         filesystems=dict(type='list', elements='dict'),
     )
 


### PR DESCRIPTION
##### SUMMARY
Fixes #2135

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmadm

##### ADDITIONAL INFORMATION

Fixes type checking for the `resolvers` parameter for `vmadm`
