### PR TITLE
MH - dicts and lists change-tracking is fixed

### DIFF
--- a/changelogs/fragments/2951-mh-vars-deepcopy.yml
+++ b/changelogs/fragments/2951-mh-vars-deepcopy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_helper module utils - fixed change-tracking for dictionaries and lists (https://github.com/ansible-collections/community.general/pull/2951).

--- a/plugins/module_utils/mh/mixins/vars.py
+++ b/plugins/module_utils/mh/mixins/vars.py
@@ -6,6 +6,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import copy
+
 
 class VarMeta(object):
     NOTHING = object()
@@ -30,11 +32,11 @@ class VarMeta(object):
         if fact is not None:
             self.fact = fact
         if initial_value is not self.NOTHING:
-            self.initial_value = initial_value
+            self.initial_value = copy.deepcopy(initial_value)
 
     def set_value(self, value):
         if not self.init:
-            self.initial_value = value
+            self.initial_value = copy.deepcopy(value)
             self.init = True
         self.value = value
         return self

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -151,16 +151,43 @@ def test_vardict():
     assert vd.meta('a').diff is False
     assert vd.meta('a').change is False
     vd['b'] = 456
+    assert vd.meta('b').output is True
+    assert vd.meta('b').diff is False
+    assert vd.meta('b').change is False
     vd.set_meta('a', diff=True, change=True)
     vd.set_meta('b', diff=True, output=False)
     vd['c'] = 789
+    assert vd.has_changed('c') is False
     vd['a'] = 'new_a'
+    assert vd.has_changed('a') is True
     vd['c'] = 'new_c'
+    assert vd.has_changed('c') is False
+    vd['b'] = 'new_b'
+    assert vd.has_changed('b') is False
     assert vd.a == 'new_a'
     assert vd.c == 'new_c'
     assert vd.output() == {'a': 'new_a', 'c': 'new_c'}
     assert vd.diff() == {'before': {'a': 123}, 'after': {'a': 'new_a'}}, "diff={0}".format(vd.diff())
 
+
+def test_variable_meta_change():
+    vd = VarDict()
+    vd.set('a', 123, change=True)
+    vd.set('b', [4, 5, 6], change=True)
+    vd.set('c', {'m': 7, 'n': 8, 'o': 9}, change=True)
+    vd.set('d', {'a1': {'a11': 33, 'a12': 34}}, change=True)
+
+    vd.a = 1234
+    assert vd.has_changed('a') is True
+    vd.b.append(7)
+    assert vd.b == [4, 5, 6, 7]
+    assert vd.has_changed('b')
+    vd.c.update({'p': 10})
+    assert vd.c == {'m': 7, 'n': 8, 'o': 9, 'p': 10}
+    assert vd.has_changed('c')
+    vd.d['a1'].update({'a13': 35})
+    assert vd.d == {'a1': {'a11': 33, 'a12': 34, 'a13': 35}}
+    assert vd.has_changed('d')
 
 class MockMH(object):
     changed = None

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -189,6 +189,7 @@ def test_variable_meta_change():
     assert vd.d == {'a1': {'a11': 33, 'a12': 34, 'a13': 35}}
     assert vd.has_changed('d')
 
+
 class MockMH(object):
     changed = None
 


### PR DESCRIPTION
##### SUMMARY
The change-tracking feature in ModuleHelper was naively retaining a reference to dictionaries and lists. Changing that to a `deepcopy()` of it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/vars.py
