### PR TITLE
tss: add option for domain authorization

### DIFF
--- a/changelogs/fragments/3228-tss-domain-authorization.yml
+++ b/changelogs/fragments/3228-tss-domain-authorization.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - tss lookup plugin - added new parameter for domain authorization
+    (https://github.com/ansible-collections/community.general/pull/3228).


### PR DESCRIPTION
Use DomainPasswordGrantAuthorizer if parameter `domain` is used.

##### SUMMARY
It's not possible to use this plugin when Thycotic uses domain authorization.
New parameter `domain` is introduced to enable this and different authorization class is used for this.
Otherwise everything stays the same.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/lookup/tss.py

##### ADDITIONAL INFORMATION
Original behavior for domain authorizing Thycotic:
```
- debug:
    msg: "{{
            lookup(
                'community.general.tss',
                secret_id,
                base_url=server,
                username=username,
                password=password
            )
        }}"
---
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'community.general.tss'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Secret Server lookup failure: Login Failed"}
```
New behavior:
```
- debug:
    msg: "{{
            lookup(
                'community.general.tss',
                secret_id,
                base_url=server,
                username=username,
                password=password,
                domain=domain
            )
        }}"
---
TASK [debug] *****************************************************************
ok: [localhost] => {
    "msg": {
        "accessRequestWorkflowMapId": -1,
        "active": true,
```
