### PR TITLE
[PR #2203/0cd0f0ea backport][stable-1] module_helper - fixed decorator cause_changes

### DIFF
--- a/changelogs/fragments/2203-modhelper-cause-changes-deco.yml
+++ b/changelogs/fragments/2203-modhelper-cause-changes-deco.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_helper module utils - fixed decorator ``cause_changes`` (https://github.com/ansible-collections/community.general/pull/2203).

--- a/plugins/module_utils/module_helper.py
+++ b/plugins/module_utils/module_helper.py
@@ -81,18 +81,27 @@ class ArgFormat(object):
         return [str(p) for p in func(value)]
 
 
-def cause_changes(func, on_success=True, on_failure=False):
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        try:
-            func(*args, **kwargs)
-            if on_success:
-                self.changed = True
-        except Exception as e:
-            if on_failure:
-                self.changed = True
-            raise
-    return wrapper
+def cause_changes(on_success=None, on_failure=None):
+
+    def deco(func):
+        if on_success is None and on_failure is None:
+            return func
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                self = args[0]
+                func(*args, **kwargs)
+                if on_success is not None:
+                    self.changed = on_success
+            except Exception:
+                if on_failure is not None:
+                    self.changed = on_failure
+                raise
+
+        return wrapper
+
+    return deco
 
 
 def module_fails_on_exception(func):

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -6,12 +6,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from collections import namedtuple
-
 import pytest
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
-    ArgFormat, DependencyCtxMgr, ModuleHelper, VarMeta, cause_changes
+    ArgFormat, DependencyCtxMgr, cause_changes
 )
 
 

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -6,10 +6,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from collections import namedtuple
+
 import pytest
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
-    ArgFormat, DependencyCtxMgr, ModuleHelper
+    ArgFormat, DependencyCtxMgr, ModuleHelper, VarMeta, cause_changes
 )
 
 
@@ -82,3 +84,45 @@ def test_dependency_ctxmgr():
     with ctx:
         import sys
     assert ctx.has_it
+
+
+class MockMH(object):
+    changed = None
+
+    def _div(self, x, y):
+        return x / y
+
+    func_none = cause_changes()(_div)
+    func_onsucc = cause_changes(on_success=True)(_div)
+    func_onfail = cause_changes(on_failure=True)(_div)
+    func_onboth = cause_changes(on_success=True, on_failure=True)(_div)
+
+
+CAUSE_CHG_DECO_PARAMS = ['method', 'expect_exception', 'expect_changed']
+CAUSE_CHG_DECO = dict(
+    none_succ=dict(method='func_none', expect_exception=False, expect_changed=None),
+    none_fail=dict(method='func_none', expect_exception=True, expect_changed=None),
+    onsucc_succ=dict(method='func_onsucc', expect_exception=False, expect_changed=True),
+    onsucc_fail=dict(method='func_onsucc', expect_exception=True, expect_changed=None),
+    onfail_succ=dict(method='func_onfail', expect_exception=False, expect_changed=None),
+    onfail_fail=dict(method='func_onfail', expect_exception=True, expect_changed=True),
+    onboth_succ=dict(method='func_onboth', expect_exception=False, expect_changed=True),
+    onboth_fail=dict(method='func_onboth', expect_exception=True, expect_changed=True),
+)
+CAUSE_CHG_DECO_IDS = sorted(CAUSE_CHG_DECO.keys())
+
+
+@pytest.mark.parametrize(CAUSE_CHG_DECO_PARAMS,
+                         [[CAUSE_CHG_DECO[tc][param]
+                           for param in CAUSE_CHG_DECO_PARAMS]
+                          for tc in CAUSE_CHG_DECO_IDS],
+                         ids=CAUSE_CHG_DECO_IDS)
+def test_cause_changes_deco(method, expect_exception, expect_changed):
+    mh = MockMH()
+    if expect_exception:
+        with pytest.raises(Exception):
+            getattr(mh, method)(1, 0)
+    else:
+        getattr(mh, method)(9, 3)
+
+    assert mh.changed == expect_changed


### PR DESCRIPTION
**This is a backport of PR #2203 as merged into main ([0cd0f0e](https://github.com/ansible-collections/community.general/commit/0cd0f0eaf670d8da8afc6137ee19a53439e06e48)).**

##### SUMMARY
The decorator `cause_changes` never really worked before. This PR fixes that and add unit tests for it.

##### ISSUE TYPE
* Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/module_helper.py
tests/unit/plugins/module_utils/test_module_helper.py
