### PR TITLE
funcd connection plugin is now usable/loadable

### DIFF
--- a/changelogs/fragments/allow_funcd_to_load.yml
+++ b/changelogs/fragments/allow_funcd_to_load.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - funcd connection can now load as a connection plugin.
+  - funcd connection plugin - can now load (https://github.com/ansible-collections/community.general/pull/2235).

--- a/changelogs/fragments/allow_funcd_to_load.yml
+++ b/changelogs/fragments/allow_funcd_to_load.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - funcd connection can now load as a connection plugin.

--- a/plugins/connection/funcd.py
+++ b/plugins/connection/funcd.py
@@ -37,12 +37,13 @@ import tempfile
 import shutil
 
 from ansible.errors import AnsibleError
+from ansible.plugins.connection import ConnectionBase
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class Connection(object):
+class Connection(ConnectionBase):
     ''' Func-based connections '''
 
     has_pipelining = False


### PR DESCRIPTION
ansible's plugin loader was updated to only load those that inherit from ConnectionBase but the plugin was never updated to do so, why it cannot load.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/funcd