### PR TITLE
jenkins_job_info: Remove necessities of password or token.

### DIFF
--- a/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
+++ b/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jenkins_job_info - Remove necessities on password or token (https://github.com/ansible-collections/community.general/pull/2948).

--- a/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
+++ b/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jenkins_job_info - remove necessities on password or token (https://github.com/ansible-collections/community.general/pull/2948).
+  - jenkins_job_info - the ``password`` and ``token`` parameters can also be omitted to retrieve only public information (https://github.com/ansible-collections/community.general/pull/2948).

--- a/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
+++ b/changelogs/fragments/2948-jenkins_job_info-remove_necessities_on_password_or_token.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jenkins_job_info - Remove necessities on password or token (https://github.com/ansible-collections/community.general/pull/2948).
+  - jenkins_job_info - remove necessities on password or token (https://github.com/ansible-collections/community.general/pull/2948).

--- a/plugins/modules/web_infrastructure/jenkins_job_info.py
+++ b/plugins/modules/web_infrastructure/jenkins_job_info.py
@@ -33,12 +33,12 @@ options:
     type: str
     description:
       - Password to authenticate with the Jenkins server.
-      - This is mutually exclusive with C(token).
+      - This is mutually exclusive with I(token).
   token:
     type: str
     description:
       - API token used to authenticate with the Jenkins server.
-      - This is mutually exclusive with C(password).
+      - This is mutually exclusive with I(password).
   url:
     type: str
     description:

--- a/plugins/modules/web_infrastructure/jenkins_job_info.py
+++ b/plugins/modules/web_infrastructure/jenkins_job_info.py
@@ -33,12 +33,10 @@ options:
     type: str
     description:
       - Password to authenticate with the Jenkins server.
-      - This is a required parameter, if C(token) is not provided.
   token:
     type: str
     description:
       - API token used to authenticate with the Jenkins server.
-      - This is a required parameter, if C(password) is not provided.
   url:
     type: str
     description:
@@ -59,6 +57,11 @@ author:
 '''
 
 EXAMPLES = '''
+# Get all Jenkins jobs anonymously
+- community.general.jenkins_job_info:
+    user: admin
+  register: my_jenkins_job_info
+
 # Get all Jenkins jobs using basic auth
 - community.general.jenkins_job_info:
     user: admin
@@ -231,9 +234,6 @@ def main():
         mutually_exclusive=[
             ['password', 'token'],
             ['name', 'glob'],
-        ],
-        required_one_of=[
-            ['password', 'token'],
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/web_infrastructure/jenkins_job_info.py
+++ b/plugins/modules/web_infrastructure/jenkins_job_info.py
@@ -33,10 +33,12 @@ options:
     type: str
     description:
       - Password to authenticate with the Jenkins server.
+      - This is mutually exclusive with C(token).
   token:
     type: str
     description:
       - API token used to authenticate with the Jenkins server.
+      - This is mutually exclusive with C(password).
   url:
     type: str
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove necessities of password or token in the jenkins_job_info module.

There are many use cases that Jenkins is allowed to visit without authentication. Also in the original implementation, the get_jenkins_connection function supports connections that exclude of password or token. So I think it should not have the restriction to make password or token necessary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jenkins_job_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
