### PR TITLE
Redfish Bootoverride Disable behaves incorrectly

### DIFF
--- a/changelogs/fragments/3006-redfish_command-bootoverride-argument-check.yaml
+++ b/changelogs/fragments/3006-redfish_command-bootoverride-argument-check.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - redfish_command - fix extraneous error caused by missing ``bootdevice`` argument 
+    when using the ``DisableBootOverride`` sub-command (https://github.com/ansible-collections/community.general/issues/3005).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1582,13 +1582,14 @@ class RedfishUtils(object):
 
         boot = data[key]
 
-        annotation = 'BootSourceOverrideTarget@Redfish.AllowableValues'
-        if annotation in boot:
-            allowable_values = boot[annotation]
-            if isinstance(allowable_values, list) and bootdevice not in allowable_values:
-                return {'ret': False,
-                        'msg': "Boot device %s not in list of allowable values (%s)" %
-                               (bootdevice, allowable_values)}
+        if override_enabled != 'Disabled':
+            annotation = 'BootSourceOverrideTarget@Redfish.AllowableValues'
+            if annotation in boot:
+                allowable_values = boot[annotation]
+                if isinstance(allowable_values, list) and bootdevice not in allowable_values:
+                    return {'ret': False,
+                            'msg': "Boot device %s not in list of allowable values (%s)" %
+                                   (bootdevice, allowable_values)}
 
         # read existing values
         cur_enabled = boot.get('BootSourceOverrideEnabled')


### PR DESCRIPTION
##### SUMMARY
Bypass the boot device argument check when the command is: DisableBootOverride
as it isn't needed to perform this operation.

Fixes #3005

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils.py

##### ADDITIONAL INFORMATION
This corrects a bug introduced in #825 from me. When disabling the redfish bootoverride = continuous, the module currently requires a boot device to be set unnecessarily. This proposed PR add a check for the Disabled command selection to bypass the boot device check as it isn't used anyway.
