### PR TITLE
java_keystore: improve error handling and returned results

### DIFF
--- a/changelogs/fragments/2183-java_keystore_improve_error_handling.yml
+++ b/changelogs/fragments/2183-java_keystore_improve_error_handling.yml
@@ -3,4 +3,4 @@ bugfixes:
   - "java_keystore - improve error handling and return ``cmd`` as documented.
     Force ``LANG``, ``LC_ALL`` and ``LC_MESSAGES`` environment variables to ``C`` to rely
     on ``keytool`` output parsing. Fix pylint's ``unused-variable`` and ``no-else-return``
-    hints. (https://github.com/ansible-collections/community.general/issues/1671)."
+    hints (https://github.com/ansible-collections/community.general/pull/2183)."

--- a/changelogs/fragments/2183-java_keystore_improve_error_handling.yml
+++ b/changelogs/fragments/2183-java_keystore_improve_error_handling.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - "java_keystore - improve error handling and return ``cmd`` as documented.
+    Force ``LANG``, ``LC_ALL`` and ``LC_MESSAGES`` environment variables to ``C`` to rely
+    on ``keytool`` output parsing. Fix pylint's ``unused-variable`` and ``no-else-return``
+    hints. (https://github.com/ansible-collections/community.general/issues/1671)."

--- a/tests/integration/targets/java_keystore/tasks/main.yml
+++ b/tests/integration/targets/java_keystore/tasks/main.yml
@@ -67,7 +67,7 @@
         private_key: "{{ lookup('file', output_dir ~ '/' ~ (item.keyname | default(item.name)) ~ '.key') }}"
         private_key_passphrase: "{{ item.passphrase | default(omit) }}"
         password: changeit
-        dest: "{{ output_dir ~ '/' ~ item.name ~ '.jks' }}"
+        dest: "{{ output_dir ~ '/' ~ (item.keyname | default(item.name)) ~ '.jks' }}"
       loop: &create_key_store_loop
         - name: cert
         - name: cert-pw

--- a/tests/integration/targets/java_keystore/tasks/main.yml
+++ b/tests/integration/targets/java_keystore/tasks/main.yml
@@ -63,8 +63,8 @@
     - name: Create a Java key store for the given certificates (check mode)
       community.general.java_keystore: &create_key_store_data
         name: example
-        certificate: "{{lookup('file', output_dir ~ '/' ~ item.name ~ '.pem') }}"
-        private_key: "{{lookup('file', output_dir ~ '/' ~ (item.keyname | default(item.name)) ~ '.key') }}"
+        certificate: "{{ lookup('file', output_dir ~ '/' ~ item.name ~ '.pem') }}"
+        private_key: "{{ lookup('file', output_dir ~ '/' ~ (item.keyname | default(item.name)) ~ '.key') }}"
         private_key_passphrase: "{{ item.passphrase | default(omit) }}"
         password: changeit
         dest: "{{ output_dir ~ '/' ~ item.name ~ '.jks' }}"


### PR DESCRIPTION
##### SUMMARY

The module currently calls `module.run_command` with `check_rc` explicitly set to **True**, although every call to `run_command` is followed by an `if rc != 0:` block. This is why those blocks are never executed, and module fails in case of alias or password mismatch, rather than regenerate the keystore.

This PR comes back to default `check_rc=False` and ensures results are returned as documented in case of error. It also fixes a buggy unit test.

UPDATE: follow the thread and #1671 to understand the change of scope of this PR and why its primary fix (overwrite keystore if password is changed) is delayed to next step.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

java_keystore