### PR TITLE
yum_versionlock: disable fedora34 integration test

### DIFF
--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -24,7 +24,7 @@
           register: lock_all_packages
 
           # This should fail when it needs user interaction and missing -y is on purpose.
-        - name: Update all packages
+        - name: Update all packages (not really)
           command: yum update --setopt=obsoletes=0
           register: update_all_locked_packages
           changed_when:

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -23,8 +23,9 @@
             state: present
           register: lock_all_packages
 
+          # This should fail when it needs user interaction and missing -y is on purpose.
         - name: Update all packages
-          command: yum update --assumeyes --setopt=obsoletes=0
+          command: yum update --setopt=obsoletes=0
           register: update_all_locked_packages
           changed_when:
             - '"No packages marked for update" not in update_all_locked_packages.stdout'

--- a/tests/integration/targets/yum_versionlock/tasks/main.yml
+++ b/tests/integration/targets/yum_versionlock/tasks/main.yml
@@ -59,4 +59,4 @@
         state: absent
       when: yum_versionlock_install is changed
   when: (ansible_distribution in ['CentOS', 'RedHat'] and ansible_distribution_major_version is version('7', '>=')) or
-        (ansible_distribution == 'Fedora')
+        (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('33', '<='))


### PR DESCRIPTION
##### SUMMARY
This test is failing on Fedora 34 and needs more investigation, this disables it for now.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI

##### ADDITIONAL INFORMATION
Also reverts change in https://github.com/ansible-collections/community.general/pull/2533 and puts a comment why.