### PR TITLE
Linode inventory plugin typo fixes

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -23,7 +23,7 @@ DOCUMENTATION = r'''
         - constructed
     options:
         plugin:
-            description: marks this as an instance of the 'linode' plugin
+            description: Marks this as an instance of the 'linode' plugin.
             required: true
             choices: ['linode', 'community.general.linode']
         access_token:

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -62,7 +62,7 @@ def test_empty_config_query_options(inventory):
     assert regions == types == tags == []
 
 
-def test_conig_query_options(inventory):
+def test_config_query_options(inventory):
     regions, types, tags = inventory._get_query_options({
         'regions': ['eu-west', 'us-east'],
         'types': ['g5-standard-2', 'g6-standard-2'],


### PR DESCRIPTION
- Fix a typo in the Linode inventory plugin unit tests
- Fix some style issues in descriptions where punctuation was missing

Signed-off-by: Kellin <kellin@retromud.org>

##### SUMMARY

While working on https://github.com/ansible-collections/community.general/pull/3203, the near example I saw for writing descriptions was missing a period. During review, it came up that this is actually incorrect style.

This merge request fixes that style issue and a typo in the unit test file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

Linode Dynamic Inventory Plugin