### PR TITLE
[nmcli] add runner and runner-hwaddr-policy for network teaming

### DIFF
--- a/changelogs/fragments/2901-nmcli_teaming.yml
+++ b/changelogs/fragments/2901-nmcli_teaming.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - add ``runner`` and ``runner_hwaddr_policy`` options (https://github.com/ansible-collections/community.general/issues/2901).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -278,7 +278,7 @@ options:
               should be set during the team lifetime.
         type: str
         choices: [ same_all, by_active, only_active ]
-        version_added: 3.3.0
+        version_added: 3.4.0
     vlanid:
         description:
             - This is only used with VLAN - VLAN ID in range <0-4095>.

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -271,7 +271,7 @@ options:
         type: str
         choices: [ broadcast, roundrobin, activebackup, loadbalance, lacp ]
         default: roundrobin
-        version_added: 3.3.0
+        version_added: 3.4.0
     runner_hwaddr_policy:
         description:
             - This  defines  the policy of how hardware addresses of team device and port devices

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -274,7 +274,7 @@ options:
         version_added: 3.4.0
     runner_hwaddr_policy:
         description:
-            - This  defines  the policy of how hardware addresses of team device and port devices
+            - This defines the policy of how hardware addresses of team device and port devices
               should be set during the team lifetime.
         type: str
         choices: [ same_all, by_active, only_active ]

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -57,7 +57,7 @@ options:
         choices: [ bond, bond-slave, bridge, bridge-slave, ethernet, generic, infiniband, ipip, sit, team, team-slave, vlan, vxlan, wifi ]
     mode:
         description:
-            - This is the type of device or network connection that you wish to create for a bond, team or bridge.
+            - This is the type of device or network connection that you wish to create for a bond or bridge.
         type: str
         choices: [ 802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast ]
         default: balance-rr
@@ -265,6 +265,20 @@ options:
               frame was received on.
         type: bool
         default: yes
+    runner:
+        description:
+            - This is the type of device or network connection that you wish to create for a team.
+        type: str
+        choices: [ broadcast, roundrobin, activebackup, loadbalance, lacp ]
+        default: roundrobin
+        version_added: 3.3.0
+    runner_hwaddr_policy:
+        description:
+            - This  defines  the policy of how hardware addresses of team device and port devices
+              should be set during the team lifetime.
+        type: str
+        choices: [ same_all, by_active, only_active ]
+        version_added: 3.3.0
     vlanid:
         description:
             - This is only used with VLAN - VLAN ID in range <0-4095>.
@@ -719,6 +733,8 @@ class Nmcli(object):
         self.hairpin = module.params['hairpin']
         self.path_cost = module.params['path_cost']
         self.mac = module.params['mac']
+        self.runner = module.params['runner']
+        self.runner_hwaddr_policy = module.params['runner_hwaddr_policy']
         self.vlanid = module.params['vlanid']
         self.vlandev = module.params['vlandev']
         self.flags = module.params['flags']
@@ -825,6 +841,11 @@ class Nmcli(object):
                 'bridge.max-age': self.maxage,
                 'bridge.priority': self.priority,
                 'bridge.stp': self.stp,
+            })
+        elif self.type == 'team':
+            options.update({
+                'team.runner': self.runner,
+                'team.runner-hwaddr-policy': self.runner_hwaddr_policy,
             })
         elif self.type == 'bridge-slave':
             options.update({
@@ -1214,6 +1235,11 @@ def main():
             ageingtime=dict(type='int', default=300),
             hairpin=dict(type='bool', default=True),
             path_cost=dict(type='int', default=100),
+            # team specific vars
+            runner=dict(type='str', default='roundrobin',
+                             choices=['broadcast', 'roundrobin', 'activebackup', 'loadbalance', 'lacp']),
+            # team active-backup runner specific options
+            runner_hwaddr_policy=dict(type='str', choices=['same_all', 'by_active', 'only_active']),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),
@@ -1245,6 +1271,10 @@ def main():
     # check for issues
     if nmcli.conn_name is None:
         nmcli.module.fail_json(msg="Please specify a name for the connection")
+    # team checks
+    if nmcli.type == "team":
+        if nmcli.runner_hwaddr_policy and not nmcli.runner == "activebackup":
+            nmcli.module.fail_json(msg="Runner-hwaddr-policy is only allowed for runner activebackup")
     # team-slave checks
     if nmcli.type == 'team-slave':
         if nmcli.master is None:

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -279,7 +279,19 @@ ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
+team.runner:                            roundrobin
 """
+
+TESTCASE_TEAM_HWADDR_POLICY_FAILS = [
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'runner_hwaddr_policy': 'by_active',
+        'state': 'present',
+        '_ansible_check_mode': False,
+    }
+]
 
 TESTCASE_TEAM_SLAVE = [
     {
@@ -1051,6 +1063,20 @@ def test_team_connection_unchanged(mocked_team_connection_unchanged, capfd):
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_HWADDR_POLICY_FAILS, indirect=['patch_ansible_module'])
+def test_team_connection_create_hwaddr_policy_fails(mocked_generic_connection_create, capfd):
+    """
+    Test : Team connection created
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results.get('failed')
+    assert results['msg']  == "Runner-hwaddr-policy is only allowed for runner activebackup"
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_SLAVE, indirect=['patch_ansible_module'])

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1076,7 +1076,7 @@ def test_team_connection_create_hwaddr_policy_fails(mocked_generic_connection_cr
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert results.get('failed')
-    assert results['msg']  == "Runner-hwaddr-policy is only allowed for runner activebackup"
+    assert results['msg'] == "Runner-hwaddr-policy is only allowed for runner activebackup"
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_SLAVE, indirect=['patch_ansible_module'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR allows to select the runner for a team configuration. It also adds the possibility of select the hwaddr-policy for the activebackup runner.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1950

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
