### PR TITLE
composer: always use --no-interaction option

### DIFF
--- a/changelogs/fragments/2348-composer-no-interaction-option-discovery-to-avoid-hang.yaml
+++ b/changelogs/fragments/2348-composer-no-interaction-option-discovery-to-avoid-hang.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - composer - use ``no-interaction`` option when discovering available options to avoid an issue where composer hangs (https://github.com/ansible-collections/community.general/pull/2348).

--- a/plugins/modules/packaging/language/composer.py
+++ b/plugins/modules/packaging/language/composer.py
@@ -169,7 +169,7 @@ def has_changed(string):
 
 def get_available_options(module, command='install'):
     # get all available options from a composer command using composer help to json
-    rc, out, err = composer_command(module, "help %s --format=json" % command)
+    rc, out, err = composer_command(module, "help %s" % command, arguments="--no-interaction --format=json")
     if rc != 0:
         output = parse_out(err)
         module.fail_json(msg=output)


### PR DESCRIPTION
##### SUMMARY
Since the composer command provides a no-interaction option, and since
we always call it non-interactively, we should always use it.

The lack of this option caused composer to not exit at least in one
instance when called as 'php /usr/local/bin/composer help install'.
The '-n' added with this patch resolved that issue.

##### ISSUE TYPE
- Bugfix Pull Request
  As far as I can tell from the open issues, I'm the first one to report this.

##### COMPONENT NAME
- composer

##### ADDITIONAL INFORMATION
Versions and stuff.

On host:
```
$ uname -a
Linux pi 5.4.0-1034-raspi #37-Ubuntu SMP PREEMPT Mon Apr 12 23:14:49 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux

$ php7.4 -v
PHP 7.4.16 (cli) (built: Mar  5 2021 07:54:38) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.16, Copyright (c), by Zend Technologies

$ php7.4 /usr/local/bin/composer -V
Composer version 2.0.12 2021-04-01 10:14:59
```

On controller:
```
$ ansible --version
ansible 2.10.8
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/george/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.9/site-packages/ansible
  executable location = /bin/ansible
  python version = 3.9.3 (default, Apr  8 2021, 23:35:02) [GCC 10.2.0]
```

Output of composer showing the `-n` option:
```
php7.4 /usr/local/bin/composer help 
Usage:
  help [options] [--] [<command_name>]

Arguments:
  command                        The command to execute
  command_name                   The command name [default: "help"]

Options:
      --xml                      To output help as XML
      --format=FORMAT            The output format (txt, xml, json, or md) [default: "txt"]
      --raw                      To output raw command help
  -h, --help                     Display this help message
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi                     Force ANSI output
      --no-ansi                  Disable ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --profile                  Display timing and memory usage information
      --no-plugins               Whether to disable plugins.
  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
      --no-cache                 Prevent use of the cache
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  The help command displays help for a given command:
  
    php /usr/local/bin/composer help list
  
  You can also output the help in other formats by using the --format option:
  
    php /usr/local/bin/composer help --format=xml list
  
  To display the list of available commands, please use the list command.
```
