### PR TITLE
redfish_utils: adding "Id" to the add user function

### DIFF
--- a/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
+++ b/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - redfish_utils module utils - if given, add account ID of user that should be created to HTTP request (https://github.com/ansible-collections/community.general/pull/3343/).

--- a/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
+++ b/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_utils - if given, add account id of user that should be created to http request (https://github.com/ansible-collections/community.general/pull/3343/)
+  - redfish_utils module utils - if given, add account ID of user that should be created to HTTP request (https://github.com/ansible-collections/community.general/pull/3343/).

--- a/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
+++ b/changelogs/fragments/3343-redfish_utils-addUser-userId.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils - if given, add account id of user that should be created to http request (https://github.com/ansible-collections/community.general/pull/3343/)

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -980,7 +980,7 @@ class RedfishUtils(object):
         if user.get('account_roleid'):
             payload['RoleId'] = user.get('account_roleid')
         if user.get('account_id'):
-          payload['Id'] = user.get('account_id')
+            payload['Id'] = user.get('account_id')
 
         response = self.post_request(self.root_uri + self.accounts_uri, payload)
         if not response['ret']:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -979,6 +979,8 @@ class RedfishUtils(object):
             payload['Password'] = user.get('account_password')
         if user.get('account_roleid'):
             payload['RoleId'] = user.get('account_roleid')
+        if user.get('account_id'):
+          payload['Id'] = user.get('account_id')
 
         response = self.post_request(self.root_uri + self.accounts_uri, payload)
         if not response['ret']:

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -56,8 +56,8 @@ options:
     required: false
     aliases: [ account_id ]
     description:
-      - ID of account to delete/modify
-      - Can also be used in account creation to work around vendor issues where the ID of the new user is required in the POST request
+      - ID of account to delete/modify.
+      - Can also be used in account creation to work around vendor issues where the ID of the new user is required in the POST request.
     type: str
   new_username:
     required: false

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -57,6 +57,7 @@ options:
     aliases: [ account_id ]
     description:
       - ID of account to delete/modify
+      - Can also be used in account creation to work around vendor issues where the ID of the new user is required in the POST request
     type: str
   new_username:
     required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some implementations of Redfish (e.g. the one in Cisco's CIMC) require the id of the new user for account creation.
I'm not that firm with Python but the proposed change should fix this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Some implementations of Redfish require the new users account id for the creation of a new user. If not given HTTP Error 400 will be displayed. The proposed change aims at adding "Id" as additional value for the payload if given by the user.
