### PR TITLE
Update commit-rights.md

### DIFF
--- a/commit-rights.md
+++ b/commit-rights.md
@@ -68,7 +68,6 @@ Individuals who have been asked to become a part of this group have generally be
 | Name                | GitHub ID            | IRC Nick           | Other                |
 | ------------------- | -------------------- | ------------------ | -------------------- |
 | Alexei Znamensky    | russoz               | russoz             |                      |
-| Amin Vakil          | aminvakil            | aminvakil          |                      |
 | Andrew Klychkov     | andersson007         | andersson007_      |                      |
 | Felix Fontein       | felixfontein         | felixfontein       |                      |
 | John R Barker       | gundalow             | gundalow           |                      |


### PR DESCRIPTION
##### SUMMARY
aminvakil is no longer involved with the Ansible Community due to United
States export controls and economic sanctions laws apply to U.S.
persons, entities, and controlled software and technology that is of
U.S. origin or that enters the U.S., including open source software.

(cherry picked from commit 518ace25621ee7ed08debd4d87509b0b2be33f2c)

##### ISSUE TYPE
- Docs Pull Request


