### PR TITLE
Avoid incorrectly marking zfs tasks as changed

### DIFF
--- a/changelogs/fragments/2454-detect_zfs_changed.yml
+++ b/changelogs/fragments/2454-detect_zfs_changed.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zfs - Certain ZFS properties, especially sizes, would lead to a task being falsely marked as "changed" even when no actual change was made. Resolves https://github.com/ansible-collections/community.general/issues/975 (https://github.com/ansible-collections/community.general/pull/2454)
+  - zfs - certain ZFS properties, especially sizes, would lead to a task being falsely marked as "changed" even when no actual change was made (https://github.com/ansible-collections/community.general/issues/975, https://github.com/ansible-collections/community.general/pull/2454).

--- a/changelogs/fragments/2454-detect_zfs_changed.yml
+++ b/changelogs/fragments/2454-detect_zfs_changed.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zfs - Certain ZFS properties, especially sizes, would lead to a task being falsely marked as "changed" even when no actual change was made
+  - zfs - Certain ZFS properties, especially sizes, would lead to a task being falsely marked as "changed" even when no actual change was made. Resolves https://github.com/ansible-collections/community.general/issues/975 (https://github.com/ansible-collections/community.general/pull/2454)

--- a/changelogs/fragments/2454-detect_zfs_changed.yml
+++ b/changelogs/fragments/2454-detect_zfs_changed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zfs - Certain ZFS properties, especially sizes, would lead to a task being falsely marked as "changed" even when no actual change was made

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -41,7 +41,8 @@ notes:
   - C(check_mode) is supported, but in certain situations it may report a task
     as changed that would not reported as changed if C(check_mode) were disabled.
     For example, this might occur when the zpool C(altroot) option is set or when
-    a size is written using human-readable notation such as C(1024M) or C(2G).
+    a size is written using human-readable notation, such as C(1M) or C(1024K),
+    instead of as an unqualified byte count, such as C(1048576).
 author:
 - Johan Wiren (@johanwiren)
 '''

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -203,7 +203,7 @@ class Zfs(object):
         for prop in self.properties:
             value = updated_properties.get(prop, None)
             if value is None:
-                self.module.fail_json(msg="zfsprop was not present after being successfully set: " + prop)
+                self.module.fail_json(msg="zfsprop was not present after being successfully set: %s" % prop)
             if current_properties.get(prop, None) != value:
                 self.changed = True
 

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -39,7 +39,7 @@ options:
     type: dict
 notes:
   - C(check_mode) is supported, but in certain situations it may report a task
-    as changed that would not reported as changed if C(check_mode) were disabled.
+    as changed that will not be reported as changed when C(check_mode) is disabled.
     For example, this might occur when the zpool C(altroot) option is set or when
     a size is written using human-readable notation, such as C(1M) or C(1024K),
     instead of as an unqualified byte count, such as C(1048576).

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -37,6 +37,11 @@ options:
       - A dictionary of zfs properties to be set.
       - See the zfs(8) man page for more information.
     type: dict
+notes:
+  - check_mode is supported, but in certain situations it may report a task
+    as changed that would not reported as changed if check_mode were disabled.
+    For example, this might occur when the zpool altroot option is set or when
+    a size is written using human-readable notation such as '1024M' or '2G'.
 author:
 - Johan Wiren (@johanwiren)
 '''

--- a/plugins/modules/storage/zfs/zfs.py
+++ b/plugins/modules/storage/zfs/zfs.py
@@ -38,10 +38,10 @@ options:
       - See the zfs(8) man page for more information.
     type: dict
 notes:
-  - check_mode is supported, but in certain situations it may report a task
-    as changed that would not reported as changed if check_mode were disabled.
-    For example, this might occur when the zpool altroot option is set or when
-    a size is written using human-readable notation such as '1024M' or '2G'.
+  - C(check_mode) is supported, but in certain situations it may report a task
+    as changed that would not reported as changed if C(check_mode) were disabled.
+    For example, this might occur when the zpool C(altroot) option is set or when
+    a size is written using human-readable notation such as C(1024M) or C(2G).
 author:
 - Johan Wiren (@johanwiren)
 '''


### PR DESCRIPTION
This change is inspired by https://github.com/ansible-collections/community.general/pull/502. I omitted the "diff mode" and focused on fixing the issue where the ZFS module incorrectly marks certain tasks as having been changed (also discussed in https://github.com/ansible-collections/community.general/issues/975)

For example, if a dataset has a quota of "1G" and the user changes it to "1024M", the actual quota vale has not changed, but since the module is doing a simple string comparison between "1G" and "1024M", it marks the step as "changed".

Instead of trying to handle all the corner cases of zfs (another example is when the zpool "altroot" property has been set, see https://github.com/ansible-collections/community.general/pull/502#discussion_r583994589), this change simply compares the output of "zfs-get" from before and after "zfs-set" is called

I tested this using the below playbook. Before this change, the `"1024M"` loop iteration was marked as changed on my machine. After the step, neither loop iteration is marked as changed.

``` yaml
---
- name: Test
  hosts: localhost
  become: yes
  become_method: sudo
  tasks:
    - name: Create dataset
      community.general.zfs:
        name: rpool/foobar
        state: present
        extra_zfs_properties:
          quota: "1G"

    - name: Update quota
      community.general.zfs:
        name: rpool/foobar
        state: present
        extra_zfs_properties:
          quota: "{{ item }}"
      loop:
        - "1024M"
        - "1G"
```
