### PR TITLE
timezone: change warning to debug

### DIFF
--- a/changelogs/fragments/1942_timezone.yml
+++ b/changelogs/fragments/1942_timezone.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- timezone - print error message to debug instead of warning when timedatectl fails (https://github.com/ansible-collections/community.general/issues/1942).

--- a/plugins/modules/system/timezone.py
+++ b/plugins/modules/system/timezone.py
@@ -107,7 +107,7 @@ class Timezone(object):
                 if rc == 0:
                     return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
                 else:
-                    module.warn('timedatectl command was found but not usable: %s. using other method.' % stderr)
+                    module.debug('timedatectl command was found but not usable: %s. using other method.' % stderr)
                     return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)


### PR DESCRIPTION
##### SUMMARY

Convert warning message to debug when timedatectl found but not usable.

Fixes: #1942

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/system/timezone.py
