### PR TITLE
archive - staging idempotency fix

### DIFF
--- a/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
+++ b/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - archive - staging fix for idempotency checks to be enabled in community.general 4.0.0
+    (https://github.com/ansible-collections/community.general/pull/2987).

--- a/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
+++ b/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - archive - staging fix for idempotency checks to be enabled in community.general 4.0.0
-    (https://github.com/ansible-collections/community.general/pull/2987).
+  - archive - refactoring prior to fix for idempotency checks (https://github.com/ansible-collections/community.general/pull/2987).

--- a/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
+++ b/changelogs/fragments/2987-archive-stage-idempotency-fix.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - archive - refactoring prior to fix for idempotency checks (https://github.com/ansible-collections/community.general/pull/2987).
+  - archive - refactoring prior to fix for idempotency checks. The fix will be a breaking change and only appear
+    in community.general 4.0.0 (https://github.com/ansible-collections/community.general/pull/2987).

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -583,10 +583,13 @@ class TarArchive(Archive):
         def py27_filter(tarinfo):
             return None if matches_exclusion_patterns(tarinfo.name, self.exclusion_patterns) else tarinfo
 
+        def py26_filter(path):
+            return legacy_filter(path, self.exclusion_patterns)
+
         if PY27:
             self.file.add(path, archive_name, recursive=False, filter=py27_filter)
         else:
-            self.file.add(path, archive_name, recursive=False, exclude=legacy_filter)
+            self.file.add(path, archive_name, recursive=False, exclude=py26_filter)
 
     def _get_checksums(self, path):
         try:

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -22,11 +22,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 # Make sure we start fresh
 
-# set global toggles
-- name: Toggle idempotency tests
-  set_fact:
-    enable_idempotency_tests: false
-
 # Test setup
 - name: Ensure zip is present to create test archive (yum)
   yum: name=zip state=latest
@@ -132,7 +127,6 @@
   loop: "{{ formats }}"
   loop_control:
     loop_var: format
-  when: enable_idempotency_tests
 
 # Test cleanup
 - name: Remove backports.lzma if previously installed (pip)

--- a/tests/integration/targets/archive/tasks/main.yml
+++ b/tests/integration/targets/archive/tasks/main.yml
@@ -22,6 +22,11 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 # Make sure we start fresh
 
+# set global toggles
+- name: Toggle idempotency tests
+  set_fact:
+    enable_idempotency_tests: false
+
 # Test setup
 - name: Ensure zip is present to create test archive (yum)
   yum: name=zip state=latest
@@ -120,6 +125,14 @@
   loop: "{{ formats }}"
   loop_control:
     loop_var: format
+
+- name: Run Idempotency tests
+  include_tasks:
+    file: ../tests/idempotency.yml
+  loop: "{{ formats }}"
+  loop_control:
+    loop_var: format
+  when: enable_idempotency_tests
 
 # Test cleanup
 - name: Remove backports.lzma if previously installed (pip)

--- a/tests/integration/targets/archive/tests/core.yml
+++ b/tests/integration/targets/archive/tests/core.yml
@@ -41,7 +41,7 @@
       - archive_no_options is changed
       - "archive_no_options.dest_state == 'archive'"
       - "{{ archive_no_options.archived | length }} == 3"
-      -
+
 - name: Remove the archive - no options ({{ format }})
   file:
     path: "{{ output_dir }}/archive_no_options.{{ format }}"

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -19,11 +19,13 @@
     format: "{{ format }}"
   register: file_content_idempotency_after
 
+# After idempotency fix result will be reliably changed for all formats
 - name: Assert task status is changed - file content idempotency ({{ format }})
   assert:
     that:
-      - file_content_idempotency_after is changed
+      - file_content_idempotency_after is not changed
       - "{{ file_content_idempotency_before.archived | sort }} == {{ file_content_idempotency_after.archived | sort }}"
+  when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - file content idempotency ({{ format }})
   file:
@@ -53,10 +55,12 @@
     format: "{{ format }}"
   register: file_name_idempotency_after
 
+# After idempotency fix result will be reliably changed for all formats
 - name: Check task status - fime name idempotency ({{ format }})
   assert:
     that:
-      - file_name_idempotency_after is changed
+      - file_name_idempotency_after is not changed
+  when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - file name idempotency ({{ format }})
   file:
@@ -86,12 +90,14 @@
     format: "{{ format }}"
   register: single_file_content_idempotency_after
 
+# After idempotency fix result will be reliably changed for all formats
 - name: Assert task status is changed - single file content idempotency ({{ format }})
   assert:
     that:
-      - single_file_content_idempotency_after is changed
+      - single_file_content_idempotency_after is not changed
       - "{{ single_file_content_idempotency_before.archived | sort }} ==
          {{ single_file_content_idempotency_after.archived | sort }}"
+  when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - single file content idempotency ({{ format }})
   file:
@@ -121,17 +127,13 @@
     format: "{{ format }}"
   register: single_file_name_idempotency_after
 
+
+# After idempotency fix result will be reliably changed for all formats
 - name: Check task status - single file name idempotency ({{ format }})
   assert:
     that:
-      - single_file_name_idempotency_after.changed == status_map[format]
-  vars:
-    status_map:
-      tar: true
-      zip: true
-      gz: false
-      bz2: false
-      xz: false
+      - single_file_name_idempotency_after is not changed
+  when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - single file name idempotency ({{ format }})
   file:

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -24,7 +24,6 @@
   assert:
     that:
       - file_content_idempotency_after is not changed
-      - "{{ file_content_idempotency_before.archived | sort }} == {{ file_content_idempotency_after.archived | sort }}"
   when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - file content idempotency ({{ format }})
@@ -95,8 +94,6 @@
   assert:
     that:
       - single_file_content_idempotency_after is not changed
-      - "{{ single_file_content_idempotency_before.archived | sort }} ==
-         {{ single_file_content_idempotency_after.archived | sort }}"
   when: "format in ('tar', 'zip')"
 
 - name: Remove archvie - single file content idempotency ({{ format }})

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -1,0 +1,142 @@
+---
+- name: Archive - file content idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_file_content_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: file_content_idempotency_before
+
+- name: Modify file - file content idempotency ({{ format }})
+  lineinfile:
+    line: bar.txt
+    regexp: "^foo.txt$"
+    path: "{{ output_dir }}/foo.txt"
+
+- name: Archive second time - file content idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_file_content_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: file_content_idempotency_after
+
+- name: Assert task status is changed - file content idempotency ({{ format }})
+  assert:
+    that:
+      - file_content_idempotency_after is changed
+      - "{{ file_content_idempotency_before.archived | sort }} == {{ file_content_idempotency_after.archived | sort }}"
+
+- name: Remove archvie - file content idempotency ({{ format }})
+  file:
+    path: "{{ output_dir }}/archive_file_content_idempotency.{{ format }}"
+    state: absent
+
+- name: Modify file back - file content idempotency ({{ format }})
+  lineinfile:
+    line: foo.txt
+    regexp: "^bar.txt$"
+    path: "{{ output_dir }}/foo.txt"
+
+- name: Archive - file name idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_file_name_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: file_name_idempotency_before
+
+- name: Rename file - file name idempotency ({{ format }})
+  command: "mv {{ output_dir}}/foo.txt {{ output_dir }}/fii.txt"
+
+- name: Archive again - file name idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_file_name_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: file_name_idempotency_after
+
+- name: Check task status - fime name idempotency ({{ format }})
+  assert:
+    that:
+      - file_name_idempotency_after is changed
+
+- name: Remove archvie - file name idempotency ({{ format }})
+  file:
+    path: "{{ output_dir }}/archive_file_name_idempotency.{{ format }}"
+    state: absent
+
+- name: Rename file back - file name idempotency ({{ format }})
+  command: "mv {{ output_dir }}/fii.txt {{ output_dir }}/foo.txt"
+
+- name: Archive - single file content idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/foo.txt"
+    dest: "{{ output_dir }}/archive_single_file_content_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: single_file_content_idempotency_before
+
+- name: Modify file - single file content idempotency ({{ format }})
+  lineinfile:
+    line: bar.txt
+    regexp: "^foo.txt$"
+    path: "{{ output_dir }}/foo.txt"
+
+- name: Archive second time - single file content idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/foo.txt"
+    dest: "{{ output_dir }}/archive_single_file_content_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: single_file_content_idempotency_after
+
+- name: Assert task status is changed - single file content idempotency ({{ format }})
+  assert:
+    that:
+      - single_file_content_idempotency_after is changed
+      - "{{ single_file_content_idempotency_before.archived | sort }} ==
+         {{ single_file_content_idempotency_after.archived | sort }}"
+
+- name: Remove archvie - single file content idempotency ({{ format }})
+  file:
+    path: "{{ output_dir }}/archive_single_file_content_idempotency.{{ format }}"
+    state: absent
+
+- name: Modify file back - single file content idempotency ({{ format }})
+  lineinfile:
+    line: foo.txt
+    regexp: "^bar.txt$"
+    path: "{{ output_dir }}/foo.txt"
+
+- name: Archive - single file name idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/foo.txt"
+    dest: "{{ output_dir }}/archive_single_file_name_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: single_file_name_idempotency_before
+
+- name: Rename file - single file name idempotency ({{ format }})
+  command: "mv {{ output_dir}}/foo.txt {{ output_dir }}/fii.txt"
+
+- name: Archive again - single file name idempotency ({{ format }})
+  archive:
+    path: "{{ output_dir }}/fii.txt"
+    dest: "{{ output_dir }}/archive_single_file_name_idempotency.{{ format }}"
+    format: "{{ format }}"
+  register: single_file_name_idempotency_after
+
+- name: Check task status - single file name idempotency ({{ format }})
+  assert:
+    that:
+      - single_file_name_idempotency_after.changed == status_map[format]
+  vars:
+    status_map:
+      tar: true
+      zip: true
+      gz: false
+      bz2: false
+      xz: false
+
+- name: Remove archvie - single file name idempotency ({{ format }})
+  file:
+    path: "{{ output_dir }}/archive_single_file_name_idempotency.{{ format }}"
+    state: absent
+
+- name: Rename file back - single file name idempotency ({{ format }})
+  command: "mv {{ output_dir }}/fii.txt {{ output_dir }}/foo.txt"

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -26,7 +26,7 @@
       - file_content_idempotency_after is not changed
   when: "format in ('tar', 'zip')"
 
-- name: Remove archvie - file content idempotency ({{ format }})
+- name: Remove archive - file content idempotency ({{ format }})
   file:
     path: "{{ output_dir }}/archive_file_content_idempotency.{{ format }}"
     state: absent
@@ -55,13 +55,13 @@
   register: file_name_idempotency_after
 
 # After idempotency fix result will be reliably changed for all formats
-- name: Check task status - fime name idempotency ({{ format }})
+- name: Check task status - file name idempotency ({{ format }})
   assert:
     that:
       - file_name_idempotency_after is not changed
   when: "format in ('tar', 'zip')"
 
-- name: Remove archvie - file name idempotency ({{ format }})
+- name: Remove archive - file name idempotency ({{ format }})
   file:
     path: "{{ output_dir }}/archive_file_name_idempotency.{{ format }}"
     state: absent
@@ -96,7 +96,7 @@
       - single_file_content_idempotency_after is not changed
   when: "format in ('tar', 'zip')"
 
-- name: Remove archvie - single file content idempotency ({{ format }})
+- name: Remove archive - single file content idempotency ({{ format }})
   file:
     path: "{{ output_dir }}/archive_single_file_content_idempotency.{{ format }}"
     state: absent
@@ -132,7 +132,7 @@
       - single_file_name_idempotency_after is not changed
   when: "format in ('tar', 'zip')"
 
-- name: Remove archvie - single file name idempotency ({{ format }})
+- name: Remove archive - single file name idempotency ({{ format }})
   file:
     path: "{{ output_dir }}/archive_single_file_name_idempotency.{{ format }}"
     state: absent


### PR DESCRIPTION
##### SUMMARY
Staging fix for idempotency checking in the `archive` module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/files/archive.py

##### ADDITIONAL INFORMATION
- The new idempotency logic compares archived filenames and checksums against the original file at `dest` if possible and falls back to comparing file size when necessary.
- Minor refactoring was performed as well.
- New idempotency tests are also added and disabled for this PR. 
- The decision to stage these changes instead of directly implementing is based on the assumption that the actual implementation would be a breaking change.