### PR TITLE
ModuleHelper - better mechanism for customizing "changed" behaviour

### DIFF
--- a/changelogs/fragments/2514-mh-improved-changed.yml
+++ b/changelogs/fragments/2514-mh-improved-changed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ModuleHelper module utils - improved mechanism for customizing the calculation of ``changed`` (https://github.com/ansible-collections/community.general/pull/2514).

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -34,7 +34,7 @@ class ModuleHelperBase(object):
         pass
 
     def __changed__(self):
-        return NotImplementedError()
+        raise NotImplementedError()
 
     @property
     def changed(self):

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -33,9 +33,15 @@ class ModuleHelperBase(object):
     def __quit_module__(self):
         pass
 
+    def __changed__(self):
+        return NotImplementedError()
+
     @property
     def changed(self):
-        return self._changed
+        try:
+            return self.__changed__()
+        except NotImplementedError:
+            return self._changed
 
     @changed.setter
     def changed(self, value):


### PR DESCRIPTION
##### SUMMARY
Instead of overriding the `changed` property, by implementing a `__changed__()` method it gets automatically used.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py

