### PR TITLE
lvol - bug fix - Convert units to lowercase when using LVS or VGS command

### DIFF
--- a/changelogs/fragments/2369-lvol_size_bug_fixes.yml
+++ b/changelogs/fragments/2369-lvol_size_bug_fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - lvol - fixed size unit capitalization to match units used between different tools for comparison (https://github.com/ansible-collections/community.general/issues/2360).
+  - lvol - fixed rounding errors (https://github.com/ansible-collections/community.general/issues/2370).

--- a/changelogs/fragments/2369-lvol_size_capitalization_bug_fix.yml
+++ b/changelogs/fragments/2369-lvol_size_capitalization_bug_fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - lvol - fixed size unit capitalization to match units used between different tools for comparison (https://github.com/ansible-collections/community.general/issues/2360).

--- a/changelogs/fragments/2369-lvol_size_capitalization_bug_fix.yml
+++ b/changelogs/fragments/2369-lvol_size_capitalization_bug_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - fixed size unit capitalization to match units used between different tools for comparison (https://github.com/ansible-collections/community.general/issues/2360).

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -505,17 +505,14 @@ def main():
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
 
-            # from LVEXTEND(8) - The resulting value is rounded upward.
-            # from LVREDUCE(8) - The resulting value for the substraction is rounded downward, for the absolute size it is rounded upward.
             if size_operator == '+':
                 size_requested += this_lv['size']
-                size_requested = this_vg['ext_size'] * ceil(size_requested / this_vg['ext_size'])
             elif size_operator == '-':
                 size_requested = this_lv['size'] - size_requested
-                size_requested -= (size_requested % this_vg['ext_size'])
-            else:
-                size_requested = this_vg['ext_size'] * ceil(size_requested / this_vg['ext_size'])
-
+                
+            # According to latest documentation (LVM2-2.03.11) all tools round down 
+            size_requested -= (size_requested % this_vg['ext_size'])
+            
             if this_lv['size'] < size_requested:
                 if (size_free > 0) and (size_free >= (size_requested - this_lv['size'])):
                     tool = module.get_bin_path("lvextend", required=True)

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -509,12 +509,12 @@ def main():
             # from LVREDUCE(8) - The resulting value for the substraction is rounded downward, for the absolute size it is rounded upward.
             if size_operator == '+':
                 size_requested += this_lv['size']
-                size_requested += this_vg['ext_size'] - (size_requested % this_vg['ext_size'])
+                size_requested = this_vg['ext_size'] * ceil(size_requested / this_vg['ext_size'])
             elif size_operator == '-':
                 size_requested = this_lv['size'] - size_requested
                 size_requested -= (size_requested % this_vg['ext_size'])
             else:
-                size_requested += this_vg['ext_size'] - (size_requested % this_vg['ext_size'])
+                size_requested = this_vg['ext_size'] * ceil(size_requested / this_vg['ext_size'])
 
             if this_lv['size'] < size_requested:
                 if (size_free > 0) and (size_free >= (size_requested - this_lv['size'])):

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -389,7 +389,7 @@ def main():
     # Get information on volume group requested
     vgs_cmd = module.get_bin_path("vgs", required=True)
     rc, current_vgs, err = module.run_command(
-        "%s --noheadings --nosuffix -o vg_name,size,free,vg_extent_size --units %s --separator ';' %s" % (vgs_cmd, unit, vg))
+        "%s --noheadings --nosuffix -o vg_name,size,free,vg_extent_size --units %s --separator ';' %s" % (vgs_cmd, unit.lower(), vg))
 
     if rc != 0:
         if state == 'absent':
@@ -403,7 +403,7 @@ def main():
     # Get information on logical volume requested
     lvs_cmd = module.get_bin_path("lvs", required=True)
     rc, current_lvs, err = module.run_command(
-        "%s -a --noheadings --nosuffix -o lv_name,size,lv_attr --units %s --separator ';' %s" % (lvs_cmd, unit, vg))
+        "%s -a --noheadings --nosuffix -o lv_name,size,lv_attr --units %s --separator ';' %s" % (lvs_cmd, unit.lower(), vg))
 
     if rc != 0:
         if state == 'absent':

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -509,10 +509,10 @@ def main():
                 size_requested += this_lv['size']
             elif size_operator == '-':
                 size_requested = this_lv['size'] - size_requested
-                
-            # According to latest documentation (LVM2-2.03.11) all tools round down 
+
+            # According to latest documentation (LVM2-2.03.11) all tools round down
             size_requested -= (size_requested % this_vg['ext_size'])
-            
+
             if this_lv['size'] < size_requested:
                 if (size_free > 0) and (size_free >= (size_requested - this_lv['size'])):
                     tool = module.get_bin_path("lvextend", required=True)


### PR DESCRIPTION
##### SUMMARY
Converted units to lowercase when using LVS or VGS command. 

Fixes #2360
Fixes #2370

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
