### PR TITLE
ModuleHelper - cmd params now taken from self.vars instead of self.module.params

### DIFF
--- a/changelogs/fragments/2517-cmd-params-from-vars.yml
+++ b/changelogs/fragments/2517-cmd-params-from-vars.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cmd (Module Helper) module utils - ``CmdMixin`` now pulls the value for ``run_command()`` params from ``self.vars``, as opposed to previously retrieving those from ``self.module.params``.
+  - cmd (Module Helper) module utils - ``CmdMixin`` now pulls the value for ``run_command()`` params from ``self.vars``, as opposed to previously retrieving those from ``self.module.params`` (https://github.com/ansible-collections/community.general/pull/2517).

--- a/changelogs/fragments/2517-cmd-params-from-vars.yml
+++ b/changelogs/fragments/2517-cmd-params-from-vars.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cmd (Module Helper) module utils - ``CmdMixin`` now pulls the value for ``run_command()`` params from ``self.vars``, as opposed to previously retrieving those from ``self.module.params``.

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -120,7 +120,7 @@ class CmdMixin(object):
             cmd_args[0] = self.module.get_bin_path(cmd_args[0], required=True)
         except ValueError:
             pass
-        param_list = params if params else self.module.params.keys()
+        param_list = params if params else self.vars.keys()
 
         for param in param_list:
             if isinstance(param, dict):
@@ -131,9 +131,9 @@ class CmdMixin(object):
                 fmt = find_format(_param)
                 value = param[_param]
             elif isinstance(param, str):
-                if param in self.module.argument_spec:
+                if param in self.vars.keys():
                     fmt = find_format(param)
-                    value = self.module.params[param]
+                    value = self.vars[param]
                 elif param in extra_params:
                     fmt = find_format(param)
                     value = extra_params[param]

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -258,7 +258,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
         params = ['channel', 'property', {'create': True}]
         if self.vars.is_array:
-            params.append({'is_array': True})
+            params.append('is_array')
         params.append({'values_and_types': (self.vars.value, value_type)})
 
         if not self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
`CmdMixin` now pulls the value for `run_command()` params from `self.vars`, as opposed to previously retrieving those from `self.module.params`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/cmd.py

