### PR TITLE
ModuleHelper: CmdMixin custom function for processing cmd results

### DIFF
--- a/changelogs/fragments/2564-mh-cmd-process-output.yml
+++ b/changelogs/fragments/2564-mh-cmd-process-output.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper module utils - method ``CmdMixin.run_command()`` now accepts ``process_output`` specifying a function to process the outcome of the underlying ``module.run_command()`` (https://github.com/ansible-collections/community.general/pull/2564).

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -152,7 +152,7 @@ class CmdMixin(object):
     def process_command_output(self, rc, out, err):
         return rc, out, err
 
-    def run_command(self, extra_params=None, params=None, *args, **kwargs):
+    def run_command(self, extra_params=None, params=None, process_output=None, *args, **kwargs):
         self.vars.cmd_args = self._calculate_args(extra_params, params)
         options = dict(self.run_command_fixed_options)
         env_update = dict(options.get('environ_update', {}))
@@ -164,4 +164,11 @@ class CmdMixin(object):
         options.update(kwargs)
         rc, out, err = self.module.run_command(self.vars.cmd_args, *args, **options)
         self.update_output(rc=rc, stdout=out, stderr=err)
-        return self.process_command_output(rc, out, err)
+        if process_output is None:
+            _process = self.process_command_output
+        elif isinstance(process_output, str):
+            _process = getattr(self, process_output)
+        else:
+            _process = process_output
+
+        return _process(rc, out, err)

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -166,8 +166,6 @@ class CmdMixin(object):
         self.update_output(rc=rc, stdout=out, stderr=err)
         if process_output is None:
             _process = self.process_command_output
-        elif isinstance(process_output, str):
-            _process = getattr(self, process_output)
         else:
             _process = process_output
 


### PR DESCRIPTION
##### SUMMARY
`CmdMixin.run_command()` now accepts a `process_output` parameter specifying a function to process the outcome of the underlying `module.run_command()`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/cmd.py
