### PR TITLE
Succesful clone from proxmox_kvm should return new vm id, not id from cloned vm.

### DIFF
--- a/changelogs/fragments/3034-promox-kvm-return-new-id.yaml
+++ b/changelogs/fragments/3034-promox-kvm-return-new-id.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox_kvm - fix result of clone, should return newid instead of vmid
+  - proxmox_kvm - fix result of clone, now returns ``newid`` instead of ``vmid`` (https://github.com/ansible-collections/community.general/pull/3034).

--- a/changelogs/fragments/3034-promox-kvm-return-new-id.yaml
+++ b/changelogs/fragments/3034-promox-kvm-return-new-id.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_kvm - fix result of clone, should return newid instead of vmid

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1303,7 +1303,7 @@ def main():
             if update:
                 module.exit_json(changed=True, vmid=vmid, msg="VM %s with vmid %s updated" % (name, vmid))
             elif clone is not None:
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
+                module.exit_json(changed=True, vmid=newid, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
             else:
                 module.exit_json(changed=True, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
         except Exception as e:


### PR DESCRIPTION
##### SUMMARY
return value vmid should be new vmid on successfully cloning a vm.

Fixes #1713
and my own issue which isn't described within Issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
```paste below
TASK [debug] *********************************************************************************************************************************************
ok: [gw1.staging....] => {
    "msg": {
        "changed": true,
        "failed": false,
        "msg": "VM gw1.staging.... with newid 162 cloned from vm with vmid 200",
        "vmid": 200
    }
}

```

Now becomes:

```paste below
TASK [debug] *********************************************************************************************************************************************
ok: [gw1.staging....] => {
    "msg": {
        "changed": true,
        "failed": false,
        "msg": "VM gw1.staging.... with newid 162 cloned from vm with vmid 200",
        "vmid": 162
    }
}
```

Take a close look at the vmid and the message.