### PR TITLE
npm - fix updating version specific modules

### DIFF
--- a/changelogs/fragments/2830-npm-version-update.yml
+++ b/changelogs/fragments/2830-npm-version-update.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "npm - When the version property is used in the npm plugin,
+    the comparison of installed vs missing will be used as name@version instead of just name,
+    allowing for version specific updates.
+    (https://github.com/ansible-collections/community.general/issues/2021)."

--- a/changelogs/fragments/2830-npm-version-update.yml
+++ b/changelogs/fragments/2830-npm-version-update.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - "npm - When the ``version`` option is used the comparison of installed vs missing will 
+  - "npm - when the ``version`` option is used the comparison of installed vs missing will
     use name@version instead of just name, allowing version specific updates
     (https://github.com/ansible-collections/community.general/issues/2021)."

--- a/changelogs/fragments/2830-npm-version-update.yml
+++ b/changelogs/fragments/2830-npm-version-update.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - "npm - When the ``version`` option is used the comparison of installed vs missing will 
-    use name@version instead of just name, allowing for version specific updates 
+    use name@version instead of just name, allowing version specific updates
     (https://github.com/ansible-collections/community.general/issues/2021)."

--- a/changelogs/fragments/2830-npm-version-update.yml
+++ b/changelogs/fragments/2830-npm-version-update.yml
@@ -1,5 +1,4 @@
 bugfixes:
-  - "npm - When the version property is used in the npm plugin,
-    the comparison of installed vs missing will be used as name@version instead of just name,
-    allowing for version specific updates.
+  - "npm - When the ``version`` option is used the comparison of installed vs missing will 
+    use name@version instead of just name, allowing for version specific updates 
     (https://github.com/ansible-collections/community.general/issues/2021)."

--- a/plugins/modules/packaging/language/npm.py
+++ b/plugins/modules/packaging/language/npm.py
@@ -181,7 +181,7 @@ class Npm(object):
                 cmd.append('--ignore-scripts')
             if self.unsafe_perm:
                 cmd.append('--unsafe-perm')
-            if self.name and add_package_name:
+            if self.name_version and add_package_name:
                 cmd.append(self.name_version)
             if self.registry:
                 cmd.append('--registry')
@@ -216,13 +216,16 @@ class Npm(object):
             self.module.fail_json(msg="Failed to parse NPM output with error %s" % to_native(e))
         if 'dependencies' in data:
             for dep in data['dependencies']:
+                dep_version = dep + '@' + str(data['dependencies'][dep]['version'])
+
                 if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:
                     missing.append(dep)
                 elif 'invalid' in data['dependencies'][dep] and data['dependencies'][dep]['invalid']:
                     missing.append(dep)
                 else:
                     installed.append(dep)
-            if self.name and self.name not in installed:
+                    installed.append(dep_version)
+            if self.name_version and self.name_version not in installed:
                 missing.append(self.name)
         # Named dependency not installed
         else:

--- a/plugins/modules/packaging/language/npm.py
+++ b/plugins/modules/packaging/language/npm.py
@@ -215,12 +215,12 @@ class Npm(object):
         except (getattr(json, 'JSONDecodeError', ValueError)) as e:
             self.module.fail_json(msg="Failed to parse NPM output with error %s" % to_native(e))
         if 'dependencies' in data:
-            for dep in data['dependencies']:
-                dep_version = dep + '@' + str(data['dependencies'][dep]['version'])
+            for dep, props in data['dependencies'].items():
+                dep_version = dep + '@' + str(props['version'])
 
-                if 'missing' in data['dependencies'][dep] and data['dependencies'][dep]['missing']:
+                if 'missing' in props and props['missing']:
                     missing.append(dep)
-                elif 'invalid' in data['dependencies'][dep] and data['dependencies'][dep]['invalid']:
+                elif 'invalid' in props and props['invalid']:
                     missing.append(dep)
                 else:
                     installed.append(dep)

--- a/tests/unit/plugins/modules/packaging/language/test_npm.py
+++ b/tests/unit/plugins/modules/packaging/language/test_npm.py
@@ -49,6 +49,66 @@ class NPMModuleTestCase(ModuleTestCase):
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
             call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
+            call(['/testbin/npm', 'install', '--global', 'coffee-script'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_version(self):
+        set_module_args({
+            'name': 'coffee-script',
+            'global': 'true',
+            'state': 'present',
+            'version': '2.5.1'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
+            call(['/testbin/npm', 'install', '--global', 'coffee-script@2.5.1'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_version_update(self):
+        set_module_args({
+            'name': 'coffee-script',
+            'global': 'true',
+            'state': 'present',
+            'version': '2.5.1'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
+            call(['/testbin/npm', 'install', '--global', 'coffee-script@2.5.1'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_version_exists(self):
+        set_module_args({
+            'name': 'coffee-script',
+            'global': 'true',
+            'state': 'present',
+            'version': '2.5.1'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertFalse(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
         ])
 
     def test_absent(self):
@@ -58,7 +118,7 @@ class NPMModuleTestCase(ModuleTestCase):
             'state': 'absent'
         })
         self.module_main_command.side_effect = [
-            (0, '{"dependencies": {"coffee-script": {}}}', ''),
+            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
             (0, '{}', ''),
         ]
 
@@ -66,5 +126,46 @@ class NPMModuleTestCase(ModuleTestCase):
 
         self.assertTrue(result['changed'])
         self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
+            call(['/testbin/npm', 'uninstall', '--global', 'coffee-script'], check_rc=True, cwd=None),
+        ])
+
+    def test_absent_version(self):
+        set_module_args({
+            'name': 'coffee-script',
+            'global': 'true',
+            'state': 'absent',
+            'version': '2.5.1'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.1"}}}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
+            call(['/testbin/npm', 'uninstall', '--global', 'coffee-script'], check_rc=True, cwd=None),
+        ])
+
+    def test_absent_version_different(self):
+        set_module_args({
+            'name': 'coffee-script',
+            'global': 'true',
+            'state': 'absent',
+            'version': '2.5.1'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{"dependencies": {"coffee-script": {"version" : "2.5.0"}}}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
             call(['/testbin/npm', 'uninstall', '--global', 'coffee-script'], check_rc=True, cwd=None),
         ])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When the `version` property is used in the `npm` plugin, the comparison of installed vs missing will be used as `name@version` instead of just `name`, allowing for version specific updates.

Fixes #2021 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

npm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
