### PR TITLE
Temporarily disable iptables_state tests

### DIFF
--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -5,3 +5,4 @@ skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)
 skip/macos              # no iptables/netfilter (Linux specific)
 skip/aix                # no iptables/netfilter (Linux specific)
+disabled  # FIXME


### PR DESCRIPTION
##### SUMMARY
Disable tests until #2627 is fixed, so that CI will run through again and not block other PRs.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
iptables_state
