### PR TITLE
keycloak_realm.py: Mark 'reset_password_allowed' as no_log=False

### DIFF
--- a/changelogs/fragments/keycloak-realm-no-log-password-reset.yml
+++ b/changelogs/fragments/keycloak-realm-no-log-password-reset.yml
@@ -1,2 +1,2 @@
-minor_changes:
-  - keycloak_realm - mark 'reset_password_allowed' as 'no_log=True' (https://github.com/ansible-collections/community.general/pull/2694)
+bugfixes:
+  - keycloak_realm - remove warning that ``reset_password_allowed`` needs to be marked as ``no_log`` (https://github.com/ansible-collections/community.general/pull/2694).

--- a/changelogs/fragments/keycloak-realm-no-log-password-reset.yml
+++ b/changelogs/fragments/keycloak-realm-no-log-password-reset.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_realm - mark 'reset_password_allowed' as 'no_log=True' (https://github.com/ansible-collections/community.general/pull/2694)

--- a/plugins/modules/identity/keycloak/keycloak_realm.py
+++ b/plugins/modules/identity/keycloak/keycloak_realm.py
@@ -654,7 +654,7 @@ def main():
         registration_flow=dict(type='str', aliases=['registrationFlow']),
         remember_me=dict(type='bool', aliases=['rememberMe']),
         reset_credentials_flow=dict(type='str', aliases=['resetCredentialsFlow']),
-        reset_password_allowed=dict(type='bool', aliases=['resetPasswordAllowed']),
+        reset_password_allowed=dict(type='bool', aliases=['resetPasswordAllowed'], no_log=False),
         revoke_refresh_token=dict(type='bool', aliases=['revokeRefreshToken']),
         smtp_server=dict(type='dict', aliases=['smtpServer']),
         ssl_required=dict(type='bool', aliases=['sslRequired']),


### PR DESCRIPTION
##### SUMMARY

This value is not sensitive but Ansible will complain about it otherwise

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_realm

##### ADDITIONAL INFORMATION

Using this module before the change:

```
[WARNING]: Module did not set no_log for reset_password_allowed
ok: [molecule_instance_1]
```

After the change:

```
ok: [molecule_instance_1]
```