### PR TITLE
[stable-1] xfconf - state absent was not honoring check_mode (#2185)

### DIFF
--- a/changelogs/fragments/2185-xfconf-absent-check-mode.yml
+++ b/changelogs/fragments/2185-xfconf-absent-check-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xfconf - module was not honoring check mode when ``state`` was ``absent`` (https://github.com/ansible-collections/community.general/pull/2185).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -220,7 +220,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
     def state_absent(self):
         if not self.module.check_mode:
-            self.run_command(params=('channel', 'property', {'reset': True}))
+            self.run_command(params=('channel', 'property', 'reset'), extra_params={"reset": True})
         self.vars.value = None
         self.update_xfconf_output(previous_value=self.vars.previous_value,
                                   value=None)

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -219,8 +219,9 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.update_xfconf_output(value=self.vars.value)
 
     def state_absent(self):
+        if not self.module.check_mode:
+            self.run_command(params=('channel', 'property', {'reset': True}))
         self.vars.value = None
-        self.run_command(params=('channel', 'property', 'reset'), extra_params={"reset": True})
         self.update_xfconf_output(previous_value=self.vars.previous_value,
                                   value=None)
 


### PR DESCRIPTION
This is a backport of PR #2185 as merged into main (9a5191d).

##### SUMMARY

Module `xfconf` was not honoring the check mode when `state=absent`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xfconf
