### PR TITLE
replace inline clear password by environment variable

### DIFF
--- a/changelogs/fragments/2177-java_keystore_1668_dont_expose_secrets_on_cmdline.yml
+++ b/changelogs/fragments/2177-java_keystore_1668_dont_expose_secrets_on_cmdline.yml
@@ -1,4 +1,4 @@
 ---
-bugfixes:
+security_fixes:
   - "java_keystore - pass secret to keytool through an environment variable to not expose it as a
     commandline argument (https://github.com/ansible-collections/community.general/issues/1668)."

--- a/changelogs/fragments/2177-java_keystore_1668_dont_expose_secrets_on_cmdline.yml
+++ b/changelogs/fragments/2177-java_keystore_1668_dont_expose_secrets_on_cmdline.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "java_keystore - pass secret to keytool through an environment variable to not expose it as a
+    commandline argument (https://github.com/ansible-collections/community.general/issues/1668)."

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -71,14 +71,14 @@ class TestCreateJavaKeystore(ModuleTestCase):
         with patch('os.remove', return_value=True):
             self.create_path.side_effect = ['/tmp/tmpgrzm2ah7']
             self.create_file.side_effect = ['/tmp/etacifitrec', '/tmp/yek_etavirp']
-            self.run_commands.side_effect = lambda module, cmd, data: (0, '', '')
+            self.run_commands.side_effect = lambda module, cmd, data, environ_update: (0, '', '')
             create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "")
             module.exit_json.assert_called_once_with(
                 changed=True,
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
-                     "-deststorepass", "changeit", "-srcstorepass", "changeit", "-noprompt"],
+                     "-deststorepass:env", "STOREPASS", "-srcstorepass:env", "STOREPASS", "-noprompt"],
                 msg='',
                 rc=0,
                 stdout_lines=''
@@ -173,7 +173,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
-                     "-deststorepass", "changeit", "-srcstorepass", "changeit", "-noprompt"],
+                     "-deststorepass:env", "STOREPASS", "-srcstorepass:env", "STOREPASS", "-noprompt"],
                 msg='',
                 rc=1
             )
@@ -306,7 +306,7 @@ class TestCertChanged(ModuleTestCase):
             self.run_commands.side_effect = [(0, 'foo: wxyz:9876:stuv', ''), (1, '', 'Oops')]
             cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             module.fail_json.assert_called_with(
-                cmd=["keytool", "-list", "-alias", "foo", "-keystore", "/path/to/keystore.jks", "-storepass", "changeit", "-v"],
+                cmd=["keytool", "-list", "-alias", "foo", "-keystore", "/path/to/keystore.jks", "-storepass:env", "STOREPASS", "-v"],
                 msg='',
                 err='Oops',
                 rc=1

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -71,7 +71,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         with patch('os.remove', return_value=True):
             self.create_path.side_effect = ['/tmp/tmpgrzm2ah7']
             self.create_file.side_effect = ['/tmp/etacifitrec', '/tmp/yek_etavirp']
-            self.run_commands.side_effect = lambda module, cmd, data, environ_update: (0, '', '')
+            self.run_commands.side_effect = [(0, '', ''), (0, '', '')]
             create_jks(module, "test", "openssl", "keytool", "/path/to/keystore.jks", "changeit", "")
             module.exit_json.assert_called_once_with(
                 changed=True,


### PR DESCRIPTION
##### SUMMARY

This PR covers secret's handling by the module. It replaces insecure and clear password in keytool's commandline arguments by storing it in an environment variable (doing this from stdin is not supported by keytool).

This is achieved with the `environ_update` argument of `module.run_command()` (i.e. on a per-command basis) rather than with a more general `module.run_command_environ_update()` (that would export the variable in all subsequent `module.run_command()` calls, that means: when it is not needed).

Fixes #1668 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

java_keytool