### PR TITLE
HAproxy - Fix drain example with correct wait_interval value

### DIFF
--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -150,7 +150,7 @@ EXAMPLES = r'''
     backend: www
     wait: yes
     drain: yes
-    wait_interval: 1
+    wait_interval: 60
     wait_retries: 60
 
 - name: Disable backend server in 'www' backend pool and drop open sessions to it


### PR DESCRIPTION
##### SUMMARY

The HAproxy module example for the `drain` usage does not match its associated comment.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

haproxy

##### ADDITIONAL INFORMATION
The drain code example would wait one second and expire after one minute while the comment describe a one minute waiting time and an expiration after one hour.