### PR TITLE
java_keystore: overwrite instead of fail when password or alias does not match

### DIFF
--- a/changelogs/fragments/2262-java_keystore-passphrase.yml
+++ b/changelogs/fragments/2262-java_keystore-passphrase.yml
@@ -1,0 +1,5 @@
+breaking_changes:
+- "java_keystore - instead of failing, now overwrites keystore if the passphrase is changed.
+  This was originally the intended behavior, but did not work due to a logic error. Make sure
+  that your playbooks and roles do not depend on the old behavior of failing instead of
+  overwriting (https://github.com/ansible-collections/community.general/issues/1671)."

--- a/changelogs/fragments/2262-java_keystore-passphrase.yml
+++ b/changelogs/fragments/2262-java_keystore-passphrase.yml
@@ -1,5 +1,8 @@
 breaking_changes:
-- "java_keystore - instead of failing, now overwrites keystore if the passphrase is changed.
+- "java_keystore - instead of failing, now overwrites keystore if the alias (name) is changed.
   This was originally the intended behavior, but did not work due to a logic error. Make sure
   that your playbooks and roles do not depend on the old behavior of failing instead of
   overwriting (https://github.com/ansible-collections/community.general/issues/1671)."
+- "java_keystore - instead of failing, now overwrites keystore if the passphrase is changed.
+  Make sure that your playbooks and roles do not depend on the old behavior of failing instead
+  of overwriting (https://github.com/ansible-collections/community.general/issues/1671)."

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -61,7 +61,7 @@ options:
       - Password that should be used to secure the keystore.
       - If the provided password fails to unlock the keystore, the module
         will re-create the keystore with the new passphrase. This behavior
-        changed in community.general 3.0.0, before the module would fail
+        changed in community.general 3.0.0, before that the module would fail
         when the password did not match.
     type: str
     required: true

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -187,16 +187,11 @@ def read_stored_certificate_fingerprint(module, keytool_bin, alias, keystore_pat
     (rc, stored_certificate_fingerprint_out, stored_certificate_fingerprint_err) = run_commands(
         module, stored_certificate_fingerprint_cmd, environ_update=dict(STOREPASS=keystore_password))
     if rc != 0:
-        # First intention was to not fail, and overwrite the keystore instead,
-        # in case of alias mismatch; but an issue in error handling caused the
-        # module to fail anyway.
-        # See: https://github.com/ansible-collections/community.general/issues/1671
-        # And: https://github.com/ansible-collections/community.general/pull/2183
-        # if "keytool error: java.lang.Exception: Alias <%s> does not exist" % alias in stored_certificate_fingerprint_out:
-        #     return "alias mismatch"
-        # if re.match(r'keytool error: java\.io\.IOException: [Kk]eystore( was tampered with, or)? password was incorrect',
-        #             stored_certificate_fingerprint_out):
-        #    return "password mismatch"
+        if "keytool error: java.lang.Exception: Alias <%s> does not exist" % alias in stored_certificate_fingerprint_out:
+            return "alias mismatch"
+        if re.match(r'keytool error: java\.io\.IOException: [Kk]eystore( was tampered with, or)? password was incorrect',
+                    stored_certificate_fingerprint_out):
+            return "password mismatch"
         return module.fail_json(msg=stored_certificate_fingerprint_out,
                                 err=stored_certificate_fingerprint_err,
                                 cmd=stored_certificate_fingerprint_cmd,

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -19,8 +19,9 @@ options:
   name:
     description:
       - Name of the certificate in the keystore.
-      - If the provided name does not exist in the keystore, the module fails.
-        This behavior will change in a next release.
+      - If the provided name does not exist in the keystore, the module
+        will re-create the keystore. This behavior changed in community.general 3.0.0,
+        before that the module would fail when the name did not match.
     type: str
     required: true
   certificate:

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -60,7 +60,9 @@ options:
     description:
       - Password that should be used to secure the keystore.
       - If the provided password fails to unlock the keystore, the module
-        fails. This behavior will change in a next release.
+        will re-create the keystore with the new passphrase. This behavior
+        changed in community.general 3.0.0, before the module would fail
+        when the password did not match.
     type: str
     required: true
   dest:

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -64,7 +64,6 @@
   loop: "{{ java_keystore_new_certs }}"
   check_mode: yes
   register: result_alias_change_check
-  when: false  # FIXME: module currently crashes
 
 - name: Create a Java keystore for the given certificates (alias changed)
   community.general.java_keystore:
@@ -72,7 +71,6 @@
     name: foobar
   loop: "{{ java_keystore_new_certs }}"
   register: result_alias_change
-  when: false  # FIXME: module currently crashes
 
 
 - name: Create a Java keystore for the given certificates (password changed, check mode)
@@ -83,7 +81,6 @@
   loop: "{{ java_keystore_new_certs }}"
   check_mode: yes
   register: result_pw_change_check
-  when: false  # FIXME: module currently crashes
 
 - name: Create a Java keystore for the given certificates (password changed)
   community.general.java_keystore:
@@ -117,7 +114,7 @@
       - result_idem_check is not changed
       - result_change is changed
       - result_change_check is changed
-      # - result_alias_change is changed        # FIXME: module currently crashes
-      # - result_alias_change_check is changed  # FIXME: module currently crashes
-      # - result_pw_change is changed           # FIXME: module currently crashes
-      # - result_pw_change_check is changed     # FIXME: module currently crashes
+      - result_alias_change is changed
+      - result_alias_change_check is changed
+      - result_pw_change is changed
+      - result_pw_change_check is changed

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -89,7 +89,6 @@
     password: hunter2
   loop: "{{ java_keystore_new_certs }}"
   register: result_pw_change
-  when: false  # FIXME: module currently crashes
 
 - name: Check that the remote certificates have not been removed
   ansible.builtin.file:

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -273,7 +273,6 @@ class TestCertChanged(ModuleTestCase):
             supports_check_mode=self.spec.supports_check_mode
         )
 
-
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder']
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''),

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -259,7 +259,7 @@ class TestCertChanged(ModuleTestCase):
             result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertTrue(result, 'Alias mismatch detected')
 
-    def test_cert_changed_fail_password_mismatch(self):
+    def test_cert_changed_password_mismatch(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',
@@ -273,7 +273,6 @@ class TestCertChanged(ModuleTestCase):
             supports_check_mode=self.spec.supports_check_mode
         )
 
-        module.fail_json = Mock()
 
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder']

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -250,8 +250,6 @@ class TestCertChanged(ModuleTestCase):
             supports_check_mode=self.spec.supports_check_mode
         )
 
-        module.fail_json = Mock()
-
         with patch('os.remove', return_value=True):
             self.create_file.side_effect = ['/tmp/placeholder']
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''),

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -256,13 +256,31 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/placeholder']
             self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''),
                                              (1, 'keytool error: java.lang.Exception: Alias <foo> does not exist', '')]
-            cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
-            module.fail_json.assert_called_once_with(
-                cmd=["keytool", "-list", "-alias", "foo", "-keystore", "/path/to/keystore.jks", "-storepass:env", "STOREPASS", "-v"],
-                msg='keytool error: java.lang.Exception: Alias <foo> does not exist',
-                err='',
-                rc=1
-            )
+            result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
+            self.assertTrue(result, 'Alias mismatch detected')
+
+    def test_cert_changed_fail_password_mismatch(self):
+        set_module_args(dict(
+            certificate='cert-foo',
+            private_key='private-foo',
+            dest='/path/to/keystore.jks',
+            name='foo',
+            password='changeit'
+        ))
+
+        module = AnsibleModule(
+            argument_spec=self.spec.argument_spec,
+            supports_check_mode=self.spec.supports_check_mode
+        )
+
+        module.fail_json = Mock()
+
+        with patch('os.remove', return_value=True):
+            self.create_file.side_effect = ['/tmp/placeholder']
+            self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''),
+                                             (1, 'keytool error: java.io.IOException: Keystore password was incorrect', '')]
+            result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
+            self.assertTrue(result, 'Password mismatch detected')
 
     def test_cert_changed_fail_read_cert(self):
         set_module_args(dict(


### PR DESCRIPTION
##### SUMMARY
Fixes #1671. Completes what @quidame started in #2183.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
java_keystore
