### PR TITLE
using get_bin_path() on atomic modules

### DIFF
--- a/changelogs/fragments/2144-atomic_get_bin_path.yml
+++ b/changelogs/fragments/2144-atomic_get_bin_path.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - atomic_container - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).
-  - atomic_host - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).
-  - atomic_image - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).
+  - atomic_container - using ``get_bin_path()`` before calling ``run_command()`` (https://github.com/ansible-collections/community.general/pull/2144).
+  - atomic_host - using ``get_bin_path()`` before calling ``run_command()`` (https://github.com/ansible-collections/community.general/pull/2144).
+  - atomic_image - using ``get_bin_path()`` before calling ``run_command()`` (https://github.com/ansible-collections/community.general/pull/2144).

--- a/changelogs/fragments/2144-atomic_get_bin_path.yml
+++ b/changelogs/fragments/2144-atomic_get_bin_path.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - atomic_container - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).
+  - atomic_host - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).
+  - atomic_image - using `get_bin_path()` before calling `run_command()` (https://github.com/ansible-collections/community.general/pull/2144).

--- a/plugins/modules/cloud/atomic/atomic_container.py
+++ b/plugins/modules/cloud/atomic/atomic_container.py
@@ -102,7 +102,8 @@ def do_install(module, mode, rootfs, container, image, values_list, backend):
     system_list = ["--system"] if mode == 'system' else []
     user_list = ["--user"] if mode == 'user' else []
     rootfs_list = ["--rootfs=%s" % rootfs] if rootfs else []
-    args = ['atomic', 'install', "--storage=%s" % backend, '--name=%s' % container] + system_list + user_list + rootfs_list + values_list + [image]
+    atomic_bin = module.get_bin_path('atomic')
+    args = [atomic_bin, 'install', "--storage=%s" % backend, '--name=%s' % container] + system_list + user_list + rootfs_list + values_list + [image]
     rc, out, err = module.run_command(args, check_rc=False)
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
@@ -112,7 +113,8 @@ def do_install(module, mode, rootfs, container, image, values_list, backend):
 
 
 def do_update(module, container, image, values_list):
-    args = ['atomic', 'containers', 'update', "--rebase=%s" % image] + values_list + [container]
+    atomic_bin = module.get_bin_path('atomic')
+    args = [atomic_bin, 'containers', 'update', "--rebase=%s" % image] + values_list + [container]
     rc, out, err = module.run_command(args, check_rc=False)
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
@@ -122,7 +124,8 @@ def do_update(module, container, image, values_list):
 
 
 def do_uninstall(module, name, backend):
-    args = ['atomic', 'uninstall', "--storage=%s" % backend, name]
+    atomic_bin = module.get_bin_path('atomic')
+    args = [atomic_bin, 'uninstall', "--storage=%s" % backend, name]
     rc, out, err = module.run_command(args, check_rc=False)
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
@@ -130,7 +133,8 @@ def do_uninstall(module, name, backend):
 
 
 def do_rollback(module, name):
-    args = ['atomic', 'containers', 'rollback', name]
+    atomic_bin = module.get_bin_path('atomic')
+    args = [atomic_bin, 'containers', 'rollback', name]
     rc, out, err = module.run_command(args, check_rc=False)
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
@@ -148,14 +152,12 @@ def core(module):
     backend = module.params['backend']
     state = module.params['state']
 
+    atomic_bin = module.get_bin_path('atomic')
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
-    out = {}
-    err = {}
-    rc = 0
 
     values_list = ["--set=%s" % x for x in values] if values else []
 
-    args = ['atomic', 'containers', 'list', '--no-trunc', '-n', '--all', '-f', 'backend=%s' % backend, '-f', 'container=%s' % name]
+    args = [atomic_bin, 'containers', 'list', '--no-trunc', '-n', '--all', '-f', 'backend=%s' % backend, '-f', 'container=%s' % name]
     rc, out, err = module.run_command(args, check_rc=False)
     if rc != 0:
         module.fail_json(rc=rc, msg=err)
@@ -194,9 +196,7 @@ def main():
         module.fail_json(msg="values is supported only with user or system mode")
 
     # Verify that the platform supports atomic command
-    rc, out, err = module.run_command('atomic -v', check_rc=False)
-    if rc != 0:
-        module.fail_json(msg="Error in running atomic command", err=err)
+    dummy = module.get_bin_path('atomic', required=True)
 
     try:
         core(module)

--- a/plugins/modules/cloud/atomic/atomic_host.py
+++ b/plugins/modules/cloud/atomic/atomic_host.py
@@ -57,18 +57,14 @@ from ansible.module_utils._text import to_native
 
 def core(module):
     revision = module.params['revision']
-    args = []
+    atomic_bin = module.get_bin_path('atomic', required=True)
 
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
 
     if revision == 'latest':
-        args = ['atomic', 'host', 'upgrade']
+        args = [atomic_bin, 'host', 'upgrade']
     else:
-        args = ['atomic', 'host', 'deploy', revision]
-
-    out = {}
-    err = {}
-    rc = 0
+        args = [atomic_bin, 'host', 'deploy', revision]
 
     rc, out, err = module.run_command(args, check_rc=False)
 


### PR DESCRIPTION
##### SUMMARY
These modules were calling `run_command()` without submitting the command through `get_bin_path()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/atomic/atomic_container.py
plugins/modules/cloud/atomic/atomic_host.py
plugins/modules/cloud/atomic/atomic_image.py
