### PR TITLE
Add proxmox_nic module

### DIFF
--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -145,6 +145,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.community.general.plugins.module_utils.proxmox import proxmox_auth_argument_spec
 
+
 def get_vmid(module, proxmox, name):
     try:
         vms = [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm.get('name') == name]

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -11,22 +11,23 @@ DOCUMENTATION = r'''
 ---
 module: proxmox_nic
 short_description: Management of NIC's for Qemu(KVM) VM's in a Proxmox VE cluster.
+version_added: 3.1.0
 description:
   - Allows you to create/update/delete NIC's on Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
 author: "Lammert Hellinga (@Kogelvis) <lammert@hellinga.it>"
 options:
   bridge:
     description:
-      - Add this interface to the specified bridge device. The Proxmox VE standard bridge is called 'vmbr0'
+      - Add this interface to the specified bridge device. The Proxmox VE standard bridge is called C(vmbr0).
     type: str
   firewall:
     description:
       - Whether this interface should be protected by the firewall.
     type: bool
-    default: False
+    default: false
   interface:
     description:
-      - Name of the interface, should be C(net[n]) where C(1 ≤ n ≤ 31)
+      - Name of the interface, should be C(net[n]) where C(1 ≤ n ≤ 31).
     type: str
     required: True
   link_down:
@@ -41,25 +42,25 @@ options:
     type: str
   model:
     description:
-      - Model is one of C(e1000 e1000-82540em e1000-82544gc e1000-82545em i82551 i82557b i82559er ne2k_isa ne2k_pci pcnet rtl8139 virtio vmxnet3)
+      - The model.
     type: str
     choices: ['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em', 'i82551', 'i82557b', 'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet',
               'rtl8139', 'virtio', 'vmxnet3']
     default: virtio
   mtu:
     description:
-      - Force MTU, for C(virtio) model only. Set to '1' to use the bridge MTU
-      - Value should be C(1 ≤ n ≤ 65520)
+      - Force MTU, for C(virtio) model only. Set to C(1) to use the bridge MTU.
+      - Value should be C(1 ≤ n ≤ 65520).
     type: int
   name:
     description:
       - Specifies the VM name. Only used on the configuration web interface.
-      - Required only for C(state=present).
+      - Required only for I(state=present).
     type: str
   queues:
     description:
       - Number of packet queues to be used on the device.
-      - Value should be C(0 ≤ n ≤ 16)
+      - Value should be C(0 ≤ n ≤ 16).
     type: int
   rate:
     description:
@@ -109,7 +110,7 @@ EXAMPLES = '''
     interface: net0
     bridge: vmbr0
     mac: "12:34:56:C0:FF:EE"
-    firewall: True
+    firewall: true
 
 - name: Delete NIC net0 targeting the vm by name
   community.general.proxmox_nic:

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -143,7 +143,7 @@ except ImportError:
     HAS_PROXMOXER = False
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-
+from ansible_collections.community.general.plugins.module_utils.proxmox import proxmox_auth_argument_spec
 
 def get_vmid(module, proxmox, name):
     try:
@@ -253,31 +253,29 @@ def delete_nic(module, proxmox, vmid, interface):
 
 
 def main():
+    module_args = proxmox_auth_argument_spec()
+    nic_args = dict(
+        bridge=dict(type='str'),
+        firewall=dict(type='bool', default=False),
+        interface=dict(type='str', required=True),
+        link_down=dict(type='bool', default=False),
+        mac=dict(type='str'),
+        model=dict(choices=['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em',
+                            'i82551', 'i82557b', 'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet',
+                            'rtl8139', 'virtio', 'vmxnet3'], default='virtio'),
+        mtu=dict(type='int'),
+        name=dict(type='str'),
+        queues=dict(type='int'),
+        rate=dict(type='float'),
+        state=dict(default='present', choices=['present', 'absent']),
+        tag=dict(type='int'),
+        trunks=dict(type='list', elements='int'),
+        vmid=dict(type='int'),
+    )
+    module_args.update(nic_args)
+
     module = AnsibleModule(
-        argument_spec=dict(
-            api_host=dict(required=True),
-            api_password=dict(no_log=True, fallback=(env_fallback, ['PROXMOX_PASSWORD'])),
-            api_token_id=dict(no_log=True),
-            api_token_secret=dict(no_log=True),
-            api_user=dict(required=True),
-            bridge=dict(type='str'),
-            firewall=dict(type='bool', default=False),
-            interface=dict(type='str', required=True),
-            link_down=dict(type='bool', default=False),
-            mac=dict(type='str'),
-            model=dict(choices=['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em',
-                                'i82551', 'i82557b', 'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet',
-                                'rtl8139', 'virtio', 'vmxnet3'], default='virtio'),
-            mtu=dict(type='int'),
-            name=dict(type='str'),
-            queues=dict(type='int'),
-            rate=dict(type='float'),
-            state=dict(default='present', choices=['present', 'absent']),
-            tag=dict(type='int'),
-            trunks=dict(type='list', elements='int'),
-            validate_certs=dict(type='bool', default=False),
-            vmid=dict(type='int'),
-        ),
+        argument_spec=module_args,
         required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
         supports_check_mode=True,

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: proxmox_nic
-short_description: Management of NIC's for Qemu(KVM) VM's in a Proxmox VE cluster.
+short_description: Management of a NIC of a Qemu(KVM) VM in a Proxmox VE cluster.
 version_added: 3.1.0
 description:
   - Allows you to create/update/delete a NIC on Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
@@ -49,7 +49,8 @@ options:
     default: virtio
   mtu:
     description:
-      - Force MTU, for C(virtio) model only. Set to C(1) to use the bridge MTU.
+      - Force MTU, for C(virtio) model only, setting will be ignored otherwise.
+      - Set to C(1) to use the bridge MTU.
       - Value should be C(1 ≤ n ≤ 65520).
     type: int
   name:
@@ -212,10 +213,9 @@ def update_nic(module, proxmox, vmid, interface, model, **kwargs):
         if model == 'virtio':
             config_provided += ",mtu={0}".format(kwargs['mtu'])
         else:
-            module.fail_json(
-                vmid=vmid,
-                msg='Unable to set MTU for nic {0} on VM with vmid {1}, model should'
-                    ' be set to \'virtio\': '.format(interface, vmid))
+            module.warn(
+                'Ignoring MTU for nic {0} on VM with vmid {1}, '
+                'model should be set to \'virtio\': '.format(interface, vmid))
 
     if kwargs['queues']:
         config_provided += ",queues={0}".format(kwargs['queues'])

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -224,9 +224,9 @@ def update_nic(module, proxmox, vmid, interface, model, **kwargs):
     vm = get_vm(proxmox, vmid)
 
     if ((interface not in vminfo) or (vminfo[interface] != config_provided)):
-        if module.check_mode:
-            return True
-        return proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(**net) is None
+        if not module.check_mode:
+            proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(**net)
+        return True
 
     return False
 
@@ -236,9 +236,9 @@ def delete_nic(module, proxmox, vmid, interface):
     vminfo = proxmox.nodes(vm[0]['node']).qemu(vmid).config.get()
 
     if interface in vminfo:
-        if module.check_mode:
-            return True
-        return proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(vmid=vmid, delete=interface) is None
+        if not module.check_mode:
+            proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(vmid=vmid, delete=interface)
+        return True
 
     return False
 

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -224,11 +224,9 @@ def update_nic(module, proxmox, vmid, interface, model, **kwargs):
     vm = get_vm(proxmox, vmid)
 
     if ((interface not in vminfo) or (vminfo[interface] != config_provided)):
-        if not module.check_mode:
-            if proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(**net) is None:
-                return True
-        else:
+        if module.check_mode:
             return True
+        return proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(**net) is None
 
     return False
 
@@ -238,11 +236,9 @@ def delete_nic(module, proxmox, vmid, interface):
     vminfo = proxmox.nodes(vm[0]['node']).qemu(vmid).config.get()
 
     if interface in vminfo:
-        if not module.check_mode:
-            if proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(vmid=vmid, delete=interface) is None:
-                return True
-        else:
+        if module.check_mode:
             return True
+        return proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(vmid=vmid, delete=interface) is None
 
     return False
 

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -1,0 +1,334 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Lammert Hellinga (@Kogelvis) <lammert@hellinga.it>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: proxmox_nic
+short_description: Management of NIC's for Qemu(KVM) VM's in a Proxmox VE cluster.
+description:
+  - Allows you to create/update/delete NIC's on Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
+author: "Lammert Hellinga (@Kogelvis) <lammert@hellinga.it>"
+options:
+  bridge:
+    description:
+      - Add this interface to the specified bridge device. The Proxmox VE standard bridge is called 'vmbr0'
+    type: str
+  firewall:
+    description:
+      - Whether this interface should be protected by the firewall.
+    type: bool
+    default: False
+  interface:
+    description:
+      - Name of the interface, should be C(net[n]) where C(1 ≤ n ≤ 31)
+    type: str
+    required: True
+  link_down:
+    description:
+      - Whether this interface should be disconnected (like pulling the plug).
+    type: bool
+    default: False
+  mac:
+    description:
+      - C(XX:XX:XX:XX:XX:XX) should be a unique MAC address. This is automatically generated if not specified.
+      - When not specified this module will keep the MAC address the same when changing an existing interface.
+    type: str
+  model:
+    description:
+      - Model is one of C(e1000 e1000-82540em e1000-82544gc e1000-82545em i82551 i82557b i82559er ne2k_isa ne2k_pci pcnet rtl8139 virtio vmxnet3)
+    type: str
+    choices: ['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em', 'i82551', 'i82557b', 'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet',
+              'rtl8139', 'virtio', 'vmxnet3']
+    default: virtio
+  mtu:
+    description:
+      - Force MTU, for C(virtio) model only. Set to '1' to use the bridge MTU
+      - Value should be C(1 ≤ n ≤ 65520)
+    type: int
+  name:
+    description:
+      - Specifies the VM name. Only used on the configuration web interface.
+      - Required only for C(state=present).
+    type: str
+  queues:
+    description:
+      - Number of packet queues to be used on the device.
+      - Value should be C(0 ≤ n ≤ 16)
+    type: int
+  rate:
+    description:
+      - Rate limit in MBps (MegaBytes per second) as floating point number.
+    type: float
+  state:
+    description:
+      - Indicates desired state of the NIC.
+    type: str
+    choices: ['present', 'absent']
+    default: present
+  tag:
+    description:
+      - VLAN tag to apply to packets on this interface.
+      - Value should be C(1 ≤ n ≤ 4094)
+    type: int
+  trunks:
+    description:
+      - VLAN trunks to pass through this interface.
+      - Format as C(vlanid[;vlanid...])
+    type: str
+  vmid:
+    description:
+      - Specifies the instance ID.
+    type: int
+extends_documentation_fragment:
+  - community.general.proxmox.documentation
+'''
+
+EXAMPLES = '''
+- name: Create NIC net0 targeting the vm by name
+  community.general.proxmox_nic:
+    api_user: root@pam
+    api_password: secret
+    api_host: proxmoxhost
+    name: my_vm
+    interface: net0
+    bridge: vmbr0
+    tag: 3
+
+- name: Create NIC net0 targeting the vm by id
+  community.general.proxmox_nic:
+    api_user: root@pam
+    api_password: secret
+    api_host: proxmoxhost
+    vmid: 103
+    interface: net0
+    bridge: vmbr0
+    mac: "12:34:56:C0:FF:EE"
+    firewall: True
+
+- name: Delete NIC net0 targeting the vm by name
+  community.general.proxmox_nic:
+    api_user: root@pam
+    api_password: secret
+    api_host: proxmoxhost
+    name: my_vm
+    interface: net0
+    state: absent
+'''
+
+RETURN = '''
+vmid:
+  description: The VM vmid.
+  returned: success
+  type: int
+  sample: 115
+msg:
+  description: A short message
+  returned: always
+  type: str
+  sample: "Nic net0 unchanged on VM with vmid 103"
+'''
+
+try:
+    from proxmoxer import ProxmoxAPI
+    HAS_PROXMOXER = True
+except ImportError:
+    HAS_PROXMOXER = False
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
+
+
+def get_vmid(proxmox, name):
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm.get('name') == name]
+
+
+def get_vm(proxmox, vmid):
+    return [vm for vm in proxmox.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
+
+
+def update_nic(module, proxmox, vmid, interface, model, **kwargs):
+    vm = get_vm(proxmox, vmid)
+
+    try:
+        vminfo = proxmox.nodes(vm[0]['node']).qemu(vmid).config.get()
+    except Exception as e:
+        module.fail_json(msg='Getting information for VM with vmid = %s failed with exception: %s' % (vmid, e))
+
+    if interface in vminfo:
+        # Convert the current config to a dictionary
+        config = vminfo[interface].split(',')
+        config.sort()
+
+        config_current = {}
+
+        for i in config:
+            kv = i.split('=')
+            try:
+                config_current[kv[0]] = kv[1]
+            except IndexError:
+                config_current[kv[0]] = ''
+
+        # determine the current model nic and mac-address
+        models = ['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em', 'i82551', 'i82557b',
+                  'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet', 'rtl8139', 'virtio', 'vmxnet3']
+        current_model = set(models) & set(config_current.keys())
+        current_model = current_model.pop()
+        current_mac = config_current[model]
+
+        # build nic config string
+        config_provided = "{0}={1}".format(model, current_mac)
+    else:
+        config_provided = model
+
+    if kwargs['mac']:
+        config_provided = "{0}={1}".format(model, kwargs['mac'])
+
+    if kwargs['bridge']:
+        config_provided += ",bridge={0}".format(kwargs['bridge'])
+
+    if kwargs['firewall']:
+        config_provided += ",firewall=1"
+
+    if kwargs['link_down']:
+        config_provided += ',link_down=1'
+
+    if kwargs['mtu']:
+        config_provided += ",mtu={0}".format(kwargs['mtu'])
+
+    if kwargs['queues']:
+        config_provided += ",queues={0}".format(kwargs['queues'])
+
+    if kwargs['rate']:
+        config_provided += ",rate={0}".format(kwargs['rate'])
+
+    if kwargs['tag']:
+        config_provided += ",tag={0}".format(kwargs['tag'])
+
+    if kwargs['trunks']:
+        config_provided += ",trunks={0}".format(kwargs['trunks'])
+
+    net = {interface: config_provided}
+    vm = get_vm(proxmox, vmid)
+
+    if ((interface not in vminfo) or (vminfo[interface] != config_provided)):
+        if proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(**net) is None:
+            return True
+
+    return False
+
+
+def delete_nic(proxmox, vmid, interface):
+    vm = get_vm(proxmox, vmid)
+    vminfo = proxmox.nodes(vm[0]['node']).qemu(vmid).config.get()
+
+    if interface in vminfo:
+        if proxmox.nodes(vm[0]['node']).qemu(vmid).config.set(vmid=vmid, delete=interface) is None:
+            return True
+
+    return False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            api_host=dict(required=True),
+            api_password=dict(no_log=True, fallback=(env_fallback, ['PROXMOX_PASSWORD'])),
+            api_token_id=dict(no_log=True),
+            api_token_secret=dict(no_log=True),
+            api_user=dict(required=True),
+            bridge=dict(type='str'),
+            firewall=dict(type='bool', default=False),
+            interface=dict(type='str', required=True),
+            link_down=dict(type='bool', default=False),
+            mac=dict(type='str'),
+            model=dict(choices=['e1000', 'e1000-82540em', 'e1000-82544gc', 'e1000-82545em',
+                                'i82551', 'i82557b', 'i82559er', 'ne2k_isa', 'ne2k_pci', 'pcnet',
+                                'rtl8139', 'virtio', 'vmxnet3'], default='virtio'),
+            mtu=dict(type='int'),
+            name=dict(type='str'),
+            queues=dict(type='int'),
+            rate=dict(type='float'),
+            state=dict(default='present', choices=['present', 'absent']),
+            tag=dict(type='int'),
+            trunks=dict(type='str'),
+            validate_certs=dict(type='bool', default=False),
+            vmid=dict(type='int'),
+        ),
+        required_together=[('api_token_id', 'api_token_secret')],
+        required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
+    )
+
+    if not HAS_PROXMOXER:
+        module.fail_json(msg='proxmoxer required for this module')
+
+    api_host = module.params['api_host']
+    api_password = module.params['api_password']
+    api_token_id = module.params['api_token_id']
+    api_token_secret = module.params['api_token_secret']
+    api_user = module.params['api_user']
+    interface = module.params['interface']
+    model = module.params['model']
+    name = module.params['name']
+    state = module.params['state']
+    validate_certs = module.params['validate_certs']
+    vmid = module.params['vmid']
+
+    auth_args = {'user': api_user}
+    if not (api_token_id and api_token_secret):
+        auth_args['password'] = api_password
+    else:
+        auth_args['token_name'] = api_token_id
+        auth_args['token_value'] = api_token_secret
+
+    try:
+        proxmox = ProxmoxAPI(api_host, verify_ssl=validate_certs, **auth_args)
+    except Exception as e:
+        module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
+
+    # If vmid is not defined then retrieve its value from the vm name,
+    if not vmid:
+        try:
+            vmid = get_vmid(proxmox, name)[0]
+        except Exception:
+            module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
+
+    # Ensure VM id exists
+    if not get_vm(proxmox, vmid):
+        module.fail_json(vmid=vmid, msg='VM with vmid = %s does not exist in cluster' % vmid)
+
+    if state == 'present':
+        try:
+            if update_nic(module, proxmox, vmid, interface, model,
+                          bridge=module.params['bridge'],
+                          firewall=module.params['firewall'],
+                          link_down=module.params['link_down'],
+                          mac=module.params['mac'],
+                          mtu=module.params['mtu'],
+                          queues=module.params['queues'],
+                          rate=module.params['rate'],
+                          tag=module.params['tag'],
+                          trunks=module.params['trunks']):
+                module.exit_json(changed=True, vmid=vmid, msg="Nic {0} updated on VM with vmid {1}".format(interface, vmid))
+            else:
+                module.exit_json(vmid=vmid, msg="Nic {0} unchanged on VM with vmid {1}".format(interface, vmid))
+        except Exception as e:
+            module.fail_json(vmid=vmid, msg='Unable to change nic {0} on VM with vmid {1}: '.format(interface, vmid) + str(e))
+
+    elif state == 'absent':
+        try:
+            if delete_nic(proxmox, vmid, interface):
+                module.exit_json(changed=True, vmid=vmid, msg="Nic {0} deleted on VM with vmid {1}".format(interface, vmid))
+            else:
+                module.exit_json(vmid=vmid, msg="Nic {0} does not exit on Vm with vmid {1}".format(interface, vmid))
+        except Exception as e:
+            module.fail_json(vmid=vmid, msg='Unable to delete nic {0} on VM with vmid {1}: '.format(interface, vmid) + str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -1,0 +1,1 @@
+cloud/misc/proxmox_nic.py

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -48,7 +48,7 @@
     api_token_secret: "{{ api_token_secret | default(omit) }}"
     validate_certs: "{{ validate_certs }}"
   register: results
-  
+
 - assert:
     that:
     - results is not changed
@@ -225,6 +225,92 @@
         - results_action_current.status == 'running'
         - results_action_current.vmid == {{ vmid }}
         - results_action_current.msg == "VM test-instance with vmid = {{ vmid }} is running"
+
+- name: VM add/change/delete NIC
+  tags: [ 'nic' ]
+  block:
+    - name: Add NIC to test VM
+      proxmox_nic:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        vmid: "{{ vmid }}"
+        state: present
+        interface: net5
+        bridge: vmbr0
+        tag: 42
+      register: results
+
+    - assert:
+        that:
+        - results is changed
+        - results.vmid == {{ vmid }}
+        - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
+
+    - name: Update NIC no changes
+      proxmox_nic:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        vmid: "{{ vmid }}"
+        state: present
+        interface: net5
+        bridge: vmbr0
+        tag: 42
+      register: results
+
+    - assert:
+        that:
+        - results is not changed
+        - results.vmid == {{ vmid }}
+        - results.msg == "Nic net5 unchanged on VM with vmid {{ vmid }}"
+
+    - name: Update NIC with changes
+      proxmox_nic:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        vmid: "{{ vmid }}"
+        state: present
+        interface: net5
+        bridge: vmbr0
+        tag: 24
+        firewall: True
+      register: results
+
+    - assert:
+        that:
+        - results is changed
+        - results.vmid == {{ vmid }}
+        - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
+
+    - name: Delete NIC
+      proxmox_nic:
+        api_host: "{{ api_host }}"
+        api_user: "{{ user }}@{{ domain }}"
+        api_password: "{{ api_password | default(omit) }}"
+        api_token_id: "{{ api_token_id | default(omit) }}"
+        api_token_secret: "{{ api_token_secret | default(omit) }}"
+        validate_certs: "{{ validate_certs }}"
+        vmid: "{{ vmid }}"
+        state: absent
+        interface: net5
+      register: results
+
+    - assert:
+        that:
+        - results is changed
+        - results.vmid == {{ vmid }}
+        - results.msg == "Nic net5 deleted on VM with vmid {{ vmid }}"
 
 - name: VM stop
   tags: [ 'stop' ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add proxmox_nic module to manage NIC's on Qemu(KVM) VM's in a Proxmox VE cluster.
Update proxmox integration tests and add tests for proxmox_nic module.

This partially solves https://github.com/ansible-collections/community.general/issues/1964#issuecomment-790499397
and allows for adding/updating/deleting network interface cards after
creating/cloning a VM.

The proxmox_nic module will keep MAC-addresses the same when updating a NIC. 
It only changes when explicitly setting a MAC-address.

I've created a separate module for handling the NIC's instead of updating the proxmox_kvm.py module.
This is done because it allows for cleaner and more manageable code. One can now manage NIC's separately.
When retrieving the VM config for a proxmox VM every piece of config is returned in one big dictionary. 
To determine the changes in (possibly 32)  network-cards would have resulted in big and ugly for-loops.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_nic
