### PR TITLE
keycloak_realm.py: Fix the `ssl_required` parameter according to the API

### DIFF
--- a/changelogs/fragments/keycloak_realm_ssl_required.yml
+++ b/changelogs/fragments/keycloak_realm_ssl_required.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - keycloak_realm module plugin - 'ssl_required' changed from a bool type to accept 'none', 'external' or 'all' (https://github.com/ansible-collections/community.general/pull/2693).

--- a/changelogs/fragments/keycloak_realm_ssl_required.yml
+++ b/changelogs/fragments/keycloak_realm_ssl_required.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - keycloak_realm module plugin - 'ssl_required' changed from a bool type to accept 'none', 'external' or 'all' (https://github.com/ansible-collections/community.general/pull/2693).
+  - keycloak_realm - ``ssl_required`` changed from a boolean type to accept the strings ``none``, ``external`` or ``all``. This is not a breaking change since the module always failed when a boolean was supplied (https://github.com/ansible-collections/community.general/pull/2693).

--- a/plugins/modules/identity/keycloak/keycloak_realm.py
+++ b/plugins/modules/identity/keycloak/keycloak_realm.py
@@ -439,9 +439,10 @@ options:
     ssl_required:
         description:
             - The realm ssl required option.
+        choices: ['all', 'external', 'none']
         aliases:
             - sslRequired
-        type: bool
+        type: str
     sso_session_idle_timeout:
         description:
             - The realm sso session idle timeout.
@@ -657,7 +658,7 @@ def main():
         reset_password_allowed=dict(type='bool', aliases=['resetPasswordAllowed']),
         revoke_refresh_token=dict(type='bool', aliases=['revokeRefreshToken']),
         smtp_server=dict(type='dict', aliases=['smtpServer']),
-        ssl_required=dict(type='bool', aliases=['sslRequired']),
+        ssl_required=dict(choices=["external", "all", "none"], aliases=['sslRequired']),
         sso_session_idle_timeout=dict(type='int', aliases=['ssoSessionIdleTimeout']),
         sso_session_idle_timeout_remember_me=dict(type='int', aliases=['ssoSessionIdleTimeoutRememberMe']),
         sso_session_max_lifespan=dict(type='int', aliases=['ssoSessionMaxLifespan']),


### PR DESCRIPTION
##### SUMMARY

The `ssl_required` parameter is a string and must be one of 'all',
'external' or 'none'. Passing a bool will make the server return a 500.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_realm

##### ADDITIONAL INFORMATION

See https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_realmrepresentation for the representation. Sadly the values are not present here. One can see them by spawning a keycloak server and going to any realm, then 'login' and there is a dropdown with the actual text values.

Let me know if you prefer an issue first!

I was also not sure how to write tests for this since there doesn't seem to be any integration tests I could find?