### PR TITLE
nmcli: allow IPv4/IPv6 configuration on ipip and sit devices

### DIFF
--- a/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
+++ b/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "nmcli - Parse ip4/ip6 configuration arguments for sit tunnels (https://github.com/ansible-collections/community.general/pull/3239)."
+  - "nmcli - added ip4/ip6 configuration arguments for ``sit`` tunnels (https://github.com/ansible-collections/community.general/issues/3238, https://github.com/ansible-collections/community.general/pull/3239)."

--- a/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
+++ b/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "nmcli - added ip4/ip6 configuration arguments for ``sit`` tunnels (https://github.com/ansible-collections/community.general/issues/3238, https://github.com/ansible-collections/community.general/pull/3239)."

--- a/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
+++ b/changelogs/fragments/3239-nmcli-sit-ip-config-bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "nmcli - Parse ip4/ip6 configuration arguments for sit tunnels (https://github.com/ansible-collections/community.general/pull/3239)."

--- a/changelogs/fragments/3239-nmcli-sit-ipip-config-bugfix.yaml
+++ b/changelogs/fragments/3239-nmcli-sit-ipip-config-bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "nmcli - added ip4/ip6 configuration arguments for ``sit`` and ``ipip`` tunnels (https://github.com/ansible-collections/community.general/issues/3238, https://github.com/ansible-collections/community.general/pull/3239)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -963,6 +963,7 @@ class Nmcli(object):
             'ethernet',
             'generic',
             'infiniband',
+            'ipip',
             'sit',
             'team',
             'vlan',

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -963,6 +963,7 @@ class Nmcli(object):
             'ethernet',
             'generic',
             'infiniband',
+            'sit',
             'team',
             'vlan',
             'wifi'

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -411,6 +411,12 @@ TESTCASE_SIT_SHOW_OUTPUT = """\
 connection.id:                          non_existent_nw_device
 connection.interface-name:              sit-existent_nw_device
 connection.autoconnect:                 yes
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
 ip-tunnel.mode:                         sit
 ip-tunnel.parent:                       non_existent_sit_device
 ip-tunnel.local:                        192.168.225.5

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -388,6 +388,12 @@ TESTCASE_IPIP_SHOW_OUTPUT = """\
 connection.id:                          non_existent_nw_device
 connection.interface-name:              ipip-existent_nw_device
 connection.autoconnect:                 yes
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
 ip-tunnel.mode:                         ipip
 ip-tunnel.parent:                       non_existent_ipip_device
 ip-tunnel.local:                        192.168.225.5


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add connection type "sit" to the allowed connection types which allows configuring IPv4/IPv6 settings.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #3238 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  nmcli:
    type: sit
    conn_name: sit_tb
    autoconnect: yes
    ip_tunnel_remote: 94.44.44.44
    ip6: 2:1:1:171::2/64
    gw6: 2:1:1:171::1
    method4: disabled
    state: present
```
###### NetworkManager configuration file /etc/NetworkManager/system-connections/ before change

```
[connection]
id=sit_tb
uuid=dcae0d3a-9703-48c2-89c6-2a0f7881fe00
type=ip-tunnel
interface-name=sit_tb
permissions=

[ip-tunnel]
mode=3
remote=94.44.44.44

[ipv4]
dns-search=
method=auto

[ipv6]
addr-gen-mode=stable-privacy
dns-search=
method=auto

[proxy]
```

###### NetworkManager configuration file /etc/NetworkManager/system-connections/ after change

```
[connection]
id=sit_tb
uuid=7a21ffc6-0d31-40c1-bcef-825ce506a136
type=ip-tunnel
interface-name=sit_tb
permissions=
timestamp=1629390525

[ip-tunnel]
mode=3
remote=94.44.44.44

[ipv4]
dns-search=
method=disabled

[ipv6]
addr-gen-mode=stable-privacy
address1=2:1:1:171::2/64,2:1:1:171::1
dns-search=
method=manual

[proxy]
```