### PR TITLE
feature request template - replace ansible-core with community.general

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,7 +21,7 @@ body:
     placeholder: >-
       I am trying to do X with the collection from the main branch on GitHub and
       I think that implementing a feature Y would be very helpful for me and
-      every other user of ansible-core because of Z.
+      every other user of community.general because of Z.
   validations:
     required: true
 


### PR DESCRIPTION
##### SUMMARY

While preparing https://github.com/ansible-collections/amazon.aws/pull/400 I noticed that the community.general feature request still talks about ansible-core rather than community.general.  This looks like a C&P error

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github/

##### ADDITIONAL INFORMATION