### PR TITLE
Keep compatibility for old getcap output formats

### DIFF
--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -116,6 +116,8 @@ class CapabilitiesModule(object):
             if ' =' in stdout:
                 # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
+            elif '=' in stdout:
+                caps = stdout.split('=')[1].strip().split()
             else:
                 # otherwise, we have a newer version here
                 # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git

--- a/plugins/modules/system/capabilities.py
+++ b/plugins/modules/system/capabilities.py
@@ -116,8 +116,8 @@ class CapabilitiesModule(object):
             if ' =' in stdout:
                 # process output of an older version of libcap
                 caps = stdout.split(' =')[1].strip().split()
-            elif '=' in stdout:
-                caps = stdout.split('=')[1].strip().split()
+            elif ' ' in stdout:
+                caps = stdout.split(' ')[1].strip().split()
             else:
                 # otherwise, we have a newer version here
                 # see original commit message of cap/v0.2.40-18-g177cd41 in libcap.git


### PR DESCRIPTION
##### SUMMARY
getcap on some systems produces output like:
/usr/bin/node cap_net_bind_service=eip

Instead of:
/usr/bin/node = cap_net_bind_service=eip

This fix adds an elif to parse this type of output as a fallback

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
parse old getcap output formats

##### ADDITIONAL INFORMATION
Running:
```getcap /usr/bin/node```

on a Kali box with eip already set, produces:
/usr/bin/node cap_net_bind_service=eip

and triggers the following ansible error:
"Unable to get capabilities of /usr/bin/node"

This change fixes the parser to account for this output format

