### PR TITLE
pamd: Add a note in docs about authselect profiles

### DIFF
--- a/plugins/modules/system/pamd.py
+++ b/plugins/modules/system/pamd.py
@@ -16,7 +16,9 @@ short_description: Manage PAM Modules
 description:
   - Edit PAM service's type, control, module path and module arguments.
   - In order for a PAM rule to be modified, the type, control and
-    module_path must match an existing rule.  See man(5) pam.d for details.
+    module_path must match an existing rule. See man(5) pam.d for details.
+notes:
+  - This module does not handle authselect profiles.
 options:
   name:
     description:


### PR DESCRIPTION
##### SUMMARY

pamd module does not handle or modify authselect profiles
which are basically template files for authselect. The autheselect
generates pam.d files from these profiles.

Fixes: #1954

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/system/pamd.py
