### PR TITLE
pids - refactor module to make version-based behavior consistent

### DIFF
--- a/changelogs/fragments/3315-pids-refactor.yml
+++ b/changelogs/fragments/3315-pids-refactor.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - pids - refactor to add support for older ``psutil`` versions to the ``pattern`` option
+    (https://github.com/ansible-collections/community.general/pull/3315).

--- a/plugins/modules/system/pids.py
+++ b/plugins/modules/system/pids.py
@@ -125,7 +125,7 @@ class PSAdapter(object):
         try:
             regex = re.compile(pattern, flags)
         except re.error as e:
-            raise PSAdapterError("'%s' is not a valid regular expression: %s" % (self._pattern, to_native(e)))
+            raise PSAdapterError("'%s' is not a valid regular expression: %s" % (pattern, to_native(e)))
 
         # See https://psutil.readthedocs.io/en/latest/#find-process-by-name for more information
         attributes = self._get_proc_attributes(proc, *self.PATTERN_ATTRS)

--- a/plugins/modules/system/pids.py
+++ b/plugins/modules/system/pids.py
@@ -113,11 +113,6 @@ class PSAdapter(object):
         pass
 
     def get_pids_by_pattern(self, pattern, ignore_case):
-        return [
-            p.pid for p in self._process_iter(*self.PATTERN_ATTRS) if self._matches_pattern(p, pattern, ignore_case)
-        ]
-
-    def _matches_pattern(self, proc, pattern, ignore_case):
         flags = 0
         if ignore_case:
             flags |= re.I
@@ -127,6 +122,9 @@ class PSAdapter(object):
         except re.error as e:
             raise PSAdapterError("'%s' is not a valid regular expression: %s" % (pattern, to_native(e)))
 
+        return [p.pid for p in self._process_iter(*self.PATTERN_ATTRS) if self._matches_regex(p, regex)]
+
+    def _matches_regex(self, proc, regex):
         # See https://psutil.readthedocs.io/en/latest/#find-process-by-name for more information
         attributes = self._get_proc_attributes(proc, *self.PATTERN_ATTRS)
         matches_name = regex.search(to_native(attributes['name']))

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -6,16 +6,18 @@
 # Test code for the pids module
 # Copyright: (c) 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- name: Attempt installation of latest 'psutil' version
+  pip:
+    name: psutil
+  ignore_errors: true
+  register: psutil_latest_install
+
 - name: Install greatest 'psutil' version which will work with all pip versions
   pip:
     name: psutil < 5.7.0
+  when: psutil_latest_install is failed
 
-- name: Attempt installation of 'psutil' >= 5.7.0 where possible
-  pip:
-    name: psutil >= 5.7.0
-  ignore_errors: true
-
-- name: "Checking the empty result" 
+- name: "Checking the empty result"
   pids: 
     name: "blahblah"
   register: emptypids

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -6,10 +6,14 @@
 # Test code for the pids module
 # Copyright: (c) 2019, Saranya Sridharan
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-- name: "Installing the psutil module"
+- name: Install greatest 'psutil' version which will work with all pip versions
   pip:
     name: psutil < 5.7.0
-    # Version 5.7.0 breaks on older pip versions. See https://github.com/ansible/ansible/pull/70667
+
+- name: Attempt installation of 'psutil' >= 5.7.0 where possible
+  pip:
+    name: psutil >= 5.7.0
+  ignore_errors: true
 
 - name: "Checking the empty result" 
   pids: 


### PR DESCRIPTION
##### SUMMARY
Cleaning up the `pids` module to ensure version specific operations are consistent across the module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/pids.py

##### ADDITIONAL INFORMATION
- Decouples `psutil` via an adapter with overridable behavior based on the package version
- Added the version based logic for the `pattern` execution path
- Tested locally with `psutils` versions `<2.0.0`, `>=2.0.0,<5.3.0`, and `>=5.3.0`