### PR TITLE
nmcli: allow `WiFi`-backed connections to support more than just `connection.slave-type=bond`

### DIFF
--- a/changelogs/fragments/2943-allow-to-make-wifi-connections-as-ports-links-of-bridges.yml
+++ b/changelogs/fragments/2943-allow-to-make-wifi-connections-as-ports-links-of-bridges.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nmcli - allow ``WiFi``-backed connections to support more than just ``connection.slave-type=bond``
+    (https://github.com/ansible-collections/community.general/issues/2943).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, `WiFi`-backed connections are coded to only allow the configuration of the property `connection.slave-type` to the value `bond` when the option `master` is defined and the option `type` is set to `wifi`. Since there are other values supported for the property `connection.slave-type`, they should also be supported in order to configure those modes of operation. This can be achieved by using the same procedure that, for example, `Ethernet`-backed connections use (I.E. it should not be required to specify `type: wifi` or `type: ethernet` when configuring the connection as a `*-slave` type).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2943

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`net_tools/nmcli.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The connection type can be one of [`bridge-slave`, `bond-slave`, `team-slave`]:
```YAML
- name: configure LAN Bridge interface
  community.general.nmcli:
    conn_name: LAN
    ifname: bridge0
    ip4: 192.168.1.1/24
    mac: AA:BB:CC:DD:EE:FF
    method4: shared
    state: present
    type: bridge

- name: configure LAN Ethernet interface
  community.general.nmcli:
    conn_name: LAN/Ethernet
    hairpin: false
    ifname: eth0
    master: bridge0
    state: present
    type: bridge-slave

- name: configure LAN WiFi interface
  community.general.nmcli:
    conn_name: LAN/WiFi
    hairpin: false
    ifname: wlan0
    master: bridge0
    ssid: Juan-Pedro
    state: present
    type: bridge-slave
    wifi:
      mode: ap
    wifi_sec:
      key-mgmt: wpa-psk
      psk: Pedro'sPassword
```