### PR TITLE
Fix yum_versionlock tests

### DIFF
--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -24,7 +24,7 @@
           register: lock_all_packages
 
         - name: Update all packages
-          command: yum update --setopt=obsoletes=0
+          command: yum update --assumeyes --setopt=obsoletes=0
           register: update_all_locked_packages
           changed_when:
             - '"No packages marked for update" not in update_all_locked_packages.stdout'


### PR DESCRIPTION
##### SUMMARY
They are currently failing because yum is waiting for an explicit yes/no input.

This makes both nightly CI runs fails, but also CI in #2525.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
