### PR TITLE
Remove ldap_entry's params option completely

### DIFF
--- a/changelogs/fragments/2257-ldap_entry-params.yml
+++ b/changelogs/fragments/2257-ldap_entry-params.yml
@@ -1,0 +1,2 @@
+removed_features:
+- "ldap_entry - the ``params`` parameter is now completely removed. Using it already triggered an error since community.general 0.1.2 (https://github.com/ansible-collections/community.general/pull/2257)."

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -25,9 +25,6 @@ notes:
     rule allowing root to modify the server configuration. If you need to use
     a simple bind to access your server, pass the credentials in I(bind_dn)
     and I(bind_pw).
-  - "The I(params) parameter was removed due to circumventing Ansible's parameter
-     handling.  The I(params) parameter started disallowing setting the I(bind_pw) parameter in
-     Ansible-2.7 as it was insecure to set the parameter that way."
 author:
   - Jiri Tyr (@jtyr)
 requirements:
@@ -187,7 +184,6 @@ def main():
         argument_spec=gen_specs(
             attributes=dict(default={}, type='dict'),
             objectClass=dict(type='list', elements='str'),
-            params=dict(type='dict'),
             state=dict(default='present', choices=['present', 'absent']),
         ),
         required_if=[('state', 'present', ['objectClass'])],
@@ -197,9 +193,6 @@ def main():
     if not HAS_LDAP:
         module.fail_json(msg=missing_required_lib('python-ldap'),
                          exception=LDAP_IMP_ERR)
-
-    if module.params['params']:
-        module.fail_json(msg="The `params` option to ldap_entry was removed since it circumvents Ansible's option handling")
 
     state = module.params['state']
 

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -48,6 +48,7 @@ options:
       - The target state of the entry.
     choices: [present, absent]
     default: present
+    type: str
 extends_documentation_fragment:
 - community.general.ldap.documentation
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -37,9 +37,6 @@ plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -36,9 +36,6 @@ plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -36,9 +36,6 @@ plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/notification/grove.py validate-modules:invalid-argument-name
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -28,9 +28,6 @@ plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:parameter-type
 plugins/modules/cloud/univention/udm_dns_zone.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
-plugins/modules/net_tools/ldap/ldap_entry.py validate-modules:undocumented-parameter # Parameter removed but reason for removal is shown by custom code
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid


### PR DESCRIPTION
##### SUMMARY
The parameter was removed in 11ef03e9dd1dc05fd80bbe74eafd89b3645965cf a year ago (first included in c.g 0.1.2), so I think it's ok to properly remove it for community.general 3.0.0. This also saves some ignore.txt lines :)

CC @russoz

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ldap_entry
