### PR TITLE
Proxmox_Inv: Adding agent network interaces fact

### DIFF
--- a/changelogs/fragments/2148-proxmox-inventory-agent-interfaces.yml
+++ b/changelogs/fragments/2148-proxmox-inventory-agent-interfaces.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- proxmox inventory plugin - added ``proxmox_agent_interfaces`` fact describing network interfaces returned from a QEMU guest agent (https://github.com/ansible-collections/community.general/pull/2148).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -217,13 +217,13 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             )['result']
 
             for iface in ifaces:
-                record = {}
-                record['name'] = iface['name']
-                record['mac-address'] = iface['hardware-address']
-                record['ip-addresses'] = [
-                    "%s/%s" % (ip['ip-address'], ip['prefix']) for ip in iface['ip-addresses']
-                ]
-                result.append(record)
+                result.append({
+                    'name': iface['name'],
+                    'mac-address': iface['hardware-address'],
+                    'ip-addresses': [
+                        "%s/%s" % (ip['ip-address'], ip['prefix']) for ip in iface['ip-addresses']
+                    ]
+                })
         except requests.HTTPError:
             pass
 

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -320,7 +320,7 @@ def test_populate(inventory, mocker):
     assert group_qemu.hosts == [host_qemu]
 
     # check if qemu-test has eth0 interface in agent_interfaces fact
-    assert 'eth0' in [ d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth0' in [d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
 
     # check if lxc-test has been discovered correctly
     group_lxc = inventory.inventory.groups['proxmox_all_lxc']

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -71,8 +71,7 @@ def get_json(url):
                  "status": "running",
                  "vmid": "100",
                  "disk": "1000",
-                 "uptime": 1000,
-                 "tags": "test, tags, here"}]
+                 "uptime": 1000}]
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu":
         # _get_qemu_per_node
         return [{"name": "test-qemu",
@@ -106,8 +105,7 @@ def get_json(url):
                  "vmid": "9001",
                  "uptime": 0,
                  "disk": 0,
-                 "status": "stopped",
-                 "tags": "test, tags, here"}]
+                 "status": "stopped"}]
     elif url == "https://localhost:8006/api2/json/pools/test":
         # _get_members_per_pool
         return {"members": [{"uptime": 1000,
@@ -164,6 +162,122 @@ def get_json(url):
                  "method6": "manual",
                  "autostart": 1,
                  "active": 1}]
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/lxc/100/config":
+        return {
+            "console": 1,
+            "rootfs": "local-lvm:vm-100-disk-0,size=4G",
+            "cmode": "tty",
+            "description": "A testnode",
+            "cores": 1,
+            "hostname": "test-lxc",
+            "arch": "amd64",
+            "tty": 2,
+            "swap": 0,
+            "cpulimit": "0",
+            "net0": "name=eth0,bridge=vmbr0,gw=10.1.1.1,hwaddr=FF:FF:FF:FF:FF:FF,ip=10.1.1.3/24,type=veth",
+            "ostype": "ubuntu",
+            "digest": "123456789abcdef0123456789abcdef01234567890",
+            "protection": 0,
+            "memory": 1000,
+            "onboot": 0,
+            "cpuunits": 1024,
+            "tags": "one, two, three",
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/config":
+        return {
+            "tags": "one, two, three",
+            "cores": 1,
+            "ide2": "none,media=cdrom",
+            "memory": 1000,
+            "kvm": 1,
+            "digest": "0123456789abcdef0123456789abcdef0123456789",
+            "description": "A test qemu",
+            "sockets": 1,
+            "onboot": 1,
+            "vmgenid": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "numa": 0,
+            "bootdisk": "scsi0",
+            "cpu": "host",
+            "name": "test-qemu",
+            "ostype": "l26",
+            "hotplug": "network,disk,usb",
+            "scsi0": "local-lvm:vm-101-disk-0,size=8G",
+            "net0": "virtio=ff:ff:ff:ff:ff:ff,bridge=vmbr0,firewall=1",
+            "agent": "1",
+            "bios": "seabios",
+            "ide0": "local-lvm:vm-101-cloudinit,media=cdrom,size=4M",
+            "boot": "cdn",
+            "scsihw": "virtio-scsi-pci",
+            "smbios1": "uuid=ffffffff-ffff-ffff-ffff-ffffffffffff"
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/agent/network-get-interfaces":
+        return {"result": [
+            {
+                "hardware-address": "00:00:00:00:00:00",
+                "ip-addresses": [
+                    {
+                        "prefix": 8,
+                        "ip-address-type": "ipv4",
+                        "ip-address": "127.0.0.1"
+                    },
+                    {
+                        "ip-address-type": "ipv6",
+                        "ip-address": "::1",
+                        "prefix": 128
+                    }],
+                "statistics": {
+                    "rx-errs": 0,
+                    "rx-bytes": 163244,
+                    "rx-packets": 1623,
+                    "rx-dropped": 0,
+                    "tx-dropped": 0,
+                    "tx-packets": 1623,
+                    "tx-bytes": 163244,
+                    "tx-errs": 0},
+                "name": "lo"},
+            {
+                "statistics": {
+                    "rx-packets": 4025,
+                    "rx-dropped": 12,
+                    "rx-bytes": 324105,
+                    "rx-errs": 0,
+                    "tx-errs": 0,
+                    "tx-bytes": 368860,
+                    "tx-packets": 3479,
+                    "tx-dropped": 0},
+                "name": "eth0",
+                "ip-addresses": [
+                    {
+                        "prefix": 24,
+                        "ip-address-type": "ipv4",
+                        "ip-address": "10.1.2.3"
+                    },
+                    {
+                        "prefix": 64,
+                        "ip-address": "fd8c:4687:e88d:1be3:5b70:7b88:c79c:293",
+                        "ip-address-type": "ipv6"
+                    }],
+                "hardware-address": "ff:ff:ff:ff:ff:ff"
+            },
+            {
+                "hardware-address": "ff:ff:ff:ff:ff:ff",
+                "ip-addresses": [
+                    {
+                        "prefix": 16,
+                        "ip-address": "10.10.2.3",
+                        "ip-address-type": "ipv4"
+                    }],
+                "name": "docker0",
+                "statistics": {
+                    "rx-bytes": 0,
+                    "rx-errs": 0,
+                    "rx-dropped": 0,
+                    "rx-packets": 0,
+                    "tx-packets": 0,
+                    "tx-dropped": 0,
+                    "tx-errs": 0,
+                    "tx-bytes": 0
+                }}]}
 
 
 def get_vm_status(node, vmtype, vmid, name):
@@ -173,6 +287,10 @@ def get_vm_status(node, vmtype, vmid, name):
 def get_option(option):
     if option == 'group_prefix':
         return 'proxmox_'
+    if option == 'facts_prefix':
+        return 'proxmox_'
+    elif option == 'want_facts':
+        return True
     else:
         return False
 
@@ -200,6 +318,9 @@ def test_populate(inventory, mocker):
     assert 'proxmox_pool_test' in inventory.inventory.groups
     group_qemu = inventory.inventory.groups['proxmox_pool_test']
     assert group_qemu.hosts == [host_qemu]
+
+    # check if qemu-test has eth0 interface in agent_interfaces fact
+    assert 'eth0' in [ d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
 
     # check if lxc-test has been discovered correctly
     group_lxc = inventory.inventory.groups['proxmox_all_lxc']

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -163,6 +163,7 @@ def get_json(url):
                  "autostart": 1,
                  "active": 1}]
     elif url == "https://localhost:8006/api2/json/nodes/testnode/lxc/100/config":
+        # _get_vm_config (lxc)
         return {
             "console": 1,
             "rootfs": "local-lvm:vm-100-disk-0,size=4G",
@@ -184,6 +185,7 @@ def get_json(url):
             "tags": "one, two, three",
         }
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/config":
+        # _get_vm_config (qemu)
         return {
             "tags": "one, two, three",
             "cores": 1,
@@ -211,6 +213,7 @@ def get_json(url):
             "smbios1": "uuid=ffffffff-ffff-ffff-ffff-ffffffffffff"
         }
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/agent/network-get-interfaces":
+        # _get_agent_network_interfaces
         return {"result": [
             {
                 "hardware-address": "00:00:00:00:00:00",


### PR DESCRIPTION
##### SUMMARY
Adding fact to proxmox inventory plugin such that if a QEMU guest has an agent enabled and the QEMU agent is running the network interfaces will be returned as `proxmox_agent_interfaces`

Fixes #2147 

##### ISSUE TYPE
- Feature Pull Request
- 
##### COMPONENT NAME
plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION
The Proxmox API does not have an obvious way to determine if a QEMU agent is running so this new logic will attempt to retrieve interface data from the agent and return nothing if the request fails. (Proxmox responds with a 500 error if agent data is requested when the agent is not running)

Proxmox uses 0,1 for boolean values and those values are returned as strings hence the following:
`if config == 'agent' and int(value):`