### PR TITLE
redis cache - better parsing of connection uri

### DIFF
--- a/changelogs/fragments/2579-redis-cache-ipv6.yml
+++ b/changelogs/fragments/2579-redis-cache-ipv6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redis cache - improved connection string parsing (https://github.com/ansible-collections/community.general/issues/497).

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -93,7 +93,7 @@ class CacheModule(BaseCacheModule):
     """
     _sentinel_service_name = None
     re_url_conn = re.compile(r'^(.*):(\d+):(\d+)(?::(.*))?$')
-    re_sent_conn = re.compile(r'(.*):(\d+)')
+    re_sent_conn = re.compile(r'^(.*):(\d+)$')
 
     def __init__(self, *args, **kwargs):
         uri = ''

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -92,7 +92,7 @@ class CacheModule(BaseCacheModule):
     performance.
     """
     _sentinel_service_name = None
-    re_url_conn = re.compile(r'^(.*):(\d+):(\d+)(?::(.*))?$')
+    re_url_conn = re.compile(r'^([^:]+|\[[^]]+\]):(\d+):(\d+)(?::(.*))?$')
     re_sent_conn = re.compile(r'^(.*):(\d+)$')
 
     def __init__(self, *args, **kwargs):

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -61,6 +61,7 @@ DOCUMENTATION = '''
         type: integer
 '''
 
+import re
 import time
 import json
 
@@ -91,6 +92,8 @@ class CacheModule(BaseCacheModule):
     performance.
     """
     _sentinel_service_name = None
+    re_url_conn = re.compile(r'^(.*):(\d+):(\d+)(?::(.*))?$')
+    re_sent_conn = re.compile(r'(.*):(\d+)')
 
     def __init__(self, *args, **kwargs):
         uri = ''
@@ -130,10 +133,17 @@ class CacheModule(BaseCacheModule):
             self._db = self._get_sentinel_connection(uri, kw)
         # normal connection
         else:
-            connection = uri.split(':')
+            connection = self._parse_connection(self.re_url_conn, uri)
             self._db = StrictRedis(*connection, **kw)
 
         display.vv('Redis connection: %s' % self._db)
+
+    @staticmethod
+    def _parse_connection(re_patt, uri):
+        match = re_patt.match(uri)
+        if not match:
+            raise AnsibleError("Unable to parse connection string")
+        return match.groups()
 
     def _get_sentinel_connection(self, uri, kw):
         """
@@ -158,7 +168,7 @@ class CacheModule(BaseCacheModule):
             except IndexError:
                 pass  # password is optional
 
-        sentinels = [tuple(shost.split(':')) for shost in connections]
+        sentinels = [self._parse_connection(self.re_sent_conn, shost) for shost in connections]
         display.vv('\nUsing redis sentinels: %s' % sentinels)
         scon = Sentinel(sentinels, **kw)
         try:

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -31,7 +31,7 @@ from ansible.release import __version__ as ansible_version
 
 def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
-    connection = 'ni 127.0.0.1:6379:1'
+    connection = '127.0.0.1:6379:1'
     if ansible_version.startswith('2.9.'):
         C.CACHE_PLUGIN_CONNECTION = connection
     assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -19,8 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
 import pytest
 
 pytest.importorskip('redis')
@@ -29,8 +27,6 @@ from ansible.plugins.loader import cache_loader
 from ansible_collections.community.general.plugins.cache.redis import CacheModule as RedisCache
 from ansible import constants as C
 from ansible.release import __version__ as ansible_version
-
-version = tuple(int(x) for x in av.split('.')[0:2])
 
 
 def test_redis_cachemodule():
@@ -44,6 +40,6 @@ def test_redis_cachemodule():
 def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
     connection = '[::1]:6379:1'
-    if version == (2, 9):
+    if ansible_version.startswith('2.9.'):
         C.CACHE_PLUGIN_CONNECTION = "c." + connection
     assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -19,14 +19,31 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 import pytest
 
 pytest.importorskip('redis')
 
 from ansible.plugins.loader import cache_loader
 from ansible_collections.community.general.plugins.cache.redis import CacheModule as RedisCache
+from ansible import constants as C
+from ansible.release import __version__ as av
+
+version = tuple(int(x) for x in av.split('.')[0:2])
 
 
 def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
-    assert isinstance(cache_loader.get('community.general.redis', **{'_uri': '127.0.0.1:6379:1'}), RedisCache)
+    connection = 'ni 127.0.0.1:6379:1'
+    if version == (2, 9):
+        C.CACHE_PLUGIN_CONNECTION = "c." + connection
+    assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)
+
+
+def test_redis_cachemodule():
+    # The _uri option is required for the redis plugin
+    connection = '[::1]:6379:1'
+    if version == (2, 9):
+        C.CACHE_PLUGIN_CONNECTION = "c." + connection
+    assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -23,10 +23,10 @@ import pytest
 
 pytest.importorskip('redis')
 
-from ansible.plugins.loader import cache_loader
-from ansible_collections.community.general.plugins.cache.redis import CacheModule as RedisCache
 from ansible import constants as C
+from ansible.plugins.loader import cache_loader
 from ansible.release import __version__ as ansible_version
+from ansible_collections.community.general.plugins.cache.redis import CacheModule as RedisCache
 
 
 def test_redis_cachemodule():

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -36,7 +36,7 @@ version = tuple(int(x) for x in av.split('.')[0:2])
 def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
     connection = 'ni 127.0.0.1:6379:1'
-    if version == (2, 9):
+    if ansible_version.startswith('2.9.'):
         C.CACHE_PLUGIN_CONNECTION = "c." + connection
     assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)
 

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -33,7 +33,7 @@ def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
     connection = 'ni 127.0.0.1:6379:1'
     if ansible_version.startswith('2.9.'):
-        C.CACHE_PLUGIN_CONNECTION = "c." + connection
+        C.CACHE_PLUGIN_CONNECTION = connection
     assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)
 
 
@@ -41,5 +41,5 @@ def test_redis_cachemodule():
     # The _uri option is required for the redis plugin
     connection = '[::1]:6379:1'
     if ansible_version.startswith('2.9.'):
-        C.CACHE_PLUGIN_CONNECTION = "c." + connection
+        C.CACHE_PLUGIN_CONNECTION = connection
     assert isinstance(cache_loader.get('community.general.redis', **{'_uri': connection}), RedisCache)

--- a/tests/unit/plugins/cache/test_redis.py
+++ b/tests/unit/plugins/cache/test_redis.py
@@ -28,7 +28,7 @@ pytest.importorskip('redis')
 from ansible.plugins.loader import cache_loader
 from ansible_collections.community.general.plugins.cache.redis import CacheModule as RedisCache
 from ansible import constants as C
-from ansible.release import __version__ as av
+from ansible.release import __version__ as ansible_version
 
 version = tuple(int(x) for x in av.split('.')[0:2])
 


### PR DESCRIPTION
##### SUMMARY
Improved the parsing of the connection string, from `.split(':')` to a regexp.

Fixes #497 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/cache/redis.py
