### PR TITLE
Updated the tss lookup plugin to reflect breaking changes introduced in the underpinning SDK

### DIFF
--- a/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
+++ b/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - Fixed issue `#3057` by bringing the plugin in line with recent breaking changes the SecretServer Python SDK.
-    (https://github.com/ansible-collections/community.general/pull/3139) 
+  - tss_plugin - Fixed issue `#3057` by bringing the plugin in line with recent breaking changes the SecretServer Python SDK.
+    (https://github.com/ansible-collections/community.general/pull/3139)

--- a/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
+++ b/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fixed issue `#3057` by bringing the plugin in line with recent breaking changes the SecretServer Python SDK.
+    (https://github.com/ansible-collections/community.general/pull/3139) 

--- a/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
+++ b/changelogs/fragments/3139-tss-lookup-plugin-update-to-make-compatible-with-sdk-v1.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - tss_plugin - Fixed issue `#3057` by bringing the plugin in line with recent breaking changes the SecretServer Python SDK.
-    (https://github.com/ansible-collections/community.general/pull/3139)
+  - tss lookup plugin - fixed incompatibility with ``python-tss-sdk`` version 1.0.0
+    (https://github.com/ansible-collections/community.general/issues/3057, https://github.com/ansible-collections/community.general/pull/3139).

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -133,6 +133,7 @@ from ansible.plugins.lookup import LookupBase
 
 display = Display()
 
+
 class LookupModule(LookupBase):
     @staticmethod
     def Client(server_parameters):

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -120,8 +120,8 @@ sdk_is_missing = False
 try:
     from thycotic.secrets.server import (
         SecretServer,
-        SecretServerAccessError,
         SecretServerError,
+        PasswordGrantAuthorizer,
     )
 except ImportError:
     sdk_is_missing = True
@@ -136,7 +136,16 @@ display = Display()
 class LookupModule(LookupBase):
     @staticmethod
     def Client(server_parameters):
-        return SecretServer(**server_parameters)
+        authorizer = PasswordGrantAuthorizer(
+            server_parameters["base_url"],
+            server_parameters["username"],
+            server_parameters["password"],
+            server_parameters["token_path_uri"],
+        )
+
+        return SecretServer(
+            server_parameters["base_url"], authorizer, server_parameters["api_path_uri"]
+        )
 
     def run(self, terms, variables, **kwargs):
         if sdk_is_missing:


### PR DESCRIPTION
##### SUMMARY
This PR updates the plugin to bring it in line with the current `python-tss-sdk` version, which added breaking changes in v1.0.0. The plugin is now compatible with the latest SDK version.  

This also fixes #3057. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`tss` lookup plugin

##### ADDITIONAL INFORMATION
No changes are needed to current playbooks, as inputs have stayed the same. Users will be encouraged to update their `python-tss-sdk` version to >1.0.0.
