### PR TITLE
Fix bug when 2 identical executions in same auth flow

### DIFF
--- a/changelogs/fragments/2904-fix-bug-when-2-identical-executions-in-same-auth-flow.yml
+++ b/changelogs/fragments/2904-fix-bug-when-2-identical-executions-in-same-auth-flow.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - keycloak_authentication - Fix bug when two identical executions in same authentication flow.
-    (https://github.com/ansible-collections/community.general/pull/2904)
+  - keycloak_authentication - fix bug when two identical executions are in the same authentication flow
+    (https://github.com/ansible-collections/community.general/pull/2904).

--- a/changelogs/fragments/2904-fix-bug-when-2-identical-executions-in-same-auth-flow.yml
+++ b/changelogs/fragments/2904-fix-bug-when-2-identical-executions-in-same-auth-flow.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - keycloak_authentication - Fix bug when two identical executions in same authentication flow.
+    (https://github.com/ansible-collections/community.general/pull/2904)

--- a/tests/unit/plugins/modules/identity/keycloak/test_keycloak_authentication.py
+++ b/tests/unit/plugins/modules/identity/keycloak/test_keycloak_authentication.py
@@ -343,7 +343,7 @@ class TestKeycloakAuthentication(ModuleTestCase):
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
         self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
         self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 1)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
+        self.assertEqual(len(mock_get_executions_representation.mock_calls), 2)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
@@ -434,7 +434,7 @@ class TestKeycloakAuthentication(ModuleTestCase):
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
         self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
         self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
+        self.assertEqual(len(mock_get_executions_representation.mock_calls), 2)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
@@ -611,7 +611,7 @@ class TestKeycloakAuthentication(ModuleTestCase):
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
         self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
         self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 1)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
+        self.assertEqual(len(mock_get_executions_representation.mock_calls), 2)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 1)
 
         # Verify that the module's changed status matches what is expected


### PR DESCRIPTION
##### SUMMARY
Currently impossible to create an authentication flow with 2 identical executions. If two execution with same name it will result as a single execution in the Keycloak configuration. 
This PR is solving this issue. 

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
For example : 
```paste below
    - name: Create an authentication flow with 2 identical execution.
      community.general.keycloak_authentication:
        auth_keycloak_url: http://localhost:8080/auth
        auth_realm: master
        auth_username: admin
        auth_password: password
        realm: master
        alias: "two_identical_exec"
        copyFrom: "first broker login"
        authenticationExecutions:
          - providerId: "test-execution1"
            requirement: "REQUIRED"
          - displayName: "test-execution1"
            requirement: "REQUIRED"
```
Would create only 1 execution "test-execution1" in the "two_identical_exec" authentication flow. 
We would like to have 2 times "test-execution1". 