### PR TITLE
nmcli: Remove dead code, 'options' never contains keys from 'param_alias'

### DIFF
--- a/changelogs/fragments/2417-nmcli_remove_dead_code.yml
+++ b/changelogs/fragments/2417-nmcli_remove_dead_code.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - remove dead code, 'options' never contains keys from 'param_alias' (https://github.com/ansible-collections/community.general/pull/2417).

--- a/changelogs/fragments/2417-nmcli_remove_dead_code.yml
+++ b/changelogs/fragments/2417-nmcli_remove_dead_code.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - remove dead code, 'options' never contains keys from 'param_alias' (https://github.com/ansible-collections/community.general/pull/2417).
+  - nmcli - remove dead code, ``options`` never contains keys from ``param_alias`` (https://github.com/ansible-collections/community.general/pull/2417).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1036,17 +1036,6 @@ class Nmcli(object):
         return conn_info
 
     def _compare_conn_params(self, conn_info, options):
-        # See nmcli(1) for details
-        param_alias = {
-            'type': 'connection.type',
-            'con-name': 'connection.id',
-            'autoconnect': 'connection.autoconnect',
-            'ifname': 'connection.interface-name',
-            'master': 'connection.master',
-            'slave-type': 'connection.slave-type',
-            'zone': 'connection.zone',
-        }
-
         changed = False
         diff_before = dict()
         diff_after = dict()
@@ -1070,13 +1059,6 @@ class Nmcli(object):
                     value = value.upper()
                     # ensure current_value is also converted to uppercase in case nmcli changes behaviour
                     current_value = current_value.upper()
-            elif key in param_alias:
-                real_key = param_alias[key]
-                if real_key in conn_info:
-                    current_value = conn_info[real_key]
-                else:
-                    # alias parameter does not exist
-                    current_value = None
             else:
                 # parameter does not exist
                 current_value = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This removes some dead code.

https://github.com/ansible-collections/community.general/blob/b10d707a8baa2530deb98a218c820762a2ce879a/plugins/modules/net_tools/nmcli.py#L1037-L1048

` _compare_conn_params` is only called from

https://github.com/ansible-collections/community.general/blob/b10d707a8baa2530deb98a218c820762a2ce879a/plugins/modules/net_tools/nmcli.py#L1096-L1101

However, `is_connection_changed` uses `connection_options` to construct the `options` dictionary

https://github.com/ansible-collections/community.general/blob/b10d707a8baa2530deb98a218c820762a2ce879a/plugins/modules/net_tools/nmcli.py#L718

and `connection_options` will never set any of the keys from `param_alias`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

For reference: https://github.com/ansible-collections/community.general/pull/2416#pullrequestreview-649947431
