### PR TITLE
nmcli: require type when state=present

### DIFF
--- a/changelogs/fragments/2859-nmcli-needs-type.yml
+++ b/changelogs/fragments/2859-nmcli-needs-type.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "nmcli - modify existing connections without type parameter"
+  - "nmcli - modify existing connections without ``type`` parameter (https://github.com/ansible-collections/community.general/issues/2858)."

--- a/changelogs/fragments/2859-nmcli-needs-type.yml
+++ b/changelogs/fragments/2859-nmcli-needs-type.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nmcli - modify existing connections without type parameter"

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1826,7 +1826,8 @@ def main():
             gsm=dict(type='dict'),
         ),
         mutually_exclusive=[['never_default4', 'gw4']],
-        required_if=[("type", "wifi", [("ssid")])],
+        required_if=[("type", "wifi", [("ssid")]),
+                     ("state", "present", [("type")])],
         supports_check_mode=True,
     )
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1720,6 +1720,15 @@ class Nmcli(object):
         options = {
             'connection.interface-name': self.ifname,
         }
+        # get the connection type of the already present connection when not given as param
+        if self.type is None:
+            type = self.show_connection().get('connection.type', None)
+            type_mapping = {
+                '802-3-ethernet': 'ethernet',
+            }
+            if type is not None:
+                self.type = type_mapping.get(type, type)
+
         options.update(self.connection_options(detect_change=True))
         return self._compare_conn_params(self.show_connection(), options)
 
@@ -1826,8 +1835,7 @@ def main():
             gsm=dict(type='dict'),
         ),
         mutually_exclusive=[['never_default4', 'gw4']],
-        required_if=[("type", "wifi", [("ssid")]),
-                     ("state", "present", [("type")])],
+        required_if=[("type", "wifi", [("ssid")])],
         supports_check_mode=True,
     )
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')


### PR DESCRIPTION
When modifying existing connections without type, no changes are made.
So require type when state is present.

##### SUMMARY
Set type as required when state=present allows deletion of connections without type.
The stronger version would be to set type as required in the argument spec.

When type is missing, all ip options are ignored for an existing connection, so a complaint is needed IMHO.

Fixes #2858 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
In plugins/modules/net_tools/nmcli.py#L768 there is a call of `self.ip_conn_type` which is True when type has a supported value.
This evaluates to False when type is not given and results in ignoring all given connection options.

```
BEFORE:
ok: [ansible1.example.com] => {
    "Exists": "Connections already exist and no changes made",
    "changed": false,
    "conn_name": "enp0s8",
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": true,
            "conn_name": "enp0s8",
            "dhcp_client_id": null,
            "dns4": null,
            "dns4_ignore_auto": false,
            "dns4_search": null,
            "dns6": null,
            "dns6_ignore_auto": false,
            "dns6_search": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": 15,
            "gw4": null,
            "gw4_ignore_auto": false,
            "gw6": null,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ifname": null,
            "ingress": null,
            "ip4": "192.168.0.2",
            "ip6": null,
            "ip_tunnel_dev": null,
            "ip_tunnel_local": null,
            "ip_tunnel_remote": null,
            "mac": null,
            "master": null,
            "maxage": 20,
            "method4": "manual",
            "method6": null,
            "miimon": null,
            "mode": "balance-rr",
            "mtu": null,
            "never_default4": false,
            "path_cost": 100,
            "primary": null,
            "priority": 128,
            "route_metric4": null,
            "routes4": null,
            "slavepriority": 32,
            "ssid": null,
            "state": "present",
            "stp": true,
            "type": null,
            "updelay": null,
            "vlandev": null,
            "vlanid": null,
            "vxlan_id": null,
            "vxlan_local": null,
            "vxlan_remote": null,
            "wifi_sec": null,
            "zone": null
        }
    },
    "state": "present"
}


AFTER:
fatal: [ansible1.example.com]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "autoconnect": true,
            "conn_name": "enp0s8",
            "dns4_ignore_auto": false,
            "dns6_ignore_auto": false,
            "forwarddelay": 15,
            "gw4_ignore_auto": false,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ip4": "192.168.0.2",
            "maxage": 20,
            "method4": "manual",
            "mode": "balance-rr",
            "never_default4": false,
            "path_cost": 100,
            "priority": 128,
            "slavepriority": 32,
            "state": "present",
            "stp": true
        }
    },
    "msg": "state is present but all of the following are missing: type"
}
```
