### PR TITLE
ali_instance_info - marked parameters for deprecation in c.g. 5.0.0

### DIFF
--- a/changelogs/fragments/2844-ali_instance_info-deprecate-params.yml
+++ b/changelogs/fragments/2844-ali_instance_info-deprecate-params.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - ali_instance_info - marked removal version of deprecated parameters ``availability_zone`` and ``instance_names`` (https://github.com/ansible-collections/community.general/issues/2429).

--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -376,8 +376,10 @@ except ImportError:
 def main():
     argument_spec = ecs_argument_spec()
     argument_spec.update(dict(
-        availability_zone=dict(aliases=['alicloud_zone']),
-        instance_ids=dict(type='list', elements='str', aliases=['ids']),
+        availability_zone=dict(aliases=['alicloud_zone'],
+                               removed_in_version="5.0.0", removed_from_collection="community.general"),
+        instance_ids=dict(type='list', elements='str', aliases=['ids'],
+                          removed_in_version="5.0.0", removed_from_collection="community.general"),
         instance_names=dict(type='list', elements='str', aliases=['names']),
         name_prefix=dict(type='str'),
         tags=dict(type='dict', aliases=['instance_tags']),

--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -35,12 +35,14 @@ description:
 options:
     availability_zone:
       description:
-        - (Deprecated) Aliyun availability zone ID in which to launch the instance. Please use filter item 'zone_id' instead.
+        - Aliyun availability zone ID in which to launch the instance.
+        - Deprecated parameter, it will be removed in community.general C(5.0.0). Please use filter item I(zone_id) instead.
       aliases: ['alicloud_zone']
       type: str
     instance_names:
       description:
-        - (Deprecated) A list of ECS instance names. Please use filter item 'instance_name' instead.
+        - A list of ECS instance names.
+        - Deprecated parameter, it will be removed in community.general C(5.0.0). Please use filter item I(instance_name) instead.
       aliases: ["names"]
       type: list
       elements: str

--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -36,13 +36,13 @@ options:
     availability_zone:
       description:
         - Aliyun availability zone ID in which to launch the instance.
-        - Deprecated parameter, it will be removed in community.general C(5.0.0). Please use filter item I(zone_id) instead.
+        - Deprecated parameter, it will be removed in community.general 5.0.0. Please use filter item I(zone_id) instead.
       aliases: ['alicloud_zone']
       type: str
     instance_names:
       description:
         - A list of ECS instance names.
-        - Deprecated parameter, it will be removed in community.general C(5.0.0). Please use filter item I(instance_name) instead.
+        - Deprecated parameter, it will be removed in community.general 5.0.0. Please use filter item I(instance_name) instead.
       aliases: ["names"]
       type: list
       elements: str


### PR DESCRIPTION
##### SUMMARY
Parameters were already marked as deprecated - pinning version 5.0.0 for removal.

Fixes #2429 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/cloud/alicloud/ali_instance_info.py

