### PR TITLE
Reading argument_specs from docs (attempt #3)

### DIFF
--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -6,23 +6,12 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.mh.exceptions import ModuleHelperException as _MHE
 from ansible_collections.community.general.plugins.module_utils.mh.deco import module_fails_on_exception
 
 
 class ModuleHelperBase(object):
-    module = None
-    ModuleHelperException = _MHE
-
-    def __init__(self, module=None):
+    def __init__(self):
         self._changed = False
-
-        if module:
-            self.module = module
-
-        if not isinstance(self.module, AnsibleModule):
-            self.module = AnsibleModule(**self.module)
 
     def __init_module__(self):
         pass
@@ -54,9 +43,12 @@ class ModuleHelperBase(object):
     def output(self):
         raise NotImplementedError()
 
+    def exit(self):
+        raise NotImplementedError()
+
     @module_fails_on_exception
     def run(self):
         self.__init_module__()
         self.__run__()
         self.__quit_module__()
-        self.module.exit_json(changed=self.has_changed(), **self.output)
+        self.exit()

--- a/plugins/module_utils/mh/mixins/module.py
+++ b/plugins/module_utils/mh/mixins/module.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# (c) 2021, Alexei Znamensky <russoz@gmail.com>
+# Copyright: (c) 2021, Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import traceback
+from functools import reduce
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.dict_transformations import dict_merge
+
+from ansible_collections.community.general.plugins.module_utils.mh.exceptions import ModuleHelperException as _MHE
+
+YAML_IMP_ERR = None
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    YAML_IMP_ERR = traceback.format_exc()
+    HAS_YAML = False
+
+
+class _YamlNotFound(Exception):
+    def __init__(self, msg, exception):
+        self.msg = msg
+        self.exception = exception
+
+
+class ModuleMixin(object):
+    module = None
+    ModuleHelperException = _MHE
+    auto_args_spec = []
+
+    @staticmethod
+    def _parse_options(options):
+        param_spec_fields = ('type', 'elements', 'required', 'default', 'choices', 'aliases')
+        result = {}
+        for opt in options:
+            opt_spec = options[opt]
+            result.update({opt: dict([(k, opt_spec[k]) for k in opt_spec if k in param_spec_fields])})
+            if 'suboptions' in opt_spec:
+                result[opt]['options'] = ModuleMixin._parse_options(opt_spec['suboptions'])
+        return result
+
+    @staticmethod
+    def _args_spec_from_docs(docs):
+        if not docs:
+            return {}
+        d = yaml.load(docs)
+        options = d['options']
+        return ModuleMixin._parse_options(options)
+
+    def auto_args(self):
+        if not HAS_YAML:
+            # unable to call module.fail_json() as module is not yet instantiated
+            raise _YamlNotFound(msg=missing_required_lib('PyYAML'), exception=YAML_IMP_ERR)
+
+        auto_args = [self.auto_args_spec] if isinstance(self.auto_args_spec, str) else self.auto_args_spec
+        opts_docs = [self._args_spec_from_docs(d) for d in auto_args]
+        opts_args = [self.module['argument_spec']] or []
+        opts_list = opts_docs + opts_args
+        options = reduce(dict_merge, opts_list)
+        return options
+
+    def __init__(self, module=None):
+        super(ModuleMixin, self).__init__()
+
+        if module:
+            self.module = module
+
+        if not isinstance(self.module, AnsibleModule):
+            if self.auto_args_spec or self.auto_args_spec_extends:
+                try:
+                    options = self.auto_args()
+                    self.module['argument_spec'] = options
+                except _YamlNotFound as yaml_not_found:
+                    # Cannot create the real module if yaml is missing, so raising error with dummy one
+                    self.module = AnsibleModule(argument_spec={"dummy": {"type": "str"}})
+                    self.module.fail_json(msg=yaml_not_found.msg, exception=yaml_not_found.exception)
+
+            self.module = AnsibleModule(**self.module)
+
+    def exit(self):
+        self.module.exit_json(changed=self.has_changed(), **self.output)

--- a/plugins/module_utils/mh/mixins/module.py
+++ b/plugins/module_utils/mh/mixins/module.py
@@ -72,7 +72,7 @@ class ModuleMixin(object):
             self.module = module
 
         if not isinstance(self.module, AnsibleModule):
-            if self.auto_args_spec or self.auto_args_spec_extends:
+            if self.auto_args_spec:
                 try:
                     options = self.auto_args()
                     self.module['argument_spec'] = options

--- a/plugins/module_utils/mh/mixins/vars.py
+++ b/plugins/module_utils/mh/mixins/vars.py
@@ -122,8 +122,8 @@ class VarDict(object):
 class VarsMixin(object):
 
     def __init__(self, module=None):
-        self.vars = VarDict()
         super(VarsMixin, self).__init__(module)
+        self.vars = VarDict()
 
     def update_vars(self, meta=None, **kwargs):
         if meta is None:

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -8,14 +8,15 @@ __metaclass__ = type
 
 from ansible.module_utils.common.dict_transformations import dict_merge
 
-from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase, AnsibleModule
+from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.cmd import CmdMixin
-from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.deps import DependencyMixin
+from ansible_collections.community.general.plugins.module_utils.mh.mixins.module import ModuleMixin, AnsibleModule
+from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarsMixin, VarDict as _VD
 
 
-class ModuleHelper(VarsMixin, DependencyMixin, ModuleHelperBase):
+class ModuleHelper(VarsMixin, DependencyMixin, ModuleMixin, ModuleHelperBase):
     _output_conflict_list = ('msg', 'exception', 'output', 'vars', 'changed')
     facts_name = None
     output_params = ()

--- a/plugins/modules/packaging/language/cpanm.py
+++ b/plugins/modules/packaging/language/cpanm.py
@@ -150,21 +150,10 @@ from ansible_collections.community.general.plugins.module_utils.module_helper im
 
 class CPANMinus(CmdMixin, ModuleHelper):
     output_params = ['name', 'version']
+    auto_args_spec = DOCUMENTATION
     module = dict(
         argument_spec=dict(
-            name=dict(type='str', aliases=['pkg']),
-            version=dict(type='str'),
-            from_path=dict(type='path'),
-            notest=dict(type='bool', default=False),
-            locallib=dict(type='path'),
-            mirror=dict(type='str'),
-            mirror_only=dict(type='bool', default=False),
-            installdeps=dict(type='bool', default=False),
-            system_lib=dict(type='bool', default=False, aliases=['use_sudo'],
-                            removed_in_version="4.0.0", removed_from_collection="community.general"),
-            executable=dict(type='path'),
-            mode=dict(type='str', choices=['compatibility', 'new'], default='compatibility'),
-            name_check=dict(type='str')
+            system_lib=dict(removed_in_version="4.0.0", removed_from_collection="community.general"),
         ),
         required_one_of=[('name', 'from_path')],
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -156,19 +156,9 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
     diff_params = 'value',
     output_params = ('property', 'channel', 'value')
     facts_params = ('property', 'channel', 'value')
+    auto_args_spec = DOCUMENTATION
     module = dict(
-        argument_spec=dict(
-            state=dict(default="present",
-                       choices=("present", "get", "absent"),
-                       type='str'),
-            channel=dict(required=True, type='str'),
-            property=dict(required=True, type='str'),
-            value_type=dict(required=False, type='list',
-                            elements='str', choices=('int', 'uint', 'bool', 'float', 'double', 'string')),
-            value=dict(required=False, type='list', elements='raw'),
-            force_array=dict(default=False, type='bool', aliases=['array']),
-            disable_facts=dict(type='bool', default=False),
-        ),
+        argument_spec={},
         required_if=[('state', 'present', ['value', 'value_type'])],
         required_together=[('value', 'value_type')],
         supports_check_mode=True,
@@ -184,9 +174,6 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         create=dict(fmt="--create", style=ArgFormat.BOOLEAN),
         values_and_types=dict(fmt=values_fmt)
     )
-
-    def update_xfconf_output(self, **kwargs):
-        self.update_vars(meta={"output": True, "fact": True}, **kwargs)
 
     def __init_module__(self):
         self.does_not = 'Property "{0}" does not exist on channel "{1}".'.format(self.module.params['property'],

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -395,42 +395,10 @@ from ansible.module_utils.urls import fetch_url
 
 
 class JIRA(StateModuleHelper):
+    auto_args_spec = DOCUMENTATION
     module = dict(
         argument_spec=dict(
-            attachment=dict(type='dict', options=dict(
-                content=dict(type='str'),
-                filename=dict(type='path', required=True),
-                mimetype=dict(type='str')
-            )),
-            uri=dict(type='str', required=True),
-            operation=dict(
-                type='str',
-                choices=['attach', 'create', 'comment', 'edit', 'update', 'fetch', 'transition', 'link', 'search'],
-                aliases=['command'], required=True
-            ),
-            username=dict(type='str', required=True),
-            password=dict(type='str', required=True, no_log=True),
-            project=dict(type='str', ),
-            summary=dict(type='str', ),
-            description=dict(type='str', ),
-            issuetype=dict(type='str', ),
-            issue=dict(type='str', aliases=['ticket']),
-            comment=dict(type='str', ),
-            comment_visibility=dict(type='dict', options=dict(
-                type=dict(type='str', choices=['group', 'role'], required=True),
-                value=dict(type='str', required=True)
-            )),
-            status=dict(type='str', ),
-            assignee=dict(type='str', ),
-            fields=dict(default={}, type='dict'),
-            linktype=dict(type='str', ),
-            inwardissue=dict(type='str', ),
-            outwardissue=dict(type='str', ),
-            jql=dict(type='str', ),
-            maxresults=dict(type='int'),
-            timeout=dict(type='float', default=10),
-            validate_certs=dict(default=True, type='bool'),
-            account_id=dict(type='str'),
+            password=dict(no_log=True),
         ),
         required_if=(
             ('operation', 'attach', ['issue', 'attachment']),


### PR DESCRIPTION
##### SUMMARY
I have been trying to find a way to close the gap between the `DOCUMENTATION.options` yaml blob and the contents of  `argument_spec` when creating an `AnsibleModule`. The internal code in Ansible is off-limits for `modules`, `module_utils`, and even for `AnsibleModule` itself.

So, the next solution that came to my mind was to defer the responsibility of picking the YAML blobs to the user. This solution adds to `ModuleHelper`, and allows module developers to remove most (if not all) of the `argument_spec`, including `suboptions`/`options` for `type='dict'` (or `elements='dict'`).

Cases that cannot be imported from the documentation:
- deprecations
- `no_log`

As per the PR, this has been applied to three modules that use `ModuleHelper`, they are all passing the tests locally. This PR starts as a WIP exactly to check if that holds true in the CI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py
plugins/module_utils/mh/mixins/vars.py
plugins/module_utils/mh/module_helper.py
plugins/modules/packaging/language/cpanm.py
plugins/modules/system/xfconf.py
plugins/modules/web_infrastructure/jira.py
