### PR TITLE
convert string returned by plugin to unicode

### DIFF
--- a/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
+++ b/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.general.hiera lookup plugin - converts the return type of plugin to unicode string (https://github.com/ansible-collections/community.general/pull/2329).
+  - hiera lookup plugin - converts the return type of plugin to unicode string (https://github.com/ansible-collections/community.general/pull/2329).

--- a/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
+++ b/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.general.hiera lookup plugin - converts the return type of plugin to unicode string (https://github.com/ans    ible-collections/community.general/pull/2329).
+  - community.general.hiera lookup plugin - converts the return type of plugin to unicode string (https://github.com/ansible-collections/community.general/pull/2329).

--- a/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
+++ b/changelogs/fragments/2329-hiera-lookup-plugin-return-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.general.hiera lookup plugin - converts the return type of plugin to unicode string (https://github.com/ans    ible-collections/community.general/pull/2329).

--- a/plugins/lookup/hiera.py
+++ b/plugins/lookup/hiera.py
@@ -63,6 +63,7 @@ import os
 
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.cmd_functions import run_cmd
+from ansible.module_utils._text import to_text
 
 ANSIBLE_HIERA_CFG = os.getenv('ANSIBLE_HIERA_CFG', '/etc/hiera.yaml')
 ANSIBLE_HIERA_BIN = os.getenv('ANSIBLE_HIERA_BIN', '/usr/bin/hiera')
@@ -78,7 +79,7 @@ class Hiera(object):
         rc, output, err = run_cmd("{0} -c {1} {2}".format(
             ANSIBLE_HIERA_BIN, ANSIBLE_HIERA_CFG, hiera_key[0]))
 
-        return output.strip()
+        return to_text(output.strip())
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Converts string returned by community.general.hiera lookup plugin to unicode.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.general.hiera

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
On python3, this plugin returns an instance of 'bytes' instead of 'str'. This is because of the implementation of ansible.utils.cmd_functions.run_cmd function. This change converts the returned value to unicode string.
Reference: https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#string-encoding
<!--- Paste verbatim command output below, e.g. before and after your change -->

