### PR TITLE
Dynamically add meta/runtime.yml redirects for integration tests to correctly report coverage

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -97,6 +97,13 @@ fi
 
 # END: HACK
 
+if [ "${script}" != "sanity" ] && [ "${script}" != "units" ]; then
+    # Adds meta/runtime.yml redirects for all modules before running integration tests.
+    # This ensures that ansible-base and ansible-core will use the "real" modules instead of the
+    # symbolic links, which results in coverage to be reported correctly.
+    "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/internal_test_tools/tools/meta_runtime.py" redirect --target both --flatmap
+fi
+
 export PYTHONIOENCODING='utf-8'
 
 if [ "${JOB_TRIGGERED_BY_NAME:-}" == "nightly-trigger" ]; then


### PR DESCRIPTION
##### SUMMARY
One problem with the flatmapping approach (symlinks) in community.general is that integration tests do not count for code coverage in plugins/modules and plugins/action (the other plugins/ directories are considered correctly). This is because Ansible loads code from the symlinks and the symlinks are reported as the filename, and not the file they link to. By temporarily adding meta/runtime.yml redirects during integration testing, at least ansible-base and ansible-core will use the real modules (and action plugins) instead of the symlinks, and thus code coverage will be reported correctly.

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI
