### PR TITLE
callback_splunk - Add user-configurable event correlation id

### DIFF
--- a/changelogs/fragments/2790-callback_splunk-batch-option.yml
+++ b/changelogs/fragments/2790-callback_splunk-batch-option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - splunk callback plugin - add ``batch`` option for user-configurable correlation ID's (https://github.com/ansible-collections/community.general/issues/2790).

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -69,7 +69,8 @@ DOCUMENTATION = '''
         default: false
         version_added: 2.0.0
       batch:
-        description: Correlation ID which can be set across multiple playbook executions
+        description:
+          - Correlation ID which can be set across multiple playbook executions
         env:
           - name: SPLUNK_BATCH
         ini:

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -68,6 +68,15 @@ DOCUMENTATION = '''
         type: bool
         default: false
         version_added: 2.0.0
+      batch:
+        description: Correlation ID which can be set across multiple playbook executions
+        env:
+          - name: SPLUNK_BATCH
+        ini:
+          - section: callback_splunk
+            key: batch
+        type: str
+        version_added: 3.3.0
 '''
 
 EXAMPLES = '''
@@ -107,7 +116,7 @@ class SplunkHTTPCollectorSource(object):
         self.ip_address = socket.gethostbyname(socket.gethostname())
         self.user = getpass.getuser()
 
-    def send_event(self, url, authtoken, validate_certs, include_milliseconds, state, result, runtime):
+    def send_event(self, url, authtoken, validate_certs, include_milliseconds, batch, state, result, runtime):
         if result._task_fields['args'].get('_ansible_check_mode') is True:
             self.ansible_check_mode = True
 
@@ -126,6 +135,8 @@ class SplunkHTTPCollectorSource(object):
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session
+        if batch is not None:
+            data['batch'] = batch
         data['status'] = state
 
         if include_milliseconds:
@@ -175,6 +186,7 @@ class CallbackModule(CallbackBase):
         self.authtoken = None
         self.validate_certs = None
         self.include_milliseconds = None
+        self.batch = None
         self.splunk = SplunkHTTPCollectorSource()
 
     def _runtime(self, result):
@@ -212,6 +224,8 @@ class CallbackModule(CallbackBase):
 
         self.include_milliseconds = self.get_option('include_milliseconds')
 
+        self.batch = self.get_option('batch')
+
     def v2_playbook_on_start(self, playbook):
         self.splunk.ansible_playbook = basename(playbook._file_name)
 
@@ -227,6 +241,7 @@ class CallbackModule(CallbackBase):
             self.authtoken,
             self.validate_certs,
             self.include_milliseconds,
+            self.batch,
             'OK',
             result,
             self._runtime(result)
@@ -238,6 +253,7 @@ class CallbackModule(CallbackBase):
             self.authtoken,
             self.validate_certs,
             self.include_milliseconds,
+            self.batch,
             'SKIPPED',
             result,
             self._runtime(result)
@@ -249,6 +265,7 @@ class CallbackModule(CallbackBase):
             self.authtoken,
             self.validate_certs,
             self.include_milliseconds,
+            self.batch,
             'FAILED',
             result,
             self._runtime(result)
@@ -260,6 +277,7 @@ class CallbackModule(CallbackBase):
             self.authtoken,
             self.validate_certs,
             self.include_milliseconds,
+            self.batch,
             'FAILED',
             result,
             self._runtime(result)
@@ -271,6 +289,7 @@ class CallbackModule(CallbackBase):
             self.authtoken,
             self.validate_certs,
             self.include_milliseconds,
+            self.batch,
             'UNREACHABLE',
             result,
             self._runtime(result)

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -70,7 +70,7 @@ DOCUMENTATION = '''
         version_added: 2.0.0
       batch:
         description:
-          - Correlation ID which can be set across multiple playbook executions
+          - Correlation ID which can be set across multiple playbook executions.
         env:
           - name: SPLUNK_BATCH
         ini:

--- a/tests/unit/plugins/callback/test_splunk.py
+++ b/tests/unit/plugins/callback/test_splunk.py
@@ -43,7 +43,10 @@ class TestSplunkClient(unittest.TestCase):
         mock_datetime.utcnow.return_value = datetime(2020, 12, 1)
         result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
 
-        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=True, state='OK', result=result, runtime=100)
+        self.splunk.send_event(
+            url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=True,
+            batch="abcefghi-1234-5678-9012-abcdefghijkl", state='OK', result=result, runtime=100
+        )
 
         args, kwargs = open_url_mock.call_args
         sent_data = json.loads(args[1])
@@ -58,7 +61,10 @@ class TestSplunkClient(unittest.TestCase):
         mock_datetime.utcnow.return_value = datetime(2020, 12, 1)
         result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
 
-        self.splunk.send_event(url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=False, state='OK', result=result, runtime=100)
+        self.splunk.send_event(
+            url='endpoint', authtoken='token', validate_certs=False, include_milliseconds=False,
+            batch="abcefghi-1234-5678-9012-abcdefghijkl", state='OK', result=result, runtime=100
+        )
 
         args, kwargs = open_url_mock.call_args
         sent_data = json.loads(args[1])


### PR DESCRIPTION
##### SUMMARY
Adding `batch` parameter as a user-configurable correlation id to associate multiple playbook executions. 

Fixes #2778

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
plugins/callback/splunk.py

##### ADDITIONAL INFORMATION
Open to suggestions for the option and/or JSON attribute name.