### PR TITLE
linode_v4: add support for `private_ip` option.

### DIFF
--- a/changelogs/fragments/2249-linode_v4-support-private_ip-option.yaml
+++ b/changelogs/fragments/2249-linode_v4-support-private_ip-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - linode_v4 - add support for ``private_ip`` option.

--- a/changelogs/fragments/2249-linode_v4-support-private_ip-option.yaml
+++ b/changelogs/fragments/2249-linode_v4-support-private_ip-option.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - linode_v4 - add support for ``private_ip`` option.
+  - linode_v4 - add support for ``private_ip`` option (https://github.com/ansible-collections/community.general/pull/2249).

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -55,7 +55,7 @@ options:
     type: str
   private_ip:
     description:
-      - If true, the created Linode will have private networking enabled and
+      - If C(true), the created Linode will have private networking enabled and
         assigned a private IPv4 address.
     type: bool
     default: false

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -58,7 +58,6 @@ options:
       - If true, the created Linode will have private networking enabled and
         assigned a private IPv4 address.
     type: bool
-    required: false
     default: false
   tags:
     description:
@@ -245,7 +244,7 @@ def initialise_module():
             authorized_keys=dict(type='list', elements='str', no_log=False),
             group=dict(type='str'),
             image=dict(type='str'),
-            private_ip=dict(type='bool', default=False, required=False),
+            private_ip=dict(type='bool', default=False),
             region=dict(type='str'),
             root_pass=dict(type='str', no_log=True),
             tags=dict(type='list', elements='str'),

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -59,6 +59,7 @@ options:
         assigned a private IPv4 address.
     type: bool
     default: false
+    version_added: 3.0.0
   tags:
     description:
       - The tags that the instance should be marked under. See

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -53,6 +53,13 @@ options:
          group labelling is deprecated but still supported. The encouraged
          method for marking instances is to use tags.
     type: str
+  private_ip:
+    description:
+      - If true, the created Linode will have private networking enabled and
+        assigned a private IPv4 address.
+    type: bool
+    required: false
+    default: false
   tags:
     description:
       - The tags that the instance should be marked under. See
@@ -238,6 +245,7 @@ def initialise_module():
             authorized_keys=dict(type='list', elements='str', no_log=False),
             group=dict(type='str'),
             image=dict(type='str'),
+            private_ip=dict(type='bool', default=False, required=False),
             region=dict(type='str'),
             root_pass=dict(type='str', no_log=True),
             tags=dict(type='list', elements='str'),
@@ -283,6 +291,7 @@ def main():
             group=module.params['group'],
             image=module.params['image'],
             label=module.params['label'],
+            private_ip=module.params['private_ip'],
             region=module.params['region'],
             root_pass=module.params['root_pass'],
             tags=module.params['tags'],


### PR DESCRIPTION
##### SUMMARY
This PR adds support for the `private_ip` parameter to the `linode.linode_v4` module.
The new parameter allows to enable private networking and to assign a private IPv4 IP upon instance creation.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`linode.linode_v4`

##### ADDITIONAL INFORMATION
Linode docs about instance creation request body:
https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema