### PR TITLE
add inventory plugin unit test `test_verify_file`

### DIFF
--- a/tests/unit/plugins/inventory/test_cobbler.py
+++ b/tests/unit/plugins/inventory/test_cobbler.py
@@ -37,5 +37,11 @@ def test_init_cache(inventory):
     assert inventory._cache[inventory.cache_key] == {}
 
 
+def test_verify_file(tmp_path, inventory):
+    file = tmp_path / "foobar.cobbler.yml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.cobber.yml') is False

--- a/tests/unit/plugins/inventory/test_cobbler.py
+++ b/tests/unit/plugins/inventory/test_cobbler.py
@@ -44,4 +44,4 @@ def test_verify_file(tmp_path, inventory):
 
 
 def test_verify_file_bad_config(inventory):
-    assert inventory.verify_file('foobar.cobber.yml') is False
+    assert inventory.verify_file('foobar.cobbler.yml') is False

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -74,5 +74,11 @@ def test_conig_query_options(inventory):
     assert tags == ['web-server']
 
 
+def test_verify_file(tmp_path, inventory):
+    file = tmp_path / "foobar.linode.yml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.linde.yml') is False

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -81,4 +81,4 @@ def test_verify_file(tmp_path, inventory):
 
 
 def test_verify_file_bad_config(inventory):
-    assert inventory.verify_file('foobar.linde.yml') is False
+    assert inventory.verify_file('foobar.linode.yml') is False

--- a/tests/unit/plugins/inventory/test_lxd.py
+++ b/tests/unit/plugins/inventory/test_lxd.py
@@ -51,6 +51,12 @@ def inventory():
     return inv
 
 
+def test_verify_file(tmp_path, inventory):
+    file = tmp_path / "foobar.lxd.yml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.lxd.yml') is False
 

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -21,6 +21,12 @@ def inventory():
     return r
 
 
+def test_verify_file(tmp_path, inventory):
+    file = tmp_path / "foobar.proxmox.yml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.proxmox.yml') is False
 

--- a/tests/unit/plugins/inventory/test_stackpath_compute.py
+++ b/tests/unit/plugins/inventory/test_stackpath_compute.py
@@ -66,6 +66,12 @@ def test_get_stack_slugs(inventory):
     ]
 
 
+def test_verify_file(tmp_path, inventory):
+    file = tmp_path / "foobar.stackpath_compute.yml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('foobar.stackpath_compute.yml') is False
 


### PR DESCRIPTION
##### SUMMARY
This PR adds a positive unit test for the inventory plugin function `verify_file`. So far there was only a negative test (non-existing config file)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
- tests/unit/plugins/inventory/test_cobbler.py
- tests/unit/plugins/inventory/test_linode.py
- tests/unit/plugins/inventory/test_lxd.py
- tests/unit/plugins/inventory/test_proxmox.py
- tests/unit/plugins/inventory/test_stackpath_compute.py
