### PR TITLE
archive - refactor and bugfix

### DIFF
--- a/changelogs/fragments/2816-archive-refactor.yml
+++ b/changelogs/fragments/2816-archive-refactor.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - archive - fixed incorrect ``state`` result values (https://github.com/ansible-collections/community.general/issues/2816).
+  - archive - fixed ``exclude_path`` values causing incorrect archive root (https://github.com/ansible-collections/community.general/issues/2816).
+  - archive - fixed improper file names for single file zip archives (https://github.com/ansible-collections/community.general/issues/2818).

--- a/changelogs/fragments/2816-archive-refactor.yml
+++ b/changelogs/fragments/2816-archive-refactor.yml
@@ -1,5 +1,5 @@
 ---
 bugfixes:
-  - archive - fixed incorrect ``state`` result values (https://github.com/ansible-collections/community.general/issues/2816).
-  - archive - fixed ``exclude_path`` values causing incorrect archive root (https://github.com/ansible-collections/community.general/issues/2816).
+  - archive - fixed incorrect ``state`` result value documentation (https://github.com/ansible-collections/community.general/pull/2816).
+  - archive - fixed ``exclude_path`` values causing incorrect archive root (https://github.com/ansible-collections/community.general/pull/2816).
   - archive - fixed improper file names for single file zip archives (https://github.com/ansible-collections/community.general/issues/2818).

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -305,8 +305,9 @@ class Archive(object):
 
     def add_single_target(self, path):
         if self.format in ('zip', 'tar'):
+            archive_name = re.sub(br'^%s' % re.escape(self.root), b'', path)
             self.open()
-            self.add(path, path[len(self.root):])
+            self.add(path, archive_name)
             self.close()
             self.destination_state = STATE_ARCHIVED
         else:

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -162,6 +162,7 @@ expanded_exclude_paths:
     returned: always
 '''
 
+import abc
 import bz2
 import glob
 import gzip
@@ -176,7 +177,7 @@ from sys import version_info
 from traceback import format_exc
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.six import PY3
 
 
@@ -230,53 +231,339 @@ def matches_exclusion_patterns(path, exclusion_patterns):
     return any(fnmatch(path, p) for p in exclusion_patterns)
 
 
-def get_filter(exclusion_patterns, format):
-    def zip_filter(path):
-        return matches_exclusion_patterns(path, exclusion_patterns)
-
-    def tar_filter(tarinfo):
-        return None if matches_exclusion_patterns(tarinfo.name, exclusion_patterns) else tarinfo
-
-    return zip_filter if format == 'zip' or not PY27 else tar_filter
+def is_archive(path):
+    return re.search(br'\.(tar|tar\.(gz|bz2|xz)|tgz|tbz2|zip)$', os.path.basename(path), re.IGNORECASE)
 
 
-def get_archive_contains(format):
-    def archive_contains(archive, name):
-        try:
-            if format == 'zip':
-                archive.getinfo(name)
+PATH_SEP = to_b(os.sep)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Archive(abc.ABCMeta):
+    def __init__(self, module):
+        self.destination = to_b(module.params['dest']) if module.params['dest'] else None
+        self.exclude_paths = module.params['exclude_path']
+        self.exclusion_patterns = module.params['exclusion_patterns'] or []
+        self.format = module.params['format']
+        self.must_archive = module.params['force_archive']
+        self.paths = module.params['path']
+
+        self.targets = []
+        self.changed = False
+        self.errors = []
+        self.excluded = []
+        self.file = None
+        self.missing = []
+        self.root = b''
+        self.state = 'absent'
+        self.successes = []
+
+        self.expanded_paths, has_globs = expand_paths(self.paths)
+
+        if not self.expanded_paths:
+            module.fail_json(
+                path=', '.join(self.paths),
+                expanded_paths=to_native(b', '.join(self.expanded_paths), errors='surrogate_or_strict'),
+                msg='Error, no source paths were found'
+            )
+
+        # Only attempt to expand the exclude paths if it exists
+        self.expanded_exclude_paths = expand_paths(self.exclude_paths)[0] if self.exclude_paths else []
+
+        if not self.must_archive:
+            # If we actually matched multiple files or TRIED to, then treat this as a multi-file archive
+            self.must_archive = any([has_globs, os.path.isdir(self.expanded_paths[0]), len(self.expanded_paths) > 1])
+        # Default created file name (for single-file archives) to <file>.<format>
+        if not self.destination and not self.must_archive:
+            self.destination = b'%s.%s' % (self.expanded_paths[0], to_b(self.format))
+        # Force archives to specify 'dest'
+        if self.must_archive and not self.destination:
+            module.fail_json(
+                dest=to_na(self.destination),
+                path=', '.join(self.paths),
+                msg='Error, must specify "dest" when archiving multiple files or trees'
+            )
+
+    def find_archive_paths(self):
+        for path in self.expanded_paths:
+            # Use the longest common directory name among all the files
+            # as the archive root path
+            if self.root == b'':
+                self.root = os.path.dirname(path) + PATH_SEP
             else:
-                archive.getmember(name)
+
+                for i in range(len(self.root)):
+                    if path[i] != self.root[i]:
+                        break
+
+                if i < len(self.root):
+                    self.root = os.path.dirname(self.root[0:i + 1])
+
+                self.root += PATH_SEP
+
+            # Don't allow archives to be created anywhere within paths to be removed
+            if self.remove and os.path.isdir(path):
+                prefix = path if path.endswith(PATH_SEP) else path + PATH_SEP
+                if self.destination.startswith(prefix):
+                    self.module.fail_json(
+                        path=', '.join(self.paths),
+                        msg='Error, created archive can not be contained in source paths when remove=True'
+                    )
+
+            if path in self.expanded_exclude_paths:
+                self.excluded.append(path)
+            else:
+                if os.path.lexists(path):
+                    self.targets.append(path)
+                else:
+                    self.missing.append(path)
+
+    def add_targets(self):
+        self.open()
+
+        try:
+            match_root = re.compile(br'^%s' % re.escape(self.root))
+            for path in self.targets:
+                if os.path.isdir(path):
+                    for directory_path, directory_names, file_names in os.walk(path, topdown=True):
+                        if not directory_path.endswith(PATH_SEP):
+                            directory_path += PATH_SEP
+
+                        for directory_name in directory_names:
+                            full_path = directory_path + directory_name
+                            archive_name = to_n(match_root.sub(b'', full_path))
+                            self.add(to_na(full_path), archive_name)
+
+                        for file_name in file_names:
+                            full_path = directory_path + file_name
+                            archive_name = to_n(match_root.sub(b'', full_path))
+
+                            # The previous code logged ``b_path`` in case of error,
+                            # but it seems more informative to log the full path here
+                            self.add(to_na(full_path), archive_name)
+                else:
+                    path = to_na(path)
+                    archive_name = to_n(match_root.sub(b'', path))
+                    self.add(path, archive_name)
+        except Exception as e:
+            archive_format = 'zip' if self.format == 'zip' else ('tar.' + self.format)
+            self.module.fail_json(
+                msg='Error when writing %s archive at %s: %s' % (archive_format, self.destination, to_na(e)),
+                exception=format_exc()
+            )
+
+        self.close()
+
+    def add_one(self, path):
+        # No source or compressed file
+        if not os.path.exists(path):
+            if self.destination_exists():
+                # if it already exists and the source file isn't there, consider this done
+                self.state = 'compress'
+            else:
+                self.state = 'absent'
+        else:
+            if self.module.check_mode:
+                if not self.destination_exists():
+                    self.changed = True
+            else:
+                size = self.destination_size()
+                try:
+                    if self.format in ('zip', 'tar'):
+                        self.open()
+                        self.add(to_na(path), to_n(path[len(self.root):]))
+                        self.close()
+                        self.state = 'archive'  # because all zip files are archives (all tar files are archives too)
+                    else:
+                        compressor = self._get_compressor()
+                        with open(path, 'rb') as f_in:
+                            with compressor(to_na(self.destination), 'wb') as f_out:
+                                shutil.copyfileobj(f_in, f_out)
+                    self.successes.append(path)
+                except OSError as e:
+                    self.module.fail_json(
+                        path=to_n(path),
+                        dest=to_n(self.destination),
+                        msg='Unable to write to compressed file: %s' % to_n(e), exception=format_exc()
+                    )
+
+                # Rudimentary check: If size changed then file changed. Not perfect, but easy.
+                if self.destination_size() != size:
+                    self.changed = True
+
+            self.state = 'compress'
+
+    def _get_compressor(self):
+        if self.format == 'gz':
+            func = gzip.open
+        elif self.format == 'bz2':
+            func = bz2.BZ2File
+        elif self.format == 'xz':
+            func = lzma.LZMAFile
+        else:
+            raise ValueError("%s has no compression function" % self.format)
+
+        return func
+
+    def remove_targets(self):
+        for path in self.successes:
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+            except OSError:
+                self.errors.append(to_n(path))
+
+        for path in self.expanded_paths:
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+            except OSError:
+                self.errors.append(to_n(path))
+
+        if self.errors:
+            self.module.fail_json(
+                dest=to_n(self.destination), msg='Error deleting some source files: ', files=self.errors
+            )
+
+    def has_archive_paths(self):
+        return bool(self.targets)
+
+    def has_excluded_or_unfound_paths(self):
+        return bool(self.missing)
+
+    def destination_exists(self):
+        return self.destination and os.path.exists(self.destination)
+
+    def destination_size(self):
+        return os.path.getsize(self.destination) if self.destination_exists() else 0
+
+    @property
+    def result(self):
+        return {
+            'archived': [to_n(p) for p in self.successes],
+            'dest': to_n(self.destination),
+            'changed': self.changed,
+            'state': self.state,
+            'arcroot': to_n(self.root),
+            'missing': [to_n(p) for p in self.missing],
+            'expanded_paths': [to_n(p) for p in self.expanded_paths],
+            'expanded_exclude_paths': [to_n(p) for p in self.expanded_exclude_paths],
+        }
+
+    @abc.abstractmethod
+    def add(self, path, archive_name):
+        pass
+
+    @abc.abstractmethod
+    def contains(self, name):
+        pass
+
+    @abc.abstractmethod
+    def open(self):
+        pass
+
+    @abc.abstractmethod
+    def close(self):
+        pass
+
+
+class ZipArchive(Archive):
+    def __init__(self, module):
+        super(ZipArchive, self).__init__(module)
+
+    def filter(self, path):
+        return matches_exclusion_patterns(path, self.exclusion_patterns)
+
+    def contains(self, name):
+        try:
+            self.file.getinfo(name)
         except KeyError:
             return False
-
         return True
 
-    return archive_contains
-
-
-def get_add_to_archive(format, filter):
-    def add_to_zip_archive(archive_file, path, archive_name):
+    def add(self, path, archive_name):
         try:
-            if not filter(path):
-                archive_file.write(path, archive_name)
+            if not self.filter(path):
+                self.file.write(path, archive_name)
         except Exception as e:
-            return e
+            self.errors.append('%s: %s' % (path, to_native(e)))
 
-        return None
+        if self.contains(archive_name):
+            self.successes.append(path)
 
-    def add_to_tar_archive(archive_file, path, archive_name):
+    def open(self):
+        self.file = zipfile.ZipFile(to_na(self.destination), 'w', zipfile.ZIP_DEFLATED, True)
+
+    def close(self):
+        self.file.close()
+
+
+class TarArchive(Archive):
+    def __init__(self, module):
+        super(TarArchive, self).__init__(module)
+
+        self.fileIO = None
+
+    def filter(self, path_or_tarinfo):
+        if PY27:
+            return self._py27_filter(path_or_tarinfo)
+        else:
+            return self._py26_filter(path_or_tarinfo)
+
+    def _py27_filter(self, tarinfo):
+        return None if matches_exclusion_patterns(tarinfo.name, self.exclusion_patterns) else tarinfo
+
+    def _py26_filter(self, path):
+        return matches_exclusion_patterns(path, self.exclusion_patterns)
+
+    def contains(self, name):
+        try:
+            self.file.getmember(name)
+        except KeyError:
+            return False
+        return True
+
+    def add(self, path, archive_name):
         try:
             if PY27:
-                archive_file.add(path, archive_name, recursive=False, filter=filter)
+                self.file.add(path, archive_name, recursive=False, filter=self.filter)
             else:
-                archive_file.add(path, archive_name, recursive=False, exclude=filter)
+                self.file.add(path, archive_name, recursive=False, exclude=self.filter)
         except Exception as e:
-            return e
+            self.errors.append('%s: %s' % (path, to_native(e)))
 
-        return None
+        if self.contains(archive_name):
+            self.successes.append(path)
 
-    return add_to_zip_archive if format == 'zip' else add_to_tar_archive
+    def open(self):
+        if self.format in ('gz','bz2'):
+            self.file = tarfile.open(to_na(self.destination), 'w|' + self.format)
+        # python3 tarfile module allows xz format but for python2 we have to create the tarfile
+        # in memory and then compress it with lzma.
+        elif self.format == 'xz':
+            self.fileIO = io.BytesIO()
+            self.file = tarfile.open(fileobj=self.fileIO, mode='w')
+        # Or plain tar archiving
+        elif self.format == 'tar':
+            self.file = tarfile.open(to_na(self.destination), 'w')
+        else:
+            self.module.fail_json(msg="%s is not a valid archive format" % self.format)
+
+    def close(self):
+        self.arcfile.close()
+        if self.format == 'xz':
+            with lzma.open(to_n(self.destination), 'wb') as f:
+                f.write(self.arcfileIO.getvalue())
+            self.arcfileIO.close()
+
+
+def get_archive(module):
+    if module.params['format'] == 'zip':
+        return ZipArchive(module)
+    else:
+        return TarArchive(module)
 
 
 def main():
@@ -294,349 +581,75 @@ def main():
         supports_check_mode=True,
     )
 
-    params = module.params
-    check_mode = module.check_mode
-    paths = params['path']
-    dest = params['dest']
-    b_dest = None if not dest else to_b(dest)
-    exclude_paths = params['exclude_path']
-    remove = params['remove']
-
-    fmt = params['format']
-    b_fmt = to_b(fmt)
-    force_archive = params['force_archive']
-    changed = False
-    state = 'absent'
-
-    exclusion_patterns = params['exclusion_patterns'] or []
-
-    # Simple or archive file compression (inapplicable with 'zip' since it's always an archive)
-    b_successes = []
-
-    # Fail early
-    if not HAS_LZMA and fmt == 'xz':
-        module.fail_json(msg=missing_required_lib("lzma or backports.lzma", reason="when using xz format"),
-                         exception=LZMA_IMP_ERR)
-        module.fail_json(msg="lzma or backports.lzma is required when using xz format.")
-
-    b_expanded_paths, globby = expand_paths(paths)
-    if not b_expanded_paths:
-        return module.fail_json(
-            path=', '.join(paths),
-            expanded_paths=to_native(b', '.join(b_expanded_paths), errors='surrogate_or_strict'),
-            msg='Error, no source paths were found'
+    if not HAS_LZMA and module.params['format'] == 'xz':
+        module.fail_json(
+            msg=missing_required_lib("lzma or backports.lzma", reason="when using xz format"), exception=LZMA_IMP_ERR
         )
 
-    # Only attempt to expand the exclude paths if it exists
-    b_expanded_exclude_paths = expand_paths(exclude_paths)[0] if exclude_paths else []
+    remove = module.params['remove']
 
-    filter = get_filter(exclusion_patterns, fmt)
-    archive_contains = get_archive_contains(fmt)
-    add_to_archive = get_add_to_archive(fmt, filter)
+    archive = get_archive(module)
 
-    # Only try to determine if we are working with an archive or not if we haven't set archive to true
-    if not force_archive:
-        # If we actually matched multiple files or TRIED to, then
-        # treat this as a multi-file archive
-        archive = globby or os.path.isdir(b_expanded_paths[0]) or len(b_expanded_paths) > 1
-    else:
-        archive = True
+    archive.find_archive_paths()
 
-    # Default created file name (for single-file archives) to
-    # <file>.<format>
-    if not b_dest and not archive:
-        b_dest = b'%s.%s' % (b_expanded_paths[0], b_fmt)
+    if not archive.has_archive_paths():
+        # Previous behavior fell through to else instead of moving straight to exit_json
+        if archive.destination_exists():
+            archive.state = 'archive' if is_archive(archive.destination) else 'compress'
+    elif archive.must_archive:
+        size = archive.destination_size()
 
-    # Force archives to specify 'dest'
-    if archive and not b_dest:
-        module.fail_json(dest=dest, path=', '.join(paths), msg='Error, must specify "dest" when archiving multiple files or trees')
-
-    b_sep = to_b(os.sep)
-
-    b_archive_paths = []
-    b_missing = []
-    b_arcroot = b''
-
-    for b_path in b_expanded_paths:
-        # Use the longest common directory name among all the files
-        # as the archive root path
-        if b_arcroot == b'':
-            b_arcroot = os.path.dirname(b_path) + b_sep
+        if module.check_mode:
+            archive.changed = True
         else:
-            for i in range(len(b_arcroot)):
-                if b_path[i] != b_arcroot[i]:
-                    break
+            archive.add_targets()
 
-            if i < len(b_arcroot):
-                b_arcroot = os.path.dirname(b_arcroot[0:i + 1])
-
-            b_arcroot += b_sep
-
-        # Don't allow archives to be created anywhere within paths to be removed
-        if remove and os.path.isdir(b_path):
-            b_path_dir = b_path
-            if not b_path.endswith(b'/'):
-                b_path_dir += b'/'
-
-            if b_dest.startswith(b_path_dir):
+            if archive.errors:
                 module.fail_json(
-                    path=', '.join(paths),
-                    msg='Error, created archive can not be contained in source paths when remove=True'
+                    msg='Errors when writing archive at %s: %s' % (
+                        to_n(archive.destination), '; '.join(archive.errors)
+                    )
                 )
 
-        if os.path.lexists(b_path) and b_path not in b_expanded_exclude_paths:
-            b_archive_paths.append(b_path)
-        else:
-            b_missing.append(b_path)
+            archive.state = 'archive'
 
-    # No source files were found but the named archive exists: are we 'compress' or 'archive' now?
-    if len(b_missing) == len(b_expanded_paths) and b_dest and os.path.exists(b_dest):
-        # Just check the filename to know if it's an archive or simple compressed file
-        if re.search(br'\.(tar|tar\.(gz|bz2|xz)|tgz|tbz2|zip)$', os.path.basename(b_dest), re.IGNORECASE):
-            state = 'archive'
-        else:
-            state = 'compress'
+        # Previous behavior set this before archiving causing it to be overwritten
+        if archive.has_excluded_or_unfound_paths():
+            archive.state = 'incomplete'
 
-    # Multiple files, or globbiness
-    elif archive:
-        if not b_archive_paths:
-            # No source files were found, but the archive is there.
-            if os.path.lexists(b_dest):
-                state = 'archive'
-        elif b_missing:
-            # SOME source files were found, but not all of them
-            state = 'incomplete'
-
-        archive = None
-        size = 0
-        errors = []
-
-        if os.path.lexists(b_dest):
-            size = os.path.getsize(b_dest)
-
-        if state != 'archive':
-            if check_mode:
-                changed = True
-
-            else:
-                try:
-                    # Slightly more difficult (and less efficient!) compression using zipfile module
-                    if fmt == 'zip':
-                        arcfile = zipfile.ZipFile(
-                            to_na(b_dest),
-                            'w',
-                            zipfile.ZIP_DEFLATED,
-                            True
-                        )
-
-                    # Easier compression using tarfile module
-                    elif fmt == 'gz' or fmt == 'bz2':
-                        arcfile = tarfile.open(to_na(b_dest), 'w|' + fmt)
-
-                    # python3 tarfile module allows xz format but for python2 we have to create the tarfile
-                    # in memory and then compress it with lzma.
-                    elif fmt == 'xz':
-                        arcfileIO = io.BytesIO()
-                        arcfile = tarfile.open(fileobj=arcfileIO, mode='w')
-
-                    # Or plain tar archiving
-                    elif fmt == 'tar':
-                        arcfile = tarfile.open(to_na(b_dest), 'w')
-
-                    b_match_root = re.compile(br'^%s' % re.escape(b_arcroot))
-                    for b_path in b_archive_paths:
-                        if os.path.isdir(b_path):
-                            # Recurse into directories
-                            for b_dirpath, b_dirnames, b_filenames in os.walk(b_path, topdown=True):
-                                if not b_dirpath.endswith(b_sep):
-                                    b_dirpath += b_sep
-
-                                for b_dirname in b_dirnames:
-                                    b_fullpath = b_dirpath + b_dirname
-                                    n_fullpath = to_na(b_fullpath)
-                                    n_arcname = to_native(b_match_root.sub(b'', b_fullpath), errors='surrogate_or_strict')
-
-                                    err = add_to_archive(arcfile, n_fullpath, n_arcname)
-                                    if err:
-                                        errors.append('%s: %s' % (n_fullpath, to_native(err)))
-
-                                for b_filename in b_filenames:
-                                    b_fullpath = b_dirpath + b_filename
-                                    n_fullpath = to_na(b_fullpath)
-                                    n_arcname = to_n(b_match_root.sub(b'', b_fullpath))
-
-                                    err = add_to_archive(arcfile, n_fullpath, n_arcname)
-                                    if err:
-                                        errors.append('Adding %s: %s' % (to_native(b_path), to_native(err)))
-
-                                    if archive_contains(arcfile, n_arcname):
-                                        b_successes.append(b_fullpath)
-                        else:
-                            path = to_na(b_path)
-                            arcname = to_n(b_match_root.sub(b'', b_path))
-
-                            err = add_to_archive(arcfile, path, arcname)
-                            if err:
-                                errors.append('Adding %s: %s' % (to_native(b_path), to_native(err)))
-
-                            if archive_contains(arcfile, arcname):
-                                b_successes.append(b_path)
-
-                except Exception as e:
-                    expanded_fmt = 'zip' if fmt == 'zip' else ('tar.' + fmt)
-                    module.fail_json(
-                        msg='Error when writing %s archive at %s: %s' % (expanded_fmt, dest, to_native(e)),
-                        exception=format_exc()
-                    )
-
-                if arcfile:
-                    arcfile.close()
-                    state = 'archive'
-
-                if fmt == 'xz':
-                    with lzma.open(b_dest, 'wb') as f:
-                        f.write(arcfileIO.getvalue())
-                    arcfileIO.close()
-
-                if errors:
-                    module.fail_json(msg='Errors when writing archive at %s: %s' % (dest, '; '.join(errors)))
-
-        if state in ['archive', 'incomplete'] and remove:
-            for b_path in b_successes:
-                try:
-                    if os.path.isdir(b_path):
-                        shutil.rmtree(b_path)
-                    elif not check_mode:
-                        os.remove(b_path)
-                except OSError:
-                    errors.append(to_native(b_path))
-
-            for b_path in b_expanded_paths:
-                try:
-                    if os.path.isdir(b_path):
-                        shutil.rmtree(b_path)
-                except OSError:
-                    errors.append(to_native(b_path))
-
-            if errors:
-                module.fail_json(dest=dest, msg='Error deleting some source files: ', files=errors)
+        if all([archive.state in ['archive', 'incomplete'], remove, not module.check_mode]):
+            archive.remove_targets()
 
         # Rudimentary check: If size changed then file changed. Not perfect, but easy.
-        if not check_mode and os.path.getsize(b_dest) != size:
-            changed = True
+        if not module.check_mode and archive.destination_size() != size:
+            archive.changed = True
 
-        if b_successes and state != 'incomplete':
-            state = 'archive'
-
-    # Simple, single-file compression
+        if archive.successes and archive.state != 'incomplete':
+            archive.state = 'archive'
     else:
-        b_path = b_expanded_paths[0]
+        path = archive.expanded_paths[0]
+        archive.add_one(path)
 
-        # No source or compressed file
-        if not (os.path.exists(b_path) or os.path.lexists(b_dest)):
-            state = 'absent'
-
-        # if it already exists and the source file isn't there, consider this done
-        elif not os.path.lexists(b_path) and os.path.lexists(b_dest):
-            state = 'compress'
-
-        else:
-            if module.check_mode:
-                if not os.path.exists(b_dest):
-                    changed = True
-            else:
-                size = 0
-                f_in = f_out = arcfile = None
-
-                if os.path.lexists(b_dest):
-                    size = os.path.getsize(b_dest)
-
-                try:
-                    if fmt == 'zip':
-                        arcfile = zipfile.ZipFile(
-                            to_na(b_dest),
-                            'w',
-                            zipfile.ZIP_DEFLATED,
-                            True
-                        )
-                        arcfile.write(
-                            to_na(b_path),
-                            to_n(b_path[len(b_arcroot):])
-                        )
-                        arcfile.close()
-                        state = 'archive'  # because all zip files are archives
-                    elif fmt == 'tar':
-                        arcfile = tarfile.open(to_na(b_dest), 'w')
-                        arcfile.add(to_na(b_path))
-                        arcfile.close()
-                    else:
-                        f_in = open(b_path, 'rb')
-
-                        n_dest = to_na(b_dest)
-                        if fmt == 'gz':
-                            f_out = gzip.open(n_dest, 'wb')
-                        elif fmt == 'bz2':
-                            f_out = bz2.BZ2File(n_dest, 'wb')
-                        elif fmt == 'xz':
-                            f_out = lzma.LZMAFile(n_dest, 'wb')
-                        else:
-                            raise OSError("Invalid format")
-
-                        shutil.copyfileobj(f_in, f_out)
-
-                    b_successes.append(b_path)
-
-                except OSError as e:
-                    module.fail_json(
-                        path=to_native(b_path),
-                        dest=dest,
-                        msg='Unable to write to compressed file: %s' % to_native(e), exception=format_exc()
-                    )
-
-                if arcfile:
-                    arcfile.close()
-                if f_in:
-                    f_in.close()
-                if f_out:
-                    f_out.close()
-
-                # Rudimentary check: If size changed then file changed. Not perfect, but easy.
-                if os.path.getsize(b_dest) != size:
-                    changed = True
-
-            state = 'compress'
-
-        if remove and not check_mode:
+        if remove and not module.check_mode:
             try:
-                os.remove(b_path)
+                os.remove(path)
 
             except OSError as e:
                 module.fail_json(
-                    path=to_native(b_path),
+                    path=to_n(path),
                     msg='Unable to remove source file: %s' % to_native(e), exception=format_exc()
                 )
-
     try:
-        file_args = module.load_file_common_arguments(params, path=b_dest)
+        file_args = module.load_file_common_arguments(module.params, path=archive.destination)
     except TypeError:
         # The path argument is only supported in Ansible-base 2.10+. Fall back to
         # pre-2.10 behavior for older Ansible versions.
-        params['path'] = b_dest
-        file_args = module.load_file_common_arguments(params)
+        module.params['path'] = archive.destination
+        file_args = module.load_file_common_arguments(module.params)
 
-    if not check_mode:
-        changed = module.set_fs_attributes_if_different(file_args, changed)
+    archive.changed = module.set_fs_attributes_if_different(file_args, archive.changed)
 
-    module.exit_json(
-        archived=[to_n(p) for p in b_successes],
-        dest=dest,
-        changed=changed,
-        state=state,
-        arcroot=to_n(b_arcroot),
-        missing=[to_n(p) for p in b_missing],
-        expanded_paths=[to_n(p) for p in b_expanded_paths],
-        expanded_exclude_paths=[to_n(p) for p in b_expanded_exclude_paths],
-    )
+    module.exit_json(**archive.result)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -44,6 +44,7 @@ options:
       - Use I(exclusion_patterns) to instead exclude files or subdirectories below any of the paths from the I(path) list.
     type: list
     elements: path
+    default: []
   exclusion_patterns:
     description:
       - Glob style patterns to exclude files or directories from the resulting archive.
@@ -131,13 +132,9 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-dest_state:
+state:
     description:
-        The current state of the archived file.
-        If 'absent', then no source files were found and the archive does not exist.
-        If 'compress', then the file source file is in the compressed state.
-        If 'archive', then the source file or paths are currently archived.
-        If 'incomplete', then an archive was created, but not all source paths were found.
+        The state of the input C(path).
     type: str
     returned: always
 missing:
@@ -266,11 +263,7 @@ class Archive(object):
 
         paths = module.params['path']
         self.expanded_paths, has_globs = expand_paths(paths)
-
-        if module.params['exclude_path']:
-            self.expanded_exclude_paths = expand_paths(module.params['exclude_path'])[0]
-        else:
-            self.expanded_exclude_paths = []
+        self.expanded_exclude_paths = expand_paths(module.params['exclude_path'])[0]
 
         self.paths = list(set(self.expanded_paths) - set(self.expanded_exclude_paths))
 
@@ -442,7 +435,6 @@ class Archive(object):
             'archived': [_to_native(p) for p in self.successes],
             'dest': _to_native(self.destination),
             'changed': self.changed,
-            'dest_state': self.destination_state,
             'arcroot': _to_native(self.root),
             'missing': [_to_native(p) for p in self.not_found],
             'expanded_paths': [_to_native(p) for p in self.expanded_paths],
@@ -559,7 +551,7 @@ def main():
             path=dict(type='list', elements='path', required=True),
             format=dict(type='str', default='gz', choices=['bz2', 'gz', 'tar', 'xz', 'zip']),
             dest=dict(type='path'),
-            exclude_path=dict(type='list', elements='path'),
+            exclude_path=dict(type='list', elements='path', default=[]),
             exclusion_patterns=dict(type='list', elements='path'),
             force_archive=dict(type='bool', default=False),
             remove=dict(type='bool', default=False),

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -589,7 +589,7 @@ def main():
             if not archive.destination_exists():
                 archive.changed = True
         else:
-            path = archive.expanded_paths[0]
+            path = archive.paths[0]
             archive.add_single_target(path)
             if archive.destination_size() != size:
                 archive.changed = True

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -411,6 +411,16 @@
     - bz2
     - xz
 
+# Dummy tests until ``dest_state`` result value can be implemented
+- name: Assert that single target tests are effective
+  assert:
+    that:
+      - single_target_test.results[0] is changed
+      - single_target_test.results[1] is changed
+      - single_target_test.results[2] is changed
+      - single_target_test.results[3] is changed
+      - single_target_test.results[4] is changed
+
 - name: Remove single target test with format={{ item }}
   file:
     path: "{{ output_dir }}/test-single-gzip.{{ item }}"
@@ -421,15 +431,6 @@
     - gz
     - bz2
     - xz
-
-- name: Assert state is correct after single target test
-  assert:
-    that:
-      - single_target_test.results[0].dest_state == 'archive'
-      - single_target_test.results[1].dest_state == 'archive'
-      - single_target_test.results[2].dest_state == 'compress'
-      - single_target_test.results[3].dest_state == 'compress'
-      - single_target_test.results[4].dest_state == 'compress'
 
 - name: Test that missing files result in incomplete state
   archive:
@@ -443,7 +444,7 @@
 - name: Assert that incomplete archive has incomplete state
   assert:
     that:
-      - incomplete_archive_result.dest_state == 'incomplete'
+      - incomplete_archive_result is changed
       - "'{{ output_dir }}/dne.txt' in incomplete_archive_result.missing"
       - "'{{ output_dir }}/foo.txt' not in incomplete_archive_result.missing"
 

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -436,7 +436,7 @@
       - "'oo.txt' not in single_target_test_contents.files"
       - "'foo.txt' in single_target_test_contents.files"
   # ``unarchive`` fails for RHEL and FreeBSD on ansible 2.x
-  when: single_target_test_contents is success
+  when: single_target_test_contents is success and single_target_test_contents is not skipped
 
 - name: Remove single target test with format={{ item }}
   file:

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -79,6 +79,8 @@
     - foo.txt
     - bar.txt
     - empty.txt
+    - sub
+    - sub/subfile.txt
 
 - name: archive using gz
   archive:
@@ -366,7 +368,7 @@
 - name: Test exclusion_patterns option
   archive:
     path: "{{ output_dir }}/*.txt"
-    dest: "{{ output_dir }}/test-archive-exclustion-patterns.tgz"
+    dest: "{{ output_dir }}/test-archive-exclusion-patterns.tgz"
     exclusion_patterns: b?r.*
   register: exclusion_patterns_result
 
@@ -375,6 +377,80 @@
     that:
       - exclusion_patterns_result is changed
       - "'bar.txt' not in exclusion_patterns_result.archived"
+
+- name: Test that excluded paths do not influence archive root
+  archive:
+    path:
+      - "{{ output_dir }}/sub/subfile.txt"
+      - "{{ output_dir }}"
+    exclude_path:
+      - "{{ output_dir }}"
+    dest: "{{ output_dir }}/test-archive-root.tgz"
+  register: archive_root_result
+
+- name: Assert that excluded paths do not influence archive root
+  assert:
+    that:
+      - archive_root_result.arcroot != output_dir
+
+- name: Remove archive root test
+  file:
+    path: "{{ output_dir }}/test-archive-root.tgz"
+    state: absent
+
+- name: Test Single Target with format={{ item }}
+  archive:
+    path: "{{ output_dir }}/foo.txt"
+    dest: "{{ output_dir }}/test-single-gzip.{{ item }}"
+    format: "{{ item }}"
+  register: "single_target_test"
+  loop:
+    - zip
+    - tar
+    - gz
+    - bz2
+    - xz
+
+- name: Remove single target test with format={{ item }}
+  file:
+    path: "{{ output_dir }}/test-single-gzip.{{ item }}"
+    state: absent
+  loop:
+    - zip
+    - tar
+    - gz
+    - bz2
+    - xz
+
+- name: Assert state is correct after single target test
+  assert:
+    that:
+      - single_target_test.results[0].dest_state == 'archive'
+      - single_target_test.results[1].dest_state == 'archive'
+      - single_target_test.results[2].dest_state == 'compress'
+      - single_target_test.results[3].dest_state == 'compress'
+      - single_target_test.results[4].dest_state == 'compress'
+
+- name: Test that missing files result in incomplete state
+  archive:
+    path:
+      - "{{ output_dir }}/*.txt"
+      - "{{ output_dir }}/dne.txt"
+    exclude_path: "{{ output_dir }}/foo.txt"
+    dest: "{{ output_dir }}/test-incomplete-archive.tgz"
+  register: incomplete_archive_result
+
+- name: Assert that incomplete archive has incomplete state
+  assert:
+    that:
+      - incomplete_archive_result.dest_state == 'incomplete'
+      - "'{{ output_dir }}/dne.txt' in incomplete_archive_result.missing"
+      - "'{{ output_dir }}/foo.txt' not in incomplete_archive_result.missing"
+
+- name: Remove incomplete archive
+  file:
+    path: "{{ output_dir }}/test-incomplete-archive.tgz"
+    state: absent
 
 - name: Remove backports.lzma if previously installed (pip)
   pip: name=backports.lzma state=absent

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -427,6 +427,7 @@
     dest: .
     list_files: true
   check_mode: true
+  ignore_errors: true
   register: single_target_test_contents
 
 - name: Assert that file names in single-file zip archives are preserved
@@ -434,6 +435,8 @@
     that:
       - "'oo.txt' not in single_target_test_contents.files"
       - "'foo.txt' in single_target_test_contents.files"
+  # ``unarchive`` fails for RHEL and FreeBSD on ansible 2.x
+  when: single_target_test_contents is success
 
 - name: Remove single target test with format={{ item }}
   file:

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -401,7 +401,7 @@
 - name: Test Single Target with format={{ item }}
   archive:
     path: "{{ output_dir }}/foo.txt"
-    dest: "{{ output_dir }}/test-single-gzip.{{ item }}"
+    dest: "{{ output_dir }}/test-single-target.{{ item }}"
     format: "{{ item }}"
   register: "single_target_test"
   loop:
@@ -421,9 +421,23 @@
       - single_target_test.results[3] is changed
       - single_target_test.results[4] is changed
 
+- name: Retrieve contents of single target archives
+  ansible.builtin.unarchive:
+    src: "{{ output_dir }}/test-single-target.zip"
+    dest: .
+    list_files: true
+  check_mode: true
+  register: single_target_test_contents
+
+- name: Assert that file names in single-file zip archives are preserved
+  assert:
+    that:
+      - "'oo.txt' not in single_target_test_contents.files"
+      - "'foo.txt' in single_target_test_contents.files"
+
 - name: Remove single target test with format={{ item }}
   file:
-    path: "{{ output_dir }}/test-single-gzip.{{ item }}"
+    path: "{{ output_dir }}/test-single-target.{{ item }}"
     state: absent
   loop:
     - zip

--- a/tests/integration/targets/archive/tasks/remove.yml
+++ b/tests/integration/targets/archive/tasks/remove.yml
@@ -117,6 +117,37 @@
 - name: verify that excluded file is still present
   file: path={{ output_dir }}/tmpdir/empty.txt state=file
 
+- name: prep our files in tmpdir again
+  copy: src={{ item }} dest={{ output_dir }}/tmpdir/{{ item }}
+  with_items:
+    - foo.txt
+    - bar.txt
+    - empty.txt
+    - sub
+    - sub/subfile.txt
+
+- name: archive using gz and remove src directory
+  archive:
+    path:
+      - "{{ output_dir }}/tmpdir/*.txt"
+      - "{{ output_dir }}/tmpdir/sub/*"
+    dest: "{{ output_dir }}/archive_remove_04.gz"
+    format: gz
+    remove: yes
+    exclude_path: "{{ output_dir }}/tmpdir/sub/subfile.txt"
+  register: archive_remove_result_04
+
+- debug: msg="{{ archive_remove_result_04 }}"
+
+- name: verify that the files archived
+  file: path={{ output_dir }}/archive_remove_04.gz state=file
+
+- name: remove our gz
+  file: path="{{ output_dir }}/archive_remove_04.gz" state=absent
+
+- name: verify that excluded sub file is still present
+  file: path={{ output_dir }}/tmpdir/sub/subfile.txt state=file
+
 - name: remove temporary directory
   file:
     path: "{{ output_dir }}/tmpdir"


### PR DESCRIPTION
##### SUMMARY
`archive` has become difficult to maintain and debug so this PR seeks to refactor the module and in the process eliminate some obvious bugs.

Fixes #2818 
##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
plugins/modules/files/archive.py

##### ADDITIONAL INFORMATION
The existing issues with `archive` exposed during refactoring seem related to three core problems:
1. Internal state management
  - Archive state is maintained throughout `main` and used both for control flow and to pass information in the `result` dict ~~(Since `state` will continue to be returned by the module with the same values I just changed the name of the intended result value to `dest_state`)~~
  - The `result` dict will never show this information however because implementing `path` or `dest` as options causes `AnsibleModule` to overwrite `state` to the file state. (See [here](https://github.com/ansible/ansible/blob/e6a7bc854cabc99eff1b46109fcde7eb28aaac23/lib/ansible/module_utils/basic.py#L1221-L1228))
  - In addition the state is often overwritten (See [here](https://github.com/ansible-collections/community.general/blob/2f2f384b4e7f9455631f9143dcb2c5f76817ed67/plugins/modules/files/archive.py#L406-L408) and [here](https://github.com/ansible-collections/community.general/blob/2f2f384b4e7f9455631f9143dcb2c5f76817ed67/plugins/modules/files/archive.py#L492-L494) for an example)
2. Poor integration of `exclude_path`
  - `exclude_path` was used to narrow down the archive paths, but that narrowed down list is not used consistently throughout the module (See [here](https://github.com/ansible-collections/community.general/blob/2f2f384b4e7f9455631f9143dcb2c5f76817ed67/plugins/modules/files/archive.py#L514-L519) and [here](https://github.com/ansible-collections/community.general/blob/2f2f384b4e7f9455631f9143dcb2c5f76817ed67/plugins/modules/files/archive.py#L533)) which causes excluded paths to be affected by remove operations for example
  - excluded_paths are also treated as missing which if the state management works correctly creates confusion
3. Check mode
  - Check mode is not applied at a high enough level to avoid destructive operations (See [here](https://github.com/ansible-collections/community.general/blob/2f2f384b4e7f9455631f9143dcb2c5f76817ed67/plugins/modules/files/archive.py#L504-L519) in particular the second `for` loop when `state='incomplete'`)
  
The refactor passed integration without issues, but I believe integration tests are incomplete so I added tests that specifically target the aforementioned issues.