### PR TITLE
rhsm_release: Fix the issue that rhsm_release module considers 8, 7Client and 7Workstation as invalid releases

### DIFF
--- a/changelogs/fragments/2571-rhsm_release-fix-release_matcher.yaml
+++ b/changelogs/fragments/2571-rhsm_release-fix-release_matcher.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rhsm_release - Fix the issue that rhsm_release module considers 8, 7Client and 7Workstation as invalid releases (https://github.com/ansible-collections/community.general/pull/2571).

--- a/changelogs/fragments/2571-rhsm_release-fix-release_matcher.yaml
+++ b/changelogs/fragments/2571-rhsm_release-fix-release_matcher.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - rhsm_release - Fix the issue that rhsm_release module considers 8, 7Client and 7Workstation as invalid releases (https://github.com/ansible-collections/community.general/pull/2571).
+  - rhsm_release - fix the issue that module considers 8, 7Client and 7Workstation as invalid releases (https://github.com/ansible-collections/community.general/pull/2571).

--- a/plugins/modules/packaging/os/rhsm_release.py
+++ b/plugins/modules/packaging/os/rhsm_release.py
@@ -57,7 +57,7 @@ from ansible.module_utils.basic import AnsibleModule
 import re
 
 # Matches release-like values such as 7.2, 5.10, 6Server, 8
-# but rejects unlikely values, like 100Server, 100.0, 1.100 etc.
+# but rejects unlikely values, like 100Server, 1.100, 7server etc.
 release_matcher = re.compile(r'\b\d{1,2}(?:\.\d{1,2}|Server|Client|Workstation|)\b')
 
 

--- a/plugins/modules/packaging/os/rhsm_release.py
+++ b/plugins/modules/packaging/os/rhsm_release.py
@@ -56,9 +56,9 @@ from ansible.module_utils.basic import AnsibleModule
 
 import re
 
-# Matches release-like values such as 7.2, 6.10, 10Server,
-# but rejects unlikely values, like 100Server, 100.0, 1.100, etc.
-release_matcher = re.compile(r'\b\d{1,2}(?:\.\d{1,2}|Server)\b')
+# Matches release-like values such as 7.2, 5.10, 6Server, 8
+# but rejects unlikely values, like 100Server, 100.0, 1.100 etc.
+release_matcher = re.compile(r'\b\d{1,2}(?:\.\d{1,2}|Server|Client|Workstation|)\b')
 
 
 def _sm_release(module, *args):

--- a/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
+++ b/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
@@ -125,12 +125,12 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
 
     def test_release_matcher(self):
         # throw a few values at the release matcher -- only sane_values should match
-        sane_values = ['1Server', '10Server', '1.10', '10.0']
+        sane_values = ['1Client', '10Server', '1.10', '10.0', '9']
         insane_values = [
             '6server',    # lowercase 's'
             '100Server',  # excessively long 'x' component
             '100.0',      # excessively long 'x' component
-            '6.100',      # excessively long 'y' component
+            '+.10',       # illegal character
             '100.100',    # excessively long 'x' and 'y' components
         ]
 

--- a/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
+++ b/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
@@ -129,8 +129,6 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
         insane_values = [
             '6server',    # lowercase 's'
             '100Server',  # excessively long 'x' component
-            '100.0',      # excessively long 'x' component
-            '+.10',       # illegal character
             '100.100',    # excessively long 'x' and 'y' components
         ]
 

--- a/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
+++ b/tests/unit/plugins/modules/packaging/os/test_rhsm_release.py
@@ -125,11 +125,12 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
 
     def test_release_matcher(self):
         # throw a few values at the release matcher -- only sane_values should match
-        sane_values = ['1Client', '10Server', '1.10', '10.0', '9']
+        sane_values = ['1Server', '1Client', '10Server', '1.10', '10.0', '9']
         insane_values = [
             '6server',    # lowercase 's'
             '100Server',  # excessively long 'x' component
             '100.100',    # excessively long 'x' and 'y' components
+            '+.-',        # illegal characters
         ]
 
         matches = self.module.release_matcher.findall(' '.join(sane_values + insane_values))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is Tong He from Red Hat MPQE Entitlement QE Team.

At present, the release_matcher in rhsm_release.py considers 8, 7Client and 7Workstation as invalid releases then resists to set these values as release version. However these 3 values are valid releases corresponding on RHEL 8, RHEL 7 Client and RHEL 7 Workstation. Hence, this PR modifies the release_matcher in rhsm_release.py and adjusts the relevant test case to fix this issue.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rhsm_release

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
At present, when we try to set release 8 through the rhsm_release module, the playbook fails with the following message:

```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "release": "8"
        }
    },
    "msg": "\"8\" does not appear to be a valid release."
}
```

This is unexpected since 8 is a common release on RHEL 8:
[root@the general] subscription-manager release --list
+-------------------------------------------+
          Available Releases
+-------------------------------------------+
8
8.0
8.1
8.2
8.3
8.4

Similar situation for 7Client and 7Workstation.
That is why I create this PR.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

