### PR TITLE
archive - idempotency enhancement for 4.0.0

### DIFF
--- a/changelogs/fragments/3075-archive-idempotency-enhancements.yml
+++ b/changelogs/fragments/3075-archive-idempotency-enhancements.yml
@@ -1,0 +1,4 @@
+---
+breaking_changes:
+  - archive - adding idempotency checks for changes to file names and content within the ``destination`` file
+    (https://github.com/ansible-collections/community.general/pull/3075).

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -182,6 +182,7 @@ import zipfile
 from fnmatch import fnmatch
 from sys import version_info
 from traceback import format_exc
+from zlib import crc32
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native
@@ -232,10 +233,6 @@ def expand_paths(paths):
             e_paths = [b_path]
         expanded_path.extend(e_paths)
     return expanded_path, is_globby
-
-
-def legacy_filter(path, exclusion_patterns):
-    return matches_exclusion_patterns(path, exclusion_patterns)
 
 
 def matches_exclusion_patterns(path, exclusion_patterns):
@@ -313,6 +310,7 @@ class Archive(object):
         if self.remove:
             self._check_removal_safety()
 
+        self.original_checksums = self.destination_checksums()
         self.original_size = self.destination_size()
 
     def add(self, path, archive_name):
@@ -378,7 +376,15 @@ class Archive(object):
             )
 
     def compare_with_original(self):
-        self.changed |= self.original_size != self.destination_size()
+        if self.original_checksums is None:
+            self.changed |= self.original_size != self.destination_size()
+        else:
+            self.changed |= self.original_checksums != self.destination_checksums()
+
+    def destination_checksums(self):
+        if self.destination_exists() and self.destination_readable():
+            return self._get_checksums(self.destination)
+        return None
 
     def destination_exists(self):
         return self.destination and os.path.exists(self.destination)
@@ -494,6 +500,10 @@ class Archive(object):
     def _add(self, path, archive_name):
         pass
 
+    @abc.abstractmethod
+    def _get_checksums(self, path):
+        pass
+
 
 class ZipArchive(Archive):
     def __init__(self, module):
@@ -513,8 +523,17 @@ class ZipArchive(Archive):
         self.file = zipfile.ZipFile(_to_native_ascii(self.destination), 'w', zipfile.ZIP_DEFLATED, True)
 
     def _add(self, path, archive_name):
-        if not legacy_filter(path, self.exclusion_patterns):
+        if not matches_exclusion_patterns(path, self.exclusion_patterns):
             self.file.write(path, archive_name)
+
+    def _get_checksums(self, path):
+        try:
+            archive = zipfile.ZipFile(_to_native_ascii(path), 'r')
+            checksums = set((info.filename, info.CRC) for info in archive.infolist())
+            archive.close()
+        except zipfile.BadZipfile:
+            checksums = set()
+        return checksums
 
 
 class TarArchive(Archive):
@@ -554,12 +573,34 @@ class TarArchive(Archive):
             return None if matches_exclusion_patterns(tarinfo.name, self.exclusion_patterns) else tarinfo
 
         def py26_filter(path):
-            return legacy_filter(path, self.exclusion_patterns)
+            return matches_exclusion_patterns(path, self.exclusion_patterns)
 
         if PY27:
             self.file.add(path, archive_name, recursive=False, filter=py27_filter)
         else:
             self.file.add(path, archive_name, recursive=False, exclude=py26_filter)
+
+    def _get_checksums(self, path):
+        try:
+            if self.format == 'xz':
+                with lzma.open(_to_native_ascii(path), 'r') as f:
+                    archive = tarfile.open(fileobj=f)
+                    checksums = set((info.name, info.chksum) for info in archive.getmembers())
+                    archive.close()
+            else:
+                archive = tarfile.open(_to_native_ascii(path), 'r|' + self.format)
+                checksums = set((info.name, info.chksum) for info in archive.getmembers())
+                archive.close()
+        except (lzma.LZMAError, tarfile.ReadError, tarfile.CompressionError):
+            try:
+                # The python implementations of gzip, bz2, and lzma do not support restoring compressed files
+                # to their original names so only file checksum is returned
+                f = self._open_compressed_file(_to_native_ascii(path), 'r')
+                checksums = set([(b'', crc32(f.read()))])
+                f.close()
+            except Exception:
+                checksums = set()
+        return checksums
 
 
 def get_archive(module):

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -247,6 +247,20 @@ def strip_prefix(prefix, string):
     return string[len(prefix):] if string.startswith(prefix) else string
 
 
+def tar_checksums(tar):
+    result = []
+    while True:
+        info = tar.next()
+        if info is None:
+            break
+
+        f = tar.extractfile(info)
+
+        result += (info.name, crc32(f.read()) if f is not None else 0)
+
+    return result
+
+
 def _to_bytes(s):
     return to_bytes(s, errors='surrogate_or_strict')
 
@@ -585,11 +599,11 @@ class TarArchive(Archive):
             if self.format == 'xz':
                 with lzma.open(_to_native_ascii(path), 'r') as f:
                     archive = tarfile.open(fileobj=f)
-                    checksums = set((info.name, info.chksum) for info in archive.getmembers())
+                    checksums = set(tar_checksums(archive))
                     archive.close()
             else:
                 archive = tarfile.open(_to_native_ascii(path), 'r|' + self.format)
-                checksums = set((info.name, info.chksum) for info in archive.getmembers())
+                checksums = set(tar_checksums(archive))
                 archive.close()
         except (lzma.LZMAError, tarfile.ReadError, tarfile.CompressionError):
             try:

--- a/plugins/modules/files/archive.py
+++ b/plugins/modules/files/archive.py
@@ -375,11 +375,11 @@ class Archive(object):
                 msg='Errors when writing archive at %s: %s' % (_to_native(self.destination), '; '.join(self.errors))
             )
 
-    def compare_with_original(self):
+    def is_different_from_original(self):
         if self.original_checksums is None:
-            self.changed |= self.original_size != self.destination_size()
+            return self.original_size != self.destination_size()
         else:
-            self.changed |= self.original_checksums != self.destination_checksums()
+            return self.original_checksums != self.destination_checksums()
 
     def destination_checksums(self):
         if self.destination_exists() and self.destination_readable():
@@ -644,7 +644,7 @@ def main():
         else:
             archive.add_targets()
             archive.destination_state = STATE_INCOMPLETE if archive.has_unfound_targets() else STATE_ARCHIVED
-            archive.compare_with_original()
+            archive.changed |= archive.is_different_from_original()
             if archive.remove:
                 archive.remove_targets()
     else:
@@ -654,7 +654,7 @@ def main():
         else:
             path = archive.paths[0]
             archive.add_single_target(path)
-            archive.compare_with_original()
+            archive.changed |= archive.is_different_from_original()
             if archive.remove:
                 archive.remove_single_target(path)
 

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -23,6 +23,8 @@
   assert:
     that:
       - file_content_idempotency_after is changed
+  # Only ``zip`` archives are guaranteed to compare file content checksums rather than header checksums
+  when: "format == 'zip'"
 
 - name: Remove archive - file content idempotency ({{ format }})
   file:
@@ -89,6 +91,8 @@
   assert:
     that:
       - single_file_content_idempotency_after is changed
+  # ``tar`` archives are not guaranteed to identify changes to file content if the file meta properties are unchanged.
+  when: "format != 'tar'"
 
 - name: Remove archive - single file content idempotency ({{ format }})
   file:

--- a/tests/integration/targets/archive/tests/idempotency.yml
+++ b/tests/integration/targets/archive/tests/idempotency.yml
@@ -19,12 +19,10 @@
     format: "{{ format }}"
   register: file_content_idempotency_after
 
-# After idempotency fix result will be reliably changed for all formats
 - name: Assert task status is changed - file content idempotency ({{ format }})
   assert:
     that:
-      - file_content_idempotency_after is not changed
-  when: "format in ('tar', 'zip')"
+      - file_content_idempotency_after is changed
 
 - name: Remove archive - file content idempotency ({{ format }})
   file:
@@ -54,12 +52,10 @@
     format: "{{ format }}"
   register: file_name_idempotency_after
 
-# After idempotency fix result will be reliably changed for all formats
 - name: Check task status - file name idempotency ({{ format }})
   assert:
     that:
-      - file_name_idempotency_after is not changed
-  when: "format in ('tar', 'zip')"
+      - file_name_idempotency_after is changed
 
 - name: Remove archive - file name idempotency ({{ format }})
   file:
@@ -89,12 +85,10 @@
     format: "{{ format }}"
   register: single_file_content_idempotency_after
 
-# After idempotency fix result will be reliably changed for all formats
 - name: Assert task status is changed - single file content idempotency ({{ format }})
   assert:
     that:
-      - single_file_content_idempotency_after is not changed
-  when: "format in ('tar', 'zip')"
+      - single_file_content_idempotency_after is changed
 
 - name: Remove archive - single file content idempotency ({{ format }})
   file:
@@ -125,11 +119,12 @@
   register: single_file_name_idempotency_after
 
 
-# After idempotency fix result will be reliably changed for all formats
+# The gz, bz2, and xz formats do not store the original file name
+# so it is not possible to identify a change in this scenario.
 - name: Check task status - single file name idempotency ({{ format }})
   assert:
     that:
-      - single_file_name_idempotency_after is not changed
+      - single_file_name_idempotency_after is changed
   when: "format in ('tar', 'zip')"
 
 - name: Remove archive - single file name idempotency ({{ format }})


### PR DESCRIPTION
##### SUMMARY
Fixes `archive` to retrieve the existing archived files and checksums if possible and compare against the resulting archive to better identify for changes in content or metadata.

Fixes #1043

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/files/archive.py

##### ADDITIONAL INFORMATION
- Treats the existing archive contents as empty if the existing file is not valid.
- Defaults to a size comparison if the existing file is not readable.
- For single file compression with `gz, bz2, xz` changes to the original file name cannot be detected so idempotency is only based on content in this case.