### PR TITLE
iptables_status: use async_status action instead of module

### DIFF
--- a/changelogs/fragments/2706-iptables_state-async_status.yml
+++ b/changelogs/fragments/2706-iptables_state-async_status.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "iptables_state - use ``async_status`` action plugin instead of module internally to check status (https://github.com/ansible-collections/community.general/pull/2706)."

--- a/plugins/action/system/iptables_state.py
+++ b/plugins/action/system/iptables_state.py
@@ -115,6 +115,9 @@ class ActionModule(ActionBase):
                     async_status_task = self._task.copy()
                     async_status_task.async_val = 0
                     async_status_task.args.clear()
+                    # For following is needed for Ansible 2.9, since its async_status action plugin
+                    # does not provide the module name when calling self._execute_module().
+                    async_status_task.action = 'ansible.builtin.async_status'
 
                     confirm_cmd = 'rm -f %s' % module_args['_back']
                     starter_cmd = 'touch %s.starter' % module_args['_back']

--- a/plugins/action/system/iptables_state.py
+++ b/plugins/action/system/iptables_state.py
@@ -113,7 +113,7 @@ class ActionModule(ActionBase):
                     module_args['_back'] = '%s/iptables.state' % async_dir
 
                     async_status_task = self._task.copy()
-                    async_status_task._task.async_val = 0
+                    async_status_task.async_val = 0
                     async_status_task.args.clear()
 
                     confirm_cmd = 'rm -f %s' % module_args['_back']


### PR DESCRIPTION
##### SUMMARY
Fixes #2700.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iptables_status
