### PR TITLE
Add ipv4 example to linode inventory docs

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -78,6 +78,9 @@ groups:
   webservers: "'web' in (tags|list)"
   mailservers: "'mail' in (tags|list)"
 compose:
+  # By default, Ansible tries to connect to the label of the instance.
+  # Since that might not be a valid name to connect to, you can
+  # replace it with the first IPv4 address of the linode as follows:
   ansible_ssh_host: ipv4[0]
   ansible_port: 2222
 '''

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -78,6 +78,7 @@ groups:
   webservers: "'web' in (tags|list)"
   mailservers: "'mail' in (tags|list)"
 compose:
+  ansible_ssh_host: ipv4[0]
   ansible_port: 2222
 '''
 


### PR DESCRIPTION
##### SUMMARY

Adds an additional line to the Linode dynamic inventory plugin to help users understand how they might actually reach one of the nodes it discovers.

Does not make any changes to code, simply enhances the docs with a one-liner.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- Linode inventory plugin

##### ADDITIONAL INFORMATION

By default, the Linode ansible plugin sets the `ansible_ssh_host` to the `label` of the Linode instance. This not useful; the label is not a DNS record (like AWS, for example) and it is completely unreachable.

The [Linode docs](https://www.linode.com/docs/guides/deploy-linodes-using-ansible/) state that you must add entries to `/etc/hosts` that match these labels. It also references a closed PR (https://github.com/ansible/ansible/pull/51196) to suggest that this `/etc/hosts` requirement will be resolved. Needing to manually add host entries would be painful and against the automated nature of dynamic inventories.

When investigating, I realized that the following variables are already available in the `compose` section:

- id
- label
- group
- status
- created
- updated
- type
- ipv4
- ipv6
- image
- region
- specs
- alerts
- backups
- hypervisor
- watchdog_enabled
- tags

By adding a reference to `ipv4` in the docs we can give users enough information to actually use this inventory plugin in a useful way.
