### PR TITLE
inventory/proxmox: Added some cases for unsupported network interface and multi-nic and unsupported guest error

### DIFF
--- a/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
+++ b/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - proxmox inventory plugin - support network interfaces without IP addresses, multiple network interfaces and unsupported guest error (https://github.com/ansible-collections/community.general/pull/2263).
+  - proxmox inventory plugin - support network interfaces without IP addresses, multiple network interfaces and unsupported/commanddisabled guest error (https://github.com/ansible-collections/community.general/pull/2263).
 minor_changes:
   - proxmox inventory plugin - allow to select whether ``ansible_host`` should be set for the proxmox nodes (https://github.com/ansible-collections/community.general/pull/2263).

--- a/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
+++ b/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
   - proxmox inventory - network interfaces without ip-addresses, multiple network interfaces and unsupported guest error (https://github.com/ansible-collections/community.general/pull/2263).
+minor_changes:
+  - proxmox inventory - allow us to select if we want ansible_host set for the proxmox nodes

--- a/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
+++ b/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox inventory - network interfaces without ip-addresses, multiple network interfaces and unsupported guest error (https://github.com/ansible-collections/community.general/pull/2263).

--- a/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
+++ b/changelogs/fragments/2259-proxmox-multi-nic-and-unsupported.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - proxmox inventory - network interfaces without ip-addresses, multiple network interfaces and unsupported guest error (https://github.com/ansible-collections/community.general/pull/2263).
+  - proxmox inventory plugin - support network interfaces without IP addresses, multiple network interfaces and unsupported guest error (https://github.com/ansible-collections/community.general/pull/2263).
 minor_changes:
-  - proxmox inventory - allow us to select if we want ansible_host set for the proxmox nodes
+  - proxmox inventory plugin - allow to select whether ``ansible_host`` should be set for the proxmox nodes (https://github.com/ansible-collections/community.general/pull/2263).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -255,7 +255,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for iface in ifaces:
                 result.append({
                     'name': iface['name'],
-                    'mac-address': iface['hardware-address'] if 'hardware-address' in iface else None,
+                    'mac-address': iface['hardware-address'] if 'hardware-address' in iface else '',
                     'ip-addresses': ["%s/%s" % (ip['ip-address'], ip['prefix']) for ip in iface['ip-addresses']] if 'ip-addresses' in iface else []
                 })
         except requests.HTTPError:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -73,8 +73,8 @@ DOCUMENTATION = '''
       want_proxmox_nodes_ansible_host:
         version_added: 2.5.1
         description:
-          - Do we want the ansible host set for the proxmox nodes?
-          - Be careful with setting this to yes as it will randomly get the first available interface in the response.
+          - Whether to set C(ansbile_host) for proxmox nodes.
+          - When set to C(true) (default), will use the first available interface. This can be different from what you expect.
         default: true
         type: bool
       strict:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -71,7 +71,10 @@ DOCUMENTATION = '''
         default: no
         type: bool
       want_proxmox_nodes_ansible_host:
-        description: Do we want the ansible host set for the proxmox nodes
+        version_added: 2.5.1
+        description:
+          - Do we want the ansible host set for the proxmox nodes?
+          - Be careful with setting this to yes as it will randomly get the first available interface, in case of multiple network interface it will retrieve the first available IP address which may not be the correct one
         default: yes
         type: bool
       strict:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -71,7 +71,7 @@ DOCUMENTATION = '''
         default: no
         type: bool
       want_proxmox_nodes_ansible_host:
-        version_added: 2.5.1
+        version_added: 3.0.0
         description:
           - Whether to set C(ansbile_host) for proxmox nodes.
           - When set to C(true) (default), will use the first available interface. This can be different from what you expect.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -241,9 +241,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 )
             )['result']
 
-            if "error" in ifaces and "class" in ifaces["error"] and ifaces["error"]["class"] == "Unsupported":
+            if "error" in ifaces and "class" in ifaces["error"] and (ifaces["error"]["class"] in ["Unsupported", "CommandDisabled"]):
                 # This happens on Windows, even though qemu agent is running, the IP address
-                # cannot be fetched, as it's unsupported
+                # cannot be fetched, as it's unsupported, also a command disabled can happen.
                 return result
 
             for iface in ifaces:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -70,6 +70,10 @@ DOCUMENTATION = '''
         description: Gather LXC/QEMU configuration facts.
         default: no
         type: bool
+      want_proxmox_nodes_ansible_host:
+        description: Do we want the ansible host set for the proxmox nodes
+        default: yes
+        type: bool
       strict:
         version_added: 2.5.0
       compose:
@@ -361,8 +365,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     self.inventory.add_child(nodes_group, node['node'])
 
                 # get node IP address
-                ip = self._get_node_ip(node['node'])
-                self.inventory.set_variable(node['node'], 'ansible_host', ip)
+                if self.get_option("want_proxmox_nodes_ansible_host"):
+                    ip = self._get_node_ip(node['node'])
+                    self.inventory.set_variable(node['node'], 'ansible_host', ip)
 
                 # get LXC containers for this node
                 node_lxc_group = self.to_safe('%s%s' % (self.get_option('group_prefix'), ('%s_lxc' % node['node']).lower()))

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -234,14 +234,21 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 )
             )['result']
 
+            if "error" in ifaces and "class" in ifaces["error"] and ifaces["error"]["class"] == "Unsupported":
+                # This happens on Windows, even though qemu agent is running, the IP address
+                # cannot be fetched, as it's unsupported
+                return result
+
             for iface in ifaces:
-                result.append({
+                iface_result = {
                     'name': iface['name'],
                     'mac-address': iface['hardware-address'],
-                    'ip-addresses': [
+                }
+                if "ip-addresses" in iface:
+                    iface_result["ip-addresses"] = [
                         "%s/%s" % (ip['ip-address'], ip['prefix']) for ip in iface['ip-addresses']
                     ]
-                })
+                result.append(iface_result)
         except requests.HTTPError:
             pass
 

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -75,7 +75,7 @@ DOCUMENTATION = '''
         description:
           - Do we want the ansible host set for the proxmox nodes?
           - Be careful with setting this to yes as it will randomly get the first available interface in the response.
-        default: yes
+        default: true
         type: bool
       strict:
         version_added: 2.5.0

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -74,7 +74,7 @@ DOCUMENTATION = '''
         version_added: 2.5.1
         description:
           - Do we want the ansible host set for the proxmox nodes?
-          - Be careful with setting this to yes as it will randomly get the first available interface, in case of multiple network interface it will retrieve the first available IP address which may not be the correct one
+          - Be careful with setting this to yes as it will randomly get the first available interface in the response.
         default: yes
         type: bool
       strict:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -255,7 +255,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for iface in ifaces:
                 result.append({
                     'name': iface['name'],
-                    'mac-address': iface['hardware-address'] if 'hardware-address' in iface else "00:00:00:00:00:00",
+                    'mac-address': iface['hardware-address'] if 'hardware-address' in iface else None,
                     'ip-addresses': ["%s/%s" % (ip['ip-address'], ip['prefix']) for ip in iface['ip-addresses']] if 'ip-addresses' in iface else []
                 })
         except requests.HTTPError:

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -520,6 +520,8 @@ def get_option(option):
         return 'proxmox_'
     elif option == 'want_facts':
         return True
+    elif option == 'want_proxmox_nodes_ansible_host':
+        return True
     else:
         return False
 
@@ -551,16 +553,12 @@ def test_populate(inventory, mocker):
     assert group_qemu.hosts == [host_qemu]
 
     # check if qemu-test has eth0 interface in agent_interfaces fact
-    assert 'eth0' in [d['name']
-                      for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth0' in [d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
 
     # check if qemu-multi-nic has multiple network interfaces
-    assert 'eth0' in [d['name']
-                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
-    assert 'eth1' in [d['name']
-                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
-    assert 'weave' in [d['name']
-                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth0' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth1' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    assert 'weave' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
 
     # check to make sure qemu-windows doesn't have proxmox_agent_interfaces
     assert "proxmox_agent_interfaces" not in host_qemu_windows.get_vars()

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -565,7 +565,7 @@ def test_populate(inventory, mocker):
     # check if interface with no mac-address or ip-address defaults correctly
     assert [iface for iface in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']
             if iface['name'] == 'nomacorip'
-            and iface['mac-address'] == "00:00:00:00:00:00"
+            and iface['mac-address'] is None
             and iface['ip-addresses'] == []
             ]
 

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -556,9 +556,15 @@ def test_populate(inventory, mocker):
     assert 'eth0' in [d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
 
     # check if qemu-multi-nic has multiple network interfaces
-    assert 'eth0' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
-    assert 'eth1' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
-    assert 'weave' in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    for iface_name in ['eth0', 'eth1', 'weave']:
+        assert iface_name in [d['name'] for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+
+    # check if interface with no mac-address or ip-address defaults correctly
+    assert [iface for iface in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']
+            if iface['name'] == 'nomacorip'
+            and iface['mac-address'] == "00:00:00:00:00:00"
+            and iface['ip-addresses'] == []
+            ]
 
     # check to make sure qemu-windows doesn't have proxmox_agent_interfaces
     assert "proxmox_agent_interfaces" not in host_qemu_windows.get_vars()

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -90,6 +90,38 @@ def get_json(url):
                  "uptime": 1000,
                  "disk": 0,
                  "status": "running"},
+                {"name": "test-qemu-windows",
+                 "cpus": 1,
+                 "mem": 1000,
+                 "template": "",
+                 "diskread": 0,
+                 "cpu": 0.01,
+                 "maxmem": 1000,
+                 "diskwrite": 0,
+                 "netout": 1000,
+                 "pid": "1001",
+                 "netin": 1000,
+                 "maxdisk": 1000,
+                 "vmid": "102",
+                 "uptime": 1000,
+                 "disk": 0,
+                 "status": "running"},
+                {"name": "test-qemu-multi-nic",
+                 "cpus": 1,
+                 "mem": 1000,
+                 "template": "",
+                 "diskread": 0,
+                 "cpu": 0.01,
+                 "maxmem": 1000,
+                 "diskwrite": 0,
+                 "netout": 1000,
+                 "pid": "1001",
+                 "netin": 1000,
+                 "maxdisk": 1000,
+                 "vmid": "103",
+                 "uptime": 1000,
+                 "disk": 0,
+                 "status": "running"},
                 {"name": "test-qemu-template",
                  "cpus": 1,
                  "mem": 0,
@@ -212,6 +244,54 @@ def get_json(url):
             "scsihw": "virtio-scsi-pci",
             "smbios1": "uuid=ffffffff-ffff-ffff-ffff-ffffffffffff"
         }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/102/config":
+        # _get_vm_config (qemu)
+        return {
+            "numa": 0,
+            "digest": "460add1531a7068d2ae62d54f67e8fb9493dece9",
+            "ide2": "none,media=cdrom",
+            "bootdisk": "sata0",
+            "name": "test-qemu-windows",
+            "balloon": 0,
+            "cpulimit": "4",
+            "agent": "1",
+            "cores": 6,
+            "sata0": "storage:vm-102-disk-0,size=100G",
+            "memory": 10240,
+            "smbios1": "uuid=127301fc-0122-48d5-8fc5-c04fa78d8146",
+            "scsihw": "virtio-scsi-pci",
+            "sockets": 1,
+            "ostype": "win8",
+            "net0": "virtio=ff:ff:ff:ff:ff:ff,bridge=vmbr0",
+            "onboot": 1
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/103/config":
+        # _get_vm_config (qemu)
+        return {
+            'scsi1': 'storage:vm-103-disk-3,size=30G',
+            'sockets': 1,
+            'memory': 8192,
+            'ostype': 'l26',
+            'scsihw': 'virtio-scsi-pci',
+            "net0": "virtio=ff:ff:ff:ff:ff:ff,bridge=vmbr0",
+            "net1": "virtio=ff:ff:ff:ff:ff:ff,bridge=vmbr1",
+            'bootdisk': 'scsi0',
+            'scsi0': 'storage:vm-103-disk-0,size=10G',
+            'name': 'test-qemu-multi-nic',
+            'cores': 4,
+            'digest': '51b7599f869b9a3f564804a0aed290f3de803292',
+            'smbios1': 'uuid=863b31c3-42ca-4a92-aed7-4111f342f70a',
+            'agent': '1,type=virtio',
+            'ide2': 'none,media=cdrom',
+            'balloon': 0,
+            'numa': 0,
+            'scsi2': 'storage:vm-103-disk-2,size=10G',
+            'serial0': 'socket',
+            'vmgenid': 'ddfb79b2-b484-4d66-88e7-6e76f2d1be77',
+            'onboot': 1,
+            'tablet': 0
+        }
+
     elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/agent/network-get-interfaces":
         # _get_agent_network_interfaces
         return {"result": [
@@ -281,6 +361,152 @@ def get_json(url):
                     "tx-errs": 0,
                     "tx-bytes": 0
                 }}]}
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/102/agent/network-get-interfaces":
+        # _get_agent_network_interfaces
+        return {"result": {'error': {'desc': 'this feature or command is not currently supported', 'class': 'Unsupported'}}}
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/103/agent/network-get-interfaces":
+        # _get_agent_network_interfaces
+        return {
+            "result": [
+                {
+                    "statistics": {
+                        "tx-errs": 0,
+                        "rx-errs": 0,
+                        "rx-dropped": 0,
+                        "tx-bytes": 48132932372,
+                        "tx-dropped": 0,
+                        "rx-bytes": 48132932372,
+                        "tx-packets": 178578980,
+                        "rx-packets": 178578980
+                    },
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "ip-addresses": [
+                        {
+                            "ip-address-type": "ipv4",
+                            "prefix": 8,
+                            "ip-address": "127.0.0.1"
+                        }
+                    ],
+                    "name": "lo"
+                },
+                {
+                    "name": "eth0",
+                    "ip-addresses": [
+                        {
+                            "ip-address-type": "ipv4",
+                            "prefix": 24,
+                            "ip-address": "172.16.0.143"
+                        }
+                    ],
+                    "statistics": {
+                        "rx-errs": 0,
+                        "tx-errs": 0,
+                        "rx-packets": 660028,
+                        "tx-packets": 304599,
+                        "tx-dropped": 0,
+                        "rx-bytes": 1846743499,
+                        "tx-bytes": 1287844926,
+                        "rx-dropped": 0
+                    },
+                    "hardware-address": "ff:ff:ff:ff:ff:ff"
+                },
+                {
+                    "name": "eth1",
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "statistics": {
+                        "rx-bytes": 235717091946,
+                        "tx-dropped": 0,
+                        "rx-dropped": 0,
+                        "tx-bytes": 123411636251,
+                        "rx-packets": 540431277,
+                        "tx-packets": 468411864,
+                        "rx-errs": 0,
+                        "tx-errs": 0
+                    },
+                    "ip-addresses": [
+                        {
+                            "ip-address": "10.0.0.133",
+                            "prefix": 24,
+                            "ip-address-type": "ipv4"
+                        }
+                    ]
+                },
+                {
+                    "name": "docker0",
+                    "ip-addresses": [
+                        {
+                            "ip-address": "172.17.0.1",
+                            "prefix": 16,
+                            "ip-address-type": "ipv4"
+                        }
+                    ],
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "statistics": {
+                        "rx-errs": 0,
+                        "tx-errs": 0,
+                        "rx-packets": 0,
+                        "tx-packets": 0,
+                        "tx-dropped": 0,
+                        "rx-bytes": 0,
+                        "rx-dropped": 0,
+                        "tx-bytes": 0
+                    }
+                },
+                {
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "name": "datapath"
+                },
+                {
+                    "name": "weave",
+                    "ip-addresses": [
+                        {
+                            "ip-address": "10.42.0.1",
+                            "ip-address-type": "ipv4",
+                            "prefix": 16
+                        }
+                    ],
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "statistics": {
+                        "rx-bytes": 127289123306,
+                        "tx-dropped": 0,
+                        "rx-dropped": 0,
+                        "tx-bytes": 43827573343,
+                        "rx-packets": 132750542,
+                        "tx-packets": 74218762,
+                        "rx-errs": 0,
+                        "tx-errs": 0
+                    }
+                },
+                {
+                    "name": "vethwe-datapath",
+                    "hardware-address": "ff:ff:ff:ff:ff:ff"
+                },
+                {
+                    "name": "vethwe-bridge",
+                    "hardware-address": "ff:ff:ff:ff:ff:ff"
+                },
+                {
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "name": "vxlan-6784"
+                },
+                {
+                    "name": "vethwepl0dfe1fe",
+                    "hardware-address": "ff:ff:ff:ff:ff:ff"
+                },
+                {
+                    "name": "vethweplf1e7715",
+                    "hardware-address": "ff:ff:ff:ff:ff:ff"
+                },
+                {
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "name": "vethwepl9d244a1"
+                },
+                {
+                    "hardware-address": "ff:ff:ff:ff:ff:ff",
+                    "name": "vethwepl2ca477b"
+                }
+            ]
+        }
 
 
 def get_vm_status(node, vmtype, vmid, name):
@@ -313,6 +539,8 @@ def test_populate(inventory, mocker):
 
     # get different hosts
     host_qemu = inventory.inventory.get_host('test-qemu')
+    host_qemu_windows = inventory.inventory.get_host('test-qemu-windows')
+    host_qemu_multi_nic = inventory.inventory.get_host('test-qemu-multi-nic')
     host_qemu_template = inventory.inventory.get_host('test-qemu-template')
     host_lxc = inventory.inventory.get_host('test-lxc')
     host_node = inventory.inventory.get_host('testnode')
@@ -323,7 +551,19 @@ def test_populate(inventory, mocker):
     assert group_qemu.hosts == [host_qemu]
 
     # check if qemu-test has eth0 interface in agent_interfaces fact
-    assert 'eth0' in [d['name'] for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth0' in [d['name']
+                      for d in host_qemu.get_vars()['proxmox_agent_interfaces']]
+
+    # check if qemu-multi-nic has multiple network interfaces
+    assert 'eth0' in [d['name']
+                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    assert 'eth1' in [d['name']
+                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+    assert 'weave' in [d['name']
+                      for d in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']]
+
+    # check to make sure qemu-windows doesn't have proxmox_agent_interfaces
+    assert "proxmox_agent_interfaces" not in host_qemu_windows.get_vars()
 
     # check if lxc-test has been discovered correctly
     group_lxc = inventory.inventory.groups['proxmox_all_lxc']

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -565,7 +565,7 @@ def test_populate(inventory, mocker):
     # check if interface with no mac-address or ip-address defaults correctly
     assert [iface for iface in host_qemu_multi_nic.get_vars()['proxmox_agent_interfaces']
             if iface['name'] == 'nomacorip'
-            and iface['mac-address'] is None
+            and iface['mac-address'] == ''
             and iface['ip-addresses'] == []
             ]
 

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -504,6 +504,9 @@ def get_json(url):
                 {
                     "hardware-address": "ff:ff:ff:ff:ff:ff",
                     "name": "vethwepl2ca477b"
+                },
+                {
+                    "name": "nomacorip",
                 }
             ]
         }


### PR DESCRIPTION
##### SUMMARY
Covers some edge cases that weren't taken into account. 

* Unsupported network-interface query even though agent is running (ex: Windows)
* Multiple network interfaces
* Network interfaces without IP addresses
* Allow us to control if we want to set ansible_host for proxmox nodes (in my case I have multiple primary nics, and it randomly cycles between them, until a more reliable way is found to dected the correct interface, this would allow us to not set the ansible_host ip)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory/proxmox
