### PR TITLE
Remove aminvakil from supershipit section as it is not needed anymore

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1,7 +1,7 @@
 automerge: true
 files:
   plugins/:
-    supershipit: aminvakil russoz
+    supershipit: russoz
   changelogs/fragments/:
     support: community
   $actions:


### PR DESCRIPTION
##### SUMMARY
After https://github.com/ansible-collections/community.general/pull/2739 has been merged, `supershipit` is no longer needed.

https://github.com/ansible-collections/community.general/pull/2739#issuecomment-855946775