### PR TITLE
[netcup_dns] Use str() to get exception message

### DIFF
--- a/changelogs/fragments/2590-netcup_dns-exception-no-message-attr.yml
+++ b/changelogs/fragments/2590-netcup_dns-exception-no-message-attr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netcup_dns - use ``str(ex)`` instead of unreliable ``ex.message`` in exception handling to fix ``AttributeError`` in error cases (https://github.com/ansible-collections/community.general/pull/2590).

--- a/plugins/modules/net_tools/netcup_dns.py
+++ b/plugins/modules/net_tools/netcup_dns.py
@@ -255,7 +255,7 @@ def main():
                 has_changed = True
 
     except Exception as ex:
-        module.fail_json(msg=ex.message)
+        module.fail_json(msg=str(ex))
 
     module.exit_json(changed=has_changed, result={"records": [record_data(r) for r in all_records]})
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The `netcup_dns` module currently wraps most of its interaction with the `nc_dnsapi` Python package in a try-catch.
In the catch-clause it assumes that every exception that could be thrown has a `message` attribute, which is not true.
If `nc_dnsapi` throws an exception of a type that doesn't have a `message` attribute, the exception handling itself fails as well:
```
AttributeError: 'Exception' object has no attribute 'message'
```

This PR changes the source of the exception string from `ex.message` to `str(ex)`, because the second one is guaranteed to always return some form of string representation of the message, regardless of which attributes the exception object has.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netcup_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Traceback (most recent call last):
  File "/tmp/ansible_netcup_dns_payload_660r169c/ansible_netcup_dns_payload.zip/ansible_collections/community/general/plugins/modules/netcup_dns.py", line 220, in main
  File "/home/user/.local/lib/python3.9/site-packages/nc_dnsapi/__init__.py", line 192, in __init__
    self.login()
File "/home/user/.local/lib/python3.9/site-packages/nc_dnsapi/__init__.py", line 107, in login
    data = self.request("login", params={"apipassword": self.__api_password})
  File "/home/user/.local/lib/python3.9/site-packages/nc_dnsapi/__init__.py", line 98, in request
    raise Exception("{} ({})".format(data['longmessage'], data['statuscode']))
Exception: More than 180 requests per minute. Please wait and retry later. Please contact our customer service to find out if the limitation of requests can be increased. (4013)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-tmp-1621704216.9399202-33110-64037118917100/AnsiballZ_netcup_dns.py", line 100, in <module>
    _ansiballz_main()
  File "/home/user/.ansible/tmp/ansible-tmp-1621704216.9399202-33110-64037118917100/AnsiballZ_netcup_dns.py", line 92, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
 File "/home/user/.ansible/tmp/ansible-tmp-1621704216.9399202-33110-64037118917100/AnsiballZ_netcup_dns.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.netcup_dns', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.netcup_dns', _modlib_path=modlib_path),
  File "/usr/lib/python3.9/runpy.py", line 210, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_netcup_dns_payload_660r169c/ansible_netcup_dns_payload.zip/ansible_collections/community/general/plugins/modules/netcup_dns.py", line 268, in <module>
  File "/tmp/ansible_netcup_dns_payload_660r169c/ansible_netcup_dns_payload.zip/ansible_collections/community/general/plugins/modules/netcup_dns.py", line 258, in main
AttributeError: 'Exception' object has no attribute 'message'
```

I have no idea what causes the first exception yet, but I'm going to start with fixing the second exception that happens during the exception handling, to get that out of the way.