### PR TITLE
django_manage - split params

### DIFF
--- a/changelogs/fragments/3334-django_manage-split-params.yaml
+++ b/changelogs/fragments/3334-django_manage-split-params.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - django_manage - parameters ``apps`` and ``fixtures`` should be splitted at whitespaces to keep backward compatibility (https://github.com/ansible-collections/community.general/issues/3333).
+  - django_manage - parameters ``apps`` and ``fixtures`` are now splitted instead of being used as a single argument (https://github.com/ansible-collections/community.general/issues/3333).

--- a/changelogs/fragments/3334-django_manage-split-params.yaml
+++ b/changelogs/fragments/3334-django_manage-split-params.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - django_manage - parameters ``apps`` and ``fixtures`` should be splitted at whitespaces to keep backward compatibility (https://github.com/ansible-collections/community.general/issues/3333).

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -305,10 +305,11 @@ def main():
 
     # these params always get tacked on the end of the command
     for param in end_of_command_params:
-        if param in ('fixtures', 'apps'):
-            run_cmd_args.extend(module.params[param].split())
-        else:
-            run_cmd_args.append(module.params[param])
+        if module.params[param]:
+            if param in ('fixtures', 'apps'):
+                run_cmd_args.extend(module.params[param].split())
+            else:
+                run_cmd_args.append(module.params[param])
 
     rc, out, err = module.run_command(run_cmd_args, cwd=project_path)
     if rc != 0:

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -62,7 +62,7 @@ options:
   clear:
     description:
       - Clear the existing files before trying to copy or link the original file.
-      - Used only with the 'collectstatic' command. The C(--noinput) argument will be added automatically.
+      - Used only with the C(collectstatic) command. The C(--noinput) argument will be added automatically.
     required: false
     default: no
     type: bool
@@ -109,9 +109,9 @@ options:
     required: false
     aliases: [test_runner]
 notes:
-  - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter
+  - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the I(virtualenv) parameter
     is specified.
-  - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already
+  - This module will create a virtualenv if the I(virtualenv) parameter is specified and a virtual environment does not already
     exist at the given location.
   - This module assumes English error messages for the C(createcachetable) command to detect table existence,
     unfortunately.

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -305,6 +305,8 @@ def main():
 
     # these params always get tacked on the end of the command
     for param in end_of_command_params:
+        if param == 'fixtures':
+            module.params[param] = module.params[param].split()
         if module.params[param]:
             run_cmd_args.append(module.params[param])
 

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -305,7 +305,7 @@ def main():
 
     # these params always get tacked on the end of the command
     for param in end_of_command_params:
-        if param == 'fixtures':
+        if param in ('fixtures', 'apps'):
             module.params[param] = module.params[param].split()
         if module.params[param]:
             run_cmd_args.append(module.params[param])

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -307,7 +307,7 @@ def main():
     for param in end_of_command_params:
         if module.params[param]:
             if param in ('fixtures', 'apps'):
-                run_cmd_args.extend(module.params[param].split())
+                run_cmd_args.extend(shlex.split(module.params[param]))
             else:
                 run_cmd_args.append(module.params[param])
 

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -306,8 +306,8 @@ def main():
     # these params always get tacked on the end of the command
     for param in end_of_command_params:
         if param in ('fixtures', 'apps'):
-            module.params[param] = module.params[param].split()
-        if module.params[param]:
+            run_cmd_args.extend(module.params[param].split())
+        else:
             run_cmd_args.append(module.params[param])
 
     rc, out, err = module.run_command(run_cmd_args, cwd=project_path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Splits module parameters `fixtures` and `apps` when passing to the command line.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3333 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/web_infrastructure/django_manage.py
