### PR TITLE
influxdb_retention_policy - add state argument to module spec (#2383)

### DIFF
--- a/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
+++ b/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - influxdb_retention_policy - add ``state`` parameter with allowed values
+    ``present`` and ``absent`` to support deletion of existing retention policies
+    (https://github.com/ansible-collections/community.general/issues/2383).
+  - influxdb_retention_policy - simplify duration logic parsing as suggested in
+    https://github.com/ansible-collections/community.general/pull/2284#discussion_r618210902
+  - influxdb_retention_policy - fix bug where ``INF`` duration values failed parsing,
+    introduced in https://github.com/ansible-collections/community.general/pull/2284

--- a/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
+++ b/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
@@ -4,5 +4,3 @@ minor_changes:
     (https://github.com/ansible-collections/community.general/issues/2383).
   - influxdb_retention_policy - simplify duration logic parsing as suggested in
     https://github.com/ansible-collections/community.general/pull/2284#discussion_r618210902
-  - influxdb_retention_policy - fix bug where ``INF`` duration values failed parsing,
-    introduced in https://github.com/ansible-collections/community.general/pull/2284

--- a/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
+++ b/changelogs/fragments/2383-influxdb_retention_policy-add-state-option.yml
@@ -2,5 +2,5 @@ minor_changes:
   - influxdb_retention_policy - add ``state`` parameter with allowed values
     ``present`` and ``absent`` to support deletion of existing retention policies
     (https://github.com/ansible-collections/community.general/issues/2383).
-  - influxdb_retention_policy - simplify duration logic parsing as suggested in
-    https://github.com/ansible-collections/community.general/pull/2284#discussion_r618210902
+  - influxdb_retention_policy - simplify duration logic parsing
+    (https://github.com/ansible-collections/community.general/pull/2385).

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -153,7 +153,6 @@ VALID_DURATION_REGEX = re.compile(r'^(INF|(\d+(ns|u|µ|ms|s|m|h|d|w)))+$')
 DURATION_REGEX = re.compile(r'(\d+)(ns|u|µ|ms|s|m|h|d|w)')
 EXTENDED_DURATION_REGEX = re.compile(r'(?:(\d+)(ns|u|µ|ms|m|h|d|w)|(\d+(?:\.\d+)?)(s))')
 
-
 DURATION_UNIT_NANOSECS = {
     'ns': 1,
     'u': 1000,
@@ -165,6 +164,9 @@ DURATION_UNIT_NANOSECS = {
     'd': 1000 * 1000 * 1000 * 60 * 60 * 24,
     'w': 1000 * 1000 * 1000 * 60 * 60 * 24 * 7,
 }
+
+MINIMUM_VALID_DURATION = 1 * DURATION_UNIT_NANOSECS['h']
+MINIMUM_VALID_SHARD_GROUP_DURATION = 1 * DURATION_UNIT_NANOSECS['h']
 
 
 def check_duration_literal(value):
@@ -221,7 +223,7 @@ def create_retention_policy(module, client):
         module.fail_json(msg="Failed to parse value of duration")
 
     influxdb_duration_format = parse_duration_literal(duration)
-    if influxdb_duration_format != 0 and influxdb_duration_format < 1 * DURATION_UNIT_NANOSECS['h']:
+    if influxdb_duration_format != 0 and influxdb_duration_format < MINIMUM_VALID_DURATION:
         module.fail_json(msg="duration value must be at least 1h")
 
     if shard_group_duration is not None:
@@ -229,7 +231,7 @@ def create_retention_policy(module, client):
             module.fail_json(msg="Failed to parse value of shard_group_duration")
 
         influxdb_shard_group_duration_format = parse_duration_literal(shard_group_duration)
-        if influxdb_shard_group_duration_format < 1 * DURATION_UNIT_NANOSECS['h']:
+        if influxdb_shard_group_duration_format < MINIMUM_VALID_SHARD_GROUP_DURATION:
             module.fail_json(msg="shard_group_duration value must be finite and at least 1h")
 
     if not module.check_mode:
@@ -258,7 +260,7 @@ def alter_retention_policy(module, client, retention_policy):
         module.fail_json(msg="Failed to parse value of duration")
 
     influxdb_duration_format = parse_duration_literal(duration)
-    if influxdb_duration_format != 0 and influxdb_duration_format < 1 * DURATION_UNIT_NANOSECS['h']:
+    if influxdb_duration_format != 0 and influxdb_duration_format < MINIMUM_VALID_DURATION:
         module.fail_json(msg="duration value must be at least 1h")
 
     if shard_group_duration is None:
@@ -268,7 +270,7 @@ def alter_retention_policy(module, client, retention_policy):
             module.fail_json(msg="Failed to parse value of shard_group_duration")
 
         influxdb_shard_group_duration_format = parse_duration_literal(shard_group_duration)
-        if influxdb_shard_group_duration_format < 1 * DURATION_UNIT_NANOSECS['h']:
+        if influxdb_shard_group_duration_format < MINIMUM_VALID_SHARD_GROUP_DURATION:
             module.fail_json(msg="shard_group_duration value must be finite and at least 1h")
 
     if (retention_policy['duration'] != influxdb_duration_format or

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -318,7 +318,7 @@ def main():
         supports_check_mode=True,
         required_if=(
             ('state', 'present', ['duration', 'replication']),
-        )
+        ),
     )
 
     state = module.params['state']

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -305,10 +305,10 @@ def main():
         state=dict(default='present', type='str', choices=['present', 'absent']),
         database_name=dict(required=True, type='str'),
         policy_name=dict(required=True, type='str'),
-        duration=dict(required=False, type='str'),
-        replication=dict(required=False, type='int'),
+        duration=dict(type='str'),
+        replication=dict(type='int'),
         default=dict(default=False, type='bool'),
-        shard_group_duration=dict(required=False, type='str'),
+        shard_group_duration=dict(type='str'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -291,15 +291,12 @@ def drop_retention_policy(module, client):
     database_name = module.params['database_name']
     policy_name = module.params['policy_name']
 
-    changed = False
-
     if not module.check_mode:
         try:
             client.drop_retention_policy(policy_name, database_name)
         except exceptions.InfluxDBClientError as e:
             module.fail_json(msg=e.content)
-        changed = True
-    module.exit_json(changed=changed)
+    module.exit_json(changed=True)
 
 
 def main():

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -70,8 +70,8 @@ EXAMPLES = r'''
 # Example influxdb_retention_policy command from Ansible Playbooks
 - name: Create 1 hour retention policy
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       duration: 1h
       replication: 1
@@ -81,8 +81,8 @@ EXAMPLES = r'''
 
 - name: Create 1 day retention policy with 1 hour shard group duration
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       duration: 1d
       replication: 1
@@ -91,8 +91,8 @@ EXAMPLES = r'''
 
 - name: Create 1 week retention policy with 1 day shard group duration
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       duration: 1w
       replication: 1
@@ -101,8 +101,8 @@ EXAMPLES = r'''
 
 - name: Create infinite retention policy with 1 week of shard group duration
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       duration: INF
       replication: 1
@@ -113,8 +113,8 @@ EXAMPLES = r'''
 
 - name: Create retention policy with complex durations
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       duration: 5d1h30m
       replication: 1
@@ -125,8 +125,8 @@ EXAMPLES = r'''
 
 - name: Drop retention policy
   community.general.influxdb_retention_policy:
-      hostname: "{{influxdb_ip_address}}"
-      database_name: "{{influxdb_database_name}}"
+      hostname: "{{ influxdb_ip_address }}"
+      database_name: "{{ influxdb_database_name }}"
       policy_name: test
       state: absent
 '''

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -35,17 +35,18 @@ options:
         choices: [ absent, present ]
         default: present
         type: str
+        version_added: 3.1.0
     duration:
         description:
             - Determines how long InfluxDB should keep the data. If specified, it
               should be C(INF) or at least one hour. If not specified, C(INF) is
               assumed. Supports complex duration expressions with multiple units.
-            - Required only if C(state) is set to C(present).
+            - Required only if I(state) is set to C(present).
         type: str
     replication:
         description:
             - Determines how many independent copies of each point are stored in the cluster.
-            - Required only if C(state) is set to C(present).
+            - Required only if I(state) is set to C(present).
         type: int
     default:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes: #2383

Add `state` parameter in module argument spec to support deletion of existing retention policies.

Also, simplify `duration` parsing logic as suggested on https://github.com/ansible-collections/community.general/pull/2284#discussion_r618210902.

~~A bug has also been discovered and fixed while developing the changes. It was introduced in my last PR (#2284) and it caused module failure when `duration` option was set to `INF` (a valid value).~~ (moved to #2396)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

influxdb_retention_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: create retention policy
  community.general.influxdb_retention_policy:
      database_name: test
      policy_name: test
      duration: 1h
      replication: 1
      state: present

- name: drop retention policy
  community.general.influxdb_retention_policy:
      database_name: test
      policy_name: test
      state: absent
```
