### PR TITLE
redhat_subscription: Add server_prefix and server_port as supported arguments

### DIFF
--- a/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
+++ b/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redhat_subscription - add server_prefix and server_port as supported arguments (https://github.com/ansible-collections/community.general/pull/2779).

--- a/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
+++ b/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redhat_subscription - add ``server_prefix`` and ``server_port`` paramaters (https://github.com/ansible-collections/community.general/pull/2779).
+  - redhat_subscription - add ``server_prefix`` and ``server_port`` parameters (https://github.com/ansible-collections/community.general/pull/2779).

--- a/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
+++ b/changelogs/fragments/2779_redhat_subscription-add_server_prefix_and_server_port.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redhat_subscription - add server_prefix and server_port as supported arguments (https://github.com/ansible-collections/community.general/pull/2779).
+  - redhat_subscription - add ``server_prefix`` and ``server_port`` paramaters (https://github.com/ansible-collections/community.general/pull/2779).

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -48,12 +48,12 @@ options:
         type: str
     server_prefix:
         description:
-            - Specify the prefix when registering to the Red Hat Subscription Management or Sat6 server
+            - Specify the prefix when registering to the Red Hat Subscription Management or Sat6 server.
         type: str
         version_added: 3.3.0
     server_port:
         description:
-            - Specify the port when registering to the Red Hat Subscription Management or Sat6 server
+            - Specify the port when registering to the Red Hat Subscription Management or Sat6 server.
         type: str
         version_added: 3.3.0
     rhsm_baseurl:
@@ -66,11 +66,11 @@ options:
         type: str
     server_proxy_hostname:
         description:
-            - Specify a HTTP proxy hostname
+            - Specify an HTTP proxy hostname.
         type: str
     server_proxy_port:
         description:
-            - Specify a HTTP proxy port
+            - Specify an HTTP proxy port.
         type: str
     server_proxy_user:
         description:

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -32,7 +32,7 @@ options:
         type: str
     username:
         description:
-            - access.redhat.com or Sat6  username
+            - access.redhat.com or Sat6 username
         type: str
     password:
         description:
@@ -46,6 +46,16 @@ options:
         description:
             - Enable or disable https server certificate verification when connecting to C(server_hostname)
         type: str
+    server_prefix:
+        description:
+            - Specify the prefix when registering to the Red Hat Subscription Management or Sat6 server
+        type: str
+        version_added: 3.3.0
+    server_port:
+        description:
+            - Specify the port when registering to the Red Hat Subscription Management or Sat6 server
+        type: str
+        version_added: 3.3.0
     rhsm_baseurl:
         description:
             - Specify CDN baseurl
@@ -782,6 +792,8 @@ def main():
             'password': {'no_log': True},
             'server_hostname': {},
             'server_insecure': {},
+            'server_prefix': {},
+            'server_port': {},
             'rhsm_baseurl': {},
             'rhsm_repo_ca_cert': {},
             'auto_attach': {'aliases': ['autosubscribe'], 'type': 'bool'},
@@ -827,6 +839,8 @@ def main():
     password = module.params['password']
     server_hostname = module.params['server_hostname']
     server_insecure = module.params['server_insecure']
+    server_prefix = module.params['server_prefix']
+    server_port = module.params['server_port']
     rhsm_baseurl = module.params['rhsm_baseurl']
     rhsm_repo_ca_cert = module.params['rhsm_repo_ca_cert']
     auto_attach = module.params['auto_attach']

--- a/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
@@ -258,6 +258,47 @@ TEST_CASES = [
             'msg': "System successfully registered to 'None'."
         }
     ],
+    # Test of registration with arguments that are not part of register options but needs to be configured
+    [
+        {
+            'state': 'present',
+            'username': 'admin',
+            'password': 'admin',
+            'org_id': 'admin',
+            'force_register': 'true',
+            'server_prefix': '/rhsm',
+            'server_port': '443'
+        },
+        {
+            'id': 'test_arguments_not_in_register_options',
+            'run_command.calls': [
+                (
+                    ['/testbin/subscription-manager', 'identity'],
+                    {'check_rc': False},
+                    (0, 'This system already registered.', '')
+                ),
+                (
+                    ['/testbin/subscription-manager',
+                     'config',
+                     '--server.prefix=/rhsm',
+                     '--server.port=443'],
+                    {'check_rc': True},
+                    (0, '', '')
+                ),
+                (
+                    ['/testbin/subscription-manager', 'register',
+                        '--force',
+                        '--org', 'admin',
+                        '--username', 'admin',
+                        '--password', 'admin'],
+                    {'check_rc': True, 'expand_user_and_vars': False},
+                    (0, '', '')
+                )
+            ],
+            'changed': True,
+            'msg': "System successfully registered to 'None'."
+        }
+    ],
     # Test of registration using username, password and proxy options
     [
         {

--- a/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
@@ -278,10 +278,10 @@ TEST_CASES = [
                     (0, 'This system already registered.', '')
                 ),
                 (
-                    ['/testbin/subscription-manager',
-                     'config',
-                     '--server.prefix=/rhsm',
-                     '--server.port=443'],
+                    ['/testbin/subscription-manager', 'config',
+                        '--server.port=443',
+                        '--server.prefix=/rhsm'
+                     ],
                     {'check_rc': True},
                     (0, '', '')
                 ),


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is Tong He from Red Hat MPQE Entitlement QE Team.

server.prefix and server.port are two arguments in 'subscription-manager config' but now not supported in this module. As I see more than one requests mentioning these, I think it is valuable to add these two as supported arguments.

This PR is in response to and implements the following feature requests:
Fixes https://github.com/ansible-collections/community.general/issues/1311
https://bugzilla.redhat.com/show_bug.cgi?id=1766342

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redhat_subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
An example of the contents in subscription-manager config:
```paste below
[server]
   hostname = [subscription.rhsm.redhat.com]
   insecure = [0]
   no_proxy = []
   port = [443]
   prefix = [/subscription]
   proxy_hostname = []
   proxy_password = []
   proxy_port = []
   proxy_scheme = [http]
   proxy_user = []
   server_timeout = [180]
   ssl_verify_depth = [3]

[rhsm]
   auto_enable_yum_plugins = [1]
   baseurl = [https://cdn.redhat.com]
   ca_cert_dir = [/etc/rhsm/ca/]
   consumercertdir = [/etc/pki/consumer]
   entitlementcertdir = [/etc/pki/entitlement]
   full_refresh_on_yum = [0]
   inotify = [1]
   manage_repos = [1]
   package_profile_on_trans = [0]
   pluginconfdir = [/etc/rhsm/pluginconf.d]
   plugindir = [/usr/share/rhsm-plugins]
   productcertdir = [/etc/pki/product]
   repo_ca_cert = /etc/rhsm/ca/redhat-entitlement-authority.pem
   repomd_gpg_url = []
   report_package_profile = [1]

[rhsmcertd]
   autoattachinterval = [1440]
   certcheckinterval = [240]
   disable = [0]
   splay = [1]

[logging]
   default_log_level = [INFO]

[] - Default value in use


```
