### PR TITLE
json_query, no more 'unkown type' errors

### DIFF
--- a/changelogs/fragments/json_query_more_types.yml
+++ b/changelogs/fragments/json_query_more_types.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - json_query filter plugin - avoid 'unknown type' errors for more Ansible internal types (https://github.com/ansible-collections/community.general/pull/2607).

--- a/plugins/filter/json_query.py
+++ b/plugins/filter/json_query.py
@@ -35,9 +35,11 @@ def json_query(data, expr):
         raise AnsibleError('You need to install "jmespath" prior to running '
                            'json_query filter')
 
-    # Hack to handle Ansible String Types
+    # Hack to handle Ansible Unsafe text, AnsibleMapping and AnsibleSequence
     # See issue: https://github.com/ansible-collections/community.general/issues/320
     jmespath.functions.REVERSE_TYPES_MAP['string'] = jmespath.functions.REVERSE_TYPES_MAP['string'] + ('AnsibleUnicode', 'AnsibleUnsafeText', )
+    jmespath.functions.REVERSE_TYPES_MAP['array'] = jmespath.functions.REVERSE_TYPES_MAP['array'] + ('AnsibleSequence', )
+    jmespath.functions.REVERSE_TYPES_MAP['object'] = jmespath.functions.REVERSE_TYPES_MAP['object'] + ('AnsibleMapping', )
     try:
         return jmespath.search(expr, data)
     except jmespath.exceptions.JMESPathError as e:


### PR DESCRIPTION
Added missing types for list and dicts, previously we had fixed the 'strings' issue

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filters/json_query