### PR TITLE
New module gitlab_project_mirrors to configure GitLab Remote Mirrors

### DIFF
--- a/changelogs/fragments/3323-gitlab_project_mirror.yml
+++ b/changelogs/fragments/3323-gitlab_project_mirror.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_project_mirror - add module to manage gitlab remote mirrors (https://github.com/ansible-collections/community.general/pull/3323)

--- a/plugins/modules/gitlab_project_mirror.py
+++ b/plugins/modules/gitlab_project_mirror.py
@@ -1,0 +1,1 @@
+source_control/gitlab/gitlab_project_mirror.py

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -21,6 +21,7 @@ description:
     this limits idempotency.
 author:
   - Max-Florian Bidlingmaier (@suukit) Max-Florian.Bidlingmaier@sap.com
+version_added: '3.7.0'
 
 requirements:
   - python >= 2.7

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -139,7 +139,7 @@ class GitLabProject(object):
     def createOrUpdateMirror(self, mirror_url, mirror_enabled, mirror_keep_divergent_refs = None, mirror_only_protected_branches = None):
         changed = False
         mirror_exists = False
-
+        self._module.fail_json(msg="Hier")
         mirrors = self.projectObject.remote_mirrors.list()
         urlParts = mirror_url.split('@')
         for mirror in mirrors:
@@ -265,11 +265,14 @@ def main():
     except gitlab.exceptions.GitlabGetError as e:
         module.fail_json(msg="Failed to find the namespace for the given user: %s" % to_native(e))
 
+    module.fail_json(msg=namespace)
+
     if not namespace:
         module.fail_json(msg="Failed to find the namespace for the project")
     project_exists = gitlab_project.existsProject(namespace, project_path)
 
     if project_exists:
+
       if state == 'present':
           if gitlab_project.createOrUpdateMirror(mirror_url, mirror_enabled, mirror_keep_divergent_refs, mirror_only_protected_branches):
               module.exit_json(changed=True, msg="Successfully created or updated the remote mirror to %s" % project_name, project=gitlab_project.projectObject._attrs)
@@ -278,6 +281,9 @@ def main():
       elif state == 'absent':
           # as GitLab API does currently not support removing remote mirrors only way is to deactivate it
           if gitlab_project.createOrUpdateMirror(mirror_url, False):
+            module.exit_json(changed=True, msg="Successfully disabled remote mirror to %s" % project_name, project=gitlab_project.projectObject._attrs)
+          else:
+            module.exit_json(changed=False, msg="No need to change remote mirror to %s" % project_name, project=gitlab_project.projectObject._attrs)
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -26,50 +26,60 @@ extends_documentation_fragment:
 - community.general.auth_basic
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  group:
-    description:
-      - Id or the full path of the group of which the projects belongs to.
-    type: str
-  project:
-    description:
-      - The name of the project.
-    required: true
-    type: str
-  path:
-    description:
-      - The path of the project you want to create, this will be server_url/<group>/path.
-      - If not supplied, name will be used.
-    type: str
-  enabled:
-    description:
-      - Is this remote mirror currently enabled?
-    type: bool
-    default: true
-  url:
-    description:
-      - URL to the git repo to mirror to in the form https://<user>:<token>@<fqdn>/<path>/<to>/<repo>.git".
-    type: str
-    required: true
-  only_protected_branches:
-    description:
-      - Mirror only protected or all branches?
-    type: bool
-  keep_divergent_refs:
-    description:
-      - Should divergent refs beeing kept?
-    type: bool
-  state:
-    description:
-      - Create/update or delete mirror
-      - Due to not beeing able to check the secrets one have to recreate if secrets change, use state=recreate
-      - Possible values are present and absent and recreate.
-    default: present
-    type: str
-    choices: ["present", "recreate"]
+    api_token:
+        description:
+            - GitLab token for logging in.
+      type: str
+    validate_certs:
+        description:
+            - Whether or not to validate TLS/SSL certificates when supplying a HTTPS endpoint.
+            - Should only be set to C(false) if you can guarantee that you are talking to the correct server
+              and no man-in-the-middle attack can happen.
+        default: true
+        type: bool
+    api_username:
+        description:
+            - The username to use for authentication against the API.
+        type: str
+    api_password:
+        description:
+            - The password to use for authentication against the API.
+        type: str
+    group:
+        description:
+            - Id or the full path of the group of which the projects belongs to.
+        type: str
+    project:
+        description:
+            - The name of the project.
+        required: true
+        type: str
+    enabled:
+        description:
+            - Is this remote mirror currently enabled?
+        type: bool
+        default: true
+    url:
+        description:
+            - URL to the git repo to mirror to in the form https://<user>:<token>@<fqdn>/<path>/<to>/<repo>.git".
+        type: str
+        required: true
+    only_protected_branches:
+        description:
+            - Mirror only protected or all branches?
+        type: bool
+    keep_divergent_refs:
+        description:
+            - Should divergent refs beeing kept?
+        type: bool
+    state:
+        description:
+            - Create/update or delete mirror
+            - Due to not beeing able to check the secrets one have to recreate if secrets change, use state=recreate
+            - Possible values are present and absent and recreate.
+        default: present
+        type: str
+        choices: ["present", "absent"]
 '''
 
 EXAMPLES = r'''
@@ -90,21 +100,11 @@ msg:
   type: str
   sample: "Success"
 
-result:
-  description: json parsed response from the server.
-  returned: always
-  type: dict
-
 error:
   description: the error message returned by the GitLab API.
   returned: failed
   type: str
   sample: "400: path is already in use"
-
-mirror:
-  description: API object.
-  returned: always
-  type: dict
 '''
 
 import traceback
@@ -208,12 +208,11 @@ def main():
         api_token=dict(type='str', no_log=True),
         group=dict(type='str'),
         project=dict(type='str', required=True),
-        path=dict(type='str'),
         url=dict(type='str', required=True),
         enabled=dict(type='bool'),
         only_protected_branches=dict(type='bool'),
         keep_divergent_refs=dict(type='bool'),
-        state=dict(type='str', default="present", choices=["recreate", "present"]),
+        state=dict(type='str', default="present", choices=["present","absent"]),
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -33,7 +33,7 @@ options:
     api_token:
         description:
             - GitLab token for logging in.
-      type: str
+        type: str
     validate_certs:
         description:
             - Whether or not to validate TLS/SSL certificates when supplying a HTTPS endpoint.
@@ -251,8 +251,8 @@ def main():
                                  project=gitlab_project.projectObject._attrs)
             else:
                 module.exit_json(changed=False,
-                msg="No need to update/create the remote mirror to %s" % project_name,
-                project=gitlab_project.projectObject._attrs)
+                                 msg="No need to update/create the remote mirror to %s" % project_name,
+                                 project=gitlab_project.projectObject._attrs)
         elif state == 'absent':
             # as GitLab API does currently not support removing remote mirrors return error to user
             module.fail_json(msg="GitLab API does not support removing mirrors. Either do it manually using GUI or update mirror with enabled=false.")

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -1,0 +1,309 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Max-Florian Bidlingmaier (Max-Florian.Bidlingmaier@sap.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: gitlab_project_mirror
+short_description: Creates/updates/deletes GitLab Project Remote Mirror
+description:
+  - When the remote mirror does not exist for the project, it will be created.
+  - Gitlab API does not allow to delete a remote mirror as of July 2021.
+  - When changes are made to the remote mirror, the mirror will be updated.
+author:
+  - Max-Florian Bidlingmaier (@suukit)
+
+requirements:
+  - python >= 2.7
+  - python-gitlab python module
+extends_documentation_fragment:
+- community.general.auth_basic
+
+options:
+  api_token:
+    description:
+      - GitLab token for logging in.
+    type: str
+  group:
+    description:
+      - Id or the full path of the group of which the projects belongs to.
+    type: str
+  project:
+    description:
+      - The name of the project.
+    required: true
+    type: str
+  path:
+    description:
+      - The path of the project you want to create, this will be server_url/<group>/path.
+      - If not supplied, name will be used.
+    type: str
+  enabled:
+    description:
+      - Is this remote mirror currently enabled?
+    type: bool
+    default: true
+  url:
+    description:
+      - URL to the git repo to mirror to in the form https://<user>:<token>@<fqdn>/<path>/<to>/<repo>.git".
+    type: str
+    required: true
+  only_protected_branches:
+    description:
+      - Mirror only protected or all branches?
+    type: bool
+  keep_divergent_refs:
+    description:
+      - Should divergent refs beeing kept?
+    type: bool
+  state:
+    description:
+      - Create/update or delete mirror
+      - Due to not beeing able to check the secrets one have to recreate if secrets change, use state=recreate
+      - Possible values are present and absent and recreate.
+    default: present
+    type: str
+    choices: ["present", "recreate"]
+'''
+
+EXAMPLES = r'''
+- name: Create Mirror for Project
+  community.general.gitlab_project_mirror:
+    api_url: https://gitlab.example.com/
+    api_token: "{{ api_token }}"
+    name: a project
+    group: "10481470"
+    url: "https://gituser:gittoken@gitserver.example.com/somerepo.git"
+    enabled: true
+'''
+
+RETURN = r'''
+msg:
+  description: Success or failure message.
+  returned: always
+  type: str
+  sample: "Success"
+
+result:
+  description: json parsed response from the server.
+  returned: always
+  type: dict
+
+error:
+  description: the error message returned by the GitLab API.
+  returned: failed
+  type: str
+  sample: "400: path is already in use"
+
+mirror:
+  description: API object.
+  returned: always
+  type: dict
+'''
+
+import traceback
+
+GITLAB_IMP_ERR = None
+try:
+    import gitlab
+    HAS_GITLAB_PACKAGE = True
+except Exception:
+    GITLAB_IMP_ERR = traceback.format_exc()
+    HAS_GITLAB_PACKAGE = False
+
+from ansible.module_utils.api import basic_auth_argument_spec
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, findProject, gitlabAuthentication
+
+
+class GitLabProject(object):
+    def __init__(self, module, gitlab_instance):
+        self._module = module
+        self._gitlab = gitlab_instance
+        self.projectObject = None
+
+    '''
+    @param mirror_url URL to where the mirror should point to
+    @param mirror_enabled Is this mirror enabled?
+    @param mirror_keep_divergent_refs Keep divergent refs?
+    @param mirror_only_protected_branches Mirror only protected banches?
+    '''
+    def createOrUpdateMirror(self, mirror_url, mirror_enabled, mirror_keep_divergent_refs, mirror_only_protected_branches):
+        changed = False
+
+        mirrors = self.projectObject.remote_mirrors.list()
+        urlParts = mirror_url.split('@')
+        for mirror in mirrors:
+          if urlParts[1] in mirror.url:
+            # mirror exists, update if needed
+            if mirror.enabled != mirror_enabled:
+              mirror.enabled = mirror_enabled
+
+
+        # Because we have already call userExists in main()
+        if self.projectObject is None:
+            project_options.update({
+                'path': options['path'],
+                'import_url': options['import_url'],
+            })
+            project_options = self.getOptionsWithValue(project_options)
+            project = self.createProject(namespace, project_options)
+            changed = True
+        else:
+            changed, project = self.updateProject(self.projectObject, project_options)
+
+        self.projectObject = project
+        if changed:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name)
+
+            try:
+                project.save()
+            except Exception as e:
+                self._module.fail_json(msg="Failed update project: %s " % e)
+            return True
+        return False
+
+    '''
+    @param namespace Namespace Object (User or Group)
+    @param arguments Attributes of the project
+    '''
+    def createProject(self, namespace, arguments):
+        if self._module.check_mode:
+            return True
+
+        arguments['namespace_id'] = namespace.id
+        try:
+            project = self._gitlab.projects.create(arguments)
+        except (gitlab.exceptions.GitlabCreateError) as e:
+            self._module.fail_json(msg="Failed to create project: %s " % to_native(e))
+
+        return project
+
+    '''
+    @param arguments Attributes of the project
+    '''
+    def getOptionsWithValue(self, arguments):
+        ret_arguments = dict()
+        for arg_key, arg_value in arguments.items():
+            if arguments[arg_key] is not None:
+                ret_arguments[arg_key] = arg_value
+
+        return ret_arguments
+
+    '''
+    @param project Project Object
+    @param arguments Attributes of the project
+    '''
+    def updateProject(self, project, arguments):
+        changed = False
+
+        for arg_key, arg_value in arguments.items():
+            if arguments[arg_key] is not None:
+                if getattr(project, arg_key) != arguments[arg_key]:
+                    setattr(project, arg_key, arguments[arg_key])
+                    changed = True
+
+        return (changed, project)
+
+
+    '''
+    @param namespace User/Group object
+    @param name Name of the project
+    '''
+    def existsProject(self, namespace, path):
+        # When project exists, object will be stored in self.projectObject.
+        project = findProject(self._gitlab, namespace.full_path + '/' + path)
+        if project:
+            self.projectObject = project
+            return True
+        return False
+
+
+def main():
+    argument_spec = basic_auth_argument_spec()
+    argument_spec.update(dict(
+        api_token=dict(type='str', no_log=True),
+        group=dict(type='str'),
+        project=dict(type='str', required=True),
+        path=dict(type='str'),
+        url=dict(type='str', required=True),
+        enabled=dict(type='bool'),
+        only_protected_branches=dict(type='bool'),
+        keep_divergent_refs=dict(type='bool'),
+        state=dict(type='str', default="present", choices=["recreate", "present"]),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['api_username', 'api_token'],
+            ['api_password', 'api_token'],
+        ],
+        required_together=[
+            ['api_username', 'api_password'],
+        ],
+        required_one_of=[
+            ['api_username', 'api_token']
+        ],
+        supports_check_mode=True,
+    )
+
+    group_identifier = module.params['group']
+    project_name = module.params['project']
+    project_path = module.params['path']
+    state = module.params['state']
+    mirror_url = module.params['url']
+    mirror_enabled = module.params['enabled']
+    mirror_only_protected_branches = module.params['only_protected_branches']
+    mirror_keep_divergent_refs = module.params['keep_divergent_refs']
+
+    if not HAS_GITLAB_PACKAGE:
+        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
+
+    gitlab_instance = gitlabAuthentication(module)
+
+    # Set project_path to project_name if it is empty.
+    if project_path is None:
+        project_path = project_name.replace(" ", "_")
+
+    gitlab_project = GitLabProject(module, gitlab_instance)
+
+    namespace = None
+    namespace_id = None
+    if group_identifier:
+        group = findGroup(gitlab_instance, group_identifier)
+        if group is None:
+            module.fail_json(msg="Failed to find project: group %s doesn't exists" % group_identifier)
+
+        namespace_id = group.id
+
+    if not namespace_id:
+        module.fail_json(msg="Failed to find the namespace or group ID which is required to look up the namespace")
+
+    try:
+        namespace = gitlab_instance.namespaces.get(namespace_id)
+    except gitlab.exceptions.GitlabGetError as e:
+        module.fail_json(msg="Failed to find the namespace for the given user: %s" % to_native(e))
+
+    if not namespace:
+        module.fail_json(msg="Failed to find the namespace for the project")
+    project_exists = gitlab_project.existsProject(namespace, project_path)
+
+    if project_exists:
+      if state == 'present':
+          if gitlab_project.createOrUpdateMirror(mirror_url, mirror_enabled, mirror_keep_divergent_refs, mirror_only_protected_branches):
+
+              module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.projectObject._attrs)
+          module.exit_json(changed=False, msg="No need to update the project %s" % project_name, project=gitlab_project.projectObject._attrs)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -135,7 +135,7 @@ class GitLabProjectMirror(object):
     @param mirror_keep_divergent_refs Keep divergent refs?
     @param mirror_only_protected_branches Mirror only protected banches?
     '''
-    def createOrUpdateMirror(self, mirror_url, mirror_enabled, mirror_keep_divergent_refs = None, mirror_only_protected_branches = None):
+    def createOrUpdateMirror(self, mirror_url, mirror_enabled, mirror_keep_divergent_refs=None, mirror_only_protected_branches=None):
         changed = False
         mirror_exists = False
         mirrors = self.projectObject.remote_mirrors.list()
@@ -152,10 +152,10 @@ class GitLabProjectMirror(object):
                 if mirror.enabled != mirror_enabled:
                     mirror.enabled = mirror_enabled
                     save_mirror = True
-                if mirror_keep_divergent_refs != None and mirror.keep_divergent_refs != mirror_keep_divergent_refs:
+                if mirror_keep_divergent_refs is not None and mirror.keep_divergent_refs != mirror_keep_divergent_refs:
                     mirror.keep_divergent_refs = mirror_keep_divergent_refs
                     save_mirror = True
-                if mirror_only_protected_branches != None and mirror.only_protected_branches != mirror_only_protected_branches:
+                if mirror_only_protected_branches is not None and mirror.only_protected_branches != mirror_only_protected_branches:
                     mirror.only_protected_branches = mirror_only_protected_branches
                     save_mirror = True
 
@@ -170,12 +170,12 @@ class GitLabProjectMirror(object):
 
         # create a new mirror
         if not mirror_exists:
-            create_data = {'url' : mirror_url,
+            create_data = {'url': mirror_url,
                            'enabled': mirror_enabled}
             if mirror_keep_divergent_refs is not None:
-              create_data['keep_divergent_refs'] = mirror_keep_divergent_refs
+                create_data['keep_divergent_refs'] = mirror_keep_divergent_refs
             if mirror_only_protected_branches is not None:
-              create_data['only_protected_branches'] = mirror_only_protected_branches
+                create_data['only_protected_branches'] = mirror_only_protected_branches
 
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully updated the project remote mirror %s" % mirror_url)
@@ -209,7 +209,7 @@ def main():
         enabled=dict(type='bool'),
         only_protected_branches=dict(type='bool'),
         keep_divergent_refs=dict(type='bool'),
-        state=dict(type='str', default="present", choices=["present","absent"]),
+        state=dict(type='str', default="present", choices=["present", "absent"]),
     ))
 
     module = AnsibleModule(
@@ -244,14 +244,19 @@ def main():
     project_exists = gitlab_project.existsProject(project_name)
 
     if project_exists:
-      if state == 'present':
-          if gitlab_project.createOrUpdateMirror(mirror_url, mirror_enabled, mirror_keep_divergent_refs, mirror_only_protected_branches):
-              module.exit_json(changed=True, msg="Successfully created or updated the remote mirror to %s" % project_name, project=gitlab_project.projectObject._attrs)
-          else:
-              module.exit_json(changed=False, msg="No need to update/create the remote mirror to %s" % project_name, project=gitlab_project.projectObject._attrs)
-      elif state == 'absent':
-          # as GitLab API does currently not support removing remote mirrors return error to user
-          module.fail_json(msg="GitLab API does not support removing mirrors. Either do it manually using GUI or update mirror with enabled=false.")
+        if state == 'present':
+            if gitlab_project.createOrUpdateMirror(mirror_url, mirror_enabled, mirror_keep_divergent_refs, mirror_only_protected_branches):
+                module.exit_json(changed=True,
+                                 msg="Successfully created or updated the remote mirror to %s" % project_name,
+                                 project=gitlab_project.projectObject._attrs)
+            else:
+                module.exit_json(changed=False,
+                msg="No need to update/create the remote mirror to %s" % project_name,
+                project=gitlab_project.projectObject._attrs)
+        elif state == 'absent':
+            # as GitLab API does currently not support removing remote mirrors return error to user
+            module.fail_json(msg="GitLab API does not support removing mirrors. Either do it manually using GUI or update mirror with enabled=false.")
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -5,7 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from os import truncate
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -206,7 +205,7 @@ def main():
         api_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         url=dict(type='str', required=True),
-        enabled=dict(type='bool'),
+        enabled=dict(type='bool', default=True),
         only_protected_branches=dict(type='bool'),
         keep_divergent_refs=dict(type='bool'),
         state=dict(type='str', default="present", choices=["present", "absent"]),

--- a/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_mirror.py
@@ -232,7 +232,6 @@ def main():
 
     group_identifier = module.params['group']
     project_name = module.params['project']
-    project_path = module.params['path']
     state = module.params['state']
     mirror_url = module.params['url']
     mirror_enabled = module.params['enabled']
@@ -243,10 +242,6 @@ def main():
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
     gitlab_instance = gitlabAuthentication(module)
-
-    # Set project_path to project_name if it is empty.
-    if project_path is None:
-        project_path = project_name.replace(" ", "_")
 
     gitlab_project = GitLabProject(module, gitlab_instance)
 
@@ -268,7 +263,7 @@ def main():
 
     if not namespace:
         module.fail_json(msg="Failed to find the namespace for the project")
-    project_exists = gitlab_project.existsProject(namespace, project_path)
+    project_exists = gitlab_project.existsProject(namespace, project_name)
 
     if project_exists:
       if state == 'present':

--- a/tests/integration/targets/gitlab_project_mirror/aliases
+++ b/tests/integration/targets/gitlab_project_mirror/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/gitlab_project_mirror/defaults/main.yml
+++ b/tests/integration/targets/gitlab_project_mirror/defaults/main.yml
@@ -1,0 +1,4 @@
+gitlab_server_url: https://gitlab.com
+gitlab_api_access_token: "token"
+gitlab_project: some_project
+gitlab_project_remote_mirror_url: "http://user:token@testmirror.local"

--- a/tests/integration/targets/gitlab_project_mirror/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_mirror/tasks/main.yml
@@ -1,0 +1,43 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Test code for gitlab_project_mirror module
+#
+# Copyright: (c) 2021, Max Bidlingmaier <Max-Florian.Bidlingmaier@sap.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Install required library
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Make sure mirror is present
+  community.general.gitlab_project_mirror:
+    api_url: "{{ gitlab_server_url }}"
+    api_token: "{{ gitlab_api_access_token }}"
+    project: "{{ gitlab_project }}"
+    url: "{{ gitlab_project_remote_mirror_url }}"
+    state: present
+  register: gitlab_project_mirror_state
+
+# as GitLab API does not allow to delete mirrors we can't be sure about this mirror is newly created
+# - name: Test member added to project
+#   assert:
+#     that:
+#       - gitlab_project_mirror_state is changed
+
+- name: Make sure mirror is present
+  community.general.gitlab_project_mirror:
+    api_url: "{{ gitlab_server_url }}"
+    api_token: "{{ gitlab_api_access_token }}"
+    project: "{{ gitlab_project }}"
+    url: "{{ gitlab_project_remote_mirror_url }}"
+    state: present
+  register: gitlab_project_mirror_state_again
+
+- name: Test module is idempotent
+  assert:
+    that:
+      - gitlab_project_mirror_state_again is not changed

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -641,6 +641,7 @@ def resp_delete_runner(url, request):
 PROJECT REMOTE MIRRORS API
 '''
 
+
 @urlmatch(scheme="http", netloc="localhost", path=r'projects/1/remote_mirrors$', method="get")
 def resp_remote_mirrors_list(url, request):
     headers = {'content-type': 'application/json'}
@@ -654,6 +655,7 @@ def resp_remote_mirrors_list(url, request):
                '"url": "https://*****:*****@gitlab.com/gitlab-org/security/gitlab.git"}]')
     content = content.encode("utf-8")
     return response(200, content, headers, None, 5, request)
+
 
 @urlmatch(scheme="http", netloc="localhost", path=r'projects/1/remote_mirrors$', method="post")
 def resp_remote_mirrors_create(url, request):

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -635,3 +635,32 @@ def resp_delete_runner(url, request):
     content = ('{}')
     content = content.encode("utf-8")
     return response(204, content, headers, None, 5, request)
+
+
+'''
+PROJECT REMOTE MIRRORS API
+'''
+
+@urlmatch(scheme="http", netloc="localhost", path=r'projects/1/remote_mirrors$', method="get")
+def resp_remote_mirrors_list(url, request):
+    headers = {'content-type': 'application/json'}
+    content = ('[{"enabled": true, "id": 101486, "last_error": null,'
+               '"last_successful_update_at": "2020-01-06T17:32:02.823Z",'
+               '"last_update_at": "2020-01-06T17:32:02.823Z",'
+               '"last_update_started_at": "2020-01-06T17:31:55.864Z",'
+               '"only_protected_branches": true,'
+               '"keep_divergent_refs": true,'
+               '"update_status": "finished",'
+               '"url": "https://*****:*****@gitlab.com/gitlab-org/security/gitlab.git"}]')
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+@urlmatch(scheme="http", netloc="localhost", path=r'projects/1/remote_mirrors$', method="post")
+def resp_remote_mirrors_create(url, request):
+    headers = {'content-type': 'application/json'}
+    content = ('{"enabled": false, "id": 101486, "last_error": null, "last_successful_update_at": null,'
+               '"last_update_at": null, "last_update_started_at": null, "only_protected_branches": false,'
+               '"keep_divergent_refs": false, "update_status": "none",'
+               '"url": "https://*****:*****@example.com/gitlab/example.git"}')
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Max Bidlingmaier (Max-Florian.Bidlingmaier@sap.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from distutils.version import LooseVersion
+
+from ansible_collections.community.general.plugins.modules.source_control.gitlab.gitlab_project_mirror import GitlabProjectMirror
+
+
+def _dummy(x):
+    """Dummy function.  Only used as a placeholder for toplevel definitions when the test is going
+    to be skipped anyway"""
+    return x
+
+
+pytestmark = []
+try:
+    from .gitlab import (GitlabModuleTestCase,
+                         python_version_match_requirement, python_gitlab_module_version,
+                         python_gitlab_version_match_requirement,
+                         resp_get_project_by_name,
+                         resp_remote_mirrors_list,
+                         resp_remote_mirrors_create,
+                        )
+
+    # GitLab module requirements
+    if python_version_match_requirement():
+        from gitlab.v4.objects import Project
+    gitlab_req_version = python_gitlab_version_match_requirement()
+    gitlab_module_version = python_gitlab_module_version()
+    if LooseVersion(gitlab_module_version) < LooseVersion(gitlab_req_version):
+        pytestmark.append(pytest.mark.skip("Could not load gitlab module required for testing (Wrong  version)"))
+except ImportError:
+    pytestmark.append(pytest.mark.skip("Could not load gitlab module required for testing"))
+
+# Unit tests requirements
+try:
+    from httmock import with_httmock  # noqa
+except ImportError:
+    pytestmark.append(pytest.mark.skip("Could not load httmock module required for testing"))
+    with_httmock = _dummy
+
+
+class TestGitlabProjectMirror(GitlabModuleTestCase):
+    @with_httmock(resp_get_project_by_name)
+    def setUp(self):
+        super(TestGitlabProjectMirror, self).setUp()
+
+        self.moduleUtil = GitLabProjectMirror(module=self.mock_module, gitlab_instance=self.gitlab_instance)
+
+    @with_httmock(resp_remote_mirrors_list)
+    @with_httmock(resp_remote_mirrors_create)
+    def test_createOrUpdateMirror(self):
+        rvalue = self.moduleUtil.createOrUpdateMirror(mirror_url='https://*****:*****@example.com/gitlab/example.git', mirror_enabled=True)
+        self.assertEqual(rvalue, True)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
@@ -52,7 +52,7 @@ class TestGitlabProjectMirror(GitlabModuleTestCase):
         super(TestGitlabProjectMirror, self).setUp()
 
         self.moduleUtil = GitLabProjectMirror(module=self.mock_module, gitlab_instance=self.gitlab_instance)
-        self.moduleUtil.existsProject(self, 'project')
+        self.moduleUtil.existsProject('project')
 
     @with_httmock(resp_remote_mirrors_list)
     @with_httmock(resp_remote_mirrors_create)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
@@ -52,6 +52,7 @@ class TestGitlabProjectMirror(GitlabModuleTestCase):
         super(TestGitlabProjectMirror, self).setUp()
 
         self.moduleUtil = GitLabProjectMirror(module=self.mock_module, gitlab_instance=self.gitlab_instance)
+        self.moduleUtil.existsProject(self, 'project')
 
     @with_httmock(resp_remote_mirrors_list)
     @with_httmock(resp_remote_mirrors_create)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
@@ -26,7 +26,7 @@ try:
                          resp_get_project_by_name,
                          resp_remote_mirrors_list,
                          resp_remote_mirrors_create,
-                        )
+                         )
 
     # GitLab module requirements
     if python_version_match_requirement():

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project_mirror.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 import pytest
 from distutils.version import LooseVersion
 
-from ansible_collections.community.general.plugins.modules.source_control.gitlab.gitlab_project_mirror import GitlabProjectMirror
+from ansible_collections.community.general.plugins.modules.source_control.gitlab.gitlab_project_mirror import GitLabProjectMirror
 
 
 def _dummy(x):


### PR DESCRIPTION
##### SUMMARY
Adds support for gitlab project's remote mirror API by introducing a new module gitlab_projkect_mirror
https://docs.gitlab.com/ee/api/remote_mirrors.html

As the API is limited and currently lacks:
- deletion of mirrors
- read out/comparison of credentials
- change of URL/credentials

the current implementation only allows adding mirrors and changing the attributes:
 - enabled
 - only_protected_branches
 - keep_divergent_refs

There is a request for adding the deletion feature upstream https://gitlab.com/gitlab-org/gitlab/-/issues/287786. This module is to be enhanced as soon as this feature is present.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
gitlab_project_mirror

##### ADDITIONAL INFORMATION
Gitlab is capable of push mirroring repositories to other git systems. This mirroring is done event based. A URL + credentials for the remote system is needed. It's also possible to configure to only mirror protected branches. The module could possibly be used to mirror a local gitlab system to github.com.