### PR TITLE
MH integration tests - added missing copyright notes

### DIFF
--- a/tests/integration/targets/module_helper/tasks/main.yml
+++ b/tests/integration/targets/module_helper/tasks/main.yml
@@ -1,3 +1,6 @@
+# (c) 2021, Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 - include_tasks: msimple.yml
 - include_tasks: mdepfail.yml
 - include_tasks: mstate.yml

--- a/tests/integration/targets/module_helper/tasks/mdepfail.yml
+++ b/tests/integration/targets/module_helper/tasks/mdepfail.yml
@@ -1,3 +1,6 @@
+# (c) 2021, Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 - name: test failing dependency
   mdepfail:
     a: 123

--- a/tests/integration/targets/module_helper/tasks/msimple.yml
+++ b/tests/integration/targets/module_helper/tasks/msimple.yml
@@ -1,3 +1,6 @@
+# (c) 2021, Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 - name: test msimple 1
   msimple:
     a: 80

--- a/tests/integration/targets/module_helper/tasks/mstate.yml
+++ b/tests/integration/targets/module_helper/tasks/mstate.yml
@@ -1,3 +1,6 @@
+# (c) 2021, Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 - name: test mstate 1
   mstate:
     a: 80


### PR DESCRIPTION
##### SUMMARY
While working on another issue, noticed those files had no copyright headers.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tests/integration/targets/module_helper/tasks/main.yml
tests/integration/targets/module_helper/tasks/mdepfail.yml
tests/integration/targets/module_helper/tasks/msimple.yml
tests/integration/targets/module_helper/tasks/mstate.yml

