### PR TITLE
zypper_repository: fix idempotency on adding repo with releasever and basearch variables

### DIFF
--- a/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
+++ b/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - zypper_repository - fix idempotency on adding repo with releasever
+  - zypper_repository - fix idempotency on adding repository with ``$releasever``
     (https://github.com/ansible-collections/community.general/issues/1985).

--- a/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
+++ b/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
@@ -1,4 +1,5 @@
 ---
 bugfixes:
-  - zypper_repository - fix idempotency on adding repository with ``$releasever``
+  - zypper_repository - fix idempotency on adding repository with
+    ``$releasever`` and ``$basearch`` variables
     (https://github.com/ansible-collections/community.general/issues/1985).

--- a/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
+++ b/changelogs/fragments/2722-zypper_repository-fix_idempotency_on_adding_repo_with_releasever.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - zypper_repository - fix idempotency on adding repo with releasever
+    (https://github.com/ansible-collections/community.general/issues/1985).

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -124,7 +124,6 @@ EXAMPLES = '''
 '''
 
 import traceback
-import re
 
 XML_IMP_ERR = None
 try:
@@ -189,7 +188,8 @@ def _repo_changes(module, realrepo, repocmp):
             if k == "url":
                 cmd = ('rpm -q --qf "%{version}" -f /etc/os-release')
                 rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-                valnew = re.sub('$releasever', stdout, valold)
+                valnew = valnew.replace('$releasever', stdout)
+                valold = valold.replace('$releasever', stdout)
                 valold, valnew = valold.rstrip("/"), valnew.rstrip("/")
             if valold != valnew:
                 return True

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -186,14 +186,16 @@ def _repo_changes(module, realrepo, repocmp):
             valold = str(repocmp[k] or "")
             valnew = v or ""
             if k == "url":
-                cmd = ['rpm', '-q', '--qf', '%{version}', '-f', '/etc/os-release']
-                rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-                valnew = valnew.replace('$releasever', stdout)
-                valold = valold.replace('$releasever', stdout)
-                cmd = ['rpm', '-q', '--qf', '%{arch}', '-f', '/etc/os-release']
-                rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-                valnew = valnew.replace('$basearch', stdout)
-                valold = valold.replace('$basearch', stdout)
+                if '$releasever' in valold or '$releasever' in valnew:
+                    cmd = ['rpm', '-q', '--qf', '%{version}', '-f', '/etc/os-release']
+                    rc, stdout, stderr = module.run_command(cmd, check_rc=True)
+                    valnew = valnew.replace('$releasever', stdout)
+                    valold = valold.replace('$releasever', stdout)
+                if '$basearch' in valold or '$basearch' in valnew:
+                    cmd = ['rpm', '-q', '--qf', '%{arch}', '-f', '/etc/os-release']
+                    rc, stdout, stderr = module.run_command(cmd, check_rc=True)
+                    valnew = valnew.replace('$basearch', stdout)
+                    valold = valold.replace('$basearch', stdout)
                 valold, valnew = valold.rstrip("/"), valnew.rstrip("/")
             if valold != valnew:
                 return True

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -186,7 +186,7 @@ def _repo_changes(module, realrepo, repocmp):
             valold = str(repocmp[k] or "")
             valnew = v or ""
             if k == "url":
-                cmd = ('rpm -q --qf "%{version}" -f /etc/os-release')
+                cmd = ['rpm', '-q', '--qf', '%{version}', '-f', '/etc/os-release']
                 rc, stdout, stderr = module.run_command(cmd, check_rc=True)
                 valnew = valnew.replace('$releasever', stdout)
                 valold = valold.replace('$releasever', stdout)

--- a/plugins/modules/packaging/os/zypper_repository.py
+++ b/plugins/modules/packaging/os/zypper_repository.py
@@ -190,6 +190,10 @@ def _repo_changes(module, realrepo, repocmp):
                 rc, stdout, stderr = module.run_command(cmd, check_rc=True)
                 valnew = valnew.replace('$releasever', stdout)
                 valold = valold.replace('$releasever', stdout)
+                cmd = ['rpm', '-q', '--qf', '%{arch}', '-f', '/etc/os-release']
+                rc, stdout, stderr = module.run_command(cmd, check_rc=True)
+                valnew = valnew.replace('$basearch', stdout)
+                valold = valold.replace('$basearch', stdout)
                 valold, valnew = valold.rstrip("/"), valnew.rstrip("/")
             if valold != valnew:
                 return True

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -154,3 +154,32 @@
 - assert:
     that:
       - remove_repo is changed
+
+- name: add a repo by basearch
+  community.general.zypper_repository:
+    name: basearchrepo
+    repo: https://packagecloud.io/netdata/netdata/opensuse/13.2/$basearch
+    state: present
+  register: add_repo
+
+- name: add a repo by basearch again
+  community.general.zypper_repository:
+    name: basearchrepo
+    repo: https://packagecloud.io/netdata/netdata/opensuse/13.2/$basearch
+    state: present
+  register: add_repo_again
+
+- assert:
+    that:
+      - add_repo is changed
+      - add_repo_again is not changed
+
+- name: remove added repo
+  community.general.zypper_repository:
+    repo: https://packagecloud.io/netdata/netdata/opensuse/13.2/x86_64
+    state: absent
+  register: remove_repo
+
+- assert:
+    that:
+      - remove_repo is changed

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -147,7 +147,7 @@
 
 - name: remove added repo
   community.general.zypper_repository:
-    repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
+    repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_{{ ansible_distribution_version }}/
     state: absent
   register: remove_repo
 

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -125,3 +125,30 @@
     priority: 100
     auto_import_keys: true
     state: "present"
+
+- name: add a repo by releasever
+  community.general.zypper_repository:
+    repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
+    state: present
+  register: add_repo
+
+- name: add a repo by releasever again
+  community.general.zypper_repository:
+    repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
+    state: present
+  register: add_repo_again
+
+- assert:
+    that:
+      - "add_repo.changed"
+      - "not add_repo_again.changed"
+
+- name: remove added repo
+  community.general.zypper_repository:
+    repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
+    state: absent
+  register: remove_repo
+
+- assert:
+    that:
+      - "remove_repo.changed"

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -128,12 +128,14 @@
 
 - name: add a repo by releasever
   community.general.zypper_repository:
+    name: testrepo
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
     state: present
   register: add_repo
 
 - name: add a repo by releasever again
   community.general.zypper_repository:
+    name: testrepo
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
     state: present
   register: add_repo_again

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -142,8 +142,8 @@
 
 - assert:
     that:
-      - "add_repo.changed"
-      - "not add_repo_again.changed"
+      - add_repo is changed
+      - add_repo_again is not changed
 
 - name: remove added repo
   community.general.zypper_repository:
@@ -153,4 +153,4 @@
 
 - assert:
     that:
-      - "remove_repo.changed"
+      - remove_repo is changed

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -128,14 +128,14 @@
 
 - name: add a repo by releasever
   community.general.zypper_repository:
-    name: testrepo
+    name: releaseverrepo
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
     state: present
   register: add_repo
 
 - name: add a repo by releasever again
   community.general.zypper_repository:
-    name: testrepo
+    name: releaseverrepo
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_$releasever/
     state: present
   register: add_repo_again


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/1985

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper_repository

##### ADDITIONAL INFORMATION
I'm not sure about this being a bugfix or feature request, please let me know if I should change it.