### PR TITLE
nmcli: Add 'slave-type bridge' to nmcli command if type is bridge-slave

### DIFF
--- a/changelogs/fragments/2409-nmcli_add_slave-type_bridge_to_nmcli_command_if_type_is_bridge-slave.yml
+++ b/changelogs/fragments/2409-nmcli_add_slave-type_bridge_to_nmcli_command_if_type_is_bridge-slave.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - if type is ``bridge-slave`` add ``slave-type bridge`` to ``nmcli`` command (https://github.com/ansible-collections/community.general/issues/2408).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -780,6 +780,7 @@ class Nmcli(object):
             })
         elif self.type == 'bridge-slave':
             options.update({
+                'connection.slave-type': 'bridge',
                 'bridge-port.path-cost': self.path_cost,
                 'bridge-port.hairpin-mode': self.hairpin,
                 'bridge-port.priority': self.slavepriority,

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -223,6 +223,7 @@ TESTCASE_BRIDGE_SLAVE_SHOW_OUTPUT = """\
 connection.id:                          non_existent_nw_device
 connection.interface-name:              br0_non_existant
 connection.autoconnect:                 yes
+connection.slave-type:                  bridge
 ipv4.never-default:                     no
 bridge-port.path-cost:                  100
 bridge-port.hairpin-mode:               yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should fix #2408: If type is `birdge-slave` then nmcli expects `slave-type brige` if any `bridge-port` settings are specified.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

