### PR TITLE
ipa_user sshpubkey can now support multi word comments in the key

### DIFF
--- a/changelogs/fragments/2159-ipa-user-sshpubkey-multi-word-comments.yaml
+++ b/changelogs/fragments/2159-ipa-user-sshpubkey-multi-word-comments.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_user Allow sshpubkey to permit multiple word comments (https://github.com/ansible-collections/community.general/pull/2159).
+  - ipa_user - allow ``sshpubkey`` to permit multiple word comments (https://github.com/ansible-collections/community.general/pull/2159).

--- a/changelogs/fragments/2159-ipa-user-sshpubkey-multi-word-comments.yaml
+++ b/changelogs/fragments/2159-ipa-user-sshpubkey-multi-word-comments.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_user Allow sshpubkey to permit multiple word comments (https://github.com/ansible-collections/community.general/pull/2159).

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -269,11 +269,13 @@ def get_user_diff(client, ipa_user, module_user):
 def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     """
     Return the public key fingerprint of a given public SSH key
-    in format "[fp] [user@host] (ssh-rsa)" where fp is of the format:
+    in format "[fp] [comment] (ssh-rsa)" where fp is of the format:
     FB:0C:AC:0A:07:94:5B:CE:75:6E:63:32:13:AD:AD:D7
     for md5 or
     SHA256:[base64]
     for sha256
+    Comments are assumed to be all characters past the second
+    whitespace character in the sshpubkey string.
     :param ssh_key:
     :param hash_algo:
     :return:
@@ -293,8 +295,9 @@ def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     if len(parts) < 3:
         return "%s (%s)" % (key_fp, key_type)
     else:
-        user_host = parts[2]
-        return "%s %s (%s)" % (key_fp, user_host, key_type)
+        comment_elements = parts[2:]
+        comment = ' '.join(comment_elements)
+        return "%s %s (%s)" % (key_fp, comment, key_type)
 
 
 def ensure(module, client):

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -280,7 +280,7 @@ def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     :param hash_algo:
     :return:
     """
-    parts = ssh_key.strip().split()
+    parts = ssh_key.strip().split(None, 2)
     if len(parts) == 0:
         return None
     key_type = parts[0]
@@ -295,8 +295,7 @@ def get_ssh_key_fingerprint(ssh_key, hash_algo='sha256'):
     if len(parts) < 3:
         return "%s (%s)" % (key_fp, key_type)
     else:
-        comment_elements = parts[2:]
-        comment = ' '.join(comment_elements)
+        comment = parts[2]
         return "%s %s (%s)" % (key_fp, comment, key_type)
 
 


### PR DESCRIPTION
##### SUMMARY
This is one potential solution to #2158: Using a public ssh key fingerprint that is valid syntax for .authorized_keys and in IPA which has a comment that is more than 1 string (1 block of characters that is not separated by any whitespace), causes the ipa_user module to fail when calling the ipa_user module with no changes.  This patch allows the comment to contain multiple words, whereas the current code assumes it will only be one string returned by split().  See the issue for more detailed breakdown of the issue encountered.

Fixes #2158 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa_user

