### PR TITLE
Keycloak role composites

### DIFF
--- a/changelogs/fragments/3275-keycloak-add-role-composites.yml
+++ b/changelogs/fragments/3275-keycloak-add-role-composites.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- keycloak_role - Enhanced the role management to manage the composites as well (https://github.com/ansible-collections/community.general/pull/3275).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -920,7 +920,6 @@ class KeycloakAPI(object):
         :param name: Name of the group to fetch.
         :param realm: Realm in which the group resides; default 'master'
         """
-        groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
             all_groups = self.get_groups(realm=realm)
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1617,7 +1617,7 @@ class KeycloakAPI(object):
         :param resource_data: [Optional] The data to send as JSON in the body of the request.
         """
         try:
-            kwargs = {'method':'DELETE', 'headers':self.restheaders, 'validate_certs': self.validate_certs}
+            kwargs = {'method': 'DELETE', 'headers': self.restheaders, 'validate_certs': self.validate_certs}
             if resource_data:
                 kwargs['data'] = json.dumps(resource_data)
             return open_url(request_url, **kwargs)
@@ -1632,6 +1632,6 @@ def role_composites_sorter(composites):
     return list(
         sorted(
             composites,
-            key=lambda x: x['client_id'] + ":ROLE:"+ x['name'] if x['client_id'] else "REALM_ROLE:" + x['name']
+            key=lambda x: x['client_id'] + ":ROLE:" + x['name'] if x['client_id'] else "REALM_ROLE:" + x['name']
         )
     )

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -263,8 +263,8 @@ def main():
             changeset[camel(param)] = new_param_value
 
     # prepare the new role
-    updated_role = before_role.copy()
-    updated_role.update(changeset)
+    desired_role = before_role.copy()
+    desired_role.update(changeset)
 
     result['proposed'] = changeset
     result['existing'] = before_role
@@ -287,17 +287,17 @@ def main():
             module.fail_json(msg='name must be specified when creating a new role')
 
         if module._diff:
-            result['diff'] = dict(before='', after=updated_role)
+            result['diff'] = dict(before='', after=desired_role)
 
         if module.check_mode:
             module.exit_json(**result)
 
         # do it for real!
         if clientid is None:
-            kc.create_realm_role(updated_role, realm)
+            kc.create_realm_role(desired_role, realm)
             after_role = kc.get_realm_role(name, realm)
         else:
-            kc.create_client_role(updated_role, clientid, realm)
+            kc.create_client_role(desired_role, clientid, realm)
             after_role = kc.get_client_role(name, clientid, realm)
 
         result['end_state'] = after_role
@@ -308,9 +308,9 @@ def main():
     else:
         if state == 'present':
             # no changes
-            if updated_role == before_role:
+            if desired_role == before_role:
                 result['changed'] = False
-                result['end_state'] = updated_role
+                result['end_state'] = desired_role
                 result['msg'] = "No changes required to role {name}.".format(name=name)
                 module.exit_json(**result)
 
@@ -318,17 +318,17 @@ def main():
             result['changed'] = True
 
             if module._diff:
-                result['diff'] = dict(before=before_role, after=updated_role)
+                result['diff'] = dict(before=before_role, after=desired_role)
 
             if module.check_mode:
                 module.exit_json(**result)
 
             # do the update
             if clientid is None:
-                kc.update_realm_role(updated_role, realm)
+                kc.update_realm_role(desired_role, realm)
                 after_role = kc.get_realm_role(name, realm)
             else:
-                kc.update_client_role(updated_role, clientid, realm)
+                kc.update_client_role(desired_role, clientid, realm)
                 after_role = kc.get_client_role(name, clientid, realm)
 
             result['end_state'] = after_role

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -77,7 +77,7 @@ options:
         description:
             - A list of the other roles that composited together by this role.
         elements: dict
-        contains:
+        suboptions:
           client_id:
             type: str
             description: The name of the client (not the cid), can be null for a role client.

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -75,7 +75,15 @@ options:
     composites:
         type: list
         description:
-            - A list dicts containing the keys client_id, and name for roles to be added into the composite.
+            - A list of the other roles that composited together by this role.
+        elements: dict
+        contains:
+          client_id:
+            type: str
+            description: The name of the client (not the cid), can be null for a role client.
+          name:
+            type: str
+            description: The name of the role.
 
 extends_documentation_fragment:
 - community.general.keycloak

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -302,6 +302,9 @@ def main():
 
         result['end_state'] = after_role
 
+        if module._diff:
+            result['diff'] = dict(before='', after=after_role)
+
         result['msg'] = 'Role {name} has been created'.format(name=name)
         module.exit_json(**result)
 
@@ -332,6 +335,9 @@ def main():
                 after_role = kc.get_client_role(name, clientid, realm)
 
             result['end_state'] = after_role
+
+            if module._diff:
+                result['diff'] = dict(before=before_role, after=after_role)
 
             result['msg'] = "Role {name} has been updated".format(name=name)
             module.exit_json(**result)

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -77,6 +77,7 @@ options:
         description:
             - A list of the other roles that composited together by this role.
         elements: dict
+        version_added: 3.6.0
         suboptions:
           client_id:
             type: str

--- a/plugins/modules/identity/keycloak/keycloak_role.py
+++ b/plugins/modules/identity/keycloak/keycloak_role.py
@@ -270,7 +270,7 @@ def main():
 
     sync_composites = 'composites' in role_params
     if sync_composites:
-        module.params['composites'] =  role_composites_sorter(module.params['composites'])
+        module.params['composites'] = role_composites_sorter(module.params['composites'])
 
     # does the role already exist?
     if clientid is None:

--- a/tests/integration/targets/keycloak_role/README.md
+++ b/tests/integration/targets/keycloak_role/README.md
@@ -6,9 +6,6 @@ docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml sto
 docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml rm -f -v
 docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml up -d
 
-# 2. Wait for keycloak to finish starting (see http://localhost:8080/auth/)
-sleep 30
-
-# 3. Run the integration tests:
+# 2. Run the integration tests:
 ansible-test integration keycloak_role --allow-unsupported -v
 ```

--- a/tests/integration/targets/keycloak_role/README.md
+++ b/tests/integration/targets/keycloak_role/README.md
@@ -1,0 +1,14 @@
+The integration test can be performed as follows:
+
+```
+# 1. Start docker-compose:
+docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml stop
+docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml rm -f -v
+docker-compose -f tests/integration/targets/keycloak_role/docker-compose.yml up -d
+
+# 2. Wait for keycloak to finish starting (see http://localhost:8080/auth/)
+sleep 30
+
+# 3. Run the integration tests:
+ansible-test integration keycloak_role --allow-unsupported -v
+```

--- a/tests/integration/targets/keycloak_role/docker-compose.yml
+++ b/tests/integration/targets/keycloak_role/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.4'
+
+services:
+  postgres:
+    image: postgres:9.6
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+
+  keycloak:
+    image: jboss/keycloak:12.0.4
+    ports:
+      - 8080:8080
+      
+    environment:
+      DB_VENDOR: postgres
+      DB_ADDR: postgres
+      DB_DATABASE: postgres
+      DB_USER: postgres
+      DB_SCHEMA: public
+      DB_PASSWORD: postgres
+      
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password
+

--- a/tests/integration/targets/keycloak_role/docker-compose.yml
+++ b/tests/integration/targets/keycloak_role/docker-compose.yml
@@ -24,4 +24,3 @@ services:
       
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: password
-

--- a/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
+++ b/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
@@ -1,0 +1,97 @@
+- name: "{{test_props.test_name}} - Create new role"
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args0:
+      realm: "{{ realm }}"
+      state: present
+    call_args: "{{ call_args0 | combine(test_props.create_args) }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: "{{test_props.test_name}} - Assert created"
+  assert:
+    that:
+      - result is changed
+      - result.existing == {}
+      - result.end_state.name == "{{ test_props.create_args.name }}"
+      - result.end_state.containerId == "{{ realm }}" or test_props.expect_to_be_realm == False
+
+- name: "{{test_props.test_name}} - Updates with no change"
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args0:
+      realm: "{{ realm }}"
+      state: present
+    call_args: "{{ call_args0 | combine(test_props.create_args) }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: "{{test_props.test_name}} - Assert role unchanged"
+  assert:
+    that:
+      - result is not changed
+
+- name: "{{test_props.test_name}} - Update role"
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args0:
+      realm: "{{ realm }}"
+      state: present
+    call_args: "{{ call_args0 | combine(test_props.update_args) }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: "{{test_props.test_name}} - Assert role updated"
+  assert:
+    that:
+      - result is changed
+      - result.existing.description == "{{ test_props.create_args.description }}"
+      - result.end_state.description == "{{ test_props.update_args.description }}"
+
+- name: "{{test_props.test_name}} - Delete existing realm role"
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args0:
+      realm: "{{ realm }}"
+      state: absent
+    call_args: "{{ call_args0 | combine(test_props.create_args) }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: "{{test_props.test_name}} - Assert role deleted"
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: "{{test_props.test_name}} - Delete absent role"
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args0:
+      realm: "{{ realm }}"
+      state: absent
+    call_args: "{{ call_args0 | combine(test_props.create_args) }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: "{{test_props.test_name}} - Assert role unchanged"
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}
+

--- a/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
+++ b/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
@@ -96,4 +96,3 @@
     that:
       - result is not changed
       - result.end_state == {}
-

--- a/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
+++ b/tests/integration/targets/keycloak_role/tasks/create_update_delete_tests.yml
@@ -18,6 +18,7 @@
       - result.existing == {}
       - result.end_state.name == "{{ test_props.create_args.name }}"
       - result.end_state.containerId == "{{ realm }}" or test_props.expect_to_be_realm == False
+      - test_props.expect_composite_length_at_create == false or result.end_state.composites|length == test_props.expect_composite_length_at_create
 
 - name: "{{test_props.test_name}} - Updates with no change"
   community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
@@ -56,6 +57,7 @@
       - result is changed
       - result.existing.description == "{{ test_props.create_args.description }}"
       - result.end_state.description == "{{ test_props.update_args.description }}"
+      - test_props.expect_composite_length_at_update == false or result.end_state.composites|length == test_props.expect_composite_length_at_update
 
 - name: "{{test_props.test_name}} - Delete existing realm role"
   community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -24,26 +24,82 @@
       state: present
   register: client
 
+- name: Create sample roles for composite testing.
+  community.general.keycloak_role: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args1:
+      realm: "{{ realm }}"
+      description: "{{ description_1 }}"
+      state: present
+    call_args: "{{call_args1 | combine(item) }}"
+  loop:
+    - {name: "testrole1-for-composite"}
+    - {name: "testrole2-for-composite", client_id: null}
+    - {name: "testrole3-for-composite", client_id: "{{ client_id }}"}
+    - {name: "testrole4-for-composite", client_id: "{{ client_id }}"}
+
 - include_tasks: create_update_delete_tests.yml
   vars:
     test_props: "{{ item }}"
   loop:
-    - test_name: "1. Realm role test"
+    - test_name: "1.1 Realm role test"
       expect_to_be_realm: true
+      expect_composite_length_at_create: false
+      expect_composite_length_at_update: false
       create_args:
         name: "{{ role }}"
         description: "{{ description_1 }}"
       update_args:
         name: "{{ role }}"
         description: "{{ description_2 }}"
-         
-    - test_name: "2. Client role test"
+
+    - test_name: "1.2 Realm role test creating with composites"
+      expect_to_be_realm: true
+      expect_composite_length_at_create: 3
+      expect_composite_length_at_update: 1
+      create_args:
+        name: "{{ role }}"
+        description: "{{ description_1 }}"
+        composites:
+          # Note: This also checks that having client_id set to null and being absent do the same thing.
+          - {name: "testrole1-for-composite", client_id: null}
+          - {name: "testrole2-for-composite"}
+          - {name: "testrole4-for-composite", client_id: "{{ client_id }}"}
+      update_args:
+        name: "{{ role }}"
+        description: "{{ description_2 }}"
+        composites:
+          - {name: "testrole3-for-composite", client_id: "{{ client_id }}"}
+
+    - test_name: "2.1 Client role test"
       expect_to_be_realm: false
+      expect_composite_length_at_create: false
+      expect_composite_length_at_update: false
       create_args:
         name: "{{ role }}"
-        client_id: "{{ client_id }}"        
+        client_id: "{{ client_id }}"
         description: "{{ description_1 }}"
       update_args:
         name: "{{ role }}"
-        client_id: "{{ client_id }}"        
+        client_id: "{{ client_id }}"
         description: "{{ description_2 }}"
+
+    - test_name: "2.2 Client role test"
+      expect_to_be_realm: false
+      expect_composite_length_at_create: 2
+      expect_composite_length_at_update: 1
+      create_args:
+        name: "{{ role }}"
+        client_id: "{{ client_id }}"
+        description: "{{ description_1 }}"
+        composites:
+          - {name: "testrole2-for-composite"}
+          - {name: "testrole3-for-composite", client_id: "{{ client_id }}"}
+      update_args:
+        name: "{{ role }}"
+        client_id: "{{ client_id }}"
+        description: "{{ description_2 }}"
+        composites:
+          - {name: "testrole1-for-composite", client_id: null}
+
+

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: "Wait for keycloak to be available"
+  command: "curl --silent {{ url }}/realms/{{admin_realm}}/"
+  args:
+    # Ignore warning as the suggestion to use get_url requires the output to be written to a file.
+    # We are just wanting to check the stdout.
+    warn: false
+  register: result
+  # We expect some JSON output that contains this key:
+  until: result.stdout.find("account-service") != -1
+  retries: 60
+  delay: 1
+  changed_when: false
+
 - name: Delete realm
   community.general.keycloak_realm: "{{ auth_args | combine(call_args) }}"
   vars:

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -101,5 +101,3 @@
         description: "{{ description_2 }}"
         composites:
           - {name: "testrole1-for-composite", client_id: null}
-
-

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -1,246 +1,49 @@
 ---
+- name: Delete realm
+  community.general.keycloak_realm: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      id: "{{ realm }}"
+      realm: "{{ realm }}"
+      state: absent
+
 - name: Create realm
-  community.general.keycloak_realm:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    id: "{{ realm }}"
-    realm: "{{ realm }}"
-    state: present
+  community.general.keycloak_realm: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      id: "{{ realm }}"
+      realm: "{{ realm }}"
+      state: present
 
 - name: Create client
-  community.general.keycloak_client:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    state: present
+  community.general.keycloak_client: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      realm: "{{ realm }}"
+      client_id: "{{ client_id }}"
+      state: present
   register: client
 
-- name: Create new realm role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    name: "{{ role }}"
-    description: "{{ description_1 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert realm role created
-  assert:
-    that:
-      - result is changed
-      - result.existing == {}
-      - result.end_state.name == "{{ role }}"
-      - result.end_state.containerId == "{{ realm }}"
-
-- name: Create existing realm role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    name: "{{ role }}"
-    description: "{{ description_1 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert realm role unchanged
-  assert:
-    that:
-      - result is not changed
-
-- name: Update realm role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    name: "{{ role }}"
-    description: "{{ description_2 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert realm role updated
-  assert:
-    that:
-      - result is changed
-      - result.existing.description == "{{ description_1 }}"
-      - result.end_state.description == "{{ description_2 }}"
-
-- name: Delete existing realm role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    name: "{{ role }}"
-    state: absent
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert realm role deleted
-  assert:
-    that:
-      - result is changed
-      - result.end_state == {}
-
-- name: Delete absent realm role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    name: "{{ role }}"
-    state: absent
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert realm role unchanged
-  assert:
-    that:
-      - result is not changed
-      - result.end_state == {}
-
-- name: Create new client role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    name: "{{ role }}"
-    description: "{{ description_1 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert client role created
-  assert:
-    that:
-      - result is changed
-      - result.existing == {}
-      - result.end_state.name == "{{ role }}"
-      - result.end_state.containerId == "{{ client.end_state.id }}"
-
-- name: Create existing client role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    name: "{{ role }}"
-    description: "{{ description_1 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert client role unchanged
-  assert:
-    that:
-      - result is not changed
-
-- name: Update client role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    name: "{{ role }}"
-    description: "{{ description_2 }}"
-    state: present
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert client role updated
-  assert:
-    that:
-      - result is changed
-      - result.existing.description == "{{ description_1 }}"
-      - result.end_state.description == "{{ description_2 }}"
-
-- name: Delete existing client role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    name: "{{ role }}"
-    state: absent
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert client role deleted
-  assert:
-    that:
-      - result is changed
-      - result.end_state == {}
-
-- name: Delete absent client role
-  community.general.keycloak_role:
-    auth_keycloak_url: "{{ url }}"
-    auth_realm: "{{ admin_realm }}"
-    auth_username: "{{ admin_user }}"
-    auth_password: "{{ admin_password }}"
-    realm: "{{ realm }}"
-    client_id: "{{ client_id }}"
-    name: "{{ role }}"
-    state: absent
-  register: result
-
-- name: Debug
-  debug:
-    var: result
-
-- name: Assert client role unchanged
-  assert:
-    that:
-      - result is not changed
-      - result.end_state == {}
+- include_tasks: create_update_delete_tests.yml
+  vars:
+    test_props: "{{ item }}"
+  loop:
+    - test_name: "1. Realm role test"
+      expect_to_be_realm: true
+      create_args:
+        name: "{{ role }}"
+        description: "{{ description_1 }}"
+      update_args:
+        name: "{{ role }}"
+        description: "{{ description_2 }}"
+         
+    - test_name: "2. Client role test"
+      expect_to_be_realm: false
+      create_args:
+        name: "{{ role }}"
+        client_id: "{{ client_id }}"        
+        description: "{{ description_1 }}"
+      update_args:
+        name: "{{ role }}"
+        client_id: "{{ client_id }}"        
+        description: "{{ description_2 }}"

--- a/tests/integration/targets/keycloak_role/vars/main.yml
+++ b/tests/integration/targets/keycloak_role/vars/main.yml
@@ -14,4 +14,3 @@ auth_args:
   auth_realm: "{{ admin_realm }}"
   auth_username: "{{ admin_user }}"
   auth_password: "{{ admin_password }}"
-

--- a/tests/integration/targets/keycloak_role/vars/main.yml
+++ b/tests/integration/targets/keycloak_role/vars/main.yml
@@ -8,3 +8,10 @@ client_id: myclient
 role: myrole
 description_1: desc 1
 description_2: desc 2
+
+auth_args:
+  auth_keycloak_url: "{{ url }}"
+  auth_realm: "{{ admin_realm }}"
+  auth_username: "{{ admin_user }}"
+  auth_password: "{{ admin_password }}"
+


### PR DESCRIPTION
##### SUMMARY
This feature is to address #3274.

The following pull request adds the ability to add/remove the role composites at create, update and delete stage
for both keycloak client roles, and keycloak realm roles.  

To simplify the implementation, I have refactored the existing code somewhat to make re-usable methods for common tests methods, and try/catch blocks related to the API requests.

I chose to make composites a property of the role which they essentially are rather than introduce a new module to 
associate them in a different way.

I also ensured that if the composite attribute is not present, any existing composites are left unchanged - this is to ensure that any situations where one has manually added composites after ansible has created the role are unaffected.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/identity/keycloak/keycloak_role.py

##### ADDITIONAL INFORMATION
I have tested as follows:
1. See the contents of `tests/integration/targets/keycloak_role/README.md`
2. Via running the following:
```
ansible-test units '.*keycloak.*' --docker --verbose
```
