### PR TITLE
fixed calls to list.extend()

### DIFF
--- a/changelogs/fragments/2161-pkgutil-list-extend.yml
+++ b/changelogs/fragments/2161-pkgutil-list-extend.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pkgutil - fixed calls to `ist.extend()`` (https://github.com/ansible-collections/community.general/pull/2161).

--- a/changelogs/fragments/2161-pkgutil-list-extend.yml
+++ b/changelogs/fragments/2161-pkgutil-list-extend.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pkgutil - fixed calls to `ist.extend()`` (https://github.com/ansible-collections/community.general/pull/2161).
+  - pkgutil - fixed calls to ``list.extend()`` (https://github.com/ansible-collections/community.general/pull/2161).

--- a/plugins/modules/packaging/os/pkgutil.py
+++ b/plugins/modules/packaging/os/pkgutil.py
@@ -130,7 +130,7 @@ def packages_not_latest(module, names, site, update_catalog):
         cmd.append('-U')
     cmd.append('-c')
     if site is not None:
-        cmd.extend('-t', site)
+        cmd.extend(['-t', site])
     if names != ['*']:
         cmd.extend(names)
     rc, out, err = run_command(module, cmd)
@@ -159,7 +159,7 @@ def package_install(module, state, pkgs, site, update_catalog, force):
     if update_catalog:
         cmd.append('-U')
     if site is not None:
-        cmd.extend('-t', site)
+        cmd.extend(['-t', site])
     if force:
         cmd.append('-f')
     cmd.extend(pkgs)
@@ -174,7 +174,7 @@ def package_upgrade(module, pkgs, site, update_catalog, force):
     if update_catalog:
         cmd.append('-U')
     if site is not None:
-        cmd.extend('-t', site)
+        cmd.extend(['-t', site])
     if force:
         cmd.append('-f')
     cmd += pkgs


### PR DESCRIPTION
##### SUMMARY
Method `list.extend()` expects one argument, an `Iterable`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/pkgutil.py
