### PR TITLE
Support older version of psutil (RHEL7 and RHEL6)

### DIFF
--- a/changelogs/fragments/2808-pids-older-psutil.yml
+++ b/changelogs/fragments/2808-pids-older-psutil.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pids - avoid crashes for older ``psutil`` versions, like on RHEL6 and RHEL7 (https://github.com/ansible-collections/community.general/pull/2808)."

--- a/plugins/modules/system/pids.py
+++ b/plugins/modules/system/pids.py
@@ -78,11 +78,23 @@ def compare_lower(a, b):
 def get_pid(name):
     pids = []
 
-    for proc in psutil.process_iter(attrs=['name', 'cmdline']):
-        if compare_lower(proc.info['name'], name) or \
-                proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], name):
-            pids.append(proc.pid)
-
+    try:
+        for proc in psutil.process_iter(attrs=['name', 'cmdline']):
+            if compare_lower(proc.info['name'], name) or \
+                    proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], name):
+                pids.append(proc.pid)
+    except TypeError:  # EL6, EL7: process_iter() takes no arguments (1 given)                        |
+        for proc in psutil.process_iter():
+            try:  # EL7
+                proc_name = proc.name()
+                proc_cmdline = proc.cmdline()
+            except TypeError:  # EL6: 'str' object is not callable
+                proc_name = proc.name
+                proc_cmdline = proc.cmdline
+            
+            if compare_lower(proc_name, name) or \
+                    proc_cmdline and compare_lower(proc_cmdline[0], name):
+                pids.append(proc.pid)
     return pids
 
 

--- a/plugins/modules/system/pids.py
+++ b/plugins/modules/system/pids.py
@@ -86,11 +86,9 @@ def get_pid(name):
     except TypeError:  # EL6, EL7: process_iter() takes no arguments (1 given)                        |
         for proc in psutil.process_iter():
             try:  # EL7
-                proc_name = proc.name()
-                proc_cmdline = proc.cmdline()
+                proc_name, proc_cmdline = proc.name(), proc.cmdline()
             except TypeError:  # EL6: 'str' object is not callable
-                proc_name = proc.name
-                proc_cmdline = proc.cmdline
+                proc_name, proc_cmdline = proc.name, proc.cmdline
             
             if compare_lower(proc_name, name) or \
                     proc_cmdline and compare_lower(proc_cmdline[0], name):

--- a/plugins/modules/system/pids.py
+++ b/plugins/modules/system/pids.py
@@ -83,13 +83,12 @@ def get_pid(name):
             if compare_lower(proc.info['name'], name) or \
                     proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], name):
                 pids.append(proc.pid)
-    except TypeError:  # EL6, EL7: process_iter() takes no arguments (1 given)                        |
+    except TypeError:  # EL6, EL7: process_iter() takes no arguments (1 given)
         for proc in psutil.process_iter():
             try:  # EL7
                 proc_name, proc_cmdline = proc.name(), proc.cmdline()
             except TypeError:  # EL6: 'str' object is not callable
                 proc_name, proc_cmdline = proc.name, proc.cmdline
-            
             if compare_lower(proc_name, name) or \
                     proc_cmdline and compare_lower(proc_cmdline[0], name):
                 pids.append(proc.pid)


### PR DESCRIPTION
##### SUMMARY
The pids module does not work out of the box on RHEL6 and RHEL7, with the system python-psutil module.

Fixes ansible/ansible#61922

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pids

##### ADDITIONAL INFORMATION
The psutil python module is a true mess, they changed the API twice. The function arguments, as well as the objects that are returned. The documentation does not make it clear which version supports what so the safest implementation is this waterfall approach.

A better approach would be to inspect the returned information, rather than trust a version, but that would not be any more efficient. In the end it is better to have something that at least works out-of-the-box on all platforms than something that requires custom updates to system packages before it works as expected. Especially for something as basic as `pids`.