### PR TITLE
Add dict filter

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -53,6 +53,8 @@ files:
   $doc_fragments/xenserver.py:
     maintainers: bvitnik
     labels: xenserver
+  $filters/dict.py:
+    maintainers: felixfontein
   $filters/dict_kv.py:
     maintainers: giner
   $filters/jc.py:

--- a/changelogs/fragments/dict-filter.yml
+++ b/changelogs/fragments/dict-filter.yml
@@ -1,5 +1,3 @@
 add plugin.filter:
   - name: dict
     description: "The ``dict`` function as a filter: converts a list of tuples to a dictionary"
-  - name: list_to_dict
-    description: Given a list of values and a list of keys, converts them to a dictionary

--- a/changelogs/fragments/dict-filter.yml
+++ b/changelogs/fragments/dict-filter.yml
@@ -1,0 +1,5 @@
+add plugin.filter:
+  - name: dict
+    description: "The ``dict`` function as a filter: converts a list of tuples to a dictionary"
+  - name: list_to_dict
+    description: Given a list of values and a list of keys, converts them to a dictionary

--- a/plugins/filter/dict.py
+++ b/plugins/filter/dict.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+def list_to_dict(values, keys):
+    '''Convert a list of values and a list of keys to a dictionary by combining these lists.
+
+    Example: ``[1, 2, 3] | community.general.list_to_dict(['k1', 'k2'])`` results in ``{'k1': 1, 'k2': 2}``.
+
+    This is equivalent to ``[1, 2, 3] | zip(['k1', 'k2']) | community.general.dict``.
+    '''
+    return dict(zip(keys, values))
+
+
+def dict_filter(sequence):
+    '''Convert a list of tuples to a dictionary.
+
+    Example: ``[[1, 2], ['a', 'b']] | community.general.dict`` results in ``{1: 2, 'a': 'b'}``
+    '''
+    return dict(sequence)
+
+
+class FilterModule(object):
+    '''Ansible jinja2 filters'''
+
+    def filters(self):
+        return {
+            'list_to_dict': list_to_dict,
+            'dict': dict_filter,
+        }

--- a/plugins/filter/dict.py
+++ b/plugins/filter/dict.py
@@ -7,16 +7,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-def list_to_dict(values, keys):
-    '''Convert a list of values and a list of keys to a dictionary by combining these lists.
-
-    Example: ``[1, 2, 3] | community.general.list_to_dict(['k1', 'k2'])`` results in ``{'k1': 1, 'k2': 2}``.
-
-    This is equivalent to ``[1, 2, 3] | zip(['k1', 'k2']) | community.general.dict``.
-    '''
-    return dict(zip(keys, values))
-
-
 def dict_filter(sequence):
     '''Convert a list of tuples to a dictionary.
 
@@ -30,6 +20,5 @@ class FilterModule(object):
 
     def filters(self):
         return {
-            'list_to_dict': list_to_dict,
             'dict': dict_filter,
         }

--- a/tests/integration/targets/filter_dict/aliases
+++ b/tests/integration/targets/filter_dict/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group3
+skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict/tasks/main.yml
+++ b/tests/integration/targets/filter_dict/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: "Test list_to_dict filter"
+  assert:
+    that:
+      - "[1, 2, 3] | community.general.list_to_dict(['k1', 'k2']) == result_1"
+      - "[1, 2] | community.general.list_to_dict(['k1', 'k2', 'k3']) == result_1"
+      - "[] | community.general.list_to_dict(['k1', 'k2', 'k3']) == dict([])"
+      - "[1, 2, 3] | community.general.list_to_dict([]) == dict([])"
+      - "[] | community.general.list_to_dict([]) == dict([])"
+  vars:
+    result_1:
+      k1: 1
+      k2: 2
+
+- name: "Test dict filter"
+  assert:
+    that:
+      - "[['a', 'b']] | community.general.dict == dict([['a', 'b']])"
+      - "[['a', 'b'], [1, 2]] | community.general.dict == dict([['a', 'b'], [1, 2]])"
+      - "[] | community.general.dict == dict([])"

--- a/tests/integration/targets/filter_dict/tasks/main.yml
+++ b/tests/integration/targets/filter_dict/tasks/main.yml
@@ -1,17 +1,4 @@
 ---
-- name: "Test list_to_dict filter"
-  assert:
-    that:
-      - "[1, 2, 3] | community.general.list_to_dict(['k1', 'k2']) == result_1"
-      - "[1, 2] | community.general.list_to_dict(['k1', 'k2', 'k3']) == result_1"
-      - "[] | community.general.list_to_dict(['k1', 'k2', 'k3']) == dict([])"
-      - "[1, 2, 3] | community.general.list_to_dict([]) == dict([])"
-      - "[] | community.general.list_to_dict([]) == dict([])"
-  vars:
-    result_1:
-      k1: 1
-      k2: 2
-
 - name: "Test dict filter"
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY
This adds a new filter:
1. `dict`: this is basically the `dict` function as a filter. Having it as a filter allows to use it in conjunction with other filters like `map`, which is not possible with the `dict` function.
2. ~~`list_to_dict`: this is a generalization of the `dict_kv` filter from single values and keys to lists of values and keys (see #1264). `x | list_to_dict(y)` is equivalent to `x | zip(y) | dict` with the above `dict` filter.~~

CC @giner you might be interested in this as well, or have opinions on it.

~~Example use case: I have a dictionary `domain_name: txt_value` (obtained from one module), and want to convert it to a list of dictionaries `{name: domain_name, value: txt_value}` to pass them to a module which waits for the TXT values for these domain names to change to the expected values. With the above filters, I can do that as `first_module_output.items() | map('community.general.list_to_dict', ['name', 'value']) | list` or - if the `list_to_dict` helper isn't there - `first_module_output.items() | map('zip', ['name', 'value']) | map('community.general.dict') | list`.~~

~~Without these filters, I would have to process key and value lists separately with `map` and `community.general.dict_kv`, `zip` them and `union` them, but I don't think I can get the `union` filter to actually do that for me. So this *might* be possible, but if it is, it will be a lot more complicated than using the new filters.~~

##### ISSUE TYPE
- New Plugin Pull Request

##### COMPONENT NAME
dict
~~list_to_dict~~
