### PR TITLE
xfconf - deprecate get state in favour of the xfconf_info module

### DIFF
--- a/changelogs/fragments/3049-xfconf-deprecate-get.yaml
+++ b/changelogs/fragments/3049-xfconf-deprecate-get.yaml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - xfconf - deprecate the `get` state. The new module `xfconf_info` should be used instead (https://github.com/ansible-collections/community.general/pull/3049).
+  - xfconf - deprecate the ``get`` state. The new module ``xfconf_info`` should be used instead (https://github.com/ansible-collections/community.general/pull/3049).

--- a/changelogs/fragments/3049-xfconf-deprecate-get.yaml
+++ b/changelogs/fragments/3049-xfconf-deprecate-get.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - xfconf - deprecate the `get` state. The new module `xfconf_info` should be used instead (https://github.com/ansible-collections/community.general/pull/3049).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -227,7 +227,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.vars.value = self.vars.previous_value
         self.vars.previous_value = None
         self.module.deprecate(
-            msg="State 'get' is deprecated. Please use the module xfconf_info instead.",
+            msg="State 'get' is deprecated. Please use the module xfconf_info instead",
             version="5.0.0", collection_name="community.general"
         )
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -227,7 +227,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
         self.vars.value = self.vars.previous_value
         self.vars.previous_value = None
         self.module.deprecate(
-            msg="State 'get' is deprecated. Please use the module xfconf_info instead",
+            msg="State 'get' is deprecated. Please use the module community.general.xfconf_info instead",
             version="5.0.0", collection_name="community.general"
         )
 

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -48,6 +48,7 @@ options:
     type: str
     description:
     - The action to take upon the property/value.
+    - State C(get) is deprecated and will be removed in community.general 5.0.0. Please use the module M(community.general.xfconf_info) instead.
     choices: [ get, present, absent ]
     default: "present"
   force_array:
@@ -225,6 +226,10 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
     def state_get(self):
         self.vars.value = self.vars.previous_value
         self.vars.previous_value = None
+        self.module.deprecate(
+            msg="State 'get' is deprecated. Please use the module xfconf_info instead.",
+            version="5.0.0", collection_name="community.general"
+        )
 
     def state_absent(self):
         if not self.module.check_mode:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -47,7 +47,7 @@ plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spe
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc  # param removed in 4.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
-plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -46,7 +46,7 @@ plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spe
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc  # param removed in 4.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
-plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -46,6 +46,6 @@ plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spe
 plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/runit.py validate-modules:parameter-type-not-in-doc  # param removed in 4.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
-plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path


### PR DESCRIPTION
##### SUMMARY
When #3045 gets merged, then this PR should follow, to deprecate the use of the `get` state in `xfconf`. The new module should be used instead.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/xfconf.py
