### PR TITLE
[WIP] read_csv - opening file as utf-8-sig

### DIFF
--- a/changelogs/fragments/2592-read-csv-utf-bom.yml
+++ b/changelogs/fragments/2592-read-csv-utf-bom.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - read_csv - opening file with encoding ``utf-8-sig`` (https://github.com/ansible-collections/community.general/issues/544).

--- a/plugins/module_utils/csv.py
+++ b/plugins/module_utils/csv.py
@@ -55,7 +55,7 @@ def initialize_dialect(dialect, **kwargs):
 
 def read_csv(data, dialect, fieldnames=None):
 
-    data = to_native(data, errors='surrogate_or_strict')
+    data = to_native(data, encoding="utf-8-sig", errors='surrogate_or_strict')
 
     if PY3:
         fake_fh = StringIO(data)

--- a/plugins/modules/files/read_csv.py
+++ b/plugins/modules/files/read_csv.py
@@ -137,8 +137,6 @@ list:
     gid: 500
 '''
 
-import io
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
@@ -180,7 +178,7 @@ def main():
         module.fail_json(msg=to_native(e))
 
     try:
-        with io.open(path, 'rb', encoding='utf-8-sig') as f:
+        with open(path, 'rb') as f:
             data = f.read()
     except (IOError, OSError) as e:
         module.fail_json(msg="Unable to open file: %s" % to_native(e))

--- a/plugins/modules/files/read_csv.py
+++ b/plugins/modules/files/read_csv.py
@@ -137,6 +137,8 @@ list:
     gid: 500
 '''
 
+import io
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
@@ -178,7 +180,7 @@ def main():
         module.fail_json(msg=to_native(e))
 
     try:
-        with open(path, 'rb') as f:
+        with io.open(path, 'rb', encoding='utf-8-sig') as f:
             data = f.read()
     except (IOError, OSError) as e:
         module.fail_json(msg="Unable to open file: %s" % to_native(e))


### PR DESCRIPTION
##### SUMMARY
Open the file with encoding `utf-8-sig` to accommodate UTF8 BOM markers.

Fixes #544 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
read_csv

