### PR TITLE
proxmox_kvm: Fix ZFS device string parsing

### DIFF
--- a/changelogs/fragments/2841-proxmox_kvm_zfs_devstr.yml
+++ b/changelogs/fragments/2841-proxmox_kvm_zfs_devstr.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "proxmox_kvm - fix parsing of Proxmox VM information with device info not containing
+    a comma, like disks backed by ZFS zvols
+    (https://github.com/ansible-collections/community.general/issues/2840)."

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -818,21 +818,23 @@ def get_vminfo(module, proxmox, node, vmid, **kwargs):
     # Split information by type
     re_net = re.compile(r'net[0-9]')
     re_dev = re.compile(r'(virtio|ide|scsi|sata)[0-9]')
-    for k, v in kwargs.items():
+    for k in kwargs.keys():
         if re_net.match(k):
-            interface = k
-            k = vm[k]
-            k = re.search('=(.*?),', k).group(1)
-            mac[interface] = k
+            mac[k] = parse_mac(vm[k])
         elif re_dev.match(k):
-            device = k
-            k = vm[k]
-            k = re.search('(.*?),', k).group(1)
-            devices[device] = k
+            devices[k] = parse_dev(vm[k])
 
     results['mac'] = mac
     results['devices'] = devices
     results['vmid'] = int(vmid)
+
+
+def parse_mac(netstr):
+    return re.search('=(.*?),', netstr).group(1)
+
+
+def parse_dev(devstr):
+    return re.search('(.*?)(,|$)', devstr).group(1)
 
 
 def settings(proxmox, vmid, node, **kwargs):

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_kvm.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_kvm.py
@@ -1,0 +1,17 @@
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.general.plugins.modules.cloud.misc.proxmox_kvm import parse_dev, parse_mac
+
+
+def test_parse_mac():
+    assert parse_mac('virtio=00:11:22:AA:BB:CC,bridge=vmbr0,firewall=1') == '00:11:22:AA:BB:CC'
+
+
+def test_parse_dev():
+    assert parse_dev('local-lvm:vm-1000-disk-0,format=qcow2') == 'local-lvm:vm-1000-disk-0'
+    assert parse_dev('local-lvm:vm-101-disk-1,size=8G') == 'local-lvm:vm-101-disk-1'
+    assert parse_dev('local-zfs:vm-1001-disk-0') == 'local-zfs:vm-1001-disk-0'


### PR DESCRIPTION
##### SUMMARY

ZFS-backed block devices may contain just the bare device name and
not have extra options like `,size=foo`, `,format=qcow2` etc. This
breaks an assumption in existing regex (which expects a comma).

Support such device strings and add a couple of testcases to validate.

Fixes #2840

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION

```
---
- name: Deploy VMs
  hosts: bigpve

  tasks:
  - name: Create new minimal VM
    community.general.proxmox_kvm:
      api_user: root@pam
      api_password: "<redacted>"
      api_host: bigpve
      name: testvm
      node: bigpve
      proxmox_default_behavior: no_defaults
      vmid: 1001
      scsihw: virtio-scsi-pci
      scsi:
        scsi0: "local-zfs:vm-1001-disk-0"
      net:
        net0: 'virtio,bridge=vmbr0'
      bootdisk: scsi0
```

On execution, it returns:
```
The full traceback is:
  File "/tmp/ansible_community.general.proxmox_kvm_payload_mqneu62g/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py", line 1300, in main
  File "/tmp/ansible_community.general.proxmox_kvm_payload_mqneu62g/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py", line 830, in get_vminfo
fatal: [bigpve]: FAILED! => {
     "msg": "creation of qemu VM testvm with vmid 1001 failed with exception='NoneType' object has no attribute 'group'",  
     ...
}
```
