### PR TITLE
[stable-1] kibana_plugin: fixed remove call + run_command with list instead of str

### DIFF
--- a/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
+++ b/changelogs/fragments/2143-kibana_plugin-fixed-function-calls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - kibana_plugin - added missing parameter to ``remove_plugin`` when using ``state=present force=true``, and fix potential quoting errors when invoking ``kibana`` (https://github.com/ansible-collections/community.general/pull/2143).

--- a/plugins/modules/database/misc/kibana_plugin.py
+++ b/plugins/modules/database/misc/kibana_plugin.py
@@ -164,22 +164,20 @@ def install_plugin(module, plugin_bin, plugin_name, url, timeout, kibana_version
         cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["present"], plugin_name]
 
         if url:
-            cmd_args.append("--url %s" % url)
+            cmd_args.extend(["--url", url])
 
     if timeout:
-        cmd_args.append("--timeout %s" % timeout)
-
-    cmd = " ".join(cmd_args)
+        cmd_args.extend(["--timeout", timeout])
 
     if module.check_mode:
-        return True, cmd, "check mode", ""
+        return True, " ".join(cmd_args), "check mode", ""
 
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         reason = parse_error(out)
         module.fail_json(msg=reason)
 
-    return True, cmd, out, err
+    return True, " ".join(cmd_args), out, err
 
 
 def remove_plugin(module, plugin_bin, plugin_name, kibana_version='4.6'):
@@ -189,23 +187,21 @@ def remove_plugin(module, plugin_bin, plugin_name, kibana_version='4.6'):
     else:
         cmd_args = [plugin_bin, "plugin", PACKAGE_STATE_MAP["absent"], plugin_name]
 
-    cmd = " ".join(cmd_args)
-
     if module.check_mode:
-        return True, cmd, "check mode", ""
+        return True, " ".join(cmd_args), "check mode", ""
 
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         reason = parse_error(out)
         module.fail_json(msg=reason)
 
-    return True, cmd, out, err
+    return True, " ".join(cmd_args), out, err
 
 
 def get_kibana_version(module, plugin_bin):
     cmd_args = [plugin_bin, '--version']
-    cmd = " ".join(cmd_args)
-    rc, out, err = module.run_command(cmd)
+
+    rc, out, err = module.run_command(cmd_args)
     if rc != 0:
         module.fail_json(msg="Failed to get Kibana version : %s" % err)
 
@@ -251,7 +247,7 @@ def main():
 
     if state == "present":
         if force:
-            remove_plugin(module, plugin_bin, name)
+            remove_plugin(module, plugin_bin, name, kibana_version)
         changed, cmd, out, err = install_plugin(module, plugin_bin, name, url, timeout, kibana_version)
 
     elif state == "absent":


### PR DESCRIPTION
##### SUMMARY
Backport of #2143 to stable-1.

CC @russoz - I had to adjust the patch since the `allow_root` parameter does not exist in stable-1. Could you please check whether it is correct?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kibana_plugin
