### PR TITLE
archive - fix removal failures for nested files with tar archives

### DIFF
--- a/changelogs/fragments/2923-archive-remove-bugfix.yml
+++ b/changelogs/fragments/2923-archive-remove-bugfix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - archive - fixed task failure when using the ``remove`` option with a ``path`` containing nested files for
+    ``format``s other than ``zip`` (https://github.com/ansible-collections/community.general/issues/2919).

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -399,13 +399,14 @@ class Archive(object):
 
     def remove_targets(self):
         for path in self.successes:
-            try:
-                if os.path.isdir(path):
-                    shutil.rmtree(path)
-                else:
-                    os.remove(path)
-            except OSError:
-                self.errors.append(_to_native(path))
+            if os.path.exists(path):
+                try:
+                    if os.path.isdir(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.remove(path)
+                except OSError:
+                    self.errors.append(_to_native(path))
         for path in self.paths:
             try:
                 if os.path.isdir(path):

--- a/tests/integration/targets/archive/tasks/remove.yml
+++ b/tests/integration/targets/archive/tasks/remove.yml
@@ -148,7 +148,39 @@
 - name: verify that excluded sub file is still present
   file: path={{ output_dir }}/tmpdir/sub/subfile.txt state=file
 
-- name: remove temporary directory
+- name: prep our files in tmpdir again
+  copy: src={{ item }} dest={{ output_dir }}/tmpdir/{{ item }}
+  with_items:
+    - foo.txt
+    - bar.txt
+    - empty.txt
+    - sub
+    - sub/subfile.txt
+
+- name: archive using gz and remove src directory
+  archive:
+    path:
+      - "{{ output_dir }}/tmpdir/"
+    dest: "{{ output_dir }}/archive_remove_05.gz"
+    format: gz
+    remove: yes
+    exclude_path: "{{ output_dir }}/tmpdir/sub/subfile.txt"
+  register: archive_remove_result_05
+
+- name: verify that the files archived
+  file: path={{ output_dir }}/archive_remove_05.gz state=file
+
+- name: Verify source files were removed
   file:
     path: "{{ output_dir }}/tmpdir"
     state: absent
+  register: archive_source_file_removal_05
+
+- name: Verify that task status is success
+  assert:
+    that:
+      - archive_remove_result_05 is success
+      - archive_source_file_removal_05 is not changed
+
+- name: remove our gz
+  file: path="{{ output_dir }}/archive_remove_05.gz" state=absent


### PR DESCRIPTION
##### SUMMARY
Fixes a bug introduced in #2816 which causes false failures when recursively removing files added to `tar` archives.
Fixes #2919
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/files/archive.py

##### ADDITIONAL INFORMATION
Pre-refactor the module never entered the following segment of code:
```python
if os.path.isdir(path):
  shutil.rmtree(path)
```
This is because sub-directories were not added to the list of successes hence the behavior was to remove each file individually and then remove the root paths. The refactor now adds all files and paths added to the archive to the list of successes so in the event that a sub-directory was removed before a file in that sub-directory a `FileNotFoundError` would be raised. The simple fix is to just check for file existence before attempting to remove a file. 

__Note:__ This was not an issue for `zip` archives because paths are not returned as members of the archive and are not included in the list of successes.