### PR TITLE
jenkins_plugin: HTTP Error 405: Method Not Allowed on disable/enable plugin #2510

### DIFF
--- a/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
+++ b/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - jenkins_plugin - Use POST method for sending request to jenkins API when ``state`` option is ``enabled`` or ``disabled`` (https://github.com/ansible-collections/community.general/issues/2510).
+  - jenkins_plugin - use POST method for sending request to jenkins API when ``state`` option is one of ``enabled``, ``disabled``, ``pinned``, ``unpinned``, or ``absent`` (https://github.com/ansible-collections/community.general/issues/2510).

--- a/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
+++ b/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - jenkins_plugin - Use POST method for enable/disable request to jenkins api (https://github.com/ansible-collections/community.general/issues/2510)
+  - jenkins_plugin - Use POST method for sending request to jenkins API when ``state`` option is ``enabled`` or ``disabled`` (https://github.com/ansible-collections/community.general/issues/2510).

--- a/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
+++ b/changelogs/fragments/2510-jenkins_plugin_use_post_method.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - jenkins_plugin - Use POST method for enable/disable request to jenkins api (https://github.com/ansible-collections/community.general/issues/2510)

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -696,7 +696,8 @@ class JenkinsPlugin(object):
         self._get_url_data(
             url,
             msg_status="Plugin not found. %s" % url,
-            msg_exception="%s has failed." % msg)
+            msg_exception="%s has failed." % msg,
+            method="POST")
 
 
 def main():


### PR DESCRIPTION
Jenkins makeEnable/makeDisable api requests requires to use POST method

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2510 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jenkins_plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
