### PR TITLE
proxmox inventory - fix parsing for offline nodes

### DIFF
--- a/changelogs/fragments/2967-proxmox_inventory-offline-node-fix.yml
+++ b/changelogs/fragments/2967-proxmox_inventory-offline-node-fix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox inventory - fixed parsing failures when some cluster nodes are offline (https://github.com/ansible-collections/community.general/issues/2931).
+  - proxmox inventory plugin - fixed parsing failures when some cluster nodes are offline (https://github.com/ansible-collections/community.general/issues/2931).

--- a/changelogs/fragments/2967-proxmox_inventory-offline-node-fix.yml
+++ b/changelogs/fragments/2967-proxmox_inventory-offline-node-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox inventory - fixed parsing failures when some cluster nodes are offline (https://github.com/ansible-collections/community.general/issues/2931).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -369,6 +369,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if node['type'] == 'node':
                     self.inventory.add_child(nodes_group, node['node'])
 
+                if node['status'] == 'offline':
+                    continue
+
                 # get node IP address
                 if self.get_option("want_proxmox_nodes_ansible_host"):
                     ip = self._get_node_ip(node['node'])

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -9,7 +9,6 @@ __metaclass__ = type
 
 import pytest
 
-from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.inventory.data import InventoryData
 from ansible_collections.community.general.plugins.inventory.proxmox import InventoryModule
 
@@ -52,7 +51,12 @@ def get_json(url):
                  "disk": 1000,
                  "maxmem": 1000,
                  "uptime": 10000,
-                 "level": ""}]
+                 "level": ""},
+                {"type": "node",
+                 "node": "testnode2",
+                 "id": "node/testnode2",
+                 "status": "offline",
+                 "ssl_fingerprint": "yy"}]
     elif url == "https://localhost:8006/api2/json/pools":
         # _get_pools
         return [{"poolid": "test"}]
@@ -554,7 +558,6 @@ def test_populate(inventory, mocker):
     host_qemu_multi_nic = inventory.inventory.get_host('test-qemu-multi-nic')
     host_qemu_template = inventory.inventory.get_host('test-qemu-template')
     host_lxc = inventory.inventory.get_host('test-lxc')
-    host_node = inventory.inventory.get_host('testnode')
 
     # check if qemu-test is in the proxmox_pool_test group
     assert 'proxmox_pool_test' in inventory.inventory.groups
@@ -584,3 +587,6 @@ def test_populate(inventory, mocker):
 
     # check if qemu template is not present
     assert host_qemu_template is None
+
+    # check that offline node is in inventory
+    assert inventory.inventory.get_host('testnode2')


### PR DESCRIPTION
##### SUMMARY
Adding logic to skip collecting facts and guests for `offline` nodes.

Fixes #2931

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION
- Removed some unused imports and variables in unit tests as well,