### PR TITLE
replace NBSP (non-blocking space) character with a regular SPACE char

### DIFF
--- a/plugins/modules/monitoring/stackdriver.py
+++ b/plugins/modules/monitoring/stackdriver.py
@@ -46,16 +46,16 @@ options:
   msg:
     type: str
     description:
-      - The contents of the annotation message, in plain text.  Limited to 256 characters. Required for annotation.
+      - The contents of the annotation message, in plain text. Limited to 256 characters. Required for annotation.
   annotated_by:
     type: str
     description:
-      - The person or robot who the annotation should be attributed to.
+      - The person or robot who the annotation should be attributed to.
     default: "Ansible"
   level:
     type: str
     description:
-      - one of INFO/WARN/ERROR, defaults to INFO if not supplied.  May affect display.
+      - one of INFO/WARN/ERROR, defaults to INFO if not supplied. May affect display.
     choices: ['INFO', 'WARN', 'ERROR']
     default: 'INFO'
   instance_id:

--- a/tests/integration/targets/alternatives/tasks/main.yml
+++ b/tests/integration/targets/alternatives/tasks/main.yml
@@ -12,7 +12,7 @@
 
   ##############
   # Test parameters:
-  # link parameter present / absent ('with_link' variable)
+  # link parameter present / absent ('with_link' variable)
   # with / without alternatives defined in alternatives file ('with_alternatives' variable)
   # auto / manual ('mode' variable)
 
@@ -56,7 +56,7 @@
         path: '{{ item }}'
         state: absent
       with_items:
-        - '{{ alternatives_dir }}/dummy'
+        - '{{ alternatives_dir }}/dummy'
 
     - file:
         path: '/usr/bin/dummy{{ item }}'

--- a/tests/integration/targets/alternatives/tasks/setup_test.yml
+++ b/tests/integration/targets/alternatives/tasks/setup_test.yml
@@ -1,11 +1,11 @@
 - template:
     src: dummy_alternative
-    dest: '{{ alternatives_dir }}/dummy'
+    dest: '{{ alternatives_dir }}/dummy'
     owner: root
     group: root
     mode: '0644'
   when: with_alternatives or ansible_os_family != 'RedHat'
 - file:
-    path: '{{ alternatives_dir }}/dummy'
+    path: '{{ alternatives_dir }}/dummy'
     state: absent
   when: not with_alternatives and ansible_os_family == 'RedHat'

--- a/tests/integration/targets/alternatives/tasks/test.yml
+++ b/tests/integration/targets/alternatives/tasks/test.yml
@@ -5,7 +5,7 @@
   - name: set alternative (using link parameter)
     alternatives:
       name: dummy
-      path: '/usr/bin/dummy{{ item }}'
+      path: '/usr/bin/dummy{{ item }}'
       link: '/usr/bin/dummy'
     register: alternative
 
@@ -20,7 +20,7 @@
   - name: set alternative (without link parameter)
     alternatives:
       name: dummy
-      path: '/usr/bin/dummy{{ item }}'
+      path: '/usr/bin/dummy{{ item }}'
     register: alternative
 
   - name: check expected command was executed
@@ -40,11 +40,11 @@
       - 'cmd.stdout == "dummy" ~ item'
 
 - name: 'check mode (manual: alternatives file existed, it has been updated)'
-  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
+  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
   when: ansible_os_family != 'RedHat' or with_alternatives or item != 1
 
 - name: 'check mode (auto: alternatives file didn''t exist, it has been created)'
-  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^auto$"'
+  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^auto$"'
   when: ansible_os_family == 'RedHat' and not with_alternatives and item == 1
 
 - name: check that alternative has been updated

--- a/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -3,7 +3,7 @@
     name: dummy
     path: '/usr/bin/dummy{{ item }}'
     link: /usr/bin/dummy
-    priority: '{{ 60 + item|int }}'
+    priority: '{{ 60 + item|int }}'
   register: alternative
 
 - name: execute dummy command
@@ -11,13 +11,13 @@
   register: cmd
 
 - name: check if link group is in manual mode
-  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
+  shell: 'head -n1 {{ alternatives_dir }}/dummy | grep "^manual$"'
 
 - name: check expected command was executed
   assert:
     that:
       - 'alternative is changed'
-      - 'cmd.stdout == "dummy{{ item }}"'
+      - 'cmd.stdout == "dummy{{ item }}"'
 
 - name: check that alternative has been updated
   command: "grep -Pzq '/bin/dummy{{ item }}\\n{{ 60 + item|int }}' '{{ alternatives_dir }}/dummy'"

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -5,9 +5,9 @@
 ####################################################################
 
 - ansible.builtin.debug:
-    msg: '{{ role_name }}'
+    msg: '{{ role_name }}'
 - ansible.builtin.debug:
-    msg: '{{ role_path|basename }}'
+    msg: '{{ role_path|basename }}'
 - import_tasks: setup.yml
 
 - include_vars: "{{ lookup('first_found', search) }}"

--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -100,7 +100,7 @@
 
 - name: "Install dosfstools and lvm2 (Linux)"
   ansible.builtin.package:
-    name: '{{ item }}'
+    name: '{{ item }}'
   with_items:
     - dosfstools
     - lvm2

--- a/tests/integration/targets/npm/tasks/no_bin_links.yml
+++ b/tests/integration/targets/npm/tasks/no_bin_links.yml
@@ -6,7 +6,7 @@
 
 - vars:
     # sample: node-v8.2.0-linux-x64.tar.xz
-    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
+    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
     package: 'ncp'
   block:
     - shell: npm --version
@@ -20,12 +20,12 @@
     - name: 'Install simple package with no_bin_links disabled'
       npm:
         path: '{{ remote_dir }}'
-        executable: '{{ node_path }}/npm'
+        executable: '{{ node_path }}/npm'
         state: present
         name: '{{ package }}'
         no_bin_links: false
       environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_install_no_bin_links_disabled
 
     - name: 'Make sure .bin folder has been created'
@@ -41,12 +41,12 @@
     - name: 'Install simple package with no_bin_links enabled'
       npm:
         path: '{{ remote_dir }}'
-        executable: '{{ node_path }}/npm'
+        executable: '{{ node_path }}/npm'
         state: present
         name: '{{ package }}'
         no_bin_links: true
       environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_install_no_bin_links_enabled
 
     - name: 'Make sure .bin folder has not been created'

--- a/tests/integration/targets/npm/tasks/test.yml
+++ b/tests/integration/targets/npm/tasks/test.yml
@@ -5,7 +5,7 @@
 
 - vars:
     # sample: node-v8.2.0-linux-x64.tar.xz
-    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
+    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
     package: 'iconv-lite'
   block:
     - shell: npm --version
@@ -19,11 +19,11 @@
     - name: 'Install simple package without dependency'
       npm:
         path: '{{ remote_dir }}'
-        executable: '{{ node_path }}/npm'
+        executable: '{{ node_path }}/npm'
         state: present
         name: '{{ package }}'
       environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_install
 
     - assert:
@@ -38,7 +38,7 @@
         state: present
         name: '{{ package }}'
       environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_reinstall
 
     - name: Check there is no change
@@ -59,7 +59,7 @@
         state: present
         name: '{{ package }}'
       environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_fix_install
 
     - name: Check result is changed and successful

--- a/tests/integration/targets/setup_openldap/tasks/main.yml
+++ b/tests/integration/targets/setup_openldap/tasks/main.yml
@@ -50,8 +50,8 @@
     - name: Copy initial config ldif file
       become: True
       copy:
-        src: 'files/{{ item }}'
-        dest: '/tmp/{{ item }}'
+        src: 'files/{{ item }}'
+        dest: '/tmp/{{ item }}'
         owner: root
         group: root
         mode: '0644'

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -100,7 +100,7 @@
   when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
 - name: Initialize postgres (Debian)
-  shell: . /usr/share/postgresql-common/maintscripts-functions && set_system_locale && /usr/bin/pg_createcluster -u postgres {{ pg_ver }} main
+  shell: . /usr/share/postgresql-common/maintscripts-functions && set_system_locale && /usr/bin/pg_createcluster -u postgres {{ pg_ver }} main
   args:
     creates: /etc/postgresql/{{ pg_ver }}/
   when: ansible_os_family == 'Debian'

--- a/tests/integration/targets/supervisorctl/tasks/install_Linux.yml
+++ b/tests/integration/targets/supervisorctl/tasks/install_Linux.yml
@@ -5,6 +5,6 @@
 
 - name: disable supervisord system service
   service:
-    name: '{{ supervisor_service_name }}'
+    name: '{{ supervisor_service_name }}'
     state: stopped
     enabled: no

--- a/tests/integration/targets/supervisorctl/tasks/main.yml
+++ b/tests/integration/targets/supervisorctl/tasks/main.yml
@@ -21,7 +21,7 @@
           - '{{ ansible_os_family }}.yml'
           - 'defaults.yml'
 
-  - include_tasks: '{{ item }}'
+  - include_tasks: '{{ item }}'
     with_first_found:
       - files:
         - 'install_{{ ansible_distribution }}.yml' # CentOS
@@ -39,7 +39,7 @@
   when: ansible_os_family != 'RedHat' or ansible_distribution_major_version|int > 6
 
   always:
-  - include_tasks: '{{ item }}'
+  - include_tasks: '{{ item }}'
     when: ansible_os_family != 'RedHat' or ansible_distribution_major_version|int > 6
     with_first_found:
       - files:

--- a/tests/integration/targets/supervisorctl/tasks/start_supervisord.yml
+++ b/tests/integration/targets/supervisorctl/tasks/start_supervisord.yml
@@ -1,5 +1,5 @@
 - name: start supervisord
-  command: 'supervisord -c {{ remote_dir }}/supervisord.conf'
+  command: 'supervisord -c {{ remote_dir }}/supervisord.conf'
 
 - name: wait_for supervisord
   ansible.builtin.wait_for:

--- a/tests/integration/targets/supervisorctl/tasks/stop_supervisord.yml
+++ b/tests/integration/targets/supervisorctl/tasks/stop_supervisord.yml
@@ -1,2 +1,2 @@
 - name: stop supervisord
-  command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} shutdown"
+  command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} shutdown"

--- a/tests/integration/targets/supervisorctl/tasks/test.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test.yml
@@ -1,7 +1,7 @@
 - name: generate supervisor configuration
   template:
     src: supervisord.conf
-    dest: '{{ remote_dir }}/supervisord.conf'
+    dest: '{{ remote_dir }}/supervisord.conf'
 
 - block:
     - import_tasks: start_supervisord.yml

--- a/tests/integration/targets/supervisorctl/tasks/test_start.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_start.yml
@@ -2,7 +2,7 @@
   supervisorctl:
     name: 'pys:py1'
     state: started
-    config: '{{ remote_dir }}/supervisord.conf'
+    config: '{{ remote_dir }}/supervisord.conf'
   register: result
   when: credentials.username == ''
 
@@ -16,7 +16,7 @@
   register: result_with_auth
   when: credentials.username != ''
 
-- command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
+- command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
 
 - name: check that service is started
   assert:
@@ -32,7 +32,7 @@
   supervisorctl:
     name: pys:py1
     state: started
-    config: '{{ remote_dir }}/supervisord.conf'
+    config: '{{ remote_dir }}/supervisord.conf'
   register: result
   when: credentials.username == ''
 
@@ -65,7 +65,7 @@
   supervisorctl:
     name: 'pys:py1'
     state: started
-    config: '{{ remote_dir }}/supervisord.conf'
+    config: '{{ remote_dir }}/supervisord.conf'
   register: result
   when: credentials.username == ''
 
@@ -110,7 +110,7 @@
   supervisorctl:
     name: 'pys:py1'
     state: started
-    config: '{{ remote_dir }}/supervisord_not_here.conf'
+    config: '{{ remote_dir }}/supervisord_not_here.conf'
   register: result
   failed_when: result is success or result is not failed
 
@@ -118,7 +118,7 @@
   supervisorctl:
     name: 'invalid'
     state: started
-    config: '{{ remote_dir }}/supervisord.conf'
+    config: '{{ remote_dir }}/supervisord.conf'
   register: result
   failed_when: result is skip or (result is success or result is not failed)
   when: credentials.username == ''
@@ -127,7 +127,7 @@
   supervisorctl:
     name: 'invalid'
     state: started
-    config: '{{ remote_dir }}/supervisord.conf'
+    config: '{{ remote_dir }}/supervisord.conf'
     username: '{{ credentials.username }}wrong_creds'
     password: '{{ credentials.password }}same_here'
   register: result

--- a/tests/integration/targets/supervisorctl/tasks/test_stop.yml
+++ b/tests/integration/targets/supervisorctl/tasks/test_stop.yml
@@ -18,7 +18,7 @@
   register: result_with_auth
   when: credentials.username != ''
 
-- command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
+- command: "supervisorctl -c {{ remote_dir }}/supervisord.conf {% if credentials.username %}-u {{ credentials.username }} -p {{ credentials.password }}{% endif %} status"
 
 - name: check that service is stopped
   assert:

--- a/tests/integration/targets/supervisorctl/templates/supervisord.conf
+++ b/tests/integration/targets/supervisorctl/templates/supervisord.conf
@@ -36,7 +36,7 @@ password = {{ credentials.password }}
 {% endif %}
 
 [supervisorctl]
-serverurl=unix://{{ supervisord_sock_path.path }}/supervisord.sock
+serverurl=unix://{{ supervisord_sock_path.path }}/supervisord.sock
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
##### SUMMARY
While examining the integration tests for hte supervisorctl module I noticed that some of the Jinja expressions had these [NBSP] characters in it - identified by the IDE.

A quick find in the whole repository showed that a number of different files had this character - mostly in Jinja expressions inside integration tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/monitoring/stackdriver.py
tests/integration/targets/alternatives/tasks/main.yml
tests/integration/targets/alternatives/tasks/setup_test.yml
tests/integration/targets/alternatives/tasks/test.yml
tests/integration/targets/alternatives/tasks/tests_set_priority.yml
tests/integration/targets/filesystem/tasks/main.yml
tests/integration/targets/filesystem/tasks/setup.yml
tests/integration/targets/npm/tasks/no_bin_links.yml
tests/integration/targets/npm/tasks/test.yml
tests/integration/targets/setup_openldap/tasks/main.yml
tests/integration/targets/setup_postgresql_db/tasks/main.yml
tests/integration/targets/supervisorctl/tasks/install_Linux.yml
tests/integration/targets/supervisorctl/tasks/main.yml
tests/integration/targets/supervisorctl/tasks/start_supervisord.yml
tests/integration/targets/supervisorctl/tasks/stop_supervisord.yml
tests/integration/targets/supervisorctl/tasks/test.yml
tests/integration/targets/supervisorctl/tasks/test_start.yml
tests/integration/targets/supervisorctl/tasks/test_stop.yml
tests/integration/targets/supervisorctl/templates/supervisord.conf
