### PR TITLE
Terraform overwrite init

### DIFF
--- a/changelogs/fragments/2573-terraform-overwrite-init.yml
+++ b/changelogs/fragments/2573-terraform-overwrite-init.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terraform - add option ``overwrite_init`` to skip init if exists (https://github.com/ansible-collections/community.general/pull/2573).


### PR DESCRIPTION
##### SUMMARY

When a Terraform workspace is already _init_, with a foreign backend creds (by S3 creds from another workspace), Terraform fails to redo _init_.

Init can be skipped if the local statefile already exists.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
Context:
By using workspaces and s3 backend, the `.terraform/terraform.tfstate` is a single file having properties to target a S3 bucket.
The S3 object is specific for each workspace (workspace name is part of object path)

Based on current shell AWS environment creds, the owner of the S3 object is subject to be specific, which makes an issue during init step, before Ansible Terraform module does workspace switch.

How to reproduce issue:
- deploy an empty terraform project with 2 workspaces + s3 backend for state
- ensure the init are using segregated IAM S3 owners across workspaces

```paste below

```
