### PR TITLE
pacman: Descriptive state documentation

### DIFF
--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -32,7 +32,7 @@ options:
         description:
           - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed)) a package.
           - C(present) and C(installed) will simply ensure that a desired package is installed.
-          - C(latest) will update the specified package if it's not of the latest available version.
+          - C(latest) will update the specified package if it is not of the latest available version.
           - C(absent) and C(removed) will remove the specified package.
         default: present
         choices: [ absent, installed, latest, present, removed ]

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -30,9 +30,12 @@ options:
 
     state:
         description:
-            - Desired state of the package.
+          - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed)) a package.
+          - C(present) and C(installed) will simply ensure that a desired package is installed.
+          - C(latest) will update the specified package if it's not of the latest available version.
+          - C(absent) and C(removed) will remove the specified package.
         default: present
-        choices: [ absent, latest, present, installed, removed ]
+        choices: [ absent, installed, latest, present, removed ]
         type: str
 
     force:


### PR DESCRIPTION
##### SUMMARY
Adds description for the parameter options in state. Mostly copied from yum docs since the options are identical there.

Fixes #2889

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pacman

