### PR TITLE
proxmox_nic: set mtu on interface even if it's not virtio

### DIFF
--- a/changelogs/fragments/2505-proxmox_nic-set_mtu_on_interface_even_not_virtio.yml
+++ b/changelogs/fragments/2505-proxmox_nic-set_mtu_on_interface_even_not_virtio.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - proxmox_nic - set mtu on interface even if it is not virtio(https://github.com/ansible-collections/community.general/pull/2505).

--- a/changelogs/fragments/2505-proxmox_nic-set_mtu_on_interface_even_not_virtio.yml
+++ b/changelogs/fragments/2505-proxmox_nic-set_mtu_on_interface_even_not_virtio.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_nic - set mtu on interface even if it is not virtio(https://github.com/ansible-collections/community.general/pull/2505).

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -211,9 +211,8 @@ def update_nic(module, proxmox, vmid, interface, model, **kwargs):
         config_provided += ',link_down=1'
 
     if kwargs['mtu']:
-        if model == 'virtio':
-            config_provided += ",mtu={0}".format(kwargs['mtu'])
-        else:
+        config_provided += ",mtu={0}".format(kwargs['mtu'])
+        if model != 'virtio':
             module.warn(
                 'Ignoring MTU for nic {0} on VM with vmid {1}, '
                 'model should be set to \'virtio\': '.format(interface, vmid))


### PR DESCRIPTION
##### SUMMARY
I missed adding a comment about setting `mtu`. Again! :(
@Kogelvis First let me apologize for bugging you again and again on this option multiple times.
Even after #2449 has been merged :)

But do you think module should set `mtu` on proxmox nic and warn instead of just warning?
I know that this does not have any effect, but as you have said and tested proxmox allows setting this on other models which are not `virtio` although they don't work. Why shouldn't this module do this too?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox_nic.py