### PR TITLE
proxmox_kvm - Fixed vmid result when VM with name exists

### DIFF
--- a/changelogs/fragments/2648-proxmox_kvm-fix-vmid-return-value.yml
+++ b/changelogs/fragments/2648-proxmox_kvm-fix-vmid-return-value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - fixed ``vmid`` return value when VM with ``name`` already exists (https://github.com/ansible-collections/community.general/issues/2648).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1226,7 +1226,7 @@ def main():
             if get_vm(proxmox, vmid) and not (update or clone):
                 module.exit_json(changed=False, vmid=vmid, msg="VM with vmid <%s> already exists" % vmid)
             elif get_vmid(proxmox, name) and not (update or clone):
-                module.exit_json(changed=False, vmid=vmid, msg="VM with name <%s> already exists" % name)
+                module.exit_json(changed=False, vmid=get_vmid(proxmox, name)[0], msg="VM with name <%s> already exists" % name)
             elif not (node, name):
                 module.fail_json(msg='node, name is mandatory for creating/updating vm')
             elif not node_check(proxmox, node):


### PR DESCRIPTION
##### SUMMARY
Updating VMID value for exit result when VM with `name` already exists. Previous behavior just returned the next id from the cluster sequence.

Fixes #2636

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox_kvm.py

##### ADDITIONAL INFORMATION
- If there are two VM's with the same name in the cluster it is still possible that the vmid result will be incorrect.