### PR TITLE
Add option 'missing' to passwordstore lookup

### DIFF
--- a/changelogs/fragments/2500-passwordstore-add_option_ignore_missing.yml
+++ b/changelogs/fragments/2500-passwordstore-add_option_ignore_missing.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - passwordstore lookup - add option ``missing`` to choose what to do if the password file is missing
+    (https://github.com/ansible-collections/community.general/pull/2500).

--- a/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -61,6 +61,37 @@
     that:
       - readpass == newpass
 
+- name: Create a password using missing=create
+  set_fact:
+    newpass: "{{ lookup('community.general.passwordstore', 'test-missing-create missing=create length=8') }}"
+
+- name: Fetch password from an existing file
+  set_fact:
+    readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create') }}"
+
+- name: Verify password
+  assert:
+    that:
+      - readpass == newpass
+
+- name: Fetch password from existing file using missing=empty
+  set_fact:
+    readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create missing=empty') }}"
+
+- name: Verify password
+  assert:
+    that:
+      - readpass == newpass
+
+- name: Fetch password from non-existing file using missing=empty
+  set_fact:
+    readpass: "{{ query('community.general.passwordstore', 'test-missing-pass missing=empty') }}"
+
+- name: Verify password
+  assert:
+    that:
+      - readpass == [ none ]
+
 # As inserting multiline passwords on the commandline would require something
 # like expect, simply create it by using default gpg on a file with the correct
 # structure.


### PR DESCRIPTION
##### SUMMARY
Add ability to ignore error on missing pass file to allow processing the
output further via another filters (mainly the default filter) without
updating the pass file itself.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/lookup/passwordstore.py

##### ADDITIONAL INFORMATION
It is currently impossible to use the default filter to handle non-existent pass files if one uses read-only password store. This PR should fix that. This adds the ability to do following:
```paste below
- set_fact:
    secret: "{{ lookup('passwordstore', 'secret ignore_missing=true') | default(default_secret, true) }}"                                                                                                  
```
