### PR TITLE
proxmox inventory plugin: Easy fix

### DIFF
--- a/changelogs/fragments/3052_proxmox_inventory_plugin.yml
+++ b/changelogs/fragments/3052_proxmox_inventory_plugin.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_inventory_plugin - It would be nice to understand why template is not a required field in the qemu.conf causing the failure, but it can remain a mystery for now (https://github.com/ansible-collections/community.general/pull/3052).
+  - proxmox inventory plugin - fixed plugin failure when a ``qemu`` guest has no ``template`` key (https://github.com/ansible-collections/community.general/pull/3052).

--- a/changelogs/fragments/3052_proxmox_inventory_plugin.yml
+++ b/changelogs/fragments/3052_proxmox_inventory_plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_inventory_plugin - It would be nice to understand why template is not a required field in the qemu.conf causing the failure, but it can remain a mystery for now (https://github.com/ansible-collections/community.general/pull/3052).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -413,7 +413,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 node_qemu_group = self.to_safe('%s%s' % (self.get_option('group_prefix'), ('%s_qemu' % node['node']).lower()))
                 self.inventory.add_group(node_qemu_group)
                 for qemu in self._get_qemu_per_node(node['node']):
-                    if qemu['template']:
+                    if qemu.get('template'):
                         continue
 
                     self.inventory.add_host(qemu['name'])


### PR DESCRIPTION

##### SUMMARY
Plugin was crashing on this line on Python 3.9.2 deployed on qemu image with debian bullseye. It doesn't crash anymore.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
community.general.proxmox

##### ADDITIONAL INFORMATION
I suspect you'll grasp it.