### PR TITLE
📝 Document nested node addition with "_" in xml module

### DIFF
--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -285,6 +285,25 @@ EXAMPLES = r'''
       z: http://z.test
     attribute: z:my_namespaced_attribute
     value: 'false'
+
+- name: Creating xml file
+  copy:
+    dest: out.xml
+    content: |-
+      <?xml version='1.0' encoding='UTF-8'?>
+      <root>
+      </root>
+- name: 
+  xml:
+    path: out.xml
+    xpath: /root
+    add_children:
+      - node:
+          attribute: attribute_text
+          _:
+            - sub_node:
+      - node2: node2_text
+      - node3: "1"  # Only strings are valid
 '''
 
 RETURN = r'''

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -286,25 +286,21 @@ EXAMPLES = r'''
     attribute: z:my_namespaced_attribute
     value: 'false'
 
-- name: Creating a XML file form a variable
-  ansible.builtin.copy:
-    dest: out.xml
-    content: |-
-      <?xml version='1.0' encoding='UTF-8'?>
-      <root>
-      </root>
-
-- name: Adding a XML node with subnodes from a YAML variable
+- name: Adding building nodes with floor subnodes from a YAML variable
   community.general.xml:
-    path: out.xml
-    xpath: /root
+    path: /foo/bar.xml
+    xpath: /business
     add_children:
-      - node:
-          attribute: attribute_text
+      - building:
+          # Attributes
+          name: Scumm bar
+          location: Monkey island
+          # Subnodes
           _:
-            - sub_node:
-      - node2: node2_text
-      - node3: "1"  # Only strings are valid
+            - floor: Pirate hall
+            - floor: Grog storage
+            - construction_date: "1990"  # Only strings are valid
+      - building: Grog factory   
 '''
 
 RETURN = r'''

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -286,14 +286,15 @@ EXAMPLES = r'''
     attribute: z:my_namespaced_attribute
     value: 'false'
 
-- name: Creating xml file
+- name: Creating a XML file form a variable
   ansible.builtin.copy:
     dest: out.xml
     content: |-
       <?xml version='1.0' encoding='UTF-8'?>
       <root>
       </root>
-- name:
+
+- name: Adding a XML node with subnodes from a YAML variable
   community.general.xml:
     path: out.xml
     xpath: /root

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -300,7 +300,7 @@ EXAMPLES = r'''
             - floor: Pirate hall
             - floor: Grog storage
             - construction_date: "1990"  # Only strings are valid
-      - building: Grog factory   
+      - building: Grog factory
 '''
 
 RETURN = r'''

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -287,14 +287,14 @@ EXAMPLES = r'''
     value: 'false'
 
 - name: Creating xml file
-  copy:
+  ansible.builtin.copy:
     dest: out.xml
     content: |-
       <?xml version='1.0' encoding='UTF-8'?>
       <root>
       </root>
 - name:
-  xml:
+  community.general.xml:
     path: out.xml
     xpath: /root
     add_children:

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -293,7 +293,7 @@ EXAMPLES = r'''
       <?xml version='1.0' encoding='UTF-8'?>
       <root>
       </root>
-- name: 
+- name:
   xml:
     path: out.xml
     xpath: /root


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change completes the documentation in community.general.xml module in regards of the use of yaml when adding a nested xml node with subnodes and/or attributes.
Nested node addition using "_" (to indicate sub nodes), and attributes are only documented in tests and issues, where is hard to find.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
xml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The possibility of using this is not documented:
``` yml
    add_children:
      - node:
          attribute: attribute_text
          _:
            - sub_node:
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
