### PR TITLE
nmcli: Disallow Wi-Fi options not supported by nmcli

### DIFF
--- a/changelogs/fragments/3141-disallow-options-unsupported-by-nmcli.yml
+++ b/changelogs/fragments/3141-disallow-options-unsupported-by-nmcli.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nmcli - query `nmcli` directly to determine available WiFi options
+    (https://github.com/ansible-collections/community.general/pull/3141).

--- a/changelogs/fragments/3141-disallow-options-unsupported-by-nmcli.yml
+++ b/changelogs/fragments/3141-disallow-options-unsupported-by-nmcli.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - nmcli - query `nmcli` directly to determine available WiFi options
+  - nmcli - query ``nmcli`` directly to determine available WiFi options
     (https://github.com/ansible-collections/community.general/pull/3141).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -979,6 +979,7 @@ class Nmcli(object):
     A subclass may wish to override the following action methods:-
             - create_connection()
             - delete_connection()
+            - edit_connection()
             - modify_connection()
             - show_connection()
             - up_connection()
@@ -1090,6 +1091,11 @@ class Nmcli(object):
         else:
             cmd = to_text(cmd)
         return self.module.run_command(cmd, use_unsafe_shell=use_unsafe_shell, data=data)
+
+    def execute_edit_commands(self, commands):
+        cmd = [self.nmcli_bin, 'con', 'edit', self.conn_name]
+        data = "\n".join(commands)
+        return self.execute_command(cmd, data=data)
 
     def connection_options(self, detect_change=False):
         # Options common to multiple connection types.
@@ -1412,9 +1418,8 @@ class Nmcli(object):
         return status
 
     def edit_connection(self):
-        data = "\n".join(self.edit_commands + ['save', 'quit'])
-        cmd = [self.nmcli_bin, 'con', 'edit', self.conn_name]
-        return self.execute_command(cmd, data=data)
+        commands = self.edit_commands + ['save', 'quit']
+        return self.execute_edit_commands(commands)
 
     def show_connection(self):
         cmd = [self.nmcli_bin, '--show-secrets', 'con', 'show', self.conn_name]
@@ -1469,10 +1474,8 @@ class Nmcli(object):
             commands = []
 
         commands += ['print %s' % setting, 'quit', 'yes']
-        data = "\n".join(commands)
-        cmd = [self.nmcli_bin, 'con', 'edit', 'type', self.type]
 
-        (rc, out, err) = self.execute_command(cmd, data=data)
+        (rc, out, err) = self.execute_edit_commands(commands)
 
         if rc != 0:
             raise NmcliModuleError(err)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -347,11 +347,9 @@ options:
                 type: str
                 choices: [ open, shared, leap ]
             fils:
-                description: Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection. One of
-                             C(NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT) (0) (use global default value), C(NM_SETTING_WIRELESS_SECURITY_FILS_DISABLE) (1)
-                             (disable FILS), C(NM_SETTING_WIRELESS_SECURITY_FILS_OPTIONAL) (2) (enable FILS if the supplicant and the access point support it)
-                             or C(NM_SETTING_WIRELESS_SECURITY_FILS_REQUIRED) (3) (enable FILS and fail if not supported). When set to
-                             C(NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT) (0) and no global default is set, FILS will be optionally enabled.
+                description: Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection. One of C(0) (use global default value),
+                             C(1) (disable FILS), C(2) (enable FILS if the supplicant and the access point support it) or C(3) (enable FILS and fail if not
+                             supported). When set to C(0) and no global default is set, FILS will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
@@ -385,11 +383,9 @@ options:
                 elements: str
                 choices: [ tkip, ccmp ]
             pmf:
-                description: Indicates whether Protected Management Frames (802.11w) must be enabled for the connection. One of
-                             C(NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT) (0) (use global default value), C(NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE) (1)
-                             (disable PMF), C(NM_SETTING_WIRELESS_SECURITY_PMF_OPTIONAL) (2) (enable PMF if the supplicant and the access point support it) or
-                             C(NM_SETTING_WIRELESS_SECURITY_PMF_REQUIRED) (3) (enable PMF and fail if not supported). When set to
-                             C(NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT) (0) and no global default is set, PMF will be optionally enabled.
+                description: Indicates whether Protected Management Frames (802.11w) must be enabled for the connection. One of C(0) (use global default
+                             value), C(1) (disable PMF), C(2) (enable PMF if the supplicant and the access point support it) or C(3) (enable PMF and fail if
+                             not supported). When set to C(0) and no global default is set, PMF will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
@@ -413,9 +409,9 @@ options:
                 type: list
                 elements: int
             wep-key-type:
-                description: Controls the interpretation of WEP keys. Allowed values are C(NM_WEP_KEY_TYPE_KEY) (1), in which case the key is either a 10- or
-                             26-character hexadecimal string, or a 5- or 13-character ASCII password; or C(NM_WEP_KEY_TYPE_PASSPHRASE) (2), in which case the
-                             passphrase is provided as a string and will be hashed using the de-facto MD5 method to derive the actual WEP key.
+                description: Controls the interpretation of WEP keys. Allowed values are C(1), in which case the key is either a 10- or 26-character
+                             hexadecimal string, or a 5- or 13-character ASCII password; or C(2), in which case the passphrase is provided as a string and will
+                             be hashed using the de-facto MD5 method to derive the actual WEP key.
                 type: int
                 choices: [ 1, 2 ]
             wep-key0:
@@ -465,11 +461,11 @@ options:
        suboptions:
             ap-isolation:
                 description: Configures AP isolation, which prevents communication between wireless devices connected to this AP. This property can be set to a
-                             value different from C(NM_TERNARY_DEFAULT) (-1) only when the interface is configured in AP mode. If set to C(NM_TERNARY_TRUE)
-                             (1), devices are not able to communicate with each other. This increases security because it protects devices against attacks from
-                             other clients in the network. At the same time, it prevents devices to access resources on the same wireless networks as file
-                             shares, printers, etc. If set to C(NM_TERNARY_FALSE) (0), devices can talk to each other. When set to C(NM_TERNARY_DEFAULT) (-1),
-                             the global default is used; in case the global default is unspecified it is assumed to be C(NM_TERNARY_FALSE) (0).
+                             value different from C(-1) only when the interface is configured in AP mode. If set to C(1), devices are not able to communicate
+                             with each other. This increases security because it protects devices against attacks from other clients in the network. At the
+                             same time, it prevents devices to access resources on the same wireless networks as file shares, printers, etc. If set to C(0),
+                             devices can talk to each other. When set to C(-1), the global default is used; in case the global default is unspecified it is
+                             assumed to be C(0).
                 type: int
                 choices: [ -1, 0, 1 ]
                 default: -1
@@ -531,10 +527,9 @@ options:
                 type: list
                 elements: str
             mac-address-randomization:
-                description: One of C(NM_SETTING_MAC_RANDOMIZATION_DEFAULT) (0) (never randomize unless the user has set a global default to randomize and the
-                             supplicant supports randomization), C(NM_SETTING_MAC_RANDOMIZATION_NEVER) (1) (never randomize the MAC address), or
-                             C(NM_SETTING_MAC_RANDOMIZATION_ALWAYS) (2) (always randomize the MAC address). This property is deprecated for
-                             C(cloned-mac-address).
+                description: One of C(0) (never randomize unless the user has set a global default to randomize and the supplicant supports randomization),
+                             C(1) (never randomize the MAC address), or C(2) (always randomize the MAC address). This property is deprecated for
+                             I(cloned-mac-address).
                 type: int
                 default: 0
                 choices: [ 0, 1, 2 ]
@@ -552,9 +547,8 @@ options:
                 type: int
                 default: 0
             powersave:
-                description: One of C(NM_SETTING_WIRELESS_POWERSAVE_DISABLE) (2) (disable Wi-Fi power saving), C(NM_SETTING_WIRELESS_POWERSAVE_ENABLE) (3)
-                             (enable Wi-Fi power saving), C(NM_SETTING_WIRELESS_POWERSAVE_IGNORE) (1) (don't touch currently configure setting) or
-                             C(NM_SETTING_WIRELESS_POWERSAVE_DEFAULT) (0) (use the globally configured value). All other values are reserved.
+                description: One of C(2) (disable Wi-Fi power saving), C(3) (enable Wi-Fi power saving), C(1) (don't touch currently configure setting) or C(0)
+                             (use the globally configured value). All other values are reserved.
                 type: int
                 default: 0
                 choices: [ 0, 1, 2, 3 ]
@@ -580,8 +574,7 @@ options:
                              C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC) (0x8), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE) (0x10),
                              C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST) (0x20), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE) (0x40),
                              C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (0x80), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (0x100) or the special values
-                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT) (0x1) (to use global settings) and C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_IGNORE) (0x8000)
-                             (to disable management of Wake-on-LAN in NetworkManager).
+                             C(0x1) (to use global settings) and C(0x8000) (to disable management of Wake-on-LAN in NetworkManager).
                              Note the sum of all option values must be specified in order to combine multiple options.
                 type: int
                 default: 1

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1092,7 +1092,8 @@ class Nmcli(object):
             cmd = to_text(cmd)
         return self.module.run_command(cmd, use_unsafe_shell=use_unsafe_shell, data=data)
 
-    def execute_edit_commands(self, commands, arguments=[]):
+    def execute_edit_commands(self, commands, arguments):
+        arguments = arguments or []
         cmd = [self.nmcli_bin, 'con', 'edit'] + arguments
         data = "\n".join(commands)
         return self.execute_command(cmd, data=data)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -583,6 +583,7 @@ options:
                              C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (0x80), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (0x100) or the special values
                              C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT) (0x1) (to use global settings) and C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_IGNORE) (0x8000)
                              (to disable management of Wake-on-LAN in NetworkManager).
+                             Note the sum of all option values must be specified in order to combine multiple options.
                 type: int
                 default: 1
        version_added: 3.5.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -339,7 +339,9 @@ options:
               U(https://networkmanager.dev/docs/api/latest/settings-802-11-wireless-security.html).'
             - 'For instance to use common WPA-PSK auth with a password:
               C({key-mgmt: wpa-psk, psk: my_password}).'
-       choices: [ key-mgmt, wep-tx-keyidx, auth-alg, proto, pairwise, group, pmf, leap-username, wep-key0, wep-key1, wep-key2, wep-key3, wep-key-flags, wep-key-type, psk, psk-flags, leap-password, leap-password-flags, wps-method, fils ]
+       choices: [ key-mgmt, wep-tx-keyidx, auth-alg, proto, pairwise, group, pmf, leap-username,
+                  wep-key0, wep-key1, wep-key2, wep-key3, wep-key-flags, wep-key-type, psk, psk-flags,
+                  leap-password, leap-password-flags, wps-method, fils ]
        type: dict
        version_added: 3.0.0
     ssid:
@@ -356,7 +358,9 @@ options:
               U(https://networkmanager.dev/docs/api/latest/settings-802-11-wireless.html).'
             - 'For instance to create a hidden AP mode WiFi connection:
               C({hidden: true, mode: ap}).'
-       choices: [ mode, band, channel, bssid, rate, tx-power, mac-address, cloned-mac-address, generate-mac-address-mask, mac-address-blacklist, mac-address-randomization, mtu, seen-bssids, hidden, powersave, wake-on-wlan, ap-isolation ]
+       choices: [ mode, band, channel, bssid, rate, tx-power, mac-address, cloned-mac-address,
+                  generate-mac-address-mask, mac-address-blacklist, mac-address-randomization, mtu,
+                  seen-bssids, hidden, powersave, wake-on-wlan, ap-isolation ]
        type: dict
        version_added: 3.5.0
     ignore_unsupported_suboptions:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -589,7 +589,7 @@ options:
             - Only 'wifi' and 'wifi_sec' options are currently affected.
        type: bool
        default: no
-       version_added: 3.5.0
+       version_added: 3.6.0
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -357,8 +357,7 @@ options:
                 default: 0
             group:
                 description: A list of group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the
-                             algorithms in the list. For maximum compatibility leave this property empty. Each list element may be one of C(wep40), C(wep104),
-                             C(tkip), or C(ccmp).
+                             algorithms in the list. For maximum compatibility leave this property empty.
                 type: list
                 elements: str
                 choices: [ wep40, wep104, tkip, ccmp ]
@@ -381,7 +380,7 @@ options:
                 type: str
             pairwise:
                 description: A list of pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in
-                             the list. For maximum compatibility leave this property empty. Each list element may be one of C(tkip) or C(ccmp).
+                             the list. For maximum compatibility leave this property empty.
                 type: list
                 elements: str
                 choices: [ tkip, ccmp ]
@@ -508,13 +507,13 @@ options:
                              is eligible to be overwritten by a default connection setting. If the value is still NULL or an empty string, the default is to
                              create a locally-administered, unicast MAC address. If the value contains one MAC address, this address is used as mask. The set
                              bits of the mask are to be filled with the current MAC address of the device, while the unset bits are subject to randomization.
-                             Setting "FE:FF:FF:00:00:00" means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
+                             Setting C(FE:FF:FF:00:00:00) means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
                              C(random) or C(stable) algorithm. If the value contains one additional MAC address after the mask, this address is used instead of
                              the current MAC address to fill the bits that shall not be randomized. For example, a value of
-                             "FE:FF:FF:00:00:00 68:F7:28:00:00:00" will set the OUI of the MAC address to 68:F7:28, while the lower bits are randomized. A
-                             value of "02:00:00:00:00:00 00:00:00:00:00:00" will create a fully scrambled globally-administered, burned-in MAC address. If the
+                             C(FE:FF:FF:00:00:00 68:F7:28:00:00:00) will set the OUI of the MAC address to 68:F7:28, while the lower bits are randomized. A
+                             value of C(02:00:00:00:00:00 00:00:00:00:00:00) will create a fully scrambled globally-administered, burned-in MAC address. If the
                              value contains more than one additional MAC addresses, one of them is chosen randomly. For example,
-                             "02:00:00:00:00:00 00:00:00:00:00:00 02:00:00:00:00:00" will create a fully scrambled MAC address, randomly locally or globally
+                             C(02:00:00:00:00:00 00:00:00:00:00:00 02:00:00:00:00:00) will create a fully scrambled MAC address, randomly locally or globally
                              administered.
                 type: str
             hidden:
@@ -528,7 +527,7 @@ options:
                 default: false
             mac-address-blacklist:
                 description: A list of permanent MAC addresses of Wi-Fi devices to which this connection should never apply. Each MAC address should be given
-                             in the standard hex-digits-and-colons notation (eg "00:11:22:33:44:55").
+                             in the standard hex-digits-and-colons notation (eg C(00:11:22:33:44:55)).
                 type: list
                 elements: str
             mac-address-randomization:
@@ -544,7 +543,7 @@ options:
                              change the MAC address of the device (i.e. MAC spoofing).
                 type: str
             mode:
-                description: Wi-Fi network mode; one of C(infrastructure), C(mesh), C(adhoc) or C(ap). If blank, infrastructure is assumed.
+                description: Wi-Fi network mode. If blank, C(infrastructure) is assumed.
                 type: str
                 choices: [ infrastructure, mesh, adhoc, ap ]
                 default: infrastructure
@@ -565,7 +564,7 @@ options:
                 type: int
                 default: 0
             seen-bssids:
-                description: A list of BSSIDs (each BSSID formatted as a MAC address like "00:11:22:33:44:55") that have been detected as part of the Wi-Fi
+                description: A list of BSSIDs (each BSSID formatted as a MAC address like C(00:11:22:33:44:55)) that have been detected as part of the Wi-Fi
                              network. NetworkManager internally tracks previously seen BSSIDs. The property is only meant for reading and reflects the BSSID
                              list of NetworkManager. The changes you make to this property will not be preserved.
                 type: list

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -462,7 +462,7 @@ options:
             wps-method:
                 description:
                     - Flags indicating which mode of WPS is to be used if any.
-                    - There's little point in changing the default setting as NetworkManager will automatically determine whether it's feasible to start WPS
+                    - There is little point in changing the default setting as NetworkManager will automatically determine whether it is feasible to start WPS
                       enrollment from the Access Point capabilities.
                     - WPS can be disabled by setting this property to a value of C(1).
                 type: int

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1317,7 +1317,14 @@ class Nmcli(object):
                          'ipv4.routes',
                          'ipv4.route-metric'
                          'ipv6.dns',
-                         'ipv6.dns-search'):
+                         'ipv6.dns-search',
+                         '802-11-wireless-security.group',
+                         '802-11-wireless-security.leap-password-flags',
+                         '802-11-wireless-security.pairwise',
+                         '802-11-wireless-security.proto',
+                         '802-11-wireless-security.psk-flags',
+                         '802-11-wireless-security.wep-key-flags',
+                         '802-11-wireless.mac-address-blacklist'):
             return list
         return str
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -415,7 +415,7 @@ options:
             psk:
                 description:
                     - Pre-Shared-Key for WPA networks.
-                    - For WPA-PSK, it's either an ASCII passphrase of 8 to 63 characters that is (as specified in the 802.11i standard) hashed to derive the
+                    - For WPA-PSK, it is either an ASCII passphrase of 8 to 63 characters that is (as specified in the 802.11i standard) hashed to derive the
                       actual key, or the key in form of 64 hexadecimal character.
                     - The WPA3-Personal networks use a passphrase of any length for SAE authentication.
                 type: str

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -629,7 +629,7 @@ options:
             - Ignore suboptions which are invalid or unsupported by the version of NetworkManager/nmcli installed on the host.
             - Only I(wifi) and I(wifi_sec) options are currently affected.
        type: bool
-       default: no
+       default: false
        version_added: 3.6.0
 '''
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -342,7 +342,7 @@ options:
        suboptions:
             auth-alg:
                 description:
-                    - When WEP is used (ie, I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
+                    - When WEP is used (that is, if I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
                     - One of C(open) for Open System, C(shared) for Shared Key, or C(leap) for Cisco LEAP.
                     - When using Cisco LEAP (that is, if I(key-mgmt=ieee8021x) and I(auth-alg=leap)) the I(leap-username) and I(leap-password) properties
                       must be specified.
@@ -378,10 +378,10 @@ options:
                 type: list
                 elements: int
             leap-password:
-                description: The login password for legacy LEAP connections (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)).
+                description: The login password for legacy LEAP connections (that is, if I(key-mgmt=ieee8021x) and I(auth-alg=leap)).
                 type: str
             leap-username:
-                description: The login username for legacy LEAP connections (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)).
+                description: The login username for legacy LEAP connections (that is, if I(key-mgmt=ieee8021x) and I(auth-alg=leap)).
                 type: str
             pairwise:
                 description:
@@ -453,7 +453,7 @@ options:
                 type: str
             wep-tx-keyidx:
                 description:
-                    - When static WEP is used (ie, I(key-mgmt) = C(none)) and a non-default WEP key index is used by the AP, put that WEP key index here.
+                    - When static WEP is used (that is, if I(key-mgmt=none)) and a non-default WEP key index is used by the AP, put that WEP key index here.
                     - Valid values are C(0) (default key) through C(3).
                     - Note that some consumer access points (like the Linksys WRT54G) number the keys C(1) - C(4).
                 type: int

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1092,8 +1092,8 @@ class Nmcli(object):
             cmd = to_text(cmd)
         return self.module.run_command(cmd, use_unsafe_shell=use_unsafe_shell, data=data)
 
-    def execute_edit_commands(self, commands):
-        cmd = [self.nmcli_bin, 'con', 'edit', self.conn_name]
+    def execute_edit_commands(self, commands, arguments=[]):
+        cmd = [self.nmcli_bin, 'con', 'edit'] + arguments
         data = "\n".join(commands)
         return self.execute_command(cmd, data=data)
 
@@ -1419,7 +1419,7 @@ class Nmcli(object):
 
     def edit_connection(self):
         commands = self.edit_commands + ['save', 'quit']
-        return self.execute_edit_commands(commands)
+        return self.execute_edit_commands(commands, arguments=[self.conn_name])
 
     def show_connection(self):
         cmd = [self.nmcli_bin, '--show-secrets', 'con', 'show', self.conn_name]
@@ -1475,7 +1475,7 @@ class Nmcli(object):
 
         commands += ['print %s' % setting, 'quit', 'yes']
 
-        (rc, out, err) = self.execute_edit_commands(commands)
+        (rc, out, err) = self.execute_edit_commands(commands, arguments=['type', self.type])
 
         if rc != 0:
             raise NmcliModuleError(err)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1699,7 +1699,7 @@ def main():
         if nmcli.wifi_sec:
             unsupported_properties['wifi_sec'] = nmcli.check_for_unsupported_properties('802-11-wireless-security')
         if nmcli.ignore_unsupported_suboptions and unsupported_properties:
-            for setting_key, properties in unsupported_properties:
+            for setting_key, properties in unsupported_properties.items():
                 for property in properties:
                     del getattr(nmcli, setting_key)[property]
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -333,16 +333,120 @@ options:
     wifi_sec:
        description:
             - The security configuration of the WiFi connection.
-            - Note the list of attribute choices may vary depending on which version of NetworkManager/nmcli
-              is installed on the host.
+            - Note the list of suboption attributes may vary depending on which version of NetworkManager/nmcli is installed on the host.
             - 'An up-to-date list of supported attributes can be found here:
               U(https://networkmanager.dev/docs/api/latest/settings-802-11-wireless-security.html).'
             - 'For instance to use common WPA-PSK auth with a password:
               C({key-mgmt: wpa-psk, psk: my_password}).'
-       choices: [ key-mgmt, wep-tx-keyidx, auth-alg, proto, pairwise, group, pmf, leap-username,
-                  wep-key0, wep-key1, wep-key2, wep-key3, wep-key-flags, wep-key-type, psk, psk-flags,
-                  leap-password, leap-password-flags, wps-method, fils ]
        type: dict
+       suboptions:
+            auth-alg:
+                description: When WEP is used (ie, key-mgmt = "none" or "ieee8021x") indicate the 802.11 authentication algorithm required by the AP here. One
+                             of "open" for Open System, "shared" for Shared Key, or "leap" for Cisco LEAP. When using Cisco LEAP (ie, key-mgmt = "ieee8021x"
+                             and auth-alg = "leap") the "leap-username" and "leap-password" properties must be specified.
+                type: str
+                choices: [ open, shared, leap ]
+            fils:
+                description: Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection. One of
+                             NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT (0) (use global default value), NM_SETTING_WIRELESS_SECURITY_FILS_DISABLE (1) (disable
+                             FILS), NM_SETTING_WIRELESS_SECURITY_FILS_OPTIONAL (2) (enable FILS if the supplicant and the access point support it) or
+                             NM_SETTING_WIRELESS_SECURITY_FILS_REQUIRED (3) (enable FILS and fail if not supported). When set to
+                             NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT (0) and no global default is set, FILS will be optionally enabled.
+                type: int
+                choices: [ 0, 1, 2, 3 ]
+                default: 0
+            group:
+                description: A list of group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the
+                             algorithms in the list. For maximum compatibility leave this property empty. Each list element may be one of "wep40", "wep104",
+                             "tkip", or "ccmp".
+                type: list
+                elements: str
+                choices: [ wep40, wep104, tkip, ccmp ]
+            key-mgmt:
+                description: Key management used for the connection. One of "none" (WEP or no password protection), "ieee8021x" (Dynamic WEP), "owe"
+                             (Opportunistic Wireless Encryption), "wpa-psk" (WPA2 + WPA3 personal), "sae" (WPA3 personal only), "wpa-eap" (WPA2 + WPA3
+                             enterprise) or "wpa-eap-suite-b-192" (WPA3 enterprise only). This property must be set for any Wi-Fi connection that uses
+                             security.
+                type: str
+                choices: [ none, ieee8021x, owe, wpa-psk, sae, wpa-eap, wpa-eap-suite-b-192 ]
+            leap-password-flags:
+                description: Flags indicating how to handle the "leap-password" property.
+                type: list
+                elements: int
+            leap-password:
+                description: The login password for legacy LEAP connections (ie, key-mgmt = "ieee8021x" and auth-alg = "leap").
+                type: str
+            leap-username:
+                description: The login username for legacy LEAP connections (ie, key-mgmt = "ieee8021x" and auth-alg = "leap").
+                type: str
+            pairwise:
+                description: A list of pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in
+                             the list. For maximum compatibility leave this property empty. Each list element may be one of "tkip" or "ccmp".
+                type: list
+                elements: str
+                choices: [ tkip, ccmp ]
+            pmf:
+                description: Indicates whether Protected Management Frames (802.11w) must be enabled for the connection. One of
+                             NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT (0) (use global default value), NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE (1) (disable
+                             PMF), NM_SETTING_WIRELESS_SECURITY_PMF_OPTIONAL (2) (enable PMF if the supplicant and the access point support it) or
+                             NM_SETTING_WIRELESS_SECURITY_PMF_REQUIRED (3) (enable PMF and fail if not supported). When set to
+                             NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT (0) and no global default is set, PMF will be optionally enabled.
+                type: int
+                choices: [ 0, 1, 2, 3 ]
+                default: 0
+            proto:
+                description: List of strings specifying the allowed WPA protocol versions to use. Each element may be one "wpa" (allow WPA) or "rsn" (allow
+                             WPA2/RSN). If not specified, both WPA and RSN connections are allowed.
+                type: list
+                elements: str
+                choices: [ wpa, rsn ]
+            psk-flags:
+                description: Flags indicating how to handle the "psk" property.
+                type: list
+                elements: int
+            psk:
+                description: Pre-Shared-Key for WPA networks. For WPA-PSK, it's either an ASCII passphrase of 8 to 63 characters that is (as specified in the
+                             802.11i standard) hashed to derive the actual key, or the key in form of 64 hexadecimal character. The WPA3-Personal networks use
+                             a passphrase of any length for SAE authentication.
+                type: str
+            wep-key-flags:
+                description: Flags indicating how to handle the "wep-key0", "wep-key1", "wep-key2", and "wep-key3" properties.
+                type: list
+                elements: int
+            wep-key-type:
+                description: Controls the interpretation of WEP keys. Allowed values are NM_WEP_KEY_TYPE_KEY (1), in which case the key is either a 10- or
+                             26-character hexadecimal string, or a 5- or 13-character ASCII password; or NM_WEP_KEY_TYPE_PASSPHRASE (2), in which case the
+                             passphrase is provided as a string and will be hashed using the de-facto MD5 method to derive the actual WEP key.
+                type: int
+                choices: [ 1, 2 ]
+            wep-key0:
+                description: Index 0 WEP key. This is the WEP key used in most networks. See the "wep-key-type" property for a description of how this key is
+                             interpreted.
+                type: str
+            wep-key1:
+                description: Index 1 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
+                             interpreted.
+                type: str
+            wep-key2:
+                description: Index 2 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
+                             interpreted.
+                type: str
+            wep-key3:
+                description: Index 3 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
+                             interpreted.
+                type: str
+            wep-tx-keyidx:
+                description: When static WEP is used (ie, key-mgmt = "none") and a non-default WEP key index is used by the AP, put that WEP key index here.
+                             Valid values are 0 (default key) through 3. Note that some consumer access points (like the Linksys WRT54G) number the keys 1 - 4.
+                type: int
+                choices: [ 0, 1, 2, 3 ]
+                default: 0
+            wps-method:
+                description: Flags indicating which mode of WPS is to be used if any. There's little point in changing the default setting as NetworkManager
+                             will automatically determine whether it's feasible to start WPS enrollment from the Access Point capabilities. WPS can be disabled
+                             by setting this property to a value of 1.
+                type: int
+                default: 0
        version_added: 3.0.0
     ssid:
        description:
@@ -352,16 +456,132 @@ options:
     wifi:
        description:
             - The configuration of the WiFi connection.
-            - Note the list of attribute choices may vary depending on which version of NetworkManager/nmcli
+            - Note the list of suboption attributes may vary depending on which version of NetworkManager/nmcli
               is installed on the host.
             - 'An up-to-date list of supported attributes can be found here:
               U(https://networkmanager.dev/docs/api/latest/settings-802-11-wireless.html).'
             - 'For instance to create a hidden AP mode WiFi connection:
               C({hidden: true, mode: ap}).'
-       choices: [ mode, band, channel, bssid, rate, tx-power, mac-address, cloned-mac-address,
-                  generate-mac-address-mask, mac-address-blacklist, mac-address-randomization, mtu,
-                  seen-bssids, hidden, powersave, wake-on-wlan, ap-isolation ]
        type: dict
+       suboptions:
+            ap-isolation:
+                description: Configures AP isolation, which prevents communication between wireless devices connected to this AP. This property can be set to a
+                             value different from NM_TERNARY_DEFAULT (-1) only when the interface is configured in AP mode. If set to NM_TERNARY_TRUE (1),
+                             devices are not able to communicate with each other. This increases security because it protects devices against attacks from
+                             other clients in the network. At the same time, it prevents devices to access resources on the same wireless networks as file
+                             shares, printers, etc. If set to NM_TERNARY_FALSE (0), devices can talk to each other. When set to NM_TERNARY_DEFAULT (-1), the
+                             global default is used; in case the global default is unspecified it is assumed to be NM_TERNARY_FALSE (0).
+                type: int
+            assigned-mac-address:
+                description: The new field for the cloned MAC address. It can be either a hardware address in ASCII representation, or one of the special
+                             values "preserve", "permanent", "random" or "stable". This field replaces the deprecated "cloned-mac-address" on D-Bus, which can
+                             only contain explicit hardware addresses. Note that this property only exists in D-Bus API. libnm and nmcli continue to call this
+                             property "cloned-mac-address".
+                type: str
+            band:
+                description: 802.11 frequency band of the network. One of "a" for 5GHz 802.11a or "bg" for 2.4GHz 802.11. This will lock associations to the
+                             Wi-Fi network to the specific band, i.e. if "a" is specified, the device will not associate with the same network in the 2.4GHz
+                             band even if the network's settings are compatible. This setting depends on specific driver capability and may not work with all
+                             drivers.
+                type: str
+                choices: [ a, bg ]
+            bssid:
+                description: If specified, directs the device to only associate with the given access point. This capability is highly driver dependent and not
+                             supported by all devices. Note this property does not control the BSSID used when creating an Ad-Hoc network and is unlikely to
+                             in the future.
+                type: str
+            channel:
+                description: Wireless channel to use for the Wi-Fi connection. The device will only join (or create for Ad-Hoc networks) a Wi-Fi network on the
+                             specified channel. Because channel numbers overlap between bands, this property also requires the "band" property to be set.
+                type: int
+                default: 0
+            cloned-mac-address:
+                description: This D-Bus field is deprecated in favor of "assigned-mac-address" which is more flexible and allows specifying special variants
+                             like "random". For libnm and nmcli, this field is called "cloned-mac-address".
+                type: str
+            generate-mac-address-mask:
+                description: With "cloned-mac-address" setting "random" or "stable", by default all bits of the MAC address are scrambled and a
+                             locally-administered, unicast MAC address is created. This property allows to specify that certain bits are fixed. Note that the
+                             least significant bit of the first MAC address will always be unset to create a unicast MAC address. If the property is NULL, it
+                             is eligible to be overwritten by a default connection setting. If the value is still NULL or an empty string, the default is to
+                             create a locally-administered, unicast MAC address. If the value contains one MAC address, this address is used as mask. The set
+                             bits of the mask are to be filled with the current MAC address of the device, while the unset bits are subject to randomization.
+                             Setting "FE:FF:FF:00:00:00" means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
+                             "random" or "stable" algorithm. If the value contains one additional MAC address after the mask, this address is used instead of
+                             the current MAC address to fill the bits that shall not be randomized. For example, a value of
+                             "FE:FF:FF:00:00:00 68:F7:28:00:00:00" will set the OUI of the MAC address to 68:F7:28, while the lower bits are randomized. A
+                             value of "02:00:00:00:00:00 00:00:00:00:00:00" will create a fully scrambled globally-administered, burned-in MAC address. If the
+                             value contains more than one additional MAC addresses, one of them is chosen randomly. For example,
+                             "02:00:00:00:00:00 00:00:00:00:00:00 02:00:00:00:00:00" will create a fully scrambled MAC address, randomly locally or globally
+                             administered.
+                type: str
+            hidden:
+                description: If TRUE, indicates that the network is a non-broadcasting network that hides its SSID. This works both in infrastructure and AP
+                             mode. In infrastructure mode, various workarounds are used for a more reliable discovery of hidden networks, such as
+                             probe-scanning the SSID. However, these workarounds expose inherent insecurities with hidden SSID networks, and thus hidden SSID
+                             networks should be used with caution. In AP mode, the created network does not broadcast its SSID. Note that marking the network
+                             as hidden may be a privacy issue for you (in infrastructure mode) or client stations (in AP mode), as the explicit probe-scans are
+                             distinctly recognizable on the air.
+                type: bool
+                default: false
+            mac-address-blacklist:
+                description: A list of permanent MAC addresses of Wi-Fi devices to which this connection should never apply. Each MAC address should be given
+                             in the standard hex-digits-and-colons notation (eg "00:11:22:33:44:55").
+                type: list
+                elements: str
+            mac-address-randomization:
+                description: One of NM_SETTING_MAC_RANDOMIZATION_DEFAULT (0) (never randomize unless the user has set a global default to randomize and the
+                             supplicant supports randomization), NM_SETTING_MAC_RANDOMIZATION_NEVER (1) (never randomize the MAC address), or
+                             NM_SETTING_MAC_RANDOMIZATION_ALWAYS (2) (always randomize the MAC address). This property is deprecated for 'cloned-mac-address'.
+                type: int
+                default: 0
+                choices: [ 0, 1, 2 ]
+            mac-address:
+                description: If specified, this connection will only apply to the Wi-Fi device whose permanent MAC address matches. This property does not
+                             change the MAC address of the device (i.e. MAC spoofing).
+                type: str
+            mode:
+                description: Wi-Fi network mode; one of "infrastructure", "mesh", "adhoc" or "ap". If blank, infrastructure is assumed.
+                type: str
+                choices: [ infrastructure, mesh, adhoc, ap ]
+                default: infrastructure
+            mtu:
+                description: If non-zero, only transmit packets of the specified size or smaller, breaking larger packets up into multiple Ethernet frames.
+                type: int
+                default: 0
+            powersave:
+                description: One of NM_SETTING_WIRELESS_POWERSAVE_DISABLE (2) (disable Wi-Fi power saving), NM_SETTING_WIRELESS_POWERSAVE_ENABLE (3) (enable
+                             Wi-Fi power saving), NM_SETTING_WIRELESS_POWERSAVE_IGNORE (1) (don't touch currently configure setting) or
+                             NM_SETTING_WIRELESS_POWERSAVE_DEFAULT (0) (use the globally configured value). All other values are reserved.
+                type: int
+                default: 0
+                choices: [ 0, 1, 2, 3 ]
+            rate:
+                description: If non-zero, directs the device to only use the specified bitrate for communication with the access point. Units are in Kb/s, ie
+                             5500 = 5.5 Mbit/s. This property is highly driver dependent and not all devices support setting a static bitrate.
+                type: int
+                default: 0
+            seen-bssids:
+                description: A list of BSSIDs (each BSSID formatted as a MAC address like "00:11:22:33:44:55") that have been detected as part of the Wi-Fi
+                             network. NetworkManager internally tracks previously seen BSSIDs. The property is only meant for reading and reflects the BSSID
+                             list of NetworkManager. The changes you make to this property will not be preserved.
+                type: list
+                elements: str
+            tx-power:
+                description: If non-zero, directs the device to use the specified transmit power. Units are dBm. This property is highly driver dependent and
+                             not all devices support setting a static transmit power.
+                type: int
+                default: 0
+            wake-on-wlan:
+                description: The NMSettingWirelessWakeOnWLan options to enable. Not all devices support all options. May be any combination of
+                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_ANY (0x2), NM_SETTING_WIRELESS_WAKE_ON_WLAN_DISCONNECT (0x4),
+                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC (0x8), NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE (0x10),
+                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST (0x20), NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE (0x40),
+                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE (0x80), NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP (0x100) or the special values
+                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT (0x1) (to use global settings) and NM_SETTING_WIRELESS_WAKE_ON_WLAN_IGNORE (0x8000) (to
+                             disable management of Wake-on-LAN in NetworkManager).
+                type: int
+                default: 1
        version_added: 3.5.0
     ignore_unsupported_suboptions:
        description:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -456,8 +456,7 @@ options:
     wifi:
        description:
             - The configuration of the WiFi connection.
-            - Note the list of suboption attributes may vary depending on which version of NetworkManager/nmcli
-              is installed on the host.
+            - Note the list of suboption attributes may vary depending on which version of NetworkManager/nmcli is installed on the host.
             - 'An up-to-date list of supported attributes can be found here:
               U(https://networkmanager.dev/docs/api/latest/settings-802-11-wireless.html).'
             - 'For instance to create a hidden AP mode WiFi connection:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1456,7 +1456,7 @@ class Nmcli(object):
 
         if setting == '802-11-wireless-security':
             set_property = 'psk'
-            set_value='FAKEVALUE'
+            set_value = 'FAKEVALUE'
             commands = ['set %s.%s %s' % (setting, set_property, set_value)]
         else:
             commands = []

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1170,12 +1170,11 @@ class Nmcli(object):
 
         return conn_info
 
-    def get_available_options(self, return_type=None, set_option=None):
-        if not return_type:
-            if self.type == 'wifi':
-                return_type = '802-11-wireless'
-            else:
-                return_type == self.type
+    def get_available_options(self, return_type, set_option=None):
+        options = []
+
+        if return_type == '802-11-wireless-security' and set_option is None:
+            set_option = 'psk'
 
         if set_option:
             commands = ['set %s.%s %s' % (return_type, set_option, set_option)]
@@ -1191,7 +1190,6 @@ class Nmcli(object):
         if rc != 0:
             raise NmcliModuleError(err)
 
-        options = []
         for line in out.splitlines():
             if (line.startswith('%s.' % return_type)):
                 pair = line.split(':', 1)
@@ -1372,7 +1370,7 @@ def main():
             nmcli.module.fail_json(msg="Please specify an interface name for the connection when type is %s" % nmcli.type)
     if nmcli.type == 'wifi':
         if nmcli.wifi:
-            available_options = nmcli.get_available_options()
+            available_options = nmcli.get_available_options('802-11-wireless')
             unsupported_options = []
             for name, value in nmcli.wifi.items():
                 if name == 'ssid':
@@ -1389,7 +1387,7 @@ def main():
             for unsupported_option in unsupported_options:
                 del nmcli.wifi[unsupported_option]
         if nmcli.wifi_sec:
-            available_options = nmcli.get_available_options(return_type='802-11-wireless-security', set_option='psk')
+            available_options = nmcli.get_available_options('802-11-wireless-security')
             unsupported_options = []
             for name, value in nmcli.wifi_sec.items():
                 if '802-11-wireless-security.%s' % name not in available_options:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -344,7 +344,7 @@ options:
                 description:
                     - When WEP is used (ie, I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
                     - One of C(open) for Open System, C(shared) for Shared Key, or C(leap) for Cisco LEAP.
-                    - When using Cisco LEAP (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)) the I(leap-username) and I(leap-password) properties
+                    - When using Cisco LEAP (that is, if I(key-mgmt=ieee8021x) and I(auth-alg=leap)) the I(leap-username) and I(leap-password) properties
                       must be specified.
                 type: str
                 choices: [ open, shared, leap ]

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -507,8 +507,8 @@ options:
                 description:
                     - 802.11 frequency band of the network.
                     - One of C(a) for 5GHz 802.11a or C(bg) for 2.4GHz 802.11.
-                    - This will lock associations to the Wi-Fi network to the specific band, i.e. if C(a) is specified, the device will not associate with the
-                      same network in the 2.4GHz band even if the network's settings are compatible.
+                    - This will lock associations to the Wi-Fi network to the specific band, so for example, if C(a) is specified, the device will not
+                      associate with the same network in the 2.4GHz band even if the network's settings are compatible.
                     - This setting depends on specific driver capability and may not work with all drivers.
                 type: str
                 choices: [ a, bg ]
@@ -565,7 +565,7 @@ options:
             mac-address-blacklist:
                 description:
                     - A list of permanent MAC addresses of Wi-Fi devices to which this connection should never apply.
-                    - Each MAC address should be given in the standard hex-digits-and-colons notation (eg C(00:11:22:33:44:55)).
+                    - Each MAC address should be given in the standard hex-digits-and-colons notation (for example, C(00:11:22:33:44:55)).
                 type: list
                 elements: str
             mac-address-randomization:
@@ -579,7 +579,7 @@ options:
             mac-address:
                 description:
                     - If specified, this connection will only apply to the Wi-Fi device whose permanent MAC address matches.
-                    - This property does not change the MAC address of the device (i.e. MAC spoofing).
+                    - This property does not change the MAC address of the device (for example for MAC spoofing).
                 type: str
             mode:
                 description: Wi-Fi network mode. If blank, C(infrastructure) is assumed.
@@ -601,7 +601,7 @@ options:
             rate:
                 description:
                     - If non-zero, directs the device to only use the specified bitrate for communication with the access point.
-                    - Units are in Kb/s, ie C(5500) = 5.5 Mbit/s.
+                    - Units are in Kb/s, so for example C(5500) = 5.5 Mbit/s.
                     - This property is highly driver dependent and not all devices support setting a static bitrate.
                 type: int
                 default: 0
@@ -620,7 +620,7 @@ options:
                       C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST) (C(0x20)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE) (C(0x40)),
                       C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (C(0x80)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (C(0x100)) or the special values
                       C(0x1) (to use global settings) and C(0x8000) (to disable management of Wake-on-LAN in NetworkManager).
-                    - Note the sum of all option values must be specified in order to combine multiple options.
+                    - Note the option values' sum must be specified in order to combine multiple options.
                 type: int
                 default: 1
        version_added: 3.5.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -341,67 +341,67 @@ options:
        type: dict
        suboptions:
             auth-alg:
-                description: When WEP is used (ie, key-mgmt = "none" or "ieee8021x") indicate the 802.11 authentication algorithm required by the AP here. One
-                             of "open" for Open System, "shared" for Shared Key, or "leap" for Cisco LEAP. When using Cisco LEAP (ie, key-mgmt = "ieee8021x"
-                             and auth-alg = "leap") the "leap-username" and "leap-password" properties must be specified.
+                description: When WEP is used (ie, I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
+                             One of C(open) for Open System, C(shared) for Shared Key, or C(leap) for Cisco LEAP. When using Cisco LEAP (ie, I(key-mgmt) =
+                             C(ieee8021x) and I(auth-alg) = C(leap)) the I(leap-username) and I(leap-password) properties must be specified.
                 type: str
                 choices: [ open, shared, leap ]
             fils:
                 description: Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection. One of
-                             NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT (0) (use global default value), NM_SETTING_WIRELESS_SECURITY_FILS_DISABLE (1) (disable
-                             FILS), NM_SETTING_WIRELESS_SECURITY_FILS_OPTIONAL (2) (enable FILS if the supplicant and the access point support it) or
-                             NM_SETTING_WIRELESS_SECURITY_FILS_REQUIRED (3) (enable FILS and fail if not supported). When set to
-                             NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT (0) and no global default is set, FILS will be optionally enabled.
+                             C(NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT) (0) (use global default value), C(NM_SETTING_WIRELESS_SECURITY_FILS_DISABLE) (1)
+                             (disable FILS), C(NM_SETTING_WIRELESS_SECURITY_FILS_OPTIONAL) (2) (enable FILS if the supplicant and the access point support it)
+                             or C(NM_SETTING_WIRELESS_SECURITY_FILS_REQUIRED) (3) (enable FILS and fail if not supported). When set to
+                             C(NM_SETTING_WIRELESS_SECURITY_FILS_DEFAULT) (0) and no global default is set, FILS will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             group:
                 description: A list of group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the
-                             algorithms in the list. For maximum compatibility leave this property empty. Each list element may be one of "wep40", "wep104",
-                             "tkip", or "ccmp".
+                             algorithms in the list. For maximum compatibility leave this property empty. Each list element may be one of C(wep40), C(wep104),
+                             C(tkip), or C(ccmp).
                 type: list
                 elements: str
                 choices: [ wep40, wep104, tkip, ccmp ]
             key-mgmt:
-                description: Key management used for the connection. One of "none" (WEP or no password protection), "ieee8021x" (Dynamic WEP), "owe"
-                             (Opportunistic Wireless Encryption), "wpa-psk" (WPA2 + WPA3 personal), "sae" (WPA3 personal only), "wpa-eap" (WPA2 + WPA3
-                             enterprise) or "wpa-eap-suite-b-192" (WPA3 enterprise only). This property must be set for any Wi-Fi connection that uses
+                description: Key management used for the connection. One of C(none) (WEP or no password protection), C(ieee8021x) (Dynamic WEP), C(owe)
+                             (Opportunistic Wireless Encryption), C(wpa-psk) (WPA2 + WPA3 personal), C(sae) (WPA3 personal only), C(wpa-eap) (WPA2 + WPA3
+                             enterprise) or C(wpa-eap-suite-b-192) (WPA3 enterprise only). This property must be set for any Wi-Fi connection that uses
                              security.
                 type: str
                 choices: [ none, ieee8021x, owe, wpa-psk, sae, wpa-eap, wpa-eap-suite-b-192 ]
             leap-password-flags:
-                description: Flags indicating how to handle the "leap-password" property.
+                description: Flags indicating how to handle the I(leap-password) property.
                 type: list
                 elements: int
             leap-password:
-                description: The login password for legacy LEAP connections (ie, key-mgmt = "ieee8021x" and auth-alg = "leap").
+                description: The login password for legacy LEAP connections (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)).
                 type: str
             leap-username:
-                description: The login username for legacy LEAP connections (ie, key-mgmt = "ieee8021x" and auth-alg = "leap").
+                description: The login username for legacy LEAP connections (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)).
                 type: str
             pairwise:
                 description: A list of pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in
-                             the list. For maximum compatibility leave this property empty. Each list element may be one of "tkip" or "ccmp".
+                             the list. For maximum compatibility leave this property empty. Each list element may be one of C(tkip) or C(ccmp).
                 type: list
                 elements: str
                 choices: [ tkip, ccmp ]
             pmf:
                 description: Indicates whether Protected Management Frames (802.11w) must be enabled for the connection. One of
-                             NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT (0) (use global default value), NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE (1) (disable
-                             PMF), NM_SETTING_WIRELESS_SECURITY_PMF_OPTIONAL (2) (enable PMF if the supplicant and the access point support it) or
-                             NM_SETTING_WIRELESS_SECURITY_PMF_REQUIRED (3) (enable PMF and fail if not supported). When set to
-                             NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT (0) and no global default is set, PMF will be optionally enabled.
+                             C(NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT) (0) (use global default value), C(NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE) (1)
+                             (disable PMF), C(NM_SETTING_WIRELESS_SECURITY_PMF_OPTIONAL) (2) (enable PMF if the supplicant and the access point support it) or
+                             C(NM_SETTING_WIRELESS_SECURITY_PMF_REQUIRED) (3) (enable PMF and fail if not supported). When set to
+                             C(NM_SETTING_WIRELESS_SECURITY_PMF_DEFAULT) (0) and no global default is set, PMF will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             proto:
-                description: List of strings specifying the allowed WPA protocol versions to use. Each element may be one "wpa" (allow WPA) or "rsn" (allow
+                description: List of strings specifying the allowed WPA protocol versions to use. Each element may be one C(wpa) (allow WPA) or C(rsn) (allow
                              WPA2/RSN). If not specified, both WPA and RSN connections are allowed.
                 type: list
                 elements: str
                 choices: [ wpa, rsn ]
             psk-flags:
-                description: Flags indicating how to handle the "psk" property.
+                description: Flags indicating how to handle the I(psk) property.
                 type: list
                 elements: int
             psk:
@@ -410,41 +410,42 @@ options:
                              a passphrase of any length for SAE authentication.
                 type: str
             wep-key-flags:
-                description: Flags indicating how to handle the "wep-key0", "wep-key1", "wep-key2", and "wep-key3" properties.
+                description: Flags indicating how to handle the I(wep-key0), I(wep-key1), I(wep-key2), and I(wep-key3) properties.
                 type: list
                 elements: int
             wep-key-type:
-                description: Controls the interpretation of WEP keys. Allowed values are NM_WEP_KEY_TYPE_KEY (1), in which case the key is either a 10- or
-                             26-character hexadecimal string, or a 5- or 13-character ASCII password; or NM_WEP_KEY_TYPE_PASSPHRASE (2), in which case the
+                description: Controls the interpretation of WEP keys. Allowed values are C(NM_WEP_KEY_TYPE_KEY) (1), in which case the key is either a 10- or
+                             26-character hexadecimal string, or a 5- or 13-character ASCII password; or C(NM_WEP_KEY_TYPE_PASSPHRASE) (2), in which case the
                              passphrase is provided as a string and will be hashed using the de-facto MD5 method to derive the actual WEP key.
                 type: int
                 choices: [ 1, 2 ]
             wep-key0:
-                description: Index 0 WEP key. This is the WEP key used in most networks. See the "wep-key-type" property for a description of how this key is
+                description: Index 0 WEP key. This is the WEP key used in most networks. See the I(wep-key-type) property for a description of how this key is
                              interpreted.
                 type: str
             wep-key1:
-                description: Index 1 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
-                             interpreted.
+                description: Index 1 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
+                             is interpreted.
                 type: str
             wep-key2:
-                description: Index 2 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
-                             interpreted.
+                description: Index 2 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
+                             is interpreted.
                 type: str
             wep-key3:
-                description: Index 3 WEP key. This WEP index is not used by most networks. See the "wep-key-type" property for a description of how this key is
-                             interpreted.
+                description: Index 3 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
+                             is interpreted.
                 type: str
             wep-tx-keyidx:
-                description: When static WEP is used (ie, key-mgmt = "none") and a non-default WEP key index is used by the AP, put that WEP key index here.
-                             Valid values are 0 (default key) through 3. Note that some consumer access points (like the Linksys WRT54G) number the keys 1 - 4.
+                description: When static WEP is used (ie, I(key-mgmt) = C(none)) and a non-default WEP key index is used by the AP, put that WEP key index
+                             here. Valid values are C(0) (default key) through C(3). Note that some consumer access points (like the Linksys WRT54G) number the
+                             keys C(1) - C(4).
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             wps-method:
                 description: Flags indicating which mode of WPS is to be used if any. There's little point in changing the default setting as NetworkManager
                              will automatically determine whether it's feasible to start WPS enrollment from the Access Point capabilities. WPS can be disabled
-                             by setting this property to a value of 1.
+                             by setting this property to a value of C(1).
                 type: int
                 default: 0
        version_added: 3.0.0
@@ -465,21 +466,23 @@ options:
        suboptions:
             ap-isolation:
                 description: Configures AP isolation, which prevents communication between wireless devices connected to this AP. This property can be set to a
-                             value different from NM_TERNARY_DEFAULT (-1) only when the interface is configured in AP mode. If set to NM_TERNARY_TRUE (1),
-                             devices are not able to communicate with each other. This increases security because it protects devices against attacks from
+                             value different from C(NM_TERNARY_DEFAULT) (-1) only when the interface is configured in AP mode. If set to C(NM_TERNARY_TRUE)
+                             (1), devices are not able to communicate with each other. This increases security because it protects devices against attacks from
                              other clients in the network. At the same time, it prevents devices to access resources on the same wireless networks as file
-                             shares, printers, etc. If set to NM_TERNARY_FALSE (0), devices can talk to each other. When set to NM_TERNARY_DEFAULT (-1), the
-                             global default is used; in case the global default is unspecified it is assumed to be NM_TERNARY_FALSE (0).
+                             shares, printers, etc. If set to C(NM_TERNARY_FALSE) (0), devices can talk to each other. When set to C(NM_TERNARY_DEFAULT) (-1),
+                             the global default is used; in case the global default is unspecified it is assumed to be C(NM_TERNARY_FALSE) (0).
                 type: int
+                choices: [ -1, 0, 1 ]
+                default: -1
             assigned-mac-address:
                 description: The new field for the cloned MAC address. It can be either a hardware address in ASCII representation, or one of the special
-                             values "preserve", "permanent", "random" or "stable". This field replaces the deprecated "cloned-mac-address" on D-Bus, which can
-                             only contain explicit hardware addresses. Note that this property only exists in D-Bus API. libnm and nmcli continue to call this
-                             property "cloned-mac-address".
+                             values C(preserve), C(permanent), C(random) or C(stable). This field replaces the deprecated I(cloned-mac-address) on D-Bus, which
+                             can only contain explicit hardware addresses. Note that this property only exists in D-Bus API. libnm and nmcli continue to call
+                             this property I(cloned-mac-address).
                 type: str
             band:
-                description: 802.11 frequency band of the network. One of "a" for 5GHz 802.11a or "bg" for 2.4GHz 802.11. This will lock associations to the
-                             Wi-Fi network to the specific band, i.e. if "a" is specified, the device will not associate with the same network in the 2.4GHz
+                description: 802.11 frequency band of the network. One of C(a) for 5GHz 802.11a or C(bg) for 2.4GHz 802.11. This will lock associations to the
+                             Wi-Fi network to the specific band, i.e. if C(a) is specified, the device will not associate with the same network in the 2.4GHz
                              band even if the network's settings are compatible. This setting depends on specific driver capability and may not work with all
                              drivers.
                 type: str
@@ -491,22 +494,22 @@ options:
                 type: str
             channel:
                 description: Wireless channel to use for the Wi-Fi connection. The device will only join (or create for Ad-Hoc networks) a Wi-Fi network on the
-                             specified channel. Because channel numbers overlap between bands, this property also requires the "band" property to be set.
+                             specified channel. Because channel numbers overlap between bands, this property also requires the I(band) property to be set.
                 type: int
                 default: 0
             cloned-mac-address:
-                description: This D-Bus field is deprecated in favor of "assigned-mac-address" which is more flexible and allows specifying special variants
-                             like "random". For libnm and nmcli, this field is called "cloned-mac-address".
+                description: This D-Bus field is deprecated in favor of I(assigned-mac-address) which is more flexible and allows specifying special variants
+                             like C(random). For libnm and nmcli, this field is called I(cloned-mac-address).
                 type: str
             generate-mac-address-mask:
-                description: With "cloned-mac-address" setting "random" or "stable", by default all bits of the MAC address are scrambled and a
+                description: With I(cloned-mac-address) setting C(random) or C(stable), by default all bits of the MAC address are scrambled and a
                              locally-administered, unicast MAC address is created. This property allows to specify that certain bits are fixed. Note that the
                              least significant bit of the first MAC address will always be unset to create a unicast MAC address. If the property is NULL, it
                              is eligible to be overwritten by a default connection setting. If the value is still NULL or an empty string, the default is to
                              create a locally-administered, unicast MAC address. If the value contains one MAC address, this address is used as mask. The set
                              bits of the mask are to be filled with the current MAC address of the device, while the unset bits are subject to randomization.
                              Setting "FE:FF:FF:00:00:00" means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
-                             "random" or "stable" algorithm. If the value contains one additional MAC address after the mask, this address is used instead of
+                             C(random) or C(stable) algorithm. If the value contains one additional MAC address after the mask, this address is used instead of
                              the current MAC address to fill the bits that shall not be randomized. For example, a value of
                              "FE:FF:FF:00:00:00 68:F7:28:00:00:00" will set the OUI of the MAC address to 68:F7:28, while the lower bits are randomized. A
                              value of "02:00:00:00:00:00 00:00:00:00:00:00" will create a fully scrambled globally-administered, burned-in MAC address. If the
@@ -529,9 +532,10 @@ options:
                 type: list
                 elements: str
             mac-address-randomization:
-                description: One of NM_SETTING_MAC_RANDOMIZATION_DEFAULT (0) (never randomize unless the user has set a global default to randomize and the
-                             supplicant supports randomization), NM_SETTING_MAC_RANDOMIZATION_NEVER (1) (never randomize the MAC address), or
-                             NM_SETTING_MAC_RANDOMIZATION_ALWAYS (2) (always randomize the MAC address). This property is deprecated for 'cloned-mac-address'.
+                description: One of C(NM_SETTING_MAC_RANDOMIZATION_DEFAULT) (0) (never randomize unless the user has set a global default to randomize and the
+                             supplicant supports randomization), C(NM_SETTING_MAC_RANDOMIZATION_NEVER) (1) (never randomize the MAC address), or
+                             C(NM_SETTING_MAC_RANDOMIZATION_ALWAYS) (2) (always randomize the MAC address). This property is deprecated for
+                             C(cloned-mac-address).
                 type: int
                 default: 0
                 choices: [ 0, 1, 2 ]
@@ -540,7 +544,7 @@ options:
                              change the MAC address of the device (i.e. MAC spoofing).
                 type: str
             mode:
-                description: Wi-Fi network mode; one of "infrastructure", "mesh", "adhoc" or "ap". If blank, infrastructure is assumed.
+                description: Wi-Fi network mode; one of C(infrastructure), C(mesh), C(adhoc) or C(ap). If blank, infrastructure is assumed.
                 type: str
                 choices: [ infrastructure, mesh, adhoc, ap ]
                 default: infrastructure
@@ -549,15 +553,15 @@ options:
                 type: int
                 default: 0
             powersave:
-                description: One of NM_SETTING_WIRELESS_POWERSAVE_DISABLE (2) (disable Wi-Fi power saving), NM_SETTING_WIRELESS_POWERSAVE_ENABLE (3) (enable
-                             Wi-Fi power saving), NM_SETTING_WIRELESS_POWERSAVE_IGNORE (1) (don't touch currently configure setting) or
-                             NM_SETTING_WIRELESS_POWERSAVE_DEFAULT (0) (use the globally configured value). All other values are reserved.
+                description: One of C(NM_SETTING_WIRELESS_POWERSAVE_DISABLE) (2) (disable Wi-Fi power saving), C(NM_SETTING_WIRELESS_POWERSAVE_ENABLE) (3)
+                             (enable Wi-Fi power saving), C(NM_SETTING_WIRELESS_POWERSAVE_IGNORE) (1) (don't touch currently configure setting) or
+                             C(NM_SETTING_WIRELESS_POWERSAVE_DEFAULT) (0) (use the globally configured value). All other values are reserved.
                 type: int
                 default: 0
                 choices: [ 0, 1, 2, 3 ]
             rate:
                 description: If non-zero, directs the device to only use the specified bitrate for communication with the access point. Units are in Kb/s, ie
-                             5500 = 5.5 Mbit/s. This property is highly driver dependent and not all devices support setting a static bitrate.
+                             C(5500) = 5.5 Mbit/s. This property is highly driver dependent and not all devices support setting a static bitrate.
                 type: int
                 default: 0
             seen-bssids:
@@ -573,20 +577,19 @@ options:
                 default: 0
             wake-on-wlan:
                 description: The NMSettingWirelessWakeOnWLan options to enable. Not all devices support all options. May be any combination of
-                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_ANY (0x2), NM_SETTING_WIRELESS_WAKE_ON_WLAN_DISCONNECT (0x4),
-                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC (0x8), NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE (0x10),
-                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST (0x20), NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE (0x40),
-                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE (0x80), NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP (0x100) or the special values
-                             NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT (0x1) (to use global settings) and NM_SETTING_WIRELESS_WAKE_ON_WLAN_IGNORE (0x8000) (to
-                             disable management of Wake-on-LAN in NetworkManager).
+                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_ANY) (0x2), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DISCONNECT) (0x4),
+                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC) (0x8), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE) (0x10),
+                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST) (0x20), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE) (0x40),
+                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (0x80), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (0x100) or the special values
+                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DEFAULT) (0x1) (to use global settings) and C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_IGNORE) (0x8000)
+                             (to disable management of Wake-on-LAN in NetworkManager).
                 type: int
                 default: 1
        version_added: 3.5.0
     ignore_unsupported_suboptions:
        description:
-            - Ignore suboptions which are invalid or unsupported by the version of NetworkManager/nmcli
-              installed on the host.
-            - Only 'wifi' and 'wifi_sec' options are currently affected.
+            - Ignore suboptions which are invalid or unsupported by the version of NetworkManager/nmcli installed on the host.
+            - Only I(wifi) and I(wifi_sec) options are currently affected.
        type: bool
        default: no
        version_added: 3.6.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1173,8 +1173,8 @@ class Nmcli(object):
     def get_available_options(self, return_type, set_option=None):
         options = []
 
-        if return_type == '802-11-wireless-security' and set_option is None:
-            set_option = 'psk'
+        if return_type == '802-11-wireless-security':
+            set_option = set_option or 'psk'
 
         if set_option:
             commands = ['set %s.%s %s' % (return_type, set_option, set_option)]

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -403,7 +403,7 @@ options:
             proto:
                 description:
                     - List of strings specifying the allowed WPA protocol versions to use.
-                    - Each element may be one C(wpa) (allow WPA) or C(rsn) (allow WPA2/RSN).
+                    - Each element may be C(wpa) (allow WPA) or C(rsn) (allow WPA2/RSN).
                     - If not specified, both WPA and RSN connections are allowed.
                 type: list
                 elements: str

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1451,13 +1451,12 @@ class Nmcli(object):
 
         return conn_info
 
-    def get_supported_properties(self, setting, set_property=None, set_value='FAKEVALUE'):
+    def get_supported_properties(self, setting):
         properties = []
 
         if setting == '802-11-wireless-security':
-            set_property = set_property or 'psk'
-
-        if set_property:
+            set_property = 'psk'
+            set_value='FAKEVALUE'
             commands = ['set %s.%s %s' % (setting, set_property, set_value)]
         else:
             commands = []

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -341,29 +341,36 @@ options:
        type: dict
        suboptions:
             auth-alg:
-                description: When WEP is used (ie, I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
-                             One of C(open) for Open System, C(shared) for Shared Key, or C(leap) for Cisco LEAP. When using Cisco LEAP (ie, I(key-mgmt) =
-                             C(ieee8021x) and I(auth-alg) = C(leap)) the I(leap-username) and I(leap-password) properties must be specified.
+                description:
+                    - When WEP is used (ie, I(key-mgmt) = C(none) or C(ieee8021x)) indicate the 802.11 authentication algorithm required by the AP here.
+                    - One of C(open) for Open System, C(shared) for Shared Key, or C(leap) for Cisco LEAP.
+                    - When using Cisco LEAP (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)) the I(leap-username) and I(leap-password) properties
+                      must be specified.
                 type: str
                 choices: [ open, shared, leap ]
             fils:
-                description: Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection. One of C(0) (use global default value),
-                             C(1) (disable FILS), C(2) (enable FILS if the supplicant and the access point support it) or C(3) (enable FILS and fail if not
-                             supported). When set to C(0) and no global default is set, FILS will be optionally enabled.
+                description:
+                    - Indicates whether Fast Initial Link Setup (802.11ai) must be enabled for the connection.
+                    - One of C(0) (use global default value), C(1) (disable FILS), C(2) (enable FILS if the supplicant and the access point support it) or C(3)
+                      (enable FILS and fail if not supported).
+                    - When set to C(0) and no global default is set, FILS will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             group:
-                description: A list of group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the
-                             algorithms in the list. For maximum compatibility leave this property empty.
+                description:
+                    - A list of group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in
+                      the list.
+                    - For maximum compatibility leave this property empty.
                 type: list
                 elements: str
                 choices: [ wep40, wep104, tkip, ccmp ]
             key-mgmt:
-                description: Key management used for the connection. One of C(none) (WEP or no password protection), C(ieee8021x) (Dynamic WEP), C(owe)
-                             (Opportunistic Wireless Encryption), C(wpa-psk) (WPA2 + WPA3 personal), C(sae) (WPA3 personal only), C(wpa-eap) (WPA2 + WPA3
-                             enterprise) or C(wpa-eap-suite-b-192) (WPA3 enterprise only). This property must be set for any Wi-Fi connection that uses
-                             security.
+                description:
+                    - Key management used for the connection.
+                    - One of C(none) (WEP or no password protection), C(ieee8021x) (Dynamic WEP), C(owe) (Opportunistic Wireless Encryption), C(wpa-psk) (WPA2
+                      + WPA3 personal), C(sae) (WPA3 personal only), C(wpa-eap) (WPA2 + WPA3 enterprise) or C(wpa-eap-suite-b-192) (WPA3 enterprise only).
+                    - This property must be set for any Wi-Fi connection that uses security.
                 type: str
                 choices: [ none, ieee8021x, owe, wpa-psk, sae, wpa-eap, wpa-eap-suite-b-192 ]
             leap-password-flags:
@@ -377,21 +384,27 @@ options:
                 description: The login username for legacy LEAP connections (ie, I(key-mgmt) = C(ieee8021x) and I(auth-alg) = C(leap)).
                 type: str
             pairwise:
-                description: A list of pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in
-                             the list. For maximum compatibility leave this property empty.
+                description:
+                    - A list of pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms in the
+                      list.
+                    - For maximum compatibility leave this property empty.
                 type: list
                 elements: str
                 choices: [ tkip, ccmp ]
             pmf:
-                description: Indicates whether Protected Management Frames (802.11w) must be enabled for the connection. One of C(0) (use global default
-                             value), C(1) (disable PMF), C(2) (enable PMF if the supplicant and the access point support it) or C(3) (enable PMF and fail if
-                             not supported). When set to C(0) and no global default is set, PMF will be optionally enabled.
+                description:
+                    - Indicates whether Protected Management Frames (802.11w) must be enabled for the connection.
+                    - One of C(0) (use global default value), C(1) (disable PMF), C(2) (enable PMF if the supplicant and the access point support it) or C(3)
+                      (enable PMF and fail if not supported).
+                    - When set to C(0) and no global default is set, PMF will be optionally enabled.
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             proto:
-                description: List of strings specifying the allowed WPA protocol versions to use. Each element may be one C(wpa) (allow WPA) or C(rsn) (allow
-                             WPA2/RSN). If not specified, both WPA and RSN connections are allowed.
+                description:
+                    - List of strings specifying the allowed WPA protocol versions to use.
+                    - Each element may be one C(wpa) (allow WPA) or C(rsn) (allow WPA2/RSN).
+                    - If not specified, both WPA and RSN connections are allowed.
                 type: list
                 elements: str
                 choices: [ wpa, rsn ]
@@ -400,47 +413,58 @@ options:
                 type: list
                 elements: int
             psk:
-                description: Pre-Shared-Key for WPA networks. For WPA-PSK, it's either an ASCII passphrase of 8 to 63 characters that is (as specified in the
-                             802.11i standard) hashed to derive the actual key, or the key in form of 64 hexadecimal character. The WPA3-Personal networks use
-                             a passphrase of any length for SAE authentication.
+                description:
+                    - Pre-Shared-Key for WPA networks.
+                    - For WPA-PSK, it's either an ASCII passphrase of 8 to 63 characters that is (as specified in the 802.11i standard) hashed to derive the
+                      actual key, or the key in form of 64 hexadecimal character.
+                    - The WPA3-Personal networks use a passphrase of any length for SAE authentication.
                 type: str
             wep-key-flags:
                 description: Flags indicating how to handle the I(wep-key0), I(wep-key1), I(wep-key2), and I(wep-key3) properties.
                 type: list
                 elements: int
             wep-key-type:
-                description: Controls the interpretation of WEP keys. Allowed values are C(1), in which case the key is either a 10- or 26-character
-                             hexadecimal string, or a 5- or 13-character ASCII password; or C(2), in which case the passphrase is provided as a string and will
-                             be hashed using the de-facto MD5 method to derive the actual WEP key.
+                description:
+                    - Controls the interpretation of WEP keys.
+                    - Allowed values are C(1), in which case the key is either a 10- or 26-character hexadecimal string, or a 5- or 13-character ASCII
+                      password; or C(2), in which case the passphrase is provided as a string and will be hashed using the de-facto MD5 method to derive the
+                      actual WEP key.
                 type: int
                 choices: [ 1, 2 ]
             wep-key0:
-                description: Index 0 WEP key. This is the WEP key used in most networks. See the I(wep-key-type) property for a description of how this key is
-                             interpreted.
+                description:
+                    - Index 0 WEP key. This is the WEP key used in most networks.
+                    - See the I(wep-key-type) property for a description of how this key is interpreted.
                 type: str
             wep-key1:
-                description: Index 1 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
-                             is interpreted.
+                description:
+                    - Index 1 WEP key. This WEP index is not used by most networks.
+                    - See the I(wep-key-type) property for a description of how this key is interpreted.
                 type: str
             wep-key2:
-                description: Index 2 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
-                             is interpreted.
+                description:
+                    - Index 2 WEP key. This WEP index is not used by most networks.
+                    - See the I(wep-key-type) property for a description of how this key is interpreted.
                 type: str
             wep-key3:
-                description: Index 3 WEP key. This WEP index is not used by most networks. See the I(wep-key-type) property for a description of how this key
-                             is interpreted.
+                description:
+                    - Index 3 WEP key. This WEP index is not used by most networks.
+                    - See the I(wep-key-type) property for a description of how this key is interpreted.
                 type: str
             wep-tx-keyidx:
-                description: When static WEP is used (ie, I(key-mgmt) = C(none)) and a non-default WEP key index is used by the AP, put that WEP key index
-                             here. Valid values are C(0) (default key) through C(3). Note that some consumer access points (like the Linksys WRT54G) number the
-                             keys C(1) - C(4).
+                description:
+                    - When static WEP is used (ie, I(key-mgmt) = C(none)) and a non-default WEP key index is used by the AP, put that WEP key index here.
+                    - Valid values are C(0) (default key) through C(3).
+                    - Note that some consumer access points (like the Linksys WRT54G) number the keys C(1) - C(4).
                 type: int
                 choices: [ 0, 1, 2, 3 ]
                 default: 0
             wps-method:
-                description: Flags indicating which mode of WPS is to be used if any. There's little point in changing the default setting as NetworkManager
-                             will automatically determine whether it's feasible to start WPS enrollment from the Access Point capabilities. WPS can be disabled
-                             by setting this property to a value of C(1).
+                description:
+                    - Flags indicating which mode of WPS is to be used if any.
+                    - There's little point in changing the default setting as NetworkManager will automatically determine whether it's feasible to start WPS
+                      enrollment from the Access Point capabilities.
+                    - WPS can be disabled by setting this property to a value of C(1).
                 type: int
                 default: 0
        version_added: 3.0.0
@@ -460,82 +484,102 @@ options:
        type: dict
        suboptions:
             ap-isolation:
-                description: Configures AP isolation, which prevents communication between wireless devices connected to this AP. This property can be set to a
-                             value different from C(-1) only when the interface is configured in AP mode. If set to C(1), devices are not able to communicate
-                             with each other. This increases security because it protects devices against attacks from other clients in the network. At the
-                             same time, it prevents devices to access resources on the same wireless networks as file shares, printers, etc. If set to C(0),
-                             devices can talk to each other. When set to C(-1), the global default is used; in case the global default is unspecified it is
-                             assumed to be C(0).
+                description:
+                    - Configures AP isolation, which prevents communication between wireless devices connected to this AP.
+                    - This property can be set to a value different from C(-1) only when the interface is configured in AP mode.
+                    - If set to C(1), devices are not able to communicate with each other. This increases security because it protects devices against attacks
+                      from other clients in the network. At the same time, it prevents devices to access resources on the same wireless networks as file
+                      shares, printers, etc.
+                    - If set to C(0), devices can talk to each other.
+                    - When set to C(-1), the global default is used; in case the global default is unspecified it is assumed to be C(0).
                 type: int
                 choices: [ -1, 0, 1 ]
                 default: -1
             assigned-mac-address:
-                description: The new field for the cloned MAC address. It can be either a hardware address in ASCII representation, or one of the special
-                             values C(preserve), C(permanent), C(random) or C(stable). This field replaces the deprecated I(cloned-mac-address) on D-Bus, which
-                             can only contain explicit hardware addresses. Note that this property only exists in D-Bus API. libnm and nmcli continue to call
-                             this property I(cloned-mac-address).
+                description:
+                    - The new field for the cloned MAC address.
+                    - It can be either a hardware address in ASCII representation, or one of the special values C(preserve), C(permanent), C(random) or
+                      C(stable).
+                    - This field replaces the deprecated I(cloned-mac-address) on D-Bus, which can only contain explicit hardware addresses.
+                    - Note that this property only exists in D-Bus API. libnm and nmcli continue to call this property I(cloned-mac-address).
                 type: str
             band:
-                description: 802.11 frequency band of the network. One of C(a) for 5GHz 802.11a or C(bg) for 2.4GHz 802.11. This will lock associations to the
-                             Wi-Fi network to the specific band, i.e. if C(a) is specified, the device will not associate with the same network in the 2.4GHz
-                             band even if the network's settings are compatible. This setting depends on specific driver capability and may not work with all
-                             drivers.
+                description:
+                    - 802.11 frequency band of the network.
+                    - One of C(a) for 5GHz 802.11a or C(bg) for 2.4GHz 802.11.
+                    - This will lock associations to the Wi-Fi network to the specific band, i.e. if C(a) is specified, the device will not associate with the
+                      same network in the 2.4GHz band even if the network's settings are compatible.
+                    - This setting depends on specific driver capability and may not work with all drivers.
                 type: str
                 choices: [ a, bg ]
             bssid:
-                description: If specified, directs the device to only associate with the given access point. This capability is highly driver dependent and not
-                             supported by all devices. Note this property does not control the BSSID used when creating an Ad-Hoc network and is unlikely to
-                             in the future.
+                description:
+                    - If specified, directs the device to only associate with the given access point.
+                    - This capability is highly driver dependent and not supported by all devices.
+                    - Note this property does not control the BSSID used when creating an Ad-Hoc network and is unlikely to in the future.
                 type: str
             channel:
-                description: Wireless channel to use for the Wi-Fi connection. The device will only join (or create for Ad-Hoc networks) a Wi-Fi network on the
-                             specified channel. Because channel numbers overlap between bands, this property also requires the I(band) property to be set.
+                description:
+                    - Wireless channel to use for the Wi-Fi connection.
+                    - The device will only join (or create for Ad-Hoc networks) a Wi-Fi network on the specified channel.
+                    - Because channel numbers overlap between bands, this property also requires the I(band) property to be set.
                 type: int
                 default: 0
             cloned-mac-address:
-                description: This D-Bus field is deprecated in favor of I(assigned-mac-address) which is more flexible and allows specifying special variants
-                             like C(random). For libnm and nmcli, this field is called I(cloned-mac-address).
+                description:
+                    - This D-Bus field is deprecated in favor of I(assigned-mac-address) which is more flexible and allows specifying special variants like
+                      C(random).
+                    - For libnm and nmcli, this field is called I(cloned-mac-address).
                 type: str
             generate-mac-address-mask:
-                description: With I(cloned-mac-address) setting C(random) or C(stable), by default all bits of the MAC address are scrambled and a
-                             locally-administered, unicast MAC address is created. This property allows to specify that certain bits are fixed. Note that the
-                             least significant bit of the first MAC address will always be unset to create a unicast MAC address. If the property is NULL, it
-                             is eligible to be overwritten by a default connection setting. If the value is still NULL or an empty string, the default is to
-                             create a locally-administered, unicast MAC address. If the value contains one MAC address, this address is used as mask. The set
-                             bits of the mask are to be filled with the current MAC address of the device, while the unset bits are subject to randomization.
-                             Setting C(FE:FF:FF:00:00:00) means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
-                             C(random) or C(stable) algorithm. If the value contains one additional MAC address after the mask, this address is used instead of
-                             the current MAC address to fill the bits that shall not be randomized. For example, a value of
-                             C(FE:FF:FF:00:00:00 68:F7:28:00:00:00) will set the OUI of the MAC address to 68:F7:28, while the lower bits are randomized. A
-                             value of C(02:00:00:00:00:00 00:00:00:00:00:00) will create a fully scrambled globally-administered, burned-in MAC address. If the
-                             value contains more than one additional MAC addresses, one of them is chosen randomly. For example,
-                             C(02:00:00:00:00:00 00:00:00:00:00:00 02:00:00:00:00:00) will create a fully scrambled MAC address, randomly locally or globally
-                             administered.
+                description:
+                    - With I(cloned-mac-address) setting C(random) or C(stable), by default all bits of the MAC address are scrambled and a
+                      locally-administered, unicast MAC address is created. This property allows to specify that certain bits are fixed.
+                    - Note that the least significant bit of the first MAC address will always be unset to create a unicast MAC address.
+                    - If the property is C(null), it is eligible to be overwritten by a default connection setting.
+                    - If the value is still c(null) or an empty string, the default is to create a locally-administered, unicast MAC address.
+                    - If the value contains one MAC address, this address is used as mask. The set bits of the mask are to be filled with the current MAC
+                      address of the device, while the unset bits are subject to randomization.
+                    - Setting C(FE:FF:FF:00:00:00) means to preserve the OUI of the current MAC address and only randomize the lower 3 bytes using the
+                      C(random) or C(stable) algorithm.
+                    - If the value contains one additional MAC address after the mask, this address is used instead of the current MAC address to fill the bits
+                      that shall not be randomized.
+                    - For example, a value of C(FE:FF:FF:00:00:00 68:F7:28:00:00:00) will set the OUI of the MAC address to 68:F7:28, while the lower bits are
+                      randomized.
+                    - A value of C(02:00:00:00:00:00 00:00:00:00:00:00) will create a fully scrambled globally-administered, burned-in MAC address.
+                    - If the value contains more than one additional MAC addresses, one of them is chosen randomly. For example,
+                      C(02:00:00:00:00:00 00:00:00:00:00:00 02:00:00:00:00:00) will create a fully scrambled MAC address, randomly locally or globally
+                      administered.
                 type: str
             hidden:
-                description: If TRUE, indicates that the network is a non-broadcasting network that hides its SSID. This works both in infrastructure and AP
-                             mode. In infrastructure mode, various workarounds are used for a more reliable discovery of hidden networks, such as
-                             probe-scanning the SSID. However, these workarounds expose inherent insecurities with hidden SSID networks, and thus hidden SSID
-                             networks should be used with caution. In AP mode, the created network does not broadcast its SSID. Note that marking the network
-                             as hidden may be a privacy issue for you (in infrastructure mode) or client stations (in AP mode), as the explicit probe-scans are
-                             distinctly recognizable on the air.
+                description:
+                    - If C(true), indicates that the network is a non-broadcasting network that hides its SSID. This works both in infrastructure and AP mode.
+                    - In infrastructure mode, various workarounds are used for a more reliable discovery of hidden networks, such as probe-scanning the SSID.
+                      However, these workarounds expose inherent insecurities with hidden SSID networks, and thus hidden SSID networks should be used with
+                      caution.
+                    - In AP mode, the created network does not broadcast its SSID.
+                    - Note that marking the network as hidden may be a privacy issue for you (in infrastructure mode) or client stations (in AP mode), as the
+                      explicit probe-scans are distinctly recognizable on the air.
                 type: bool
                 default: false
             mac-address-blacklist:
-                description: A list of permanent MAC addresses of Wi-Fi devices to which this connection should never apply. Each MAC address should be given
-                             in the standard hex-digits-and-colons notation (eg C(00:11:22:33:44:55)).
+                description:
+                    - A list of permanent MAC addresses of Wi-Fi devices to which this connection should never apply.
+                    - Each MAC address should be given in the standard hex-digits-and-colons notation (eg C(00:11:22:33:44:55)).
                 type: list
                 elements: str
             mac-address-randomization:
-                description: One of C(0) (never randomize unless the user has set a global default to randomize and the supplicant supports randomization),
-                             C(1) (never randomize the MAC address), or C(2) (always randomize the MAC address). This property is deprecated for
-                             I(cloned-mac-address).
+                description:
+                    - One of C(0) (never randomize unless the user has set a global default to randomize and the supplicant supports randomization), C(1)
+                      (never randomize the MAC address), or C(2) (always randomize the MAC address).
+                    - This property is deprecated for I(cloned-mac-address).
                 type: int
                 default: 0
                 choices: [ 0, 1, 2 ]
             mac-address:
-                description: If specified, this connection will only apply to the Wi-Fi device whose permanent MAC address matches. This property does not
-                             change the MAC address of the device (i.e. MAC spoofing).
+                description:
+                    - If specified, this connection will only apply to the Wi-Fi device whose permanent MAC address matches.
+                    - This property does not change the MAC address of the device (i.e. MAC spoofing).
                 type: str
             mode:
                 description: Wi-Fi network mode. If blank, C(infrastructure) is assumed.
@@ -547,35 +591,36 @@ options:
                 type: int
                 default: 0
             powersave:
-                description: One of C(2) (disable Wi-Fi power saving), C(3) (enable Wi-Fi power saving), C(1) (don't touch currently configure setting) or C(0)
-                             (use the globally configured value). All other values are reserved.
+                description:
+                    - One of C(2) (disable Wi-Fi power saving), C(3) (enable Wi-Fi power saving), C(1) (don't touch currently configure setting) or C(0) (use
+                      the globally configured value).
+                    - All other values are reserved.
                 type: int
                 default: 0
                 choices: [ 0, 1, 2, 3 ]
             rate:
-                description: If non-zero, directs the device to only use the specified bitrate for communication with the access point. Units are in Kb/s, ie
-                             C(5500) = 5.5 Mbit/s. This property is highly driver dependent and not all devices support setting a static bitrate.
+                description:
+                    - If non-zero, directs the device to only use the specified bitrate for communication with the access point.
+                    - Units are in Kb/s, ie C(5500) = 5.5 Mbit/s.
+                    - This property is highly driver dependent and not all devices support setting a static bitrate.
                 type: int
                 default: 0
-            seen-bssids:
-                description: A list of BSSIDs (each BSSID formatted as a MAC address like C(00:11:22:33:44:55)) that have been detected as part of the Wi-Fi
-                             network. NetworkManager internally tracks previously seen BSSIDs. The property is only meant for reading and reflects the BSSID
-                             list of NetworkManager. The changes you make to this property will not be preserved.
-                type: list
-                elements: str
             tx-power:
-                description: If non-zero, directs the device to use the specified transmit power. Units are dBm. This property is highly driver dependent and
-                             not all devices support setting a static transmit power.
+                description:
+                    - If non-zero, directs the device to use the specified transmit power.
+                    - Units are dBm.
+                    - This property is highly driver dependent and not all devices support setting a static transmit power.
                 type: int
                 default: 0
             wake-on-wlan:
-                description: The NMSettingWirelessWakeOnWLan options to enable. Not all devices support all options. May be any combination of
-                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_ANY) (0x2), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DISCONNECT) (0x4),
-                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC) (0x8), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE) (0x10),
-                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST) (0x20), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE) (0x40),
-                             C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (0x80), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (0x100) or the special values
-                             C(0x1) (to use global settings) and C(0x8000) (to disable management of Wake-on-LAN in NetworkManager).
-                             Note the sum of all option values must be specified in order to combine multiple options.
+                description:
+                    - The NMSettingWirelessWakeOnWLan options to enable. Not all devices support all options.
+                    - May be any combination of C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_ANY) (C(0x2)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_DISCONNECT) (C(0x4)),
+                      C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_MAGIC) (C(0x8)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_GTK_REKEY_FAILURE) (C(0x10)),
+                      C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_EAP_IDENTITY_REQUEST) (C(0x20)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_4WAY_HANDSHAKE) (C(0x40)),
+                      C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_RFKILL_RELEASE) (C(0x80)), C(NM_SETTING_WIRELESS_WAKE_ON_WLAN_TCP) (C(0x100)) or the special values
+                      C(0x1) (to use global settings) and C(0x8000) (to disable management of Wake-on-LAN in NetworkManager).
+                    - Note the sum of all option values must be specified in order to combine multiple options.
                 type: int
                 default: 1
        version_added: 3.5.0

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -507,6 +507,68 @@ TESTCASE_SECURE_WIRELESS = [
     }
 ]
 
+TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT = """\
+802-11-wireless.ssid:                   --
+802-11-wireless.mode:                   infrastructure
+802-11-wireless.band:                   --
+802-11-wireless.channel:                0
+802-11-wireless.bssid:                  --
+802-11-wireless.rate:                   0
+802-11-wireless.tx-power:               0
+802-11-wireless.mac-address:            --
+802-11-wireless.cloned-mac-address:     --
+802-11-wireless.generate-mac-address-mask:--
+802-11-wireless.mac-address-blacklist:  --
+802-11-wireless.mac-address-randomization:default
+802-11-wireless.mtu:                    auto
+802-11-wireless.seen-bssids:            --
+802-11-wireless.hidden:                 no
+802-11-wireless.powersave:              0 (default)
+802-11-wireless.wake-on-wlan:           0x1 (default)
+802-11-wireless.ap-isolation:           -1 (default)
+"""
+
+TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT = """\
+802-11-wireless.ssid:                   --
+802-11-wireless.mode:                   infrastructure
+802-11-wireless.band:                   --
+802-11-wireless.channel:                0
+802-11-wireless.bssid:                  --
+802-11-wireless.rate:                   0
+802-11-wireless.tx-power:               0
+802-11-wireless.mac-address:            --
+802-11-wireless.cloned-mac-address:     --
+802-11-wireless.generate-mac-address-mask:--
+802-11-wireless.mac-address-blacklist:  --
+802-11-wireless.mac-address-randomization:default
+802-11-wireless.mtu:                    auto
+802-11-wireless.seen-bssids:            --
+802-11-wireless.hidden:                 no
+802-11-wireless.powersave:              0 (default)
+802-11-wireless.wake-on-wlan:           0x1 (default)
+802-11-wireless.ap-isolation:           -1 (default)
+802-11-wireless-security.key-mgmt:      --
+802-11-wireless-security.wep-tx-keyidx: 0
+802-11-wireless-security.auth-alg:      --
+802-11-wireless-security.proto:         --
+802-11-wireless-security.pairwise:      --
+802-11-wireless-security.group:         --
+802-11-wireless-security.pmf:           0 (default)
+802-11-wireless-security.leap-username: --
+802-11-wireless-security.wep-key0:      --
+802-11-wireless-security.wep-key1:      --
+802-11-wireless-security.wep-key2:      --
+802-11-wireless-security.wep-key3:      --
+802-11-wireless-security.wep-key-flags: 0 (none)
+802-11-wireless-security.wep-key-type:  unknown
+802-11-wireless-security.psk:           testingtestingtesting
+802-11-wireless-security.psk-flags:     0 (none)
+802-11-wireless-security.leap-password: --
+802-11-wireless-security.leap-password-flags:0 (none)
+802-11-wireless-security.wps-method:    0x0 (default)
+802-11-wireless-security.fils:          0 (default)
+"""
+
 TESTCASE_DUMMY_STATIC = [
     {
         'type': 'dummy',
@@ -698,9 +760,43 @@ def mocked_ethernet_connection_dhcp_to_static(mocker):
 
 
 @pytest.fixture
+def mocked_wireless_create(mocker):
+    mocker_set(mocker,
+               execute_return=(0, TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
+def mocked_secure_wireless_create(mocker):
+    mocker_set(mocker,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+                   (0, "", ""),
+               ))
+
+
+@pytest.fixture
 def mocked_secure_wireless_create_failure(mocker):
     mocker_set(mocker,
-               execute_return=(1, "", ""))
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT, ""),
+                   (1, "", ""),
+               ))
+
+
+@pytest.fixture
+def mocked_secure_wireless_modify(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+                   (0, "", ""),
+                   (0, "", ""),
+               ))
 
 
 @pytest.fixture
@@ -709,6 +805,7 @@ def mocked_secure_wireless_modify_failure(mocker):
                connection_exists=True,
                execute_return=None,
                execute_side_effect=(
+                   (0, TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT, ""),
                    (0, "", ""),
                    (1, "", ""),
                ))
@@ -1629,7 +1726,7 @@ def test_ethernet_connection_static_unchanged(mocked_ethernet_connection_static_
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_WIRELESS, indirect=['patch_ansible_module'])
-def test_create_wireless(mocked_generic_connection_create, capfd):
+def test_create_wireless(mocked_wireless_create, capfd):
     """
     Test : Create wireless connection
     """
@@ -1637,10 +1734,22 @@ def test_create_wireless(mocked_generic_connection_create, capfd):
     with pytest.raises(SystemExit):
         nmcli.main()
 
-    assert nmcli.Nmcli.execute_command.call_count == 1
+    assert nmcli.Nmcli.execute_command.call_count == 2
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, add_kw = arg_list[0]
 
+    get_available_options_args, get_available_options_kw = arg_list[0]
+    assert get_available_options_args[0][0] == '/usr/bin/nmcli'
+    assert get_available_options_args[0][1] == 'con'
+    assert get_available_options_args[0][2] == 'edit'
+    assert get_available_options_args[0][3] == 'type'
+    assert get_available_options_args[0][4] == 'wifi'
+
+    get_available_options_data = get_available_options_kw['data'].split()
+    for param in ['print', '802-11-wireless',
+                  'quit', 'yes']:
+        assert param in get_available_options_data
+
+    add_args, add_kw = arg_list[1]
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'
     assert add_args[0][2] == 'add'
@@ -1664,7 +1773,7 @@ def test_create_wireless(mocked_generic_connection_create, capfd):
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
-def test_create_secure_wireless(mocked_generic_connection_create, capfd):
+def test_create_secure_wireless(mocked_secure_wireless_create, capfd):
     """
     Test : Create secure wireless connection
     """
@@ -1672,10 +1781,22 @@ def test_create_secure_wireless(mocked_generic_connection_create, capfd):
     with pytest.raises(SystemExit):
         nmcli.main()
 
-    assert nmcli.Nmcli.execute_command.call_count == 2
+    assert nmcli.Nmcli.execute_command.call_count == 3
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, add_kw = arg_list[0]
 
+    get_available_options_args, get_available_options_kw = arg_list[0]
+    assert get_available_options_args[0][0] == '/usr/bin/nmcli'
+    assert get_available_options_args[0][1] == 'con'
+    assert get_available_options_args[0][2] == 'edit'
+    assert get_available_options_args[0][3] == 'type'
+    assert get_available_options_args[0][4] == 'wifi'
+
+    get_available_options_data = get_available_options_kw['data'].split()
+    for param in ['print', '802-11-wireless-security',
+                  'quit', 'yes']:
+        assert param in get_available_options_data
+
+    add_args, add_kw = arg_list[1]
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'
     assert add_args[0][2] == 'add'
@@ -1691,7 +1812,7 @@ def test_create_secure_wireless(mocked_generic_connection_create, capfd):
                   '802-11-wireless-security.key-mgmt', 'wpa-psk']:
         assert param in add_args_text
 
-    edit_args, edit_kw = arg_list[1]
+    edit_args, edit_kw = arg_list[2]
     assert edit_args[0][0] == '/usr/bin/nmcli'
     assert edit_args[0][1] == 'con'
     assert edit_args[0][2] == 'edit'
@@ -1718,10 +1839,22 @@ def test_create_secure_wireless_failure(mocked_secure_wireless_create_failure, c
     with pytest.raises(SystemExit):
         nmcli.main()
 
-    assert nmcli.Nmcli.execute_command.call_count == 1
+    assert nmcli.Nmcli.execute_command.call_count == 2
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, add_kw = arg_list[0]
 
+    get_available_options_args, get_available_options_kw = arg_list[0]
+    assert get_available_options_args[0][0] == '/usr/bin/nmcli'
+    assert get_available_options_args[0][1] == 'con'
+    assert get_available_options_args[0][2] == 'edit'
+    assert get_available_options_args[0][3] == 'type'
+    assert get_available_options_args[0][4] == 'wifi'
+
+    get_available_options_data = get_available_options_kw['data'].split()
+    for param in ['print', '802-11-wireless-security',
+                  'quit', 'yes']:
+        assert param in get_available_options_data
+
+    add_args, add_kw = arg_list[1]
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'
     assert add_args[0][2] == 'add'
@@ -1744,17 +1877,36 @@ def test_create_secure_wireless_failure(mocked_secure_wireless_create_failure, c
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
-def test_modify_secure_wireless(mocked_generic_connection_modify, capfd):
+def test_modify_secure_wireless(mocked_secure_wireless_modify, capfd):
     """
     Test : Modify secure wireless connection
     """
 
     with pytest.raises(SystemExit):
         nmcli.main()
-    assert nmcli.Nmcli.execute_command.call_count == 2
+    assert nmcli.Nmcli.execute_command.call_count == 4
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, add_kw = arg_list[0]
 
+    get_available_options_args, get_available_options_kw = arg_list[0]
+    assert get_available_options_args[0][0] == '/usr/bin/nmcli'
+    assert get_available_options_args[0][1] == 'con'
+    assert get_available_options_args[0][2] == 'edit'
+    assert get_available_options_args[0][3] == 'type'
+    assert get_available_options_args[0][4] == 'wifi'
+
+    get_available_options_data = get_available_options_kw['data'].split()
+    for param in ['print', '802-11-wireless-security',
+                  'quit', 'yes']:
+        assert param in get_available_options_data
+
+    show_args, show_kw = arg_list[1]
+    assert show_args[0][0] == '/usr/bin/nmcli'
+    assert show_args[0][1] == '--show-secrets'
+    assert show_args[0][2] == 'con'
+    assert show_args[0][3] == 'show'
+    assert show_args[0][4] == 'non_existent_nw_device'
+
+    add_args, add_kw = arg_list[2]
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'
     assert add_args[0][2] == 'modify'
@@ -1767,7 +1919,7 @@ def test_modify_secure_wireless(mocked_generic_connection_modify, capfd):
                   '802-11-wireless-security.key-mgmt', 'wpa-psk']:
         assert param in add_args_text
 
-    edit_args, edit_kw = arg_list[1]
+    edit_args, edit_kw = arg_list[3]
     assert edit_args[0][0] == '/usr/bin/nmcli'
     assert edit_args[0][1] == 'con'
     assert edit_args[0][2] == 'edit'
@@ -1794,10 +1946,29 @@ def test_modify_secure_wireless_failure(mocked_secure_wireless_modify_failure, c
     with pytest.raises(SystemExit):
         nmcli.main()
 
-    assert nmcli.Nmcli.execute_command.call_count == 2
+    assert nmcli.Nmcli.execute_command.call_count == 3
     arg_list = nmcli.Nmcli.execute_command.call_args_list
-    add_args, add_kw = arg_list[1]
 
+    get_available_options_args, get_available_options_kw = arg_list[0]
+    assert get_available_options_args[0][0] == '/usr/bin/nmcli'
+    assert get_available_options_args[0][1] == 'con'
+    assert get_available_options_args[0][2] == 'edit'
+    assert get_available_options_args[0][3] == 'type'
+    assert get_available_options_args[0][4] == 'wifi'
+
+    get_available_options_data = get_available_options_kw['data'].split()
+    for param in ['print', '802-11-wireless-security',
+                  'quit', 'yes']:
+        assert param in get_available_options_data
+
+    show_args, show_kw = arg_list[1]
+    assert show_args[0][0] == '/usr/bin/nmcli'
+    assert show_args[0][1] == '--show-secrets'
+    assert show_args[0][2] == 'con'
+    assert show_args[0][3] == 'show'
+    assert show_args[0][4] == 'non_existent_nw_device'
+
+    add_args, add_kw = arg_list[2]
     assert add_args[0][0] == '/usr/bin/nmcli'
     assert add_args[0][1] == 'con'
     assert add_args[0][2] == 'modify'

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -528,25 +528,8 @@ TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT = """\
 802-11-wireless.ap-isolation:           -1 (default)
 """
 
-TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT = """\
-802-11-wireless.ssid:                   --
-802-11-wireless.mode:                   infrastructure
-802-11-wireless.band:                   --
-802-11-wireless.channel:                0
-802-11-wireless.bssid:                  --
-802-11-wireless.rate:                   0
-802-11-wireless.tx-power:               0
-802-11-wireless.mac-address:            --
-802-11-wireless.cloned-mac-address:     --
-802-11-wireless.generate-mac-address-mask:--
-802-11-wireless.mac-address-blacklist:  --
-802-11-wireless.mac-address-randomization:default
-802-11-wireless.mtu:                    auto
-802-11-wireless.seen-bssids:            --
-802-11-wireless.hidden:                 no
-802-11-wireless.powersave:              0 (default)
-802-11-wireless.wake-on-wlan:           0x1 (default)
-802-11-wireless.ap-isolation:           -1 (default)
+TESTCASE_DEFAULT_SECURE_WIRELESS_SHOW_OUTPUT = \
+    TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT + """\
 802-11-wireless-security.key-mgmt:      --
 802-11-wireless-security.wep-tx-keyidx: 0
 802-11-wireless-security.auth-alg:      --

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -745,7 +745,11 @@ def mocked_ethernet_connection_dhcp_to_static(mocker):
 @pytest.fixture
 def mocked_wireless_create(mocker):
     mocker_set(mocker,
-               execute_return=(0, TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT, ""))
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_DEFAULT_WIRELESS_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
 
 
 @pytest.fixture


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since both the `wifi` & `wifi_sec` options do not have a static list of suboptions (it depends on `nmcli's` version), we should query `nmcli` to determine which options are available on the client. Currently, when applying changes containing invalid/unsupported options, only the first option will be shown, show all of them instead. Also added new option to allow the play to display a warning and continue when invalid/unsupported options are present, the default is to fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`net_tools/nmcli.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
When specifying invalid/unsupported Wi-Fi options in the `wifi` and/or `wifi_sec` dict.
### I.E.
* **`ssid` was specified via `wifi.ssid`:**
  ```YAML
  type: wifi
  ssid: SSID_SHOULD_BE_SPECIFIED_HERE
  wifi:
    ssid: SSID_SHOULD_NOT_BE_SPECIFIED_HERE
  ```
  * Before:
    * No error message is given, so the user is unaware of any potential issue/disparity.
  * After:
    ```
    [WARNING]: Ignoring option 'wifi.ssid', it must be specified with option 'ssid'
    ```

* **Invalid option was specified via `wifi`:**
  ```YAML
  type: wifi
  ssid: SSID
  wifi:
    INVALID_1: This is a bad option
    INVALID_2: This is a bad option
    INVALID_3: This is a bad option
  ```
  * Before (note only the first invalid/unsupported option is detected):
    ```
    fatal: [router]: FAILED! => {"changed": false, "msg": "Error: invalid property 'INVALID_1': 'INVALID_1' not among [ssid, mode, band, channel, bssid, rate, tx-power, mac-address, cloned-mac-address, generate-mac-address-mask, mac-address-blacklist, mac-address-randomization, mtu, seen-bssids, hidden, powersave, wake-on-wlan, ap-isolation].\n", "name": "WLAN", "rc": 2}
    ```
  * After:
    ```
    fatal: [router]: FAILED! => {"changed": false, "msg": "Invalid or unsupported option(s): \"wifi.INVALID_1\", \"wifi.INVALID_2\", \"wifi.INVALID_3\""}

    ```

* **Invalid option was specified via `wifi` with `ignore_unsupported_suboptions` enabled:**
  ```YAML
  ignore_unsupported_suboptions: yes
  type: wifi
  ssid: SSID
  wifi:
    INVALID_1: This is a bad option
    INVALID_2: This is a bad option
    INVALID_3: This is a bad option
  ```
  * Before (note only the first invalid/unsupported option is detected):
    ```
    fatal: [router]: FAILED! => {"changed": false, "msg": "Error: invalid property 'INVALID_1': 'INVALID_1' not among [ssid, mode, band, channel, bssid, rate, tx-power, mac-address, cloned-mac-address, generate-mac-address-mask, mac-address-blacklist, mac-address-randomization, mtu, seen-bssids, hidden, powersave, wake-on-wlan, ap-isolation].\n", "name": "WLAN", "rc": 2}
    ```
  * After:
    ```
    [WARNING]: Invalid or unsupported option(s): 'wifi.INVALID_1', 'wifi.INVALID_2', 'wifi.INVALID_3'
    ```