### PR TITLE
Add path_join compatibility shim

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -59,6 +59,8 @@ files:
     maintainers: kellyjonbrazil
   $filters/list.py:
     maintainers: vbotka
+  $filters/path_join_shim.py:
+    maintainers: felixfontein
   $filters/time.py:
     maintainers: resmo
   $httpapis/:

--- a/changelogs/fragments/path_join-shim-filter.yml
+++ b/changelogs/fragments/path_join-shim-filter.yml
@@ -1,0 +1,3 @@
+add plugin.filter:
+  - name: path_join
+    description: Redirects to ansible.builtin.path_join for ansible-base 2.10 or newer, and provides a compatible implementation for Ansible 2.9

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -611,3 +611,10 @@ plugin_routing:
       redirect: community.docker.docker_swarm
     kubevirt:
       redirect: community.kubevirt.kubevirt
+  filter:
+    path_join:
+      # The ansible.builtin.path_join filter has been added in ansible-base 2.10.
+      # Since plugin routing is only available since ansible-base 2.10, this
+      # redirect will be used for ansible-base 2.10 or later, and the included
+      # path_join filter will be used for Ansible 2.9 or earlier.
+      redirect: ansible.builtin.path_join

--- a/plugins/filter/path_join_shim.py
+++ b/plugins/filter/path_join_shim.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020-2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import os.path
+
+
+def path_join(list):
+    '''Join list of paths.
+
+    This is a minimal shim for ansible.builtin.path_join included in ansible-base 2.10.
+    This should only be called by Ansible 2.9 or earlier. See meta/runtime.yml for details.
+    '''
+    return os.path.join(*list)
+
+
+class FilterModule(object):
+    '''Ansible jinja2 filters'''
+
+    def filters(self):
+        return {
+            'path_join': path_join,
+        }

--- a/tests/integration/targets/filter_path_join_shim/aliases
+++ b/tests/integration/targets/filter_path_join_shim/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_path_join_shim/tasks/main.yml
+++ b/tests/integration/targets/filter_path_join_shim/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: "Test path_join filter"
+  assert:
+    that:
+      - "['a', 'b'] | community.general.path_join == 'a/b'"
+      - "['a', '/b'] | community.general.path_join == '/b'"
+      - "[''] | community.general.path_join == ''"


### PR DESCRIPTION
##### SUMMARY
The `path_join` filter has been added in ansible-base 2.10. Since it is very useful, and people might want to use it with Ansible 2.9 as well (or write roles using it that work for both 2.9 and newer), this PR provides a compatibility shim using redirects (used for ansible-base 2.10, ansible-core 2.11 or newer) and a fallback implementation of the filter which will be used with Ansible 2.9.

Using redirects for 2.10+ makes sure that the builtin implementation is preferred over the fallback implementation provided by this PR for ansible-base and ansible-core.

##### ISSUE TYPE
- New Plugin Pull Request

##### COMPONENT NAME
path_join
