### PR TITLE
Add opentelemetry callback plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -62,6 +62,9 @@ files:
   $callbacks/nrdp.py:
     maintainers: rverchere
   $callbacks/null.py: {}
+  $callbacks/opentelemetry.py:
+    maintainers: v1v
+    keywords: opentelemetry observability
   $callbacks/say.py:
     notify: chris-short
     maintainers: $team_macos

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -272,7 +272,22 @@ class CallbackModule(CallbackBase):
         else:
             self.tasks_data = OrderedDict()
 
+        if (self.is_otel_exporter_disabled()) :
+            raise_from(
+                AnsibleError('The OTEL endpoint environment variable is not configured.'),
+                None)
+
         self.opentelemetry = OpenTelemetrySource(display=self._display)
+
+    def is_otel_exporter_disabled(self):
+        """
+		verify if the environment variable context was configured to point to an OTEL endpoint
+		Wee https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+		"""
+        return (os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT', None) is None and
+                os.getenv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', None) is None and
+                os.getenv('OTEL_EXPORTER_ZIPKIN_ENDPOINT', None) is None and
+                os.getenv('OTEL_EXPORTER_JAEGER_ENDPOINT', None) is None)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(CallbackModule, self).set_options(task_keys=task_keys,

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -299,7 +299,11 @@ class CallbackModule(CallbackBase):
     def transform_option_to_boolean_or_default(self, option_name, default):
         """ Look for the given option and if a string boolean then convert to a boolean type """
 
-        value = self.get_option(option_name)
+        return self.transform_to_boolean_or_default(self.get_option(option_name), default)
+
+    def transform_to_boolean_or_default(self, value, default):
+        """ Transform string boolean to boolean or apply default value """
+
         if value is None:
             return default
         if isinstance(value, str):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -272,7 +272,7 @@ class CallbackModule(CallbackBase):
         else:
             self.tasks_data = OrderedDict()
 
-        if (self.is_otel_exporter_disabled()) :
+        if (self.is_otel_exporter_disabled()):
             raise_from(
                 AnsibleError('The OTEL endpoint environment variable is not configured.'),
                 None)
@@ -281,9 +281,9 @@ class CallbackModule(CallbackBase):
 
     def is_otel_exporter_disabled(self):
         """
-		verify if the environment variable context was configured to point to an OTEL endpoint
-		Wee https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
-		"""
+        verify if the environment variable context was configured to point to an OTEL endpoint
+        See https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+        """
         return (os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT', None) is None and
                 os.getenv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', None) is None and
                 os.getenv('OTEL_EXPORTER_ZIPKIN_ENDPOINT', None) is None and

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     version_added: 3.5.0
     description:
       - This callback create distributed traces for each Ansible task with OpenTelemetry.
-      - You can configure the OTEL exporter with some environment variables. See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
+      - You can configure the OTEL exporter with environment variables. See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
     options:
       include_setup_tasks:
         default: true
@@ -104,7 +104,7 @@ class OpenTelemetrySource(object):
         self.host = socket.gethostname()
         try:
             self.ip_address = socket.gethostbyname(socket.gethostname())
-        except:
+        except Exception as e:
             self.ip_address = None
         self.user = getpass.getuser()
 
@@ -165,7 +165,7 @@ class OpenTelemetrySource(object):
             if parent_start_time is None:
                 parent_start_time = task.start
             if not include_setup_tasks and task.action == 'setup':
-                ##if task.action in C._ACTION_SETUP:  supported from 2.11.0
+                # if task.action in C._ACTION_SETUP:  supported from 2.11.0
                 continue
             tasks.append(task)
 
@@ -187,11 +187,11 @@ class OpenTelemetrySource(object):
         with tracer.start_as_current_span(ansible_playbook, start_time=parent_start_time) as parent:
             parent.set_status(status)
             # Populate trace metadata attributes
-            if not self.ansible_version is None:
+            if self.ansible_version is not None:
                 parent.set_attribute("ansible.version", self.ansible_version)
             parent.set_attribute("ansible.session", self.session)
             parent.set_attribute("ansible.host.name", self.host)
-            if not self.ip_address is None:
+            if self.ip_address is not None:
                 parent.set_attribute("ansible.host.ip", self.ip_address)
             parent.set_attribute("ansible.host.user", self.user)
             for task in tasks:
@@ -242,7 +242,7 @@ class OpenTelemetrySource(object):
         if span is None:
             self._display.warning('span object is None. Please double check if that is expected.')
         else:
-            if not attributeValue is None:
+            if attributeValue is not None:
                 span.set_attribute(attributeName, attributeValue)
 
 
@@ -423,9 +423,9 @@ class TaskData:
         self.play = play
         self.host_data = OrderedDict()
         if sys.version_info >= (3, 7):
-          self.start = time.time_ns()
+            self.start = time.time_ns()
         else:
-          self.start = _time_ns()
+            self.start = _time_ns()
         self.action = action
         self.args = args
 
@@ -451,6 +451,6 @@ class HostData:
         self.status = status
         self.result = result
         if sys.version_info >= (3, 7):
-          self.finish = time.time_ns()
+            self.finish = time.time_ns()
         else:
-          self.finish = _time_ns()
+            self.finish = _time_ns()

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -20,14 +20,14 @@ DOCUMENTATION = '''
         description:
           - Hide the arguments for a task.
         env:
-          - name: OPENTELEMETRY_HIDE_TASK_ARGUMENTS
+          - name: ANSIBLE_OPENTELEMETRY_HIDE_TASK_ARGUMENTS
       console_output:
         default: false
         type: bool
         description:
           - Print distributed traces in the terminal.
         env:
-          - name: OPENTELEMETRY_CONSOLE_OUTPUT
+          - name: ANSIBLE_OPENTELEMETRY_CONSOLE_OUTPUT
       otel_service_name:
         default: ansible
         type: str
@@ -240,11 +240,11 @@ class CallbackModule(CallbackBase):
     """
     This callback creates distributed traces.
     This plugin makes use of the following environment variables:
-        OPENTELEMETRY_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
+        ANSIBLE_OPENTELEMETRY_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
                                      Default: false
         OTEL_SERVICE_NAME (optional): The service name resource attribute.
                                      Default: ansible
-        OPENTELEMETRY_CONSOLE_OUTPUT (optional): Print distributed traces in the terminal.
+        ANSIBLE_OPENTELEMETRY_CONSOLE_OUTPUT (optional): Print distributed traces in the terminal.
                                      Default: false
     Requires:
         opentelemetry-api

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -1,0 +1,374 @@
+# (C) 2021, Victor Martinez <VictorMartinezRubio@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    author: Victor Martinez (@v1v)  <VictorMartinezRubio@gmail.com>
+    name: opentelemetry
+    type: notification
+    short_description: create distributed traces with OpenTelemetry.
+    version_added: historical
+    description:
+      - This callback create distributed traces for each ansible task with OpenTelemetry.
+    options:
+      include_setup_tasks:
+        name: Include setup tasks
+        default: True
+        description: Should the setup tasks be included in the distributed traces
+        env:
+          - name: INCLUDE_SETUP_TASKS
+      hide_task_arguments:
+        name: Hide the arguments for a task
+        default: False
+        description: Hide the arguments for a task
+        env:
+          - name: HIDE_TASK_ARGUMENTS
+      service_name:
+        name: Set the service name.
+        default: ansible
+        description: Hide the arguments for a task
+        env:
+          - name: OTEL_SERVICE_NAME
+      otel_exporter:
+        name: Use the OTEL exporter and its environment variables. https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
+        default: False
+        description: Use the OTEL exporter and its environment variables. https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
+        env:
+          - name: OTEL_EXPORTER
+      insecure_otel_exporter:
+        name: Use insecure connection.
+        default: False
+        description: Use insecure connection.
+        env:
+          - name: OTEL_EXPORTER_INSECURE
+      span_id:
+        name: A valid span identifier to be used as the parent span.
+        default: None
+        description: A valid span identifier to be used as the parent span.
+        env:
+          - name: SPAN_ID
+      trace_id:
+        name: A valid trace identifier to be used as the parent trace.
+        default: None
+        description: A valid trace identifier to be used as the parent trace.
+        env:
+          - name: TRACE_ID
+    requirements:
+      - opentelemetry-api (python lib)
+      - opentelemetry-exporter-otlp (python lib)
+      - opentelemetry-sdk (python lib)
+'''
+
+import os
+import sys
+import time
+
+from ansible import constants as C
+from ansible.plugins.callback import CallbackBase
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.trace.status import Status, StatusCode
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+        BatchSpanProcessor
+    )
+    from opentelemetry.util._time import _time_ns
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+
+try:
+    from collections import OrderedDict
+    HAS_ORDERED_DICT = True
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+        HAS_ORDERED_DICT = True
+    except ImportError:
+        HAS_ORDERED_DICT = False
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback creates distributed traces.
+    This plugin makes use of the following environment variables:
+        SPAN_ID (optional): A valid span identifier to be used as the parent span.
+        TRACE_ID (optional): A valid trace identifier to be used as the parent trace.
+        INCLUDE_SETUP_TASKS (optional): Should the setup tasks be includedt
+                                     Default: True
+        HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
+                                     Default: False
+        OTEL_SERVICE_NAME (optional): The service name
+                                     Default: ansible
+        OTEL_EXPORTER (optional): Use the OTEL exporter and its environment variables. https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
+                                     Default: False
+        OTEL_EXPORTER_INSECURE (optional): Insecure connection
+                                     Default: False
+    Requires:
+        opentelemetry-api
+        opentelemetry-exporter-otlp
+        opentelemetry-sdk
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'community.general.opentelemetry'
+    CALLBACK_NEEDS_ENABLED = True
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+        self._include_setup_tasks = os.getenv('INCLUDE_SETUP_TASKS', 'True').lower()
+        self._hide_task_arguments = os.getenv('HIDE_TASK_ARGUMENTS', 'False').lower()
+        self._service = os.getenv('OTEL_SERVICE_NAME', 'ansible').lower()
+        self._otel_exporter = os.getenv('OTEL_EXPORTER', 'False').lower() == 'true'
+        self._insecure_otel_exporter = os.getenv('OTEL_EXPORTER_INSECURE', 'False').lower() == 'true'
+        self._span_id = os.getenv('SPAN_ID', None)
+        self._trace_id = os.getenv('TRACE_ID', None)
+        self._playbook_path = None
+        self._playbook_name = None
+        self._play_name = None
+        self._task_data = None
+        self.errors = 0
+        self.disabled = False
+
+        if not HAS_OTEL:
+            self.disabled = True
+            self._display.warning('The `opentelemetry-api`, `opentelemetry-exporter-otlp` or `opentelemetry-sdk` python modules are not installed. '
+                                  'Disabling the `opentelemetry` callback plugin.')
+
+        if not self._otel_exporter:
+            self.disabled = True
+            self._display.warning('The `OTEL_EXPORTER` has been set to False.'
+                                  'Disabling the `opentelemetry` callback plugin.')
+
+        if HAS_ORDERED_DICT:
+            self._task_data = OrderedDict()
+        else:
+            self.disabled = True
+            self._display.warning('The `ordereddict` python module is not installed. '
+                                  'Disabling the `opentelemetry` callback plugin.')
+
+        if not self._span_id is None:
+            self._display.warning('The `span_id` has not been implemented yet.')
+
+        if not self._trace_id is None:
+            self._display.warning('The `trace_id` has not been implemented yet.')
+
+
+    def _start_task(self, task):
+        """ record the start of a task for one or more hosts """
+
+        uuid = task._uuid
+
+        if uuid in self._task_data:
+            return
+
+        play = self._play_name
+        name = task.get_name().strip()
+        path = task.get_path()
+        action = task.action
+        args = None
+
+        if not task.no_log and self._hide_task_arguments == 'false':
+            args = ', '.join(('%s=%s' % a for a in task.args.items()))
+
+        self._task_data[uuid] = TaskData(uuid, name, path, play, action, args)
+
+    def _finish_task(self, status, result):
+        """ record the results of a task for a single host """
+
+        task_uuid = result._task._uuid
+
+        if hasattr(result, '_host'):
+            host_uuid = result._host._uuid
+            host_name = result._host.name
+        else:
+            host_uuid = 'include'
+            host_name = 'include'
+
+        task_data = self._task_data[task_uuid]
+
+        # ignore failure if expected and toggle result if asked for
+        if status == 'failed' and 'EXPECTED FAILURE' in task_data.name:
+            status = 'ok'
+        elif 'TOGGLE RESULT' in task_data.name:
+            if status == 'failed':
+                status = 'ok'
+            elif status == 'ok':
+                status = 'failed'
+
+        task_data.add_host(HostData(host_uuid, host_name, status, result))
+
+    def _update_span_data(self, task_data, host_data, span):
+        """ update the span with the given TaskData and HostData """
+
+        name = '[%s] %s: %s' % (host_data.name, task_data.play, task_data.name)
+
+        message = "success"
+        status = Status(status_code=StatusCode.OK)
+        if host_data.status == 'included':
+            rc = 0
+        else:
+            res = host_data.result._result
+            rc = res.get('rc', 0)
+            if host_data.status == 'failed':
+                if 'exception' in res:
+                    message = res['exception'].strip().split('\n')[-1]
+                elif 'msg' in res:
+                    message = res['msg']
+                else:
+                    message = 'failed'
+                status = Status(status_code=StatusCode.ERROR)
+            elif host_data.status == 'skipped':
+                if 'skip_reason' in res:
+                    message = res['skip_reason']
+                else:
+                    message = 'skipped'
+                status = Status(status_code=StatusCode.UNSET)
+
+        span.set_status(status)
+        self._set_span_attribute(span, "ansible.task.args", task_data.args)
+        self._set_span_attribute(span, "ansible.task.module", task_data.action)
+        self._set_span_attribute(span, "ansible.task.message", message)
+        self._set_span_attribute(span, "ansible.task.name", name)
+        self._set_span_attribute(span, "ansible.task.result", rc)
+        self._set_span_attribute(span, "ansible.task.host.name", host_data.name)
+        self._set_span_attribute(span, "ansible.task.host.status", host_data.status)
+        span.end(end_time=host_data.finish)
+
+    def _set_span_attribute(self, span, attributeName, attributeValue):
+        """ update the span attribute with the given attribute and value if not None """
+
+        if span is None:
+            self._display.warning('span object is None. Please double check if that is expected.')
+        else:
+            if not attributeValue is None:
+                span.set_attribute(attributeName, attributeValue)
+
+    def _generate_distributed_traces(self, status):
+        """ generate distributed traces from the collected TaskData and HostData """
+
+        tasks = []
+        parent_start_time = None
+        for task_uuid, task_data in self._task_data.items():
+            if parent_start_time is None:
+                parent_start_time = task_data.start
+            if self._include_setup_tasks == 'false' and task_data.action == 'setup':
+                ##if task_data.action in C._ACTION_SETUP:  supported from 2.11.0
+                continue
+            tasks.append(task_data)
+
+        trace.set_tracer_provider(
+            TracerProvider(
+                resource=Resource.create({SERVICE_NAME: self._service})
+            )
+        )
+        processor = SimpleSpanProcessor(ConsoleSpanExporter())
+
+        if self._otel_exporter:
+            processor = BatchSpanProcessor(OTLPSpanExporter(insecure=self._insecure_otel_exporter))
+
+        trace.get_tracer_provider().add_span_processor(processor)
+
+        tracer = trace.get_tracer(__name__)
+
+        with tracer.start_as_current_span(self._playbook_name, start_time=parent_start_time) as parent:
+            parent.set_status(status)
+            for task_data in tasks:
+                for host_uuid, host_data in task_data.host_data.items():
+                    with tracer.start_as_current_span(task_data.name, start_time=task_data.start, end_on_exit=False) as span:
+                        self._update_span_data(task_data, host_data, span)
+
+    def v2_playbook_on_start(self, playbook):
+        self._playbook_path = playbook._file_name
+        self._playbook_name = os.path.splitext(os.path.basename(self._playbook_path))[0]
+
+    def v2_playbook_on_play_start(self, play):
+        self._play_name = play.get_name()
+
+    def v2_runner_on_no_hosts(self, task):
+        self._start_task(task)
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self._start_task(task)
+
+    def v2_playbook_on_cleanup_task_start(self, task):
+        self._start_task(task)
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self._start_task(task)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self.errors += 1
+        self._finish_task('failed', result)
+
+    def v2_runner_on_ok(self, result):
+        self._finish_task('ok', result)
+
+    def v2_runner_on_skipped(self, result):
+        self._finish_task('skipped', result)
+
+    def v2_playbook_on_include(self, included_file):
+        self._finish_task('included', included_file)
+
+    def v2_playbook_on_stats(self, stats):
+        if self.errors == 0:
+            status = Status(status_code=StatusCode.OK)
+        else:
+            status = Status(status_code=StatusCode.ERROR)
+        self._generate_distributed_traces(status)
+
+    def v2_runner_on_async_failed(self, result, **kwargs):
+        self.errors += 1
+
+class TaskData:
+    """
+    Data about an individual task.
+    """
+
+    def __init__(self, uuid, name, path, play, action, args):
+        self.uuid = uuid
+        self.name = name
+        self.path = path
+        self.play = play
+        self.host_data = OrderedDict()
+        if sys.version_info >= (3, 7):
+          self.start = time.time_ns()
+        else:
+          self.start = _time_ns()
+        self.action = action
+        self.args = args
+
+    def add_host(self, host):
+        if host.uuid in self.host_data:
+            if host.status == 'included':
+                # concatenate task include output from multiple items
+                host.result = '%s\n%s' % (self.host_data[host.uuid].result, host.result)
+            else:
+                return
+
+        self.host_data[host.uuid] = host
+
+
+class HostData:
+    """
+    Data about an individual host.
+    """
+
+    def __init__(self, uuid, name, status, result):
+        self.uuid = uuid
+        self.name = name
+        self.status = status
+        self.result = result
+        if sys.version_info >= (3, 7):
+          self.finish = time.time_ns()
+        else:
+          self.finish = _time_ns()

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
     short_description: Create distributed traces with OpenTelemetry
     version_added: 3.7.0
     description:
-      - This callback create distributed traces for each Ansible task with OpenTelemetry.
+      - This callback creates distributed traces for each Ansible task with OpenTelemetry.
       - You can configure the OpenTelemetry exporter and SDK with environment variables.
       - See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
       - See U(https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry-sdk-environment-variables).
@@ -39,9 +39,9 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 examples: |
-  Whitelist the plugin in ansible.cfg:
+  Enable the plugin in ansible.cfg:
     [defaults]
-    callback_whitelist = community.general.opentelemetry
+    callbacks_enabled = community.general.opentelemetry
 
   Set the environment variable:
     export OTEL_EXPORTER_OTLP_ENDPOINT=<your endpoint (OTLP/HTTP)>
@@ -58,7 +58,6 @@ import uuid
 
 from os.path import basename
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import raise_from
 from ansible.plugins.callback import CallbackBase
@@ -272,7 +271,7 @@ class CallbackModule(CallbackBase):
 
         self.otel_service_name = self.get_option('otel_service_name')
 
-        if self.otel_service_name is None:
+        if not self.otel_service_name:
             self.otel_service_name = 'ansible'
 
         # See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -272,22 +272,7 @@ class CallbackModule(CallbackBase):
         else:
             self.tasks_data = OrderedDict()
 
-        if (self.is_otel_exporter_disabled()) :
-            raise_from(
-                AnsibleError('The OTEL endpoint environment variable is not configured.'),
-                None)
-
         self.opentelemetry = OpenTelemetrySource(display=self._display)
-
-    def is_otel_exporter_disabled(self):
-        """
-		verify if the environment variable context was configured to point to an OTEL endpoint
-		Wee https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
-		"""
-        return (os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT', None) is None and
-                os.getenv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', None) is None and
-                os.getenv('OTEL_EXPORTER_ZIPKIN_ENDPOINT', None) is None and
-                os.getenv('OTEL_EXPORTER_JAEGER_ENDPOINT', None) is None)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(CallbackModule, self).set_options(task_keys=task_keys,

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -97,6 +97,7 @@ except ImportError:
 else:
     ORDER_LIBRARY_IMPORT_ERROR = None
 
+
 class OpenTelemetrySource(object):
     def __init__(self, display):
         self.ansible_playbook = ""

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -12,7 +12,9 @@ DOCUMENTATION = '''
     version_added: 3.7.0
     description:
       - This callback create distributed traces for each Ansible task with OpenTelemetry.
-      - You can configure the OTEL exporter with environment variables. See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
+      - You can configure the OpenTelemetry exporter and SDL with environment variables.
+      - See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
+      - See U(https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry-sdk-environment-variables).
     options:
       hide_task_arguments:
         default: false
@@ -239,17 +241,6 @@ class OpenTelemetrySource(object):
 class CallbackModule(CallbackBase):
     """
     This callback creates distributed traces.
-    This plugin makes use of the following environment variables:
-        ANSIBLE_OPENTELEMETRY_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
-                                     Default: false
-        OTEL_SERVICE_NAME (optional): The service name resource attribute.
-                                     Default: ansible
-        ANSIBLE_OPENTELEMETRY_CONSOLE_OUTPUT (optional): Print distributed traces in the terminal.
-                                     Default: false
-    Requires:
-        opentelemetry-api
-        opentelemetry-exporter-otlp
-        opentelemetry-sdk
     """
 
     CALLBACK_VERSION = 2.0

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -142,15 +142,6 @@ class OpenTelemetrySource(object):
         if self.ansible_version is None and result._task_fields['args'].get('_ansible_version'):
             self.ansible_version = result._task_fields['args'].get('_ansible_version')
 
-        # ignore failure if expected and toggle result if asked for
-        if status == 'failed' and 'EXPECTED FAILURE' in task.name:
-            status = 'ok'
-        elif 'TOGGLE RESULT' in task.name:
-            if status == 'failed':
-                status = 'ok'
-            elif status == 'ok':
-                status = 'failed'
-
         task.add_host(HostData(host_uuid, host_name, status, result))
 
     def generate_distributed_traces(self, insecure_otel_exporter, otel_service_name, console_output, ansible_playbook, tasks_data, status):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -8,14 +8,14 @@ DOCUMENTATION = '''
     author: Victor Martinez (@v1v)  <VictorMartinezRubio@gmail.com>
     name: opentelemetry
     type: notification
-    short_description: create distributed traces with OpenTelemetry.
-    version_added: historical
+    short_description: Create distributed traces with OpenTelemetry
+    version_added: 3.5.0
     description:
-      - This callback create distributed traces for each ansible task with OpenTelemetry.
+      - This callback create distributed traces for each Ansible task with OpenTelemetry.
     options:
       include_setup_tasks:
         name: Include setup tasks
-        default: True
+        default: true
         description: Should the setup tasks be included in the distributed traces
         env:
           - name: INCLUDE_SETUP_TASKS

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -133,7 +133,7 @@ class OpenTelemetrySource(object):
 
         task_uuid = result._task._uuid
 
-        if hasattr(result, '_host'):
+        if hasattr(result, '_host') and result._host is not None:
             host_uuid = result._host._uuid
             host_name = result._host.name
         else:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -274,33 +274,19 @@ class CallbackModule(CallbackBase):
 
         self.opentelemetry = OpenTelemetrySource(display=self._display)
 
-    def transform_option_to_boolean_or_default(self, option_name, default):
-        """ Look for the given option and if a string boolean then convert to a boolean type """
-
-        return self.transform_to_boolean_or_default(self.get_option(option_name), default)
-
-    def transform_to_boolean_or_default(self, value, default):
-        """ Transform string boolean to boolean or apply default value """
-
-        if value is None:
-            return default
-        if isinstance(value, str):
-            return value.lower() in ['true']
-        return value
-
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super(CallbackModule, self).set_options(task_keys=task_keys,
                                                 var_options=var_options,
                                                 direct=direct)
 
-        self.hide_task_arguments = self.transform_option_to_boolean_or_default('hide_task_arguments', False)
+        self.hide_task_arguments = self.get_option('hide_task_arguments')
 
         self.otel_service_name = self.get_option('otel_service_name')
 
         if self.otel_service_name is None:
             self.otel_service_name = 'ansible'
 
-        self.console_output = self.transform_option_to_boolean_or_default('console_output', False)
+        self.console_output = self.get_option('console_output')
 
         # See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
         self.insecure_otel_exporter = os.getenv('OTEL_EXPORTER_OTLP_INSECURE', 'false').lower() == 'true'

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -272,7 +272,7 @@ class CallbackModule(CallbackBase):
         else:
             self.tasks_data = OrderedDict()
 
-        if (self.is_otel_exporter_disabled()):
+        if (self.is_otel_exporter_disabled()) :
             raise_from(
                 AnsibleError('The OTEL endpoint environment variable is not configured.'),
                 None)
@@ -281,9 +281,9 @@ class CallbackModule(CallbackBase):
 
     def is_otel_exporter_disabled(self):
         """
-        verify if the environment variable context was configured to point to an OTEL endpoint
-        See https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
-        """
+		verify if the environment variable context was configured to point to an OTEL endpoint
+		Wee https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+		"""
         return (os.getenv('OTEL_EXPORTER_OTLP_ENDPOINT', None) is None and
                 os.getenv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', None) is None and
                 os.getenv('OTEL_EXPORTER_ZIPKIN_ENDPOINT', None) is None and

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     version_added: 3.7.0
     description:
       - This callback create distributed traces for each Ansible task with OpenTelemetry.
-      - You can configure the OpenTelemetry exporter and SDL with environment variables.
+      - You can configure the OpenTelemetry exporter and SDK with environment variables.
       - See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
       - See U(https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry-sdk-environment-variables).
     options:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -239,7 +239,7 @@ class OpenTelemetrySource(object):
     def set_span_attribute(self, span, attributeName, attributeValue):
         """ update the span attribute with the given attribute and value if not None """
 
-        if span is None:
+        if span is None and self._display is not None:
             self._display.warning('span object is None. Please double check if that is expected.')
         else:
             if attributeValue is not None:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -43,17 +43,6 @@ DOCUMENTATION = '''
           - Use insecure connection.
         env:
           - name: OTEL_EXPORTER_INSECURE
-      span_id:
-        default: None
-        description:
-          - A valid span identifier to be used as the parent span.
-        env:
-          - name: SPAN_ID
-      trace_id:
-        default: None
-        description: A valid trace identifier to be used as the parent trace.
-        env:
-          - name: TRACE_ID
     requirements:
       - opentelemetry-api (python lib)
       - opentelemetry-exporter-otlp (python lib)
@@ -98,8 +87,6 @@ class CallbackModule(CallbackBase):
     """
     This callback creates distributed traces.
     This plugin makes use of the following environment variables:
-        SPAN_ID (optional): A valid span identifier to be used as the parent span.
-        TRACE_ID (optional): A valid trace identifier to be used as the parent trace.
         OPENTELEMETRY_INCLUDE_SETUP_TASKS (optional): Should the setup tasks be included
                                      Default: true
         OPENTELEMETRY_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
@@ -129,8 +116,6 @@ class CallbackModule(CallbackBase):
         self._service = os.getenv('OTEL_SERVICE_NAME', 'ansible').lower()
         self._otel_exporter = os.getenv('OTEL_EXPORTER', 'false').lower() == 'true'
         self._insecure_otel_exporter = os.getenv('OTEL_EXPORTER_INSECURE', 'false').lower() == 'true'
-        self._span_id = os.getenv('SPAN_ID', None)
-        self._trace_id = os.getenv('TRACE_ID', None)
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -154,12 +139,6 @@ class CallbackModule(CallbackBase):
             self.disabled = True
             self._display.warning('The `ordereddict` python module is not installed. '
                                   'Disabling the `opentelemetry` callback plugin.')
-
-        if not self._span_id is None:
-            self._display.warning('The `span_id` has not been implemented yet.')
-
-        if not self._trace_id is None:
-            self._display.warning('The `trace_id` has not been implemented yet.')
 
 
     def _start_task(self, task):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -16,19 +16,21 @@ DOCUMENTATION = '''
     options:
       hide_task_arguments:
         default: false
-        type: boolean
+        type: bool
         description:
           - Hide the arguments for a task.
         env:
           - name: OPENTELEMETRY_HIDE_TASK_ARGUMENTS
       console_output:
         default: false
+        type: bool
         description:
           - Print distributed traces in the terminal.
         env:
           - name: OPENTELEMETRY_CONSOLE_OUTPUT
       otel_service_name:
         default: ansible
+        type: str
         description:
           - The service name resource attribute.
         env:
@@ -246,8 +248,8 @@ class CallbackModule(CallbackBase):
                                      Default: false
         OTEL_SERVICE_NAME (optional): The service name resource attribute.
                                      Default: ansible
-        OTEL_CONSOLE_OUTPUT (optional): Print distributed traces in the terminal.
-                                     Default: true
+        OPENTELEMETRY_CONSOLE_OUTPUT (optional): Print distributed traces in the terminal.
+                                     Default: false
     Requires:
         opentelemetry-api
         opentelemetry-exporter-otlp

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -241,8 +241,6 @@ class CallbackModule(CallbackBase):
     """
     This callback creates distributed traces.
     This plugin makes use of the following environment variables:
-        OPENTELEMETRY_INCLUDE_SETUP_TASKS (optional): Should the setup tasks be included in the distributed traces
-                                     Default: true
         OPENTELEMETRY_HIDE_TASK_ARGUMENTS (optional): Hide the arguments for a task
                                      Default: false
         OTEL_SERVICE_NAME (optional): The service name resource attribute.

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -9,13 +9,14 @@ DOCUMENTATION = '''
     name: opentelemetry
     type: notification
     short_description: Create distributed traces with OpenTelemetry
-    version_added: 2.5.0
+    version_added: 3.7.0
     description:
       - This callback create distributed traces for each Ansible task with OpenTelemetry.
       - You can configure the OTEL exporter with environment variables. See U(https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html).
     options:
       hide_task_arguments:
         default: false
+        type: boolean
         description:
           - Hide the arguments for a task.
         env:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -92,6 +92,51 @@ else:
     ORDER_LIBRARY_IMPORT_ERROR = None
 
 
+class TaskData:
+    """
+    Data about an individual task.
+    """
+
+    def __init__(self, uuid, name, path, play, action, args):
+        self.uuid = uuid
+        self.name = name
+        self.path = path
+        self.play = play
+        self.host_data = OrderedDict()
+        if sys.version_info >= (3, 7):
+            self.start = time.time_ns()
+        else:
+            self.start = _time_ns()
+        self.action = action
+        self.args = args
+
+    def add_host(self, host):
+        if host.uuid in self.host_data:
+            if host.status == 'included':
+                # concatenate task include output from multiple items
+                host.result = '%s\n%s' % (self.host_data[host.uuid].result, host.result)
+            else:
+                return
+
+        self.host_data[host.uuid] = host
+
+
+class HostData:
+    """
+    Data about an individual host.
+    """
+
+    def __init__(self, uuid, name, status, result):
+        self.uuid = uuid
+        self.name = name
+        self.status = status
+        self.result = result
+        if sys.version_info >= (3, 7):
+            self.finish = time.time_ns()
+        else:
+            self.finish = _time_ns()
+
+
 class OpenTelemetrySource(object):
     def __init__(self, display):
         self.ansible_playbook = ""
@@ -354,48 +399,3 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_async_failed(self, result, **kwargs):
         self.errors += 1
-
-
-class TaskData:
-    """
-    Data about an individual task.
-    """
-
-    def __init__(self, uuid, name, path, play, action, args):
-        self.uuid = uuid
-        self.name = name
-        self.path = path
-        self.play = play
-        self.host_data = OrderedDict()
-        if sys.version_info >= (3, 7):
-            self.start = time.time_ns()
-        else:
-            self.start = _time_ns()
-        self.action = action
-        self.args = args
-
-    def add_host(self, host):
-        if host.uuid in self.host_data:
-            if host.status == 'included':
-                # concatenate task include output from multiple items
-                host.result = '%s\n%s' % (self.host_data[host.uuid].result, host.result)
-            else:
-                return
-
-        self.host_data[host.uuid] = host
-
-
-class HostData:
-    """
-    Data about an individual host.
-    """
-
-    def __init__(self, uuid, name, status, result):
-        self.uuid = uuid
-        self.name = name
-        self.status = status
-        self.result = result
-        if sys.version_info >= (3, 7):
-            self.finish = time.time_ns()
-        else:
-            self.finish = _time_ns()

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -10,16 +10,21 @@ from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock, Mock
 from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, CallbackModule
 from collections import OrderedDict
-from datetime import datetime
+import sys
+
+OPENTELEMETRY_MINIMUM_PYTHON_VERSION = (3, 7)
 
 
 class TestOpentelemetry(unittest.TestCase):
-    @patch('ansible_collections.community.general.plugins.callback.opentelemetry._time_ns')
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
-    def setUp(self, mock_socket, mock__time_ns):
+    def setUp(self, mock_socket):
+        # TODO: this python version validation won't be needed as long as the _time_ns call is mocked.
+        if sys.version_info < OPENTELEMETRY_MINIMUM_PYTHON_VERSION:
+            self.skipTest("Python %s+ is needed for OpenTelemetry" %
+                          ",".join(map(str, OPENTELEMETRY_MINIMUM_PYTHON_VERSION)))
+
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
-        mock__time_ns.return_value = datetime(2020, 12, 1)
         self.opentelemetry = OpenTelemetrySource(display=None)
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -8,9 +8,7 @@ from ansible.playbook.task import Task
 from ansible.executor.task_result import TaskResult
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock, Mock
-from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData
-from datetime import datetime
-
+from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, CallbackModule
 from collections import OrderedDict
 
 
@@ -85,4 +83,19 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(host_data.uuid, 'include')
         self.assertEqual(host_data.name, 'include')
         self.assertEqual(host_data.status, 'ok')
+
+    def test_transform_to_boolean_or_default(self):
+        callbackModule = CallbackModule()
+
+        result = callbackModule.transform_to_boolean_or_default(None, False)
+        self.assertFalse(result)
+
+        result = callbackModule.transform_to_boolean_or_default('', False)
+        self.assertFalse(result)
+
+        result = callbackModule.transform_to_boolean_or_default('true', False)
+        self.assertTrue(result)
+
+        result = callbackModule.transform_to_boolean_or_default('false', True)
+        self.assertFalse(result)
 

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -98,4 +98,3 @@ class TestOpentelemetry(unittest.TestCase):
 
         result = callbackModule.transform_to_boolean_or_default('false', True)
         self.assertFalse(result)
-

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -31,6 +31,7 @@ class TestOpentelemetry(unittest.TestCase):
         self.mock_task.get_name = MagicMock(return_value='mytask')
         self.mock_task.get_path = MagicMock(return_value='/mypath')
         self.my_task = TaskData('myuuid', 'mytask', '/mypath', 'myplay', 'myaction', '')
+        self.my_task_result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
 
     def test_start_task(self):
         tasks_data = OrderedDict()
@@ -51,14 +52,13 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(task_data.args, '')
 
     def test_finish_task_with_a_host_match(self):
-        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
         tasks_data = OrderedDict()
         tasks_data['myuuid'] = self.my_task
 
         self.opentelemetry.finish_task(
             tasks_data,
             'ok',
-            result
+            self.my_task_result
         )
 
         task_data = tasks_data['myuuid']

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -10,13 +10,16 @@ from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock, Mock
 from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, CallbackModule
 from collections import OrderedDict
+from datetime import datetime
 
 
 class TestOpentelemetry(unittest.TestCase):
+    @patch('ansible_collections.community.general.plugins.callback.opentelemetry._time_ns')
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
-    def setUp(self, mock_socket):
+    def setUp(self, mock_socket, mock__time_ns):
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
+        mock__time_ns.return_value = datetime(2020, 12, 1)
         self.opentelemetry = OpenTelemetrySource(display=None)
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -6,7 +6,7 @@ __metaclass__ = type
 
 from ansible.executor.task_result import TaskResult
 from ansible_collections.community.general.tests.unit.compat import unittest
-from ansible_collections.community.general.tests.unit.compat.mock import patch, call, MagicMock, Mock
+from ansible_collections.community.general.tests.unit.compat.mock import patch, Mock
 from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource
 from datetime import datetime
 
@@ -16,24 +16,24 @@ from collections import OrderedDict
 
 
 class TestOpentelemetry(unittest.TestCase):
+    @patch('ansible_collections.community.general.plugins.callback.opentelemetry.play')
+    @patch('ansible_collections.community.general.plugins.callback.opentelemetry.task')
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
-    def setUp(self, mock_socket):
+    def setUp(self, mock_socket, mock_task, mock_play):
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
+        mock_task.get_name.return_value = 'mytask'
+        mock_task.get_path.return_value = 'mypath'
+        mock_task.action = 'myaction'
+        mock_task.no_log = False
+        mock_task._role = 'myrole'
+        mock_task._uuid = 'myuuid'
+        mock_task.args = {}
+        mock_play.get_name.return_value = 'myplay'
         self.opentelemetry = OpenTelemetrySource(display=None)
-        self.mock_task = Mock('MockTask')
-        self.mock_task.get_name.return_value = 'mytask'
-        self.mock_task.get_path.return_value = 'mypath'
-        self.mock_task.action = 'myaction'
-        self.mock_task.no_log = False
-        self.mock_task._role = 'myrole'
-        self.mock_task._uuid = 'myuuid'
-        self.mock_task.args = {}
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')
         self.mock_host.name = 'myhost'
-        self.mock_play = Mock('MockPlay')
-        self.mock_play.get_name.return_value = 'myplay'
 
     def test_start_task(self):
         result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -14,6 +14,7 @@ import json
 
 from collections import OrderedDict
 
+
 class TestOpentelemetry(unittest.TestCase):
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
     def setUp(self, mock_socket):
@@ -46,4 +47,3 @@ class TestOpentelemetry(unittest.TestCase):
         )
 
         tasks_data['myuuid'].uuid = 'myuuid'
-

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -1,0 +1,49 @@
+# (C) 2021, Victor Martinez <VictorMartinezRubio@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.executor.task_result import TaskResult
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import patch, call, MagicMock, Mock
+from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource
+from datetime import datetime
+
+import json
+
+from collections import OrderedDict
+
+class TestOpentelemetry(unittest.TestCase):
+    @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
+    def setUp(self, mock_socket):
+        mock_socket.gethostname.return_value = 'my-host'
+        mock_socket.gethostbyname.return_value = '1.2.3.4'
+        self.opentelemetry = OpenTelemetrySource()
+        self.mock_task = Mock('MockTask')
+        self.mock_task.get_name.return_value = 'mytask'
+        self.mock_task.get_path.return_value = 'mypath'
+        self.mock_task.action = 'myaction'
+        self.mock_task.no_log = False
+        self.mock_task._role = 'myrole'
+        self.mock_task._uuid = 'myuuid'
+        self.mock_task.args = {}
+        self.task_fields = {'args': {}}
+        self.mock_host = Mock('MockHost')
+        self.mock_host.name = 'myhost'
+        self.mock_play = Mock('MockPlay')
+        self.mock_play.get_name.return_value = 'myplay'
+
+    def test_start_task(self):
+        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
+        tasks_data = OrderedDict()
+
+        self.opentelemetry.start_task(
+            tasks_data,
+            False,
+            'myplay',
+            self.mock_task
+        )
+
+        tasks_data['myuuid'].uuid = 'myuuid'
+

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -4,10 +4,11 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.playbook.task import Task
 from ansible.executor.task_result import TaskResult
 from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock, Mock
-from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource
+from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData
 from datetime import datetime
 
 from collections import OrderedDict
@@ -15,26 +16,25 @@ from collections import OrderedDict
 
 class TestOpentelemetry(unittest.TestCase):
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
-    def setUp(self, mock_socket, mock_task, mock_play):
+    def setUp(self, mock_socket):
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
         self.opentelemetry = OpenTelemetrySource(display=None)
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')
         self.mock_host.name = 'myhost'
-        self.mock_task = MagicMock('MockHost')
-        self.mock_task.get_name.return_value = 'mytask'
-        self.mock_task.get_path.return_value = 'mypath'
+        self.mock_host._uuid = 'myhost_uuid'
+        self.mock_task = Task()
         self.mock_task.action = 'myaction'
         self.mock_task.no_log = False
         self.mock_task._role = 'myrole'
         self.mock_task._uuid = 'myuuid'
         self.mock_task.args = {}
-        self.mock_play = MagicMock('MockPlay')
-        self.mock_play.get_name.return_value = 'myplay'
+        self.mock_task.get_name = MagicMock(return_value='mytask')
+        self.mock_task.get_path = MagicMock(return_value='/mypath')
+        self.my_task = TaskData('myuuid', 'mytask', '/mypath', 'myplay', 'myaction', '')
 
     def test_start_task(self):
-        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
         tasks_data = OrderedDict()
 
         self.opentelemetry.start_task(
@@ -44,4 +44,45 @@ class TestOpentelemetry(unittest.TestCase):
             self.mock_task
         )
 
-        tasks_data['myuuid'].uuid = 'myuuid'
+        task_data = tasks_data['myuuid']
+        self.assertEqual(task_data.uuid, 'myuuid')
+        self.assertEqual(task_data.name, 'mytask')
+        self.assertEqual(task_data.path, '/mypath')
+        self.assertEqual(task_data.play, 'myplay')
+        self.assertEqual(task_data.action, 'myaction')
+        self.assertEqual(task_data.args, '')
+
+    def test_finish_task_with_a_host_match(self):
+        result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)
+        tasks_data = OrderedDict()
+        tasks_data['myuuid'] = self.my_task
+
+        self.opentelemetry.finish_task(
+            tasks_data,
+            'ok',
+            result
+        )
+
+        task_data = tasks_data['myuuid']
+        host_data = task_data.host_data['myhost_uuid']
+        self.assertEqual(host_data.uuid, 'myhost_uuid')
+        self.assertEqual(host_data.name, 'myhost')
+        self.assertEqual(host_data.status, 'ok')
+
+    def test_finish_task_without_a_host_match(self):
+        result = TaskResult(host=None, task=self.mock_task, return_data={}, task_fields=self.task_fields)
+        tasks_data = OrderedDict()
+        tasks_data['myuuid'] = self.my_task
+
+        self.opentelemetry.finish_task(
+            tasks_data,
+            'ok',
+            result
+        )
+
+        task_data = tasks_data['myuuid']
+        host_data = task_data.host_data['include']
+        self.assertEqual(host_data.uuid, 'include')
+        self.assertEqual(host_data.name, 'include')
+        self.assertEqual(host_data.status, 'ok')
+

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -91,18 +91,3 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(host_data.uuid, 'include')
         self.assertEqual(host_data.name, 'include')
         self.assertEqual(host_data.status, 'ok')
-
-    def test_transform_to_boolean_or_default(self):
-        callbackModule = CallbackModule()
-
-        result = callbackModule.transform_to_boolean_or_default(None, False)
-        self.assertFalse(result)
-
-        result = callbackModule.transform_to_boolean_or_default('', False)
-        self.assertFalse(result)
-
-        result = callbackModule.transform_to_boolean_or_default('true', False)
-        self.assertTrue(result)
-
-        result = callbackModule.transform_to_boolean_or_default('false', True)
-        self.assertFalse(result)

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -20,7 +20,7 @@ class TestOpentelemetry(unittest.TestCase):
     def setUp(self, mock_socket):
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
-        self.opentelemetry = OpenTelemetrySource()
+        self.opentelemetry = OpenTelemetrySource(display=None)
         self.mock_task = Mock('MockTask')
         self.mock_task.get_name.return_value = 'mytask'
         self.mock_task.get_path.return_value = 'mypath'

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -6,34 +6,32 @@ __metaclass__ = type
 
 from ansible.executor.task_result import TaskResult
 from ansible_collections.community.general.tests.unit.compat import unittest
-from ansible_collections.community.general.tests.unit.compat.mock import patch, Mock
+from ansible_collections.community.general.tests.unit.compat.mock import patch, MagicMock, Mock
 from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource
 from datetime import datetime
-
-import json
 
 from collections import OrderedDict
 
 
 class TestOpentelemetry(unittest.TestCase):
-    @patch('ansible_collections.community.general.plugins.callback.opentelemetry.play')
-    @patch('ansible_collections.community.general.plugins.callback.opentelemetry.task')
     @patch('ansible_collections.community.general.plugins.callback.opentelemetry.socket')
     def setUp(self, mock_socket, mock_task, mock_play):
         mock_socket.gethostname.return_value = 'my-host'
         mock_socket.gethostbyname.return_value = '1.2.3.4'
-        mock_task.get_name.return_value = 'mytask'
-        mock_task.get_path.return_value = 'mypath'
-        mock_task.action = 'myaction'
-        mock_task.no_log = False
-        mock_task._role = 'myrole'
-        mock_task._uuid = 'myuuid'
-        mock_task.args = {}
-        mock_play.get_name.return_value = 'myplay'
         self.opentelemetry = OpenTelemetrySource(display=None)
         self.task_fields = {'args': {}}
         self.mock_host = Mock('MockHost')
         self.mock_host.name = 'myhost'
+        self.mock_task = MagicMock('MockHost')
+        self.mock_task.get_name.return_value = 'mytask'
+        self.mock_task.get_path.return_value = 'mypath'
+        self.mock_task.action = 'myaction'
+        self.mock_task.no_log = False
+        self.mock_task._role = 'myrole'
+        self.mock_task._uuid = 'myuuid'
+        self.mock_task.args = {}
+        self.mock_play = MagicMock('MockPlay')
+        self.mock_play.get_name.return_value = 'myplay'
 
     def test_start_task(self):
         result = TaskResult(host=self.mock_host, task=self.mock_task, return_data={}, task_fields=self.task_fields)

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -26,3 +26,7 @@ datadog-api-client >= 1.0.0b3 ; python_version >= '3.6'
 # requirement for dnsimple module
 dnsimple >= 2 ; python_version >= '3.6'
 dataclasses ; python_version == '3.6'
+
+# requirement for the opentelemetry callback plugin
+opentelemetry-api ; python_version >= '3.6'
+opentelemetry-sdk ; python_version >= '3.6'

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -29,4 +29,5 @@ dataclasses ; python_version == '3.6'
 
 # requirement for the opentelemetry callback plugin
 opentelemetry-api ; python_version >= '3.6'
+opentelemetry-exporter-otlp ; python_version >= '3.6'
 opentelemetry-sdk ; python_version >= '3.6'


### PR DESCRIPTION
##### SUMMARY

Send distributed traces for the ansible runs with OpenTelemetry

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

plugins/callback/opentelemetry.py

##### ADDITIONAL INFORMATION

You can configure this plugin and then run your playbook with the below environment variables. Those environment variables are the ones defined by the opentelemetry project (see https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html)

In order to configure this plugins is requried to install the below python libs:

```bash
pip3 install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
```

Then you can start sending traces to your OTEL endpoint:

```bash
$ OTEL_SERVICE_NAME='ansible-otel' \
   OTEL_EXPORTER_OTLP_ENDPOINT='<your_otlp_endpoint>' \
   OTEL_EXPORTER_OTLP_HEADERS='authorization=Bearer <your_token>' \
   ansible-playbook <your_playbook>
```

Or even you can see the distributed traces in the console:

```bash
$ OPENTELEMETRY_CONSOLE_OUTPUT=true \
   ansible-playbook <your_playbook>
```

This is vendor agnostic, as long as the OpenTelemetry is supported those traces are sent, for instance, when running the `molecule test` the `converge` stage produced the below traces for one of our roles.

![image](https://user-images.githubusercontent.com/2871786/127119303-9ce9d909-da4f-49b3-aa1d-d96d72d64351.png)

Molecule was configured with something like:

```
provisioner:
  name: ansible
  env:
    JUNIT_OUTPUT_DIR: $MOLECULE_SCENARIO_DIRECTORY/test-results
  config_options:
    defaults:
      callback_plugins: $MOLECULE_SCENARIO_DIRECTORY/../../../../callback_plugins
      callback_whitelist: opentelemetry
```

##### Questions

- Can I add some ITs to help? 

##### Tasks

- [x] Add tests
- [x] Verify changes locally.
- [x] Verify changes in a staging environment.

##### Follow ups

The below follow ups will be tackle in future PRs after merging this

1) Add context propagation
2) Handle task failures as errors
