### PR TITLE
Allow keycloak modules to take token as parameter for the auth. 

### DIFF
--- a/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
+++ b/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
-  - keycloak_* modules - allow the keycloak modules to take a token for the
+  - keycloak_* modules - allow the keycloak modules to use a token for the
     authentication, the modules can take either a token or the credentials
     (https://github.com/ansible-collections/community.general/pull/2250).

--- a/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
+++ b/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
   - keycloak_* modules - allow the keycloak modules to take a token for the
-    authentification, the modules can take either a token or the credentials
+    authentication, the modules can take either a token or the credentials
     (https://github.com/ansible-collections/community.general/pull/2250).

--- a/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
+++ b/changelogs/fragments/2250-allow-keycloak-modules-to-take-token-as-param.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - keycloak_* modules - allow the keycloak modules to take a token for the
+    authentification, the modules can take either a token or the credentials
+    (https://github.com/ansible-collections/community.general/pull/2250).

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -30,7 +30,6 @@ options:
         description:
             - Keycloak realm name to authenticate to for API access.
         type: str
-        required: true
 
     auth_client_secret:
         description:
@@ -41,7 +40,6 @@ options:
         description:
             - Username to authenticate for API access with.
         type: str
-        required: true
         aliases:
           - username
 
@@ -49,9 +47,13 @@ options:
         description:
             - Password to authenticate for API access with.
         type: str
-        required: true
         aliases:
           - password
+
+    token:
+    description:
+        - Authentication token for Keycloak API.
+    type: str
 
     validate_certs:
         description:

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -51,9 +51,10 @@ options:
           - password
 
     token:
-    description:
-        - Authentication token for Keycloak API.
-    type: str
+        description:
+            - Authentication token for Keycloak API.
+        type: str
+        version_added: 3.0.0
 
     validate_certs:
         description:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -62,7 +62,7 @@ def keycloak_argument_spec():
         auth_username=dict(type='str', aliases=['username']),
         auth_password=dict(type='str', aliases=['password'], no_log=True),
         validate_certs=dict(type='bool', default=True),
-        token=dict(type='str', default=None, no_log=True),
+        token=dict(type='str', no_log=True),
     )
 
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -55,13 +55,14 @@ def keycloak_argument_spec():
     :return: argument_spec dict
     """
     return dict(
-        auth_keycloak_url=dict(type='str', aliases=['url'], required=True, no_log=False),
+        auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
         auth_client_id=dict(type='str', default='admin-cli'),
-        auth_realm=dict(type='str', required=True),
+        auth_realm=dict(type='str', default=None),
         auth_client_secret=dict(type='str', default=None, no_log=True),
-        auth_username=dict(type='str', aliases=['username'], required=True),
-        auth_password=dict(type='str', aliases=['password'], required=True, no_log=True),
-        validate_certs=dict(type='bool', default=True)
+        auth_username=dict(type='str', aliases=['username'], default=None),
+        auth_password=dict(type='str', aliases=['password'], default=None, no_log=True),
+        validate_certs=dict(type='bool', default=True),
+        token=dict(type='str', default=None, no_log=True),
     )
 
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -74,41 +74,55 @@ class KeycloakError(Exception):
     pass
 
 
-def get_token(base_url, validate_certs, auth_realm, client_id,
-              auth_username, auth_password, client_secret):
-    if not base_url.lower().startswith(('http', 'https')):
-        raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
-    auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
-    temp_payload = {
-        'grant_type': 'password',
-        'client_id': client_id,
-        'client_secret': client_secret,
-        'username': auth_username,
-        'password': auth_password,
-    }
-    # Remove empty items, for instance missing client_secret
-    payload = dict(
-        (k, v) for k, v in temp_payload.items() if v is not None)
-    try:
-        r = json.loads(to_native(open_url(auth_url, method='POST',
-                                          validate_certs=validate_certs,
-                                          data=urlencode(payload)).read()))
-    except ValueError as e:
-        raise KeycloakError(
-            'API returned invalid JSON when trying to obtain access token from %s: %s'
-            % (auth_url, str(e)))
-    except Exception as e:
-        raise KeycloakError('Could not obtain access token from %s: %s'
-                            % (auth_url, str(e)))
+def get_token(module_params):
+    """ Obtains connection header with token for the authentication, 
+        token already given or obtained from credentials
+        :param module_params: parameters of the module
+        :return: connection header
+    """
+    token = module_params.get('token')
+    if token is None:
+        base_url = module_params.get('auth_keycloak_url')
+        validate_certs = module_params.get('validate_certs')
+        auth_realm = module_params.get('auth_realm')
+        client_id = module_params.get('auth_client_id')
+        auth_username = module_params.get('auth_username')
+        auth_password = module_params.get('auth_password')
+        client_secret = module_params.get('auth_client_secret')
+        if not base_url.lower().startswith(('http', 'https')):
+            raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
+        auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
+        temp_payload = {
+            'grant_type': 'password',
+            'client_id': client_id,
+            'client_secret': client_secret,
+            'username': auth_username,
+            'password': auth_password,
+        }
+        # Remove empty items, for instance missing client_secret
+        payload = dict(
+            (k, v) for k, v in temp_payload.items() if v is not None)
+        try:
+            r = json.loads(to_native(open_url(auth_url, method='POST',
+                                              validate_certs=validate_certs,
+                                              data=urlencode(payload)).read()))
+        except ValueError as e:
+            raise KeycloakError(
+                'API returned invalid JSON when trying to obtain access token from %s: %s'
+                % (auth_url, str(e)))
+        except Exception as e:
+            raise KeycloakError('Could not obtain access token from %s: %s'
+                                % (auth_url, str(e)))
 
-    try:
-        return {
-            'Authorization': 'Bearer ' + r['access_token'],
+        try:
+            token = r['access_token']
+        except KeyError:
+            raise KeycloakError(
+                'Could not obtain access token from %s' % auth_url)
+    return {
+            'Authorization': 'Bearer ' + token,
             'Content-Type': 'application/json'
         }
-    except KeyError:
-        raise KeycloakError(
-            'Could not obtain access token from %s' % auth_url)
 
 
 class KeycloakAPI(object):

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -55,7 +55,7 @@ def keycloak_argument_spec():
     :return: argument_spec dict
     """
     return dict(
-        auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
+        auth_keycloak_url=dict(type='str', aliases=['url'], required=True, no_log=False),
         auth_client_id=dict(type='str', default='admin-cli'),
         auth_realm=dict(type='str'),
         auth_client_secret=dict(type='str', default=None, no_log=True),

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -81,6 +81,11 @@ def get_token(module_params):
         :return: connection header
     """
     token = module_params.get('token')
+    base_url = module_params.get('auth_keycloak_url')
+
+    if not base_url.lower().startswith(('http', 'https')):
+        raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
+
     if token is None:
         base_url = module_params.get('auth_keycloak_url')
         validate_certs = module_params.get('validate_certs')
@@ -89,8 +94,6 @@ def get_token(module_params):
         auth_username = module_params.get('auth_username')
         auth_password = module_params.get('auth_password')
         client_secret = module_params.get('auth_client_secret')
-        if not base_url.lower().startswith(('http', 'https')):
-            raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
         auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
         temp_payload = {
             'grant_type': 'password',

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -57,7 +57,7 @@ def keycloak_argument_spec():
     return dict(
         auth_keycloak_url=dict(type='str', aliases=['url'], required=True),
         auth_client_id=dict(type='str', default='admin-cli'),
-        auth_realm=dict(type='str', default=None),
+        auth_realm=dict(type='str'),
         auth_client_secret=dict(type='str', default=None, no_log=True),
         auth_username=dict(type='str', aliases=['username']),
         auth_password=dict(type='str', aliases=['password'], default=None, no_log=True),

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -59,7 +59,7 @@ def keycloak_argument_spec():
         auth_client_id=dict(type='str', default='admin-cli'),
         auth_realm=dict(type='str', default=None),
         auth_client_secret=dict(type='str', default=None, no_log=True),
-        auth_username=dict(type='str', aliases=['username'], default=None),
+        auth_username=dict(type='str', aliases=['username']),
         auth_password=dict(type='str', aliases=['password'], default=None, no_log=True),
         validate_certs=dict(type='bool', default=True),
         token=dict(type='str', default=None, no_log=True),

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -75,7 +75,7 @@ class KeycloakError(Exception):
 
 
 def get_token(module_params):
-    """ Obtains connection header with token for the authentication, 
+    """ Obtains connection header with token for the authentication,
         token already given or obtained from credentials
         :param module_params: parameters of the module
         :return: connection header
@@ -120,8 +120,8 @@ def get_token(module_params):
             raise KeycloakError(
                 'Could not obtain access token from %s' % auth_url)
     return {
-            'Authorization': 'Bearer ' + token,
-            'Content-Type': 'application/json'
+        'Authorization': 'Bearer ' + token,
+        'Content-Type': 'application/json'
         }
 
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -60,7 +60,7 @@ def keycloak_argument_spec():
         auth_realm=dict(type='str'),
         auth_client_secret=dict(type='str', default=None, no_log=True),
         auth_username=dict(type='str', aliases=['username']),
-        auth_password=dict(type='str', aliases=['password'], default=None, no_log=True),
+        auth_password=dict(type='str', aliases=['password'], no_log=True),
         validate_certs=dict(type='bool', default=True),
         token=dict(type='str', default=None, no_log=True),
     )

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -83,7 +83,7 @@ def get_token(module_params):
     token = module_params.get('token')
     base_url = module_params.get('auth_keycloak_url')
 
-    if not None and not base_url.lower().startswith(('http', 'https')):
+    if not base_url.lower().startswith(('http', 'https')):
         raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
 
     if token is None:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -122,7 +122,7 @@ def get_token(module_params):
     return {
         'Authorization': 'Bearer ' + token,
         'Content-Type': 'application/json'
-        }
+    }
 
 
 class KeycloakAPI(object):

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -83,7 +83,7 @@ def get_token(module_params):
     token = module_params.get('token')
     base_url = module_params.get('auth_keycloak_url')
 
-    if not base_url.lower().startswith(('http', 'https')):
+    if not None and not base_url.lower().startswith(('http', 'https')):
         raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
 
     if token is None:

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -511,7 +511,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create or update Keycloak client (minimal example), authentification with credentials
+- name: Create or update Keycloak client (minimal example), authentication with credentials
   local_action:
     module: keycloak_client
     auth_client_id: admin-cli

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -522,7 +522,7 @@ EXAMPLES = '''
     client_id: test
     state: present
 
-- name: Create or update Keycloak client (minimal example), authentification with token
+- name: Create or update Keycloak client (minimal example), authentication with token
   delegate_to: localhost
   community.general.keycloak_client:
     auth_client_id: admin-cli

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -512,18 +512,17 @@ author:
 
 EXAMPLES = '''
 - name: Create or update Keycloak client (minimal example), authentication with credentials
-  local_action:
-    module: keycloak_client
-    auth_client_id: admin-cli
+  community.general.keycloak_client:
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
     client_id: test
     state: present
+  delegate_to: localhost
+
 
 - name: Create or update Keycloak client (minimal example), authentication with token
-  delegate_to: localhost
   community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -531,10 +530,11 @@ EXAMPLES = '''
     token: TOKEN
     client_id: test
     state: present
+  delegate_to: localhost
+
 
 - name: Delete a Keycloak client
-  local_action:
-    module: keycloak_client
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -542,10 +542,11 @@ EXAMPLES = '''
     auth_password: PASSWORD
     client_id: test
     state: absent
+  delegate_to: localhost
+
 
 - name: Create or update a Keycloak client (with all the bells and whistles)
-  local_action:
-    module: keycloak_client
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -629,6 +630,7 @@ EXAMPLES = '''
       use.jwks.url: true
       jwks.url: JWKS_URL_FOR_CLIENT_AUTH_JWT
       jwt.credential.certificate: JWT_CREDENTIAL_CERTIFICATE_FOR_CLIENT_AUTH
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -752,7 +752,9 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['client_id', 'id']]))
+                           required_one_of=([['id', 'name'],
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
+                           required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
     result = dict(changed=False, msg='', diff={}, proposed={}, existing={}, end_state={})
 

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -752,7 +752,7 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['id', 'name'],
+                           required_one_of=([['client_id', 'id'],
                                              ['token', 'auth_realm', 'auth_username', 'auth_password']]),
                            required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -511,7 +511,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create or update Keycloak client (minimal example)
+- name: Create or update Keycloak client (minimal example), authentification with credentials
   local_action:
     module: keycloak_client
     auth_client_id: admin-cli
@@ -519,6 +519,16 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+    client_id: test
+    state: present
+
+- name: Create or update Keycloak client (minimal example), authentification with token
+  local_action:
+    module: keycloak_client
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    token: TOKEN
     client_id: test
     state: present
 
@@ -746,15 +756,7 @@ def main():
 
     # Obtain access token, initialize API
     try:
-        connection_header = get_token(
-            base_url=module.params.get('auth_keycloak_url'),
-            validate_certs=module.params.get('validate_certs'),
-            auth_realm=module.params.get('auth_realm'),
-            client_id=module.params.get('auth_client_id'),
-            auth_username=module.params.get('auth_username'),
-            auth_password=module.params.get('auth_password'),
-            client_secret=module.params.get('auth_client_secret'),
-        )
+        connection_header = get_token(module.params)
     except KeycloakError as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -523,8 +523,8 @@ EXAMPLES = '''
     state: present
 
 - name: Create or update Keycloak client (minimal example), authentification with token
-  local_action:
-    module: keycloak_client
+  delegate_to: localhost
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -306,7 +306,9 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['id', 'name']]))
+                           required_one_of=([['id', 'name'],
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
+                           required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
     result = dict(changed=False, msg='', diff={}, proposed={}, existing={}, end_state={})
 

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -180,7 +180,7 @@ EXAMPLES = '''
     realm: master
     name: this_is_a_test
 
-- name: Create or update Keycloak client template (minimal), authentification with token
+- name: Create or update Keycloak client template (minimal), authentication with token
   delegate_to: localhost
   community.general.keycloak_clienttemplate:
     auth_client_id: admin-cli

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -169,7 +169,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create or update Keycloak client template (minimal)
+- name: Create or update Keycloak client template (minimal), authentification with credentials
   local_action:
     module: keycloak_clienttemplate
     auth_client_id: admin-cli
@@ -177,6 +177,16 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+    realm: master
+    name: this_is_a_test
+
+- name: Create or update Keycloak client template (minimal), authentification with token
+  local_action:
+    module: keycloak_clienttemplate
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    token: TOKEN
     realm: master
     name: this_is_a_test
 
@@ -302,15 +312,7 @@ def main():
 
     # Obtain access token, initialize API
     try:
-        connection_header = get_token(
-            base_url=module.params.get('auth_keycloak_url'),
-            validate_certs=module.params.get('validate_certs'),
-            auth_realm=module.params.get('auth_realm'),
-            client_id=module.params.get('auth_client_id'),
-            auth_username=module.params.get('auth_username'),
-            auth_password=module.params.get('auth_password'),
-            client_secret=module.params.get('auth_client_secret'),
-        )
+        connection_header = get_token(module.params)
     except KeycloakError as e:
         module.fail_json(msg=str(e))
     kc = KeycloakAPI(module, connection_header)

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -170,8 +170,7 @@ author:
 
 EXAMPLES = '''
 - name: Create or update Keycloak client template (minimal), authentication with credentials
-  local_action:
-    module: keycloak_clienttemplate
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -179,9 +178,9 @@ EXAMPLES = '''
     auth_password: PASSWORD
     realm: master
     name: this_is_a_test
+  delegate_to: localhost
 
 - name: Create or update Keycloak client template (minimal), authentication with token
-  delegate_to: localhost
   community.general.keycloak_clienttemplate:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -189,10 +188,10 @@ EXAMPLES = '''
     token: TOKEN
     realm: master
     name: this_is_a_test
+  delegate_to: localhost
 
 - name: Delete Keycloak client template
-  local_action:
-    module: keycloak_clienttemplate
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -201,10 +200,10 @@ EXAMPLES = '''
     realm: master
     state: absent
     name: test01
+  delegate_to: localhost
 
 - name: Create or update Keycloak client template (with a protocol mapper)
-  local_action:
-    module: keycloak_clienttemplate
+  community.general.keycloak_client:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master
@@ -227,6 +226,7 @@ EXAMPLES = '''
         protocolMapper: oidc-usermodel-property-mapper
     full_scope_allowed: false
     id: bce6f5e9-d7d3-4955-817e-c5b7f8d65b3f
+  delegate_to: localhost
 '''
 
 RETURN = '''

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -169,7 +169,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create or update Keycloak client template (minimal), authentification with credentials
+- name: Create or update Keycloak client template (minimal), authentication with credentials
   local_action:
     module: keycloak_clienttemplate
     auth_client_id: admin-cli

--- a/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
+++ b/plugins/modules/identity/keycloak/keycloak_clienttemplate.py
@@ -181,8 +181,8 @@ EXAMPLES = '''
     name: this_is_a_test
 
 - name: Create or update Keycloak client template (minimal), authentification with token
-  local_action:
-    module: keycloak_clienttemplate
+  delegate_to: localhost
+  community.general.keycloak_clienttemplate:
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     auth_realm: master

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -215,7 +215,6 @@ from ansible_collections.community.general.plugins.module_utils.identity.keycloa
 from ansible.module_utils.basic import AnsibleModule
 
 
-
 def main():
     """
     Module execution

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -228,7 +228,6 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         attributes=dict(type='dict'),
-        token=dict(type='str'),
     )
 
     argument_spec.update(meta_args)

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -81,7 +81,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create a Keycloak group, authentification with credentials
+- name: Create a Keycloak group, authentication with credentials
   community.general.keycloak_group:
     name: my-new-kc-group
     realm: MyCustomRealm

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -93,7 +93,7 @@ EXAMPLES = '''
     auth_password: PASSWORD
   delegate_to: localhost
 
-- name: Create a Keycloak group, authentification with token
+- name: Create a Keycloak group, authentication with token
   community.general.keycloak_group:
     name: my-new-kc-group
     realm: MyCustomRealm

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -215,6 +215,7 @@ from ansible_collections.community.general.plugins.module_utils.identity.keycloa
 from ansible.module_utils.basic import AnsibleModule
 
 
+
 def main():
     """
     Module execution

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -81,7 +81,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create a Keycloak group, authentification with credentials 
+- name: Create a Keycloak group, authentification with credentials
   community.general.keycloak_group:
     name: my-new-kc-group
     realm: MyCustomRealm
@@ -93,14 +93,14 @@ EXAMPLES = '''
     auth_password: PASSWORD
   delegate_to: localhost
 
-  - name: Create a Keycloak group, authentification with token  
+- name: Create a Keycloak group, authentification with token
   community.general.keycloak_group:
     name: my-new-kc-group
     realm: MyCustomRealm
     state: present
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
-    token: TOKEN 
+    token: TOKEN
   delegate_to: localhost
 
 - name: Delete a keycloak group
@@ -236,20 +236,20 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['id', 'name'], 
-                           ['token', 'auth_realm', 'auth_username', 'auth_password']]),
+                           required_one_of=([['id', 'name'],
+                                             ['token', 'auth_realm', 'auth_username', 'auth_password']]),
                            required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
     result = dict(changed=False, msg='', diff={}, group='')
 
     # Obtain access token, initialize API
-    token = module.params.get('token') 
-    if(token != None): 
+    token = module.params.get('token')
+    if(token is not None):
         connection_header = {
             'Authorization': token,
             'Content-Type': 'application/json'
         }
-    else: 
+    else:
         try:
             connection_header = get_token(
                 base_url=module.params.get('auth_keycloak_url'),

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -215,7 +215,6 @@ from ansible_collections.community.general.plugins.module_utils.identity.keycloa
 from ansible.module_utils.basic import AnsibleModule
 
 
-
 def main():
     """
     Module execution
@@ -243,25 +242,10 @@ def main():
     result = dict(changed=False, msg='', diff={}, group='')
 
     # Obtain access token, initialize API
-    token = module.params.get('token')
-    if(token is not None):
-        connection_header = {
-            'Authorization': token,
-            'Content-Type': 'application/json'
-        }
-    else:
-        try:
-            connection_header = get_token(
-                base_url=module.params.get('auth_keycloak_url'),
-                validate_certs=module.params.get('validate_certs'),
-                auth_realm=module.params.get('auth_realm'),
-                client_id=module.params.get('auth_client_id'),
-                auth_username=module.params.get('auth_username'),
-                auth_password=module.params.get('auth_password'),
-                client_secret=module.params.get('auth_client_secret'),
-            )
-        except KeycloakError as e:
-            module.fail_json(msg=str(e))
+    try:
+        connection_header = get_token(module.params)
+    except KeycloakError as e:
+        module.fail_json(msg=str(e))
 
     kc = KeycloakAPI(module, connection_header)
 

--- a/plugins/modules/identity/keycloak/keycloak_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_group.py
@@ -81,7 +81,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Create a Keycloak group
+- name: Create a Keycloak group, authentification with credentials 
   community.general.keycloak_group:
     name: my-new-kc-group
     realm: MyCustomRealm
@@ -91,6 +91,16 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  delegate_to: localhost
+
+  - name: Create a Keycloak group, authentification with token  
+  community.general.keycloak_group:
+    name: my-new-kc-group
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    token: TOKEN 
   delegate_to: localhost
 
 - name: Delete a keycloak group
@@ -205,6 +215,7 @@ from ansible_collections.community.general.plugins.module_utils.identity.keycloa
 from ansible.module_utils.basic import AnsibleModule
 
 
+
 def main():
     """
     Module execution
@@ -217,30 +228,41 @@ def main():
         realm=dict(default='master'),
         id=dict(type='str'),
         name=dict(type='str'),
-        attributes=dict(type='dict')
+        attributes=dict(type='dict'),
+        token=dict(type='str'),
     )
 
     argument_spec.update(meta_args)
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['id', 'name']]))
+                           required_one_of=([['id', 'name'], 
+                           ['token', 'auth_realm', 'auth_username', 'auth_password']]),
+                           required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
     result = dict(changed=False, msg='', diff={}, group='')
 
     # Obtain access token, initialize API
-    try:
-        connection_header = get_token(
-            base_url=module.params.get('auth_keycloak_url'),
-            validate_certs=module.params.get('validate_certs'),
-            auth_realm=module.params.get('auth_realm'),
-            client_id=module.params.get('auth_client_id'),
-            auth_username=module.params.get('auth_username'),
-            auth_password=module.params.get('auth_password'),
-            client_secret=module.params.get('auth_client_secret'),
-        )
-    except KeycloakError as e:
-        module.fail_json(msg=str(e))
+    token = module.params.get('token') 
+    if(token != None): 
+        connection_header = {
+            'Authorization': token,
+            'Content-Type': 'application/json'
+        }
+    else: 
+        try:
+            connection_header = get_token(
+                base_url=module.params.get('auth_keycloak_url'),
+                validate_certs=module.params.get('validate_certs'),
+                auth_realm=module.params.get('auth_realm'),
+                client_id=module.params.get('auth_client_id'),
+                auth_username=module.params.get('auth_username'),
+                auth_password=module.params.get('auth_password'),
+                client_secret=module.params.get('auth_client_secret'),
+            )
+        except KeycloakError as e:
+            module.fail_json(msg=str(e))
+
     kc = KeycloakAPI(module, connection_header)
 
     realm = module.params.get('realm')

--- a/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_connect.py
+++ b/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_connect.py
@@ -78,7 +78,7 @@ def test_connect_to_keycloak_with_creds(mock_good_connection):
 
 def test_connect_to_keycloak_with_token(mock_good_connection):
     module_params_token = {
-        'base_url': 'http://keycloak.url/auth',
+        'auth_keycloak_url': 'http://keycloak.url/auth',
         'validate_certs': True,
         'client_id': 'admin-cli',
         'token': "alongtoken"

--- a/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_connect.py
+++ b/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_connect.py
@@ -11,6 +11,16 @@ from ansible_collections.community.general.plugins.module_utils.identity.keycloa
 from ansible.module_utils.six import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
+module_params_creds = {
+    'auth_keycloak_url': 'http://keycloak.url/auth',
+    'validate_certs': True,
+    'auth_realm': 'master',
+    'client_id': 'admin-cli',
+    'auth_username': 'admin',
+    'auth_password': 'admin',
+    'client_secret': None,
+}
+
 
 def build_mocked_request(get_id_user_count, response_dict):
     def _mocked_requests(*args, **kwargs):
@@ -58,16 +68,22 @@ def mock_good_connection(mocker):
     )
 
 
-def test_connect_to_keycloak(mock_good_connection):
-    keycloak_header = get_token(
-        base_url='http://keycloak.url/auth',
-        validate_certs=True,
-        auth_realm='master',
-        client_id='admin-cli',
-        auth_username='admin',
-        auth_password='admin',
-        client_secret=None
-    )
+def test_connect_to_keycloak_with_creds(mock_good_connection):
+    keycloak_header = get_token(module_params_creds)
+    assert keycloak_header == {
+        'Authorization': 'Bearer alongtoken',
+        'Content-Type': 'application/json'
+    }
+
+
+def test_connect_to_keycloak_with_token(mock_good_connection):
+    module_params_token = {
+        'base_url': 'http://keycloak.url/auth',
+        'validate_certs': True,
+        'client_id': 'admin-cli',
+        'token': "alongtoken"
+    }
+    keycloak_header = get_token(module_params_token)
     assert keycloak_header == {
         'Authorization': 'Bearer alongtoken',
         'Content-Type': 'application/json'
@@ -87,15 +103,7 @@ def mock_bad_json_returned(mocker):
 
 def test_bad_json_returned(mock_bad_json_returned):
     with pytest.raises(KeycloakError) as raised_error:
-        get_token(
-            base_url='http://keycloak.url/auth',
-            validate_certs=True,
-            auth_realm='master',
-            client_id='admin-cli',
-            auth_username='admin',
-            auth_password='admin',
-            client_secret=None
-        )
+        get_token(module_params_creds)
     # cannot check all the message, different errors message for the value
     # error in python 2.6, 2.7 and 3.*.
     assert (
@@ -125,15 +133,7 @@ def mock_401_returned(mocker):
 
 def test_error_returned(mock_401_returned):
     with pytest.raises(KeycloakError) as raised_error:
-        get_token(
-            base_url='http://keycloak.url/auth',
-            validate_certs=True,
-            auth_realm='master',
-            client_id='admin-cli',
-            auth_username='notadminuser',
-            auth_password='notadminpassword',
-            client_secret=None
-        )
+        get_token(module_params_creds)
     assert str(raised_error.value) == (
         'Could not obtain access token from http://keycloak.url'
         '/auth/realms/master/protocol/openid-connect/token: '
@@ -154,15 +154,7 @@ def mock_json_without_token_returned(mocker):
 
 def test_json_without_token_returned(mock_json_without_token_returned):
     with pytest.raises(KeycloakError) as raised_error:
-        get_token(
-            base_url='http://keycloak.url/auth',
-            validate_certs=True,
-            auth_realm='master',
-            client_id='admin-cli',
-            auth_username='admin',
-            auth_password='admin',
-            client_secret=None
-        )
+        get_token(module_params_creds)
     assert str(raised_error.value) == (
         'Could not obtain access token from http://keycloak.url'
         '/auth/realms/master/protocol/openid-connect/token'


### PR DESCRIPTION
##### SUMMARY
This PR allow the module to receive either a token or the credentials for the authentication to make call to the Keycloak API . 

Also refactor `DOCUMENTATION` 
- Add an example a group creation with token 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`keycloak_group.py` 
`keycloak.py` 



```
