### PR TITLE
Create directories for the blacklist file if needed

### DIFF
--- a/changelogs/fragments/3158-kernel_blacklist-create-dir.yml
+++ b/changelogs/fragments/3158-kernel_blacklist-create-dir.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - kernel_blacklist - Create directory for the blacklist file when it's missing (https://github.com/ansible-collections/community.general/pull/3158).
+  - kernel_blacklist - create directory for the blacklist file when it is missing (https://github.com/ansible-collections/community.general/pull/3158).

--- a/changelogs/fragments/3158-kernel_blacklist-create-dir.yml
+++ b/changelogs/fragments/3158-kernel_blacklist-create-dir.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - kernel_blacklist - Create directory for the blacklist file when it's missing (https://github.com/ansible-collections/community.general/pull/3158).

--- a/plugins/modules/system/kernel_blacklist.py
+++ b/plugins/modules/system/kernel_blacklist.py
@@ -45,7 +45,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible.module_utils._text import to_text
 
 class Blacklist(object):
     def __init__(self, module, filename, checkmode):
@@ -55,6 +55,12 @@ class Blacklist(object):
 
     def create_file(self):
         if not self.checkmode and not os.path.exists(self.filename):
+            destpath = os.path.dirname(self.filename)
+            if destpath and not os.path.exists(destpath):
+                try:
+                    os.makedirs(destpath)
+                except Exception as e:
+                    module.fail_json(msg='Error creating %s (%s)' % (to_text(destpath), to_text(e)))
             open(self.filename, 'a').close()
             return True
         elif self.checkmode and not os.path.exists(self.filename):

--- a/plugins/modules/system/kernel_blacklist.py
+++ b/plugins/modules/system/kernel_blacklist.py
@@ -45,7 +45,8 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
+
 
 class Blacklist(object):
     def __init__(self, module, filename, checkmode):
@@ -60,7 +61,7 @@ class Blacklist(object):
                 try:
                     os.makedirs(destpath)
                 except Exception as e:
-                    module.fail_json(msg='Error creating %s (%s)' % (to_text(destpath), to_text(e)))
+                    self.module.fail_json(msg='Error creating %s (%s)' % (to_text(destpath), to_text(e)))
             open(self.filename, 'a').close()
             return True
         elif self.checkmode and not os.path.exists(self.filename):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently the `kernel_blacklist` module fails if the path of the `blacklist_file` (e.g. `/etc/modprobe.d/blacklist-ansible.conf` ) doesn't exist. 
Where as if the file doesn't exist then it is created, so it would make sense to have the path created as well.

This PR adds path (directory) creation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kernel_blacklist

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before changes:
```python
redirecting (type: connection) ansible.builtin.podman to containers.podman.podman
<ubuntu2004> RUN [b'/usr/bin/podman', b'mount', b'ubuntu2004']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'echo ~ && sleep 0']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.
ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457 `" && echo ansible-tmp-1628259131.468759-1705241-240177810910457="` echo /root/.ansible/tmp/a
nsible-tmp-1628259131.468759-1705241-240177810910457 `" ) && sleep 0']
redirecting (type: modules) ansible.builtin.kernel_blacklist to community.general.kernel_blacklist
Using module file /usr/lib/python3.9/site-packages/ansible_collections/community/general/plugins/modules/kernel_blacklist.py
<ubuntu2004> PUT /home/g/.ansible/tmp/ansible-local-1703552twcis9y5/tmp0c1oiyyk TO /root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/Ans
iballZ_kernel_blacklist.py
<ubuntu2004> RUN [b'/usr/bin/podman', b'cp', b'/home/g/.ansible/tmp/ansible-local-1703552twcis9y5/tmp0c1oiyyk', b'ubuntu2004:/root/.ansible/tmp/ansible-tmp-162
8259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'chmod u+x /root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810
910457/ /root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py && sleep 0']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b"sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-aiazcufqvrpbzedbableo
ussmzkbyxfa ; /usr/bin/python3.8 /root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py' && sleep 0"]
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'rm -f -r /root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-2401778109
10457/ > /dev/null 2>&1 && sleep 0']
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py", line 100, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py", line 92, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.kernel_blacklist', init_globals=dict(_module_fqn='ansible_collections.comm
unity.general.plugins.modules.kernel_blacklist', _modlib_path=modlib_path),
  File "/usr/lib/python3.8/runpy.py", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible_kernel_blacklist_payload.zip/ansible_collections/community/general/plugins/modules/kernel_blackl
ist.py", line 160, in <module>
  File "/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible_kernel_blacklist_payload.zip/ansible_collections/community/general/plugins/modules/kernel_blackl
ist.py", line 142, in main
  File "/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible_kernel_blacklist_payload.zip/ansible_collections/community/general/plugins/modules/kernel_blackl
ist.py", line 65, in create_file
FileNotFoundError: [Errno 2] No such file or directory: '/etc/modprobe.d/blacklist-ansible.conf'
fatal: [ubuntu2004]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_bl
acklist.py\", line 100, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1628259131.468759-1705241-240177810910457/AnsiballZ_kernel_
blacklist.py\", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1628259131.468
759-1705241-240177810910457/AnsiballZ_kernel_blacklist.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.pl
ugins.modules.kernel_blacklist', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.kernel_blacklist', _modlib_path=modlib_pa
th),\n  File \"/usr/lib/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/p
ython3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.8/runpy.py\", line 87, in _run_cod
e\n    exec(code, run_globals)\n  File \"/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible_kernel_blacklist_payload.zip/ansible_collections/community/gene
ral/plugins/modules/kernel_blacklist.py\", line 160, in <module>\n  File \"/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible_kernel_blacklist_payload.zip/
ansible_collections/community/general/plugins/modules/kernel_blacklist.py\", line 142, in main\n  File \"/tmp/ansible_kernel_blacklist_payload_nh7n5spr/ansible
_kernel_blacklist_payload.zip/ansible_collections/community/general/plugins/modules/kernel_blacklist.py\", line 65, in create_file\nFileNotFoundError: [Errno 2
] No such file or directory: '/etc/modprobe.d/blacklist-ansible.conf'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

```

after changes:
```python
redirecting (type: connection) ansible.builtin.podman to containers.podman.podman
<ubuntu2004> RUN [b'/usr/bin/podman', b'mount', b'ubuntu2004']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'echo ~ && sleep 0']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.
ansible/tmp/ansible-tmp-1628259283.93314-1708912-129707327907330 `" && echo ansible-tmp-1628259283.93314-1708912-129707327907330="` echo /root/.ansible/tmp/ans
ible-tmp-1628259283.93314-1708912-129707327907330 `" ) && sleep 0']
redirecting (type: modules) ansible.builtin.kernel_blacklist to community.general.kernel_blacklist
Using module file /usr/lib/python3.9/site-packages/ansible_collections/community/general/plugins/modules/kernel_blacklist.py
<ubuntu2004> PUT /home/g/.ansible/tmp/ansible-local-1707341_1pmfk7c/tmpg8iu0bha TO /root/.ansible/tmp/ansible-tmp-1628259283.93314-1708912-129707327907330/Ansi
ballZ_kernel_blacklist.py
<ubuntu2004> RUN [b'/usr/bin/podman', b'cp', b'/home/g/.ansible/tmp/ansible-local-1707341_1pmfk7c/tmpg8iu0bha', b'ubuntu2004:/root/.ansible/tmp/ansible-tmp-162
8259283.93314-1708912-129707327907330/AnsiballZ_kernel_blacklist.py']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'chmod u+x /root/.ansible/tmp/ansible-tmp-1628259283.93314-1708912-1297073279
07330/ /root/.ansible/tmp/ansible-tmp-1628259283.93314-1708912-129707327907330/AnsiballZ_kernel_blacklist.py && sleep 0']
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b"sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-npagyadjzkooetqwlutwb
jxitdbwkbby ; /usr/bin/python3.8 /root/.ansible/tmp/ansible-tmp-1628259283.93314-1708912-129707327907330/AnsiballZ_kernel_blacklist.py' && sleep 0"]
<ubuntu2004> RUN [b'/usr/bin/podman', b'exec', b'ubuntu2004', b'/bin/sh', b'-c', b'rm -f -r /root/.ansible/tmp/ansible-tmp-1628259283.93314-1708912-12970732790
7330/ > /dev/null 2>&1 && sleep 0']
NOTIFIED HANDLER sensa.bootstrap : Update initramfs for ubuntu2004
changed: [ubuntu2004] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "blacklist_file": null,
            "name": "floppy",
            "state": "present"
        }
    },
    "name": "floppy",
    "state": "present"
}

```