### PR TITLE
iptables_state: fix per-table initialization command

### DIFF
--- a/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
+++ b/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
@@ -1,6 +1,6 @@
 ---
 bugfixes:
-  - "iptables_state module - fix initialization of iptables from null state when adressing
+  - "iptables_state - fix initialization of iptables from null state when adressing
     more than one table (https://github.com/ansible-collections/community.general/issues/2523)."
   - "iptables_state - fix a 'FutureWarning' in a regex and do some basic code clean up
     (https://github.com/ansible-collections/community.general/pull/2525)."

--- a/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
+++ b/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - "iptables_state module - fix initialization of iptables from null state when adressing
+    more than one table (https://github.com/ansible-collections/community.general/issues/2523)."
+minor_changes:
+  - "iptables_state - fix a 'FutureWarning' in a regex and trivial pylints (unused-variable,
+    unused-import and more) (https://github.com/ansible-collections/community.general/pull/2525)."

--- a/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
+++ b/changelogs/fragments/2525-iptables_state-fix-initialization-command.yml
@@ -2,6 +2,5 @@
 bugfixes:
   - "iptables_state module - fix initialization of iptables from null state when adressing
     more than one table (https://github.com/ansible-collections/community.general/issues/2523)."
-minor_changes:
-  - "iptables_state - fix a 'FutureWarning' in a regex and trivial pylints (unused-variable,
-    unused-import and more) (https://github.com/ansible-collections/community.general/pull/2525)."
+  - "iptables_state - fix a 'FutureWarning' in a regex and do some basic code clean up
+    (https://github.com/ansible-collections/community.general/pull/2525)."

--- a/plugins/action/system/iptables_state.py
+++ b/plugins/action/system/iptables_state.py
@@ -163,9 +163,9 @@ class ActionModule(ActionBase):
                         del result[key]
 
                 if result.get('invocation', {}).get('module_args'):
-                    if '_timeout' in result['invocation']['module_args']:
-                        del result['invocation']['module_args']['_back']
-                        del result['invocation']['module_args']['_timeout']
+                    for key in ('_back', '_timeout', '_async_dir', 'jid'):
+                        if result['invocation']['module_args'].get(key):
+                            del result['invocation']['module_args'][key]
 
                 async_status_args['mode'] = 'cleanup'
                 dummy = self._execute_module(

--- a/plugins/action/system/iptables_state.py
+++ b/plugins/action/system/iptables_state.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 import time
 
 from ansible.plugins.action import ActionBase
-from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleConnectionFailure
+from ansible.errors import AnsibleActionFail, AnsibleConnectionFailure
 from ansible.utils.vars import merge_hash
 from ansible.utils.display import Display
 
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
         the async wrapper results (those with the ansible_job_id key).
         '''
         # At least one iteration is required, even if timeout is 0.
-        for i in range(max(1, timeout)):
+        for dummy in range(max(1, timeout)):
             async_result = self._execute_module(
                 module_name='ansible.builtin.async_status',
                 module_args=module_args,
@@ -76,7 +76,6 @@ class ActionModule(ActionBase):
             task_async = self._task.async_val
             check_mode = self._play_context.check_mode
             max_timeout = self._connection._play_context.timeout
-            module_name = self._task.action
             module_args = self._task.args
 
             if module_args.get('state', None) == 'restored':
@@ -133,7 +132,7 @@ class ActionModule(ActionBase):
                 # The module is aware to not process the main iptables-restore
                 # command before finding (and deleting) the 'starter' cookie on
                 # the host, so the previous query will not reach ssh timeout.
-                garbage = self._low_level_execute_command(starter_cmd, sudoable=self.DEFAULT_SUDOABLE)
+                dummy = self._low_level_execute_command(starter_cmd, sudoable=self.DEFAULT_SUDOABLE)
 
                 # As the main command is not yet executed on the target, here
                 # 'finished' means 'failed before main command be executed'.
@@ -143,7 +142,7 @@ class ActionModule(ActionBase):
                     except AttributeError:
                         pass
 
-                    for x in range(max_timeout):
+                    for dummy in range(max_timeout):
                         time.sleep(1)
                         remaining_time -= 1
                         # - AnsibleConnectionFailure covers rejected requests (i.e.
@@ -151,7 +150,7 @@ class ActionModule(ActionBase):
                         # - ansible_timeout is able to cover dropped requests (due
                         #   to a rule or policy DROP) if not lower than async_val.
                         try:
-                            garbage = self._low_level_execute_command(confirm_cmd, sudoable=self.DEFAULT_SUDOABLE)
+                            dummy = self._low_level_execute_command(confirm_cmd, sudoable=self.DEFAULT_SUDOABLE)
                             break
                         except AnsibleConnectionFailure:
                             continue
@@ -169,7 +168,7 @@ class ActionModule(ActionBase):
                         del result['invocation']['module_args']['_timeout']
 
                 async_status_args['mode'] = 'cleanup'
-                garbage = self._execute_module(
+                dummy = self._execute_module(
                     module_name='ansible.builtin.async_status',
                     module_args=async_status_args,
                     task_vars=task_vars,

--- a/plugins/modules/system/iptables_state.py
+++ b/plugins/modules/system/iptables_state.py
@@ -325,9 +325,9 @@ def filter_and_format_state(string):
     Remove timestamps to ensure idempotence between runs. Also remove counters
     by default. And return the result as a list.
     '''
-    string = re.sub('((^|\n)# (Generated|Completed)[^\n]*) on [^\n]*', '\\1', string)
+    string = re.sub(r'((^|\n)# (Generated|Completed)[^\n]*) on [^\n]*', r'\1', string)
     if not module.params['counters']:
-        string = re.sub('[[][0-9]+:[0-9]+[]]', '[0:0]', string)
+        string = re.sub(r'\[[0-9]+:[0-9]+\]', r'[0:0]', string)
     lines = string.splitlines()
     while '' in lines:
         lines.remove('')
@@ -345,8 +345,8 @@ def per_table_state(command, state):
         if '*%s' % t in state.splitlines():
             COMMAND.extend(['--table', t])
             (rc, out, err) = module.run_command(COMMAND, check_rc=True)
-            out = re.sub('(^|\n)(# Generated|# Completed|[*]%s|COMMIT)[^\n]*' % t, '', out)
-            out = re.sub(' *[[][0-9]+:[0-9]+[]] *', '', out)
+            out = re.sub(r'(^|\n)(# Generated|# Completed|[*]%s|COMMIT)[^\n]*' % t, r'', out)
+            out = re.sub(r' *\[[0-9]+:[0-9]+\] *', r'', out)
             table = out.splitlines()
             while '' in table:
                 table.remove('')

--- a/plugins/modules/system/iptables_state.py
+++ b/plugins/modules/system/iptables_state.py
@@ -313,12 +313,9 @@ def initialize_from_null_state(initializer, initcommand, table):
     if table is None:
         table = 'filter'
 
-    tmpfd, tmpfile = tempfile.mkstemp()
-    with os.fdopen(tmpfd, 'w') as f:
-        f.write('*%s\nCOMMIT\n' % table)
-
-    initializer.append(tmpfile)
-    (rc, out, err) = module.run_command(initializer, check_rc=True)
+    commandline = list(initializer)
+    commandline += ['-t', table]
+    (rc, out, err) = module.run_command(commandline, check_rc=True)
     (rc, out, err) = module.run_command(initcommand, check_rc=True)
     return (rc, out, err)
 
@@ -402,7 +399,7 @@ def main():
     changed = False
     COMMANDARGS = []
     INITCOMMAND = [bin_iptables_save]
-    INITIALIZER = [bin_iptables_restore]
+    INITIALIZER = [bin_iptables, '-L', '-n']
     TESTCOMMAND = [bin_iptables_restore, '--test']
 
     if counters:


### PR DESCRIPTION
##### SUMMARY

This PR fixes 2 function design flows (in the same function):
- Don't modify the value of a variable that is reused at each iteration (per-table) of the loop to avoid cumulative arguments over the loop.
- Use a more neutral command (`iptables -L` rather than `iptables-restore`, no need of temporary files) to load per-table needed modules.

Also cleanup code (pylints and a FutureWarning about regexp).

Fixes #2523 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

iptables_state