### PR TITLE
Github modules: unify authentication handling

### DIFF
--- a/plugins/doc_fragments/github.py
+++ b/plugins/doc_fragments/github.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Erinn Looney-Triggs
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    # Common parameters for GitHub
+    DOCUMENTATION = '''
+description:
+- Authentication can be done with a I(token).
+options:
+  token:
+    description:
+    - Access Token used for authentication to GitHub.
+    type: str
+    required: true
+'''

--- a/plugins/modules/source_control/github/github_webhook_info.py
+++ b/plugins/modules/source_control/github/github_webhook_info.py
@@ -9,12 +9,19 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: github_webhook_info
+
 short_description: Query information about GitHub webhooks
+
 description:
   - "Query information about GitHub webhooks"
   - This module was called C(github_webhook_facts) before Ansible 2.9. The usage did not change.
+
+extends_documentation_fragment:
+- community.general.github
+
 requirements:
   - "PyGithub >= 1.3.5"
+
 options:
   repository:
     description:
@@ -23,21 +30,6 @@ options:
     required: true
     aliases:
       - repo
-  user:
-    description:
-      - User to authenticate to GitHub as
-    type: str
-    required: true
-  password:
-    description:
-      - Password to authenticate to GitHub with
-    type: str
-    required: false
-  token:
-    description:
-      - Token to authenticate to GitHub with
-    type: str
-    required: false
   github_url:
     description:
       - Base URL of the github api
@@ -117,13 +109,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             repository=dict(type='str', required=True, aliases=["repo"]),
-            user=dict(type='str', required=True),
-            password=dict(type='str', required=False, no_log=True),
-            token=dict(type='str', required=False, no_log=True),
+            token=dict(type='str', required=True, no_log=True),
             github_url=dict(
                 type='str', required=False, default="https://api.github.com")),
-        mutually_exclusive=(('password', 'token'), ),
-        required_one_of=(("password", "token"), ),
         supports_check_mode=True)
 
     if not HAS_GITHUB:
@@ -131,9 +119,7 @@ def main():
                          exception=GITHUB_IMP_ERR)
 
     try:
-        github_conn = github.Github(
-            module.params["user"],
-            module.params.get("password") or module.params.get("token"),
+        github_conn = github.Github(module.params.get("token"),
             base_url=module.params["github_url"])
     except github.GithubException as err:
         module.fail_json(msg="Could not connect to GitHub at %s: %s" % (

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -51,7 +51,6 @@ plugins/modules/remote_management/manageiq/manageiq_tags.py validate-modules:par
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:doc-default-does-not-match-spec
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/stacki/stacki_host.py validate-modules:undocumented-parameter
-plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid
 plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/launchd.py use-argspec-type-path  # False positive


### PR DESCRIPTION
##### SUMMARY
This began as a project to unify the github modules using a common syntax, some were using user, others username, some access_token, others token. However, It quickly spiraled as it turns out username password auth no longer works at all against the GitHub API: https://docs.github.com/en/rest/overview/other-authentication-methods#via-username-and-password and so user/username and password were removed completely. It's possible that a user running GitHub Enterprise Server may still be able to use basic auth on an old version of GHES, but anything current should be token based. 

I am unsure whether this requires a deprecation notice etc. as it is already gone from GitHub and will not work anyway it doesn't make sense to me to deprecate, but this is not my project :). 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
- github_deploy_key
- github_release
- github_repo
- github_webhook_info
- github_webhook


