### PR TITLE
xfconf - state absent was not honoring check_mode

### DIFF
--- a/changelogs/fragments/2185-xfconf-absent-check-mode.yml
+++ b/changelogs/fragments/2185-xfconf-absent-check-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xfconf - module was not honoring check mode when ``state`` was ``absent`` (https://github.com/ansible-collections/community.general/pull/2185).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -237,8 +237,9 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.update_xfconf_output(value=self.vars.value)
 
     def state_absent(self):
+        if not self.module.check_mode:
+            self.run_command(params=('channel', 'property', {'reset': True}))
         self.vars.value = None
-        self.run_command(params=('channel', 'property', {'reset': True}))
         self.update_xfconf_output(previous_value=self.vars.previous_value,
                                   value=None)
 


### PR DESCRIPTION
##### SUMMARY
Module `xfconf` was not honoring the check mode when `state=absent`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xfconf
