### PR TITLE
mh CmdMixin - added ArgFormat.BOOLEAN_NOT and logic

### DIFF
--- a/changelogs/fragments/3290-mh-cmd-boolean-not.yaml
+++ b/changelogs/fragments/3290-mh-cmd-boolean-not.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper cmd module utils - added the ``ArgFormat`` style ``BOOLEAN_NOT``, to add CLI parameters when the module argument is false-ish (https://github.com/ansible-collections/community.general/pull/3290).

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -16,6 +16,7 @@ class ArgFormat(object):
     BOOLEAN = 0
     PRINTF = 1
     FORMAT = 2
+    BOOLEAN_NOT = 3
 
     @staticmethod
     def stars_deco(num):
@@ -50,12 +51,14 @@ class ArgFormat(object):
 
         _fmts = {
             ArgFormat.BOOLEAN: lambda _fmt, v: ([_fmt] if bool(v) else []),
+            ArgFormat.BOOLEAN_NOT: lambda _fmt, v: ([] if bool(v) else [_fmt]),
             ArgFormat.PRINTF: printf_fmt,
             ArgFormat.FORMAT: lambda _fmt, v: [_fmt.format(v)],
         }
 
         self.name = name
         self.stars = stars
+        self.style = style
 
         if fmt is None:
             fmt = "{0}"
@@ -76,7 +79,7 @@ class ArgFormat(object):
             self.arg_format = (self.stars_deco(stars))(self.arg_format)
 
     def to_text(self, value):
-        if value is None:
+        if value is None and self.style != ArgFormat.BOOLEAN_NOT:
             return []
         func = self.arg_format
         return [str(p) for p in func(value)]

--- a/tests/unit/plugins/module_utils/test_module_helper.py
+++ b/tests/unit/plugins/module_utils/test_module_helper.py
@@ -24,6 +24,12 @@ ARG_FORMATS = dict(
                           False, []),
     simple_boolean_none=("--superflag", ArgFormat.BOOLEAN, 0,
                          None, []),
+    simple_boolean_not_true=("--superflag", ArgFormat.BOOLEAN_NOT, 0,
+                             True, []),
+    simple_boolean_not_false=("--superflag", ArgFormat.BOOLEAN_NOT, 0,
+                              False, ["--superflag"]),
+    simple_boolean_not_none=("--superflag", ArgFormat.BOOLEAN_NOT, 0,
+                             None, ["--superflag"]),
     single_printf=("--param=%s", ArgFormat.PRINTF, 0,
                    "potatoes", ["--param=potatoes"]),
     single_printf_no_substitution=("--param", ArgFormat.PRINTF, 0,
@@ -65,7 +71,7 @@ def test_arg_format(fmt, style, stars, value, expected):
     af = ArgFormat('name', fmt, style, stars)
     actual = af.to_text(value)
     print("formatted string = {0}".format(actual))
-    assert actual == expected
+    assert actual == expected, "actual = {0}".format(actual)
 
 
 ARG_FORMATS_FAIL = dict(
@@ -218,7 +224,7 @@ CAUSE_CHG_DECO_IDS = sorted(CAUSE_CHG_DECO.keys())
 
 @pytest.mark.parametrize(CAUSE_CHG_DECO_PARAMS,
                          [[CAUSE_CHG_DECO[tc][param]
-                           for param in CAUSE_CHG_DECO_PARAMS]
+                          for param in CAUSE_CHG_DECO_PARAMS]
                           for tc in CAUSE_CHG_DECO_IDS],
                          ids=CAUSE_CHG_DECO_IDS)
 def test_cause_changes_deco(method, expect_exception, expect_changed):


### PR DESCRIPTION
##### SUMMARY
Added the negation of the usual `ArgFormat.BOOLEAN` logic: if the boolean parameter is not there or it's `False`, add the command argument in the CLI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/cmd.py
