### PR TITLE
removed extraneous dependency in integration test

### DIFF
--- a/tests/integration/targets/apache2_module/meta/main.yml
+++ b/tests/integration/targets/apache2_module/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - prepare_tests

--- a/tests/integration/targets/archive/meta/main.yml
+++ b/tests/integration/targets/archive/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - setup_pkg_mgr
-  - prepare_tests

--- a/tests/integration/targets/deploy_helper/meta/main.yml
+++ b/tests/integration/targets/deploy_helper/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - prepare_tests

--- a/tests/integration/targets/flatpak/meta/main.yml
+++ b/tests/integration/targets/flatpak/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
-  - prepare_tests
   - setup_flatpak_remote

--- a/tests/integration/targets/flatpak_remote/meta/main.yml
+++ b/tests/integration/targets/flatpak_remote/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
-  - prepare_tests
   - setup_flatpak_remote

--- a/tests/integration/targets/gem/meta/main.yml
+++ b/tests/integration/targets/gem/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - setup_pkg_mgr
-  - prepare_tests

--- a/tests/integration/targets/hg/meta/main.yml
+++ b/tests/integration/targets/hg/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - setup_pkg_mgr
-  - prepare_tests

--- a/tests/integration/targets/iso_create/meta/main.yml
+++ b/tests/integration/targets/iso_create/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - setup_pkg_mgr
-  - prepare_tests

--- a/tests/integration/targets/iso_extract/meta/main.yml
+++ b/tests/integration/targets/iso_extract/meta/main.yml
@@ -1,4 +1,3 @@
 dependencies:
   - setup_pkg_mgr
-  - prepare_tests
   - setup_epel

--- a/tests/integration/targets/launchd/meta/main.yml
+++ b/tests/integration/targets/launchd/meta/main.yml
@@ -1,4 +1,0 @@
----
-
-dependencies:
-  - prepare_tests

--- a/tests/integration/targets/locale_gen/meta/main.yml
+++ b/tests/integration/targets/locale_gen/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - prepare_tests

--- a/tests/integration/targets/zypper/meta/main.yml
+++ b/tests/integration/targets/zypper/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - prepare_tests

--- a/tests/integration/targets/zypper_repository/meta/main.yml
+++ b/tests/integration/targets/zypper_repository/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - prepare_tests


### PR DESCRIPTION
##### SUMMARY
References to no longer used things.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/apache2_module/meta/main.yml
tests/integration/targets/archive/meta/main.yml
tests/integration/targets/deploy_helper/meta/main.yml
tests/integration/targets/flatpak/meta/main.yml
tests/integration/targets/flatpak_remote/meta/main.yml
tests/integration/targets/gem/meta/main.yml
tests/integration/targets/hg/meta/main.yml
tests/integration/targets/iso_create/meta/main.yml
tests/integration/targets/iso_extract/meta/main.yml
tests/integration/targets/launchd/meta/main.yml
tests/integration/targets/locale_gen/meta/main.yml
tests/integration/targets/zypper/meta/main.yml
tests/integration/targets/zypper_repository/meta/main.yml
