### PR TITLE
puppet - replace stdout with console in logdest option

### DIFF
--- a/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
+++ b/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - puppet - replace ``console` with ``stdout`` in ``logdest`` option (https://github.com/ansible-collections/community.general/issues/1190).

--- a/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
+++ b/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - puppet - replace ``console` with ``stdout`` in ``logdest`` option when all has been chosen (https://github.com/ansible-collections/community.general/issues/1190).
+  - puppet - replace ``console` with ``stdout`` in ``logdest`` option when ``all`` has been chosen (https://github.com/ansible-collections/community.general/issues/1190).

--- a/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
+++ b/changelogs/fragments/2407-puppet-change_stdout_to_console.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - puppet - replace ``console` with ``stdout`` in ``logdest`` option (https://github.com/ansible-collections/community.general/issues/1190).
+  - puppet - replace ``console` with ``stdout`` in ``logdest`` option when all has been chosen (https://github.com/ansible-collections/community.general/issues/1190).

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -57,8 +57,8 @@ options:
     - C(all) will go to both C(console) and C(syslog).
     - C(stdout) will be deprecated and replaced by C(console).
     type: str
-    choices: [ all, console, syslog, stdout ]
-    default: console
+    choices: [ all, stdout, syslog ]
+    default: stdout
   certname:
     description:
       - The name to use when handling certificates.
@@ -173,7 +173,7 @@ def main():
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
             noop=dict(type='bool'),
-            logdest=dict(type='str', default='console', choices=['all', 'console', 'syslog', 'stdout']),
+            logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
                 removed_in_version='7.0.0', removed_from_collection='community.general'),
@@ -269,8 +269,6 @@ def main():
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':
             cmd += "--logdest syslog "
-        if p['logdest'] == 'stdout':
-            cmd += "--logdest stdout "
         if p['logdest'] == 'all':
             cmd += " --logdest syslog --logdest console"
         if p['modulepath']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -54,10 +54,10 @@ options:
   logdest:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
-    - C(all) will go to both C(stdout) and C(syslog).
+    - C(all) will go to both C(console) and C(syslog).
     type: str
-    choices: [ all, stdout, syslog ]
-    default: stdout
+    choices: [ all, console, syslog ]
+    default: console
   certname:
     description:
       - The name to use when handling certificates.
@@ -127,7 +127,7 @@ EXAMPLES = r'''
   community.general.puppet:
     noop: yes
 
-- name: Run a manifest with debug, log to both syslog and stdout, specify module path
+- name: Run a manifest with debug, log to both syslog and console, specify module path
   community.general.puppet:
     modulepath: /etc/puppet/modules:/opt/stack/puppet-modules:/usr/share/openstack-puppet/modules
     logdest: all
@@ -172,7 +172,7 @@ def main():
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
             noop=dict(type='bool'),
-            logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
+            logdest=dict(type='str', default='console', choices=['all', 'console', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
                 removed_in_version='7.0.0', removed_from_collection='community.general'),
@@ -269,7 +269,7 @@ def main():
         if p['logdest'] == 'syslog':
             cmd += "--logdest syslog "
         if p['logdest'] == 'all':
-            cmd += " --logdest syslog --logdest stdout"
+            cmd += " --logdest syslog --logdest console"
         if p['modulepath']:
             cmd += "--modulepath='%s'" % p['modulepath']
         if p['environment']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -55,7 +55,7 @@ options:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
     - C(all) will go to both C(console) and C(syslog).
-    - C(stdout) is deprecated and has been replaced by C(console) since community.general 3.1.0.
+    - C(stdout) will be deprecated and replaced by C(console).
     type: str
     choices: [ all, console, syslog, stdout ]
     default: console
@@ -270,12 +270,7 @@ def main():
         if p['logdest'] == 'syslog':
             cmd += "--logdest syslog "
         if p['logdest'] == 'stdout':
-            cmd += "--logdest console "
-            module.warn(
-                'The "logdest" option has changed its default value from'
-                '"stdout" to "console" from community.general 3.0.1.'
-                'To remove this warning, please change its value to'
-                '"console" or nothing (default).')
+            cmd += "--logdest stdout "
         if p['logdest'] == 'all':
             cmd += " --logdest syslog --logdest console"
         if p['modulepath']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -55,7 +55,7 @@ options:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
     - C(all) will go to both C(console) and C(syslog).
-    - C(stdout) is deprecated and has been replaced by C(console) since 3.0.1.
+    - C(stdout) is deprecated and has been replaced by C(console) since community.general 3.1.0.
     type: str
     choices: [ all, console, syslog, stdout ]
     default: console

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -55,8 +55,9 @@ options:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
     - C(all) will go to both C(console) and C(syslog).
+    - C(stdout) is deprecated and has been replaced by C(console) since 3.0.1.
     type: str
-    choices: [ all, console, syslog ]
+    choices: [ all, console, syslog, stdout ]
     default: console
   certname:
     description:
@@ -270,6 +271,11 @@ def main():
             cmd += "--logdest syslog "
         if p['logdest'] == 'stdout':
             cmd += "--logdest console "
+            module.warn(
+                'The "logdest" option has changed its default value from'
+                '"stdout" to "console" from community.general 3.0.1.'
+                'To remove this warning, please change its value to'
+                '"console" or nothing (default).')
         if p['logdest'] == 'all':
             cmd += " --logdest syslog --logdest console"
         if p['modulepath']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -172,7 +172,7 @@ def main():
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
             noop=dict(type='bool'),
-            logdest=dict(type='str', default='console', choices=['all', 'console', 'syslog']),
+            logdest=dict(type='str', default='console', choices=['all', 'console', 'syslog', 'stdout']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
                 removed_in_version='7.0.0', removed_from_collection='community.general'),
@@ -268,6 +268,8 @@ def main():
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':
             cmd += "--logdest syslog "
+        if p['logdest'] == 'stdout':
+            cmd += "--logdest console "
         if p['logdest'] == 'all':
             cmd += " --logdest syslog --logdest console"
         if p['modulepath']:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/1190

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
puppet

##### ADDITIONAL INFORMATION
I guess it would be best if there could be an alias from `stdout` to `console` for now showing a deprecation warning, therefore users which have explicitly stated `stdout` (although it won't work) don't face issues with this change.

https://puppet.com/docs/puppet/7.6/man/agent.html
https://puppet.com/docs/puppet/6.22/man/agent.html
https://puppet.com/docs/puppet/5.5/man/agent.html

> `--logdest`
Where to send log messages. Choose between 'syslog' (the POSIX syslog service), 'eventlog' (the Windows Event Log), 'console', or the path to a log file.