### PR TITLE
django_manage: Remove scottanderson42 and tastychutney as maintainers.

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1108,7 +1108,8 @@ files:
   $modules/web_infrastructure/deploy_helper.py:
     maintainers: ramondelafuente
   $modules/web_infrastructure/django_manage.py:
-    maintainers: scottanderson42 russoz tastychutney
+    maintainers: russoz
+    ignore: scottanderson42 tastychutney
     labels: django_manage
   $modules/web_infrastructure/ejabberd_user.py:
     maintainers: privateip


### PR DESCRIPTION

##### SUMMARY
I have neither maintained nor contributed to this module for years, nor has my alter-ego tastychutney.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/django_manage.py

##### ADDITIONAL INFORMATION
Note: tastychutney is another github account of mine that was also added as a maintainer.
