### PR TITLE
Update influxdb_user.py Fixed Multiple No Privileges

### DIFF
--- a/changelogs/fragments/2499-influxdb_user-fix-multiple-no-privileges.yml
+++ b/changelogs/fragments/2499-influxdb_user-fix-multiple-no-privileges.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - influxdb_user - fix bug where an influxdb user has no privileges for 2 or more databases (https://github.com/ansible-collections/community.general/pull/2499).

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -173,7 +173,7 @@ def set_user_grants(module, client, user_name, grants):
                 if v['privilege'] == 'ALL PRIVILEGES':
                     v['privilege'] = 'ALL'
                 parsed_grants.add(v)
-                
+
         # check if the current grants are included in the desired ones
         for current_grant in parsed_grants:
             if current_grant not in grants:

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -173,8 +173,7 @@ def set_user_grants(module, client, user_name, grants):
                 if v['privilege'] == 'ALL PRIVILEGES':
                     v['privilege'] = 'ALL'
                 parsed_grants.add(v)
-
-
+                
         # check if the current grants are included in the desired ones
         for current_grant in parsed_grants:
             if current_grant not in grants:

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -166,16 +166,17 @@ def set_user_grants(module, client, user_name, grants):
 
     try:
         current_grants = client.get_list_privileges(user_name)
+        parsed_grants = []
         # Fix privileges wording
         for i, v in enumerate(current_grants):
-            if v['privilege'] == 'ALL PRIVILEGES':
-                v['privilege'] = 'ALL'
-                current_grants[i] = v
-            elif v['privilege'] == 'NO PRIVILEGES':
-                del(current_grants[i])
+            if v['privilege'] != 'NO PRIVILEGES':
+                if v['privilege'] == 'ALL PRIVILEGES':
+                    v['privilege'] = 'ALL'
+                parsed_grants.add(v)
+
 
         # check if the current grants are included in the desired ones
-        for current_grant in current_grants:
+        for current_grant in parsed_grants:
             if current_grant not in grants:
                 if not module.check_mode:
                     client.revoke_privilege(current_grant['privilege'],
@@ -185,7 +186,7 @@ def set_user_grants(module, client, user_name, grants):
 
         # check if the desired grants are included in the current ones
         for grant in grants:
-            if grant not in current_grants:
+            if grant not in parsed_grants:
                 if not module.check_mode:
                     client.grant_privilege(grant['privilege'],
                                            grant['database'],


### PR DESCRIPTION
**SUMMARY**
The current implementation iterates through the grants and removes the NO PRIVILEGE entries in the list.

However if a user has no privileges to 2 or more influx databases, the list will change size and there will always be 1 remaining NO PRIVILEGE entry in the list. This will result in an exception (error parsing query: found NO, expected READ, WRITE, ALL [PRIVILEGES] at line 1) when trying to revoke this privilege.

My proposed solution is to create a new list that excludes the NO PRIVILEGES entries in the first place.

**ISSUE TYPE**
Bugfix Pull Request

**COMPONENT NAME**
influxdb_user

**ADDITIONAL INFORMATION**
To replicate:

Create 2 or more influx databases
Add influx User