### PR TITLE
Redis: slave -> replica

### DIFF
--- a/changelogs/fragments/2867-redis-terminology.yml
+++ b/changelogs/fragments/2867-redis-terminology.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "redis - allow to use the term ``replica`` instead of ``slave``, which has been the official Redis terminology since 2018 (https://github.com/ansible-collections/community.general/pull/2867)."

--- a/tests/integration/targets/redis_info/defaults/main.yml
+++ b/tests/integration/targets/redis_info/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 redis_password: PASS
 master_port: 6379
-slave_port: 6380
+replica_port: 6380

--- a/tests/integration/targets/redis_info/tasks/main.yml
+++ b/tests/integration/targets/redis_info/tasks/main.yml
@@ -33,9 +33,9 @@
     - result.info.tcp_port == master_port
     - result.info.role == 'master'
 
-- name: redis_info - connect to slave
+- name: redis_info - connect to replica
   community.general.redis_info:
-    login_port: "{{ slave_port }}"
+    login_port: "{{ replica_port }}"
     login_password: "{{ redis_password }}"
   register: result
 
@@ -43,5 +43,5 @@
     that:
     - result is not changed
     - result.info is defined
-    - result.info.tcp_port == slave_port
+    - result.info.tcp_port == replica_port
     - result.info.role == 'slave'

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -28,8 +28,8 @@ master_conf: /etc/redis-master.conf
 master_datadir: /var/lib/redis-master
 master_logdir: /var/log/redis-master
 
-# Slave
-slave_port: 6380
-slave_conf: /etc/redis-slave.conf
-slave_datadir: /var/lib/redis-slave
-slave_logdir: /var/log/redis-slave
+# Replica
+replica_port: 6380
+replica_conf: /etc/redis-replica.conf
+replica_datadir: /var/lib/redis-replica
+replica_logdir: /var/log/redis-replica

--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -22,6 +22,13 @@ redis_module: "{{ (ansible_python_version is version('2.7', '>=')) | ternary('re
 
 redis_password: PASS
 
+old_redis: >-
+  {{
+    (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int <= 7) or
+    (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int <= 18) or
+    (ansible_os_family == 'FreeBSD' and ansible_distribution_major_version|int <= 12)
+  }}
+
 # Master
 master_port: 6379
 master_conf: /etc/redis-master.conf

--- a/tests/integration/targets/setup_redis_replication/handlers/main.yml
+++ b/tests/integration/targets/setup_redis_replication/handlers/main.yml
@@ -1,7 +1,7 @@
 - name: stop redis services
   shell: |
     kill -TERM $(cat /var/run/redis_{{ master_port }}.pid)
-    kill -TERM $(cat /var/run/redis_{{ slave_port }}.pid)
+    kill -TERM $(cat /var/run/redis_{{ replica_port }}.pid)
   listen: cleanup redis
 
 - name: remove redis packages
@@ -27,8 +27,8 @@
   - "{{ master_datadir }}"
   - "{{ master_logdir }}"
   - /var/run/redis_{{ master_port }}.pid
-  - "{{ slave_conf }}"
-  - "{{ slave_datadir }}"
-  - "{{ slave_logdir }}"
-  - /var/run/redis_{{ slave_port }}.pid
+  - "{{ replica_conf }}"
+  - "{{ replica_datadir }}"
+  - "{{ replica_logdir }}"
+  - /var/run/redis_{{ replica_port }}.pid
   listen: cleanup redis

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -84,7 +84,7 @@
   shell: "{{ redis_bin[ansible_distribution] }} {{ master_conf }}"
 
 - name: Start redis replica
-  shell: "{{ redis_bin[ansible_distribution] }} {{ replica_conf }} --replicaof 127.0.0.1 {{ master_port }}"
+  shell: "{{ redis_bin[ansible_distribution] }} {{ replica_conf }} --{% if old_redis %}slaveof{% else %}replicaof{% endif %} 127.0.0.1 {{ master_port }}"
 
 - name: Wait for redis master to be started
   ansible.builtin.wait_for:

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -1,5 +1,5 @@
 # We run two servers listening different ports
-# to be able to check replication (one server for master, another for slave).
+# to be able to check replication (one server for master, another for replica).
 
 - name: Install redis server apt dependencies
   apt:
@@ -56,8 +56,8 @@
   loop:
   - "{{ master_datadir }}"
   - "{{ master_logdir }}"
-  - "{{ slave_datadir }}"
-  - "{{ slave_logdir }}"
+  - "{{ replica_datadir }}"
+  - "{{ replica_logdir }}"
 
 - name: Create redis configs
   copy:
@@ -75,16 +75,16 @@
     port: "{{ master_port }}"
     logdir: "{{ master_logdir }}"
     datadir: "{{ master_datadir }}"
-  - file: "{{ slave_conf }}"
-    port: "{{ slave_port }}"
-    logdir: "{{ slave_logdir }}"
-    datadir: "{{ slave_datadir }}"
+  - file: "{{ replica_conf }}"
+    port: "{{ replica_port }}"
+    logdir: "{{ replica_logdir }}"
+    datadir: "{{ replica_datadir }}"
 
 - name: Start redis master
   shell: "{{ redis_bin[ansible_distribution] }} {{ master_conf }}"
 
-- name: Start redis slave
-  shell: "{{ redis_bin[ansible_distribution] }} {{ slave_conf }} --slaveof 127.0.0.1 {{ master_port }}"
+- name: Start redis replica
+  shell: "{{ redis_bin[ansible_distribution] }} {{ replica_conf }} --replicaof 127.0.0.1 {{ master_port }}"
 
 - name: Wait for redis master to be started
   ansible.builtin.wait_for:
@@ -95,10 +95,10 @@
     connect_timeout: 5
     timeout: 30
 
-- name: Wait for redis slave to be started
+- name: Wait for redis replica to be started
   ansible.builtin.wait_for:
     host: 127.0.0.1
-    port: "{{ slave_port }}"
+    port: "{{ replica_port }}"
     state: started
     delay: 1
     connect_timeout: 5


### PR DESCRIPTION
##### SUMMARY
In 2018, Redis started replacing `slave` with `replica` (https://github.com/redis/redis/issues/5335). The module still forces users to use `slave`. Let's change that!

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redis
