### PR TITLE
 nmcli: Compare MAC addresses case insensitively

### DIFF
--- a/changelogs/fragments/2416-nmcli_compare_mac_addresses_case_insensitively.yml
+++ b/changelogs/fragments/2416-nmcli_compare_mac_addresses_case_insensitively.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - compare MAC addresses case insesitively to fix potentially non idempotency task (https://github.com/ansible-collections/community.general/issues/2409).
+  - nmcli - compare MAC addresses case insensitively to fix idempotency issue (https://github.com/ansible-collections/community.general/issues/2409).

--- a/changelogs/fragments/2416-nmcli_compare_mac_addresses_case_insensitively.yml
+++ b/changelogs/fragments/2416-nmcli_compare_mac_addresses_case_insensitively.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - compare MAC addresses case insesitively to fix potentially non idempotency task (https://github.com/ansible-collections/community.general/issues/2409).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1064,7 +1064,7 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
-                if key in ['bridge.mac-address', '802-3-ethernet.cloned-mac-address']:
+                if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = str.upper(value)
             elif key in param_alias:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1066,7 +1066,7 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
-                    value = str.upper(value)
+                    value = value.upper()
             elif key in param_alias:
                 real_key = param_alias[key]
                 if real_key in conn_info:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1041,7 +1041,6 @@ class Nmcli(object):
             'con-name': 'connection.id',
             'autoconnect': 'connection.autoconnect',
             'ifname': 'connection.interface-name',
-            'mac': self.mac_setting,
             'master': 'connection.master',
             'slave-type': 'connection.slave-type',
             'zone': 'connection.zone',
@@ -1065,6 +1064,9 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
+                if key in ['bridge.mac-address', '802-3-ethernet.cloned-mac-address']:
+                    # MAC addresses are case insensitive, nmcli always reports them in uppercase
+                    value = str.upper(value)
             elif key in param_alias:
                 real_key = param_alias[key]
                 if real_key in conn_info:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1067,6 +1067,8 @@ class Nmcli(object):
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()
+                    # ensure current_value is also converted to uppercase in case nmcli changes behaviour
+                    current_value = current_value.upper()
             elif key in param_alias:
                 real_key = param_alias[key]
                 if real_key in conn_info:

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -184,6 +184,7 @@ TESTCASE_BRIDGE = [
         'ifname': 'br0_non_existant',
         'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
+        'mac': '52:54:00:ab:cd:ef',
         'maxage': 100,
         'stp': True,
         'state': 'present',
@@ -200,6 +201,7 @@ ipv4.addresses:                         10.10.10.10/24
 ipv4.gateway:                           10.10.10.1
 ipv4.never-default:                     no
 ipv6.method:                            auto
+bridge.mac-address:                     52:54:00:AB:CD:EF
 bridge.stp:                             yes
 bridge.max-age:                         100
 bridge.ageing-time:                     300


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This should fix #2415: If the key in `conn_info` is either `bridge.mac-address` or `802-3-ethernet.cloned-mac-address` it compares the values (the current MAC from `nmcli connection show` address and the MAC address given as parameter to the `community.general.nmcli` module) in a case insensitive manner.  



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

It also removes 'mac' from the list of potential parameter aliases:

https://github.com/ansible-collections/community.general/blob/main/plugins/modules/net_tools/nmcli.py#L1044

since that's already taken care of:

https://github.com/ansible-collections/community.general/blob/main/plugins/modules/net_tools/nmcli.py#L745

This avoids potential code duplication: The keys `bridge.mac-address` or `802-3-ethernet.cloned-mac-address` are (if present) always going to be found in `conn_info` but not in `param_alias` so analogous to `ipv4.routes` they can be fixed in this branch

https://github.com/ansible-collections/community.general/blob/main/plugins/modules/net_tools/nmcli.py#L1058
                