### PR TITLE
Fix issue where multiselect field in userauthtype did not allow multiple values

### DIFF
--- a/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
+++ b/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_user - Fix ``userauthtype`` option to take in list of strings for the multi-select field instead of single string (https://github.com/ansible-collections/community.general/pull/2174).
+  - ipa_user - fix ``userauthtype`` option to take in list of strings for the multi-select field instead of single string (https://github.com/ansible-collections/community.general/pull/2174).

--- a/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
+++ b/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_user - Fix ``userauthtype`` option to take in list of strings for the multi-select field instead of single string (https://github.com/ansible-collections/community.general/pull/2174).

--- a/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
+++ b/changelogs/fragments/2174-ipa-user-userauthtype-multiselect.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - ipa_user - fix ``userauthtype`` option to take in list of strings for the multi-select field instead of single string (https://github.com/ansible-collections/community.general/pull/2174).

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -151,7 +151,9 @@ EXAMPLES = r'''
   community.general.ipa_user:
     name: pinky
     state: present
-    userauthtype: ['otp', 'radius']
+    userauthtype:
+      - otp
+      - radius
     ipa_host: ipa.example.com
     ipa_user: admin
     ipa_pass: topsecret

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -94,7 +94,8 @@ options:
     description:
     - The authentication type to use for the user.
     choices: ["password", "radius", "otp", "pkinit", "hardened"]
-    type: str
+    type: list
+    elements: str
     version_added: '1.2.0'
 extends_documentation_fragment:
 - community.general.ipa.documentation
@@ -146,11 +147,11 @@ EXAMPLES = r'''
     ipa_pass: topsecret
     update_password: on_create
 
-- name: Ensure pinky is present and using one time password authentication
+- name: Ensure pinky is present and using one time password and RADIUS authentication
   community.general.ipa_user:
     name: pinky
     state: present
-    userauthtype: otp
+    userauthtype: ['otp', 'radius']
     ipa_host: ipa.example.com
     ipa_user: admin
     ipa_pass: topsecret
@@ -361,7 +362,7 @@ def main():
                          telephonenumber=dict(type='list', elements='str'),
                          title=dict(type='str'),
                          homedirectory=dict(type='str'),
-                         userauthtype=dict(type='str',
+                         userauthtype=dict(type='list', elements='str',
                                            choices=['password', 'radius', 'otp', 'pkinit', 'hardened']))
 
     module = AnsibleModule(argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY
The ipa_user module has a field for userauthtype, which is currently set to str. It also lists choices, which all seem to be the valid choices. However, the field is multiselect in IPA. With the type str and fixed choices, only one value is permitted with this implementation.

The solution is easy and just changing the type to list of str seems to work. That includes in a backwards compatible way (existing playbooks should still work). However, please validate this. 

Fixes #2173

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa_user

