### PR TITLE
java_keystore: pass in secret to keytool via stdin

### DIFF
--- a/changelogs/fragments/2526-java_keystore-password-via-stdin.yml
+++ b/changelogs/fragments/2526-java_keystore-password-via-stdin.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "java_keystore - replace envvar by stdin to pass secret to ``keytool``
+    (https://github.com/ansible-collections/community.general/pull/2526)."

--- a/plugins/modules/system/java_keystore.py
+++ b/plugins/modules/system/java_keystore.py
@@ -290,11 +290,11 @@ class JavaKeystore:
 
     def read_stored_certificate_fingerprint(self):
         stored_certificate_fingerprint_cmd = [
-            self.keytool_bin, "-list", "-alias", self.name, "-keystore",
-            self.keystore_path, "-storepass:env", "STOREPASS", "-v"
+            self.keytool_bin, "-list", "-alias", self.name,
+            "-keystore", self.keystore_path, "-v"
         ]
         (rc, stored_certificate_fingerprint_out, stored_certificate_fingerprint_err) = self.module.run_command(
-            stored_certificate_fingerprint_cmd, environ_update=dict(STOREPASS=self.password), check_rc=False)
+            stored_certificate_fingerprint_cmd, data=self.password, check_rc=False)
         if rc != 0:
             if "keytool error: java.lang.Exception: Alias <%s> does not exist" % self.name \
                     in stored_certificate_fingerprint_out:
@@ -428,12 +428,10 @@ class JavaKeystore:
                                "-srckeystore", keystore_p12_path,
                                "-srcstoretype", "pkcs12",
                                "-alias", self.name,
-                               "-deststorepass:env", "STOREPASS",
-                               "-srcstorepass:env", "STOREPASS",
                                "-noprompt"]
 
         (rc, import_keystore_out, dummy) = self.module.run_command(
-            import_keystore_cmd, data=None, environ_update=dict(STOREPASS=self.password), check_rc=False
+            import_keystore_cmd, data='%s\n%s\n%s' % (self.password, self.password, self.password), check_rc=False
         )
         if rc != 0:
             return self.module.fail_json(msg=import_keystore_out, cmd=import_keystore_cmd, rc=rc)

--- a/tests/unit/plugins/modules/system/test_java_keystore.py
+++ b/tests/unit/plugins/modules/system/test_java_keystore.py
@@ -80,7 +80,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
                 'cmd': ["keytool", "-importkeystore",
                         "-destkeystore", "/path/to/keystore.jks",
                         "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
-                        "-deststorepass:env", "STOREPASS", "-srcstorepass:env", "STOREPASS", "-noprompt"],
+                        "-noprompt"],
                 'msg': '',
                 'rc': 0
             }
@@ -183,7 +183,7 @@ class TestCreateJavaKeystore(ModuleTestCase):
                 cmd=["keytool", "-importkeystore",
                      "-destkeystore", "/path/to/keystore.jks",
                      "-srckeystore", "/tmp/tmpgrzm2ah7", "-srcstoretype", "pkcs12", "-alias", "test",
-                     "-deststorepass:env", "STOREPASS", "-srcstorepass:env", "STOREPASS", "-noprompt"],
+                     "-noprompt"],
                 msg='',
                 rc=1
             )
@@ -354,7 +354,7 @@ class TestCertChanged(ModuleTestCase):
             jks = JavaKeystore(module)
             jks.cert_changed()
             module.fail_json.assert_called_with(
-                cmd=["keytool", "-list", "-alias", "foo", "-keystore", "/path/to/keystore.jks", "-storepass:env", "STOREPASS", "-v"],
+                cmd=["keytool", "-list", "-alias", "foo", "-keystore", "/path/to/keystore.jks", "-v"],
                 msg='',
                 err='Oops',
                 rc=1


### PR DESCRIPTION
##### SUMMARY

Follows up #1668 and #2177 

For whatever reason, I missed what *from stdin* is meaning (probably blinded by my habits with openssl or gpg, where `stdin` or file descriptor `0` are explicit arguments). There is no option to pass in secrets to `keytool` via stdin should be understood like: "secrets are passed in keytool via stdin when -storepass option is not used." 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

java_keystore