### PR TITLE
Add Jira attach operation

### DIFF
--- a/changelogs/fragments/2192-add-jira-attach.yml
+++ b/changelogs/fragments/2192-add-jira-attach.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jira - added ``attach`` operation, which allows a user to attach a file to an issue (https://github.com/ansible-collections/community.general/pull/2192).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -172,21 +172,19 @@ options:
       filename:
         required: true
         type: path
-        description: >
-          The path to the file to upload (from the remote node) or, if I(content) is specified,
-          the filename to use for the attachment
+        description:
+          - The path to the file to upload (from the remote node) or, if I(content) is specified,
+            the filename to use for the attachment
       content:
-        required: false
         type: str
-        description: >
-          The Base64 encoded contents of the file to attach. If not specified, the contents of I(filename) will be
-          used instead.
+        description:
+          - The Base64 encoded contents of the file to attach. If not specified, the contents of I(filename) will be
+            used instead.
       mimetype:
-        required: false
         type: str
-        description: >
-          The MIME type to supply for the upload. If not specified, best-effort detection will be
-          done.
+        description:
+          - The MIME type to supply for the upload. If not specified, best-effort detection will be
+            done.
 
 notes:
   - "Currently this only works with basic-auth."
@@ -623,10 +621,10 @@ def main():
     global module
     module = AnsibleModule(
         argument_spec=dict(
-            attachment=dict(type='dict', default=None, options=dict(
-                content=dict(type='str', default=None),
+            attachment=dict(type='dict', options=dict(
+                content=dict(type='str'),
                 filename=dict(type='path', required=True),
-                mimetype=dict(type='str', default=None)
+                mimetype=dict(type='str')
             )),
             uri=dict(type='str', required=True),
             operation=dict(type='str', choices=['attach', 'create', 'comment', 'edit', 'update', 'fetch', 'transition', 'link', 'search'],

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -174,7 +174,7 @@ options:
         type: path
         description:
           - The path to the file to upload (from the remote node) or, if I(content) is specified,
-            the filename to use for the attachment
+            the filename to use for the attachment.
       content:
         type: str
         description:


### PR DESCRIPTION
##### SUMMARY
Adds the `attach` operation to the `web_infrastructure.jira` module,
which allows a user to attach a file to an issue. The user can supply
either the path to a file, which will be read from storage, or a file
name and content (as bytes).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`community.general.web_infrastructure.jira`

##### ADDITIONAL INFORMATION
N/A