### PR TITLE
jenkins_build: Support stop a running Jenkins build

### DIFF
--- a/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
+++ b/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - jenkins_build - support stop a running jenkins build (https://github.com/ansible-collections/community.general/pull/2850).
+bugfixes:
+  - jenkins_build - check build_number before delete a jenkins build (https://github.com/ansible-collections/community.general/pull/2850).

--- a/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
+++ b/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - jenkins_build - support stop a running jenkins build (https://github.com/ansible-collections/community.general/pull/2850).
+  - jenkins_build - support stopping a running jenkins build (https://github.com/ansible-collections/community.general/pull/2850).
 bugfixes:
-  - jenkins_build - check build_number before delete a jenkins build (https://github.com/ansible-collections/community.general/pull/2850).
+  - jenkins_build - examine presence of ``build_number`` before deleting a jenkins build (https://github.com/ansible-collections/community.general/pull/2850).

--- a/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
+++ b/changelogs/fragments/2850-jenkins_build-support-stop-jenkins-build.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jenkins_build - support stop a running jenkins build (https://github.com/ansible-collections/community.general/pull/2850).

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -198,15 +198,17 @@ class JenkinsBuild:
                                   exception=traceback.format_exc())
 
     def stopped_build(self):
+        build_info = None
         try:
             build_info = self.server.get_build_info(self.name, self.build_number)
             if build_info['building'] is True:
                 self.server.stop_build(self.name, self.build_number)
-            else:
-                self.module.exit_json(**self.result)
         except Exception as e:
             self.module.fail_json(msg='Unable to stop build for %s: %s' % (self.jenkins_url, to_native(e)),
                                   exception=traceback.format_exc())
+        else:
+            if build_info['building'] is False:
+                self.module.exit_json(**self.result)
 
     def absent_build(self):
         try:

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -16,7 +16,7 @@ description:
     - Manage Jenkins builds with Jenkins REST API.
 requirements:
   - "python-jenkins >= 0.4.12"
-author: 
+author:
   - Brett Milford (@brettmilford)
   - Tong He (@unnecessary-username)
 options:
@@ -69,14 +69,14 @@ EXAMPLES = '''
     user: admin
     password: asdfg
     url: http://localhost:8080
-    
+
 - name: Stop a running jenkins build anonymously
   community.general.jenkins_build:
     name: "stop-check"
     build_number: 3
     state: stopped
     url: http://localhost:8080
-    
+
 - name: Delete a jenkins build using token authentication
   community.general.jenkins_build:
     name: "delete-experiment"

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
 __metaclass__ = type
 
 DOCUMENTATION = '''
@@ -121,7 +120,6 @@ from time import sleep
 JENKINS_IMP_ERR = None
 try:
     import jenkins
-
     python_jenkins_installed = True
 except ImportError:
     JENKINS_IMP_ERR = traceback.format_exc()

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 DOCUMENTATION = '''
@@ -120,6 +121,7 @@ from time import sleep
 JENKINS_IMP_ERR = None
 try:
     import jenkins
+
     python_jenkins_installed = True
 except ImportError:
     JENKINS_IMP_ERR = traceback.format_exc()
@@ -171,7 +173,8 @@ class JenkinsBuild:
         try:
             build_number = self.server.get_job_info(self.name)['nextBuildNumber']
         except Exception as e:
-            self.module.fail_json(msg='Unable to get job info from Jenkins server, %s' % to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(msg='Unable to get job info from Jenkins server, %s' % to_native(e),
+                                  exception=traceback.format_exc())
 
         return build_number
 
@@ -181,7 +184,8 @@ class JenkinsBuild:
             return response
 
         except Exception as e:
-            self.module.fail_json(msg='Unable to fetch build information, %s' % to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(msg='Unable to fetch build information, %s' % to_native(e),
+                                  exception=traceback.format_exc())
 
     def present_build(self):
         self.build_number = self.get_next_build()
@@ -247,7 +251,7 @@ def main():
             url=dict(default="http://localhost:8080"),
             user=dict(),
         ),
-        mutually_exclusive=[['password', 'token'],],
+        mutually_exclusive=[['password', 'token']],
         required_if=[['state', 'absent', ['build_number'], True], ['state', 'stopped', ['build_number'], True]],
     )
 

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -200,7 +200,7 @@ class JenkinsBuild:
     def stopped_build(self):
         try:
             build_info = self.server.get_build_info(self.name, self.build_number)
-            if build_info['building'] == True:
+            if build_info['building'] is True:
                 self.server.stop_build(self.name, self.build_number)
             else:
                 self.module.exit_json(**self.result)

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -39,6 +39,7 @@ options:
   state:
     description:
       - Attribute that specifies if the build is to be created, deleted or stopped.
+      - The C(stopped) state has been added in community.general 3.3.0.
     default: present
     choices: ['present', 'absent', 'stopped']
     type: str

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -257,7 +257,7 @@ def main():
     if module.params.get('state') == "present":
         jenkins_build.present_build()
     elif module.params.get('state') == "stopped":
-        jenkins_build.stop_build()
+        jenkins_build.stopped_build()
     else:
         jenkins_build.absent_build()
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -54,9 +54,6 @@ class JenkinsMock():
             "result": "SUCCESS"
         }
 
-    def get_build_status(self):
-        pass
-
     def build_job(self, *args):
         return None
 
@@ -79,9 +76,6 @@ class JenkinsMockIdempotent():
             "building": False,
             "result": "ABORTED"
         }
-
-    def get_build_status(self):
-        pass
 
     def build_job(self, *args):
         return None
@@ -139,7 +133,7 @@ class TestJenkinsBuild(unittest.TestCase):
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMock()
 
-        with self.assertRaises(AnsibleExitJson):
+        with self.assertRaises(AnsibleExitJson) as return_json:
             set_module_args({
                 "name": "host-check",
                 "build_number": "1234",
@@ -149,10 +143,11 @@ class TestJenkinsBuild(unittest.TestCase):
             })
             jenkins_build.main()
 
+        self.assertTrue(return_json.exception.args[0]['changed'])
+
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
     def test_module_stop_build_again(self, jenkins_connection, test_deps):
-        # The stopped_build function is idempotent.
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMockIdempotent()
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -50,6 +50,7 @@ class JenkinsMock():
 
     def get_build_info(self, name, build_number):
         return {
+            "building": True,
             "result": "SUCCESS"
         }
 
@@ -64,6 +65,7 @@ class JenkinsMock():
 
     def stop_build(self, name, build_number):
         return None
+
 
 class JenkinsMockIdempotent():
 
@@ -89,6 +91,7 @@ class JenkinsMockIdempotent():
 
     def stop_build(self, name, build_number):
         return None
+
 
 class TestJenkinsBuild(unittest.TestCase):
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -108,7 +108,24 @@ class TestJenkinsBuild(unittest.TestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
-    def test_module_stopped_build(self, jenkins_connection, test_deps):
+    def test_module_stop_build(self, jenkins_connection, test_deps):
+        test_deps.return_value = None
+        jenkins_connection.return_value = JenkinsMock()
+
+        with self.assertRaises(AnsibleExitJson):
+            set_module_args({
+                "name": "host-check",
+                "build_number": "1234",
+                "state": "stopped",
+                "user": "abc",
+                "token": "xyz"
+            })
+            jenkins_build.main()
+
+    @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
+    @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
+    def test_module_stop_build_idempotent(self, jenkins_connection, test_deps):
+        # The stopped_build function is idempotent.
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMock()
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -108,7 +108,7 @@ class TestJenkinsBuild(unittest.TestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
-    def test_module_stop_build(self, jenkins_connection, test_deps):
+    def test_module_stopped_build(self, jenkins_connection, test_deps):
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMock()
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -50,7 +50,7 @@ class JenkinsMock():
         }
 
     def get_build_info(self, name, build_number):
-        if self.idempotent == False:
+        if self.idempotent is False:
             return {
                 "building": True,
                 "result": "SUCCESS"
@@ -71,8 +71,8 @@ class JenkinsMock():
         return None
 
     def stop_build(self, name, build_number):
-        if self.idempotent == False:
-            self.idempotent == True
+        if self.idempotent is False:
+            self.idempotent = True
             return None
         else:
             exit_json(changed=False)
@@ -151,8 +151,7 @@ class TestJenkinsBuild(unittest.TestCase):
             })
             jenkins_build.main()
 
-        result = json.load(return_json)
-        self.assertFalse(result['changed'])
+        self.assertFalse(return_json.exception.args[0]['changed'])
 
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -42,7 +42,6 @@ def fail_json(*args, **kwargs):
 
 
 class JenkinsMock():
-    idempotent = False
 
     def get_job_info(self, name):
         return {
@@ -50,7 +49,7 @@ class JenkinsMock():
         }
 
     def get_build_info(self, name, build_number):
-        if self.idempotent is False:
+        if self.token:
             return {
                 "building": True,
                 "result": "SUCCESS"
@@ -71,11 +70,7 @@ class JenkinsMock():
         return None
 
     def stop_build(self, name, build_number):
-        if self.idempotent is False:
-            self.idempotent = True
-            return None
-        else:
-            exit_json(changed=False)
+        return None
 
 
 class TestJenkinsBuild(unittest.TestCase):
@@ -136,7 +131,7 @@ class TestJenkinsBuild(unittest.TestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
-    def test_module_stop_build_idempotent(self, jenkins_connection, test_deps):
+    def test_module_stop_build_again(self, jenkins_connection, test_deps):
         # The stopped_build function is idempotent.
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMock()
@@ -147,7 +142,7 @@ class TestJenkinsBuild(unittest.TestCase):
                 "build_number": "1234",
                 "state": "stopped",
                 "user": "abc",
-                "token": "xyz"
+                "password": "xyz"
             })
             jenkins_build.main()
 

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -62,6 +62,9 @@ class JenkinsMock():
     def delete_build(self, name, build_number):
         return None
 
+    def stop_build(self, name, build_number):
+        return None
+
 
 class TestJenkinsBuild(unittest.TestCase):
 
@@ -80,6 +83,16 @@ class TestJenkinsBuild(unittest.TestCase):
             jenkins_build.main()
 
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
+    def test_module_fail_when_missing_build_number(self, test_deps):
+        test_deps.return_value = None
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                "name": "required-if",
+                "state": "stopped"
+            })
+            jenkins_build.main()
+
+    @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
     @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
     def test_module_create_build(self, jenkins_connection, test_deps):
         test_deps.return_value = None
@@ -88,6 +101,22 @@ class TestJenkinsBuild(unittest.TestCase):
         with self.assertRaises(AnsibleExitJson):
             set_module_args({
                 "name": "host-check",
+                "user": "abc",
+                "token": "xyz"
+            })
+            jenkins_build.main()
+
+    @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.test_dependencies')
+    @patch('ansible_collections.community.general.plugins.modules.web_infrastructure.jenkins_build.JenkinsBuild.get_jenkins_connection')
+    def test_module_stop_build(self, jenkins_connection, test_deps):
+        test_deps.return_value = None
+        jenkins_connection.return_value = JenkinsMock()
+
+        with self.assertRaises(AnsibleExitJson):
+            set_module_args({
+                "name": "host-check",
+                "build_number": "1234",
+                "state": "stopped",
                 "user": "abc",
                 "token": "xyz"
             })

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -49,16 +49,9 @@ class JenkinsMock():
         }
 
     def get_build_info(self, name, build_number):
-        if self.token:
-            return {
-                "building": True,
-                "result": "SUCCESS"
-            }
-        else:
-            return {
-                "building": False,
-                "result": "ABORTED"
-            }
+        return {
+            "result": "SUCCESS"
+        }
 
     def get_build_status(self):
         pass
@@ -72,6 +65,30 @@ class JenkinsMock():
     def stop_build(self, name, build_number):
         return None
 
+class JenkinsMockIdempotent():
+
+    def get_job_info(self, name):
+        return {
+            "nextBuildNumber": 1235
+        }
+
+    def get_build_info(self, name, build_number):
+        return {
+            "building": False,
+            "result": "ABORTED"
+        }
+
+    def get_build_status(self):
+        pass
+
+    def build_job(self, *args):
+        return None
+
+    def delete_build(self, name, build_number):
+        return None
+
+    def stop_build(self, name, build_number):
+        return None
 
 class TestJenkinsBuild(unittest.TestCase):
 
@@ -134,7 +151,7 @@ class TestJenkinsBuild(unittest.TestCase):
     def test_module_stop_build_again(self, jenkins_connection, test_deps):
         # The stopped_build function is idempotent.
         test_deps.return_value = None
-        jenkins_connection.return_value = JenkinsMock()
+        jenkins_connection.return_value = JenkinsMockIdempotent()
 
         with self.assertRaises(AnsibleExitJson) as return_json:
             set_module_args({


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The jenkins_build module at present has only 2 states support to create or delete a Jenkins job build. However python-jenkins, which jenkins_build module based on, support not only create and delete a Jenkins job, but also stop a running Jenkins job. Stopping a running Jenkins job is not that common comparing to creation or deletion, but still useful as sometimes people might encounter a weird situation that their Jenkins job runs 'forever'. 
So this PR mainly aims to support stop a running Jenkins build (adding a state 'stopped' to support this). Meanwhile I enrich the document content and test cases.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jenkins_build

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Below is the source code of python-jenkins 0.4.12, the stop_build function is already inside so the dependencies remain the same.
https://opendev.org/jjb/python-jenkins/src/tag/0.4.12/jenkins/__init__.py
<!--- Paste verbatim command output below, e.g. before and after your change -->
