### PR TITLE
`with_filetree:`: use `splitext` for compatibility with `template:`

### DIFF
--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -31,6 +31,8 @@ EXAMPLES = r"""
 - name: Template files (explicitly skip directories in order to use the 'src' attribute)
   ansible.builtin.template:
     src: '{{ item.src }}'
+    # your template files should be stored with a .j2 file extension,
+    # but should not be deployed with it. splitext|first removes it.
     dest: /web/{{ item.path | splitext | first }}
     mode: '{{ item.mode }}'
   with_community.general.filetree: web/

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -31,7 +31,7 @@ EXAMPLES = r"""
 - name: Template files (explicitly skip directories in order to use the 'src' attribute)
   ansible.builtin.template:
     src: '{{ item.src }}'
-    dest: /web/{{ item.path }}
+    dest: /web/{{ item.path | splitext | first }}
     mode: '{{ item.mode }}'
   with_community.general.filetree: web/
   when: item.state == 'file'

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     state: link
-    follow: false # avoid corrupting target files if the link already exists
+    follow: false  # avoid corrupting target files if the link already exists
     force: yes
     mode: '{{ item.mode }}'
   with_community.general.filetree: web/

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -31,7 +31,7 @@ EXAMPLES = r"""
 - name: Template files (explicitly skip directories in order to use the 'src' attribute)
   ansible.builtin.template:
     src: '{{ item.src }}'
-    # your template files should be stored with a .j2 file extension,
+    # Your template files should be stored with a .j2 file extension,
     # but should not be deployed with it. splitext|first removes it.
     dest: /web/{{ item.path | splitext | first }}
     mode: '{{ item.mode }}'

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -44,7 +44,6 @@ EXAMPLES = r"""
     dest: /web/{{ item.path }}
     state: link
     force: yes
-    mode: '{{ item.mode }}'
   with_community.general.filetree: web/
   when: item.state == 'link'
 

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -43,7 +43,9 @@ EXAMPLES = r"""
     src: '{{ item.src }}'
     dest: /web/{{ item.path }}
     state: link
+    follow: false # avoid corrupting target files if the link already exists
     force: yes
+    mode: '{{ item.mode }}'
   with_community.general.filetree: web/
   when: item.state == 'link'
 


### PR DESCRIPTION

##### SUMMARY

The example code given deploys files with their .j2 extensions intact, which is probably not what you want.

Furthermore, the example code corrupts symlink target files to 0777 permissions.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME

`with_filetree`

