### PR TITLE
[backport][stable-2] proxmox_kvm: Fix ZFS device string parsing (#2841)

### DIFF
--- a/changelogs/fragments/2841-proxmox_kvm_zfs_devstr.yml
+++ b/changelogs/fragments/2841-proxmox_kvm_zfs_devstr.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "proxmox_kvm - fix parsing of Proxmox VM information with device info not containing
+    a comma, like disks backed by ZFS zvols
+    (https://github.com/ansible-collections/community.general/issues/2840)."

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -828,9 +828,6 @@ def get_vminfo(module, proxmox, node, vmid, **kwargs):
     results['vmid'] = int(vmid)
 
 
-<<<<<<< HEAD
-def settings(module, proxmox, vmid, node, name, **kwargs):
-=======
 def parse_mac(netstr):
     return re.search('=(.*?),', netstr).group(1)
 
@@ -840,7 +837,6 @@ def parse_dev(devstr):
 
 
 def settings(proxmox, vmid, node, **kwargs):
->>>>>>> db713bd0 (proxmox_kvm: Fix ZFS device string parsing (#2841))
     proxmox_node = proxmox.nodes(node)
 
     # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -836,7 +836,7 @@ def parse_dev(devstr):
     return re.search('(.*?)(,|$)', devstr).group(1)
 
 
-def settings(proxmox, vmid, node, **kwargs):
+def settings(module, proxmox, vmid, node, **kwargs):
     proxmox_node = proxmox.nodes(node)
 
     # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -836,7 +836,7 @@ def parse_dev(devstr):
     return re.search('(.*?)(,|$)', devstr).group(1)
 
 
-def settings(module, proxmox, vmid, node, **kwargs):
+def settings(module, proxmox, vmid, node, name, **kwargs):
     proxmox_node = proxmox.nodes(node)
 
     # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -815,27 +815,32 @@ def get_vminfo(module, proxmox, node, vmid, **kwargs):
             del kwargs[k]
 
     # Split information by type
-    for k, v in kwargs.items():
-        if re.match(r'net[0-9]', k) is not None:
-            interface = k
-            k = vm[k]
-            k = re.search('=(.*?),', k).group(1)
-            mac[interface] = k
-        if (re.match(r'virtio[0-9]', k) is not None or
-                re.match(r'ide[0-9]', k) is not None or
-                re.match(r'scsi[0-9]', k) is not None or
-                re.match(r'sata[0-9]', k) is not None):
-            device = k
-            k = vm[k]
-            k = re.search('(.*?),', k).group(1)
-            devices[device] = k
+    re_net = re.compile(r'net[0-9]')
+    re_dev = re.compile(r'(virtio|ide|scsi|sata)[0-9]')
+    for k in kwargs.keys():
+        if re_net.match(k):
+            mac[k] = parse_mac(vm[k])
+        elif re_dev.match(k):
+            devices[k] = parse_dev(vm[k])
 
     results['mac'] = mac
     results['devices'] = devices
     results['vmid'] = int(vmid)
 
 
+<<<<<<< HEAD
 def settings(module, proxmox, vmid, node, name, **kwargs):
+=======
+def parse_mac(netstr):
+    return re.search('=(.*?),', netstr).group(1)
+
+
+def parse_dev(devstr):
+    return re.search('(.*?)(,|$)', devstr).group(1)
+
+
+def settings(proxmox, vmid, node, **kwargs):
+>>>>>>> db713bd0 (proxmox_kvm: Fix ZFS device string parsing (#2841))
     proxmox_node = proxmox.nodes(node)
 
     # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_kvm.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_kvm.py
@@ -1,0 +1,17 @@
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.general.plugins.modules.cloud.misc.proxmox_kvm import parse_dev, parse_mac
+
+
+def test_parse_mac():
+    assert parse_mac('virtio=00:11:22:AA:BB:CC,bridge=vmbr0,firewall=1') == '00:11:22:AA:BB:CC'
+
+
+def test_parse_dev():
+    assert parse_dev('local-lvm:vm-1000-disk-0,format=qcow2') == 'local-lvm:vm-1000-disk-0'
+    assert parse_dev('local-lvm:vm-101-disk-1,size=8G') == 'local-lvm:vm-101-disk-1'
+    assert parse_dev('local-zfs:vm-1001-disk-0') == 'local-zfs:vm-1001-disk-0'


### PR DESCRIPTION
ZFS-backed block devices may contain just the bare device name and
not have extra options like `,size=foo`, `,format=qcow2` etc. This
breaks an assumption in existing regex (which expects a comma).

Support such device strings and add a couple of testcases to validate.

Manually backport of #2841 