### PR TITLE
gitlab_user: add support for identity provider

### DIFF
--- a/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
+++ b/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "gitlab_user - Add functionality for adding an external identity provider to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)"

--- a/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
+++ b/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
@@ -1,3 +1,5 @@
 ---
 minor_changes:
+  - "gitlab_user - specifying a password is no longer necessary (https://github.com/ansible-collections/community.general/pull/2691)."
+  - "gitlab_user - allow to reset an existing password with the new ``reset_password`` option (https://github.com/ansible-collections/community.general/pull/2691)."
   - "gitlab_user - add functionality for adding external identity providers to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)."

--- a/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
+++ b/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "gitlab_user - Add functionality for adding an external identity provider to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)"
+  - "gitlab_user - add functionality for adding an external identity provider to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)."

--- a/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
+++ b/changelogs/fragments/2691-gitlab_user-support-identity-provider.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "gitlab_user - add functionality for adding an external identity provider to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)."
+  - "gitlab_user - add functionality for adding external identity providers to a GitLab user (https://github.com/ansible-collections/community.general/pull/2691)."

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -527,7 +527,7 @@ class GitLabUser(object):
 
 
 def sanitize_arguments(arguments):
-    for key, value in dict(arguments).items():
+    for key, value in list(arguments.items()):
         if value is None:
             del arguments[key]
     return arguments

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -56,6 +56,7 @@ options:
   reset_password:
     description:
       - Wether the user can change its password or not.
+    default: False
     type: bool
   email:
     description:
@@ -439,7 +440,7 @@ class GitLabUser(object):
                         "extern_uid": arguments['extern_uid']['value']
                     }
 
-                    if not new_identity in user.identities:
+                    if new_identity not in user.identities:
                         setattr(user, 'provider', arguments['provider']['value'])
                         setattr(user, 'extern_uid', arguments['extern_uid']['value'])
                         changed = True

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -488,9 +488,6 @@ class GitLabUser(object):
     @param overwrite_identities Overwrite user identities with identities passed to this module
     '''
     def addIdentities(self, user, identities, overwrite_identities=False):
-        if self._module.check_mode:
-            return True
-
         changed = False
         if overwrite_identities:
             changed = self.deleteIdentities(user, identities)
@@ -499,7 +496,8 @@ class GitLabUser(object):
             if identity not in user.identities:
                 setattr(user, 'provider', identity['provider'])
                 setattr(user, 'extern_uid', identity['extern_uid'])
-                user.save()
+                if not self._module.check_mode:
+                    user.save()
                 changed = True
         return changed
 
@@ -508,13 +506,11 @@ class GitLabUser(object):
     @param identites List of identities to be added/updated
     '''
     def deleteIdentities(self, user, identities):
-        if self._module.check_mode:
-            return True
-
         changed = False
         for identity in user.identities:
             if identity not in identities:
-                user.identityproviders.delete(identity['provider'])
+                if not self._module.check_mode:
+                    user.identityproviders.delete(identity['provider'])
                 changed = True
         return changed
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -119,11 +119,12 @@ options:
   identities:
     description:
       - List of identities to be added/updated for this user.
+    elements: dict
     type: list
     version_added: 3.3.0
   overwrite_identities:
     description:
-      - Overwrite identities with identities added in this module
+      - Overwrite identities with identities added in this module.
     type: bool
     default: no
     version_added: 3.3.0
@@ -163,8 +164,9 @@ EXAMPLES = '''
     username: myusername
     password: mysecretpassword
     email: me@example.com
-    provider: Keycloak
-    extern_uid: f278f95c-12c7-4d51-996f-758cc2eb11bc
+    identities:
+    - provider: Keycloak
+      extern_uid: f278f95c-12c7-4d51-996f-758cc2eb11bc
     state: present
     group: super_group/mon_group
     access_level: owner
@@ -495,9 +497,9 @@ class GitLabUser(object):
     def deleteIdentities(self, user, identities):
         changed = False
         for identity in user.identities:
-                if identity not in identities:
-                    user.identityproviders.delete(identity['provider'])
-                    changed = True
+            if identity not in identities:
+                user.identityproviders.delete(identity['provider'])
+                changed = True
         return changed
 
     '''

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -53,6 +53,10 @@ options:
       - GitLab server enforces minimum password length to 8, set this value with 8 or more characters.
       - Required only if C(state) is set to C(present).
     type: str
+  reset_password:
+    description:
+      - Wether the user can change its password or not.
+    type: bool
   email:
     description:
       - The email that belongs to the user.
@@ -424,16 +428,17 @@ class GitLabUser(object):
 
         arguments = sanitize_arguments(arguments)
 
-        new_identity = {
-                "provider": arguments['provider']['value'],
-                "extern_uid": arguments['extern_uid']['value']
-        }
-
         for arg_key, arg_value in arguments.items():
             av = arg_value['value']
 
             if av is not None:
                 if arg_key == "provider" or arg_key == "extern_uid":
+
+                    new_identity = {
+                        "provider": arguments['provider']['value'],
+                        "extern_uid": arguments['extern_uid']['value']
+                    }
+
                     if not new_identity in user.identities:
                         setattr(user, 'provider', arguments['provider']['value'])
                         setattr(user, 'extern_uid', arguments['extern_uid']['value'])
@@ -534,7 +539,7 @@ def main():
         state=dict(type='str', default="present", choices=["absent", "present", "blocked", "unblocked"]),
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True),
-        reset_password=dict(type='str', default=False,  no_log=True),
+        reset_password=dict(type='bool', default=False, no_log=True),
         email=dict(type='str'),
         sshkey_name=dict(type='str'),
         sshkey_file=dict(type='str', no_log=False),

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -55,7 +55,7 @@ options:
     type: str
   reset_password:
     description:
-      - Wether the user can change its password or not.
+      - Whether the user can change its password or not.
     default: false
     type: bool
     version_added: 3.3.0

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -541,7 +541,7 @@ def main():
         state=dict(type='str', default="present", choices=["absent", "present", "blocked", "unblocked"]),
         username=dict(type='str', required=True),
         password=dict(type='str', no_log=True),
-        reset_password=dict(type='bool', default=False, no_log=True),
+        reset_password=dict(type='bool', default=False, no_log=False),
         email=dict(type='str'),
         sshkey_name=dict(type='str'),
         sshkey_file=dict(type='str', no_log=False),

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -119,11 +119,13 @@ options:
   provider:
     description:
       - External provider for this user.
+    version_added: 3.2.0
     type: str
   extern_uid:
     description:
       - External UID for this user.
     type: str
+    version_added: 3.2.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -588,7 +588,7 @@ def main():
         confirm=dict(type='bool', default=True),
         isadmin=dict(type='bool', default=False),
         external=dict(type='bool', default=False),
-        identities=dict(type='list'),
+        identities=dict(type='list', elements='dict'),
         overwrite_identities=dict(type='bool', default=False)
     ))
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -467,6 +467,7 @@ class GitLabUser(object):
         if self._module.check_mode:
             return True
 
+        identities = None
         if 'identities' in arguments:
             identities = arguments['identities']
             del arguments['identities']

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -58,7 +58,7 @@ options:
       - Wether the user can change its password or not.
     default: false
     type: bool
-    version_added: 3.2.0
+    version_added: 3.3.0
   email:
     description:
       - The email that belongs to the user.
@@ -128,14 +128,14 @@ options:
         type: str
       extern_uid:
         description:
-          - UID for external identity
+          - User ID for external identity.
         type: str
     version_added: 3.3.0
   overwrite_identities:
     description:
       - Overwrite identities with identities added in this module.
     type: bool
-    default: no
+    default: false
     version_added: 3.3.0
 '''
 
@@ -289,7 +289,7 @@ class GitLabUser(object):
                         'value': options['isadmin'], 'setter': 'admin'
                     },
                     'external': {'value': options['external']},
-                    'identities': {'value': options['identities']}
+                    'identities': {'value': options['identities']},
                 },
                 {
                     # put "uncheckable" params here, this means params
@@ -298,7 +298,7 @@ class GitLabUser(object):
                     'skip_reconfirmation': {'value': not options['confirm']},
                     'password': {'value': options['password']},
                     'reset_password': {'value': options['reset_password']},
-                    'overwrite_identities': {'value': options['overwrite_identities']}
+                    'overwrite_identities': {'value': options['overwrite_identities']},
                 }
             )
 
@@ -590,7 +590,7 @@ def main():
         isadmin=dict(type='bool', default=False),
         external=dict(type='bool', default=False),
         identities=dict(type='list', elements='dict'),
-        overwrite_identities=dict(type='bool', default=False)
+        overwrite_identities=dict(type='bool', default=False),
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -56,7 +56,7 @@ options:
   reset_password:
     description:
       - Wether the user can change its password or not.
-    default: False
+    default: false
     type: bool
     version_added: 3.2.0
   email:

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -154,8 +154,7 @@ EXAMPLES = '''
   community.general.gitlab_user:
     api_url: https://gitlab.example.com/
     validate_certs: True
-    api_username: dj-wasabi
-    api_password: "MySecretPassword"
+    api_token: "{{ access_token }}"
     name: My Name
     username: myusername
     password: mysecretpassword

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -119,8 +119,17 @@ options:
   identities:
     description:
       - List of identities to be added/updated for this user.
-    elements: dict
     type: list
+    elements: dict
+    suboptions:
+      provider:
+        description:
+          - The name of the external identity provider
+        type: str
+      extern_uid:
+        description:
+          - UID for external identity
+        type: str
     version_added: 3.3.0
   overwrite_identities:
     description:

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -257,7 +257,8 @@ class GitLabUser(object):
                 'admin': options['isadmin'],
                 'external': options['external'],
                 'provider': options['provider'],
-                'extern_uid': options['extern_uid']})
+                'extern_uid': options['extern_uid'],
+            })
             changed = True
         else:
             changed, user = self.updateUser(

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -119,6 +119,7 @@ options:
   identities:
     description:
       - List of identities to be added/updated for this user.
+      - To remove all other identities from this user, set I(overwrite_identities=true).
     type: list
     elements: dict
     suboptions:
@@ -134,6 +135,8 @@ options:
   overwrite_identities:
     description:
       - Overwrite identities with identities added in this module.
+      - This means that all identities that the user has and that are not listed in I(identities) are removed from the user.
+      - This is only done if a list is provided for I(identities). To remove all identities, provide an empty list.
     type: bool
     default: false
     version_added: 3.3.0

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -488,6 +488,9 @@ class GitLabUser(object):
     @param overwrite_identities Overwrite user identities with identities passed to this module
     '''
     def addIdentities(self, user, identities, overwrite_identities=False):
+        if self._module.check_mode:
+            return True
+
         changed = False
         if overwrite_identities:
             changed = self.deleteIdentities(user, identities)
@@ -505,6 +508,9 @@ class GitLabUser(object):
     @param identites List of identities to be added/updated
     '''
     def deleteIdentities(self, user, identities):
+        if self._module.check_mode:
+            return True
+
         changed = False
         for identity in user.identities:
             if identity not in identities:

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -58,6 +58,7 @@ options:
       - Wether the user can change its password or not.
     default: False
     type: bool
+    version_added: 3.2.0
   email:
     description:
       - The email that belongs to the user.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change includes the functionality to add and identity provider and the external UID that is required to use an external provider (e.g. Keycloak, google_oauth2, ...).
With this change I also included the option `reset_pasword` because either `password` or `reset_password` is required by the GitLab API. If you use an external identity provider you don't want/need to set a password so that is why the `reset_password` was mandatory for this change.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `gitlab_user`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This module changes are for people who want to connect their external identity provider with a GitLab user.
You can add users with or without external provider now.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Create GitLab user] ***********************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "msg": "Successfully created or updated the user testuser123", "user": {"avatar_url": "https://secure.gravatar.com/avatar/59bca95eaaceda1e2d33fa725775d122?s=80&d=identicon", "bio": "", "bio_html": "", "can_create_group": true, "can_create_project": true, "color_scheme_id": 1, "confirmed_at": null, "created_at": "2021-06-02T11:18:49.522+02:00", "current_sign_in_at": null, "email": "lennert@example.be", "external": false, "id": 74, "identities": [{"extern_uid": "f232f...", "provider": "Keycloak"}], "is_admin": false, "job_title": "", "last_activity_on": null, "last_sign_in_at": null, "linkedin": "", "location": null, "name": "Test user", "note": null, "organization": null, "private_profile": false, "projects_limit": 100, "public_email": "", "skype": "", "state": "active", "theme_id": 2, "twitter": "", "two_factor_enabled": false, "username": "testuser123", "web_url": "https://git.example.com/testuser123", "website_url": "", "work_information": null}}
```
