### PR TITLE
CI: Spread nightly runs out

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -14,15 +14,20 @@ pr:
 
 schedules:
   - cron: 0 8 * * *
-    displayName: Nightly
+    displayName: Nightly (main)
     always: true
     branches:
       include:
         - main
+  - cron: 0 10 * * *
+    displayName: Nightly (active stable branches)
+    always: true
+    branches:
+      include:
         - stable-2
         - stable-3
-  - cron: 0 8 * * 0
-    displayName: Weekly (old branches)
+  - cron: 0 11 * * 0
+    displayName: Weekly (old stable branches)
     always: true
     branches:
       include:


### PR DESCRIPTION
##### SUMMARY
As discussed in #ansible-devel and #ansible-community, this moves the stable CI runs to different times:
- 7 UTC ansible/ansible nightly runs,
- 8 UTC c.g main branch nightly run,
- 9 UTC most community collections (AZP) nightly runs,
- 10 UTC c.g stable-2 and stable-3 (active stable branches) nightly runs,
- 11 UTC c.g weekly run for old stable branches (right now stable-1) which only get important bugfixes and/or security fixes

@gundalow I've adjusted your suggestion a bit to avoid the other community collections, and I've implented a suggestion you already had earlier. Does this schedule make sense?

CC @relrod 

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
