### PR TITLE
Proxmox inv fix agent string parsing

### DIFF
--- a/changelogs/fragments/2245-proxmox_fix_agent_string_handling.yml
+++ b/changelogs/fragments/2245-proxmox_fix_agent_string_handling.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox inventory - added handling of commas in KVM agent configuration string (https://github.com/ansible-collections/community.general/pull/2245)

--- a/changelogs/fragments/2245-proxmox_fix_agent_string_handling.yml
+++ b/changelogs/fragments/2245-proxmox_fix_agent_string_handling.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox inventory - added handling of commas in KVM agent configuration string (https://github.com/ansible-collections/community.general/pull/2245)
+  - proxmox inventory - added handling of commas in KVM agent configuration string (https://github.com/ansible-collections/community.general/pull/2245).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -281,6 +281,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     parsed_value = [tag.strip() for tag in value.split(",")]
                     self.inventory.set_variable(name, parsed_key, parsed_value)
 
+                # The first field in the agent string tells you whether the agent is enabled
+                # the rest of the comma separated string is extra config for the agent
+                #if config == 'agent' and int(value.split(',')[0]):
                 if config == 'agent' and int(value):
                     agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
                     agent_iface_value = self._get_agent_network_interfaces(node, vmid, vmtype)

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -283,8 +283,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
                 # The first field in the agent string tells you whether the agent is enabled
                 # the rest of the comma separated string is extra config for the agent
-                #if config == 'agent' and int(value.split(',')[0]):
-                if config == 'agent' and int(value):
+                if config == 'agent' and int(value.split(',')[0]):
                     agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
                     agent_iface_value = self._get_agent_network_interfaces(node, vmid, vmtype)
                     if agent_iface_value:

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -205,7 +205,7 @@ def get_json(url):
             "hotplug": "network,disk,usb",
             "scsi0": "local-lvm:vm-101-disk-0,size=8G",
             "net0": "virtio=ff:ff:ff:ff:ff:ff,bridge=vmbr0,firewall=1",
-            "agent": "1",
+            "agent": "1,fstrim_cloned_disks=1",
             "bios": "seabios",
             "ide0": "local-lvm:vm-101-cloudinit,media=cdrom,size=4M",
             "boot": "cdn",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed that when you enable options on KVM guest agents the inventory plugin started showing messages like:

```
[WARNING]:  * Failed to parse /root/projects/playground/inventory/proxmox.yml with
ansible_collections.community.general.plugins.inventory.proxmox plugin: invalid literal for int() with base 10:
'1,fstrim_cloned_disks=1'
```
I found it was caused by the feature added in (I just missed this testcase :-) ) #2148
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
