### PR TITLE
Bugfix: PyGithub does not support explicit port in base_url

### DIFF
--- a/changelogs/fragments/2204-github_repo-fix-baseurl_port.yml
+++ b/changelogs/fragments/2204-github_repo-fix-baseurl_port.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - PyGithub bug does not allow explicit port in base_url for github_repo.py (https://github.com/PyGithub/PyGithub/issues/1913). Specifying port is not required.
+  - github_repo - PyGithub bug does not allow explicit port in ``base_url``. Specifying port is not required (https://github.com/PyGithub/PyGithub/issues/1913). 

--- a/changelogs/fragments/2204-github_repo-fix-baseurl_port.yml
+++ b/changelogs/fragments/2204-github_repo-fix-baseurl_port.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - PyGithub bug does not allow explicit port in base_url for github_repo.py (https://github.com/PyGithub/PyGithub/issues/1913). Specifying port is not required.

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -121,9 +121,9 @@ except Exception:
 
 def authenticate(username=None, password=None, access_token=None):
     if access_token:
-        return Github(base_url="https://api.github.com:443", login_or_token=access_token)
+        return Github(base_url="https://api.github.com", login_or_token=access_token)
     else:
-        return Github(base_url="https://api.github.com:443", login_or_token=username, password=password)
+        return Github(base_url="https://api.github.com", login_or_token=username, password=password)
 
 
 def create_repo(gh, name, organization=None, private=False, description='', check_mode=False):

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -17,42 +17,42 @@ def debug_mock(url, request):
     print(request.original.__dict__)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/orgs/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/orgs/.*', method="get")
 def get_orgs_mock(url, request):
-    match = re.search(r"api\.github\.com:443/orgs/(?P<org>[^/]+)", request.url)
+    match = re.search(r"api\.github\.com/orgs/(?P<org>[^/]+)", request.url)
     org = match.group("org")
 
     # https://docs.github.com/en/rest/reference/orgs#get-an-organization
     headers = {'content-type': 'application/json'}
     content = {
         "login": org,
-        "url": "https://api.github.com:443/orgs/{0}".format(org)
+        "url": "https://api.github.com/orgs/{0}".format(org)
     }
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/user', method="get")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/user', method="get")
 def get_user_mock(url, request):
     # https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
     headers = {'content-type': 'application/json'}
     content = {
         "login": "octocat",
-        "url": "https://api.github.com:443/users/octocat"
+        "url": "https://api.github.com/users/octocat"
     }
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/repos/.*/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="get")
 def get_repo_notfound_mock(url, request):
     return response(404, "{\"message\": \"Not Found\"}", "", "Not Found", 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/repos/.*/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="get")
 def get_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com:443/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
+        r"api\.github\.com/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
@@ -61,7 +61,7 @@ def get_repo_mock(url, request):
     content = {
         "name": repo,
         "full_name": "{0}/{1}".format(org, repo),
-        "url": "https://api.github.com:443/repos/{0}/{1}".format(org, repo),
+        "url": "https://api.github.com/repos/{0}/{1}".format(org, repo),
         "private": False,
         "description": "This your first repo!",
         "default_branch": "master",
@@ -71,10 +71,10 @@ def get_repo_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/orgs/.*/repos', method="post")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/orgs/.*/repos', method="post")
 def create_new_org_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com:443/orgs/(?P<org>[^/]+)/repos", request.url)
+        r"api\.github\.com/orgs/(?P<org>[^/]+)/repos", request.url)
     org = match.group("org")
     repo = json.loads(request.body)
 
@@ -90,7 +90,7 @@ def create_new_org_repo_mock(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/user/repos', method="post")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/user/repos', method="post")
 def create_new_user_repo_mock(url, request):
     repo = json.loads(request.body)
 
@@ -106,10 +106,10 @@ def create_new_user_repo_mock(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/repos/.*/.*', method="patch")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="patch")
 def patch_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com:443/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
+        r"api\.github\.com/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
@@ -119,7 +119,7 @@ def patch_repo_mock(url, request):
     content = {
         "name": repo,
         "full_name": "{0}/{1}".format(org, repo),
-        "url": "https://api.github.com:443/repos/{0}/{1}".format(org, repo),
+        "url": "https://api.github.com/repos/{0}/{1}".format(org, repo),
         "private": body['private'],
         "description": body['description'],
         "default_branch": "master",
@@ -129,13 +129,13 @@ def patch_repo_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/repos/.*/.*', method="delete")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_mock(url, request):
     # https://docs.github.com/en/rest/reference/repos#delete-a-repository
     return response(204, None, None, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com:443$', path=r'/repos/.*/.*', method="delete")
+@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_notfound_mock(url, request):
     # https://docs.github.com/en/rest/reference/repos#delete-a-repository
     return response(404, "{\"message\": \"Not Found\"}", "", "Not Found", 5, request)

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -17,9 +17,9 @@ def debug_mock(url, request):
     print(request.original.__dict__)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/orgs/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/orgs/.*', method="get")
 def get_orgs_mock(url, request):
-    match = re.search(r"api\.github\.com/orgs/(?P<org>[^/]+)", request.url)
+    match = re.search(r"api\.github\.com(:[0-9]+)?/orgs/(?P<org>[^/]+)", request.url)
     org = match.group("org")
 
     # https://docs.github.com/en/rest/reference/orgs#get-an-organization
@@ -32,7 +32,7 @@ def get_orgs_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/user', method="get")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/user', method="get")
 def get_user_mock(url, request):
     # https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
     headers = {'content-type': 'application/json'}
@@ -44,15 +44,15 @@ def get_user_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="get")
 def get_repo_notfound_mock(url, request):
     return response(404, "{\"message\": \"Not Found\"}", "", "Not Found", 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="get")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="get")
 def get_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
+        r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
@@ -71,10 +71,10 @@ def get_repo_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/orgs/.*/repos', method="post")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/orgs/.*/repos', method="post")
 def create_new_org_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com/orgs/(?P<org>[^/]+)/repos", request.url)
+        r"api\.github\.com(:[0-9]+)?/orgs/(?P<org>[^/]+)/repos", request.url)
     org = match.group("org")
     repo = json.loads(request.body)
 
@@ -90,7 +90,7 @@ def create_new_org_repo_mock(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/user/repos', method="post")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/user/repos', method="post")
 def create_new_user_repo_mock(url, request):
     repo = json.loads(request.body)
 
@@ -106,10 +106,10 @@ def create_new_user_repo_mock(url, request):
     return response(201, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="patch")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="patch")
 def patch_repo_mock(url, request):
     match = re.search(
-        r"api\.github\.com/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
+        r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
     org = match.group("org")
     repo = match.group("repo")
 
@@ -129,13 +129,13 @@ def patch_repo_mock(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="delete")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_mock(url, request):
     # https://docs.github.com/en/rest/reference/repos#delete-a-repository
     return response(204, None, None, None, 5, request)
 
 
-@urlmatch(netloc=r'api\.github\.com.*$', path=r'/repos/.*/.*', method="delete")
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_notfound_mock(url, request):
     # https://docs.github.com/en/rest/reference/repos#delete-a-repository
     return response(404, "{\"message\": \"Not Found\"}", "", "Not Found", 5, request)


### PR DESCRIPTION
##### SUMMARY
PyGithub bug does not allow explicit port in base_url for github_repo.py

Fixes #2193

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
github_repo

##### ADDITIONAL INFORMATION
There is an issue open in PyGithub repo: https://github.com/PyGithub/PyGithub/issues/1913
