### PR TITLE
Add integration test for classic snap

### DIFF
--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -96,50 +96,50 @@
           - remove_again is not changed
           - remove_again_check is not changed
 
-    - name: Make sure package from classic snap is not installed
-      community.general.snap:
-        name: nvim
-        state: absent
-
-    - name: Install package from classic snap
-      community.general.snap:
-        name: nvim
-        state: present
-        classic: true
-      register: classic_install
-
-    # testing classic idempotency
-    - name: Install package from classic snap again
-      community.general.snap:
-        name: nvim
-        state: present
-        classic: true
-      register: classic_install_again
-
-    - name: Assert package has been installed just once
-      assert:
-        that:
-          - classic_install is changed
-          - classic_install_again is not changed
-
-    # this is just testing if a package which has been installed
-    # with true classic can be removed without setting classic to true
-    - name: Remove package from classic snap without setting classic to true
-      community.general.snap:
-        name: nvim
-        state: absent
-      register: classic_remove_without_true_classic
-
-    - name: Remove package from classic snap with setting classic to true
-      community.general.snap:
-        name: nvim
-        state: absent
-        classic: true
-      register: classic_remove_with_true_classic
-
-    - name: Assert package has been removed without setting classic to true
-      assert:
-        that:
-          - classic_remove_without_ture_classic is changed
-          - classic_remove_with_ture_classic is not changed
+#    - name: Make sure package from classic snap is not installed
+#      community.general.snap:
+#        name: nvim
+#        state: absent
+#
+#    - name: Install package from classic snap
+#      community.general.snap:
+#        name: nvim
+#        state: present
+#        classic: true
+#      register: classic_install
+#
+#    # testing classic idempotency
+#    - name: Install package from classic snap again
+#      community.general.snap:
+#        name: nvim
+#        state: present
+#        classic: true
+#      register: classic_install_again
+#
+#    - name: Assert package has been installed just once
+#      assert:
+#        that:
+#          - classic_install is changed
+#          - classic_install_again is not changed
+#
+#    # this is just testing if a package which has been installed
+#    # with true classic can be removed without setting classic to true
+#    - name: Remove package from classic snap without setting classic to true
+#      community.general.snap:
+#        name: nvim
+#        state: absent
+#      register: classic_remove_without_true_classic
+#
+#    - name: Remove package from classic snap with setting classic to true
+#      community.general.snap:
+#        name: nvim
+#        state: absent
+#        classic: true
+#      register: classic_remove_with_true_classic
+#
+#    - name: Assert package has been removed without setting classic to true
+#      assert:
+#        that:
+#          - classic_remove_without_ture_classic is changed
+#          - classic_remove_with_ture_classic is not changed
   when: has_snap

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -108,6 +108,7 @@
         classic: true
       register: classic_install
 
+    # testing classic idempotency
     - name: Install package from classic snap again
       community.general.snap:
         name: nvim
@@ -121,23 +122,24 @@
           - classic_install is changed
           - classic_install_again is not changed
 
-    - name: Remove package from classic snap
+    # this is just testing if a package which has been installed
+    # with true classic can be removed without setting classic to true
+    - name: Remove package from classic snap without setting classic to true
+      community.general.snap:
+        name: nvim
+        state: absent
+      register: classic_remove_without_true_classic
+
+    - name: Remove package from classic snap with setting classic to true
       community.general.snap:
         name: nvim
         state: absent
         classic: true
-      register: classic_remove
+      register: classic_remove_with_true_classic
 
-    - name: Remove package from classic snap again
-      community.general.snap:
-        name: nvim
-        state: absent
-        classic: true
-      register: classic_remove_again
-
-    - name: Assert package has been removed just once
+    - name: Assert package has been removed without setting classic to true
       assert:
         that:
-          - classic_remove is changed
-          - classic_remove_again is not changed
+          - classic_remove_without_ture_classic is changed
+          - classic_remove_with_ture_classic is not changed
   when: has_snap

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -95,4 +95,49 @@
           - remove_check is changed
           - remove_again is not changed
           - remove_again_check is not changed
+
+    - name: Make sure package from classic snap is not installed
+      community.general.snap:
+        name: nvim
+        state: absent
+
+    - name: Install package from classic snap
+      community.general.snap:
+        name: nvim
+        state: present
+        classic: true
+      register: classic_install
+
+    - name: Install package from classic snap again
+      community.general.snap:
+        name: nvim
+        state: present
+        classic: true
+      register: classic_install_again
+
+    - name: Assert package has been installed just once
+      assert:
+        that:
+          - classic_install is changed
+          - classic_install_again is not changed
+
+    - name: Remove package from classic snap
+      community.general.snap:
+        name: nvim
+        state: absent
+        classic: true
+      register: classic_remove
+
+    - name: Remove package from classic snap again
+      community.general.snap:
+        name: nvim
+        state: absent
+        classic: true
+      register: classic_remove_again
+
+    - name: Assert package has been removed just once
+      assert:
+        that:
+          - classic_remove is changed
+          - classic_remove_again is not changed
   when: has_snap


### PR DESCRIPTION
##### SUMMARY
Tests should pass after https://github.com/ansible-collections/community.general/pull/2918 has been merged.
Also I've added `classic` to remove as well, I guess that should not have any effect? If it does this should be documented.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/snap.py