### PR TITLE
openbsd_pkg: Fix KeyError

### DIFF
--- a/changelogs/fragments/3336-openbsd_pkg-fix-KeyError.yml
+++ b/changelogs/fragments/3336-openbsd_pkg-fix-KeyError.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - openbsd_pkg - fix crash from ``KeyError`` exception when package installs,
+    but ``pkg_add`` returns with a non-zero exit code
+    (https://github.com/ansible-collections/community.general/pull/3336).

--- a/plugins/modules/packaging/os/openbsd_pkg.py
+++ b/plugins/modules/packaging/os/openbsd_pkg.py
@@ -246,6 +246,7 @@ def package_present(names, pkg_spec, module):
                     if match:
                         # It turns out we were able to install the package.
                         module.debug("package_present(): we were able to install package for name '%s'" % name)
+                        pkg_spec[name]['changed'] = True
                     else:
                         # We really did fail, fake the return code.
                         module.debug("package_present(): we really did fail for name '%s'" % name)


### PR DESCRIPTION
##### SUMMARY

If package installation has an error after the package is install (e.g.
when running tags), then there will be output on stderr and the fallback
regex will match; however, since pkg_add exited non-zero, changed is
never added as a key to the dictionary. As a result the code at the end
of main that checks if anything has changed raises a KeyError.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openbsd_pkg

##### ADDITIONAL INFORMATION

```
The full traceback is:
Traceback (most recent call last):
  File "/home/mark/.ansible/tmp/ansible-tmp-1630863821.4813468-24031-269464171722171/AnsiballZ_openbsd_pkg.py", line 247, in <module>
    _ansiballz_main()
  File "/home/mark/.ansible/tmp/ansible-tmp-1630863821.4813468-24031-269464171722171/AnsiballZ_openbsd_pkg.py", line 237, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/mark/.ansible/tmp/ansible-tmp-1630863821.4813468-24031-269464171722171/AnsiballZ_openbsd_pkg.py", line 110, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.openbsd_pkg', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.openbsd_pkg', _modlib_path=modlib_path),
  File "/usr/local/lib/python3.9/runpy.py", line 210, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/local/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_openbsd_pkg_payload_kfyna2ml/ansible_openbsd_pkg_payload.zip/ansible_collections/community/general/plugins/modules/openbsd_pkg.py", line 653, in <module>
  File "/tmp/ansible_openbsd_pkg_payload_kfyna2ml/ansible_openbsd_pkg_payload.zip/ansible_collections/community/general/plugins/modules/openbsd_pkg.py", line 639, in main
KeyError: 'changed'
```
