### PR TITLE
openbsd_pkg: Fix regexp matching crash

### DIFF
--- a/changelogs/fragments/3161-openbsd-pkg-fix-regexp-matching-crash.yml
+++ b/changelogs/fragments/3161-openbsd-pkg-fix-regexp-matching-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openbsd_pkg - fix regexp matching crash. This bug could trigger on package names with special characters, for example ``g++`` (https://github.com/ansible-collections/community.general/pull/3161).

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -241,7 +241,7 @@ def package_present(names, pkg_spec, module):
                     # "file:/local/package/directory/ is empty" message on stderr
                     # while still installing the package, so we need to look for
                     # for a message like "packagename-1.0: ok" just in case.
-                    match = re.search(r"\W%s-[^:]+: ok\W" % pkg_spec[name]['stem'], pkg_spec[name]['stdout'])
+                    match = re.search(r"\W%s-[^:]+: ok\W" % re.escape(pkg_spec[name]['stem']), pkg_spec[name]['stdout'])
 
                     if match:
                         # It turns out we were able to install the package.
@@ -295,7 +295,7 @@ def package_latest(names, pkg_spec, module):
             pkg_spec[name]['changed'] = False
             for installed_name in pkg_spec[name]['installed_names']:
                 module.debug("package_latest(): checking for pre-upgrade package name: %s" % installed_name)
-                match = re.search(r"\W%s->.+: ok\W" % installed_name, pkg_spec[name]['stdout'])
+                match = re.search(r"\W%s->.+: ok\W" % re.escape(installed_name), pkg_spec[name]['stdout'])
                 if match:
                     module.debug("package_latest(): pre-upgrade package name match: %s" % installed_name)
 


### PR DESCRIPTION
##### SUMMARY
Fix regexp crash caused by missing escaping of package name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openbsd_pkg

##### ADDITIONAL INFORMATION
When a package name contains special characters (e.g. "g++"), they are
interpreted as part of the regexp.

This can lead to a crash with an error in the python re module, for
instance with "g++":

    sre_constants.error: multiple repeat

Fix this by escaping the package name.
