### PR TITLE
Small Documentation Example Of Cask Leveraging

### DIFF
--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -127,7 +127,8 @@ EXAMPLES = '''
     state: present
     install_options: with-baz,enable-debug
 
-- community.general.homebrew:
+- name: Install formula foo with 'brew' from cask 
+  community.general.homebrew:
     name: homebrew/cask/foo
     state: present
 

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -10,10 +10,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.six import iteritems, string_types
-from ansible.module_utils.basic import AnsibleModule
-import re
-import os.path
 __metaclass__ = type
 
 
@@ -134,7 +130,7 @@ EXAMPLES = '''
 - name: Install formula foo with 'brew' from cask
   community.general.homebrew:
     name: homebrew/cask/foo
-    state: present
+    state: present 
 
 - name: Use ignored-pinned option while upgrading all
   community.general.homebrew:
@@ -163,6 +159,12 @@ changed_pkgs:
     sample: ['git', 'git-cola']
     version_added: '0.2.0'
 '''
+
+import os.path
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems, string_types
 
 
 # exceptions -------------------------------------------------------------- {{{
@@ -212,8 +214,7 @@ class Homebrew(object):
     '''
 
     INVALID_PATH_REGEX = _create_regex_group_complement(VALID_PATH_CHARS)
-    INVALID_BREW_PATH_REGEX = _create_regex_group_complement(
-        VALID_BREW_PATH_CHARS)
+    INVALID_BREW_PATH_REGEX = _create_regex_group_complement(VALID_BREW_PATH_CHARS)
     INVALID_PACKAGE_REGEX = _create_regex_group_complement(VALID_PACKAGE_CHARS)
     # /class regexes ----------------------------------------------- }}}
 
@@ -633,8 +634,7 @@ class Homebrew(object):
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
-            self.message = 'Package installed: {0}'.format(
-                self.current_package)
+            self.message = 'Package installed: {0}'.format(self.current_package)
             return True
         else:
             self.failed = True
@@ -756,8 +756,7 @@ class Homebrew(object):
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
-            self.message = 'Package uninstalled: {0}'.format(
-                self.current_package)
+            self.message = 'Package uninstalled: {0}'.format(self.current_package)
             return True
         else:
             self.failed = True
@@ -781,8 +780,7 @@ class Homebrew(object):
 
         if not self._current_package_is_installed():
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(
-                self.current_package)
+            self.message = 'Package not installed: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
@@ -809,8 +807,7 @@ class Homebrew(object):
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be linked: {0}.'.format(
-                self.current_package)
+            self.message = 'Package could not be linked: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
     def _link_packages(self):
@@ -830,8 +827,7 @@ class Homebrew(object):
 
         if not self._current_package_is_installed():
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(
-                self.current_package)
+            self.message = 'Package not installed: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
@@ -858,8 +854,7 @@ class Homebrew(object):
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be unlinked: {0}.'.format(
-                self.current_package)
+            self.message = 'Package could not be unlinked: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
     def _unlink_packages(self):
@@ -899,8 +894,7 @@ def main():
                 default=False,
                 aliases=["update-brew"],
                 type='bool',
-                deprecated_aliases=[
-                    dict(name='update-brew', version='5.0.0', collection_name='community.general')],
+                deprecated_aliases=[dict(name='update-brew', version='5.0.0', collection_name='community.general')],
             ),
             upgrade_all=dict(
                 default=False,
@@ -922,8 +916,7 @@ def main():
         supports_check_mode=True,
     )
 
-    module.run_command_environ_update = dict(
-        LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     p = module.params
 

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -127,6 +127,10 @@ EXAMPLES = '''
     state: present
     install_options: with-baz,enable-debug
 
+- community.general.homebrew:
+    name: homebrew/cask/foo
+    state: present
+
 - name: Use ignored-pinned option while upgrading all
   community.general.homebrew:
     upgrade_all: yes

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -10,6 +10,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils.basic import AnsibleModule
+import re
+import os.path
 __metaclass__ = type
 
 
@@ -127,7 +131,7 @@ EXAMPLES = '''
     state: present
     install_options: with-baz,enable-debug
 
-- name: Install formula foo with 'brew' from cask 
+- name: Install formula foo with 'brew' from cask
   community.general.homebrew:
     name: homebrew/cask/foo
     state: present
@@ -159,12 +163,6 @@ changed_pkgs:
     sample: ['git', 'git-cola']
     version_added: '0.2.0'
 '''
-
-import os.path
-import re
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems, string_types
 
 
 # exceptions -------------------------------------------------------------- {{{
@@ -214,7 +212,8 @@ class Homebrew(object):
     '''
 
     INVALID_PATH_REGEX = _create_regex_group_complement(VALID_PATH_CHARS)
-    INVALID_BREW_PATH_REGEX = _create_regex_group_complement(VALID_BREW_PATH_CHARS)
+    INVALID_BREW_PATH_REGEX = _create_regex_group_complement(
+        VALID_BREW_PATH_CHARS)
     INVALID_PACKAGE_REGEX = _create_regex_group_complement(VALID_PACKAGE_CHARS)
     # /class regexes ----------------------------------------------- }}}
 
@@ -634,7 +633,8 @@ class Homebrew(object):
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
-            self.message = 'Package installed: {0}'.format(self.current_package)
+            self.message = 'Package installed: {0}'.format(
+                self.current_package)
             return True
         else:
             self.failed = True
@@ -756,7 +756,8 @@ class Homebrew(object):
             self.changed_count += 1
             self.changed_pkgs.append(self.current_package)
             self.changed = True
-            self.message = 'Package uninstalled: {0}'.format(self.current_package)
+            self.message = 'Package uninstalled: {0}'.format(
+                self.current_package)
             return True
         else:
             self.failed = True
@@ -780,7 +781,8 @@ class Homebrew(object):
 
         if not self._current_package_is_installed():
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(self.current_package)
+            self.message = 'Package not installed: {0}.'.format(
+                self.current_package)
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
@@ -807,7 +809,8 @@ class Homebrew(object):
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be linked: {0}.'.format(self.current_package)
+            self.message = 'Package could not be linked: {0}.'.format(
+                self.current_package)
             raise HomebrewException(self.message)
 
     def _link_packages(self):
@@ -827,7 +830,8 @@ class Homebrew(object):
 
         if not self._current_package_is_installed():
             self.failed = True
-            self.message = 'Package not installed: {0}.'.format(self.current_package)
+            self.message = 'Package not installed: {0}.'.format(
+                self.current_package)
             raise HomebrewException(self.message)
 
         if self.module.check_mode:
@@ -854,7 +858,8 @@ class Homebrew(object):
             return True
         else:
             self.failed = True
-            self.message = 'Package could not be unlinked: {0}.'.format(self.current_package)
+            self.message = 'Package could not be unlinked: {0}.'.format(
+                self.current_package)
             raise HomebrewException(self.message)
 
     def _unlink_packages(self):
@@ -894,7 +899,8 @@ def main():
                 default=False,
                 aliases=["update-brew"],
                 type='bool',
-                deprecated_aliases=[dict(name='update-brew', version='5.0.0', collection_name='community.general')],
+                deprecated_aliases=[
+                    dict(name='update-brew', version='5.0.0', collection_name='community.general')],
             ),
             upgrade_all=dict(
                 default=False,
@@ -916,7 +922,8 @@ def main():
         supports_check_mode=True,
     )
 
-    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+    module.run_command_environ_update = dict(
+        LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     p = module.params
 

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -130,7 +130,7 @@ EXAMPLES = '''
 - name: Install formula foo with 'brew' from cask
   community.general.homebrew:
     name: homebrew/cask/foo
-    state: present 
+    state: present
 
 - name: Use ignored-pinned option while upgrading all
   community.general.homebrew:


### PR DESCRIPTION
- Just a lil' demo showing that we can utilize homebrew/cask/foo syntax
for given name of package to grab associated cask pacakge

Resolves: patch/sml-doc-example-update

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Was encountering issues leveraging "homebrew_cask" realized that "homebrew" can also preform in the similar manner if given a certain syntax with the "name" property - so decided to make a small example to maybe demonstrate the use of installing cask based packages with "homebrew" if so desired

Just a little doc/example update, that may/or/may-not be useful for someone.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
homebrew.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
