### PR TITLE
Terraform: ensure workspace is reset to current value

### DIFF
--- a/changelogs/fragments/2634-terraform-switch-workspace.yml
+++ b/changelogs/fragments/2634-terraform-switch-workspace.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - terraform - ensure the workspace is set back to its previous value when the apply fails (https://github.com/ansible-collections/community.general/pull/2634).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -442,10 +442,10 @@ def main():
         if rc != 0:
             if workspace_ctx["current"] != workspace:
                 select_workspace(command[0], project_path, workspace_ctx["current"])
-            module.fail_json(
-                msg=err.rstrip(),
-                rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err, stderr_lines=err.splitlines(),
-                cmd=' '.join(command))
+            module.fail_json(msg=err.rstrip(), rc=rc, stdout=out,
+                             stdout_lines=out.splitlines(), stderr=err,
+                             stderr_lines=err.splitlines(),
+                             cmd=' '.join(command))
         # checks out to decide if changes were made during execution
         if ' 0 added, 0 changed' not in out and not state == "absent" or ' 0 destroyed' not in out:
             changed = True

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -438,7 +438,14 @@ def main():
         command.append(plan_file)
 
     if needs_application and not module.check_mode and not state == 'planned':
-        rc, out, err = module.run_command(command, check_rc=True, cwd=project_path)
+        rc, out, err = module.run_command(command, check_rc=False, cwd=project_path)
+        if rc != 0:
+            if workspace_ctx["current"] != workspace:
+                select_workspace(command[0], project_path, workspace_ctx["current"])
+            module.fail_json(
+                msg=err.rstrip(),
+                rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err, stderr_lines=err.splitlines(),
+                cmd=' '.join(command))
         # checks out to decide if changes were made during execution
         if ' 0 added, 0 changed' not in out and not state == "absent" or ' 0 destroyed' not in out:
             changed = True


### PR DESCRIPTION
##### SUMMARY
When terraform apply is failing (topology syntax valid, but unable to complete change), the module ends without resetting the workspace.

Instead of relying on `module.run_command()` exception, this PR resets workspace and renders equivalent output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
How to reproduce:
The following playbook + topology is expected to fail, since "test" bucket name is not available.
Run and check if topology workspace is back to "default" after the playbook failure.

```paste below
# playbook:
- hosts: localhost
  tasks:
  - community.general.terraform:
      workspace: "foo"
      state: "present"

# topology
resource "aws_s3_bucket" "main" {
  bucket = "test"
}
```

There is still an issue if the **plan** fails, IMHO this needs little refactoring to improve workspace switching.