### PR TITLE
influxdb_user: allow creation of first user with auth enabled (#2364)

### DIFF
--- a/changelogs/fragments/2364-influxdb_user-first_user.yml
+++ b/changelogs/fragments/2364-influxdb_user-first_user.yml
@@ -1,5 +1,5 @@
 bugfixes:
   - influxdb_user - allow creation of admin users when InfluxDB authentication
     is enabled but no other user exists on the database. In this scenario,
-    InfluxDB 1.x allows only CREATE USER queries and reject any other query.
+    InfluxDB 1.x allows only ``CREATE USER`` queries and rejects any other query
     (https://github.com/ansible-collections/community.general/issues/2364).

--- a/changelogs/fragments/2364-influxdb_user-first_user.yml
+++ b/changelogs/fragments/2364-influxdb_user-first_user.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - influxdb_user - allow creation of admin users when InfluxDB authentication
+    is enabled but no other user exists on the database. In this scenario,
+    InfluxDB 1.x allows only CREATE USER queries and reject any other query.
+    (https://github.com/ansible-collections/community.general/issues/2364).

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -100,6 +100,8 @@ RETURN = r'''
 #only defaults
 '''
 
+import json
+
 from ansible.module_utils.urls import ConnectionError
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -115,7 +117,7 @@ def find_user(module, client, user_name):
             if user['user'] == user_name:
                 user_result = user
                 break
-    except (ConnectionError, influx.exceptions.InfluxDBClientError) as e:
+    except ConnectionError as e:
         module.fail_json(msg=to_native(e))
     return user_result
 
@@ -198,6 +200,9 @@ def set_user_grants(module, client, user_name, grants):
     return changed
 
 
+INFLUX_AUTH_FIRST_USER_REQUIRED = "error authorizing query: create admin user first or disable authentication"
+
+
 def main():
     argument_spec = influx.InfluxDb.influxdb_argument_spec()
     argument_spec.update(
@@ -219,7 +224,17 @@ def main():
     grants = module.params['grants']
     influxdb = influx.InfluxDb(module)
     client = influxdb.connect_to_influxdb()
-    user = find_user(module, client, user_name)
+
+    user = None
+    try:
+        user = find_user(module, client, user_name)
+    except influx.exceptions.InfluxDBClientError as e:
+        if e.code == 403:
+            msg = json.loads(e.content)
+            if msg["error"] != INFLUX_AUTH_FIRST_USER_REQUIRED:
+                module.fail_json(msg=to_native(e))
+        else:
+            module.fail_json(msg=to_native(e))
 
     changed = False
 

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -230,8 +230,14 @@ def main():
         user = find_user(module, client, user_name)
     except influx.exceptions.InfluxDBClientError as e:
         if e.code == 403:
-            msg = json.loads(e.content)
-            if msg["error"] != INFLUX_AUTH_FIRST_USER_REQUIRED:
+            reason = None
+            try:
+                msg = json.loads(e.content)
+                reason = msg["error"]
+            except (json.decoder.JSONDecodeError, KeyError):
+                module.fail_json(msg=to_native(e))
+
+            if reason != INFLUX_AUTH_FIRST_USER_REQUIRED:
                 module.fail_json(msg=to_native(e))
         else:
             module.fail_json(msg=to_native(e))

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -234,7 +234,7 @@ def main():
             try:
                 msg = json.loads(e.content)
                 reason = msg["error"]
-            except (json.decoder.JSONDecodeError, KeyError):
+            except (KeyError, ValueError):
                 module.fail_json(msg=to_native(e))
 
             if reason != INFLUX_AUTH_FIRST_USER_REQUIRED:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #2364

When starting an InfluxDB database with authentication enabled **and** no created users, InfluxDB automatically disables authentication for login but only allows `CREATE USER` queries.

Currently, `influxdb_user` module performs a series of check before executing that query, in order to ensure module idempotence, but it does not take into account that those checks fail on this specific scenario. As in this case we can be sure that we are creating and not updating an user (as we are sure that this user does not exist), we can safely bypass all checks if a 403 error is returned with an specific error message.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

influxdb_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

InfluxDB returns 403 errors for any authorization (not authentication) issues. In this case, a 403 error is returned both if we are in the "no user" scenario and when login user does not have enough permissions. The only difference is in the HTTP response body, which is a JSON with an `error` key. This key is being checked literally to ensure that this error is due to no existing users.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
403 {"error": "error authorizing query: create admin user first or disable authentication"}
```
