### PR TITLE
Keycloak: Fix bug on keycloak_authentication, requirement not always updated

### DIFF
--- a/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
+++ b/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - keycloak_authentication - fix bug, the requirement was always on DISABLED when creating a new authentication flow
+    https://github.com/ansible-collections/community.general/pull/3330.

--- a/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
+++ b/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
@@ -1,3 +1,3 @@
 bugfixes:
   - keycloak_authentication - fix bug, the requirement was always on ``DISABLED`` when creating a new authentication flow
-    https://github.com/ansible-collections/community.general/pull/3330.
+    (https://github.com/ansible-collections/community.general/pull/3330).

--- a/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
+++ b/changelogs/fragments/3330-bugfix-keycloak-authentication-flow-requirements-not-set-correctly.yml.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - keycloak_authentication - fix bug, the requirement was always on DISABLED when creating a new authentication flow
+  - keycloak_authentication - fix bug, the requirement was always on ``DISABLED`` when creating a new authentication flow
     https://github.com/ansible-collections/community.general/pull/3330.

--- a/plugins/modules/identity/keycloak/keycloak_authentication.py
+++ b/plugins/modules/identity/keycloak/keycloak_authentication.py
@@ -195,15 +195,10 @@ def create_or_update_executions(kc, config, realm='master'):
     :param kc: Keycloak API access.
     :param config: Representation of the authentication flow including it's executions.
     :param realm: Realm
-    :return: True if executions have been modified. False otherwise.
-<<<<<<< HEAD
     :return: tuple (changed, dict(before, after)
         WHERE
         bool changed indicates if changes have been made
         dict(str, str) shows state before and after creation/update
-=======
-    :return: Dict with key "before" and "after" to describe the changes, None if no modification
->>>>>>> Fix diff mode when updating authentication flow with keycloak_authentication module
     """
     try:
         changed = False

--- a/plugins/modules/identity/keycloak/keycloak_authentication.py
+++ b/plugins/modules/identity/keycloak/keycloak_authentication.py
@@ -234,6 +234,8 @@ def create_or_update_executions(kc, config, realm='master'):
                 elif new_exec["providerId"] is not None:
                     kc.create_execution(new_exec, flowAlias=flow_alias_parent, realm=realm)
                     exec_found = True
+                    exec_index = new_exec_index
+                    id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
                     after += str(new_exec) + '\n'
                 elif new_exec["displayName"] is not None:
                     kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm)

--- a/plugins/modules/identity/keycloak/keycloak_authentication.py
+++ b/plugins/modules/identity/keycloak/keycloak_authentication.py
@@ -196,10 +196,14 @@ def create_or_update_executions(kc, config, realm='master'):
     :param config: Representation of the authentication flow including it's executions.
     :param realm: Realm
     :return: True if executions have been modified. False otherwise.
+<<<<<<< HEAD
     :return: tuple (changed, dict(before, after)
         WHERE
         bool changed indicates if changes have been made
         dict(str, str) shows state before and after creation/update
+=======
+    :return: Dict with key "before" and "after" to describe the changes, None if no modification
+>>>>>>> Fix diff mode when updating authentication flow with keycloak_authentication module
     """
     try:
         changed = False

--- a/plugins/modules/identity/keycloak/keycloak_authentication.py
+++ b/plugins/modules/identity/keycloak/keycloak_authentication.py
@@ -240,6 +240,8 @@ def create_or_update_executions(kc, config, realm='master'):
                 elif new_exec["displayName"] is not None:
                     kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm)
                     exec_found = True
+                    exec_index = new_exec_index
+                    id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
                     after += str(new_exec) + '\n'
                 if exec_found:
                     changed = True


### PR DESCRIPTION
##### SUMMARY
When a new execution is created by the keycloak_authentication module, the requirement is always on DISABLED even if ENABLED is given as argument. 
With this fix, the requirement will correspond to the requirement given in argument to the module. 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
keycloak_authentication

##### ADDITIONAL INFORMATION
For example : 
```
    - name: Create an authentication flow with 2 identical execution.
      community.general.keycloak_authentication:
        auth_keycloak_url: http://localhost:8080/auth
        auth_realm: master
        auth_username: admin
        auth_password: password
        realm: master
        alias: "two_identical_exec"
        copyFrom: "first broker login"
        authenticationExecutions:
          - providerId: "test-execution1"
            requirement: "REQUIRED"
          - displayName: "test-execution1"
            requirement: "REQUIRED"

```
If the authentication flow doesn't exist already, the requirement will be DISABLED and not REQUIRED as expected. 
The Pull Request is fixing this issue. 