### PR TITLE
udm_dns_record: Fix handling of PTR records (#3244)

### DIFF
--- a/changelogs/fragments/3256-fix-ptr-handling-in-udm_dns_record.yml
+++ b/changelogs/fragments/3256-fix-ptr-handling-in-udm_dns_record.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - udm_dns_record - fixed managing of PTR records, which can never have worked before (https://github.com/ansible-collections/community.general/pull/3256).

--- a/plugins/modules/cloud/univention/udm_dns_record.py
+++ b/plugins/modules/cloud/univention/udm_dns_record.py
@@ -34,11 +34,13 @@ options:
         description:
             - "Name of the record, this is also the DNS record. E.g. www for
                www.example.com."
+            - For PTR records this has to be the IP address.
     zone:
         type: str
         required: true
         description:
             - Corresponding DNS zone for this record, e.g. example.com.
+            - For PTR records this has to be the full reverse zone (e.g. 1.1.192.in-addr.arpa).
     type:
         type: str
         required: true
@@ -112,6 +114,7 @@ try:
     HAVE_IPADDRESS = True
 except ImportError:
     pass
+
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/cloud/univention/udm_dns_record.py
+++ b/plugins/modules/cloud/univention/udm_dns_record.py
@@ -88,6 +88,7 @@ EXAMPLES = '''
 RETURN = '''#'''
 
 HAVE_UNIVENTION = False
+HAVE_IPADDRESS = False
 try:
     from univention.admin.handlers.dns import (
         forward_zone,
@@ -106,8 +107,11 @@ from ansible_collections.community.general.plugins.module_utils.univention_umc i
     config,
     uldap,
 )
-import ipaddress
-
+try:
+    import ipaddress
+    HAVE_IPADDRESS = True
+except ImportError:
+    pass
 
 def main():
     module = AnsibleModule(
@@ -143,6 +147,8 @@ def main():
 
     workname = name
     if type == 'ptr_record':
+        if not HAVE_IPADDRESS:
+            module.fail_json(msg="This module requires the 'ipaddress' python module to manage PTR records.")
         try:
             ipaddr_rev = ipaddress.ip_address(name).reverse_pointer
             if zone.find('arpa') == -1:

--- a/plugins/modules/cloud/univention/udm_dns_record.py
+++ b/plugins/modules/cloud/univention/udm_dns_record.py
@@ -7,7 +7,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import ipaddress
 
 
 DOCUMENTATION = '''
@@ -107,6 +106,7 @@ from ansible_collections.community.general.plugins.module_utils.univention_umc i
     config,
     uldap,
 )
+import ipaddress
 
 
 def main():
@@ -150,7 +150,7 @@ def main():
             subnet_offset = ipaddr_rev.find(zone)
             if subnet_offset == -1:
                 raise Exception("IP address is not part of zone.")
-            workname = ipaddr_rev[0:subnet_offset-1]
+            workname = ipaddr_rev[0:subnet_offset - 1]
         except Exception as e:
             module.fail_json(
                 msg='handling PTR record for {0} in zone {1} failed: {2}'.format(name, zone, e)


### PR DESCRIPTION
##### SUMMARY
Before, it was not possible to manage PTR records in Univention DNS,
due to broken zone lookups and improper used parameters of the object.
This patch fixes the PTR handling, allowing both v4 and v6 entries.
Fixes #3244

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
udm_dns_record
