### PR TITLE
kibana_plugin: fixed remove call + run_command with list instead of str

### DIFF
--- a/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
+++ b/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - kibana_plugin - added missing parameters to ``remove_plugin`` when using ``state=present force=true`` (https://github.com/ansible-collections/community.general/pull/2143).

--- a/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
+++ b/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - kibana_plugin - added missing parameters to ``remove_plugin`` when using ``state=present force=true`` (https://github.com/ansible-collections/community.general/pull/2143).
+  - kibana_plugin - added missing parameters to ``remove_plugin`` when using ``state=present force=true``, and fix potential quoting errors when invoking ``kibana`` (https://github.com/ansible-collections/community.general/pull/2143).

--- a/plugins/modules/database/misc/kibana_plugin.py
+++ b/plugins/modules/database/misc/kibana_plugin.py
@@ -178,17 +178,15 @@ def install_plugin(module, plugin_bin, plugin_name, url, timeout, allow_root, ki
     if allow_root:
         cmd_args.append('--allow-root')
 
-    cmd = " ".join(cmd_args)
-
     if module.check_mode:
-        return True, cmd, "check mode", ""
+        return True, " ".join(cmd_args), "check mode", ""
 
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         reason = parse_error(out)
         module.fail_json(msg=reason)
 
-    return True, cmd, out, err
+    return True, " ".join(cmd_args), out, err
 
 
 def remove_plugin(module, plugin_bin, plugin_name, allow_root, kibana_version='4.6'):
@@ -269,7 +267,7 @@ def main():
 
     if state == "present":
         if force:
-            remove_plugin(module, plugin_bin, name)
+            remove_plugin(module, plugin_bin, name, allow_root, kibana_version)
         changed, cmd, out, err = install_plugin(module, plugin_bin, name, url, timeout, allow_root, kibana_version)
 
     elif state == "absent":

--- a/plugins/modules/database/misc/kibana_plugin.py
+++ b/plugins/modules/database/misc/kibana_plugin.py
@@ -199,17 +199,15 @@ def remove_plugin(module, plugin_bin, plugin_name, allow_root, kibana_version='4
     if allow_root:
         cmd_args.append('--allow-root')
 
-    cmd = " ".join(cmd_args)
-
     if module.check_mode:
-        return True, cmd, "check mode", ""
+        return True, " ".join(cmd_args), "check mode", ""
 
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         reason = parse_error(out)
         module.fail_json(msg=reason)
 
-    return True, cmd, out, err
+    return True, " ".join(cmd_args), out, err
 
 
 def get_kibana_version(module, plugin_bin, allow_root):
@@ -218,8 +216,7 @@ def get_kibana_version(module, plugin_bin, allow_root):
     if allow_root:
         cmd_args.append('--allow-root')
 
-    cmd = " ".join(cmd_args)
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         module.fail_json(msg="Failed to get Kibana version : %s" % err)
 

--- a/plugins/modules/database/misc/kibana_plugin.py
+++ b/plugins/modules/database/misc/kibana_plugin.py
@@ -170,10 +170,10 @@ def install_plugin(module, plugin_bin, plugin_name, url, timeout, allow_root, ki
         cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["present"], plugin_name]
 
         if url:
-            cmd_args.append("--url %s" % url)
+            cmd_args.extend(["--url", url])
 
     if timeout:
-        cmd_args.append("--timeout %s" % timeout)
+        cmd_args.extend(["--timeout", timeout])
 
     if allow_root:
         cmd_args.append('--allow-root')


### PR DESCRIPTION
##### SUMMARY
Added missing arguments to `remove_plugin()` when `state=present force=true`.

While at it, when calling `run_command()` it was converting a list to str, so changed it to keep the list.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kibana_plugin
