### PR TITLE
Add inherited properties support for Rudder inventory script

### DIFF
--- a/scripts/inventory/rudder.py
+++ b/scripts/inventory/rudder.py
@@ -146,6 +146,18 @@ class RudderInventory(object):
         cache.write(json_data)
         cache.close()
 
+    def get_inherited_properties(self, node_id):
+        ''' Gets the node properties and inherited properties from Rudder api'''
+
+        path = '/nodes/' + node_id + '/inheritedProperties'
+        result = self.api_call(path)
+        properties = []
+        if 'properties' in result['data'][0]:
+            # only keep the keys and values
+            for prop in result['data'][0]['properties']:
+                properties.append({'name': prop['name'], 'value': prop['value']})
+        return properties
+
     def get_nodes(self):
         ''' Gets the nodes list from Rudder '''
 
@@ -157,10 +169,7 @@ class RudderInventory(object):
         for node in result['data']['nodes']:
             nodes[node['id']] = {}
             nodes[node['id']]['hostname'] = node['hostname']
-            if 'properties' in node:
-                nodes[node['id']]['properties'] = node['properties']
-            else:
-                nodes[node['id']]['properties'] = []
+            nodes[node['id']]['properties'] = self.get_inherited_properties(node['id'])
 
         return nodes
 


### PR DESCRIPTION
##### SUMMARY
Rudder 6.1 introduced inherited properties in Rudder, which are only available through a new api endpoint.
The inventory script needs to be updated to query this new endpoint to retrieve all the defined properties.

Documentation of the new endpoint is available here: https://docs.rudder.io/api/v/13/#operation/nodeInheritedProperties

There is no need to keep compatibility since older Rudder version are not supported any more.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rudder

##### ADDITIONAL INFORMATIONS
