### PR TITLE
redfish: add a disable etag parameter for systems that don't fully support the…

### DIFF
--- a/changelogs/fragments/3268-redfish-disable-etag.yaml
+++ b/changelogs/fragments/3268-redfish-disable-etag.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "redfish_utils redfish_command redfish_config - Add parameter to disable etag use for PUT/POST/PATCH requests when found in GET request. (https://github.com/ansible-collections/community.general/pull/3268)."
+  - "redfish_command and redfish_config - add parameter to disable etag use for PUT/POST/PATCH requests when found in GET request (https://github.com/ansible-collections/community.general/pull/3268)."

--- a/changelogs/fragments/3268-redfish-disable-etag.yaml
+++ b/changelogs/fragments/3268-redfish-disable-etag.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "redfish_utils redfish_command redfish_config - Add parameter to disable etag use for PUT/POST/PATCH requests when found in GET request. (https://github.com/ansible-collections/community.general/pull/3268)."

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -122,7 +122,6 @@ options:
     type: str
     version_added: '0.2.0'
   disable_etag:
-    required: false
     description:
       - Disable etag use for PUT/POST/PATCH requests when found in GET request.
     type: bool

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -121,6 +121,12 @@ options:
       - The ID of the System, Manager or Chassis to modify
     type: str
     version_added: '0.2.0'
+  disable_etag:
+    required: false
+    description:
+      - Disable etag use for PUT/POST/PATCH requests when found in GET request
+    type: bool
+    default: False
   update_image_uri:
     required: false
     description:
@@ -609,6 +615,7 @@ def main():
             boot_next=dict(),
             boot_override_mode=dict(choices=['Legacy', 'UEFI']),
             resource_id=dict(),
+            disable_etag=dict(type='bool', default=False),
             update_image_uri=dict(),
             update_protocol=dict(),
             update_targets=dict(type='list', elements='str', default=[]),
@@ -667,6 +674,9 @@ def main():
     # System, Manager or Chassis ID to modify
     resource_id = module.params['resource_id']
 
+    # Flag to disable etag
+    disable_etag = module.params['disable_etag']
+
     # update options
     update_opts = {
         'update_image_uri': module.params['update_image_uri'],
@@ -689,7 +699,7 @@ def main():
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_utils = RedfishUtils(creds, root_uri, timeout, module,
-                            resource_id=resource_id, data_modification=True)
+                            resource_id=resource_id, data_modification=True, disable_etag=disable_etag)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -126,7 +126,8 @@ options:
     description:
       - Disable etag use for PUT/POST/PATCH requests when found in GET request
     type: bool
-    default: False
+    default: false
+    version_added: 3.6.0
   update_image_uri:
     required: false
     description:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -124,7 +124,7 @@ options:
   disable_etag:
     required: false
     description:
-      - Disable etag use for PUT/POST/PATCH requests when found in GET request
+      - Disable etag use for PUT/POST/PATCH requests when found in GET request.
     type: bool
     default: false
     version_added: 3.6.0

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -79,11 +79,11 @@ options:
     type: str
     version_added: '0.2.0'
   disable_etag:
-    required: false
     description:
-      - Disable etag use for PUT/POST/PATCH requests when found in GET request
+      - Disable etag use for PUT/POST/PATCH requests when found in GET request.
     type: bool
-    default: False
+    default: false
+    version_added: 3.6.0
   nic_addr:
     required: false
     description:

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -78,6 +78,12 @@ options:
       - The ID of the System, Manager or Chassis to modify
     type: str
     version_added: '0.2.0'
+  disable_etag:
+    required: false
+    description:
+      - Disable etag use for PUT/POST/PATCH requests when found in GET request
+    type: bool
+    default: False
   nic_addr:
     required: false
     description:
@@ -233,6 +239,7 @@ def main():
                 default={}
             ),
             resource_id=dict(),
+            disable_etag=dict(type='bool', default=False),
             nic_addr=dict(default='null'),
             nic_config=dict(
                 type='dict',
@@ -271,6 +278,9 @@ def main():
     # System, Manager or Chassis ID to modify
     resource_id = module.params['resource_id']
 
+    # Flag to disable etag
+    disable_etag = module.params['disable_etag']
+
     # manager nic
     nic_addr = module.params['nic_addr']
     nic_config = module.params['nic_config']
@@ -278,7 +288,7 @@ def main():
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_utils = RedfishUtils(creds, root_uri, timeout, module,
-                            resource_id=resource_id, data_modification=True)
+                            resource_id=resource_id, data_modification=True, disable_etag=disable_etag)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:


### PR DESCRIPTION
… feature

##### SUMMARY
There are instances we have seen where etag is present within the GET request, but PATCHINGing with that etag returns in a 412 return code. This is despite the etag remaining consistent. I can only conclude the vendor has a bug and/or the feature is incomplete. This MR provides an option to disable etag If-Match when needed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Module_utils: redfish_utils
Modules: redfish_command, redfish_config

##### ADDITIONAL INFORMATION

This MR is a result of encountering the error below.

> HTTP Error 412 on PATCH request to 'https://192.168.1.1/redfish/v1/Systems/SYSTEM1', extended message: 'The request has been rejected since precondition doesn't match selected resource or selected resource has been updated.'

To validate the resource did not change, I debugged the application to make sure the etag did not change before or after the request.
