### PR TITLE
tss: add option for token authorization

### DIFF
--- a/changelogs/fragments/3327-tss-token-authorization.yml
+++ b/changelogs/fragments/3327-tss-token-authorization.yml
@@ -1,5 +1,5 @@
 minor_changes:
   - tss lookup plugin - added ``token`` parameter for token authorization;
     ``username`` and ``password`` are optional when ``token`` is provided;
-    updated examples because ``base_url`` is already requried everywhere
+    updated examples to include ``token`` and ``domain`` parameters
     (https://github.com/ansible-collections/community.general/pull/3327).

--- a/changelogs/fragments/3327-tss-token-authorization.yml
+++ b/changelogs/fragments/3327-tss-token-authorization.yml
@@ -1,5 +1,4 @@
 minor_changes:
   - tss lookup plugin - added ``token`` parameter for token authorization;
-    ``username`` and ``password`` are optional when ``token`` is provided;
-    updated examples to include ``token`` and ``domain`` parameters
+    ``username`` and ``password`` are optional when ``token`` is provided
     (https://github.com/ansible-collections/community.general/pull/3327).

--- a/changelogs/fragments/3327-tss-token-authorization.yml
+++ b/changelogs/fragments/3327-tss-token-authorization.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - tss lookup plugin - added new parameter for token authorization
+    parameters username and password are made optional because of this
+    (https://github.com/ansible-collections/community.general/pull/3327).

--- a/changelogs/fragments/3327-tss-token-authorization.yml
+++ b/changelogs/fragments/3327-tss-token-authorization.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - tss lookup plugin - added new parameter for token authorization
-    parameters username and password are made optional because of this
+  - tss lookup plugin - added ``token`` parameter for token authorization;
+    ``username`` and ``password`` are optional when ``token`` is provided
     (https://github.com/ansible-collections/community.general/pull/3327).

--- a/changelogs/fragments/3327-tss-token-authorization.yml
+++ b/changelogs/fragments/3327-tss-token-authorization.yml
@@ -1,4 +1,5 @@
 minor_changes:
   - tss lookup plugin - added ``token`` parameter for token authorization;
-    ``username`` and ``password`` are optional when ``token`` is provided
+    ``username`` and ``password`` are optional when ``token`` is provided;
+    updated examples because ``base_url`` is already requried everywhere
     (https://github.com/ansible-collections/community.general/pull/3327).

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -100,18 +100,6 @@ _list:
 EXAMPLES = r"""
 - hosts: localhost
   vars:
-      secret: "{{ lookup('community.general.tss', 1) }}"
-  tasks:
-      - ansible.builtin.debug:
-          msg: >
-            the password is {{
-              (secret['items']
-                | items2dict(key_name='slug',
-                             value_name='itemValue'))['password']
-            }}
-
-- hosts: localhost
-  vars:
       secret: >-
         {{
             lookup(
@@ -133,8 +121,37 @@ EXAMPLES = r"""
 
 - hosts: localhost
   vars:
+      secret: >-
+        {{
+            lookup(
+                'community.general.tss',
+                102,
+                base_url='https://secretserver.domain.com/SecretServer/',
+                username='user.name',
+                password='password',
+                domain='domain'
+            )
+        }}
+  tasks:
+      - ansible.builtin.debug:
+          msg: >
+            the password is {{
+              (secret['items']
+                | items2dict(key_name='slug',
+                             value_name='itemValue'))['password']
+            }}
+
+- hosts: localhost
+  vars:
       secret_password: >-
-        {{ ((lookup('community.general.tss', 1) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password'] }}"
+        {{
+            ((lookup(
+                'community.general.tss',
+                102,
+                base_url='https://secretserver.domain.com/SecretServer/',
+                token='thycotic_access_token',
+            )  | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password']
+        }}
   tasks:
       - ansible.builtin.debug:
           msg: the password is {{ secret_password }}

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -38,7 +38,9 @@ options:
               key: username
         required: false
     password:
-        description: The password associated with the supplied username.
+        description:
+            - The password associated with the supplied username.
+            - Required when I(token) is not provided.
         env:
             - name: TSS_PASSWORD
         ini:
@@ -60,6 +62,7 @@ options:
     token:
         description:
           - Existing token for Thycotic authorizer.
+          - If provided, I(username) and I(password) are not needed.
           - Requires C(python-tss-sdk) version 1.0.0 or greater.
         env:
             - name: TSS_TOKEN

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -36,7 +36,6 @@ options:
         ini:
             - section: tss_lookup
               key: username
-        required: false
     password:
         description:
             - The password associated with the supplied username.
@@ -46,7 +45,6 @@ options:
         ini:
             - section: tss_lookup
               key: password
-        required: false
     domain:
         default: ""
         description:
@@ -70,7 +68,6 @@ options:
         ini:
             - section: tss_lookup
               key: token
-        required: false
         version_added: 3.7.0
     api_path_uri:
         default: /api/v1

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -221,6 +221,11 @@ class TSSClientV1(TSSClient):
 
     @staticmethod
     def _get_authorizer(**server_parameters):
+        if server_parameters.get("token"):
+            return AccessTokenAuthorizer(
+                server_parameters["token"],
+            )
+
         if server_parameters.get("domain"):
             return DomainPasswordGrantAuthorizer(
                 server_parameters["base_url"],
@@ -228,11 +233,6 @@ class TSSClientV1(TSSClient):
                 server_parameters["domain"],
                 server_parameters["password"],
                 server_parameters["token_path_uri"],
-            )
-
-        if server_parameters.get("token"):
-            return AccessTokenAuthorizer(
-                server_parameters["token"],
             )
 
         return PasswordGrantAuthorizer(

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -51,6 +51,7 @@ options:
         default: ""
         description:
           - The domain with which to request the OAuth2 Access Grant.
+          - Optional when I(token) is not provided.
           - Requires C(python-tss-sdk) version 1.0.0 or greater.
         env:
             - name: TSS_DOMAIN

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -58,9 +58,9 @@ options:
         required: false
         version_added: 3.6.0
     token:
-        default: ""
         description:
           - Existing token for Thycotic authorizer.
+          - Requires C(python-tss-sdk) version 1.0.0 or greater.
         env:
             - name: TSS_TOKEN
         ini:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -36,7 +36,7 @@ options:
         ini:
             - section: tss_lookup
               key: username
-        required: true
+        required: false
     password:
         description: The password associated with the supplied username.
         env:
@@ -44,7 +44,7 @@ options:
         ini:
             - section: tss_lookup
               key: password
-        required: true
+        required: false
     domain:
         default: ""
         description:
@@ -57,6 +57,17 @@ options:
               key: domain
         required: false
         version_added: 3.6.0
+    token:
+        default: ""
+        description:
+          - Existing token for Thycotic authorizer.
+        env:
+            - name: TSS_TOKEN
+        ini:
+            - section: tss_lookup
+              key: token
+        required: false
+        version_added: 3.7.0
     api_path_uri:
         default: /api/v1
         description: The path to append to the base URL to form a valid REST
@@ -142,12 +153,13 @@ except ImportError:
     HAS_TSS_SDK = False
 
 try:
-    from thycotic.secrets.server import PasswordGrantAuthorizer, DomainPasswordGrantAuthorizer
+    from thycotic.secrets.server import PasswordGrantAuthorizer, DomainPasswordGrantAuthorizer, AccessTokenAuthorizer
 
     HAS_TSS_AUTHORIZER = True
 except ImportError:
     PasswordGrantAuthorizer = None
     DomainPasswordGrantAuthorizer = None
+    AccessTokenAuthorizer = None
     HAS_TSS_AUTHORIZER = False
 
 
@@ -218,6 +230,11 @@ class TSSClientV1(TSSClient):
                 server_parameters["token_path_uri"],
             )
 
+        if server_parameters.get("token"):
+            return AccessTokenAuthorizer(
+                server_parameters["token"],
+            )
+
         return PasswordGrantAuthorizer(
             server_parameters["base_url"],
             server_parameters["username"],
@@ -238,6 +255,7 @@ class LookupModule(LookupBase):
             username=self.get_option("username"),
             password=self.get_option("password"),
             domain=self.get_option("domain"),
+            token=self.get_option("token"),
             api_path_uri=self.get_option("api_path_uri"),
             token_path_uri=self.get_option("token_path_uri"),
         )


### PR DESCRIPTION
Use `AccessTokenAuthorizer` if parameter `token` is used.

##### SUMMARY
Thycotic and hvac library also support authorizing with access token. It is useful when you already have such a token so you can seamlessly use it.

Parameters username and password are optional now because of this.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/lookup/tss.py

##### ADDITIONAL INFORMATION
Playbook example:
```
- hosts: localhost
  gather_facts: no
  tasks:
    - name: Get the password
      debug:
        msg: "{{ ((lookup(
                'community.general.tss',
                tss_secret_id,
                base_url=tss_server,
                token=tss_token,
                ) | from_json).get('items') | items2dict(key_name='slug', value_name='itemValue'))['password']
              }}"
      run_once: True
```

Output:

```
PLAY [localhost] *****************************************************************************************************


TASK [Get the password] **********************************************************************************************
ok: [localhost -> localhost] => {
    "msg": "SECRET_PASSWORD"
}

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
