### PR TITLE
java_keystore: fix keystore type

### DIFF
--- a/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
+++ b/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - "java_keystore - explicit destination store type ``jks``
-    (https://github.com/ansible-collections/community.general/issues/2515)."
+  - "java_keystore - add parameter ``keystore_type`` to control output file format and override ``keytool`` default
+    type, that depends on Java version (https://github.com/ansible-collections/community.general/issues/2515)."

--- a/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
+++ b/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "java_keystore - explicit destination store type ``jks``
+    (https://github.com/ansible-collections/community.general/issues/2515)."

--- a/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
+++ b/changelogs/fragments/2516_fix_2515_keystore_type_jks.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - "java_keystore - add parameter ``keystore_type`` to control output file format and override ``keytool`` default
-    type, that depends on Java version (https://github.com/ansible-collections/community.general/issues/2515)."
+  - "java_keystore - add parameter ``keystore_type`` to control output file format and override ``keytool``'s
+    default, which depends on Java version (https://github.com/ansible-collections/community.general/issues/2515)."

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -516,11 +516,12 @@ def hex_decode(s):
     return s.hex()
 
 
-class ArgumentSpec:
-    def __init__(self):
-        self.supports_check_mode = True
-        self.add_file_common_args = True
-        argument_spec = dict(
+def main():
+    choose_between = (['certificate', 'certificate_path'],
+                      ['private_key', 'private_key_path'])
+
+    module = AnsibleModule(
+        argument_spec=dict(
             name=dict(type='str', required=True),
             dest=dict(type='path', required=True),
             certificate=dict(type='str', no_log=True),
@@ -532,24 +533,11 @@ class ArgumentSpec:
             ssl_backend=dict(type='str', default='openssl', choices=['openssl', 'cryptography']),
             keystore_type=dict(type='str', choices=['jks', 'pkcs12']),
             force=dict(type='bool', default=False),
-        )
-        choose_between = (
-            ['certificate', 'certificate_path'],
-            ['private_key', 'private_key_path'],
-        )
-        self.argument_spec = argument_spec
-        self.required_one_of = choose_between
-        self.mutually_exclusive = choose_between
-
-
-def main():
-    spec = ArgumentSpec()
-    module = AnsibleModule(
-        argument_spec=spec.argument_spec,
-        required_one_of=spec.required_one_of,
-        mutually_exclusive=spec.mutually_exclusive,
-        supports_check_mode=spec.supports_check_mode,
-        add_file_common_args=spec.add_file_common_args,
+        ),
+        required_one_of=choose_between,
+        mutually_exclusive=choose_between,
+        supports_check_mode=True,
+        add_file_common_args=True,
     )
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
 

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -425,6 +425,7 @@ class JavaKeystore:
 
         import_keystore_cmd = [self.keytool_bin, "-importkeystore",
                                "-destkeystore", self.keystore_path,
+                               "-deststoretype", "jks",
                                "-srckeystore", keystore_p12_path,
                                "-srcstoretype", "pkcs12",
                                "-alias", self.name,

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -335,7 +335,7 @@ class JavaKeystore:
                 rc=rc
             )
 
-        if self.keystore_type not in (None, self.is_jks_or_pkcs12()):
+        if self.keystore_type not in (None, self.current_type()):
             return "keystore type mismatch"
 
         stored_certificate_match = re.search(r"SHA256: ([\w:]+)", stored_certificate_fingerprint_out)
@@ -348,7 +348,7 @@ class JavaKeystore:
 
         return stored_certificate_match.group(1)
 
-    def is_jks_or_pkcs12(self):
+    def current_type(self):
         magic_bytes = b'\xfe\xed\xfe\xed'
         with open(self.keystore_path, 'rb') as fd:
             header = fd.read(4)

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -97,6 +97,23 @@ options:
       - openssl
       - cryptography
     version_added: 3.1.0
+  keystore_type:
+    description:
+      - Type of the Java keystore.
+      - When this option is omitted and the keystore doesn't already exist, the
+        behavior is to follow C(keytool) default store type, that depends on
+        Java version, and is C(pkcs12) since Java 9, and C(jks) before (may also
+        be C(pkcs12) if new default has been backported to this version).
+      - When this option is omitted and the keystore already exists, the current
+        type is left untouched, unless another option leads to overwrite the
+        keystore (in that case, this option behaves like for keystore creation).
+      - When I(keystore_type) is set, the keystore is created with this type if
+        it doesn't exist, or is converted to the given type in case of mismatch.
+    type: str
+    choices:
+      - jks
+      - pkcs12
+    version_added: 3.2.0
 requirements:
   - openssl in PATH (when I(ssl_backend=openssl))
   - keytool in PATH
@@ -107,6 +124,7 @@ author:
 extends_documentation_fragment:
   - files
 seealso:
+  - module: community.crypto.openssl_pkcs12
   - module: community.general.java_cert
 notes:
   - I(certificate) and I(private_key) require that their contents are available

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -351,15 +351,10 @@ class JavaKeystore:
         return stored_certificate_match.group(1)
 
     def is_jks_or_pkcs12(self):
+        magic_bytes = b'\xfe\xed\xfe\xed'
         with open(self.keystore_path, 'rb') as fd:
-            content = fd.read()
-        try:
-            magic_bytes = bytes('\xfe\xed\xfe\xed')
-            is_jks = content.startswith(magic_bytes)
-        except TypeError:
-            magic_bytes = bytes([0xFE, 0xED, 0xFE, 0xED])
-            is_jks = content.startswith(magic_bytes)
-        if is_jks:
+            header = fd.read(4)
+        if header == magic_bytes:
             return 'jks'
         return 'pkcs12'
 

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -335,10 +335,8 @@ class JavaKeystore:
                 rc=rc
             )
 
-        if self.keystore_type is not None:
-            keystore_type = self.is_jks_or_pkcs12()
-            if keystore_type != self.keystore_type:
-                return "keystore type mismatch"
+        if self.keystore_type not in (None, self.is_jks_or_pkcs12()):
+            return "keystore type mismatch"
 
         stored_certificate_match = re.search(r"SHA256: ([\w:]+)", stored_certificate_fingerprint_out)
         if not stored_certificate_match:

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -492,7 +492,6 @@ class JavaKeystore:
         keystore_backup = None
         if self.exists():
             keystore_backup = self.keystore_path + '.tmpbak'
-            self.module.add_cleanup_file(keystore_backup)
             # Preserve properties of the source file
             self.module.preserved_copy(self.keystore_path, keystore_backup)
             os.remove(self.keystore_path)
@@ -507,10 +506,13 @@ class JavaKeystore:
         if rc != 0 or not self.exists():
             if keystore_backup is not None:
                 self.module.preserved_copy(keystore_backup, self.keystore_path)
+                os.remove(keystore_backup)
             self.result['err'] = import_keystore_err
             return self.module.fail_json(**self.result)
 
         self.update_permissions()
+        if keystore_backup is not None:
+            os.remove(keystore_backup)
         self.result['changed'] = True
         return self.result
 

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -101,8 +101,8 @@ options:
     description:
       - Type of the Java keystore.
       - When this option is omitted and the keystore doesn't already exist, the
-        behavior is to follow C(keytool) default store type, that depends on
-        Java version, and is C(pkcs12) since Java 9, and C(jks) before (may also
+        behavior follows C(keytool)'s default store type which depends on
+        Java version; C(pkcs12) since Java 9 and C(jks) prior (may also
         be C(pkcs12) if new default has been backported to this version).
       - When this option is omitted and the keystore already exists, the current
         type is left untouched, unless another option leads to overwrite the
@@ -133,8 +133,8 @@ notes:
     while I(certificate_path) and I(private_key_path) require that the files are
     available on the target host.
   - By design, any change of a value of options I(keystore_type), I(name) or
-    I(password), as well as changes of key or certificate materials lead to the
-    overwriting of the existing I(dest).
+    I(password), as well as changes of key or certificate materials will cause
+    the existing I(dest) to be overwritten.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -179,7 +179,7 @@ msg:
   sample: "Unable to find the current certificate fingerprint in ..."
 
 err:
-  description: Output from stderr of keytool/openssl command after execution of given command or an error.
+  description: Output from stderr of keytool/openssl command after error of given command.
   returned: failure
   type: str
   sample: "Keystore password is too short - must be at least 6 characters\n"
@@ -513,7 +513,6 @@ class JavaKeystore:
         self.update_permissions()
         self.result['changed'] = True
         return self.result
-
 
     def exists(self):
         return os.path.exists(self.keystore_path)

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -110,7 +110,6 @@
     password: hunter2
     keystore_type: jks
   loop: "{{ java_keystore_new_certs }}"
-  check_mode: yes
   register: result_type_jks
 
 
@@ -149,7 +148,6 @@
     name: foobar
     password: hunter2
   loop: "{{ java_keystore_new_certs }}"
-  check_mode: yes
   register: result_type_omit
 
 

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -93,6 +93,16 @@
   register: result_pw_change
 
 
+- name: Create a Java keystore for the given certificates (force keystore type pkcs12, check mode)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+    keystore_type: pkcs12
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_pkcs12_check
+
 - name: Create a Java keystore for the given certificates (force keystore type jks, check mode)
   community.general.java_keystore:
     <<: *java_keystore_params
@@ -179,8 +189,10 @@
       - result_pw_change is changed
       - result_pw_change_check is changed
       # We don't know if we start from jks or pkcs12 format, anyway check mode
-      # and actual mode must return the same 'changed' state
-      - result_type_jks.changed == result_type_jks_check.changed
+      # and actual mode must return the same 'changed' state, and 'jks' and
+      # 'pkcs12' must give opposite results on a same host.
+      - result_type_jks_check.changed != result_type_pkcs12_check.changed
+      - result_type_jks_check.changed == result_type_jks.changed
       - result_type_change is changed
       - result_type_change_check is changed
       - result_type_omit is not changed

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -123,6 +123,29 @@
   register: result_type_jks
 
 
+- name: Stat keystore (before failure)
+  ansible.builtin.stat:
+    path: "{{ output_dir ~ '/' ~ (item.keyname | d(item.name)) ~ '.jks' }}"
+  loop: "{{ java_keystore_new_certs }}"
+  register: result_stat_before
+
+- name: Fail to create a Java keystore for the given certificates (password too short)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: short
+    keystore_type: jks
+  loop: "{{ java_keystore_new_certs }}"
+  register: result_fail_jks
+  ignore_errors: true
+
+- name: Stat keystore (after failure)
+  ansible.builtin.stat:
+    path: "{{ output_dir ~ '/' ~ (item.keyname | d(item.name)) ~ '.jks' }}"
+  loop: "{{ java_keystore_new_certs }}"
+  register: result_stat_after
+
+
 - name: Create a Java keystore for the given certificates (keystore type changed, check mode)
   community.general.java_keystore:
     <<: *java_keystore_params
@@ -188,12 +211,25 @@
       - result_alias_change_check is changed
       - result_pw_change is changed
       - result_pw_change_check is changed
+
       # We don't know if we start from jks or pkcs12 format, anyway check mode
       # and actual mode must return the same 'changed' state, and 'jks' and
       # 'pkcs12' must give opposite results on a same host.
       - result_type_jks_check.changed != result_type_pkcs12_check.changed
       - result_type_jks_check.changed == result_type_jks.changed
+
       - result_type_change is changed
       - result_type_change_check is changed
       - result_type_omit is not changed
       - result_type_omit_check is not changed
+
+      # keystore properties must remain the same after failure
+      - result_fail_jks is failed
+      - result_stat_before.results[0].stat.uid == result_stat_after.results[0].stat.uid
+      - result_stat_before.results[1].stat.uid == result_stat_after.results[1].stat.uid
+      - result_stat_before.results[0].stat.gid == result_stat_after.results[0].stat.gid
+      - result_stat_before.results[1].stat.gid == result_stat_after.results[1].stat.gid
+      - result_stat_before.results[0].stat.mode == result_stat_after.results[0].stat.mode
+      - result_stat_before.results[1].stat.mode == result_stat_after.results[1].stat.mode
+      - result_stat_before.results[0].stat.checksum == result_stat_after.results[0].stat.checksum
+      - result_stat_before.results[1].stat.checksum == result_stat_after.results[1].stat.checksum

--- a/tests/integration/targets/java_keystore/tasks/tests.yml
+++ b/tests/integration/targets/java_keystore/tasks/tests.yml
@@ -24,6 +24,7 @@
     private_key_passphrase: "{{ item.passphrase | d(omit) }}"
     password: changeit
     ssl_backend: "{{ ssl_backend }}"
+    keystore_type: "{{ item.keystore_type | d(omit) }}"
   loop: "{{ java_keystore_certs }}"
   check_mode: yes
   register: result_check
@@ -91,6 +92,67 @@
   loop: "{{ java_keystore_new_certs }}"
   register: result_pw_change
 
+
+- name: Create a Java keystore for the given certificates (force keystore type jks, check mode)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+    keystore_type: jks
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_jks_check
+
+- name: Create a Java keystore for the given certificates (force keystore type jks)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+    keystore_type: jks
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_jks
+
+
+- name: Create a Java keystore for the given certificates (keystore type changed, check mode)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+    keystore_type: pkcs12
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_change_check
+
+- name: Create a Java keystore for the given certificates (keystore type changed)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+    keystore_type: pkcs12
+  loop: "{{ java_keystore_new_certs }}"
+  register: result_type_change
+
+
+- name: Create a Java keystore for the given certificates (omit keystore type, check mode)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_omit_check
+
+- name: Create a Java keystore for the given certificates (omit keystore type)
+  community.general.java_keystore:
+    <<: *java_keystore_params
+    name: foobar
+    password: hunter2
+  loop: "{{ java_keystore_new_certs }}"
+  check_mode: yes
+  register: result_type_omit
+
+
 - name: Check that the remote certificates have not been removed
   ansible.builtin.file:
     path: "{{ output_dir ~ '/' ~ item.name ~ '.pem' }}"
@@ -118,3 +180,10 @@
       - result_alias_change_check is changed
       - result_pw_change is changed
       - result_pw_change_check is changed
+      # We don't know if we start from jks or pkcs12 format, anyway check mode
+      # and actual mode must return the same 'changed' state
+      - result_type_jks.changed == result_type_jks_check.changed
+      - result_type_change is changed
+      - result_type_change_check is changed
+      - result_type_omit is not changed
+      - result_type_omit_check is not changed

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -180,7 +180,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             jks = JavaKeystore(module)
             jks.create()
             module.fail_json.assert_called_once_with(
-                changed=true,
+                changed=True,
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -28,6 +28,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
         self.mock_create_path = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_path')
+        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.is_jks_or_pkcs12')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
         self.mock_os_path_exists = patch('os.path.exists',
@@ -40,6 +41,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.get_bin_path = self.mock_get_bin_path.start()
         self.create_file = self.mock_create_file.start()
         self.create_path = self.mock_create_path.start()
+        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
         self.selinux_context = self.mock_selinux_context.start()
         self.is_special_selinux_path = self.mock_is_special_selinux_path.start()
         self.os_path_exists = self.mock_os_path_exists.start()
@@ -49,6 +51,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         super(TestCreateJavaKeystore, self).tearDown()
         self.mock_create_file.stop()
         self.mock_create_path.stop()
+        self.mock_is_jks_or_pkcs12.stop()
         self.mock_run_command.stop()
         self.mock_get_bin_path.stop()
         self.mock_selinux_context.stop()
@@ -198,8 +201,10 @@ class TestCertChanged(ModuleTestCase):
         super(TestCertChanged, self).setUp()
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
+        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.is_jks_or_pkcs12')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
         self.run_command = self.mock_run_command.start()
         self.create_file = self.mock_create_file.start()
         self.get_bin_path = self.mock_get_bin_path.start()
@@ -208,6 +213,7 @@ class TestCertChanged(ModuleTestCase):
         """Teardown."""
         super(TestCertChanged, self).tearDown()
         self.mock_create_file.stop()
+        self.mock_is_jks_or_pkcs12.stop()
         self.mock_run_command.stop()
         self.mock_get_bin_path.stop()
 
@@ -229,6 +235,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/placeholder', '']
             self.run_command.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: abcd:1234:efgh', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
+            self.is_jks_or_pkcs12.side_effect = ['jks']
             jks = JavaKeystore(module)
             result = jks.cert_changed()
             self.assertFalse(result, 'Fingerprint is identical')
@@ -251,6 +258,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/placeholder', '']
             self.run_command.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: wxyz:9876:stuv', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
+            self.is_jks_or_pkcs12.side_effect = ['jks']
             jks = JavaKeystore(module)
             result = jks.cert_changed()
             self.assertTrue(result, 'Fingerprint mismatch')
@@ -322,6 +330,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/tmpdj6bvvme', '']
             self.run_command.side_effect = [(1, '', 'Oops'), (0, 'SHA256: wxyz:9876:stuv', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
+            self.is_jks_or_pkcs12.side_effect = ['jks']
             jks = JavaKeystore(module)
             jks.cert_changed()
             module.fail_json.assert_called_once_with(

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -78,7 +78,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             assert jks.create() == {
                 'changed': True,
                 'cmd': ["keytool", "-importkeystore",
-                        "-destkeystore", "/path/to/keystore.jks", "-deststoretype", "jks",
+                        "-destkeystore", "/path/to/keystore.jks",
                         "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
                         "-noprompt"],
                 'msg': '',
@@ -181,7 +181,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             jks.create()
             module.fail_json.assert_called_once_with(
                 cmd=["keytool", "-importkeystore",
-                     "-destkeystore", "/path/to/keystore.jks", "-deststoretype", "jks",
+                     "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
                      "-noprompt"],
                 msg='',

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -78,7 +78,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             assert jks.create() == {
                 'changed': True,
                 'cmd': ["keytool", "-importkeystore",
-                        "-destkeystore", "/path/to/keystore.jks",
+                        "-destkeystore", "/path/to/keystore.jks", "-deststoretype", "jks",
                         "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
                         "-noprompt"],
                 'msg': '',
@@ -181,7 +181,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             jks.create()
             module.fail_json.assert_called_once_with(
                 cmd=["keytool", "-importkeystore",
-                     "-destkeystore", "/path/to/keystore.jks",
+                     "-destkeystore", "/path/to/keystore.jks", "-deststoretype", "jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
                      "-noprompt"],
                 msg='',
@@ -254,7 +254,7 @@ class TestCertChanged(ModuleTestCase):
             result = jks.cert_changed()
             self.assertTrue(result, 'Fingerprint mismatch')
 
-    def test_cert_changed_fail_alias_does_not_exist(self):
+    def test_cert_changed_alias_does_not_exist(self):
         set_module_args(dict(
             certificate='cert-foo',
             private_key='private-foo',

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -183,7 +183,6 @@ class TestCreateJavaKeystore(ModuleTestCase):
             jks = JavaKeystore(module)
             jks.create()
             module.fail_json.assert_called_once_with(
-                changed=True,
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -180,6 +180,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
             jks = JavaKeystore(module)
             jks.create()
             module.fail_json.assert_called_once_with(
+                changed=true,
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -28,7 +28,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
         self.mock_create_path = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_path')
-        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.is_jks_or_pkcs12')
+        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.is_jks_or_pkcs12')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
         self.mock_os_path_exists = patch('os.path.exists',
@@ -201,13 +201,13 @@ class TestCertChanged(ModuleTestCase):
         super(TestCertChanged, self).setUp()
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
-        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.is_jks_or_pkcs12')
+        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.is_jks_or_pkcs12')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
-        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
         self.run_command = self.mock_run_command.start()
         self.create_file = self.mock_create_file.start()
         self.get_bin_path = self.mock_get_bin_path.start()
+        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
 
     def tearDown(self):
         """Teardown."""

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -28,7 +28,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
         self.mock_create_path = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_path')
-        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.is_jks_or_pkcs12')
+        self.mock_current_type = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.current_type')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
         self.mock_os_path_exists = patch('os.path.exists',
@@ -41,7 +41,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         self.get_bin_path = self.mock_get_bin_path.start()
         self.create_file = self.mock_create_file.start()
         self.create_path = self.mock_create_path.start()
-        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
+        self.current_type = self.mock_current_type.start()
         self.selinux_context = self.mock_selinux_context.start()
         self.is_special_selinux_path = self.mock_is_special_selinux_path.start()
         self.os_path_exists = self.mock_os_path_exists.start()
@@ -51,7 +51,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
         super(TestCreateJavaKeystore, self).tearDown()
         self.mock_create_file.stop()
         self.mock_create_path.stop()
-        self.mock_is_jks_or_pkcs12.stop()
+        self.mock_current_type.stop()
         self.mock_run_command.stop()
         self.mock_get_bin_path.stop()
         self.mock_selinux_context.stop()
@@ -201,19 +201,19 @@ class TestCertChanged(ModuleTestCase):
         super(TestCertChanged, self).setUp()
         self.spec = ArgumentSpec()
         self.mock_create_file = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.create_file')
-        self.mock_is_jks_or_pkcs12 = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.is_jks_or_pkcs12')
+        self.mock_current_type = patch('ansible_collections.community.general.plugins.modules.system.java_keystore.JavaKeystore.current_type')
         self.mock_run_command = patch('ansible.module_utils.basic.AnsibleModule.run_command')
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
         self.run_command = self.mock_run_command.start()
         self.create_file = self.mock_create_file.start()
         self.get_bin_path = self.mock_get_bin_path.start()
-        self.is_jks_or_pkcs12 = self.mock_is_jks_or_pkcs12.start()
+        self.current_type = self.mock_current_type.start()
 
     def tearDown(self):
         """Teardown."""
         super(TestCertChanged, self).tearDown()
         self.mock_create_file.stop()
-        self.mock_is_jks_or_pkcs12.stop()
+        self.mock_current_type.stop()
         self.mock_run_command.stop()
         self.mock_get_bin_path.stop()
 
@@ -235,7 +235,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/placeholder', '']
             self.run_command.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: abcd:1234:efgh', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
-            self.is_jks_or_pkcs12.side_effect = ['jks']
+            self.current_type.side_effect = ['jks']
             jks = JavaKeystore(module)
             result = jks.cert_changed()
             self.assertFalse(result, 'Fingerprint is identical')
@@ -258,7 +258,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/placeholder', '']
             self.run_command.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: wxyz:9876:stuv', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
-            self.is_jks_or_pkcs12.side_effect = ['jks']
+            self.current_type.side_effect = ['jks']
             jks = JavaKeystore(module)
             result = jks.cert_changed()
             self.assertTrue(result, 'Fingerprint mismatch')
@@ -330,7 +330,7 @@ class TestCertChanged(ModuleTestCase):
             self.create_file.side_effect = ['/tmp/tmpdj6bvvme', '']
             self.run_command.side_effect = [(1, '', 'Oops'), (0, 'SHA256: wxyz:9876:stuv', '')]
             self.get_bin_path.side_effect = ['keytool', 'openssl', '']
-            self.is_jks_or_pkcs12.side_effect = ['jks']
+            self.current_type.side_effect = ['jks']
             jks = JavaKeystore(module)
             jks.cert_changed()
             module.fail_json.assert_called_once_with(


### PR DESCRIPTION
##### SUMMARY

This PR ensures the created keystore is of type JKS by adding an explicit `-deststoretype jks` (needed with keytool from OpenJDK 11)

Fixes #2515 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

java_keystore