### PR TITLE
datadog_event : Adding api_host as an optional parameter

### DIFF
--- a/changelogs/fragments/2774-datadog_event_api_parameter.yml
+++ b/changelogs/fragments/2774-datadog_event_api_parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "Adding ``api_host`` as an optional parameter to ``datadog_event.py`` to allow users who use ``datadog_event`` Ansible module to define a datadog API endpoint instead of using the default one considering not all datadog deployme$
+- "datadog_event - adding parameter ``api_host`` to allow selecting a datadog API endpoint instead of using the default one (https://github.com/ansible-collections/community.general/issues/2774, https://github.com/ansible-collections/community.general/pull/2775)."

--- a/changelogs/fragments/2774-datadog_event_api_parameter.yml
+++ b/changelogs/fragments/2774-datadog_event_api_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Adding ``api_host`` as an optional parameter to ``datadog_event.py`` to allow users who use ``datadog_event`` Ansible module to define a datadog API endpoint instead of using the default one considering not all datadog deployme$

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -152,7 +152,7 @@ def main():
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],
     }
-    if module.params['api_key'] is not None:
+    if module.params['api_host'] is not None:
         options['api_host'] = module.params['api_host']
 
     initialize(**options)

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     tags: 'aa,bb,#host:{{ inventory_hostname }}'
 
-- name: Post an event with several tags
+- name: Post an event with several tags to another endpoint
   community.general.datadog_event:
     title: Testing from ansible
     text: Test

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -113,6 +113,7 @@ def main():
         argument_spec=dict(
             api_key=dict(required=True, no_log=True),
             app_key=dict(required=True, no_log=True),
+            api_host=dict(required=False, default='https://api.datadoghq.com'),
             title=dict(required=True),
             text=dict(required=True),
             date_happened=dict(type='int'),
@@ -131,7 +132,8 @@ def main():
 
     options = {
         'api_key': module.params['api_key'],
-        'app_key': module.params['app_key']
+        'app_key': module.params['app_key'],
+        'api_host': module.params['api_host']
     }
 
     initialize(**options)

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -149,7 +149,7 @@ def main():
         'app_key': module.params['app_key'],
     }
     if module.params['api_key'] is not None:
-		options['api_host'] = module.params['api_host'] 
+	options['api_host'] = module.params['api_host'] 
 
     initialize(**options)
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -57,6 +57,7 @@ options:
     api_host:
         type: str
         description: ["DataDog API endpoint URL."]
+        version_added: '3.3.0'
     tags:
         type: list
         elements: str

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -133,7 +133,7 @@ def main():
     options = {
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],
-        'api_host': module.params['api_host']
+        'api_host': module.params['api_host'],
     }
 
     initialize(**options)

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -149,7 +149,7 @@ def main():
         'app_key': module.params['app_key'],
     }
     if module.params['api_key'] is not None:
-	options['api_host'] = module.params['api_host'] 
+        options['api_host'] = module.params['api_host'] 
 
     initialize(**options)
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -128,7 +128,7 @@ def main():
         argument_spec=dict(
             api_key=dict(required=True, no_log=True),
             app_key=dict(required=True, no_log=True),
-            api_host=dict(required=False),
+            api_host=dict(type='str', required=False),
             title=dict(required=True),
             text=dict(required=True),
             date_happened=dict(type='int'),

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -143,7 +143,7 @@ def main():
     # Prepare Datadog
     if not HAS_DATADOG:
         module.fail_json(msg=missing_required_lib('datadogpy'), exception=DATADOG_IMP_ERR)
-
+        
     options = {
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -94,7 +94,7 @@ EXAMPLES = '''
     api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     tags: 'aa,bb,#host:{{ inventory_hostname }}'
-    
+
 - name: Post an event with several tags
   community.general.datadog_event:
     title: Testing from ansible
@@ -103,7 +103,7 @@ EXAMPLES = '''
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     api_host: 'https://example.datadoghq.eu'
     tags: 'aa,bb,#host:{{ inventory_hostname }}'
-    
+
 '''
 
 import platform
@@ -143,7 +143,7 @@ def main():
     # Prepare Datadog
     if not HAS_DATADOG:
         module.fail_json(msg=missing_required_lib('datadogpy'), exception=DATADOG_IMP_ERR)
-        
+
     options = {
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -56,7 +56,8 @@ options:
         - If not specified, it defaults to the remote system's hostname.
     api_host:
         type: str
-        description: ["DataDog API endpoint URL."]
+        description:
+        - DataDog API endpoint URL.
         version_added: '3.3.0'
     tags:
         type: list

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -143,13 +143,13 @@ def main():
     # Prepare Datadog
     if not HAS_DATADOG:
         module.fail_json(msg=missing_required_lib('datadogpy'), exception=DATADOG_IMP_ERR)
-        
+
     options = {
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],
     }
     if module.params['api_key'] is not None:
-        options['api_host'] = module.params['api_host'] 
+		options['api_host'] = module.params['api_host'] 
 
     initialize(**options)
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -54,6 +54,9 @@ options:
         description:
         - Host name to associate with the event.
         - If not specified, it defaults to the remote system's hostname.
+    api_host:
+        type: str
+        description: ["DataDog API endpoint URL."]
     tags:
         type: list
         elements: str
@@ -90,6 +93,16 @@ EXAMPLES = '''
     api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     tags: 'aa,bb,#host:{{ inventory_hostname }}'
+    
+- name: Post an event with several tags
+  community.general.datadog_event:
+    title: Testing from ansible
+    text: Test
+    api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
+    app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
+    api_host: 'https://example.datadoghq.eu'
+    tags: 'aa,bb,#host:{{ inventory_hostname }}'
+    
 '''
 
 import platform
@@ -113,7 +126,7 @@ def main():
         argument_spec=dict(
             api_key=dict(required=True, no_log=True),
             app_key=dict(required=True, no_log=True),
-            api_host=dict(required=False, default='https://api.datadoghq.com'),
+            api_host=dict(required=False),
             title=dict(required=True),
             text=dict(required=True),
             date_happened=dict(type='int'),
@@ -129,12 +142,13 @@ def main():
     # Prepare Datadog
     if not HAS_DATADOG:
         module.fail_json(msg=missing_required_lib('datadogpy'), exception=DATADOG_IMP_ERR)
-
+        
     options = {
         'api_key': module.params['api_key'],
         'app_key': module.params['app_key'],
-        'api_host': module.params['api_host'],
     }
+    if module.params['api_key'] is not None:
+        options['api_host'] = module.params['api_host'] 
 
     initialize(**options)
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -149,7 +149,7 @@ def main():
         'app_key': module.params['app_key'],
     }
     if module.params['api_key'] is not None:
-        options['api_host'] = module.params['api_host'] 
+        options['api_host'] = module.params['api_host']
 
     initialize(**options)
 

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -131,7 +131,7 @@ def main():
         argument_spec=dict(
             api_key=dict(required=True, no_log=True),
             app_key=dict(required=True, no_log=True),
-            api_host=dict(type='str', required=False),
+            api_host=dict(type='str'),
             title=dict(required=True),
             text=dict(required=True),
             date_happened=dict(type='int'),

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -103,7 +103,10 @@ EXAMPLES = '''
     api_key: 9775a026f1ca7d1c6c5af9d94d9595a4
     app_key: j4JyCYfefWHhgFgiZUqRm63AXHNZQyPGBfJtAzmN
     api_host: 'https://example.datadoghq.eu'
-    tags: 'aa,bb,#host:{{ inventory_hostname }}'
+    tags:
+      - aa
+      - b
+      - '#host:{{ inventory_hostname }}'
 
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Users need the ability to define an API endpoint for the datadog_event Ansible module to send data to. By default, it sends to ``api.datadog.com`` which is not necessarily always the case. 
This change is to add an optional ``api_host`` parameter to pass to the module in order for the events to reach the right location. 

This is related to issue #2774 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
datadog_event

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The change mainly targets ``plugins/modules/monitoring/datadog/datadog_event.py`` to allow users to define datadog ``api_host`` in their playbooks

As a result of this change, the playbook now would accept ``api_host`` as an optional parameter for datadog_event module where it takes a string value. Example playbook after this change:

```yaml (paste below)
---
- name: Test
  hosts: localhost
  tasks:
  - name: datadog_test
    community.general.datadog_event:
      title: Test
      text: This is just a test
      priority: low
      tags: '#group:heros'
      # The URL is for demonstration purposes
      api_host: 'Avengers.datadoghq.eu'
      api_key: KEY
      app_key: KEY
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
