### PR TITLE
nmcli: do not set IP configuration bond slaves

### DIFF
--- a/changelogs/fragments/2223_nmcli_no_IP_config_on_slave.yaml
+++ b/changelogs/fragments/2223_nmcli_no_IP_config_on_slave.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "nmcli - do not set IP configuration on slave connection (https://github.com/ansible-collections/community.general/pull/2223)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -695,7 +695,7 @@ class Nmcli(object):
         }
 
         # IP address options.
-        if self.ip_conn_type:
+        if self.ip_conn_type and not self.master:
             options.update({
                 'ipv4.addresses': self.ip4,
                 'ipv4.dhcp-client-id': self.dhcp_client_id,


### PR DESCRIPTION
The master interface holds the IP configuration. If we try to update the
IP configuration of the slaves, NetworkManager raises an error.