### PR TITLE
linode_v4 - fixed error message

### DIFF
--- a/changelogs/fragments/2430-linodev4-error-message.yml
+++ b/changelogs/fragments/2430-linodev4-error-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linode_v4 - changed the error message to point to the correct bugtracker URL (https://github.com/ansible-collections/community.general/pull/2430).

--- a/plugins/modules/cloud/linode/linode_v4.py
+++ b/plugins/modules/cloud/linode/linode_v4.py
@@ -208,9 +208,8 @@ def create_linode(module, client, **kwargs):
         else:
             return response._raw_json
     except TypeError:
-        module.fail_json(msg='Unable to parse Linode instance creation'
-                             ' response. Please raise a bug against this'
-                             ' module on https://github.com/ansible/ansible/issues'
+        module.fail_json(msg='Unable to parse Linode instance creation response. Please raise a bug against this'
+                             ' module on https://github.com/ansible-collections/community.general/issues'
                          )
 
 


### PR DESCRIPTION
##### SUMMARY
Error message referred to Ansible's bugtracker URL in github. Changing to c.g.'s one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/linode/linode_v4.py

