### PR TITLE
Nmcli add options

### DIFF
--- a/changelogs/fragments/2732-nmcli_add_options.yml
+++ b/changelogs/fragments/2732-nmcli_add_options.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nmcli - Add option routing_rules4 and may_fail4 (https://github.com/ansible-collections/community.general/issues/2730).
+  - nmcli - Add disabled option to method6 (https://github.com/ansible-collections/community.general/issues/2730).

--- a/changelogs/fragments/2732-nmcli_add_options.yml
+++ b/changelogs/fragments/2732-nmcli_add_options.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - nmcli - add options ``routing_rules4`` and ``may_fail4`` (https://github.com/ansible-collections/community.general/issues/2730).
+  - nmcli - add ``routing_rules4`` and ``may_fail4`` options (https://github.com/ansible-collections/community.general/issues/2730).
   - nmcli - add ``disabled`` value to ``method6`` option (https://github.com/ansible-collections/community.general/issues/2730).

--- a/changelogs/fragments/2732-nmcli_add_options.yml
+++ b/changelogs/fragments/2732-nmcli_add_options.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - nmcli - Add option routing_rules4 and may_fail4 (https://github.com/ansible-collections/community.general/issues/2730).
+  - nmcli - add options ``routing_rules4`` and ``may_fail4`` (https://github.com/ansible-collections/community.general/issues/2730).
   - nmcli - add ``disabled`` value to ``method6`` option (https://github.com/ansible-collections/community.general/issues/2730).

--- a/changelogs/fragments/2732-nmcli_add_options.yml
+++ b/changelogs/fragments/2732-nmcli_add_options.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - nmcli - Add option routing_rules4 and may_fail4 (https://github.com/ansible-collections/community.general/issues/2730).
-  - nmcli - Add disabled option to method6 (https://github.com/ansible-collections/community.general/issues/2730).
+  - nmcli - add ``disabled`` value to ``method6`` option (https://github.com/ansible-collections/community.general/issues/2730).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -99,6 +99,7 @@ options:
         description:
             - Is the same as in an 'ip route add' command, except always requires specifying a priority.
         type: str
+        version_added: 3.2.0
     never_default4:
         description:
             - Set as default route.
@@ -134,7 +135,8 @@ options:
         description:
             - If you need I(ip4) configured before network-online.target is reached, set the the property to no.
         type: bool
-        default: yes
+        default: true
+        version_added: 3.2.0
     ip6:
         description:
             - The IPv6 address to this interface.

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -175,6 +175,7 @@ options:
         description:
             - Configuration method to be used for IPv6
             - If I(ip6) is set, C(ipv6.method) is automatically set to C(manual) and this parameter is not needed.
+            - C(disabled) was added in community.general 3.2.0.
         type: str
         choices: [ignore, auto, dhcp, link-local, manual, shared, disabled]
         version_added: 2.2.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -97,7 +97,7 @@ options:
         version_added: 2.0.0
     routing_rules4:
         description:
-            - Is the same as in an 'ip route add' command, except always requires specifying a priority.
+            - Is the same as in an C(ip route add) command, except always requires specifying a priority.
         type: str
         version_added: 3.2.0
     never_default4:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -126,6 +126,9 @@ options:
         type: str
         choices: [auto, link-local, manual, shared, disabled]
         version_added: 2.2.0
+    may_fail4:
+        description:
+            - If I(ip6) 
     ip6:
         description:
             - The IPv6 address to this interface.
@@ -675,11 +678,13 @@ class Nmcli(object):
         self.gw4_ignore_auto = module.params['gw4_ignore_auto']
         self.routes4 = module.params['routes4']
         self.route_metric4 = module.params['route_metric4']
+        self.routing_rules4 = module.params['routing_rules4']
         self.never_default4 = module.params['never_default4']
         self.dns4 = module.params['dns4']
         self.dns4_search = module.params['dns4_search']
         self.dns4_ignore_auto = module.params['dns4_ignore_auto']
         self.method4 = module.params['method4']
+        self.may_fail4 = module.params['may_fail4']
         self.ip6 = module.params['ip6']
         self.gw6 = module.params['gw6']
         self.gw6_ignore_auto = module.params['gw6_ignore_auto']
@@ -762,8 +767,10 @@ class Nmcli(object):
                 'ipv4.ignore-auto-routes': self.gw4_ignore_auto,
                 'ipv4.routes': self.routes4,
                 'ipv4.route-metric': self.route_metric4,
+                'ipv4.routing-rules': self.routing_rules4,
                 'ipv4.never-default': self.never_default4,
                 'ipv4.method': self.ipv4_method,
+                'ipv4.may-fail': self.may_fail4,
                 'ipv6.addresses': self.ip6,
                 'ipv6.dns': self.dns6,
                 'ipv6.dns-search': self.dns6_search,
@@ -1155,11 +1162,13 @@ def main():
             gw4_ignore_auto=dict(type='bool', default=False),
             routes4=dict(type='list', elements='str'),
             route_metric4=dict(type='int'),
+            routing_rules4=dict(type='str'),
             never_default4=dict(type='bool', default=False),
             dns4=dict(type='list', elements='str'),
             dns4_search=dict(type='list', elements='str'),
             dns4_ignore_auto=dict(type='bool', default=False),
             method4=dict(type='str', choices=['auto', 'link-local', 'manual', 'shared', 'disabled']),
+            may_fail4=dict(type='bool', default=True),
             dhcp_client_id=dict(type='str'),
             ip6=dict(type='str'),
             gw6=dict(type='str'),
@@ -1168,6 +1177,7 @@ def main():
             dns6_search=dict(type='list', elements='str'),
             dns6_ignore_auto=dict(type='bool', default=False),
             method6=dict(type='str', choices=['ignore', 'auto', 'dhcp', 'link-local', 'manual', 'shared']),
+            may_fail6=dict(type='bool', default=True),
             # Bond Specific vars
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -136,7 +136,7 @@ options:
             - If you need I(ip4) configured before C(network-online.target) is reached, set this option to C(false).
         type: bool
         default: true
-        version_added: 3.2.0
+        version_added: 3.3.0
     ip6:
         description:
             - The IPv6 address to this interface.

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -95,6 +95,10 @@ options:
             - Set metric level of ipv4 routes configured on interface.
         type: int
         version_added: 2.0.0
+    routing_rules4:
+        description:
+            - Is the same as in an 'ip route add' command, except always requires specifying a priority.
+        type: str
     never_default4:
         description:
             - Set as default route.
@@ -128,7 +132,9 @@ options:
         version_added: 2.2.0
     may_fail4:
         description:
-            - If I(ip6) 
+            - If you need I(ip4) configured before network-online.target is reached, set the the property to no.
+        type: bool
+        default: yes
     ip6:
         description:
             - The IPv6 address to this interface.
@@ -168,7 +174,7 @@ options:
             - Configuration method to be used for IPv6
             - If I(ip6) is set, C(ipv6.method) is automatically set to C(manual) and this parameter is not needed.
         type: str
-        choices: [ignore, auto, dhcp, link-local, manual, shared]
+        choices: [ignore, auto, dhcp, link-local, manual, shared, disabled]
         version_added: 2.2.0
     mtu:
         description:
@@ -1176,8 +1182,7 @@ def main():
             dns6=dict(type='list', elements='str'),
             dns6_search=dict(type='list', elements='str'),
             dns6_ignore_auto=dict(type='bool', default=False),
-            method6=dict(type='str', choices=['ignore', 'auto', 'dhcp', 'link-local', 'manual', 'shared']),
-            may_fail6=dict(type='bool', default=True),
+            method6=dict(type='str', choices=['ignore', 'auto', 'dhcp', 'link-local', 'manual', 'shared', 'disabled']),
             # Bond Specific vars
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -99,7 +99,7 @@ options:
         description:
             - Is the same as in an C(ip route add) command, except always requires specifying a priority.
         type: str
-        version_added: 3.2.0
+        version_added: 3.3.0
     never_default4:
         description:
             - Set as default route.

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -133,7 +133,7 @@ options:
         version_added: 2.2.0
     may_fail4:
         description:
-            - If you need I(ip4) configured before network-online.target is reached, set the the property to no.
+            - If you need I(ip4) configured before C(network-online.target) is reached, set this option to C(false).
         type: bool
         default: true
         version_added: 3.2.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -175,7 +175,7 @@ options:
         description:
             - Configuration method to be used for IPv6
             - If I(ip6) is set, C(ipv6.method) is automatically set to C(manual) and this parameter is not needed.
-            - C(disabled) was added in community.general 3.2.0.
+            - C(disabled) was added in community.general 3.3.0.
         type: str
         choices: [ignore, auto, dhcp, link-local, manual, shared, disabled]
         version_added: 2.2.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -951,6 +951,7 @@ class Nmcli(object):
                        'ipv4.never-default',
                        'ipv4.ignore-auto-dns',
                        'ipv4.ignore-auto-routes',
+                       'ipv4.may-fail',
                        'ipv6.ignore-auto-dns',
                        'ipv6.ignore-auto-routes'):
             return bool

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -98,6 +98,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -128,6 +129,7 @@ ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
 ipv4.dns-search:                        search.redhat.com
+ipv4.may-fail:                          yes
 ipv6.dns-search:                        search6.redhat.com
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
@@ -158,6 +160,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -187,6 +190,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -218,6 +222,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -275,6 +280,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -370,6 +376,7 @@ ipv4.dhcp-client-id:                    00:11:22:AA:BB:CC:DD
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
@@ -399,6 +406,7 @@ ipv4.gateway:                           10.10.10.1
 ipv4.ignore-auto-dns:                   no
 ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
+ipv4.may-fail:                          yes
 ipv4.dns:                               1.1.1.1,8.8.8.8
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add option `routing_rules4` and `may_fail4` which translates to `ipv4.routing-rules` and `ipv4.may-fail` respctively.
Add `disabled` option to method6 to be able to completely disabled IPv6.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2730 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/net_tools/nmcli.py
