### PR TITLE
[scaleway inventory] Fix JSON object must be str, not 'bytes'

### DIFF
--- a/changelogs/fragments/2771-scaleway_inventory_json_accept_byte_array.yml
+++ b/changelogs/fragments/2771-scaleway_inventory_json_accept_byte_array.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - scaleway plugin inventory - fix ``JSON object must be str, not 'bytes'`` with python 3.5
-    (https://github.com/ansible-collections/community.general/issues/2769)
+  - scaleway plugin inventory - fix ``JSON object must be str, not 'bytes'`` with Python 3.5
+    (https://github.com/ansible-collections/community.general/issues/2769).

--- a/changelogs/fragments/2771-scaleway_inventory_json_accept_byte_array.yml
+++ b/changelogs/fragments/2771-scaleway_inventory_json_accept_byte_array.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - scaleway plugin inventory - fix ``JSON object must be str, not 'bytes'`` with python 3.5
+    (https://github.com/ansible-collections/community.general/issues/2769)

--- a/plugins/inventory/scaleway.py
+++ b/plugins/inventory/scaleway.py
@@ -105,7 +105,7 @@ def _fetch_information(token, url):
         except Exception as e:
             raise AnsibleError("Error while fetching %s: %s" % (url, to_native(e)))
         try:
-            raw_json = json.loads(response.read())
+            raw_json = json.loads(response.read().decode('UTF-8'))
         except ValueError:
             raise AnsibleError("Incorrect JSON payload")
 

--- a/plugins/inventory/scaleway.py
+++ b/plugins/inventory/scaleway.py
@@ -89,7 +89,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible_collections.community.general.plugins.module_utils.scaleway import SCALEWAY_LOCATION, parse_pagination_link
 from ansible.module_utils.urls import open_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 import ansible.module_utils.six.moves.urllib.parse as urllib_parse
 
@@ -105,7 +105,7 @@ def _fetch_information(token, url):
         except Exception as e:
             raise AnsibleError("Error while fetching %s: %s" % (url, to_native(e)))
         try:
-            raw_json = json.loads(response.read().decode('UTF-8'))
+            raw_json = json.loads(to_text(response.read()))
         except ValueError:
             raise AnsibleError("Incorrect JSON payload")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix error `JSON error object must be str, not 'bytes'` : issue #2769 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/scaleway.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change :
```paste below
ansible-inventory [core 2.11.1] 
  config file = None
  configured module search path = ['/home/loic/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/loic/.local/lib/python3.5/site-packages/ansible
  ansible collection location = /home/loic/.ansible/collections:/usr/share/ansible/collections
  executable location = .local/bin/ansible-inventory
  python version = 3.5.3 (default, Apr  5 2021, 09:00:41) [GCC 6.3.0 20170516]
  jinja version = 2.11.3
  libyaml = False
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /home/loic/ansible/inventory/scaleway.yml as it did not pass its verify_file() method
script declined parsing /home/loic/ansible/inventory/scaleway.yml as it did not pass its verify_file() method
redirecting (type: inventory) ansible.builtin.scaleway to community.general.scaleway
Loading collection community.general from /home/loic/.ansible/collections/ansible_collections/community/general
Trying secret FileVaultSecret(filename='/home/loic/.vault_pass') for vault_id=default
toml declined parsing /home/loic/ansible/inventory/scaleway.yml as it did not pass its verify_file() method
[WARNING]:  * Failed to parse /home/loic/ansible/inventory/scaleway.yml with auto plugin: Error while fetching https://api.scaleway.com/instance/v1/zones/pl-waw-1/servers: the JSON object must be str, not 'bytes'
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/home/loic/.ansible/collections/ansible_collections/community/general/plugins/inventory/scaleway.py", line 281, in parse
    self.do_zone_inventory(zone=zone, token=token, tags=tags, hostname_preferences=hostname_preference)
  File "/home/loic/.ansible/collections/ansible_collections/community/general/plugins/inventory/scaleway.py", line 250, in do_zone_inventory
    raw_zone_hosts_infos = _fetch_information(url=url, token=token)
  File "/home/loic/.ansible/collections/ansible_collections/community/general/plugins/inventory/scaleway.py", line 107, in _fetch_information
    raise AnsibleError("Error while fetching %s: %s" % (url, to_native(e)))
[WARNING]:  * Failed to parse /home/loic/ansible/inventory/scaleway.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/plugins/inventory/yaml.py", line 112, in parse
    raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
[WARNING]:  * Failed to parse /home/loic/ansible/inventory/scaleway.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending in ':' is not allowed, this character is reserved to provide a port.
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/loic/.local/lib/python3.5/site-packages/ansible/plugins/inventory/ini.py", line 136, in parse
    raise AnsibleParserError(e)
[WARNING]: Unable to parse /home/loic/ansible/inventory/scaleway.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
@all:
  |--@ungrouped:
```

After the change:
```paste below
ansible-inventory [core 2.11.1] 
  config file = None
  configured module search path = ['/home/loic/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/loic/.local/lib/python3.5/site-packages/ansible
  ansible collection location = /home/loic/.ansible/collections:/usr/share/ansible/collections
  executable location = .local/bin/ansible-inventory
  python version = 3.5.3 (default, Apr  5 2021, 09:00:41) [GCC 6.3.0 20170516]
  jinja version = 2.11.3
  libyaml = False
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /home/loic/ansible/inventory/scaleway.yml as it did not pass its verify_file() method
script declined parsing /home/loic/ansible/inventory/scaleway.yml as it did not pass its verify_file() method
redirecting (type: inventory) ansible.builtin.scaleway to community.general.scaleway
Loading collection community.general from /home/loic/.ansible/collections/ansible_collections/community/general
Trying secret FileVaultSecret(filename='/home/loic/.vault_pass') for vault_id=default
Not replacing invalid character(s) "{'-'}" in group name (fr-par-2)
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
Parsed /home/loic/ansible/inventory/scaleway.yml inventory source with auto plugin
@all:
  |--@ams1:
  |--@fr-par-2:
  |  |--server1
  |--@par1:
  |  |--server2
  |  |--server3
  |--@par2:
  |--@ungrouped:
```
