### PR TITLE
Add comment_visibility parameter for comment operation for jira module

### DIFF
--- a/changelogs/fragments/2556-add-comment_visibility-parameter-for-comment-operation-of-jira-module.yml
+++ b/changelogs/fragments/2556-add-comment_visibility-parameter-for-comment-operation-of-jira-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jira - add comment visibility parameter for comment operation of jira module

--- a/changelogs/fragments/2556-add-comment_visibility-parameter-for-comment-operation-of-jira-module.yml
+++ b/changelogs/fragments/2556-add-comment_visibility-parameter-for-comment-operation-of-jira-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jira - add comment visibility parameter for comment operation of jira module
+  - jira - add comment visibility parameter for comment operation (https://github.com/ansible-collections/community.general/pull/2556).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -416,6 +416,10 @@ class JIRA(StateModuleHelper):
             issuetype=dict(type='str', ),
             issue=dict(type='str', aliases=['ticket']),
             comment=dict(type='str', ),
+            comment_visibility=dict(type='dict', suboptions=dict(
+                type=dict(type='str', choices=['group', 'role'], required=True),
+                value=dict(type='str', required=True),
+            )),            
             status=dict(type='str', ),
             assignee=dict(type='str', ),
             fields=dict(default={}, type='dict'),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -477,7 +477,7 @@ class JIRA(StateModuleHelper):
             'body': self.vars.comment
         }
         # if comment_visibility is specified restrict visibility
-        if params['comment_visibility'] != None:
+        if params['comment_visibility'] is not None:
             data['visibility'] = params['comment_visibility']
 
         url = self.vars.restbase + '/issue/' + self.vars.issue + '/comment'

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -416,9 +416,11 @@ class JIRA(StateModuleHelper):
             issuetype=dict(type='str', ),
             issue=dict(type='str', aliases=['ticket']),
             comment=dict(type='str', ),
-            comment_visibility=dict(type='dict', suboptions=dict(
-                type=dict(type='str', choices=['group', 'role'], required=True),
-                value=dict(type='str', required=True),
+            comment_visibility=dict(
+                type='dict',
+                options=dict(
+                    type=dict(type='str', choices=['group', 'role'], required=True),
+                    value=dict(type='str', required=True),
             )),
             status=dict(type='str', ),
             assignee=dict(type='str', ),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -88,7 +88,6 @@ options:
 
   comment_visibility:
     type: dict
-    required: false
     description:
      - Used to specify comment comment visibility.
      - See U(https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post) for details.

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -419,7 +419,7 @@ class JIRA(StateModuleHelper):
             comment_visibility=dict(type='dict', suboptions=dict(
                 type=dict(type='str', choices=['group', 'role'], required=True),
                 value=dict(type='str', required=True),
-            )),            
+            )),
             status=dict(type='str', ),
             assignee=dict(type='str', ),
             fields=dict(default={}, type='dict'),
@@ -481,8 +481,8 @@ class JIRA(StateModuleHelper):
             'body': self.vars.comment
         }
         # if comment_visibility is specified restrict visibility
-        if params['comment_visibility'] is not None:
-            data['visibility'] = params['comment_visibility']
+        if self.vars.comment_visibility is not None:
+            data['visibility'] = self.vars.comment_visibility
 
         url = self.vars.restbase + '/issue/' + self.vars.issue + '/comment'
         self.vars.meta = self.post(url, data)

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -416,11 +416,9 @@ class JIRA(StateModuleHelper):
             issuetype=dict(type='str', ),
             issue=dict(type='str', aliases=['ticket']),
             comment=dict(type='str', ),
-            comment_visibility=dict(
-                type='dict',
-                options=dict(
-                    type=dict(type='str', choices=['group', 'role'], required=True),
-                    value=dict(type='str', required=True),
+            comment_visibility=dict(type='dict', options=dict(
+                type=dict(type='str', choices=['group', 'role'], required=True),
+                value=dict(type='str', required=True),
             )),
             status=dict(type='str', ),
             assignee=dict(type='str', ),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -91,10 +91,10 @@ options:
     description:
      - Used to specify comment comment visibility.
      - See U(https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post) for details.
-    options:
+    suboptions:
       type:
         description:
-         - Use type to specify which if the visibility restriction types will be used.
+         - Use type to specify which of the JIRA visibility restriction types will be used.
         type: str
         required: true
         choices: [group, role]
@@ -418,7 +418,7 @@ class JIRA(StateModuleHelper):
             comment=dict(type='str', ),
             comment_visibility=dict(type='dict', options=dict(
                 type=dict(type='str', choices=['group', 'role'], required=True),
-                value=dict(type='str', required=True),
+                value=dict(type='str', required=True)
             )),
             status=dict(type='str', ),
             assignee=dict(type='str', ),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -86,6 +86,26 @@ options:
      - The comment text to add.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 
+  comment_visibility:
+    type: dict
+    required: false
+    description:
+     - Used to specify comment comment visibility.
+     - See U(https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post) for details.
+    options:
+    type:
+      description:
+       - Use type to specify which if the visibility restriction types will be used.
+      type: str
+      required: true
+      choices: [group, role]
+    value:
+      description:
+       - Use value to specify value corresponding to the type of visibility restriction. E.g. name of the group or role.
+      type: str
+      required: true
+    version_added: '3.2.0'
+
   status:
     type: str
     required: false
@@ -222,6 +242,18 @@ EXAMPLES = r"""
     issue: '{{ issue.meta.key }}'
     operation: comment
     comment: A comment added by Ansible
+
+- name: Comment on issue with restricted visibility
+  community.general.jira:
+    uri: '{{ server }}'
+    username: '{{ user }}'
+    password: '{{ pass }}'
+    issue: '{{ issue.meta.key }}'
+    operation: comment
+    comment: A comment added by Ansible
+    comment_visibility:
+      type: role
+      value: Developers
 
 # Assign an existing issue using edit
 - name: Assign an issue using free-form fields
@@ -445,6 +477,10 @@ class JIRA(StateModuleHelper):
         data = {
             'body': self.vars.comment
         }
+        # if comment_visibility is specified restrict visibility
+        if params['comment_visibility'] != None:
+            data['visibility'] = params['comment_visibility']
+
         url = self.vars.restbase + '/issue/' + self.vars.issue + '/comment'
         self.vars.meta = self.post(url, data)
 

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -100,7 +100,7 @@ options:
         choices: [group, role]
       value:
         description:
-         - Use value to specify value corresponding to the type of visibility restriction. E.g. name of the group or role.
+         - Use value to specify value corresponding to the type of visibility restriction. For example name of the group or role.
         type: str
         required: true
     version_added: '3.2.0'

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -93,17 +93,17 @@ options:
      - Used to specify comment comment visibility.
      - See U(https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post) for details.
     options:
-    type:
-      description:
-       - Use type to specify which if the visibility restriction types will be used.
-      type: str
-      required: true
-      choices: [group, role]
-    value:
-      description:
-       - Use value to specify value corresponding to the type of visibility restriction. E.g. name of the group or role.
-      type: str
-      required: true
+      type:
+        description:
+         - Use type to specify which if the visibility restriction types will be used.
+        type: str
+        required: true
+        choices: [group, role]
+      value:
+        description:
+         - Use value to specify value corresponding to the type of visibility restriction. E.g. name of the group or role.
+        type: str
+        required: true
     version_added: '3.2.0'
 
   status:


### PR DESCRIPTION
##### SUMMARY

This change includes the additional parameter for the jira module. When operation is set to comment, comment_visibility will be used to limit the visibility of the comment. JIRA itself provide 2 means for declaring the visibility: group and role. The parameter needs to include the type and value fields. For this reason the parameter is not simple but rather a dict.
Replaces: #2555

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

jira
ADDITIONAL INFORMATION

For more information on visibility of comments in JIRA please see Visibility object under following section:
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post