### PR TITLE
lxd_container: do not ignore volatile configs

### DIFF
--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -36,7 +36,6 @@ options:
             GET /1.0/containers/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
             are different, they this module tries to apply the configurations.
-          - The key starts with 'volatile.' are ignored for this comparison.
           - Not all config values are supported to apply the existing container.
             Maybe you need to delete and recreate a container.
         type: dict
@@ -557,8 +556,8 @@ class LXDContainerManagement(object):
     def _needs_to_change_container_config(self, key):
         if key not in self.config:
             return False
+        old_configs = self.old_container_json['metadata'][key]
         if key == 'config':
-            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:
                     return True
@@ -566,7 +565,6 @@ class LXDContainerManagement(object):
                     return True
             return False
         else:
-            old_configs = self.old_container_json['metadata'][key]
             return self.config[key] != old_configs
 
     def _needs_to_apply_container_configs(self):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Treat `volatile.` configs as any other configs. This prevents reporting change every time a `volatile.` config option is set in the task. That happens for instance when one wants to setup stable MAC address for a container, using config option `volatile.eth0.hwaddr`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxd_container

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Lets have this playbook:
```yaml
- hosts: localhost
  tasks:
    - name: Setup lxd containers
      lxd_container:
        name: test
        state: started
        config:
          volatile.eth0.hwaddr: "00:16:3e:ee:ca:fe"
        source:
          type: image
          mode: pull
          server: https://images.linuxcontainers.org
          protocol: simplestreams
          alias: ubuntu/focal
        profiles:
          - default
        wait_for_ipv4_addresses: true
```
Let's run it for the first time:
```console
$ lxd init --auto
$ ansible-playbook site.yaml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: packaging Python module unavailable; unable to validate collection
Ansible version requirements

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Setup lxd containers] ****************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Then run it again:
```console
$ ansible-playbook site.yaml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: packaging Python module unavailable; unable to validate collection
Ansible version requirements

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Setup lxd containers] ****************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
After this change, any subsequent runs will not report change, like this:
```console
$ ansible-playbook site.yaml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: packaging Python module unavailable; unable to validate collection
Ansible version requirements

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Setup lxd containers] ****************************************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```