### PR TITLE
lxd_container: do not ignore volatile configs by option

### DIFF
--- a/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
+++ b/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "As noted by oskar456, the module ignores 'volatile' options. This fix allows this behavior to be switched off. The new behavior should be changed to the default in the next releases. Therefore a corresponding deprecate warning was inserted."
+  - "lxd_container - add ``ignore_volatile_options`` option which allows to disable the behavior that the module ignores options starting with ``volatile.`` (https://github.com/ansible-collections/community.general/pull/3331)."

--- a/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
+++ b/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "As noted by oskar456, the module ignores "volatile" options. This fix allows this behavior to be switched off. The new behavior should be changed to the default in the next releases. Therefore a corresponding deprecate warning was inserted."

--- a/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
+++ b/changelogs/fragments/3331-do_not_ignore_volatile_configs_by_option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "As noted by oskar456, the module ignores "volatile" options. This fix allows this behavior to be switched off. The new behavior should be changed to the default in the next releases. Therefore a corresponding deprecate warning was inserted."
+  - "As noted by oskar456, the module ignores 'volatile' options. This fix allows this behavior to be switched off. The new behavior should be changed to the default in the next releases. Therefore a corresponding deprecate warning was inserted."

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -32,8 +32,7 @@ options:
           - 'The config for the container (e.g. {"limits.cpu": "2"}).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1)'
           - If the container already exists and its "config" value in metadata
-            obtained from
-            GET /1.0/containers/<name>
+            obtained from GET /1.0/containers/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
           - The key starts with 'volatile.' are ignored for this comparison when I(ignore_volatile_options=true).
           - Not all config values are supported to apply the existing container.
@@ -45,7 +44,7 @@ options:
           - If set to C(true), options starting with C(volatile.) are ignored. As a result,
             they are reapplied for each execution.
           - This default behavior can be changed by setting this option to C(false).
-          - The default value C(true) will be deprecated in community.general 4.0.0
+          - The default value C(true) will be deprecated in community.general 4.0.0,
             and will change to C(false) in community.general 5.0.0.
         type: bool
         default: true
@@ -219,7 +218,7 @@ EXAMPLES = '''
     - name: Create a started container
       community.general.lxd_container:
         name: mycontainer
-        ignore_volatile_options: True
+        ignore_volatile_options: true
         state: started
         source:
           type: image
@@ -290,7 +289,7 @@ EXAMPLES = '''
     - name: Create LXD container
       community.general.lxd_container:
         name: new-container-1
-        ignore_volatile_options: True
+        ignore_volatile_options: true
         state: started
         source:
           type: image
@@ -301,7 +300,7 @@ EXAMPLES = '''
     - name: Create container on another node
       community.general.lxd_container:
         name: new-container-2
-        ignore_volatile_options: True
+        ignore_volatile_options: true
         state: started
         source:
           type: image
@@ -729,10 +728,11 @@ def main():
         ),
         supports_check_mode=False,
     )
-    if module.params['ignore_volatile_options']:
-        module.deprecate(
-            'The default behavior ignore the "volatile."-options. This will change in the future. Please test your scripts by "ignore_volatile_options: False"',
-            version='4.0.0', collection_name='community.general')
+    # if module.params['ignore_volatile_options']:
+    #     module.deprecate(
+    #         'The default behavior ignore the "volatile."-options. This will change in the future.
+    #         Please test your scripts by
+    #         "ignore_volatile_options: False"', version='5.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -47,7 +47,7 @@ options:
           - The default value C(true) will be deprecated in community.general 4.0.0,
             and will change to C(false) in community.general 5.0.0.
         type: bool
-        default: true
+        required: false
         version_added: 3.7.0
     profiles:
         description:
@@ -626,7 +626,7 @@ class LXDContainerManagement(object):
         try:
             if self.trust_password is not None:
                 self.client.authenticate(self.trust_password)
-            self.ignore_volatile_options = self.module.params['ignore_volatile_options']
+            self.ignore_volatile_options = self.module.params.get('ignore_volatile_options', default=True)
 
             self.old_container_json = self._get_container_json()
             self.old_state = self._container_json_to_module_state(self.old_container_json)

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -47,6 +47,7 @@ options:
           - The default value C(true) will be deprecated in community.general 4.0.0,
             and will change to C(false) in community.general 5.0.0.
         type: bool
+        default: true
         required: false
         version_added: 3.7.0
     profiles:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -576,7 +576,7 @@ class LXDContainerManagement(object):
                 if old_configs[k] != v:
                     return True
             return False
-        elif key == 'config' and self.config['ignore_volatile_options']:  # old behavior to ignore "volatile"-options
+        elif key == 'config':  # old behavior to ignore "volatile"-options
             old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -42,14 +42,14 @@ options:
         required: false
     ignore_volatile_options:
         description:
-            - If set to C(true), options starting with C(volatile.) are ignored. As a result,
-              they are reapplied for each execution.
-            - This default behavior can be changed by setting this option to C(false).
-            - The default value C(true) will be deprecated in community.general 4.0.0,
-              and will change to C(false) in community.general 5.0.0.
-            type: bool
-            default: true
-            version_added: 3.7.0
+          - If set to C(true), options starting with C(volatile.) are ignored. As a result,
+            they are reapplied for each execution.
+          - This default behavior can be changed by setting this option to C(false).
+          - The default value C(true) will be deprecated in community.general 4.0.0
+            and will change to C(false) in community.general 5.0.0.
+        type: bool
+        default: true
+        version_added: 3.7.0
     profiles:
         description:
           - Profile to be used by the container

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -31,9 +31,10 @@ options:
         description:
           - 'The config for the container (e.g. {"limits.cpu": "2"}).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1)'
-          - If the container already exists and its "config" value in metadata
+          - If the container already exists and its "config" values in metadata
             obtained from GET /1.0/containers/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
+            are different, this module tries to apply the configurations.
           - The keys starting with C(volatile.) are ignored for this comparison when I(ignore_volatile_options=true).
         type: dict
         required: false

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -46,7 +46,7 @@ options:
               reapplied for each execution.
               The default behavior is retained and can be changed by setting it to false.
               In the future, the behavior of the 'volatile.'-options not to ignore the standard.
-            type: boolean
+            type: bool
             default: True
     profiles:
         description:
@@ -568,16 +568,16 @@ class LXDContainerManagement(object):
     def _needs_to_change_container_config(self, key):
         if key not in self.config:
             return False
-        if key == 'config' and not self.config['ignore_volatile_options']:  # next default behavior
-            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items())
+        if key == 'config' and self.config['ignore_volatile_options']:  # old behavior to ignore "volatile"-options
+            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:
                     return True
                 if old_configs[k] != v:
                     return True
             return False
-        elif key == 'config':  # old behavior to ignore "volatile"-options
-            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
+        elif key == 'config':  # next default behavior
+            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items())
             for k, v in self.config['config'].items():
                 if k not in old_configs:
                     return True
@@ -728,7 +728,8 @@ def main():
     )
     if module.params['ignore_volatile_options']:
         module.deprecate(
-            'The default behavior ignore the "volatile."-options. This will change in the future. Please test your scripts by "ignore_volatile_options: False"')
+            'The default behavior ignore the "volatile."-options. This will change in the future. Please test your scripts by "ignore_volatile_options: False"',
+            version='4.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -35,19 +35,21 @@ options:
             obtained from
             GET /1.0/containers/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
-            are different, they this module tries to apply the configurations.
+          - The key starts with 'volatile.' are ignored for this comparison when I(ignore_volatile_options=true).
           - Not all config values are supported to apply the existing container.
             Maybe you need to delete and recreate a container.
         type: dict
         required: false
     ignore_volatile_options:
-            description:
-            - Previously, 'volatile.'-options were ignored and, as a result,
-              reapplied for each execution.
-              The default behavior is retained and can be changed by setting it to false.
-              In the future, the behavior of the 'volatile.'-options not to ignore the standard.
+        description:
+            - If set to C(true), options starting with C(volatile.) are ignored. As a result,
+              they are reapplied for each execution.
+            - This default behavior can be changed by setting this option to C(false).
+            - The default value C(true) will be deprecated in community.general 4.0.0,
+              and will change to C(false) in community.general 5.0.0.
             type: bool
-            default: True
+            default: true
+            version_added: 3.7.0
     profiles:
         description:
           - Profile to be used by the container
@@ -183,7 +185,7 @@ EXAMPLES = '''
     - name: Create a started container
       community.general.lxd_container:
         name: mycontainer
-        ignore_volatile_options: True
+        ignore_volatile_options: true
         state: started
         source:
           type: image

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -569,7 +569,7 @@ class LXDContainerManagement(object):
     def _needs_to_change_container_config(self, key):
         if key not in self.config:
             return False
-        if key == 'config' and self.ignore_volatile_options:  # old behavior to ignore "volatile"-options
+        if key == 'config' and self.ignore_volatile_options:  # the old behavior is to ignore configurations by keyword "volatile"
             old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:
@@ -674,7 +674,6 @@ def main():
             ),
             ignore_volatile_options=dict(
                 type='bool',
-                default=True
             ),
             devices=dict(
                 type='dict',
@@ -730,9 +729,10 @@ def main():
     )
     # if module.params['ignore_volatile_options']:
     #     module.deprecate(
-    #         'The default behavior ignore the "volatile."-options. This will change in the future.
-    #         Please test your scripts by
-    #         "ignore_volatile_options: False"', version='5.0.0', collection_name='community.general')
+    #         'If the keyword "volatile" is used in a playbook in the config section, a
+    #         "changed" message will appear with every run, even without a change to the playbook.
+    #         This will change in the future.
+    #         Please test your scripts by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -626,7 +626,8 @@ class LXDContainerManagement(object):
         try:
             if self.trust_password is not None:
                 self.client.authenticate(self.trust_password)
-            self.ignore_volatile_options = self.module.params.get('ignore_volatile_options', default=True)
+            #  self.ignore_volatile_options = self.module.params.get('ignore_volatile_options', default=True)
+            self.ignore_volatile_options = self.module.params.get('ignore_volatile_options')
 
             self.old_container_json = self._get_container_json()
             self.old_state = self._container_json_to_module_state(self.old_container_json)
@@ -674,6 +675,7 @@ def main():
             ),
             ignore_volatile_options=dict(
                 type='bool',
+                default=True
             ),
             devices=dict(
                 type='dict',
@@ -727,7 +729,8 @@ def main():
         ),
         supports_check_mode=False,
     )
-    # if module.params['ignore_volatile_options']:
+    # if module.params['ignore_volatile_options'] is None:
+    #     module.params['ignore_volatile_options'] = True
     #     module.deprecate(
     #         'If the keyword "volatile" is used in a playbook in the config section, a
     #         "changed" message will appear with every run, even without a change to the playbook.

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -34,9 +34,7 @@ options:
           - If the container already exists and its "config" value in metadata
             obtained from GET /1.0/containers/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
-          - The key starts with 'volatile.' are ignored for this comparison when I(ignore_volatile_options=true).
-          - Not all config values are supported to apply the existing container.
-            Maybe you need to delete and recreate a container.
+          - The keys starting with C(volatile.) are ignored for this comparison when I(ignore_volatile_options=true).
         type: dict
         required: false
     ignore_volatile_options:
@@ -627,7 +625,6 @@ class LXDContainerManagement(object):
         try:
             if self.trust_password is not None:
                 self.client.authenticate(self.trust_password)
-            #  self.ignore_volatile_options = self.module.params.get('ignore_volatile_options', default=True)
             self.ignore_volatile_options = self.module.params.get('ignore_volatile_options')
 
             self.old_container_json = self._get_container_json()

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -568,7 +568,7 @@ class LXDContainerManagement(object):
     def _needs_to_change_container_config(self, key):
         if key not in self.config:
             return False
-        if key == 'config' and self.config['ignore_volatile_options']:  # old behavior to ignore "volatile"-options
+        if key == 'config' and self.ignore_volatile_options:  # old behavior to ignore "volatile"-options
             old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:
@@ -625,6 +625,7 @@ class LXDContainerManagement(object):
         try:
             if self.trust_password is not None:
                 self.client.authenticate(self.trust_password)
+            self.ignore_volatile_options = self.module.params['ignore_volatile_options']
 
             self.old_container_json = self._get_container_json()
             self.old_state = self._container_json_to_module_state(self.old_container_json)


### PR DESCRIPTION
##### SUMMARY
As noted by oskar456, the module ignores "volatile" options. This fix allows this behavior to be switched off. 
The new behavior should be changed to the default in the next releases. 
Therefore a corresponding deprecate warning was inserted. 

Fixes #2466

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
lxd_container

##### ADDITIONAL INFORMATION
See #2466
