### PR TITLE
pacemaker_cluster: Add option to get status.

### DIFF
--- a/plugins/modules/clustering/pacemaker_cluster.py
+++ b/plugins/modules/clustering/pacemaker_cluster.py
@@ -20,7 +20,7 @@ options:
     state:
       description:
         - Indicate desired state of the cluster
-      choices: [ cleanup, offline, online, restart ]
+      choices: [ cleanup, offline, online, restart, status ]
       required: yes
     node:
       description:
@@ -155,7 +155,7 @@ def set_node(module, state, timeout, force, node='all'):
 
 def main():
     argument_spec = dict(
-        state=dict(type='str', choices=['online', 'offline', 'restart', 'cleanup']),
+        state=dict(type='str', choices=['online', 'offline', 'restart', 'cleanup', 'status']),
         node=dict(type='str'),
         timeout=dict(type='int', default=300),
         force=dict(type='bool', default=True),
@@ -214,6 +214,10 @@ def main():
         cluster_state = get_cluster_status(module)
         module.exit_json(changed=True,
                          out=cluster_state)
+    
+    if state in ['status']:
+        cluster_state = get_cluster_status(module)
+        module.exit_json(changed=False, out=cluster_state)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Add an option to return the status of the cluster without making any changes.

##### COMPONENT NAME
pacemaker_cluster

##### ADDITIONAL INFORMATION
Sample tasks:

```
- name: get cluster status
    community.general.pacemaker_cluster:
      state: status
    register: result

  - debug:
      var: result
```

Result:

```
LAY [PCS] ************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************
ok: [satrhel7-1.localdomain.local]
ok: [satrhel7-2.localdomain.local]

TASK [get cluster status] *********************************************************************************************
ok: [satrhel7-1.localdomain.local]
ok: [satrhel7-2.localdomain.local]

TASK [debug] **********************************************************************************************************
ok: [satrhel7-1.localdomain.local] => {
    "result": {
        "changed": false,
        "failed": false,
        "out": "offline"
    }
}
ok: [satrhel7-2.localdomain.local] => {
    "result": {
        "changed": false,
        "failed": false,
        "out": "offline"
    }
}

PLAY RECAP ************************************************************************************************************
satrhel7-1.localdomain.local : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
satrhel7-2.localdomain.local : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```