### PR TITLE
add deprecation warning for python-dnsimple 1

### DIFF
--- a/changelogs/fragments/3267-dnsimple1-deprecation.yml
+++ b/changelogs/fragments/3267-dnsimple1-deprecation.yml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-  - "add deprecation warning if python-dnsimple < 2.0.0 is used (https://github.com/ansible-collections/community.general/pull/2946#discussion_r667624693)"
+  - "dnsimple - python-dnsimple < 2.0.0 is deprecated and support for it will be removed in community.general 5.0.0 (https://github.com/ansible-collections/community.general/pull/2946#discussion_r667624693)"

--- a/changelogs/fragments/3267-dnsimple1-deprecation.yml
+++ b/changelogs/fragments/3267-dnsimple1-deprecation.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - "add deprecation warning if python-dnsimple < 2.0.0 is used (https://github.com/ansible-collections/community.general/pull/2946#discussion_r667624693)"

--- a/changelogs/fragments/3267-dnsimple1-deprecation.yml
+++ b/changelogs/fragments/3267-dnsimple1-deprecation.yml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-  - "dnsimple - python-dnsimple < 2.0.0 is deprecated and support for it will be removed in community.general 5.0.0 (https://github.com/ansible-collections/community.general/pull/2946#discussion_r667624693)"
+  - "dnsimple - python-dnsimple < 2.0.0 is deprecated and support for it will be removed in community.general 5.0.0 (https://github.com/ansible-collections/community.general/pull/2946#discussion_r667624693)."

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -82,7 +82,8 @@ options:
     version_added: 3.5.0
 requirements:
   - "dnsimple >= 1.0.0"
-  - "Support for C(dnsimple < 2) is deprecated and will be removed in community.general 5.0.0"
+notes:
+  - "Support for C(dnsimple < 2) is deprecated and will be removed in community.general 5.0.0."
 author: "Alex Coomans (@drcapulet)"
 '''
 

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -82,6 +82,7 @@ options:
     version_added: 3.5.0
 requirements:
   - "dnsimple >= 1.0.0"
+  - "Support for C(dnsimple < 2) is deprecated and will be removed in C(community.general >= 5.0.0)"
 author: "Alex Coomans (@drcapulet)"
 '''
 
@@ -402,6 +403,11 @@ def main():
         if DNSIMPLE_MAJOR_VERSION > 1:
             ds = DNSimpleV2(account_email, account_api_token, sandbox, module)
         else:
+            module.deprecate(
+                'Support for python-dnsimple < 2 is deprected. '
+                'Update python-dnsimple to version >= 2.0.0',
+                version='5.0.0', collection_name='community.general'
+            )
             ds = DNSimpleV1(account_email, account_api_token, sandbox, module)
         # Let's figure out what operation we want to do
         # No domain, return a list

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -404,7 +404,7 @@ def main():
             ds = DNSimpleV2(account_email, account_api_token, sandbox, module)
         else:
             module.deprecate(
-                'Support for python-dnsimple < 2 is deprected. '
+                'Support for python-dnsimple < 2 is deprecated. '
                 'Update python-dnsimple to version >= 2.0.0',
                 version='5.0.0', collection_name='community.general'
             )

--- a/plugins/modules/net_tools/dnsimple.py
+++ b/plugins/modules/net_tools/dnsimple.py
@@ -82,7 +82,7 @@ options:
     version_added: 3.5.0
 requirements:
   - "dnsimple >= 1.0.0"
-  - "Support for C(dnsimple < 2) is deprecated and will be removed in C(community.general >= 5.0.0)"
+  - "Support for C(dnsimple < 2) is deprecated and will be removed in community.general 5.0.0"
 author: "Alex Coomans (@drcapulet)"
 '''
 


### PR DESCRIPTION
##### SUMMARY
This is a followup PR to https://github.com/ansible-collections/community.general/pull/2946 to add a deprecation warning for `python-dnsimple < 2` in `community.general >= 4.0.0` 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dnsimple

##### ADDITIONAL INFORMATION
- add deprecation warning if `python-dnsimple < 2` is used
