### PR TITLE
redfish: clean etag of quotes before patch

### DIFF
--- a/changelogs/fragments/3296-clean-etag.yaml
+++ b/changelogs/fragments/3296-clean-etag.yaml
@@ -1,3 +1,2 @@
 minor_changes:
   - "redfish_command and redfish_config and redfish_utils module utils - add parameter to strip etag of quotes before patch, since some vendors do not properly If-Match etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."
-

--- a/changelogs/fragments/3296-clean-etag.yaml
+++ b/changelogs/fragments/3296-clean-etag.yaml
@@ -1,2 +1,3 @@
 minor_changes:
-  - "redfish_command and redfish_config - add parameter to strip etag of quotes before patch, since some vendors do not properly If-Match etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."
+  - "redfish_command and redfish_config and redfish_utils module utils - add parameter to strip etag of quotes before patch, since some vendors do not properly If-Match etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."
+

--- a/changelogs/fragments/3296-clean-etag.yaml
+++ b/changelogs/fragments/3296-clean-etag.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "redfish_utils - clean etag of quotes before patch since some vendors double quote header etag (https://github.com/ansible-collections/community.general/pull/3296)."

--- a/changelogs/fragments/3296-clean-etag.yaml
+++ b/changelogs/fragments/3296-clean-etag.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "redfish_command and redfish_config and redfish_utils module utils - add parameter to strip etag of quotes before patch, since some vendors do not properly If-Match etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."
+  - "redfish_command and redfish_config and redfish_utils module utils - add parameter to strip etag of quotes before patch, since some vendors do not properly ``If-Match`` etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."

--- a/changelogs/fragments/3296-clean-etag.yaml
+++ b/changelogs/fragments/3296-clean-etag.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "redfish_utils - clean etag of quotes before patch since some vendors double quote header etag (https://github.com/ansible-collections/community.general/pull/3296)."
+  - "redfish_command and redfish_config - add parameter to strip etag of quotes before patch, since some vendors do not properly If-Match etag with quotes (https://github.com/ansible-collections/community.general/pull/3296)."

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -29,7 +29,7 @@ FAIL_MSG = 'Issuing a data modification command without specifying the '\
 class RedfishUtils(object):
 
     def __init__(self, creds, root_uri, timeout, module, resource_id=None,
-                 data_modification=False):
+                 data_modification=False, strip_etag_quotes=False):
         self.root_uri = root_uri
         self.creds = creds
         self.timeout = timeout
@@ -37,6 +37,7 @@ class RedfishUtils(object):
         self.service_root = '/redfish/v1/'
         self.resource_id = resource_id
         self.data_modification = data_modification
+        self.strip_etag_quotes = strip_etag_quotes
         self._init_session()
 
     def _auth_params(self, headers):
@@ -121,8 +122,8 @@ class RedfishUtils(object):
             if not etag:
                 etag = r['data'].get('@odata.etag')
             if etag:
-                # Clean etag and apply If-Match
-                etag = etag.strip("'\"")
+                if self.strip_etag_quotes:
+                    etag = etag.strip('"')
                 req_headers['If-Match'] = etag
         username, password, basic_auth = self._auth_params(req_headers)
         try:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -121,6 +121,8 @@ class RedfishUtils(object):
             if not etag:
                 etag = r['data'].get('@odata.etag')
             if etag:
+                # Clean etag and apply If-Match
+                etag = etag.strip("'\"")
                 req_headers['If-Match'] = etag
         username, password, basic_auth = self._auth_params(req_headers)
         try:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -215,7 +215,7 @@ options:
         C(If-Match) only matches the unquoted etag string.
     type: bool
     default: false
-    version_added: 3.6.0
+    version_added: 3.7.0
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -207,6 +207,16 @@ options:
         description:
           - The transfer method to use with the image
         type: str
+  strip_etag_quotes:
+    required: false
+    description:
+      - Removes surrounding quotes of etag used in If-Match header
+        of PATCH requests
+      - Only use this option to resolve bad vendor implementation where
+        If-Match only matches the unquoted etag string
+    type: bool
+    default: False
+    version_added: 3.6.0
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -631,7 +641,8 @@ def main():
                     transfer_protocol_type=dict(),
                     transfer_method=dict(),
                 )
-            )
+            ),
+            strip_etag_quotes=dict(type='bool', default=False)
         ),
         required_together=[
             ('username', 'password'),
@@ -686,10 +697,13 @@ def main():
     # VirtualMedia options
     virtual_media = module.params['virtual_media']
 
+    # Etag options
+    strip_etag_quotes = module.params['strip_etag_quotes']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_utils = RedfishUtils(creds, root_uri, timeout, module,
-                            resource_id=resource_id, data_modification=True)
+                            resource_id=resource_id, data_modification=True, strip_etag_quotes=strip_etag_quotes)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -208,14 +208,13 @@ options:
           - The transfer method to use with the image
         type: str
   strip_etag_quotes:
-    required: false
     description:
-      - Removes surrounding quotes of etag used in If-Match header
-        of PATCH requests
+      - Removes surrounding quotes of etag used in C(If-Match) header
+        of C(PATCH) requests.
       - Only use this option to resolve bad vendor implementation where
-        If-Match only matches the unquoted etag string
+        C(If-Match) only matches the unquoted etag string.
     type: bool
-    default: False
+    default: false
     version_added: 3.6.0
 
 author: "Jose Delarosa (@jose-delarosa)"
@@ -642,7 +641,7 @@ def main():
                     transfer_method=dict(),
                 )
             ),
-            strip_etag_quotes=dict(type='bool', default=False)
+            strip_etag_quotes=dict(type='bool', default=False),
         ),
         required_together=[
             ('username', 'password'),

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -91,6 +91,16 @@ options:
       - setting dict of EthernetInterface on OOB controller
     type: dict
     version_added: '0.2.0'
+  strip_etag_quotes:
+    required: false
+    description:
+      - Removes surrounding quotes of etag used in If-Match header
+        of PATCH requests
+      - Only use this option to resolve bad vendor implementation where
+        If-Match only matches the unquoted etag string
+    type: bool
+    default: False
+    version_added: 3.6.0
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -237,7 +247,8 @@ def main():
             nic_config=dict(
                 type='dict',
                 default={}
-            )
+            ),
+            strip_etag_quotes=dict(type='bool', default=False)
         ),
         required_together=[
             ('username', 'password'),
@@ -275,10 +286,13 @@ def main():
     nic_addr = module.params['nic_addr']
     nic_config = module.params['nic_config']
 
+    # Etag options
+    strip_etag_quotes = module.params['strip_etag_quotes']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
     rf_utils = RedfishUtils(creds, root_uri, timeout, module,
-                            resource_id=resource_id, data_modification=True)
+                            resource_id=resource_id, data_modification=True, strip_etag_quotes=strip_etag_quotes)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -247,7 +247,7 @@ def main():
                 type='dict',
                 default={}
             ),
-            strip_etag_quotes=dict(type='bool', default=False)
+            strip_etag_quotes=dict(type='bool', default=False),
         ),
         required_together=[
             ('username', 'password'),

--- a/plugins/modules/remote_management/redfish/redfish_config.py
+++ b/plugins/modules/remote_management/redfish/redfish_config.py
@@ -92,15 +92,14 @@ options:
     type: dict
     version_added: '0.2.0'
   strip_etag_quotes:
-    required: false
     description:
-      - Removes surrounding quotes of etag used in If-Match header
-        of PATCH requests
+      - Removes surrounding quotes of etag used in C(If-Match) header
+        of C(PATCH) requests.
       - Only use this option to resolve bad vendor implementation where
-        If-Match only matches the unquoted etag string
+        C(If-Match) only matches the unquoted etag string.
     type: bool
-    default: False
-    version_added: 3.6.0
+    default: false
+    version_added: 3.7.0
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''


### PR DESCRIPTION
##### SUMMARY
Some vendors surround header etag with quotes, which need to be cleaned before sending a patch

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Module_utils: redfish_utils

##### ADDITIONAL INFORMATION
Example response data that causes the issue.
Response data with clean etag:
{…"@odata.etag":"143417f8d77c4e179cfdf8edb1cbb921"}
 
Response header with double quoted etag:
{'Etag': '"143417f8d77c4e179cfdf8edb1cbb921"', …}

This MR simply cleans the etag of surrounding quotes prior to patching.