### PR TITLE
[stable-1] fix CI

### DIFF
--- a/tests/integration/targets/inventory_kubevirt/constraints.txt
+++ b/tests/integration/targets/inventory_kubevirt/constraints.txt
@@ -1,1 +1,2 @@
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
+ruamel.yaml.clib <= 0.2.2 ; python_version <= '2.7' # 0.2.4 require python 3.5 or later, 0.2.3 is yanked

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -17,7 +17,7 @@ httmock
 
 # requirement for kubevirt modules
 openshift ; python_version >= '2.7'
-ruamel.yaml.clib <= 0.2.2 ; python_version <= '2.7' # 0.2.4 require python 3.5 or later, 0.2.3 is yanked
+ruamel.yaml.clib <= 0.2.2 ; python_version == '2.7' # 0.2.4 require python 3.5 or later, 0.2.3 is yanked
 
 # requirement for maven_artifact module
 lxml

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -17,6 +17,7 @@ httmock
 
 # requirement for kubevirt modules
 openshift ; python_version >= '2.7'
+ruamel.yaml.clib <= 0.2.2 ; python_version <= '2.7' # 0.2.4 require python 3.5 or later, 0.2.3 is yanked
 
 # requirement for maven_artifact module
 lxml

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -43,6 +43,7 @@ botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the follo
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
+ruamel.yaml.clib <= 0.2.2 ; python_version <= '2.7' # 0.2.4 require python 3.5 or later, 0.2.3 is yanked
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
Currently some CI runs die because ruamel.yaml.clib 0.2.4 no longer supports Python 2.7.

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI
