### PR TITLE
jenkins_plugin: fix Python 2 compatibility issue

### DIFF
--- a/changelogs/fragments/2340-jenkins_plugin-py2.yml
+++ b/changelogs/fragments/2340-jenkins_plugin-py2.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "jenkins_plugin - fixes Python 2 compatibility issue (https://github.com/ansible-collections/community.general/pull/2340)."

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -276,6 +276,7 @@ from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils._text import to_native
 import base64
 import hashlib
+import io
 import json
 import os
 import tempfile
@@ -560,7 +561,7 @@ class JenkinsPlugin(object):
 
         # Open the updates file
         try:
-            f = open(updates_file, encoding='utf-8')
+            f = io.open(updates_file, encoding='utf-8')
         except IOError as e:
             self.module.fail_json(
                 msg="Cannot open temporal updates file.",


### PR DESCRIPTION
##### SUMMARY
Resolves #1921.

I chose to only replace the non-binary `open()` call with `io.open()`, instead of globally replacing `open()` in that module by `io.open()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jenkins_plugin
