### PR TITLE
proxmox{,_kvm}: set default value of proxmox_default_behavior to no_defaults

### DIFF
--- a/changelogs/fragments/2937-proxmox_kvm-change_default_values.yml
+++ b/changelogs/fragments/2937-proxmox_kvm-change_default_values.yml
@@ -1,4 +1,4 @@
 ---
-bugfixes:
+breaking_changes:
   - proxmox - the default of the ``proxmox_default_behavior`` has been changed from ``compatibility`` to ``no_defaults`` (https://github.com/ansible-collections/community.general/pull/2937).
   - proxmox_kvm - the default of the ``proxmox_default_behavior`` has been changed from ``compatibility`` to ``no_defaults`` (https://github.com/ansible-collections/community.general/pull/2937).

--- a/changelogs/fragments/2937-proxmox_kvm-change_default_values.yml
+++ b/changelogs/fragments/2937-proxmox_kvm-change_default_values.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox - the default of the ``proxmox_default_behavior`` has been changed from ``compatibility`` to ``no_defaults`` (https://github.com/ansible-collections/community.general/pull/2937).
+  - proxmox_kvm - the default of the ``proxmox_default_behavior`` has been changed from ``compatibility`` to ``no_defaults`` (https://github.com/ansible-collections/community.general/pull/2937).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -548,13 +548,6 @@ def main():
         template_store = module.params['ostemplate'].split(":")[0]
     timeout = module.params['timeout']
 
-    if module.params['proxmox_default_behavior'] is None:
-        module.params['proxmox_default_behavior'] = 'compatibility'
-        module.deprecate(
-            'The proxmox_default_behavior option will change its default value from "compatibility" to '
-            '"no_defaults" in community.general 4.0.0. To remove this warning, please specify an explicit value for it now',
-            version='4.0.0', collection_name='community.general'
-        )
     if module.params['proxmox_default_behavior'] == 'compatibility':
         old_default_values = dict(
             disk="3",

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -163,13 +163,11 @@ options:
       - Various module options used to have default values. This cause problems when
         user expects different behavior from proxmox by default or fill options which cause
         problems when they have been set.
-      - The default value is C(compatibility), which will ensure that the default values
+      - The default value is C(no_defaults), which will ensure that no default values
         are used when the values are not explicitly specified by the user.
-      - From community.general 4.0.0 on, the default value will switch to C(no_defaults). To avoid
-        deprecation warnings, please set I(proxmox_default_behavior) to an explicit
-        value.
       - This affects the I(disk), I(cores), I(cpus), I(memory), I(onboot), I(swap), I(cpuunits) options.
     type: str
+    default: "no_defaults"
     choices:
       - compatibility
       - no_defaults
@@ -521,7 +519,7 @@ def main():
             unprivileged=dict(type='bool', default=False),
             description=dict(type='str'),
             hookscript=dict(type='str'),
-            proxmox_default_behavior=dict(type='str', choices=['compatibility', 'no_defaults']),
+            proxmox_default_behavior=dict(type='str', default="no_defaults", choices=['compatibility', 'no_defaults']),
         ),
         required_if=[('state', 'present', ['node', 'hostname', 'ostemplate'])],
         required_together=[('api_token_id', 'api_token_secret')],

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -165,6 +165,7 @@ options:
         problems when they have been set.
       - The default value is C(no_defaults), which will ensure that no default values
         are used when the values are not explicitly specified by the user.
+      - The default has been switched from C(compatibility) to C(no_defaults) in community.genral 4.0.0.
       - This affects the I(disk), I(cores), I(cpus), I(memory), I(onboot), I(swap), I(cpuunits) options.
     type: str
     default: "no_defaults"

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -494,6 +494,7 @@ options:
         problems when they have been set.
       - The default value is C(no_defaults), which will ensure that no default values
         are used when the values are not explicitly specified by the user.
+      - The default has been switched from C(compatibility) to C(no_defaults) in community.genral 4.0.0.
       - This affects the I(acpi), I(autostart), I(balloon), I(boot), I(cores), I(cpu),
         I(cpuunits), I(force), I(format), I(kvm), I(memory), I(onboot), I(ostype), I(sockets),
         I(tablet), I(template), I(vga), options.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -492,15 +492,13 @@ options:
       - Various module options used to have default values. This cause problems when
         user expects different behavior from proxmox by default or fill options which cause
         problems when they have been set.
-      - The default value is C(compatibility), which will ensure that the default values
+      - The default value is C(no_defaults), which will ensure that no default values
         are used when the values are not explicitly specified by the user.
-      - From community.general 4.0.0 on, the default value will switch to C(no_defaults). To avoid
-        deprecation warnings, please set I(proxmox_default_behavior) to an explicit
-        value.
       - This affects the I(acpi), I(autostart), I(balloon), I(boot), I(cores), I(cpu),
         I(cpuunits), I(force), I(format), I(kvm), I(memory), I(onboot), I(ostype), I(sockets),
         I(tablet), I(template), I(vga), options.
     type: str
+    default: "no_defaults"
     choices:
       - compatibility
       - no_defaults
@@ -1091,7 +1089,7 @@ def main():
             virtio=dict(type='dict'),
             vmid=dict(type='int'),
             watchdog=dict(),
-            proxmox_default_behavior=dict(type='str', choices=['compatibility', 'no_defaults']),
+            proxmox_default_behavior=dict(type='str', default="no_defaults", choices=['compatibility', 'no_defaults']),
         ),
         mutually_exclusive=[('delete', 'revert'), ('delete', 'update'), ('revert', 'update'), ('clone', 'update'), ('clone', 'delete'), ('clone', 'revert')],
         required_together=[('api_token_id', 'api_token_secret')],

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1121,13 +1121,6 @@ def main():
     vmid = module.params['vmid']
     validate_certs = module.params['validate_certs']
 
-    if module.params['proxmox_default_behavior'] is None:
-        module.params['proxmox_default_behavior'] = 'compatibility'
-        module.deprecate(
-            'The proxmox_default_behavior option will change its default value from "compatibility" to '
-            '"no_defaults" in community.general 4.0.0. To remove this warning, please specify an explicit value for it now',
-            version='4.0.0', collection_name='community.general'
-        )
     if module.params['proxmox_default_behavior'] == 'compatibility':
         old_default_values = dict(
             acpi=True,


### PR DESCRIPTION
##### SUMMARY
Follow up on #850.

Should not be backported to `stable-3` nor `stable-2`.

##### ISSUE TYPE
- Breaking Change Pull Request

##### COMPONENT NAME
proxmox
proxmox_kvm