### PR TITLE
modified redfish_config and idrac_redfish_config to skip incorrect attributes

### DIFF
--- a/changelogs/fragments/2334-redfish_config-skip-incorrect-attributes.yml
+++ b/changelogs/fragments/2334-redfish_config-skip-incorrect-attributes.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - plugins/module_utils/redfish_utils.py - Modified set_bios_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output (https://github.com/ansible-collections/community.general/issues/1995)
-  - plugins/modules/remote_management/redfish/idrac_redfish_config.py - Modified set_manager_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output. Modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995)
-  - plugins/modules/remote_management/redfish/redfish_config.py Modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995)
+  - redfish_utils module utils - modified set_bios_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output (https://github.com/ansible-collections/community.general/issues/1995).
+  - idrac_redfish_config - modified set_manager_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output. Modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995).
+  - redfish_config - modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995).

--- a/changelogs/fragments/2334-redfish_config-skip-incorrect-attributes.yml
+++ b/changelogs/fragments/2334-redfish_config-skip-incorrect-attributes.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - plugins/module_utils/redfish_utils.py - Modified set_bios_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output (https://github.com/ansible-collections/community.general/issues/1995)
+  - plugins/modules/remote_management/redfish/idrac_redfish_config.py - Modified set_manager_attributes function to skip invalid attribute instead of returning. Added skipped attributes to output. Modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995)
+  - plugins/modules/remote_management/redfish/redfish_config.py Modified module exit to add warning variable (https://github.com/ansible-collections/community.general/issues/1995)

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1601,19 +1601,27 @@ class RedfishUtils(object):
 
         # Make a copy of the attributes dict
         attrs_to_patch = dict(attributes)
+        # List to hold attributes not found
+        attrs_bad = {}
 
         # Check the attributes
-        for attr in attributes:
-            if attr not in data[u'Attributes']:
-                return {'ret': False, 'msg': "BIOS attribute %s not found" % attr}
+        for attr_name, attr_value in attributes.items():
+            # Check if attribute exists
+            if attr_name not in data[u'Attributes']:
+                # Remove and proceed to next attribute if this isn't valid
+                attrs_bad.update({attr_name: attr_value})
+                del attrs_to_patch[attr_name]
+                continue
+
             # If already set to requested value, remove it from PATCH payload
-            if data[u'Attributes'][attr] == attributes[attr]:
-                del attrs_to_patch[attr]
+            if data[u'Attributes'][attr_name] == attributes[attr_name]:
+                del attrs_to_patch[attr_name]
 
         # Return success w/ changed=False if no attrs need to be changed
         if not attrs_to_patch:
             return {'ret': True, 'changed': False,
-                    'msg': "BIOS attributes already set"}
+                    'msg': "BIOS attributes already set",
+                    'warning': "Incorrect attributes %s" % (attrs_bad)}
 
         # Get the SettingsObject URI
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
@@ -1623,7 +1631,9 @@ class RedfishUtils(object):
         response = self.patch_request(self.root_uri + set_bios_attr_uri, payload)
         if response['ret'] is False:
             return response
-        return {'ret': True, 'changed': True, 'msg': "Modified BIOS attribute"}
+        return {'ret': True, 'changed': True,
+                'msg': "Modified BIOS attributes %s" % (attrs_to_patch),
+                'warning': "Incorrect attributes %s" % (attrs_bad)}
 
     def set_boot_order(self, boot_list):
         if not boot_list:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1617,11 +1617,15 @@ class RedfishUtils(object):
             if data[u'Attributes'][attr_name] == attributes[attr_name]:
                 del attrs_to_patch[attr_name]
 
+        warning = ""
+        if attrs_bad:
+            warning = "Incorrect attributes %s" % (attrs_bad)
+
         # Return success w/ changed=False if no attrs need to be changed
         if not attrs_to_patch:
             return {'ret': True, 'changed': False,
                     'msg': "BIOS attributes already set",
-                    'warning': "Incorrect attributes %s" % (attrs_bad)}
+                    'warning': warning}
 
         # Get the SettingsObject URI
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
@@ -1633,7 +1637,7 @@ class RedfishUtils(object):
             return response
         return {'ret': True, 'changed': True,
                 'msg': "Modified BIOS attributes %s" % (attrs_to_patch),
-                'warning': "Incorrect attributes %s" % (attrs_bad)}
+                'warning': warning}
 
     def set_boot_order(self, boot_list):
         if not boot_list:

--- a/plugins/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_config.py
@@ -204,11 +204,14 @@ class IdracRedfishUtils(RedfishUtils):
             else:
                 attrs_to_patch.update({attr_name: attr_value})
 
-        if not attrs_to_patch:
+        warning = ""
+        if attrs_bad:
+            warning = "Incorrect attributes %s" % (attrs_bad)
 
+        if not attrs_to_patch:
             return {'ret': True, 'changed': False,
                     'msg': "No changes made. Manager attributes already set.",
-                    'warning': "Incorrect attributes %s" % (attrs_bad)}
+                    'warning': warning}
 
         payload = {"Attributes": attrs_to_patch}
         response = self.patch_request(self.root_uri + manager_uri + "/" + key, payload)
@@ -217,7 +220,7 @@ class IdracRedfishUtils(RedfishUtils):
 
         return {'ret': True, 'changed': True,
                 'msg': "%s: Modified Manager attributes %s" % (command, attrs_to_patch),
-                'warning': "Incorrect attributes skipped %s" % (attrs_bad)}
+                'warning': warning}
 
 
 CATEGORY_COMMANDS_ALL = {

--- a/plugins/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_config.py
@@ -305,7 +305,10 @@ def main():
 
     # Return data back or fail with proper message
     if result['ret'] is True:
-        module.exit_json(changed=result['changed'], msg=to_native(result['msg']), warning=to_native(result['warning']))
+        if result.get('warning'):
+            module.warn(to_native(result['warning']))
+
+        module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
     else:
         module.fail_json(msg=to_native(result['msg']))
 

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -307,7 +307,10 @@ def main():
 
     # Return data back or fail with proper message
     if result['ret'] is True:
-        module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
+        if result.get('warning'):
+            module.exit_json(changed=result['changed'], msg=to_native(result['msg']), warning=to_native(result['warning']))
+        else:
+            module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
     else:
         module.fail_json(msg=to_native(result['msg']))
 

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -308,9 +308,9 @@ def main():
     # Return data back or fail with proper message
     if result['ret'] is True:
         if result.get('warning'):
-            module.exit_json(changed=result['changed'], msg=to_native(result['msg']), warning=to_native(result['warning']))
-        else:
-            module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
+            module.warn(to_native(result['warning']))
+
+        module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
     else:
         module.fail_json(msg=to_native(result['msg']))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- plugins/module_utils/redfish_utils.py
    - Modified `set_bios_attributes` function to skip invalid attribute instead of returning. Added skipped attributes to output
- plugins/modules/remote_management/redfish/idrac_redfish_config.py
    - Modified `set_manager_attributes` function to skip invalid attribute instead of returning. Added skipped attributes to output
    - Modified module exit to add warning variable
- plugins/modules/remote_management/redfish/redfish_config.py
    - Modified module exit to add warning variable

Fixes #1995

Signed-off-by: Trevor Squillario Trevor_Squillario@Dell.com

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
idrac_redfish_config and redfish_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
