### PR TITLE
MH cmd - changed default language from C to C.UTF-8

### DIFF
--- a/changelogs/fragments/2959-mh-cmd-c-utf8.yaml
+++ b/changelogs/fragments/2959-mh-cmd-c-utf8.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_helper cmd module utils - changed default locale from C to C.UTF-8 (https://github.com/ansible-collections/community.general/pull/2959).

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -90,7 +90,7 @@ class CmdMixin(object):
     command_args_formats = {}
     run_command_fixed_options = {}
     check_rc = False
-    force_lang = "C"
+    force_lang = "C.UTF-8"
 
     @property
     def module_formats(self):

--- a/tests/unit/plugins/modules/packaging/language/test_cpanm.py
+++ b/tests/unit/plugins/modules/packaging/language/test_cpanm.py
@@ -38,7 +38,7 @@ TEST_CASES = [
                 ),
                 (
                     ['/testbin/cpanm', 'Dancer'],
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                     (0, '', '',),  # output rc, out, err
                 ),
             ],
@@ -65,7 +65,7 @@ TEST_CASES = [
             'id': 'install_dancer',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'Dancer'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -77,7 +77,7 @@ TEST_CASES = [
             'id': 'install_distribution_file_compatibility',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'MIYAGAWA/Plack-0.99_05.tar.gz'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -89,7 +89,7 @@ TEST_CASES = [
             'id': 'install_distribution_file',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'MIYAGAWA/Plack-0.99_05.tar.gz'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -101,7 +101,7 @@ TEST_CASES = [
             'id': 'install_into_locallib',
             'run_command.calls': [(
                 ['/testbin/cpanm', '--local-lib', '/srv/webapps/my_app/extlib', 'Dancer'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -113,7 +113,7 @@ TEST_CASES = [
             'id': 'install_from_local_directory',
             'run_command.calls': [(
                 ['/testbin/cpanm', '/srv/webapps/my_app/src/'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -125,7 +125,7 @@ TEST_CASES = [
             'id': 'install_into_locallib_no_unit_testing',
             'run_command.calls': [(
                 ['/testbin/cpanm', '--notest', '--local-lib', '/srv/webapps/my_app/extlib', 'Dancer'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -137,7 +137,7 @@ TEST_CASES = [
             'id': 'install_from_mirror',
             'run_command.calls': [(
                 ['/testbin/cpanm', '--mirror', 'http://cpan.cpantesters.org/', 'Dancer'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -158,7 +158,7 @@ TEST_CASES = [
             'id': 'install_minversion_implicit',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'Dancer~1.0'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -170,7 +170,7 @@ TEST_CASES = [
             'id': 'install_minversion_explicit',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'Dancer~1.5'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -182,7 +182,7 @@ TEST_CASES = [
             'id': 'install_specific_version',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'Dancer@1.7'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -215,7 +215,7 @@ TEST_CASES = [
             'id': 'install_specific_version_from_git_url_explicit',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'git://github.com/plack/Plack.git@1.7'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,
@@ -228,7 +228,7 @@ TEST_CASES = [
             'id': 'install_specific_version_from_git_url_implicit',
             'run_command.calls': [(
                 ['/testbin/cpanm', 'git://github.com/plack/Plack.git@2.5'],
-                {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
+                {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': True},
                 (0, '', '',),  # output rc, out, err
             )],
             'changed': True,

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -49,7 +49,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '100\n', '',),
                 ),
@@ -69,7 +69,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/i_dont_exist'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (1, '', 'Property "/general/i_dont_exist" does not exist on channel "xfwm4".\n',),
                 ),
@@ -89,7 +89,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
                 ),
@@ -109,7 +109,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/use_compositing'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'true', '',),
                 ),
@@ -129,7 +129,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/use_compositing'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'false', '',),
                 ),
@@ -155,7 +155,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '100\n', '',),
                 ),
@@ -164,7 +164,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
                      '--create', '--type', 'int', '--set', '90'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -190,7 +190,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '90\n', '',),
                 ),
@@ -199,7 +199,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
                      '--create', '--type', 'int', '--set', '90'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -225,7 +225,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
                 ),
@@ -235,7 +235,7 @@ TEST_CASES = [
                      '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
                      '--type', 'string', '--set', 'C'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -261,7 +261,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
                 ),
@@ -271,7 +271,7 @@ TEST_CASES = [
                      '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
                      '--type', 'string', '--set', 'C'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),
@@ -295,7 +295,7 @@ TEST_CASES = [
                     # Calling of following command will be asserted
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
                 ),
@@ -304,7 +304,7 @@ TEST_CASES = [
                     ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
                      '--reset'],
                     # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
+                    {'environ_update': {'LANGUAGE': 'C.UTF-8', 'LC_ALL': 'C.UTF-8'}, 'check_rc': False},
                     # Mock of returned code, stdout and stderr
                     (0, '', '',),
                 ),


### PR DESCRIPTION
##### SUMMARY
Given the de-facto standard for Ansible is UTF-8, it only makes sense to fix that default to use that encoding. The pure "C" locale works with a 7-bit ascii encoding by default, limiting a lot of what can be done.

In fact, while coding the new module in #2933, the output of `ansible-galaxy role list` could not be parsed because it contained non-ASCII characters.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/cmd.py
