### PR TITLE
Replace ansible.module_utils._text by ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/ansible-core-_text.yml
+++ b/changelogs/fragments/ansible-core-_text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Avoid internal ansible-core module_utils in favor of equivalent public API available since at least Ansible 2.9 (https://github.com/ansible-collections/community.general/pull/2877)."

--- a/plugins/action/system/shutdown.py
+++ b/plugins/action/system/shutdown.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.common.collections import is_string
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display

--- a/plugins/become/doas.py
+++ b/plugins/become/doas.py
@@ -81,7 +81,7 @@ DOCUMENTATION = '''
 
 import re
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.become import BecomeBase
 
 

--- a/plugins/become/ksu.py
+++ b/plugins/become/ksu.py
@@ -82,7 +82,7 @@ DOCUMENTATION = '''
 
 import re
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.become import BecomeBase
 
 

--- a/plugins/cache/redis.py
+++ b/plugins/cache/redis.py
@@ -67,7 +67,7 @@ import json
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
 from ansible.plugins.cache import BaseCacheModule
 from ansible.release import __version__ as ansible_base_version

--- a/plugins/callback/diy.py
+++ b/plugins/callback/diy.py
@@ -792,7 +792,7 @@ from ansible.utils.color import colorize, hostcolor
 from ansible.template import Templar
 from ansible.vars.manager import VariableManager
 from ansible.plugins.callback.default import CallbackModule as Default
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class DummyStdout(object):

--- a/plugins/callback/log_plays.py
+++ b/plugins/callback/log_plays.py
@@ -31,7 +31,7 @@ import time
 import json
 
 from ansible.utils.path import makedirs_safe
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase

--- a/plugins/callback/logentries.py
+++ b/plugins/callback/logentries.py
@@ -111,7 +111,7 @@ try:
 except ImportError:
     HAS_FLATDICT = False
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.callback import CallbackBase
 
 # Todo:

--- a/plugins/callback/mail.py
+++ b/plugins/callback/mail.py
@@ -62,7 +62,7 @@ import re
 import smtplib
 
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.plugins.callback import CallbackBase
 

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -40,7 +40,7 @@ import difflib
 
 from ansible import constants as C
 from ansible.plugins.callback import CallbackBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     codeCodes = C.COLOR_CODES

--- a/plugins/callback/slack.py
+++ b/plugins/callback/slack.py
@@ -58,7 +58,7 @@ import os
 import uuid
 
 from ansible import context
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.urls import open_url
 from ansible.plugins.callback import CallbackBase
 

--- a/plugins/callback/unixy.py
+++ b/plugins/callback/unixy.py
@@ -22,7 +22,7 @@ DOCUMENTATION = '''
 from os.path import basename
 from ansible import constants as C
 from ansible import context
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.utils.color import colorize, hostcolor
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -25,7 +25,7 @@ import re
 import string
 import sys
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.six import string_types
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.callback import CallbackBase, strip_internal_keys, module_response_deepcopy

--- a/plugins/connection/chroot.py
+++ b/plugins/connection/chroot.py
@@ -54,7 +54,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.basic import is_executable
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 

--- a/plugins/connection/iocage.py
+++ b/plugins/connection/iocage.py
@@ -32,7 +32,7 @@ DOCUMENTATION = '''
 import subprocess
 
 from ansible_collections.community.general.plugins.connection.jail import Connection as Jail
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.errors import AnsibleError
 from ansible.utils.display import Display
 

--- a/plugins/connection/jail.py
+++ b/plugins/connection/jail.py
@@ -38,7 +38,7 @@ import traceback
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -43,7 +43,7 @@ except ImportError:
     pass
 
 from ansible import errors
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase
 
 

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -46,7 +46,7 @@ from distutils.spawn import find_executable
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.connection import ConnectionBase
 
 

--- a/plugins/connection/qubes.py
+++ b/plugins/connection/qubes.py
@@ -39,7 +39,7 @@ DOCUMENTATION = '''
 
 import subprocess
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase, ensure_connect
 from ansible.errors import AnsibleConnectionFailure
 from ansible.utils.display import Display

--- a/plugins/connection/zone.py
+++ b/plugins/connection/zone.py
@@ -33,7 +33,7 @@ import traceback
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 

--- a/plugins/filter/from_csv.py
+++ b/plugins/filter/from_csv.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.csv import (initialize_dialect, read_csv, CSVError,
                                                                             DialectNotAvailableError,

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -72,7 +72,7 @@ from distutils.version import LooseVersion
 import socket
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.six import iteritems
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, to_safe_group_name

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -82,7 +82,7 @@ keyed_groups:
 '''
 
 from ansible.errors import AnsibleError, AnsibleParserError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 
 try:

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -124,7 +124,7 @@ import time
 import os
 import socket
 from ansible.plugins.inventory import BaseInventoryPlugin
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible.module_utils.six import raise_from
 from ansible.errors import AnsibleError, AnsibleParserError

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -56,7 +56,7 @@ from subprocess import Popen, PIPE
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.process import get_bin_path
 

--- a/plugins/inventory/online.py
+++ b/plugins/inventory/online.py
@@ -61,7 +61,7 @@ from sys import version as python_version
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import open_url
 from ansible.plugins.inventory import BaseInventoryPlugin
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.six.moves.urllib.parse import urljoin
 

--- a/plugins/inventory/scaleway.py
+++ b/plugins/inventory/scaleway.py
@@ -100,7 +100,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible_collections.community.general.plugins.module_utils.scaleway import SCALEWAY_LOCATION, parse_pagination_link
 from ansible.module_utils.urls import open_url
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 import ansible.module_utils.six.moves.urllib.parse as urllib_parse
 

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -56,7 +56,7 @@ import os
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.process import get_bin_path

--- a/plugins/lookup/consul_kv.py
+++ b/plugins/lookup/consul_kv.py
@@ -106,7 +106,7 @@ import os
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     import consul

--- a/plugins/lookup/cyberarkpassword.py
+++ b/plugins/lookup/cyberarkpassword.py
@@ -74,7 +74,7 @@ from subprocess import Popen
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.parsing.splitter import parse_kv
-from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 from ansible.utils.display import Display
 
 display = Display()

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -152,7 +152,7 @@ RETURN = """
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import socket
 
 try:

--- a/plugins/lookup/dnstxt.py
+++ b/plugins/lookup/dnstxt.py
@@ -54,7 +54,7 @@ except ImportError:
     pass
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.lookup import LookupBase
 
 # ==============================================================

--- a/plugins/lookup/etcd3.py
+++ b/plugins/lookup/etcd3.py
@@ -138,7 +138,7 @@ import re
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleError, AnsibleLookupError
 

--- a/plugins/lookup/filetree.py
+++ b/plugins/lookup/filetree.py
@@ -124,7 +124,7 @@ except ImportError:
     pass
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.utils.display import Display
 
 display = Display()

--- a/plugins/lookup/hiera.py
+++ b/plugins/lookup/hiera.py
@@ -63,7 +63,7 @@ import os
 
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.cmd_functions import run_cmd
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 ANSIBLE_HIERA_CFG = os.getenv('ANSIBLE_HIERA_CFG', '/etc/hiera.yaml')
 ANSIBLE_HIERA_BIN = os.getenv('ANSIBLE_HIERA_BIN', '/usr/bin/hiera')

--- a/plugins/lookup/lastpass.py
+++ b/plugins/lookup/lastpass.py
@@ -39,7 +39,7 @@ RETURN = """
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.lookup import LookupBase
 
 

--- a/plugins/lookup/lmdb_kv.py
+++ b/plugins/lookup/lmdb_kv.py
@@ -55,7 +55,7 @@ _raw:
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 HAVE_LMDB = True
 try:
     import lmdb

--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -74,7 +74,7 @@ _list:
 
 from ansible.plugins.lookup import LookupBase
 from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import WapiLookup
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 
 

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -84,7 +84,7 @@ _list:
 
 from ansible.plugins.lookup import LookupBase
 from ansible_collections.community.general.plugins.module_utils.net_tools.nios.api import WapiLookup
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 
 

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -103,7 +103,7 @@ from subprocess import Popen, PIPE
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 class OnePass(object):

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -142,7 +142,7 @@ import yaml
 
 from distutils import util
 from ansible.errors import AnsibleError, AnsibleAssertionError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.utils.display import Display
 from ansible.utils.encrypt import random_password
 from ansible.plugins.lookup import LookupBase

--- a/plugins/lookup/random_string.py
+++ b/plugins/lookup/random_string.py
@@ -138,7 +138,7 @@ import string
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/redis.py
+++ b/plugins/lookup/redis.py
@@ -80,7 +80,7 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/shelvefile.py
+++ b/plugins/lookup/shelvefile.py
@@ -36,7 +36,7 @@ import shelve
 
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 class LookupModule(LookupBase):

--- a/plugins/module_utils/_netapp.py
+++ b/plugins/module_utils/_netapp.py
@@ -41,7 +41,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from ansible.module_utils.ansible_release import __version__ as ansible_version

--- a/plugins/module_utils/csv.py
+++ b/plugins/module_utils/csv.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 import csv
 from io import BytesIO, StringIO
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import PY3
 
 

--- a/plugins/module_utils/gandi_livedns_api.py
+++ b/plugins/module_utils/gandi_livedns_api.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -12,7 +12,7 @@ from distutils.version import StrictVersion
 
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     from urllib import quote_plus  # Python 2.X

--- a/plugins/module_utils/hwc_utils.py
+++ b/plugins/module_utils/hwc_utils.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from ansible.module_utils.basic import (AnsibleModule, env_fallback,
                                         missing_required_lib)
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class HwcModuleException(Exception):

--- a/plugins/module_utils/ibm_sa_utils.py
+++ b/plugins/module_utils/ibm_sa_utils.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import traceback
 
 from functools import wraps
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import missing_required_lib
 
 PYXCLI_INSTALLED = True

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -35,7 +35,7 @@ import traceback
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 
 URL_REALMS = "{url}/admin/realms"
 URL_REALM = "{url}/admin/realms/{realm}"

--- a/plugins/module_utils/ipa.py
+++ b/plugins/module_utils/ipa.py
@@ -18,7 +18,7 @@ import socket
 import uuid
 
 import re
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url, HAS_GSSAPI

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import traceback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 try:
     import ldap

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -20,7 +20,7 @@ import ssl
 from ansible.module_utils.urls import generic_urlparse
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.six.moves import http_client
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 # httplib/http.client connection using unix domain socket
 HTTPConnection = http_client.HTTPConnection

--- a/plugins/module_utils/net_tools/nios/api.py
+++ b/plugins/module_utils/net_tools/nios/api.py
@@ -14,9 +14,9 @@ __metaclass__ = type
 
 import os
 from functools import partial
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.common.validation import check_type_dict
 

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from ansible.module_utils import six
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common._collections_compat import Mapping
 
 

--- a/plugins/module_utils/oracle/oci_utils.py
+++ b/plugins/module_utils/oracle/oci_utils.py
@@ -38,7 +38,7 @@ except ImportError:
     HAS_OCI_PY_SDK = False
 
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.six import iteritems
 
 __version__ = "1.6.0-dev"

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -6,8 +6,8 @@ __metaclass__ = type
 
 import json
 from ansible.module_utils.urls import open_url
-from ansible.module_utils._text import to_native
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves import http_client
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
 from ansible.module_utils.six.moves.urllib.parse import urlparse

--- a/plugins/module_utils/source_control/bitbucket.py
+++ b/plugins/module_utils/source_control/bitbucket.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 

--- a/plugins/module_utils/utm_utils.py
+++ b/plugins/module_utils/utm_utils.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 

--- a/plugins/module_utils/vexata.py
+++ b/plugins/module_utils/vexata.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     HAS_VEXATAPI = False
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import env_fallback
 
 VXOS_VERSION = None

--- a/plugins/modules/cloud/atomic/atomic_container.py
+++ b/plugins/modules/cloud/atomic/atomic_container.py
@@ -95,7 +95,7 @@ msg:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def do_install(module, mode, rootfs, container, image, values_list, backend):

--- a/plugins/modules/cloud/atomic/atomic_host.py
+++ b/plugins/modules/cloud/atomic/atomic_host.py
@@ -52,7 +52,7 @@ import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def core(module):

--- a/plugins/modules/cloud/atomic/atomic_image.py
+++ b/plugins/modules/cloud/atomic/atomic_image.py
@@ -69,7 +69,7 @@ msg:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def do_upgrade(module, image):

--- a/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
+++ b/plugins/modules/cloud/dimensiondata/dimensiondata_network.py
@@ -113,7 +113,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.dimensiondata import HAS_LIBCLOUD, DimensionDataModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 if HAS_LIBCLOUD:
     from libcloud.compute.base import NodeLocation

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -433,7 +433,7 @@ else:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
 from ansible.module_utils.six.moves import xrange
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils.common.text.converters import to_text, to_bytes
 
 
 # LXC_COMPRESSION_MAP is a map of available compression types when creating

--- a/plugins/modules/cloud/misc/cloud_init_data_facts.py
+++ b/plugins/modules/cloud/misc/cloud_init_data_facts.py
@@ -85,7 +85,7 @@ cloud_init_data_facts:
 import os
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 CLOUD_INIT_PATH = "/var/lib/cloud/data"

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -364,7 +364,7 @@ except ImportError:
     HAS_PROXMOXER = False
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 VZ_TYPE = None

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -771,7 +771,7 @@ except ImportError:
     HAS_PROXMOXER = False
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_nextvmid(module, proxmox):

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -119,7 +119,7 @@ except ImportError:
     HAS_PROXMOXER = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 VZ_TYPE = None

--- a/plugins/modules/cloud/packet/packet_device.py
+++ b/plugins/modules/cloud/packet/packet_device.py
@@ -275,7 +275,7 @@ import uuid
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PACKET_SDK = True
 try:

--- a/plugins/modules/cloud/packet/packet_ip_subnet.py
+++ b/plugins/modules/cloud/packet/packet_ip_subnet.py
@@ -151,7 +151,7 @@ import uuid
 import re
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PACKET_SDK = True
 

--- a/plugins/modules/cloud/packet/packet_project.py
+++ b/plugins/modules/cloud/packet/packet_project.py
@@ -122,7 +122,7 @@ id:
 '''
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PACKET_SDK = True
 

--- a/plugins/modules/cloud/packet/packet_volume.py
+++ b/plugins/modules/cloud/packet/packet_volume.py
@@ -168,7 +168,7 @@ description:
 import uuid
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PACKET_SDK = True
 

--- a/plugins/modules/cloud/packet/packet_volume_attachment.py
+++ b/plugins/modules/cloud/packet/packet_volume_attachment.py
@@ -130,7 +130,7 @@ device_id:
 import uuid
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PACKET_SDK = True
 

--- a/plugins/modules/cloud/profitbricks/profitbricks.py
+++ b/plugins/modules/cloud/profitbricks/profitbricks.py
@@ -198,7 +198,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import xrange
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 LOCATIONS = ['us/las',

--- a/plugins/modules/cloud/profitbricks/profitbricks_volume.py
+++ b/plugins/modules/cloud/profitbricks/profitbricks_volume.py
@@ -149,7 +149,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import xrange
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 uuid_match = re.compile(

--- a/plugins/modules/cloud/pubnub/pubnub_blocks.py
+++ b/plugins/modules/cloud/pubnub/pubnub_blocks.py
@@ -247,7 +247,7 @@ except ImportError:
     exceptions = None
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 def pubnub_user(module):

--- a/plugins/modules/cloud/rackspace/rax_cdb_user.py
+++ b/plugins/modules/cloud/rackspace/rax_cdb_user.py
@@ -77,7 +77,7 @@ except ImportError:
     HAS_PYRAX = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.community.general.plugins.module_utils.rax import rax_argument_spec, rax_required_together, rax_to_dict, setup_rax_module
 
 

--- a/plugins/modules/cloud/scaleway/scaleway_security_group_rule.py
+++ b/plugins/modules/cloud/scaleway/scaleway_security_group_rule.py
@@ -133,7 +133,7 @@ data:
 import traceback
 
 from ansible_collections.community.general.plugins.module_utils.scaleway import SCALEWAY_LOCATION, scaleway_argument_spec, Scaleway, payload_from_object
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:

--- a/plugins/modules/cloud/smartos/vmadm.py
+++ b/plugins/modules/cloud/smartos/vmadm.py
@@ -404,7 +404,7 @@ import traceback
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 # While vmadm(1M) supports a -E option to return any errors in JSON, the
 # generated JSON does not play well with the JSON parsers of Python.

--- a/plugins/modules/clustering/consul/consul_kv.py
+++ b/plugins/modules/clustering/consul/consul_kv.py
@@ -136,7 +136,7 @@ EXAMPLES = '''
     state: acquire
 '''
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     import consul

--- a/plugins/modules/clustering/etcd3.py
+++ b/plugins/modules/clustering/etcd3.py
@@ -119,7 +119,7 @@ old_value:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 try:

--- a/plugins/modules/clustering/nomad/nomad_job.py
+++ b/plugins/modules/clustering/nomad/nomad_job.py
@@ -84,7 +84,7 @@ EXAMPLES = '''
 import json
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 import_nomad = None
 try:

--- a/plugins/modules/clustering/nomad/nomad_job_info.py
+++ b/plugins/modules/clustering/nomad/nomad_job_info.py
@@ -270,7 +270,7 @@ import os
 import json
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 import_nomad = None
 try:

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -108,7 +108,7 @@ except ImportError:
     KAZOO_INSTALLED = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def main():

--- a/plugins/modules/database/influxdb/influxdb_query.py
+++ b/plugins/modules/database/influxdb/influxdb_query.py
@@ -64,7 +64,7 @@ query_results:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.influxdb import InfluxDb
 
 

--- a/plugins/modules/database/influxdb/influxdb_retention_policy.py
+++ b/plugins/modules/database/influxdb/influxdb_retention_policy.py
@@ -145,7 +145,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.influxdb import InfluxDb
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 VALID_DURATION_REGEX = re.compile(r'^(INF|(\d+(ns|u|µ|ms|s|m|h|d|w)))+$')

--- a/plugins/modules/database/influxdb/influxdb_user.py
+++ b/plugins/modules/database/influxdb/influxdb_user.py
@@ -104,7 +104,7 @@ import json
 
 from ansible.module_utils.urls import ConnectionError
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible_collections.community.general.plugins.module_utils.influxdb as influx
 
 

--- a/plugins/modules/database/influxdb/influxdb_write.py
+++ b/plugins/modules/database/influxdb/influxdb_write.py
@@ -61,7 +61,7 @@ RETURN = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.influxdb import InfluxDb
 
 

--- a/plugins/modules/database/misc/odbc.py
+++ b/plugins/modules/database/misc/odbc.py
@@ -78,7 +78,7 @@ row_count:
 '''
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 HAS_PYODBC = None
 try:

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -143,7 +143,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.formatters import human_to_bytes
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import re
 
 

--- a/plugins/modules/database/misc/redis_info.py
+++ b/plugins/modules/database/misc/redis_info.py
@@ -196,7 +196,7 @@ except ImportError:
     HAS_REDIS_PACKAGE = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def redis_client(**client_params):

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -103,7 +103,7 @@ query_result:
 import csv
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import StringIO
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def csv_to_list(rawcsv):

--- a/plugins/modules/database/vertica/vertica_configuration.py
+++ b/plugins/modules/database/vertica/vertica_configuration.py
@@ -76,7 +76,7 @@ else:
     pyodbc_found = True
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NotSupportedError(Exception):

--- a/plugins/modules/database/vertica/vertica_info.py
+++ b/plugins/modules/database/vertica/vertica_info.py
@@ -74,7 +74,7 @@ else:
     pyodbc_found = True
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NotSupportedError(Exception):

--- a/plugins/modules/database/vertica/vertica_role.py
+++ b/plugins/modules/database/vertica/vertica_role.py
@@ -87,7 +87,7 @@ else:
     pyodbc_found = True
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NotSupportedError(Exception):

--- a/plugins/modules/database/vertica/vertica_schema.py
+++ b/plugins/modules/database/vertica/vertica_schema.py
@@ -109,7 +109,7 @@ else:
     pyodbc_found = True
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NotSupportedError(Exception):

--- a/plugins/modules/database/vertica/vertica_user.py
+++ b/plugins/modules/database/vertica/vertica_user.py
@@ -118,7 +118,7 @@ else:
     pyodbc_found = True
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class NotSupportedError(Exception):

--- a/plugins/modules/files/filesize.py
+++ b/plugins/modules/files/filesize.py
@@ -224,7 +224,7 @@ import os
 import math
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # These are the multiplicative suffixes understood (or returned) by dd and

--- a/plugins/modules/files/iso_create.py
+++ b/plugins/modules/files/iso_create.py
@@ -153,7 +153,7 @@ except ImportError:
     HAS_PYCDLIB = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def add_file(module, iso_file=None, src_file=None, file_path=None, rock_ridge=None, use_joliet=None, use_udf=None):

--- a/plugins/modules/files/read_csv.py
+++ b/plugins/modules/files/read_csv.py
@@ -138,7 +138,7 @@ list:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.csv import (initialize_dialect, read_csv, CSVError,
                                                                             DialectNotAvailableError,

--- a/plugins/modules/files/sapcar_extract.py
+++ b/plugins/modules/files/sapcar_extract.py
@@ -90,7 +90,7 @@ import os
 from tempfile import NamedTemporaryFile
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_list_of_files(dir_name):

--- a/plugins/modules/files/xattr.py
+++ b/plugins/modules/files/xattr.py
@@ -94,7 +94,7 @@ import os
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_xattr_keys(module, path, follow):

--- a/plugins/modules/files/xml.py
+++ b/plugins/modules/files/xml.py
@@ -369,7 +369,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, json_dict_bytes_to_unicode, missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.common._collections_compat import MutableMapping
 
 _IDENT = r"[a-zA-Z-][a-zA-Z0-9_\-\.]*"

--- a/plugins/modules/identity/ipa/ipa_config.py
+++ b/plugins/modules/identity/ipa/ipa_config.py
@@ -194,7 +194,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class ConfigIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_dnsrecord.py
+++ b/plugins/modules/identity/ipa/ipa_dnsrecord.py
@@ -151,7 +151,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class DNSRecordIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -71,7 +71,7 @@ zone:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class DNSZoneIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_group.py
+++ b/plugins/modules/identity/ipa/ipa_group.py
@@ -115,7 +115,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class GroupIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_hbacrule.py
+++ b/plugins/modules/identity/ipa/ipa_hbacrule.py
@@ -153,7 +153,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class HBACRuleIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_host.py
+++ b/plugins/modules/identity/ipa/ipa_host.py
@@ -163,7 +163,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class HostIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_hostgroup.py
+++ b/plugins/modules/identity/ipa/ipa_hostgroup.py
@@ -86,7 +86,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class HostGroupIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_otpconfig.py
+++ b/plugins/modules/identity/ipa/ipa_otpconfig.py
@@ -78,7 +78,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class OTPConfigIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_otptoken.py
+++ b/plugins/modules/identity/ipa/ipa_otptoken.py
@@ -168,7 +168,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, sanitize_keys
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class OTPTokenIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_pwpolicy.py
+++ b/plugins/modules/identity/ipa/ipa_pwpolicy.py
@@ -127,7 +127,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class PwPolicyIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_role.py
+++ b/plugins/modules/identity/ipa/ipa_role.py
@@ -131,7 +131,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class RoleIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_service.py
+++ b/plugins/modules/identity/ipa/ipa_service.py
@@ -82,7 +82,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class ServiceIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_subca.py
+++ b/plugins/modules/identity/ipa/ipa_subca.py
@@ -77,7 +77,7 @@ subca:
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class SubCAIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_sudocmd.py
+++ b/plugins/modules/identity/ipa/ipa_sudocmd.py
@@ -63,7 +63,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class SudoCmdIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_sudocmdgroup.py
+++ b/plugins/modules/identity/ipa/ipa_sudocmdgroup.py
@@ -72,7 +72,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class SudoCmdGroupIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_sudorule.py
+++ b/plugins/modules/identity/ipa/ipa_sudorule.py
@@ -178,7 +178,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class SudoRuleIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_user.py
+++ b/plugins/modules/identity/ipa/ipa_user.py
@@ -172,7 +172,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class UserIPAClient(IPAClient):

--- a/plugins/modules/identity/ipa/ipa_vault.py
+++ b/plugins/modules/identity/ipa/ipa_vault.py
@@ -135,7 +135,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class VaultIPAClient(IPAClient):

--- a/plugins/modules/identity/onepassword_info.py
+++ b/plugins/modules/identity/onepassword_info.py
@@ -163,7 +163,7 @@ import re
 
 from subprocess import Popen, PIPE
 
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/monitoring/bigpanda.py
+++ b/plugins/modules/monitoring/bigpanda.py
@@ -130,7 +130,7 @@ import socket
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/monitoring/circonus_annotation.py
+++ b/plugins/modules/monitoring/circonus_annotation.py
@@ -155,7 +155,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import PY3
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def check_requests_dep(module):

--- a/plugins/modules/monitoring/datadog/datadog_event.py
+++ b/plugins/modules/monitoring/datadog/datadog_event.py
@@ -123,7 +123,7 @@ except Exception:
     HAS_DATADOG = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -198,7 +198,7 @@ except Exception:
     HAS_DATADOG = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/monitoring/honeybadger_deployment.py
+++ b/plugins/modules/monitoring/honeybadger_deployment.py
@@ -67,7 +67,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/monitoring/rollbar_deployment.py
+++ b/plugins/modules/monitoring/rollbar_deployment.py
@@ -84,7 +84,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/monitoring/sensu/sensu_check.py
+++ b/plugins/modules/monitoring/sensu/sensu_check.py
@@ -179,7 +179,7 @@ import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def sensu_check(module, path, name, state='present', backup=False):

--- a/plugins/modules/monitoring/sensu/sensu_silence.py
+++ b/plugins/modules/monitoring/sensu/sensu_silence.py
@@ -97,7 +97,7 @@ RETURN = '''
 
 import json
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 

--- a/plugins/modules/monitoring/sensu/sensu_subscription.py
+++ b/plugins/modules/monitoring/sensu/sensu_subscription.py
@@ -66,7 +66,7 @@ import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def sensu_subscription(module, path, name, state='present', backup=False):

--- a/plugins/modules/monitoring/spectrum_model_attrs.py
+++ b/plugins/modules/monitoring/spectrum_model_attrs.py
@@ -142,7 +142,7 @@ changed_attrs:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import quote
 import json

--- a/plugins/modules/monitoring/stackdriver.py
+++ b/plugins/modules/monitoring/stackdriver.py
@@ -96,7 +96,7 @@ import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/monitoring/statusio_maintenance.py
+++ b/plugins/modules/monitoring/statusio_maintenance.py
@@ -177,7 +177,7 @@ import datetime
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import open_url
 
 

--- a/plugins/modules/monitoring/uptimerobot.py
+++ b/plugins/modules/monitoring/uptimerobot.py
@@ -56,7 +56,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 API_BASE = "https://api.uptimerobot.com/"

--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -360,7 +360,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/net_tools/haproxy.py
+++ b/plugins/modules/net_tools/haproxy.py
@@ -211,7 +211,7 @@ import time
 from string import Template
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"

--- a/plugins/modules/net_tools/ip_netns.py
+++ b/plugins/modules/net_tools/ip_netns.py
@@ -58,7 +58,7 @@ RETURN = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class Namespace(object):

--- a/plugins/modules/net_tools/ipify_facts.py
+++ b/plugins/modules/net_tools/ipify_facts.py
@@ -62,7 +62,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class IpifyFacts(object):

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -166,7 +166,7 @@ modlist:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
 import re
 

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -104,7 +104,7 @@ RETURN = """
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
 
 LDAP_IMP_ERR = None

--- a/plugins/modules/net_tools/ldap/ldap_search.py
+++ b/plugins/modules/net_tools/ldap/ldap_search.py
@@ -77,7 +77,7 @@ EXAMPLES = r"""
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
 
 LDAP_IMP_ERR = None

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -650,7 +650,7 @@ RETURN = r"""#
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 import re
 
 

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -198,7 +198,7 @@ except ImportError:
     HAVE_DNSPYTHON = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class RecordManager(object):

--- a/plugins/modules/net_tools/omapi_host.py
+++ b/plugins/modules/net_tools/omapi_host.py
@@ -140,7 +140,7 @@ except ImportError:
     pureomapi_found = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 
 class OmapiHostManager:

--- a/plugins/modules/net_tools/pritunl/pritunl_org.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_org.py
@@ -78,7 +78,7 @@ response:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible_collections.community.general.plugins.module_utils.net_tools.pritunl.api import (
     PritunlException,

--- a/plugins/modules/net_tools/pritunl/pritunl_org_info.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_org_info.py
@@ -75,7 +75,7 @@ organizations:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible_collections.community.general.plugins.module_utils.net_tools.pritunl.api import (
     PritunlException,

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -142,7 +142,7 @@ response:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible_collections.community.general.plugins.module_utils.net_tools.pritunl.api import (
     PritunlException,

--- a/plugins/modules/net_tools/pritunl/pritunl_user_info.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user_info.py
@@ -93,7 +93,7 @@ users:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
 from ansible_collections.community.general.plugins.module_utils.net_tools.pritunl.api import (
     PritunlException,

--- a/plugins/modules/net_tools/snmp_facts.py
+++ b/plugins/modules/net_tools/snmp_facts.py
@@ -190,7 +190,7 @@ except Exception:
     HAS_PYSNMP = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class DefineOid(object):

--- a/plugins/modules/notification/hipchat.py
+++ b/plugins/modules/notification/hipchat.py
@@ -96,7 +96,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.six.moves.urllib.request import pathname2url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/notification/irc.py
+++ b/plugins/modules/notification/irc.py
@@ -137,7 +137,7 @@ import ssl
 import time
 import traceback
 
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/notification/jabber.py
+++ b/plugins/modules/notification/jabber.py
@@ -92,7 +92,7 @@ except ImportError:
     HAS_XMPP = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/notification/mail.py
+++ b/plugins/modules/notification/mail.py
@@ -204,7 +204,7 @@ from email.header import Header
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import PY3
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/notification/mqtt.py
+++ b/plugins/modules/notification/mqtt.py
@@ -136,7 +136,7 @@ except ImportError:
     HAS_PAHOMQTT = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # ===========================================

--- a/plugins/modules/notification/sendgrid.py
+++ b/plugins/modules/notification/sendgrid.py
@@ -136,7 +136,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/notification/syslogger.py
+++ b/plugins/modules/notification/syslogger.py
@@ -98,7 +98,7 @@ import syslog
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_facility(facility):

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -261,7 +261,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 
 
 def split_pre_existing_dir(dirname):

--- a/plugins/modules/packaging/language/npm.py
+++ b/plugins/modules/packaging/language/npm.py
@@ -141,7 +141,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class Npm(object):

--- a/plugins/modules/packaging/language/pear.py
+++ b/plugins/modules/packaging/language/pear.py
@@ -111,7 +111,7 @@ EXAMPLES = r'''
 
 import os
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/packaging/language/pip_package_info.py
+++ b/plugins/modules/packaging/language/pip_package_info.py
@@ -89,7 +89,7 @@ packages:
 import json
 import os
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.facts.packages import CLIMgr
 

--- a/plugins/modules/packaging/os/flatpak_remote.py
+++ b/plugins/modules/packaging/os/flatpak_remote.py
@@ -119,7 +119,7 @@ stdout:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 
 def add_remote(module, binary, name, flatpakrepo_url, method):

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -142,7 +142,7 @@ import re
 import tempfile
 from distutils import version
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems, string_types
 

--- a/plugins/modules/packaging/os/mas.py
+++ b/plugins/modules/packaging/os/mas.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
 RETURN = r''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from distutils.version import StrictVersion
 import os
 

--- a/plugins/modules/packaging/os/pacman_key.py
+++ b/plugins/modules/packaging/os/pacman_key.py
@@ -118,7 +118,7 @@ import os.path
 import tempfile
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class PacmanKey(object):

--- a/plugins/modules/packaging/os/portage.py
+++ b/plugins/modules/packaging/os/portage.py
@@ -229,7 +229,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def query_package(module, package, action):

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -277,7 +277,7 @@ import tempfile
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves import configparser
 
 

--- a/plugins/modules/packaging/os/rhn_channel.py
+++ b/plugins/modules/packaging/os/rhn_channel.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
 '''
 
 import ssl
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import xmlrpc_client
 

--- a/plugins/modules/packaging/os/yum_versionlock.py
+++ b/plugins/modules/packaging/os/yum_versionlock.py
@@ -75,7 +75,7 @@ state:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class YumVersionLock:

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -216,7 +216,7 @@ EXAMPLES = '''
 import xml
 import re
 from xml.dom.minidom import parseString as parseXML
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/remote_management/cobbler/cobbler_sync.py
+++ b/plugins/modules/remote_management/cobbler/cobbler_sync.py
@@ -72,7 +72,7 @@ import ssl
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import xmlrpc_client
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 def main():

--- a/plugins/modules/remote_management/cobbler/cobbler_system.py
+++ b/plugins/modules/remote_management/cobbler/cobbler_system.py
@@ -151,7 +151,7 @@ import ssl
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import xmlrpc_client
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 IFPROPS_MAPPING = dict(
     bondingopts='bonding_opts',

--- a/plugins/modules/remote_management/hpilo/hpilo_info.py
+++ b/plugins/modules/remote_management/hpilo/hpilo_info.py
@@ -128,7 +128,7 @@ except ImportError:
     HAS_HPILO = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # Suppress warnings from hpilo

--- a/plugins/modules/remote_management/lenovoxcc/xcc_redfish_command.py
+++ b/plugins/modules/remote_management/lenovoxcc/xcc_redfish_command.py
@@ -283,7 +283,7 @@ redfish_facts:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
 
 

--- a/plugins/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_command.py
@@ -82,7 +82,7 @@ msg:
 import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class IdracRedfishUtils(RedfishUtils):

--- a/plugins/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_config.py
@@ -150,7 +150,7 @@ from ansible.module_utils.common.validation import (
     check_required_arguments
 )
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class IdracRedfishUtils(RedfishUtils):

--- a/plugins/modules/remote_management/redfish/idrac_redfish_info.py
+++ b/plugins/modules/remote_management/redfish/idrac_redfish_info.py
@@ -120,7 +120,7 @@ msg:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class IdracRedfishUtils(RedfishUtils):

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -551,7 +551,7 @@ msg:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # More will be added as module features are expanded

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -204,7 +204,7 @@ msg:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 # More will be added as module features are expanded

--- a/plugins/modules/remote_management/wakeonlan.py
+++ b/plugins/modules/remote_management/wakeonlan.py
@@ -65,7 +65,7 @@ import struct
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def wakeonlan(module, mac, broadcast, port):

--- a/plugins/modules/source_control/github/github_release.py
+++ b/plugins/modules/source_control/github/github_release.py
@@ -135,7 +135,7 @@ except ImportError:
     HAS_GITHUB_API = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/source_control/github/github_webhook.py
+++ b/plugins/modules/source_control/github/github_webhook.py
@@ -148,7 +148,7 @@ except ImportError:
     HAS_GITHUB = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def _create_hook_config(module):

--- a/plugins/modules/source_control/github/github_webhook_info.py
+++ b/plugins/modules/source_control/github/github_webhook_info.py
@@ -94,7 +94,7 @@ except ImportError:
     HAS_GITHUB = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def _munge_hook(hook_obj):

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -124,7 +124,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import findProject, gitlabAuthentication
 

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -131,7 +131,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, gitlabAuthentication
 

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -174,7 +174,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import findProject, gitlabAuthentication
 

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -181,7 +181,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, findProject, gitlabAuthentication
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -129,7 +129,7 @@ project_variable:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six import integer_types

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -169,7 +169,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -236,7 +236,7 @@ except Exception:
 
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, gitlabAuthentication
 

--- a/plugins/modules/source_control/hg.py
+++ b/plugins/modules/source_control/hg.py
@@ -89,7 +89,7 @@ EXAMPLES = '''
 import os
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class Hg(object):

--- a/plugins/modules/storage/emc/emc_vnx_sg_member.py
+++ b/plugins/modules/storage/emc/emc_vnx_sg_member.py
@@ -79,7 +79,7 @@ hluid:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.storage.emc.emc_vnx import emc_vnx_argument_spec
 
 LIB_IMP_ERR = None

--- a/plugins/modules/system/crypttab.py
+++ b/plugins/modules/system/crypttab.py
@@ -76,7 +76,7 @@ import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 
 def main():

--- a/plugins/modules/system/dpkg_divert.py
+++ b/plugins/modules/system/dpkg_divert.py
@@ -161,7 +161,7 @@ import os
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 
 def diversion_state(module, command, path):

--- a/plugins/modules/system/filesystem.py
+++ b/plugins/modules/system/filesystem.py
@@ -110,7 +110,7 @@ import re
 import stat
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class Device(object):

--- a/plugins/modules/system/interfaces_file.py
+++ b/plugins/modules/system/interfaces_file.py
@@ -145,7 +145,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def lineDict(line):

--- a/plugins/modules/system/iptables_state.py
+++ b/plugins/modules/system/iptables_state.py
@@ -232,7 +232,7 @@ import filecmp
 import shutil
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 
 IPTABLES = dict(

--- a/plugins/modules/system/launchd.py
+++ b/plugins/modules/system/launchd.py
@@ -114,7 +114,7 @@ from abc import ABCMeta, abstractmethod
 from time import sleep
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class ServiceState:

--- a/plugins/modules/system/listen_ports_facts.py
+++ b/plugins/modules/system/listen_ports_facts.py
@@ -137,7 +137,7 @@ ansible_facts:
 
 import re
 import platform
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/system/locale_gen.py
+++ b/plugins/modules/system/locale_gen.py
@@ -40,7 +40,7 @@ import re
 from subprocess import Popen, PIPE, call
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 LOCALE_NORMALIZATION = {
     ".utf8": ".UTF-8",

--- a/plugins/modules/system/nosh.py
+++ b/plugins/modules/system/nosh.py
@@ -315,7 +315,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.service import fail_if_missing
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def run_sys_ctl(module, args):

--- a/plugins/modules/system/openwrt_init.py
+++ b/plugins/modules/system/openwrt_init.py
@@ -72,7 +72,7 @@ RETURN = '''
 import os
 import glob
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 
 module = None
 init_script = None

--- a/plugins/modules/system/pam_limits.py
+++ b/plugins/modules/system/pam_limits.py
@@ -138,7 +138,7 @@ import re
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def _assert_is_valid_value(module, item, value, prefix=''):

--- a/plugins/modules/system/runit.py
+++ b/plugins/modules/system/runit.py
@@ -84,7 +84,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class Sv(object):

--- a/plugins/modules/system/sefcontext.py
+++ b/plugins/modules/system/sefcontext.py
@@ -102,7 +102,7 @@ RETURN = r'''
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 SELINUX_IMP_ERR = None
 try:

--- a/plugins/modules/system/selinux_permissive.py
+++ b/plugins/modules/system/selinux_permissive.py
@@ -63,7 +63,7 @@ except ImportError:
     SEOBJECT_IMP_ERR = traceback.format_exc()
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/system/selogin.py
+++ b/plugins/modules/system/selogin.py
@@ -113,7 +113,7 @@ except ImportError:
 
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def semanage_login_add(module, login, seuser, do_reload, serange='s0', sestore=''):

--- a/plugins/modules/system/seport.py
+++ b/plugins/modules/system/seport.py
@@ -109,7 +109,7 @@ except ImportError:
     HAVE_SEOBJECT = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_runtime_status(ignore_selinux_state=False):

--- a/plugins/modules/system/ssh_config.py
+++ b/plugins/modules/system/ssh_config.py
@@ -157,7 +157,7 @@ except ImportError:
     STORM_IMP_ERR = traceback.format_exc()
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class SSHConfig():

--- a/plugins/modules/system/svc.py
+++ b/plugins/modules/system/svc.py
@@ -91,7 +91,7 @@ import re
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def _load_dist_subclass(cls, *args, **kwargs):

--- a/plugins/modules/web_infrastructure/deploy_helper.py
+++ b/plugins/modules/web_infrastructure/deploy_helper.py
@@ -274,7 +274,7 @@ import time
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class DeployHelper(object):

--- a/plugins/modules/web_infrastructure/htpasswd.py
+++ b/plugins/modules/web_infrastructure/htpasswd.py
@@ -97,7 +97,7 @@ import tempfile
 import traceback
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 PASSLIB_IMP_ERR = None
 try:

--- a/plugins/modules/web_infrastructure/jenkins_build.py
+++ b/plugins/modules/web_infrastructure/jenkins_build.py
@@ -127,7 +127,7 @@ except ImportError:
     python_jenkins_installed = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class JenkinsBuild:

--- a/plugins/modules/web_infrastructure/jenkins_job.py
+++ b/plugins/modules/web_infrastructure/jenkins_job.py
@@ -167,7 +167,7 @@ except ImportError:
     python_jenkins_installed = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class JenkinsJob(object):

--- a/plugins/modules/web_infrastructure/jenkins_job_info.py
+++ b/plugins/modules/web_infrastructure/jenkins_job_info.py
@@ -146,7 +146,7 @@ except ImportError:
     HAS_JENKINS = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def get_jenkins_connection(module):

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -273,7 +273,7 @@ from ansible.module_utils.six.moves import http_cookiejar as cookiejar
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils.six import text_type, binary_type
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import base64
 import hashlib
 import io

--- a/plugins/modules/web_infrastructure/jenkins_script.py
+++ b/plugins/modules/web_infrastructure/jenkins_script.py
@@ -107,7 +107,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import http_cookiejar as cookiejar
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def is_csrf_protection_enabled(module):

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -390,7 +390,7 @@ import traceback
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import StateModuleHelper, cause_changes
 from ansible.module_utils.six.moves.urllib.request import pathname2url
-from ansible.module_utils._text import to_text, to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_text, to_bytes, to_native
 from ansible.module_utils.urls import fetch_url
 
 

--- a/plugins/modules/web_infrastructure/nginx_status_info.py
+++ b/plugins/modules/web_infrastructure/nginx_status_info.py
@@ -94,7 +94,7 @@ data:
 import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class NginxStatusInfo(object):

--- a/plugins/modules/web_infrastructure/rundeck_acl_policy.py
+++ b/plugins/modules/web_infrastructure/rundeck_acl_policy.py
@@ -123,7 +123,7 @@ after:
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 import json
 import re
 

--- a/plugins/modules/web_infrastructure/rundeck_project.py
+++ b/plugins/modules/web_infrastructure/rundeck_project.py
@@ -103,7 +103,7 @@ after:
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 import json
 

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_aaa_group.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_aaa_group.py
@@ -188,7 +188,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_aaa_group_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_aaa_group_info.py
@@ -101,7 +101,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert.py
@@ -132,7 +132,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_ca_host_key_cert_info.py
@@ -79,7 +79,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_dns_host.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_dns_host.py
@@ -128,7 +128,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address.py
@@ -108,7 +108,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_network_interface_address_info.py
@@ -75,7 +75,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_auth_profile.py
@@ -307,7 +307,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_exception.py
@@ -204,7 +204,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_frontend.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_frontend.py
@@ -234,7 +234,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_frontend_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_frontend_info.py
@@ -120,7 +120,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_location.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_location.py
@@ -178,7 +178,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_location_info.py
+++ b/plugins/modules/web_infrastructure/sophos_utm/utm_proxy_location_info.py
@@ -101,7 +101,7 @@ result:
 """
 
 from ansible_collections.community.general.plugins.module_utils.utm_utils import UTM, UTMModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():

--- a/plugins/modules/web_infrastructure/taiga_issue.py
+++ b/plugins/modules/web_infrastructure/taiga_issue.py
@@ -117,7 +117,7 @@ import traceback
 from os import getenv
 from os.path import isfile
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 TAIGA_IMP_ERR = None
 try:

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -9,7 +9,7 @@ import os
 
 from ansible.errors import AnsibleParserError
 from ansible.parsing.dataloader import DataLoader
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 class DictDataLoader(DataLoader):

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible.module_utils.six import PY3
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @contextmanager

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible.parsing.vault import VaultSecret
 

--- a/tests/unit/plugins/module_utils/conftest.py
+++ b/tests/unit/plugins/module_utils/conftest.py
@@ -12,7 +12,7 @@ import pytest
 
 import ansible.module_utils.basic
 from ansible.module_utils.six import PY3, string_types
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 
 

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -9,7 +9,7 @@ import json
 import pytest
 
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 
 

--- a/tests/unit/plugins/modules/monitoring/test_circonus_annotation.py
+++ b/tests/unit/plugins/modules/monitoring/test_circonus_annotation.py
@@ -11,7 +11,7 @@ import uuid
 from urllib3.response import HTTPResponse
 
 from ansible_collections.community.general.tests.unit.compat.mock import patch
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules.monitoring import circonus_annotation
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -8,7 +8,7 @@ import json
 
 import pytest
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.community.general.plugins.modules.net_tools import nmcli
 
 pytestmark = pytest.mark.usefixtures('patch_ansible_module')

--- a/tests/unit/plugins/modules/packaging/os/test_rhn_register.py
+++ b/tests/unit/plugins/modules/packaging/os/test_rhn_register.py
@@ -8,7 +8,7 @@ import os
 
 from ansible_collections.community.general.tests.unit.compat.mock import mock_open
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 import ansible.module_utils.six
 from ansible.module_utils.six.moves import xmlrpc_client
 from ansible_collections.community.general.plugins.modules.packaging.os import rhn_register

--- a/tests/unit/plugins/modules/remote_management/lenovoxcc/test_xcc_redfish_command.py
+++ b/tests/unit/plugins/modules/remote_management/lenovoxcc/test_xcc_redfish_command.py
@@ -8,7 +8,7 @@ from ansible_collections.community.general.tests.unit.compat import mock
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 import ansible_collections.community.general.plugins.modules.remote_management.lenovoxcc.xcc_redfish_command as module
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import set_module_args, exit_json, fail_json

--- a/tests/unit/plugins/modules/system/test_ufw.py
+++ b/tests/unit/plugins/modules/system/test_ufw.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 import ansible_collections.community.general.plugins.modules.system.ufw as module
 
 import json

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -8,7 +8,7 @@ import json
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def set_module_args(args):

--- a/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/web_infrastructure/test_jenkins_build.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules.web_infrastructure import jenkins_build
 
 import json


### PR DESCRIPTION
##### SUMMARY
While the private API `ansible.module_utils._text` was the default place to get `to_text`, `to_bytes` and `to_native` for a long time, at least since Ansible 2.9 there's a non-private alternative: `ansible.module_utils.common.text.converters`. So let's use it :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various plugins
