### PR TITLE
ModuleHelper variables management

### DIFF
--- a/changelogs/fragments/2162-modhelper-variables.yml
+++ b/changelogs/fragments/2162-modhelper-variables.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper module utils - added mechanism to manage variables, providing automatic output of variables, change status and diff information (https://github.com/ansible-collections/community.general/pull/2162/files).

--- a/changelogs/fragments/2162-modhelper-variables.yml
+++ b/changelogs/fragments/2162-modhelper-variables.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_helper module utils - added mechanism to manage variables, providing automatic output of variables, change status and diff information (https://github.com/ansible-collections/community.general/pull/2162/files).
+  - module_helper module utils - added mechanism to manage variables, providing automatic output of variables, change status and diff information (https://github.com/ansible-collections/community.general/pull/2162).

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -159,7 +159,7 @@ class DependencyCtxMgr(AbstractContextManager):
         return self.msg or str(self.exc_val)
 
 
-class VariableMeta(object):
+class VarMeta(object):
     def __init__(self, diff=False, output=False, change=None):
         self.init = False
         self.initial_value = None
@@ -196,7 +196,7 @@ class VariableMeta(object):
         }
 
     def __str__(self):
-        return"<VariableMeta: value={0}, initial={1}, diff={2}, output={3}, change={4}>".format(
+        return"<VarMeta: value={0}, initial={1}, diff={2}, output={3}, change={4}>".format(
             self.value, self.initial_value, self.diff, self.output, self.change
         )
 
@@ -233,7 +233,7 @@ class ModuleHelper(object):
             else:
                 if 'output' not in kwargs:
                     kwargs['output'] = True
-                meta = VariableMeta(**kwargs)
+                meta = VarMeta(**kwargs)
             meta.set_value(value)
             self._meta[name] = meta
 

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -125,11 +125,10 @@ def module_fails_on_exception(func):
         except ModuleHelperException as e:
             if e.update_output:
                 self.update_output(e.update_output)
-            self.module.fail_json(msg=e.msg, exception=traceback.format_exc(), **self.output)
+            self.module.fail_json(msg=e.msg, exception=traceback.format_exc(), output=self.output, vars=self.vars, **self.output)
         except Exception as e:
             msg = "Module failed with exception: {0}".format(str(e).strip())
-            exception = traceback.format_exc()
-            self.module.fail_json(msg=msg, exception=exception, **self.output)
+            self.module.fail_json(msg=msg, exception=traceback.format_exc(), output=self.output, vars=self.vars, **self.output)
     return wrapper
 
 

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -16,8 +16,6 @@ from ansible.module_utils.common.dict_transformations import dict_merge
 
 
 class ModuleHelperException(Exception):
-    exclude_from_output = ('update_output', 'msg', 'exception')
-
     @staticmethod
     def _get_remove(key, kwargs):
         if key in kwargs:
@@ -28,7 +26,6 @@ class ModuleHelperException(Exception):
 
     def __init__(self, *args, **kwargs):
         self.msg = self._get_remove('msg', kwargs) or "Module failed with exception: {0}".format(self)
-        self.update_output = dict((k, v) for k, v in kwargs.items() if k not in self.exclude_from_output)
         self.update_output = self._get_remove('update_output', kwargs) or {}
         super(ModuleHelperException, self).__init__(*args)
 

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -11,7 +11,7 @@ from functools import partial, wraps
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.vars import combine_vars
+from ansible.module_utils.common.dict_transformations import dict_merge
 
 
 class ModuleHelperException(Exception):
@@ -313,7 +313,7 @@ class ModuleHelper(object):
         if self.module._diff:
             diff = result.get('diff', {})
             vars_diff = self.vars.diff() or {}
-            result['diff'] = combine_vars(dict(diff), vars_diff)
+            result['diff'] = dict_merge(dict(diff), vars_diff)
         return result
 
     @module_fails_on_exception

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -195,7 +195,7 @@ class VarMeta(object):
         }
 
     def __str__(self):
-        return"<VarMeta: value={0}, initial={1}, diff={2}, output={3}, change={4}>".format(
+        return "<VarMeta: value={0}, initial={1}, diff={2}, output={3}, change={4}>".format(
             self.value, self.initial_value, self.diff, self.output, self.change
         )
 

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -14,7 +14,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 class ModuleHelperException(Exception):
-    exclude_from_output = ('update_output', 'output', 'vars', 'msg', 'exception')
+    exclude_from_output = ('update_output', 'msg', 'exception')
 
     @staticmethod
     def _get_remove(key, kwargs):
@@ -128,11 +128,11 @@ def module_fails_on_exception(func):
         except ModuleHelperException as e:
             if e.update_output:
                 self.update_output(e.update_output)
-            self.module.fail_json(changed=False, msg=e.msg, exception=traceback.format_exc(), output=self.output, vars=self.vars, **self.output)
+            self.module.fail_json(msg=e.msg, exception=traceback.format_exc(), **self.output)
         except Exception as e:
             msg = "Module failed with exception: {0}".format(str(e).strip())
             exception = traceback.format_exc()
-            self.module.fail_json(changed=False, msg=msg, exception=exception, output=self.output, vars=self.vars, **self.output)
+            self.module.fail_json(msg=msg, exception=exception, **self.output)
     return wrapper
 
 
@@ -189,8 +189,8 @@ class ModuleHelper(object):
     _dependencies = []
     module = None
     facts_name = None
-    output_vars = []
-    diff_vars = []
+    output_params = ()
+    diff_params = ()
 
     class VarDict(UserDict):
         def __init__(self):
@@ -247,7 +247,7 @@ class ModuleHelper(object):
 
         for name, value in self.module.params.items():
             self.vars[name] = value
-            self.vars.set_meta(name, diff=name in self.diff_vars, output=name in self.output_vars)
+            self.vars.set_meta(name, diff=name in self.diff_params, output=name in self.output_params)
 
     def update_output(self, **kwargs):
         self.output_dict.update(kwargs)

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -461,5 +461,5 @@ class CmdModuleHelper(CmdMixin, ModuleHelper):
     pass
 
 
-class CmdStateModuleHelper(CmdMixin, StateMixin):
+class CmdStateModuleHelper(CmdMixin, StateMixin, ModuleHelper):
     pass

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -212,6 +212,9 @@ class ModuleHelper(object):
             self._data = dict()
             self._meta = dict()
 
+        def __getitem__(self, item):
+            return self._data[item]
+
         def __setitem__(self, key, value):
             self.set(key, value)
 

--- a/tests/integration/targets/module_helper/aliases
+++ b/tests/integration/targets/module_helper/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group4

--- a/tests/integration/targets/module_helper/library/mdepfail.py
+++ b/tests/integration/targets/module_helper/library/mdepfail.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2021, Alexei Znamensky <russoz@gmail.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+module: mdepfail
+author: "Alexei Znamensky (@russoz)"
+short_description: Simple module for testing
+description:
+  - Simple module test description.
+options:
+  a:
+    description: aaaa
+    type: int
+  b:
+    description: bbbb
+    type: str
+  c:
+    description: cccc
+    type: str
+'''
+
+EXAMPLES = ""
+
+RETURN = ""
+
+from ansible_collections.community.general.plugins.module_utils.module_helper import ModuleHelper
+from ansible.module_utils.basic import missing_required_lib
+
+with ModuleHelper.dependency("nopackagewiththisname", missing_required_lib("nopackagewiththisname")):
+    import nopackagewiththisname
+
+
+class MSimple(ModuleHelper):
+    output_params = ('a', 'b', 'c')
+    module = dict(
+        argument_spec=dict(
+            a=dict(type='int'),
+            b=dict(type='str'),
+            c=dict(type='str'),
+        ),
+    )
+
+    def __init_module__(self):
+        self.vars.set('value', None)
+        self.vars.set('abc', "abc", diff=True)
+
+    def __run__(self):
+        if (0 if self.vars.a is None else self.vars.a) >= 100:
+            raise Exception("a >= 100")
+        if self.vars.c == "abc change":
+            self.vars['abc'] = "changed abc"
+        if self.vars.get('a', 0) == 2:
+            self.vars['b'] = str(self.vars.b) * 2
+            self.vars['c'] = str(self.vars.c) * 2
+
+
+def main():
+    msimple = MSimple()
+    msimple.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/module_helper/library/msimple.py
+++ b/tests/integration/targets/module_helper/library/msimple.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2021, Alexei Znamensky <russoz@gmail.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+module: msimple
+author: "Alexei Znamensky (@russoz)"
+short_description: Simple module for testing
+description:
+  - Simple module test description.
+options:
+  a:
+    description: aaaa
+    type: int
+  b:
+    description: bbbb
+    type: str
+  c:
+    description: cccc
+    type: str
+'''
+
+EXAMPLES = ""
+
+RETURN = ""
+
+from ansible_collections.community.general.plugins.module_utils.module_helper import ModuleHelper
+
+
+class MSimple(ModuleHelper):
+    output_params = ('a', 'b', 'c')
+    module = dict(
+        argument_spec=dict(
+            a=dict(type='int'),
+            b=dict(type='str'),
+            c=dict(type='str'),
+        ),
+    )
+
+    def __init_module__(self):
+        self.vars.set('value', None)
+        self.vars.set('abc', "abc", diff=True)
+
+    def __run__(self):
+        if (0 if self.vars.a is None else self.vars.a) >= 100:
+            raise Exception("a >= 100")
+        if self.vars.c == "abc change":
+            self.vars['abc'] = "changed abc"
+        if self.vars.get('a', 0) == 2:
+            self.vars['b'] = str(self.vars.b) * 2
+            self.vars['c'] = str(self.vars.c) * 2
+
+
+def main():
+    msimple = MSimple()
+    msimple.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/module_helper/library/mstate.py
+++ b/tests/integration/targets/module_helper/library/mstate.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2021, Alexei Znamensky <russoz@gmail.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+module: mstate
+author: "Alexei Znamensky (@russoz)"
+short_description: State-based module for testing
+description:
+  - State-based module test description.
+options:
+  a:
+    description: aaaa
+    type: int
+    required: yes
+  b:
+    description: bbbb
+    type: str
+  c:
+    description: cccc
+    type: str
+  state:
+    description: test states
+    type: str
+    choices: [join, b_x_a, c_x_a, both_x_a]
+    default: join
+'''
+
+EXAMPLES = ""
+
+RETURN = ""
+
+from ansible_collections.community.general.plugins.module_utils.module_helper import StateModuleHelper
+
+
+class MState(StateModuleHelper):
+    output_params = ('a', 'b', 'c', 'state')
+    module = dict(
+        argument_spec=dict(
+            a=dict(type='int', required=True),
+            b=dict(type='str'),
+            c=dict(type='str'),
+            state=dict(type='str', choices=['join', 'b_x_a', 'c_x_a', 'both_x_a', 'nop'], default='join'),
+        ),
+    )
+
+    def __init_module__(self):
+        self.vars.set('result', "abc", diff=True)
+
+    def state_join(self):
+        self.vars['result'] = "".join([str(self.vars.a), str(self.vars.b), str(self.vars.c)])
+
+    def state_b_x_a(self):
+        self.vars['result'] = str(self.vars.b) * self.vars.a
+
+    def state_c_x_a(self):
+        self.vars['result'] = str(self.vars.c) * self.vars.a
+
+    def state_both_x_a(self):
+        self.vars['result'] = (str(self.vars.b) + str(self.vars.c)) * self.vars.a
+
+    def state_nop(self):
+        pass
+
+
+def main():
+    mstate = MState()
+    mstate.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/module_helper/tasks/main.yml
+++ b/tests/integration/targets/module_helper/tasks/main.yml
@@ -1,1 +1,2 @@
 - include_tasks: msimple.yml
+- include_tasks: mdepfail.yml

--- a/tests/integration/targets/module_helper/tasks/main.yml
+++ b/tests/integration/targets/module_helper/tasks/main.yml
@@ -1,2 +1,3 @@
 - include_tasks: msimple.yml
 - include_tasks: mdepfail.yml
+- include_tasks: mstate.yml

--- a/tests/integration/targets/module_helper/tasks/main.yml
+++ b/tests/integration/targets/module_helper/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: msimple.yml

--- a/tests/integration/targets/module_helper/tasks/mdepfail.yml
+++ b/tests/integration/targets/module_helper/tasks/mdepfail.yml
@@ -9,4 +9,6 @@
     that:
       - result.failed is true
       - '"Failed to import" in result.msg'
+      - '"nopackagewiththisname" in result.msg'
       - '"ModuleNotFoundError:" in result.exception'
+      - '"nopackagewiththisname" in result.exception'

--- a/tests/integration/targets/module_helper/tasks/mdepfail.yml
+++ b/tests/integration/targets/module_helper/tasks/mdepfail.yml
@@ -1,0 +1,12 @@
+- name: test failing dependency
+  mdepfail:
+    a: 123
+  ignore_errors: yes
+  register: result
+
+- name: assert failing dependency
+  assert:
+    that:
+      - result.failed is true
+      - '"Failed to import" in result.msg'
+      - '"ModuleNotFoundError:" in result.exception'

--- a/tests/integration/targets/module_helper/tasks/msimple.yml
+++ b/tests/integration/targets/module_helper/tasks/msimple.yml
@@ -1,0 +1,54 @@
+- name: test msimple 1
+  msimple:
+    a: 80
+  register: simple1
+
+- name: assert simple1
+  assert:
+    that:
+      - simple1.a == 80
+      - simple1.abc == "abc"
+      - simple1.changed is false
+      - simple1.value is none
+
+- name: test msimple 2
+  msimple:
+    a: 101
+  ignore_errors: yes
+  register: simple2
+
+- name: assert simple2
+  assert:
+    that:
+      - simple2.a == 101
+      - 'simple2.msg == "Module failed with exception: a >= 100"'
+      - simple2.abc == "abc"
+      - simple2.failed is true
+      - simple2.changed is false
+      - simple2.value is none
+
+- name: test msimple 3
+  msimple:
+    a: 2
+    b: potatoes
+  register: simple3
+
+- name: assert simple3
+  assert:
+    that:
+      - simple3.a == 2
+      - simple3.b == "potatoespotatoes"
+      - simple3.c == "NoneNone"
+      - simple3.changed is false
+
+- name: test msimple 4
+  msimple:
+    c: abc change
+  register: simple4
+
+- name: assert simple4
+  assert:
+    that:
+      - simple4.c == "abc change"
+      - simple4.abc == "changed abc"
+      - simple4.changed is true

--- a/tests/integration/targets/module_helper/tasks/mstate.yml
+++ b/tests/integration/targets/module_helper/tasks/mstate.yml
@@ -1,0 +1,79 @@
+- name: test mstate 1
+  mstate:
+    a: 80
+    b: banana
+    c: cashew
+    state: nop
+  register: state1
+
+- name: assert state1
+  assert:
+    that:
+      - state1.a == 80
+      - state1.b == "banana"
+      - state1.c == "cashew"
+      - state1.result == "abc"
+      - state1.changed is false
+
+- name: test mstate 2
+  mstate:
+    a: 80
+    b: banana
+    c: cashew
+  register: state2
+
+- name: assert state2
+  assert:
+    that:
+      - state2.a == 80
+      - state2.b == "banana"
+      - state2.c == "cashew"
+      - state2.result == "80bananacashew"
+      - state2.changed is true
+
+- name: test mstate 3
+  mstate:
+    a: 3
+    b: banana
+    state: b_x_a
+  register: state3
+
+- name: assert state3
+  assert:
+    that:
+      - state3.a == 3
+      - state3.b == "banana"
+      - state3.result == "bananabananabanana"
+      - state3.changed is true
+
+- name: test mstate 4
+  mstate:
+    a: 4
+    c: cashew
+    state: c_x_a
+  register: state4
+
+- name: assert state4
+  assert:
+    that:
+      - state4.a == 4
+      - state4.c == "cashew"
+      - state4.result == "cashewcashewcashewcashew"
+      - state4.changed is true
+
+- name: test mstate 5
+  mstate:
+    a: 5
+    b: foo
+    c: bar
+    state: both_x_a
+  register: state5
+
+- name: assert state3
+  assert:
+    that:
+      - state5.a == 5
+      - state5.b == "foo"
+      - state5.c == "bar"
+      - state5.result == "foobarfoobarfoobarfoobarfoobar"
+      - state5.changed is true

--- a/tests/integration/targets/module_helper/tasks/mstate.yml
+++ b/tests/integration/targets/module_helper/tasks/mstate.yml
@@ -69,7 +69,7 @@
     state: both_x_a
   register: state5
 
-- name: assert state3
+- name: assert state5
   assert:
     that:
       - state5.a == 5

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import pytest
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
-    ArgFormat, DependencyCtxMgr, ModuleHelper
+    ArgFormat, DependencyCtxMgr, ModuleHelper, VariableMeta
 )
 
 
@@ -105,3 +105,60 @@ def test_dependency_ctxmgr():
     with ctx:
         import sys
     assert ctx.has_it
+
+
+def test_variable_meta():
+    meta = VariableMeta()
+    assert meta.output is False
+    assert meta.diff is False
+    assert meta.value is None
+    meta.set("abc")
+    assert meta.initial_value == "abc"
+    assert meta.value == "abc"
+    assert meta.obtain_diff() is None
+    meta.set("def")
+    assert meta.initial_value == "abc"
+    assert meta.value == "def"
+    assert meta.obtain_diff() is None
+
+
+def test_variable_meta_diff():
+    meta = VariableMeta(diff=True)
+    assert meta.output is False
+    assert meta.diff is True
+    assert meta.value is None
+    meta.set("abc")
+    assert meta.initial_value == "abc"
+    assert meta.value == "abc"
+    assert meta.obtain_diff() is None
+    meta.set("def")
+    assert meta.initial_value == "abc"
+    assert meta.value == "def"
+    assert meta.obtain_diff() == {"before": "abc", "after": "def"}
+    meta.set("ghi")
+    assert meta.initial_value == "abc"
+    assert meta.value == "ghi"
+    assert meta.obtain_diff() == {"before": "abc", "after": "ghi"}
+
+
+def test_vardict():
+    vd = ModuleHelper.VarDict()
+    vd['a'] = 123
+    assert vd['a'] == 123
+    assert vd.a == 123
+    assert 'a' in vd._meta
+    assert vd.get_meta('a').output is True
+    assert vd.get_meta('a').diff is False
+    vd['b'] = 456
+    vd.set_meta('a', diff=True)
+    vd.set_meta('b', diff=True, output=False)
+    vd['c'] = 789
+    vd['a'] = 'new_a'
+    vd['c'] = 'new_c'
+    assert vd.a == 'new_a'
+    assert vd.c == 'new_c'
+    assert vd.output() == {'a': 'new_a', 'c': 'new_c'}
+    assert vd.diff() == {
+        'before': {'a': 123},
+        'after': {'a': 'new_a'},
+    }

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -160,4 +160,3 @@ def test_vardict():
     assert vd.c == 'new_c'
     assert vd.output() == {'a': 'new_a', 'c': 'new_c'}
     assert vd.diff() == {'before': {'a': 123}, 'after': {'a': 'new_a'}}, "diff={0}".format(vd.diff())
-

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import pytest
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
-    ArgFormat, DependencyCtxMgr, ModuleHelper, VariableMeta
+    ArgFormat, DependencyCtxMgr, ModuleHelper, VarMeta
 )
 
 
@@ -108,7 +108,7 @@ def test_dependency_ctxmgr():
 
 
 def test_variable_meta():
-    meta = VariableMeta()
+    meta = VarMeta()
     assert meta.output is False
     assert meta.diff is False
     assert meta.value is None
@@ -123,7 +123,7 @@ def test_variable_meta():
 
 
 def test_variable_meta_diff():
-    meta = VariableMeta(diff=True)
+    meta = VarMeta(diff=True)
     assert meta.output is False
     assert meta.diff is True
     assert meta.value is None

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -112,14 +112,14 @@ def test_variable_meta():
     assert meta.output is False
     assert meta.diff is False
     assert meta.value is None
-    meta.set("abc")
+    meta.set_value("abc")
     assert meta.initial_value == "abc"
     assert meta.value == "abc"
-    assert meta.obtain_diff() is None
-    meta.set("def")
+    assert meta.diff_result is None
+    meta.set_value("def")
     assert meta.initial_value == "abc"
     assert meta.value == "def"
-    assert meta.obtain_diff() is None
+    assert meta.diff_result is None
 
 
 def test_variable_meta_diff():
@@ -127,30 +127,31 @@ def test_variable_meta_diff():
     assert meta.output is False
     assert meta.diff is True
     assert meta.value is None
-    meta.set("abc")
+    meta.set_value("abc")
     assert meta.initial_value == "abc"
     assert meta.value == "abc"
-    assert meta.obtain_diff() is None
-    meta.set("def")
+    assert meta.diff_result is None
+    meta.set_value("def")
     assert meta.initial_value == "abc"
     assert meta.value == "def"
-    assert meta.obtain_diff() == {"before": "abc", "after": "def"}
-    meta.set("ghi")
+    assert meta.diff_result == {"before": "abc", "after": "def"}
+    meta.set_value("ghi")
     assert meta.initial_value == "abc"
     assert meta.value == "ghi"
-    assert meta.obtain_diff() == {"before": "abc", "after": "ghi"}
+    assert meta.diff_result == {"before": "abc", "after": "ghi"}
 
 
 def test_vardict():
     vd = ModuleHelper.VarDict()
-    vd['a'] = 123
+    vd.set('a', 123)
     assert vd['a'] == 123
     assert vd.a == 123
     assert 'a' in vd._meta
-    assert vd.get_meta('a').output is True
-    assert vd.get_meta('a').diff is False
+    assert vd.meta('a').output is True
+    assert vd.meta('a').diff is False
+    assert vd.meta('a').change is False
     vd['b'] = 456
-    vd.set_meta('a', diff=True)
+    vd.set_meta('a', diff=True, change=True)
     vd.set_meta('b', diff=True, output=False)
     vd['c'] = 789
     vd['a'] = 'new_a'
@@ -158,7 +159,5 @@ def test_vardict():
     assert vd.a == 'new_a'
     assert vd.c == 'new_c'
     assert vd.output() == {'a': 'new_a', 'c': 'new_c'}
-    assert vd.diff() == {
-        'before': {'a': 123},
-        'after': {'a': 'new_a'},
-    }
+    assert vd.diff() == {'before': {'a': 123}, 'after': {'a': 'new_a'}}, "diff={0}".format(vd.diff())
+


### PR DESCRIPTION
##### SUMMARY
Revamp on how ModuleHelper manages module variables. This is a new feature that brings automation to:
- publishing the variables on the output
- calculating the `changed` result
- generating `diff` result

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/module_helper.py
tests/integration/targets/module_helper/aliases
tests/integration/targets/module_helper/library/mdepfail.py
tests/integration/targets/module_helper/library/msimple.py
tests/integration/targets/module_helper/library/mstate.py
tests/integration/targets/module_helper/tasks/main.yml
tests/integration/targets/module_helper/tasks/mdepfail.yml
tests/integration/targets/module_helper/tasks/msimple.yml
tests/integration/targets/module_helper/tasks/mstate.yml
tests/unit/plugins/module_utils/test_module_helper.py

