### PR TITLE
_mount module utils - fixed sanity checks

### DIFF
--- a/changelogs/fragments/2883-_mount-fixed-sanity-checks.yml
+++ b/changelogs/fragments/2883-_mount-fixed-sanity-checks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - _mount module utils - fixed the sanity checks (https://github.com/ansible-collections/community.general/pull/2883).

--- a/plugins/module_utils/_mount.py
+++ b/plugins/module_utils/_mount.py
@@ -48,6 +48,10 @@
 # agrees to be bound by the terms and conditions of this License
 # Agreement.
 
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
 import os
 
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,6 +1,4 @@
 plugins/module_utils/cloud.py pylint:bad-option-value  # a pylint test that is disabled was modified over time
-plugins/module_utils/_mount.py future-import-boilerplate
-plugins/module_utils/_mount.py metaclass-boilerplate
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,5 +1,3 @@
-plugins/module_utils/_mount.py future-import-boilerplate
-plugins/module_utils/_mount.py metaclass-boilerplate
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,5 +1,3 @@
-plugins/module_utils/_mount.py future-import-boilerplate
-plugins/module_utils/_mount.py metaclass-boilerplate
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,6 +1,4 @@
 plugins/module_utils/cloud.py pylint:bad-option-value  # a pylint test that is disabled was modified over time
-plugins/module_utils/_mount.py future-import-boilerplate
-plugins/module_utils/_mount.py metaclass-boilerplate
 plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/rackspace/rax.py use-argspec-type-path


### PR DESCRIPTION
##### SUMMARY
Copying from https://github.com/ansible-collections/ansible.posix/blob/main/plugins/module_utils/mount.py the file `_mount.py` is no longer triggering sanity checks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/_mount.py
