### PR TITLE
BOTMETA.yml: remove myself from zypper_repository

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -717,8 +717,9 @@ files:
     labels: zypper
     ignore: dirtyharrycallahan robinro
   $modules/packaging/os/zypper_repository.py:
-    maintainers: $team_suse matze
+    maintainers: $team_suse
     labels: zypper
+    ignore: matze
   $modules/remote_management/cobbler/:
     maintainers: dagwieers
   $modules/remote_management/hpilo/:


### PR DESCRIPTION
##### SUMMARY

Remove myself as maintainer from the zypper_repository module.

See #1985.

##### COMPONENT NAME

zypper_repository
