### PR TITLE
contributing: make expected behavior clearer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Note that reviewing does not only mean code review, but also offering comments o
 Also, consider taking up a valuable, reviewed, but abandoned pull request which you could politely ask the original authors to complete yourself.
 
 * Try committing your changes with an informative but short commit message.
-* Don't squash your commits and force-push to your branch if not needed. Reviews of your pull request are much easier with individual commits to comprehend the pull request history. All commits of your pull request branch will be squashed into one commit by the team upon merge.
+* Do not squash your commits and force-push to your branch if not needed. Reviews of your pull request are much easier with individual commits to comprehend the pull request history. All commits of your pull request branch will be squashed into one commit by GitHub upon merge.
 * Do not add merge commits to your PR. The bot will complain and you will have to rebase ([instructions for rebasing](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html)) to remove them before your PR can be merged. To avoid that git automatically does merges during pulls, you can configure it to do rebases instead by running `git config pull.rebase true` inside the respository checkout.
 
 You can also read [our Quick-start development guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ Note that reviewing does not only mean code review, but also offering comments o
 Also, consider taking up a valuable, reviewed, but abandoned pull request which you could politely ask the original authors to complete yourself.
 
 * Try committing your changes with an informative but short commit message.
-* All commits of a pull request branch will be squashed into one commit at last. That does not mean you must have only one commit on your pull request, though!
-* Please try not to force-push if it is not needed, so reviewers and other users looking at your pull request later can see the pull request commit history.
+* Don't squash your commits and force-push to your branch if not needed. Reviews of your pull request are much easier with individual commits to comprehend the pull request history. All commits of your pull request branch will be squashed into one commit by the team upon merge.
 * Do not add merge commits to your PR. The bot will complain and you will have to rebase ([instructions for rebasing](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html)) to remove them before your PR can be merged. To avoid that git automatically does merges during pulls, you can configure it to do rebases instead by running `git config pull.rebase true` inside the respository checkout.
 
 You can also read [our Quick-start development guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst).


### PR DESCRIPTION
##### SUMMARY

reformulate the preference of not having squashed commits clearer,
shorter and more precise.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
When I read these two list items in the contributing guide, I interpreted them differently than what was said in https://github.com/ansible-collections/community.general/pull/3164#discussion_r684644504
I tried to reformulate them to make it clearer what is the preferred way. The original sentence did not clearly say that squashing is discouraged, but the reason was given in the line below that one.