### PR TITLE
module_helper - implemented classmethod to start the module

### DIFF
--- a/changelogs/fragments/3206-mh-classmethod.yaml
+++ b/changelogs/fragments/3206-mh-classmethod.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper module_utils - added classmethod to trigger the execution of MH modules (https://github.com/ansible-collections/community.general/pull/3206).

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -66,7 +66,6 @@ class ModuleHelperBase(object):
 
     @classmethod
     def execute(cls, module=None):
-        instance = cls(module)
-        instance.run()
+        cls(module).run()
 
     make_it_so = execute

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -67,5 +67,3 @@ class ModuleHelperBase(object):
     @classmethod
     def execute(cls, module=None):
         cls(module).run()
-
-    make_it_so = execute

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -63,3 +63,10 @@ class ModuleHelperBase(object):
         if 'failed' not in output:
             output['failed'] = False
         self.module.exit_json(changed=self.has_changed(), **output)
+
+    @classmethod
+    def execute(cls, module=None):
+        instance = cls(module)
+        instance.run()
+
+    make_it_so = execute

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -45,6 +45,9 @@ class ModuleHelper(VarsMixin, DependencyMixin, ModuleHelperBase):
     def _vars_changed(self):
         return any(self.vars.has_changed(v) for v in self.vars.change_vars())
 
+    def __changed__(self):
+        return False
+
     def has_changed(self):
         return self.changed or self._vars_changed()
 

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -45,9 +45,6 @@ class ModuleHelper(VarsMixin, DependencyMixin, ModuleHelperBase):
     def _vars_changed(self):
         return any(self.vars.has_changed(v) for v in self.vars.change_vars())
 
-    def __changed__(self):
-        return False
-
     def has_changed(self):
         return self.changed or self._vars_changed()
 

--- a/plugins/modules/packaging/language/cpanm.py
+++ b/plugins/modules/packaging/language/cpanm.py
@@ -248,7 +248,7 @@ class CPANMinus(CmdMixin, ModuleHelper):
 
 
 def main():
-    CPANMinus.make_it_so()
+    CPANMinus.execute()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/packaging/language/cpanm.py
+++ b/plugins/modules/packaging/language/cpanm.py
@@ -248,8 +248,7 @@ class CPANMinus(CmdMixin, ModuleHelper):
 
 
 def main():
-    cpanm = CPANMinus()
-    cpanm.run()
+    CPANMinus.make_it_so()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -277,8 +277,7 @@ class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
 
 
 def main():
-    xfconf = XFConfProperty()
-    xfconf.run()
+    XFConfProperty.execute()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
I had second thoughts about that discussion in https://github.com/ansible-collections/community.general/pull/2933#pullrequestreview-711513025 and I thought it would be OK to have a classmethod to trigger the module. (Cc: @webknjaz )

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py
plugins/module_utils/mh/module_helper.py
plugins/modules/packaging/language/cpanm.py
plugins/modules/system/xfconf.py
