### PR TITLE
redfish_command: allow setting the BootSourceOverrideMode property

### DIFF
--- a/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
+++ b/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - Add ``boot_override_mode`` argument to BootSourceOverride commands (https://github.com/ansible-collections/community.general/issues/3134).
+  - redfish_command - add ``boot_override_mode`` argument to BootSourceOverride commands (https://github.com/ansible-collections/community.general/issues/3134).

--- a/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
+++ b/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - Add `boot_override_mode` argument to BootSourceOverride commands (https://github.com/ansible-collections/community.general/issues/3134).

--- a/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
+++ b/changelogs/fragments/3135-add-redfish_command-bootoverridemode.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_command - Add `boot_override_mode` argument to BootSourceOverride commands (https://github.com/ansible-collections/community.general/issues/3134).
+  - redfish_command - Add ``boot_override_mode`` argument to BootSourceOverride commands (https://github.com/ansible-collections/community.general/issues/3134).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1565,6 +1565,7 @@ class RedfishUtils(object):
         uefi_target = boot_opts.get('uefi_target')
         boot_next = boot_opts.get('boot_next')
         override_enabled = boot_opts.get('override_enabled')
+        boot_override_mode = boot_opts.get('boot_override_mode')
 
         if not bootdevice and override_enabled != 'Disabled':
             return {'ret': False,
@@ -1596,6 +1597,10 @@ class RedfishUtils(object):
         target = boot.get('BootSourceOverrideTarget')
         cur_uefi_target = boot.get('UefiTargetBootSourceOverride')
         cur_boot_next = boot.get('BootNext')
+        cur_override_mode = boot.get('BootSourceOverrideMode')
+
+        if not boot_override_mode:
+            boot_override_mode = cur_override_mode
 
         if override_enabled == 'Disabled':
             payload = {
@@ -1632,12 +1637,13 @@ class RedfishUtils(object):
                 }
             }
         else:
-            if cur_enabled == override_enabled and target == bootdevice:
+            if cur_enabled == override_enabled and target == bootdevice and cur_override_mode == boot_override_mode:
                 # If properties are already set, no changes needed
                 return {'ret': True, 'changed': False}
             payload = {
                 'Boot': {
                     'BootSourceOverrideEnabled': override_enabled,
+                    'BootSourceOverrideMode': boot_override_mode,
                     'BootSourceOverrideTarget': bootdevice
                 }
             }

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -89,9 +89,9 @@ options:
   boot_override_mode:
     required: false
     description:
-      - Boot mode when using an override 
+      - Boot mode when using an override
     type: str
-    choices: [ Legacy, UEFI ] 
+    choices: [ Legacy, UEFI ]
   uefi_target:
     required: false
     description:
@@ -293,11 +293,11 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Set one-time boot to BiosSetup 
+  - name: Set one-time boot to BiosSetup
     community.general.redfish_command:
       category: Systems
       command: SetOneTimeBoot
-      bootnext: BiosSetup 
+      bootnext: BiosSetup
       boot_override_mode: Legacy
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -86,6 +86,12 @@ options:
       - Timeout in seconds for URL requests to OOB controller
     default: 10
     type: int
+  boot_override_mode:
+    required: false
+    description:
+      - Boot mode when using an override 
+    type: str
+    choices: [ Legacy, UEFI ] 
   uefi_target:
     required: false
     description:
@@ -283,6 +289,16 @@ EXAMPLES = '''
       command: EnableContinuousBootOverride
       resource_id: 437XR1138R2
       bootdevice: "{{ bootdevice }}"
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+
+  - name: Set one-time boot to BiosSetup 
+    community.general.redfish_command:
+      category: Systems
+      command: SetOneTimeBoot
+      bootnext: BiosSetup 
+      boot_override_mode: Legacy
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -591,6 +607,7 @@ def main():
             timeout=dict(type='int', default=10),
             uefi_target=dict(),
             boot_next=dict(),
+            boot_override_mode=dict(choices=['Legacy', 'UEFI']),
             resource_id=dict(),
             update_image_uri=dict(),
             update_protocol=dict(),
@@ -662,7 +679,8 @@ def main():
     boot_opts = {
         'bootdevice': module.params['bootdevice'],
         'uefi_target': module.params['uefi_target'],
-        'boot_next': module.params['boot_next']
+        'boot_next': module.params['boot_next'],
+        'boot_override_mode': module.params['boot_override_mode']
     }
 
     # VirtualMedia options

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -92,6 +92,7 @@ options:
       - Boot mode when using an override
     type: str
     choices: [ Legacy, UEFI ]
+    version_added: 3.5.0
   uefi_target:
     required: false
     description:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -87,7 +87,6 @@ options:
     default: 10
     type: int
   boot_override_mode:
-    required: false
     description:
       - Boot mode when using an override
     type: str

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -681,7 +681,7 @@ def main():
         'bootdevice': module.params['bootdevice'],
         'uefi_target': module.params['uefi_target'],
         'boot_next': module.params['boot_next'],
-        'boot_override_mode': module.params['boot_override_mode']
+        'boot_override_mode': module.params['boot_override_mode'],
     }
 
     # VirtualMedia options

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -88,7 +88,7 @@ options:
     type: int
   boot_override_mode:
     description:
-      - Boot mode when using an override
+      - Boot mode when using an override.
     type: str
     choices: [ Legacy, UEFI ]
     version_added: 3.5.0


### PR DESCRIPTION
##### SUMMARY
Expose BootOverrideMode parameter to redfish_command to allow setting by user during run.

Fixes #3134

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_command
redfish_utils

##### ADDITIONAL INFORMATION
It's now possible to do the following:

```
tasks:
  - name: Set Pxe Boot 
    community.general.redfish_command:
      category: Systems
      command: SetOneTimeBoot 
      boot_override_mode: Legacy
      bootdevice: Pxe
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

This allows choosing the boot mode used for the override target, if different from the current running state of the machine.