### PR TITLE
Dimensiondata network str format

### DIFF
--- a/changelogs/fragments/2139-dimensiondata_network-str-format.yml
+++ b/changelogs/fragments/2139-dimensiondata_network-str-format.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dimensiondata_network - bug when formatting message, instead of % a simple comma was used (https://github.com/ansible-collections/community.general/pull/2139).

--- a/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
+++ b/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
@@ -260,7 +260,7 @@ class DimensionDataNetworkModule(DimensionDataModule):
                 )
 
             self.module.fail_json(
-                "Unexpected failure deleting network with id %s", network.id
+                "Unexpected failure deleting network with id %s" % network.id
             )
 
         except DimensionDataAPIException as e:


### PR DESCRIPTION
##### SUMMARY
Bug when formatting message, instead of `%` a simple comma was used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dimensiondata_network

