### PR TITLE
nmcli: Add support for additional Wi-Fi network options

### DIFF
--- a/changelogs/fragments/3081-add-wifi-option-to-nmcli-module.yml
+++ b/changelogs/fragments/3081-add-wifi-option-to-nmcli-module.yml
@@ -1,2 +1,3 @@
 minor_changes:
-- nmcli - add ``wifi`` option to support managing Wi-Fi Settings (I.E. ``hidden`` & ``mode``) (https://github.com/ansible-collections/community.general/pull/3081).
+  - nmcli - add ``wifi`` option to support managing Wi-Fi settings such as ``hidden`` or ``mode``
+    (https://github.com/ansible-collections/community.general/pull/3081).

--- a/changelogs/fragments/3081-add-wifi-option-to-nmcli-module.yml
+++ b/changelogs/fragments/3081-add-wifi-option-to-nmcli-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- nmcli - add ``wifi`` option to support managing Wi-Fi Settings (I.E. ``hidden`` & ``mode``) (https://github.com/ansible-collections/community.general/pull/3081).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Maintaining an `ap` mode or mode other than `infrastructure` wifi connection is not supported with the `nmcli` module. This is because the only arguments currently available for configuring `wifi` type connections are `wifi_sec` and `ssid`. Adding an additional argument, `wifi`, allows all available `802-11-wireless` (A.K.A. `wifi`) options to be managed.

I.E.:
```shell
$ nmcli connection show WLAN | grep '^802-11-wireless\.' | awk '{print $1}' | cut -d: -f1
802-11-wireless.ssid
802-11-wireless.mode
802-11-wireless.band
802-11-wireless.channel
802-11-wireless.bssid
802-11-wireless.rate
802-11-wireless.tx-power
802-11-wireless.mac-address
802-11-wireless.cloned-mac-address
802-11-wireless.generate-mac-address-mask
802-11-wireless.mac-address-blacklist
802-11-wireless.mac-address-randomization
802-11-wireless.mtu
802-11-wireless.seen-bssids
802-11-wireless.hidden
802-11-wireless.powersave
802-11-wireless.wake-on-wlan
802-11-wireless.ap-isolation
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`net_tools/nmcli.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```shell
Before:
> nmcli connection show WLAN | grep '^802-11-wireless\.mode'
802-11-wireless.mode:                   infrastructure
```
```shell
After (using `wifi: { mode: ap }`):
> nmcli connection show WLAN | grep '^802-11-wireless\.mode'
802-11-wireless.mode:                   ap
```
