### PR TITLE
fix sudorule_add_allow_command_group

### DIFF
--- a/changelogs/fragments/2821-ipa_sudorule.yml
+++ b/changelogs/fragments/2821-ipa_sudorule.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "ipa_sudorule - call ``sudorule_add_allow_command`` method instead of  ``sudorule_add_allow_command_group``
+    (https://github.com/ansible-collections/community.general/issues/2442)."

--- a/plugins/modules/identity/ipa/ipa_sudorule.py
+++ b/plugins/modules/identity/ipa/ipa_sudorule.py
@@ -237,7 +237,7 @@ class SudoRuleIPAClient(IPAClient):
         return self._post_json(method='sudorule_add_allow_command', name=name, item={'sudocmd': item})
 
     def sudorule_add_allow_command_group(self, name, item):
-        return self._post_json(method='sudorule_add_allow_command_group', name=name, item={'sudocmdgroup': item})
+        return self._post_json(method='sudorule_add_allow_command', name=name, item={'sudocmdgroup': item})
 
     def sudorule_remove_allow_command(self, name, item):
         return self._post_json(method='sudorule_remove_allow_command', name=name, item=item)


### PR DESCRIPTION
fix sudorule_add_allow_command_group is not working on freeIPA 4.8.7 at least, sudorule_add_allow_command should be used instead with item sudocmdgroup

##### SUMMARY
Fixes #2442

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa_sudorule

##### ADDITIONAL INFORMATION
Before
```
"msg": "response sudorule_add_allow_command_group: unknown command 'sudorule_add_allow_command_group'"
```

After, message is gone and request is processed correctly in FreeIPA Server