### PR TITLE
filesize: overwrite default `unsafe_writes` documentation

### DIFF
--- a/plugins/modules/files/filesize.py
+++ b/plugins/modules/files/filesize.py
@@ -87,6 +87,11 @@ options:
       - I(force=true) and I(sparse=true) are mutually exclusive.
     type: bool
     default: false
+  unsafe_writes:
+    description:
+      - This option is silently ignored. This module always modifies file
+        size in-place.
+    type: bool
 
 notes:
   - This module supports C(check_mode) and C(diff).

--- a/plugins/modules/files/filesize.py
+++ b/plugins/modules/files/filesize.py
@@ -91,7 +91,6 @@ options:
     description:
       - This option is silently ignored. This module always modifies file
         size in-place.
-    type: bool
 
 notes:
   - This module supports C(check_mode) and C(diff).


### PR DESCRIPTION
##### SUMMARY

Overwrite default `unsafe_writes` documentation to say that it does nothing here since the module modifies files in-place.

Fixes #2589 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

filesize