### PR TITLE
Add one-liner lookup example

### DIFF
--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -106,7 +106,8 @@ EXAMPLES = r"""
 
 - hosts: localhost
   vars:
-      secret_password: "{{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
+      secret_password: >-
+        {{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
   tasks:
       - ansible.builtin.debug:
           msg: the password is {{ secret_password}}

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -103,6 +103,13 @@ EXAMPLES = r"""
                 | items2dict(key_name='slug',
                              value_name='itemValue'))['password']
             }}
+            
+- hosts: localhost
+  vars:
+      secret_password: "{{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
+  tasks:
+      - ansible.builtin.debug:
+          msg: the password is {{ secret_password}}
 """
 
 from ansible.errors import AnsibleError, AnsibleOptionsError

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -103,7 +103,7 @@ EXAMPLES = r"""
                 | items2dict(key_name='slug',
                              value_name='itemValue'))['password']
             }}
-            
+
 - hosts: localhost
   vars:
       secret_password: "{{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -110,7 +110,7 @@ EXAMPLES = r"""
         {{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
   tasks:
       - ansible.builtin.debug:
-          msg: the password is {{ secret_password}}
+          msg: the password is {{ secret_password }}
 """
 
 from ansible.errors import AnsibleError, AnsibleOptionsError


### PR DESCRIPTION
##### SUMMARY
Adds a description of how to use the TSS lookup in a one-liner.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tss

##### ADDITIONAL INFORMATION
I spent several days bashing my head against a wall trying to understand why trying to access `['items']` gave the following error:
```
The task includes an option with an undefined variable. The error was: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'items'
```

Eventually I found out this was because the object was just a string, not an interpreted variable yet.

If this one-liner lookup example would be in the documentation, it would've saved me multiple days of screaming into the void hoping for it to return my desperate cries for help.

Please consider merging this to protect the sanity of the next person who needs to retrieve data from Thycotic.
