### PR TITLE
Bugfix: github_repo does not apply defaults on existing repos

### DIFF
--- a/changelogs/fragments/2386-github_repo-fix-idempotency-issues.yml
+++ b/changelogs/fragments/2386-github_repo-fix-idempotency-issues.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - github_repo - ``private`` and ``description`` attributes should not be set to default values when the repo already exists (https://github.com/ansible-collections/community.general/pull/2386).

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -76,7 +76,8 @@ options:
     version_added: "3.5.0"
   force_defaults:
     description:
-    - Overwrite current description and private attributes with defaults if not set.
+    - Overwrite current I(description) and I(private) attributes with defaults if set to C(true), which currently is the default.
+    - The default for this option will be deprecated in a future version of this collection, and eventually change to C(false).
     type: bool
     default: true
     required: false

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -42,14 +42,16 @@ options:
   description:
     description:
     - Description for the repository.
-    - Defaults to empty when creating a new repository.
+    - Defaults to empty if force_defaults=true, which is the default in this module.
+    - Defaults to empty if force_defaults=false when creating a new repository.
     - This is only used when I(state) is C(present).
     type: str
     required: false
   private:
     description:
     - Whether the repository should be private or not.
-    - Defaults to C(false) when creating a new repository.
+    - Defaults to C(false) if force_defaults=true, which is the default in this module.
+    - Defaults to C(false) if force_defaults=false when creating a new repository.
     - This is only used when I(state) is C(present).
     type: bool
     required: false
@@ -74,10 +76,11 @@ options:
     version_added: "3.5.0"
   force_defaults:
     description:
-    - Overwrite current repository attributes with defaults if not set.
+    - Overwrite current description and private attributes with defaults if not set.
     type: bool
     default: true
     required: false
+    version_added: 4.1.0
 requirements:
 - PyGithub>=1.54
 notes:
@@ -206,8 +209,8 @@ def delete_repo(gh, name, organization=None, check_mode=False):
 
 def run_module(params, check_mode=False):
     if params['force_defaults']:
-        params['description'] = params.get('description') or ''
-        params['private'] = params.get('private') or False
+        params['description'] = params['description'] or ''
+        params['private'] = params['private'] or False
 
     gh = authenticate(
         username=params['username'], password=params['password'], access_token=params['access_token'],

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -42,16 +42,16 @@ options:
   description:
     description:
     - Description for the repository.
-    - Defaults to empty if force_defaults=true, which is the default in this module.
-    - Defaults to empty if force_defaults=false when creating a new repository.
+    - Defaults to empty if I(force_defaults=true), which is the default in this module.
+    - Defaults to empty if I(force_defaults=false) when creating a new repository.
     - This is only used when I(state) is C(present).
     type: str
     required: false
   private:
     description:
     - Whether the repository should be private or not.
-    - Defaults to C(false) if force_defaults=true, which is the default in this module.
-    - Defaults to C(false) if force_defaults=false when creating a new repository.
+    - Defaults to C(false) if I(force_defaults=true), which is the default in this module.
+    - Defaults to C(false) if I(force_defaults=false) when creating a new repository.
     - This is only used when I(state) is C(present).
     type: bool
     required: false

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -72,6 +72,12 @@ options:
     type: str
     default: 'https://api.github.com'
     version_added: "3.5.0"
+  force_defaults:
+    description:
+    - Overwrite current repository attributes with defaults if not set.
+    type: bool
+    default: true
+    required: false
 requirements:
 - PyGithub>=1.54
 notes:
@@ -92,6 +98,7 @@ EXAMPLES = '''
     description: "Just for fun"
     private: yes
     state: present
+    force_defaults: no
   register: result
 
 - name: Delete the repository
@@ -198,6 +205,10 @@ def delete_repo(gh, name, organization=None, check_mode=False):
 
 
 def run_module(params, check_mode=False):
+    if params['force_defaults']:
+        params['description'] = params.get('description') or ''
+        params['private'] = params.get('private') or False
+
     gh = authenticate(
         username=params['username'], password=params['password'], access_token=params['access_token'],
         api_url=params['api_url'])
@@ -231,6 +242,7 @@ def main():
         private=dict(type='bool'),
         description=dict(type='str'),
         api_url=dict(type='str', required=False, default='https://api.github.com'),
+        force_defaults=dict(type='bool', default=True),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -228,8 +228,8 @@ def main():
         state=dict(type='str', required=False, default="present",
                    choices=["present", "absent"]),
         organization=dict(type='str', required=False, default=None),
-        private=dict(type='bool', required=False, default=False),
-        description=dict(type='str', required=False, default=''),
+        private=dict(type='bool'),
+        description=dict(type='str'),
         api_url=dict(type='str', required=False, default='https://api.github.com'),
     )
     module = AnsibleModule(

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -49,7 +49,7 @@ options:
   private:
     description:
     - Whether the repository should be private or not.
-    - Defaults to C(False) when creating a new repository.
+    - Defaults to C(false) when creating a new repository.
     - This is only used when I(state) is C(present).
     type: bool
     required: false
@@ -151,7 +151,10 @@ def create_repo(gh, name, organization=None, private=None, description=None, che
     except UnknownObjectException:
         if not check_mode:
             repo = target.create_repo(
-                name=name, private=private or GithubObject.NotSet, description=description or GithubObject.NotSet)
+                name=name,
+                private=GithubObject.NotSet if private is None else private,
+                description=GithubObject.NotSet if description is None else description,
+            )
             result['repo'] = repo.raw_data
 
         result['changed'] = True
@@ -218,10 +221,9 @@ def run_module(params, check_mode=False):
 
 def main():
     module_args = dict(
-        username=dict(type='str', required=False, default=None),
-        password=dict(type='str', required=False, default=None, no_log=True),
-        access_token=dict(type='str', required=False,
-                          default=None, no_log=True),
+        username=dict(type='str'),
+        password=dict(type='str', no_log=True),
+        access_token=dict(type='str', no_log=True),
         name=dict(type='str', required=True),
         state=dict(type='str', required=False, default="present",
                    choices=["present", "absent"]),

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -164,7 +164,7 @@ def create_repo(gh, name, organization=None, private=None, description=None, che
         if repo is None or repo.raw_data['private'] != private:
             changes['private'] = private
     if description is not None:
-        if repo is None or (repo.raw_data['description'] or '') != description:
+        if repo is None or repo.raw_data['description'] not in (description, description or None):
             changes['description'] = description
 
     if changes:

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -42,16 +42,16 @@ options:
   description:
     description:
     - Description for the repository.
+    - Defaults to empty when creating a new repository.
     - This is only used when I(state) is C(present).
     type: str
-    default: ''
     required: false
   private:
     description:
-    - Whether the new repository should be private or not.
+    - Whether the repository should be private or not.
+    - Defaults to C(False) when creating a new repository.
     - This is only used when I(state) is C(present).
     type: bool
-    default: no
     required: false
   state:
     description:

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -182,7 +182,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": False,
             "state": "present",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
 
         self.assertEqual(result['changed'], True)
@@ -202,7 +203,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": None,
             "private": None,
             "state": "present",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
 
         self.assertEqual(result['changed'], True)
@@ -222,7 +224,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": True,
             "state": "present",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], True)
@@ -240,7 +243,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": True,
             "state": "present",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], True)
@@ -257,7 +261,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": None,
             "private": None,
             "state": "present",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], False)
         self.assertEqual(result['repo']['private'], True)
@@ -276,7 +281,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": False,
             "state": "absent",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], True)
 
@@ -293,7 +299,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": False,
             "state": "absent",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], True)
 
@@ -310,7 +317,8 @@ class TestGithubRepo(unittest.TestCase):
             "description": "Just for fun",
             "private": True,
             "state": "absent",
-            "api_url": "https://api.github.com"
+            "api_url": "https://api.github.com",
+            "force_defaults": False,
         })
         self.assertEqual(result['changed'], False)
 

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -70,6 +70,27 @@ def get_repo_mock(url, request):
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
+@urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="get")
+def get_private_repo_mock(url, request):
+    match = re.search(
+        r"api\.github\.com(:[0-9]+)?/repos/(?P<org>[^/]+)/(?P<repo>[^/]+)", request.url)
+    org = match.group("org")
+    repo = match.group("repo")
+
+    # https://docs.github.com/en/rest/reference/repos#get-a-repository
+    headers = {'content-type': 'application/json'}
+    content = {
+        "name": repo,
+        "full_name": "{0}/{1}".format(org, repo),
+        "url": "https://api.github.com/repos/{0}/{1}".format(org, repo),
+        "private": True,
+        "description": "This your first repo!",
+        "default_branch": "master",
+        "allow_rebase_merge": True
+    }
+    content = json.dumps(content).encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
 
 @urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/orgs/.*/repos', method="post")
 def create_new_org_repo_mock(url, request):
@@ -83,8 +104,8 @@ def create_new_org_repo_mock(url, request):
     content = {
         "name": repo['name'],
         "full_name": "{0}/{1}".format(org, repo['name']),
-        "private": repo['private'],
-        "description": repo['description']
+        "private": repo.get('private', False),
+        "description": repo.get('description')
     }
     content = json.dumps(content).encode("utf-8")
     return response(201, content, headers, None, 5, request)
@@ -99,8 +120,8 @@ def create_new_user_repo_mock(url, request):
     content = {
         "name": repo['name'],
         "full_name": "{0}/{1}".format("octocat", repo['name']),
-        "private": repo['private'],
-        "description": repo['description']
+        "private": repo.get('private', False),
+        "description": repo.get('description')
     }
     content = json.dumps(content).encode("utf-8")
     return response(201, content, headers, None, 5, request)
@@ -120,14 +141,13 @@ def patch_repo_mock(url, request):
         "name": repo,
         "full_name": "{0}/{1}".format(org, repo),
         "url": "https://api.github.com/repos/{0}/{1}".format(org, repo),
-        "private": body['private'],
-        "description": body['description'],
+        "private": body.get('private', False),
+        "description": body.get('description'),
         "default_branch": "master",
         "allow_rebase_merge": True
     }
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
-
 
 @urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_mock(url, request):
@@ -165,6 +185,26 @@ class TestGithubRepo(unittest.TestCase):
 
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], False)
+        self.assertEqual(result['repo']['description'], 'Just for fun')
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_repo_notfound_mock)
+    @with_httmock(create_new_org_repo_mock)
+    def test_create_new_org_repo_incomplete(self):
+        result = github_repo.run_module({
+            'username': None,
+            'password': None,
+            "access_token": "mytoken",
+            "organization": "MyOrganization",
+            "name": "myrepo",
+            "description": None,
+            "private": None,
+            "state": "present"
+        })
+
+        self.assertEqual(result['changed'], True)
+        self.assertEqual(result['repo']['private'], False)
+        self.assertEqual(result['repo']['description'], None)
 
     @with_httmock(get_user_mock)
     @with_httmock(get_repo_notfound_mock)
@@ -201,6 +241,23 @@ class TestGithubRepo(unittest.TestCase):
         })
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], True)
+
+    @with_httmock(get_orgs_mock)
+    @with_httmock(get_private_repo_mock)
+    def test_idempotency_existing_org_private_repo(self):
+        result = github_repo.run_module({
+            'username': None,
+            'password': None,
+            "access_token": "mytoken",
+            "organization": "MyOrganization",
+            "name": "myrepo",
+            "description": None,
+            "private": None,
+            "state": "present"
+        })
+        self.assertEqual(result['changed'], False)
+        self.assertEqual(result['repo']['private'], True)
+        self.assertEqual(result['repo']['description'], 'This your first repo!')
 
     @with_httmock(get_orgs_mock)
     @with_httmock(get_repo_mock)

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -70,6 +70,7 @@ def get_repo_mock(url, request):
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
+
 @urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="get")
 def get_private_repo_mock(url, request):
     match = re.search(
@@ -148,6 +149,7 @@ def patch_repo_mock(url, request):
     }
     content = json.dumps(content).encode("utf-8")
     return response(200, content, headers, None, 5, request)
+
 
 @urlmatch(netloc=r'api\.github\.com(:[0-9]+)?$', path=r'/repos/.*/.*', method="delete")
 def delete_repo_mock(url, request):

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -201,7 +201,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": None,
             "private": None,
-            "state": "present"
+            "state": "present",
+            "api_url": "https://api.github.com"
         })
 
         self.assertEqual(result['changed'], True)
@@ -255,7 +256,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": None,
             "private": None,
-            "state": "present"
+            "state": "present",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], False)
         self.assertEqual(result['repo']['private'], True)


### PR DESCRIPTION
##### SUMMARY
Fixes #2376.

Module github_repo sets parameter default values when not specified in existing repos.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
github_repo

##### ADDITIONAL INFORMATION
Module github_repo is applying defaults when repo already exists. However, defaults must be set only when the repo is created. Otherwise, not specifying a parameter will apply default value, which is a wrong behaviour.

Also, two tests are include in order to ensure this behaviour:
* `test_create_new_org_repo_incomplete`: new repo with default values
* `test_idempotency_existing_org_private_repo`: preserve `private` and `description` on existing repos