### PR TITLE
Temporarily disable passwordstore lookup tests on macOS and OSX

### DIFF
--- a/tests/integration/targets/lookup_passwordstore/aliases
+++ b/tests/integration/targets/lookup_passwordstore/aliases
@@ -3,3 +3,5 @@ destructive
 skip/aix
 skip/rhel
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller
+skip/osx  # FIXME https://github.com/ansible-collections/community.general/issues/2978
+skip/macos  # FIXME https://github.com/ansible-collections/community.general/issues/2978


### PR DESCRIPTION
##### SUMMARY
See #2978.

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI
