### PR TITLE
github_repo: support GitHub on premise installations

### DIFF
--- a/changelogs/fragments/3038-enhance_github_repo_api_url.yml
+++ b/changelogs/fragments/3038-enhance_github_repo_api_url.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - github_repo - add new options ``api_url`` (https://github.com/ansible-collections/community.general/pull/3038) to allow working with on premises installations
+  - github_repo - add new option ``api_url``  to allow working with on premises installations (https://github.com/ansible-collections/community.general/pull/3038).

--- a/changelogs/fragments/3038-enhance_github_repo_api_url.yml
+++ b/changelogs/fragments/3038-enhance_github_repo_api_url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - github_repo - add new options ``api_url`` (https://github.com/ansible-collections/community.general/pull/3038) to allow working with on premises installations

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -70,7 +70,6 @@ options:
     description:
     - URL to the GitHub API if not using github.com but you own instance.
     type: str
-    required: false
     default: 'https://api.github.com'
     version_added: "3.5.0"
 requirements:

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -66,6 +66,13 @@ options:
     - When I(state) is C(present), the repository will be created in the current user profile.
     type: str
     required: false
+  api_url:
+    description:
+    - URL to the GitHub API if not using github.com but you own instance.
+    type: str
+    required: false
+    default: 'https://api.github.com'
+    version_added: "3.5.0"
 requirements:
 - PyGithub>=1.54
 notes:
@@ -119,11 +126,14 @@ except Exception:
     HAS_GITHUB_PACKAGE = False
 
 
-def authenticate(username=None, password=None, access_token=None):
+def authenticate(username=None, password=None, access_token=None, api_url=None):
+    if not api_url:
+        return None
+
     if access_token:
-        return Github(base_url="https://api.github.com", login_or_token=access_token)
+        return Github(base_url=api_url, login_or_token=access_token)
     else:
-        return Github(base_url="https://api.github.com", login_or_token=username, password=password)
+        return Github(base_url=api_url, login_or_token=username, password=password)
 
 
 def create_repo(gh, name, organization=None, private=False, description='', check_mode=False):
@@ -185,7 +195,8 @@ def delete_repo(gh, name, organization=None, check_mode=False):
 
 def run_module(params, check_mode=False):
     gh = authenticate(
-        username=params['username'], password=params['password'], access_token=params['access_token'])
+        username=params['username'], password=params['password'], access_token=params['access_token'],
+        api_url=params['api_url'])
     if params['state'] == "absent":
         return delete_repo(
             gh=gh,
@@ -216,6 +227,7 @@ def main():
         organization=dict(type='str', required=False, default=None),
         private=dict(type='bool', required=False, default=False),
         description=dict(type='str', required=False, default=''),
+        api_url=dict(type='str', required=False, default='https://api.github.com'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/tests/unit/plugins/modules/source_control/github/test_github_repo.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_repo.py
@@ -159,7 +159,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": False,
-            "state": "present"
+            "state": "present",
+            "api_url": "https://api.github.com"
         })
 
         self.assertEqual(result['changed'], True)
@@ -177,7 +178,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": True,
-            "state": "present"
+            "state": "present",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], True)
@@ -194,7 +196,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": True,
-            "state": "present"
+            "state": "present",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], True)
         self.assertEqual(result['repo']['private'], True)
@@ -211,7 +214,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": False,
-            "state": "absent"
+            "state": "absent",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], True)
 
@@ -227,7 +231,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": False,
-            "state": "absent"
+            "state": "absent",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], True)
 
@@ -243,7 +248,8 @@ class TestGithubRepo(unittest.TestCase):
             "name": "myrepo",
             "description": "Just for fun",
             "private": True,
-            "state": "absent"
+            "state": "absent",
+            "api_url": "https://api.github.com"
         })
         self.assertEqual(result['changed'], False)
 


### PR DESCRIPTION
##### SUMMARY
The module github_repo is enhanced to accept an optional api_url and allow operations agains on premise installation. 
api_url is optional an has a default to api.github.com to not break the former behavior of this module. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
github_repo

##### ADDITIONAL INFORMATION
-