### PR TITLE
influxdb_retention_policy: fix duration parsing to support INF values

### DIFF
--- a/changelogs/fragments/2284-influxdb_retention_policy-fix_duration_parsing.yml
+++ b/changelogs/fragments/2284-influxdb_retention_policy-fix_duration_parsing.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - influxdb_retention_policy - fix bug where ``INF`` duration values failed parsing
+    (https://github.com/ansible-collections/community.general/pull/2385).

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -129,7 +129,7 @@ from ansible_collections.community.general.plugins.module_utils.influxdb import 
 from ansible.module_utils._text import to_native
 
 
-VALID_DURATION_REGEX = re.compile(r'^(\d+(ns|u|µ|ms|s|m|h|d|w))+$')
+VALID_DURATION_REGEX = re.compile(r'^(INF|(\d+(ns|u|µ|ms|s|m|h|d|w)))+$')
 
 DURATION_REGEX = re.compile(r'(\d+)(ns|u|µ|ms|s|m|h|d|w)')
 EXTENDED_DURATION_REGEX = re.compile(r'(?:(\d+)(ns|u|µ|ms|m|h|d|w)|(\d+(?:\.\d+)?)(s))')
@@ -217,7 +217,7 @@ def create_retention_policy(module, client):
 
         influxdb_shard_group_duration_format = parse_duration_literal(shard_group_duration)
         if influxdb_shard_group_duration_format < 3600000000000:
-            module.fail_json(msg="shard_group_duration value must be at least 1h")
+            module.fail_json(msg="shard_group_duration value must be finite and at least 1h")
 
     if not module.check_mode:
         try:
@@ -256,7 +256,7 @@ def alter_retention_policy(module, client, retention_policy):
 
         influxdb_shard_group_duration_format = parse_duration_literal(shard_group_duration)
         if influxdb_shard_group_duration_format < 3600000000000:
-            module.fail_json(msg="shard_group_duration value must be at least 1h")
+            module.fail_json(msg="shard_group_duration value must be finite and at least 1h")
 
     if (retention_policy['duration'] != influxdb_duration_format or
             retention_policy['shardGroupDuration'] != influxdb_shard_group_duration_format or


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

A bug was introduced in my last PR (#2284) and it caused module failure when duration option was set to INF (a valid value) while creating or altering InfluxDB retention policies.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

influxdb_retention_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Cherry-picked from #2385 so it can be backported to 3.0.1