### PR TITLE
Add integration tests for snap

### DIFF
--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -1,0 +1,5 @@
+shippable/posix/group1
+skip/aix
+skip/freebsd
+skip/osx
+skip/macos

--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -3,3 +3,4 @@ skip/aix
 skip/freebsd
 skip/osx
 skip/macos
+disabled #FIXME 2609

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -4,12 +4,21 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
-- block:
-    - name: install snapd
-      apt:
-        name: snapd
-        state: present
+- name: install snapd
+  apt:
+    name: snapd
+    state: present
+  register: snapd_install_ubuntu
+  when: ansible_distribution == 'Ubuntu'
 
+- name: install snapd
+  dnf:
+    name: snapd
+    state: present
+  register: snapd_install_fedora
+  when: ansible_distribution == 'Fedora'
+
+- block:
     - name: install package
       community.general.snap:
         name: hello-world
@@ -43,10 +52,21 @@
         state: absent
       register: remove_again
 
-    - name: Assert package has been installed just once
+    - name: Assert package has been removed just once
       assert:
         that:
           - remove is changed
           - remove_again is not changed
+  when: ansible_distribution in ['Ubuntu','Fedora']
 
-  when: ansible_distribution == 'Ubuntu'
+- name: Remove snapd in case it was not installed
+  apt:
+    name: snapd
+    state: absent
+  when: snapd_install_ubuntu is changed and ansible_distribution == 'Ubuntu'
+
+- name: Remove snapd in case it was not installed
+  dnf:
+    name: snapd
+    state: absent
+  when: snapd_install_fedora is changed and ansible_distribution == 'Fedora'

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- block:
+    - name: install snapd
+      apt:
+        name: snapd
+        state: present
+
+    - name: install package
+      community.general.snap:
+        name: hello-world
+        state: present
+      register: install
+
+    - name: install package again
+      community.general.snap:
+        name: hello-world
+        state: present
+      register: install_again
+
+    - name: Assert package has been installed just once
+      assert:
+        that:
+          - install is changed
+          - install_again is not changed
+
+    - name: check package has been installed correctly
+      command: hello-world
+
+    - name: remove package
+      community.general.snap:
+        name: hello-world
+        state: absent
+      register: remove
+
+    - name: remove package again
+      community.general.snap:
+        name: hello-world
+        state: absent
+      register: remove_again
+
+    - name: Assert package has been installed just once
+      assert:
+        that:
+          - remove is changed
+          - remove_again is not changed
+
+  when: ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
##### SUMMARY
Quick basic integration tests for snap (only ubuntu and fedora right now)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/snap.py

##### ADDITIONAL INFORMATION
This will fail right now until #2906 has been fixed.