### PR TITLE
Hana query userstore

### DIFF
--- a/changelogs/fragments/3125-hana-query-userstore.yaml
+++ b/changelogs/fragments/3125-hana-query-userstore.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hana_query - added the abillity to use hdbuserstore (https://github.com/ansible-collections/community.general/pull/3125).

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (c) 2021, Rainer Leber <rainerleber@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -31,7 +31,11 @@ options:
         default: false
         version_added: 3.5.0
     password:
-        description: The password to connect to the database.
+        description:
+          - The password to connect to the database.
+          - "B(Note:) Since the passwords have to be passed as command line arguments, I(userstore=true) should
+            be used whenever possible, as command line arguments can be seen by other users
+            on the same machine."
         type: str
     autocommit:
         description: Autocommit the statement.

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -144,7 +144,7 @@ def main():
             autocommit=dict(type='bool', default=True),
         ),
         required_one_of=[('query', 'filepath')],
-        required_if=['userstore', False, ['password']], 
+        required_if=[('userstore', False, ['password'])], 
         supports_check_mode=False,
     )
     rc, out, err, out_raw = [0, [], "", ""]

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -23,12 +23,10 @@ options:
     user:
         description: A dedicated username. Defaults to C(SYSTEM).
         type: str
-        required: false
         default: SYSTEM
     userstore:
         description: If true the user must be in hdbuserstore.
         type: bool
-        required: false
         default: false
     password:
         description: The password to connect to the database.
@@ -125,7 +123,7 @@ def main():
             instance=dict(type='str', required=True),
             encrypted=dict(type='bool', required=False, default=False),
             host=dict(type='str', required=False),
-            user=dict(type='str', required=True, default='SYSTEM'),
+            user=dict(type='str', required=True, default="SYSTEM"),
             userstore=dict(type='bool', required=False),
             password=dict(type='str', required=False, no_log=True),
             database=dict(type='str', required=False),

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -21,7 +21,7 @@ options:
         type: str
         required: true
     user:
-        description: A dedicated username. Defaults to C(SYSTEM).
+        description: A dedicated username. The user could be also in hdbuserstore. Defaults to C(SYSTEM).
         type: str
         default: SYSTEM
     userstore:

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -26,14 +26,13 @@ options:
         type: str
         default: SYSTEM
     userstore:
-        description: If true the user must be in hdbuserstore.
+        description: If C(true) the user must be in hdbuserstore.
         type: bool
         default: false
         version_added: 3.5.0
     password:
         description: The password to connect to the database.
         type: str
-        required: false
     autocommit:
         description: Autocommit the statement.
         type: bool
@@ -138,7 +137,7 @@ def main():
             host=dict(type='str', required=False),
             user=dict(type='str', default="SYSTEM"),
             userstore=dict(type='bool', default=False),
-            password=dict(type='str', required=False, no_log=True),
+            password=dict(type='str', no_log=True),
             database=dict(type='str', required=False),
             query=dict(type='list', elements='str', required=False),
             filepath=dict(type='list', elements='path', required=False),

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -23,11 +23,13 @@ options:
     user:
         description: A dedicated username. Defaults to C(SYSTEM).
         type: str
-        default: SYSTEM
+    userstore:
+        description: If true the user must be in hdbuserstore.
+        type: bool
     password:
         description: The password to connect to the database.
         type: str
-        required: true
+        required: false
     autocommit:
         description: Autocommit the statement.
         type: bool
@@ -119,8 +121,9 @@ def main():
             instance=dict(type='str', required=True),
             encrypted=dict(type='bool', required=False, default=False),
             host=dict(type='str', required=False),
-            user=dict(type='str', required=False, default="SYSTEM"),
-            password=dict(type='str', required=True, no_log=True),
+            user=dict(type='str', required=False),
+            userstore=dict(type='bool', required=False),
+            password=dict(type='str', required=False, no_log=True),
             database=dict(type='str', required=False),
             query=dict(type='list', elements='str', required=False),
             filepath=dict(type='list', elements='path', required=False),
@@ -136,6 +139,7 @@ def main():
     sid = (params['sid']).upper()
     instance = params['instance']
     user = params['user']
+    userstore = params['userstore']
     password = params['password']
     autocommit = params['autocommit']
     host = params['host']
@@ -155,13 +159,16 @@ def main():
     if encrypted is True:
         command.extend(['-attemptencrypt'])
     if autocommit is False:
-        command.extend(['-z'])
+        command.extend(['-z']) 
     if host is not None:
         command.extend(['-n', host])
     if database is not None:
         command.extend(['-d', database])
     # -x Suppresses additional output, such as the number of selected rows in a result set.
-    command.extend(['-x', '-i', instance, '-u', user, '-p', password])
+    if userstore:
+        command.extend(['-x', '-U', user])
+    else:
+        command.extend(['-x', '-i', instance, '-u', user, '-p', password])
 
     if filepath is not None:
         command.extend(['-I'])

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -28,6 +28,7 @@ options:
         description: If true the user must be in hdbuserstore.
         type: bool
         default: false
+        version_added: 3.5.0
     password:
         description: The password to connect to the database.
         type: str
@@ -143,6 +144,7 @@ def main():
             autocommit=dict(type='bool', default=True),
         ),
         required_one_of=[('query', 'filepath')],
+        required_if=['userstore', False, ['password']], 
         supports_check_mode=False,
     )
     rc, out, err, out_raw = [0, [], "", ""]

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -23,9 +23,13 @@ options:
     user:
         description: A dedicated username. Defaults to C(SYSTEM).
         type: str
+        required: false
+        default: SYSTEM
     userstore:
         description: If true the user must be in hdbuserstore.
         type: bool
+        required: false
+        default: false
     password:
         description: The password to connect to the database.
         type: str
@@ -121,7 +125,7 @@ def main():
             instance=dict(type='str', required=True),
             encrypted=dict(type='bool', required=False, default=False),
             host=dict(type='str', required=False),
-            user=dict(type='str', required=False),
+            user=dict(type='str', required=True, default='SYSTEM'),
             userstore=dict(type='bool', required=False),
             password=dict(type='str', required=False, no_log=True),
             database=dict(type='str', required=False),

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -144,7 +144,7 @@ def main():
             autocommit=dict(type='bool', default=True),
         ),
         required_one_of=[('query', 'filepath')],
-        required_if=[('userstore', False, ['password'])], 
+        required_if=[('userstore', False, ['password'])],
         supports_check_mode=False,
     )
     rc, out, err, out_raw = [0, [], "", ""]

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -124,7 +124,7 @@ def main():
             encrypted=dict(type='bool', required=False, default=False),
             host=dict(type='str', required=False),
             user=dict(type='str', required=True, default="SYSTEM"),
-            userstore=dict(type='bool', required=False),
+            userstore=dict(type='bool', required=False, default=False),
             password=dict(type='str', required=False, no_log=True),
             database=dict(type='str', required=False),
             query=dict(type='list', elements='str', required=False),

--- a/plugins/modules/database/saphana/hana_query.py
+++ b/plugins/modules/database/saphana/hana_query.py
@@ -93,6 +93,17 @@ EXAMPLES = r'''
     - /tmp/HANA_CPU_UtilizationPerCore_2.00.020+.txt
     - /tmp/HANA.txt
     host: "localhost"
+
+- name: Run several queries from user store
+  community.general.hana_query:
+    sid: "hdb"
+    instance: "01"
+    user: hdbstoreuser
+    userstore: true
+    query:
+    - "select user_name from users;"
+    - select * from users;
+    autocommit: False
 '''
 
 RETURN = r'''
@@ -121,15 +132,15 @@ def main():
         argument_spec=dict(
             sid=dict(type='str', required=True),
             instance=dict(type='str', required=True),
-            encrypted=dict(type='bool', required=False, default=False),
+            encrypted=dict(type='bool', default=False),
             host=dict(type='str', required=False),
-            user=dict(type='str', required=True, default="SYSTEM"),
-            userstore=dict(type='bool', required=False, default=False),
+            user=dict(type='str', default="SYSTEM"),
+            userstore=dict(type='bool', default=False),
             password=dict(type='str', required=False, no_log=True),
             database=dict(type='str', required=False),
             query=dict(type='list', elements='str', required=False),
             filepath=dict(type='list', elements='path', required=False),
-            autocommit=dict(type='bool', required=False, default=True),
+            autocommit=dict(type='bool', default=True),
         ),
         required_one_of=[('query', 'filepath')],
         supports_check_mode=False,
@@ -161,7 +172,7 @@ def main():
     if encrypted is True:
         command.extend(['-attemptencrypt'])
     if autocommit is False:
-        command.extend(['-z']) 
+        command.extend(['-z'])
     if host is not None:
         command.extend(['-n', host])
     if database is not None:


### PR DESCRIPTION
##### SUMMARY
This PR add the ability to use the userstore instead of username and password

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hana_query

##### ADDITIONAL INFORMATION
```
The hdbuserstore is a secretstore where the connection string and the credentials for a specific user is stored.
```

