### PR TITLE
fix error for Consul Inventory script

### DIFF
--- a/changelogs/fragments/2252-consul_io_inventory_script_error.yml
+++ b/changelogs/fragments/2252-consul_io_inventory_script_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix error when not using suffixes

--- a/changelogs/fragments/2252-consul_io_inventory_script_error.yml
+++ b/changelogs/fragments/2252-consul_io_inventory_script_error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - fix error when not using suffixes
+  - consul_io inventory script - fix error when not using suffixes (https://github.com/ansible-collections/community.general/pull/2252).

--- a/scripts/inventory/consul_io.py
+++ b/scripts/inventory/consul_io.py
@@ -291,12 +291,12 @@ class ConsulInventory(object):
         return consul_ok and service_ok
 
     def consul_get_kv_inmemory(self, key):
-        result = filter(lambda x: x['Key'] == key, self.inmemory_kv)
-        return list(result).pop() if list(result) else None
+        result = list(filter(lambda x: x['Key'] == key, self.inmemory_kv))
+        return result.pop() if result else None
 
     def consul_get_node_inmemory(self, node):
-        result = filter(lambda x: x['Node'] == node, self.inmemory_nodes)
-        return {"Node": list(result).pop(), "Services": {}} if list(result) else None
+        result = list(filter(lambda x: x['Node'] == node, self.inmemory_nodes))
+        return {"Node": result.pop(), "Services": {}} if result else None
 
     def load_data_for_datacenter(self, datacenter):
         '''processes all the nodes in a particular datacenter'''
@@ -475,7 +475,7 @@ class ConsulConfig(dict):
 
     def read_settings(self):
         ''' Reads the settings from the consul_io.ini file (or consul.ini for backwards compatibility)'''
-        config = configparser.ConfigParser()
+        config = configparser.SafeConfigParser()
         if os.path.isfile(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini'):
             config.read(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini')
         else:

--- a/scripts/inventory/consul_io.py
+++ b/scripts/inventory/consul_io.py
@@ -324,10 +324,10 @@ class ConsulInventory(object):
 
         self.load_groups_from_kv(node_data)
         self.load_node_metadata_from_kv(node_data)
-        if self.config.bulk_load != 'true':
-            self.load_availability_groups(node_data, datacenter)
-            for name, service in node_data['Services'].items():
-                self.load_data_from_service(name, service, node_data)
+        
+        self.load_availability_groups(node_data, datacenter)
+        for name, service in node_data['Services'].items():
+            self.load_data_from_service(name, service, node_data)
 
     def load_node_metadata_from_kv(self, node_data):
         ''' load the json dict at the metadata path defined by the kv_metadata value

--- a/scripts/inventory/consul_io.py
+++ b/scripts/inventory/consul_io.py
@@ -324,7 +324,7 @@ class ConsulInventory(object):
 
         self.load_groups_from_kv(node_data)
         self.load_node_metadata_from_kv(node_data)
-        
+
         self.load_availability_groups(node_data, datacenter)
         for name, service in node_data['Services'].items():
             self.load_data_from_service(name, service, node_data)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix Python filter error: AttributeError: 'filter' object has no attribute 'pop'
* Fix error with following consul_io.ini
```
# Ansible Consul external inventory script settings.

[consul]

bulk_load = false
url = http://localhost:8500
datacenter = dc1
tags = true
kv_groups=ansible/groups
kv_metadata=ansible/metadata
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* Consul inventory script
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I have following nodes on consul
![image](https://user-images.githubusercontent.com/21155445/115101917-b8cdec00-9f82-11eb-8813-264896f7a4e0.png)
Error while executing the script
```
➜ python consul_io.py --list
consul_io.py:478: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = configparser.SafeConfigParser()
Traceback (most recent call last):
  File "consul_io.py", line 553, in <module>
    ConsulInventory()
  File "consul_io.py", line 242, in __init__
    self.load_data_for_datacenter(config.datacenter)
  File "consul_io.py", line 309, in load_data_for_datacenter
    self.load_data_for_node(node['Node'], datacenter)
  File "consul_io.py", line 318, in load_data_for_node
    node_data = self.consul_get_node_inmemory(node)
  File "consul_io.py", line 299, in consul_get_node_inmemory
    return {"Node": result.pop(), "Services": {}} if result else None
AttributeError: 'filter' object has no attribute 'pop'
```
After fixing *ConfigParser* and *AttributeError: 'filter' object has no attribute 'pop'*
Error became
```
➜ python consul_io.py --list
Traceback (most recent call last):
  File "consul_io.py", line 553, in <module>
    ConsulInventory()
  File "consul_io.py", line 242, in __init__
    self.load_data_for_datacenter(config.datacenter)
  File "consul_io.py", line 309, in load_data_for_datacenter
    self.load_data_for_node(node['Node'], datacenter)
  File "consul_io.py", line 319, in load_data_for_node
    node = node_data['Node']
TypeError: 'NoneType' object is not subscriptable
```
And after fixing the rest, the result is as expected
```
➜ ansible-inventory -i consul_io.py --playbook-dir . --graph
@all:
  |--@agent1:
  |  |--172.20.0.4
  |--@agent1_tag1:
  |  |--172.20.0.4
  |--@agent1_test:
  |  |--172.20.0.4
  |--@agent2:
  |  |--172.20.0.2
  |--@agent2_tag2:
  |  |--172.20.0.2
  |--@agent2_test:
  |  |--172.20.0.2
  |--@consul:
  |  |--172.20.0.3
  |--@dc1:
  |  |--172.20.0.2
  |  |--172.20.0.3
  |  |--172.20.0.4
  |--@ungrouped:
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
