### PR TITLE
nmcli: manual overwrite MAC address for any devices

### DIFF
--- a/changelogs/fragments/2224_nmcli_allow_MAC_overwrite.yaml
+++ b/changelogs/fragments/2224_nmcli_allow_MAC_overwrite.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "nmcli - don't restrict the ability to manually set the MAC address to the bridge. (https://github.com/ansible-collections/community.general/pull/2224)"

--- a/changelogs/fragments/2224_nmcli_allow_MAC_overwrite.yaml
+++ b/changelogs/fragments/2224_nmcli_allow_MAC_overwrite.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- "nmcli - don't restrict the ability to manually set the MAC address to the bridge. (https://github.com/ansible-collections/community.general/pull/2224)"
+- "nmcli - don't restrict the ability to manually set the MAC address to the bridge (https://github.com/ansible-collections/community.general/pull/2224)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -210,7 +210,7 @@ options:
         default: 300
     mac:
         description:
-            - This is only used with bridge - MAC address of the bridge.
+            - MAC address of the connection.
             - Note this requires a recent kernel feature, originally introduced in 3.15 upstream kernel.
         type: str
     slavepriority:
@@ -714,7 +714,7 @@ class Nmcli(object):
             })
 
         # Layer 2 options.
-        if self.mac_conn_type:
+        if self.mac:
             options.update({self.mac_setting: self.mac})
 
         if self.mtu_conn_type:
@@ -809,10 +809,6 @@ class Nmcli(object):
             'team',
             'vlan',
         )
-
-    @property
-    def mac_conn_type(self):
-        return self.type == 'bridge'
 
     @property
     def mac_setting(self):


### PR DESCRIPTION
Don't restrict the ability to manually set the MAC address to the
bridge. NetworkManager is able to set a static MAC address to the
vaste majority of the device types.