### PR TITLE
nmcli: writing secrets to command line is a security hole

### DIFF
--- a/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
+++ b/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
@@ -1,6 +1,6 @@
 security_fixes:
   - nmcli - Writing secrets to command line is a security hole. In order to resolve
-    this, set the ``data`` argument of `run_command()` to call ``nmcli con edit``
+    this, set the ``data`` argument of ``run_command()`` to call ``nmcli con edit``
     with the proper ``set property value`` command(s) containing potential ``secrets``
-    passed in via `stdin` after calls to ``nmcli con add`` or ``nmcli con modify``.
+    passed in via ``stdin`` after calls to ``nmcli con add`` or ``nmcli con modify``.
     (https://github.com/ansible-collections/community.general/issues/3145).

--- a/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
+++ b/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
@@ -1,6 +1,4 @@
 security_fixes:
-  - nmcli - Writing secrets to command line is a security hole. In order to resolve
-    this, set the ``data`` argument of ``run_command()`` to call ``nmcli con edit``
-    with the proper ``set property value`` command(s) containing potential ``secrets``
-    passed in via ``stdin`` after calls to ``nmcli con add`` or ``nmcli con modify``.
+  - nmcli - do not pass WiFi secrets on the ``nmcli`` command line. Use ``nmcli con edit``
+    instead and pass secrets as ``stdin``
     (https://github.com/ansible-collections/community.general/issues/3145).

--- a/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
+++ b/changelogs/fragments/3160-pass-wifi-secrets-via-stdin-to-nmcli-module.yml
@@ -1,0 +1,6 @@
+security_fixes:
+  - nmcli - Writing secrets to command line is a security hole. In order to resolve
+    this, set the ``data`` argument of `run_command()` to call ``nmcli con edit``
+    with the proper ``set property value`` command(s) containing potential ``secrets``
+    passed in via `stdin` after calls to ``nmcli con add`` or ``nmcli con modify``.
+    (https://github.com/ansible-collections/community.general/issues/3145).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1089,10 +1089,10 @@ class Nmcli(object):
 
         # Constructing the command.
         for key, value in options.items():
-            if key in self.SECRET_OPTIONS:
-                self.edit_commands += ['set %s %s' % (key, value)]
-                continue
             if value is not None:
+                if key in self.SECRET_OPTIONS:
+                    self.edit_commands += ['set %s %s' % (key, value)]
+                    continue
                 cmd.extend([key, value])
 
         return self.execute_command(cmd)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -709,7 +709,7 @@ class Nmcli(object):
     platform = 'Generic'
     distribution = None
 
-    wifi_sec_secret_options = [
+    WIFI_SEC_SECRET_OPTIONS = [
         '802-11-wireless-security.leap-password',
         '802-11-wireless-security.psk',
         '802-11-wireless-security.wep-key0',
@@ -1089,7 +1089,7 @@ class Nmcli(object):
 
         # Constructing the command.
         for key, value in options.items():
-            if key in self.wifi_sec_secret_options:
+            if key in self.WIFI_SEC_SECRET_OPTIONS:
                 self.edit_commands += ['set %s %s' % (key, value)]
                 continue
             if value is not None:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -709,6 +709,15 @@ class Nmcli(object):
     platform = 'Generic'
     distribution = None
 
+    wifi_sec_secret_options = [
+        '802-11-wireless-security.leap-password',
+        '802-11-wireless-security.psk',
+        '802-11-wireless-security.wep-key0',
+        '802-11-wireless-security.wep-key1',
+        '802-11-wireless-security.wep-key2',
+        '802-11-wireless-security.wep-key3'
+    ]
+
     def __init__(self, module):
         self.module = module
         self.state = module.params['state']
@@ -1080,7 +1089,7 @@ class Nmcli(object):
 
         # Constructing the command.
         for key, value in options.items():
-            if key in self.wifi_sec_secret_options():
+            if key in self.wifi_sec_secret_options:
                 self.edit_commands += ['set ' + key + ' ' + value]
                 continue
             if value is not None:
@@ -1217,17 +1226,6 @@ class Nmcli(object):
         }
         options.update(self.connection_options(detect_change=True))
         return self._compare_conn_params(self.show_connection(), options)
-
-    @staticmethod
-    def wifi_sec_secret_options():
-        return [
-            '802-11-wireless-security.leap-password',
-            '802-11-wireless-security.psk',
-            '802-11-wireless-security.wep-key0',
-            '802-11-wireless-security.wep-key1',
-            '802-11-wireless-security.wep-key2',
-            '802-11-wireless-security.wep-key3'
-        ]
 
 
 def main():

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -709,14 +709,14 @@ class Nmcli(object):
     platform = 'Generic'
     distribution = None
 
-    WIFI_SEC_SECRET_OPTIONS = [
+    WIFI_SEC_SECRET_OPTIONS = (
         '802-11-wireless-security.leap-password',
         '802-11-wireless-security.psk',
         '802-11-wireless-security.wep-key0',
         '802-11-wireless-security.wep-key1',
         '802-11-wireless-security.wep-key2',
         '802-11-wireless-security.wep-key3'
-    ]
+    )
 
     def __init__(self, module):
         self.module = module

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1090,7 +1090,7 @@ class Nmcli(object):
         # Constructing the command.
         for key, value in options.items():
             if key in self.wifi_sec_secret_options:
-                self.edit_commands += ['set ' + key + ' ' + value]
+                self.edit_commands += ['set %s %s' % (key, value)]
                 continue
             if value is not None:
                 cmd.extend([key, value])

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1127,9 +1127,7 @@ class Nmcli(object):
         return status
 
     def edit_connection(self):
-        self.edit_commands += ['save', 'quit']
-        data = "\n".join(self.edit_commands)
-        self.edit_commands = []
+        data = "\n".join(self.edit_commands + ['save', 'quit'])
         cmd = [self.nmcli_bin, 'con', 'edit', self.conn_name]
         return self.execute_command(cmd, data=data)
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -709,7 +709,7 @@ class Nmcli(object):
     platform = 'Generic'
     distribution = None
 
-    WIFI_SEC_SECRET_OPTIONS = (
+    SECRET_OPTIONS = (
         '802-11-wireless-security.leap-password',
         '802-11-wireless-security.psk',
         '802-11-wireless-security.wep-key0',
@@ -1089,7 +1089,7 @@ class Nmcli(object):
 
         # Constructing the command.
         for key, value in options.items():
-            if key in self.WIFI_SEC_SECRET_OPTIONS:
+            if key in self.SECRET_OPTIONS:
                 self.edit_commands += ['set %s %s' % (key, value)]
                 continue
             if value is not None:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1098,9 +1098,17 @@ class Nmcli(object):
         return self.execute_command(cmd)
 
     def create_connection(self):
-        status = self.connection_update('create')
+        (rc, out, err) = self.connection_update('create')
+        if rc != 0:
+            raise NmcliModuleError(err)
+        else:
+            status = (rc, out, err)
         if self.edit_commands:
-            status = self.edit_connection()
+            (rc, out, err) = self.edit_connection()
+            if rc != 0:
+                raise NmcliModuleError(err)
+            else:
+                status = (rc, out, err)
         if self.create_connection_up:
             status = self.up_connection()
         return status
@@ -1121,9 +1129,17 @@ class Nmcli(object):
         return self.execute_command(cmd)
 
     def modify_connection(self):
-        status = self.connection_update('modify')
+        (rc, out, err) = self.connection_update('modify')
+        if rc != 0:
+            raise NmcliModuleError(err)
+        else:
+            status = (rc, out, err)
         if self.edit_commands:
-            status = self.edit_connection()
+            (rc, out, err) = self.edit_connection()
+            if rc != 0:
+                raise NmcliModuleError(err)
+            else:
+                status = (rc, out, err)
         return status
 
     def edit_connection(self):

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1098,17 +1098,9 @@ class Nmcli(object):
         return self.execute_command(cmd)
 
     def create_connection(self):
-        (rc, out, err) = self.connection_update('create')
-        if rc != 0:
-            raise NmcliModuleError(err)
-        else:
-            status = (rc, out, err)
-        if self.edit_commands:
-            (rc, out, err) = self.edit_connection()
-            if rc != 0:
-                raise NmcliModuleError(err)
-            else:
-                status = (rc, out, err)
+        status = self.connection_update('create')
+        if status[0] == 0 and self.edit_commands:
+            status = self.edit_connection()
         if self.create_connection_up:
             status = self.up_connection()
         return status
@@ -1129,17 +1121,9 @@ class Nmcli(object):
         return self.execute_command(cmd)
 
     def modify_connection(self):
-        (rc, out, err) = self.connection_update('modify')
-        if rc != 0:
-            raise NmcliModuleError(err)
-        else:
-            status = (rc, out, err)
-        if self.edit_commands:
-            (rc, out, err) = self.edit_connection()
-            if rc != 0:
-                raise NmcliModuleError(err)
-            else:
-                status = (rc, out, err)
+        status = self.connection_update('modify')
+        if status[0] == 0 and self.edit_commands:
+            status = self.edit_connection()
         return status
 
     def edit_connection(self):

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1740,7 +1740,7 @@ def test_create_secure_wireless_failure(mocked_secure_wireless_create_failure, c
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert results.get('failed')
-    assert not 'changed' in results
+    assert 'changed' not in results
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
@@ -1813,7 +1813,7 @@ def test_modify_secure_wireless_failure(mocked_secure_wireless_modify_failure, c
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert results.get('failed')
-    assert not 'changed' in results
+    assert 'changed' not in results
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_DUMMY_STATIC, indirect=['patch_ansible_module'])

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -698,6 +698,23 @@ def mocked_ethernet_connection_dhcp_to_static(mocker):
 
 
 @pytest.fixture
+def mocked_secure_wireless_create_failure(mocker):
+    mocker_set(mocker,
+               execute_return=(1, "", ""))
+
+
+@pytest.fixture
+def mocked_secure_wireless_modify_failure(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, "", ""),
+                   (1, "", ""),
+               ))
+
+
+@pytest.fixture
 def mocked_dummy_connection_static_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
@@ -1680,10 +1697,123 @@ def test_create_secure_wireless(mocked_generic_connection_create, capfd):
     assert edit_args[0][2] == 'edit'
     assert edit_args[0][3] == 'non_existent_nw_device'
 
+    edit_kw_data = edit_kw['data'].split()
+    for param in ['802-11-wireless-security.psk', 'VERY_SECURE_PASSWORD',
+                  'save',
+                  'quit']:
+        assert param in edit_kw_data
+
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
+def test_create_secure_wireless_failure(mocked_secure_wireless_create_failure, capfd):
+    """
+    Test : Create secure wireless connection w/failure
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[0]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'add'
+    assert add_args[0][3] == 'type'
+    assert add_args[0][4] == 'wifi'
+    assert add_args[0][5] == 'con-name'
+    assert add_args[0][6] == 'non_existent_nw_device'
+
+    add_args_text = list(map(to_text, add_args[0]))
+    for param in ['connection.interface-name', 'wireless_non_existant',
+                  'ipv4.addresses', '10.10.10.10/24',
+                  '802-11-wireless.ssid', 'Brittany',
+                  '802-11-wireless-security.key-mgmt', 'wpa-psk']:
+        assert param in add_args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results.get('failed')
+    assert not 'changed' in results
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
+def test_modify_secure_wireless(mocked_generic_connection_modify, capfd):
+    """
+    Test : Modify secure wireless connection
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+    assert nmcli.Nmcli.execute_command.call_count == 2
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[0]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'modify'
+    assert add_args[0][3] == 'non_existent_nw_device'
+
+    add_args_text = list(map(to_text, add_args[0]))
+    for param in ['connection.interface-name', 'wireless_non_existant',
+                  'ipv4.addresses', '10.10.10.10/24',
+                  '802-11-wireless.ssid', 'Brittany',
+                  '802-11-wireless-security.key-mgmt', 'wpa-psk']:
+        assert param in add_args_text
+
+    edit_args, edit_kw = arg_list[1]
+    assert edit_args[0][0] == '/usr/bin/nmcli'
+    assert edit_args[0][1] == 'con'
+    assert edit_args[0][2] == 'edit'
+    assert edit_args[0][3] == 'non_existent_nw_device'
+
+    edit_kw_data = edit_kw['data'].split()
+    for param in ['802-11-wireless-security.psk', 'VERY_SECURE_PASSWORD',
+                  'save',
+                  'quit']:
+        assert param in edit_kw_data
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SECURE_WIRELESS, indirect=['patch_ansible_module'])
+def test_modify_secure_wireless_failure(mocked_secure_wireless_modify_failure, capfd):
+    """
+    Test : Modify secure wireless connection w/failure
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 2
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[1]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'modify'
+    assert add_args[0][3] == 'non_existent_nw_device'
+
+    add_args_text = list(map(to_text, add_args[0]))
+    for param in ['connection.interface-name', 'wireless_non_existant',
+                  'ipv4.addresses', '10.10.10.10/24',
+                  '802-11-wireless.ssid', 'Brittany',
+                  '802-11-wireless-security.key-mgmt', 'wpa-psk']:
+        assert param in add_args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results.get('failed')
+    assert not 'changed' in results
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_DUMMY_STATIC, indirect=['patch_ansible_module'])

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1655,7 +1655,7 @@ def test_create_secure_wireless(mocked_generic_connection_create, capfd):
     with pytest.raises(SystemExit):
         nmcli.main()
 
-    assert nmcli.Nmcli.execute_command.call_count == 1
+    assert nmcli.Nmcli.execute_command.call_count == 2
     arg_list = nmcli.Nmcli.execute_command.call_args_list
     add_args, add_kw = arg_list[0]
 
@@ -1671,9 +1671,14 @@ def test_create_secure_wireless(mocked_generic_connection_create, capfd):
     for param in ['connection.interface-name', 'wireless_non_existant',
                   'ipv4.addresses', '10.10.10.10/24',
                   '802-11-wireless.ssid', 'Brittany',
-                  '802-11-wireless-security.key-mgmt', 'wpa-psk',
-                  '802-11-wireless-security.psk', 'VERY_SECURE_PASSWORD']:
+                  '802-11-wireless-security.key-mgmt', 'wpa-psk']:
         assert param in add_args_text
+
+    edit_args, edit_kw = arg_list[1]
+    assert edit_args[0][0] == '/usr/bin/nmcli'
+    assert edit_args[0][1] == 'con'
+    assert edit_args[0][2] == 'edit'
+    assert edit_args[0][3] == 'non_existent_nw_device'
 
     out, err = capfd.readouterr()
     results = json.loads(out)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since #2220, adding WiFi secrets via the `wifi_sec` option would cause those secrets to be appended to the `cmd` [here](https://github.com/ansible-collections/community.general/blob/6a8eb7b388c53acce4d8d701bda86fc9382df7b9/plugins/modules/net_tools/nmcli.py#L960). The best practice for `secrets` input is to reduce their exposure and pass them in via `stdin`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3145

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`net_tools/nmcli.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
In order to resolve this, I used the [data argument](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L1860) of `run_command` to call `nmcli con edit` with the proper `set` commands containing any potential "`secrets`" passed in via `stdin` after completing a `nmcli con add` or `nmcli con modify`.

There are no changes visible to the user.
