### PR TITLE
pacman: add 'executable' option to use an alternative pacman binary

### DIFF
--- a/changelogs/fragments/2524-pacman_add_bin_option.yml
+++ b/changelogs/fragments/2524-pacman_add_bin_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pacman - add 'bin' option to use an alternative pacman binary (https://github.com/ansible-collections/community.general/issues/2524)

--- a/changelogs/fragments/2524-pacman_add_bin_option.yml
+++ b/changelogs/fragments/2524-pacman_add_bin_option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pacman - add ``bin`` option to use an alternative pacman binary (https://github.com/ansible-collections/community.general/issues/2524).
+  - pacman - add ``executable`` option to use an alternative pacman binary (https://github.com/ansible-collections/community.general/issues/2524).

--- a/changelogs/fragments/2524-pacman_add_bin_option.yml
+++ b/changelogs/fragments/2524-pacman_add_bin_option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pacman - add 'bin' option to use an alternative pacman binary (https://github.com/ansible-collections/community.general/issues/2524)
+  - pacman - add ``bin`` option to use an alternative pacman binary (https://github.com/ansible-collections/community.general/issues/2524).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -44,7 +44,7 @@ options:
         default: no
         type: bool
 
-    bin:
+    executable:
         description:
             - Name of binary to use. This can either be C(pacman) or a pacman compatible AUR helper.
             - Beware that AUR helpers might behave unexpectedly and are therefore not recommended.
@@ -89,7 +89,7 @@ options:
 notes:
   - When used with a C(loop:) each package will be processed individually,
     it is much more efficient to pass the list directly to the I(name) option.
-  - To use an AUR helper (I(bin) option), a few extra setup steps might be required beforehand.
+  - To use an AUR helper (I(executable) option), a few extra setup steps might be required beforehand.
     For example, a dedicated build user with permissions to install packages could be necessary.
 '''
 
@@ -123,7 +123,7 @@ EXAMPLES = '''
   community.general.pacman:
     name: foo
     state: present
-    bin: yay
+    executable: yay
     extra_args: --builddir /var/cache/yay
 
 - name: Upgrade package foo
@@ -436,7 +436,7 @@ def main():
             name=dict(type='list', elements='str', aliases=['pkg', 'package']),
             state=dict(type='str', default='present', choices=['present', 'installed', 'latest', 'absent', 'removed']),
             force=dict(type='bool', default=False),
-            bin=dict(type='str', default='pacman'),
+            executable=dict(type='str', default='pacman'),
             extra_args=dict(type='str', default=''),
             upgrade=dict(type='bool', default=False),
             upgrade_extra_args=dict(type='str', default=''),
@@ -455,7 +455,7 @@ def main():
     p = module.params
 
     # find pacman binary
-    pacman_path = module.get_bin_path(p['bin'], True)
+    pacman_path = module.get_bin_path(p['executable'], True)
 
     # normalize the state parameter
     if p['state'] in ['present', 'installed']:

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -46,8 +46,11 @@ options:
 
     bin:
         description:
-            - Name of pacman binary or AUR helper that shares the same interface as pacman.
+            - Name of binary to use. This can either be C(pacman) or a pacman compatible AUR helper.
+            - Beware that AUR helpers might behave unexpectedly and are therefore not recommended.
         default: pacman
+        type: str
+        version_added: 3.1.0
 
     extra_args:
         description:
@@ -86,6 +89,8 @@ options:
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
+  - To use an AUR helper (`bin` option), a few extra setup steps might be required beforehand.
+    For example, a dedicated build user with permissions to install packages could be necessary.
 '''
 
 RETURN = '''
@@ -115,11 +120,11 @@ EXAMPLES = '''
     state: present
 
 - name: Install package from AUR using a Pacman compatible AUR helper
-  pacman:
+  community.general.pacman:
     name: foo
     state: present
     bin: yay
-    extra_args: --noconfirm --builddir /tmp/yay-build
+    extra_args: --builddir /var/cache/yay
 
 - name: Upgrade package foo
   community.general.pacman:

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -87,9 +87,9 @@ options:
         type: str
 
 notes:
-  - When used with a `loop:` each package will be processed individually,
-    it is much more efficient to pass the list directly to the `name` option.
-  - To use an AUR helper (`bin` option), a few extra setup steps might be required beforehand.
+  - When used with a C(loop:) each package will be processed individually,
+    it is much more efficient to pass the list directly to the I(name) option.
+  - To use an AUR helper (I(bin) option), a few extra setup steps might be required beforehand.
     For example, a dedicated build user with permissions to install packages could be necessary.
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

There are some nice [AUR helpers](https://wiki.archlinux.org/index.php/AUR_helpers) that extend the pacman interface and can be used interchangeably with pacman. This PR adds the option to specify the binary to be used, when executing package queries on Arch Linux.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

pacman

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

With this PR an AUR package can be easily installed using [YAY](https://github.com/Jguer/yay). In this example the user needs to provide a non-root user with the privileges to install packages, otherwise yay will refuse to work:

```yaml
tasks:
  - pacman:
      state: present
      name: foo
      bin: yay
      extra_args: --noconfirm --builddir /tmp/yay-build
    become_user: yay
```
