### PR TITLE
zfs_delegate_admin: drop choices from permissions

### DIFF
--- a/changelogs/fragments/2540-zfs-delegate-choices.yml
+++ b/changelogs/fragments/2540-zfs-delegate-choices.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zfs_delegate_admin - drop choices from permissions, allowing any permission supported by the underlying zfs commands (https://github.com/ansible-collections/community.general/pull/2540).

--- a/plugins/modules/storage/zfs/zfs_delegate_admin.py
+++ b/plugins/modules/storage/zfs/zfs_delegate_admin.py
@@ -51,8 +51,9 @@ options:
   permissions:
     description:
       - The list of permission(s) to delegate (required if C(state) is C(present)).
+      - Supported permissions depend on the ZFS version in use. See for example
+        U(https://openzfs.github.io/openzfs-docs/man/8/zfs-allow.8.html) for OpenZFS.
     type: list
-    choices: [ allow, clone, create, destroy, diff, hold, mount, promote, readonly, receive, release, rename, rollback, send, share, snapshot, unallow ]
     elements: str
   local:
     description:
@@ -248,10 +249,7 @@ def main():
             users=dict(type='list', elements='str'),
             groups=dict(type='list', elements='str'),
             everyone=dict(type='bool', default=False),
-            permissions=dict(type='list', elements='str',
-                             choices=['allow', 'clone', 'create', 'destroy', 'diff', 'hold', 'mount', 'promote',
-                                      'readonly', 'receive', 'release', 'rename', 'rollback', 'send', 'share',
-                                      'snapshot', 'unallow']),
+            permissions=dict(type='list', elements='str'),
             local=dict(type='bool'),
             descendents=dict(type='bool'),
             recursive=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY

instead of whitelisting some subset of known existing permissions, just
allow any string to be used as permissions. this way, any permission
supported by the underlying zfs commands can be used, eg. 'bookmark',
'load-key', 'change-key' and all property permissions, which were
missing from the choices list.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zfs_delegate_admin

##### ADDITIONAL INFORMATION

`ansible -b -vvvv -m zfs_delegate_admin -a 'name=z users=lauri permissions=bookmark' localhost`:
Before:
```
localhost | FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "everyone": false,
            "name": "z",
            "permissions": [
                "bookmark"
            ],
            "recursive": false,
            "state": "present",
            "users": [
                "lauri"
            ]
        }
    },
    "msg": "value of permissions must be one or more of: allow, clone, create, destroy, diff, hold, mount, promote, readonly, receive, release, rename, rollback, send, share, snapshot, unallow. Got no match for: bookmark"
}
```
After:
```
localhost | CHANGED => {
    "changed": true,
    "invocation": {
        "module_args": {
            "descendents": null,
            "everyone": false,
            "groups": null,
            "local": null,
            "name": "z",
            "permissions": [
                "bookmark"
            ],
            "recursive": false,
            "state": "present",
            "users": [
                "lauri"
            ]
        }
    },
    "msg": "ZFS delegated admin permissions updated",
    "state": "present",
    "stdout": "",
    "stdout_lines": []
}

```
