### PR TITLE
Xen orchestra inventory plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -163,6 +163,8 @@ files:
     keywords: opennebula dynamic inventory script
   $inventories/proxmox.py:
     maintainers: $team_virt ilijamt
+  $inventories/xen_orchestra.py:
+    maintainers: shinuza
   $inventories/icinga2.py:
     maintainers: bongoeadgc6
   $inventories/scaleway.py:

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -2,14 +2,15 @@
 # Copyright (c) 2021 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-
-from jsonrpc_websocket import Server
-from ansible.errors import AnsibleError
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 import asyncio
 import json
 import os
 import re
+
+from ansible.errors import AnsibleError
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+from jsonrpc_websocket import Server
 
 
 DOCUMENTATION = '''
@@ -36,27 +37,27 @@ DOCUMENTATION = '''
         api_host:
             description:
                 - API host to XOA API.
-                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_API_HOST) will be used instead.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(ANSIBLE_XO_API_HOST) will be used instead.
             default: '192.168.1.123'
             type: str
             env:
-                - name: XO_API_HOST
+                - name: ANSIBLE_XO_API_HOST
         user:
             description:
                 - Xen Orchestra user.
-                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_USER) will be used instead.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(ANSIBLE_XO_USER) will be used instead.
             required: yes
             type: str
             env:
-                - name: XO_USER
+                - name: ANSIBLE_XO_USER
         password:
             description:
                 - Xen Orchestra password.
-                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_PASSWORD) will be used instead.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(ANSIBLE_XO_PASSWORD) will be used instead.
             required: yes
             type: str
             env:
-                - name: XO_PASSWORD
+                - name: ANSIBLE_XO_PASSWORD
         validate_certs:
             description: Verify SSL certificate if using HTTPS.
             type: boolean

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -179,7 +179,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _add_hosts(self, hosts, pools):
         for host in hosts.values():
             address = host['address']
-            group_name = self.to_safe("xo_host_{}".format(host['name_label']))
+            group_name = self.to_safe("xo_host_{0}".format(host['name_label']))
             pool_name = self._pool_group_name_for_uuid(pools, host['$poolId'])
 
             self.inventory.add_group(group_name)
@@ -201,7 +201,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _add_pools(self, pools):
         for pool in pools.values():
-            group_name = self.to_safe("xo_pool_{}".format(pool['name_label']))
+            group_name = self.to_safe("xo_pool_{0}".format(pool['name_label']))
 
             self.inventory.add_group(group_name)
 
@@ -209,13 +209,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _pool_group_name_for_uuid(self, pools, pool_uuid) -> str:
         for pool in pools:
             if pool == pool_uuid:
-                return self.to_safe("xo_pool_{}".format(pools[pool_uuid]['name_label']))
+                return self.to_safe("xo_pool_{0}".format(pools[pool_uuid]['name_label']))
 
     # TODO: Refactor
     def _host_group_name_for_uuid(self, hosts, host_uuid) -> str:
         for host in hosts:
             if host == host_uuid:
-                return self.to_safe("xo_host_{}".format(hosts[host_uuid]['name_label']))
+                return self.to_safe("xo_host_{0}".format(hosts[host_uuid]['name_label']))
 
     def _populate(self, objects):
         # Prepare general groups

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -137,7 +137,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         payload = {'id': self.pointer, 'jsonrpc': '2.0', 'method': 'session.signIn', 'params': {
             'username': user, 'password': password}}
         self.conn.send(json.dumps(payload))
-        result = self.conn.recv()
+        result = json.loads(self.conn.recv())
 
         if 'error' in result:
             raise AnsibleError(

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -115,7 +115,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_objects(self):
         async def req():
             server = Server(
-                f'{self.protocol}://{self.xoa_api_host}/api/', ssl=self.validate_certs)
+                '{0}://{1}/api/'.format(self.protocol, self.xoa_api_host), ssl=self.validate_certs)
 
             await server.ws_connect()
             await server.session.signIn(username=self.xoa_user, password=self.xoa_password)

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from jsonrpc_websocket import Server
+from ansible.errors import AnsibleError
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+import asyncio
+import json
+import os
+import re
+
+
+DOCUMENTATION = '''
+    name: xen_orchestra
+    short_description: Xen Orchestra inventory source
+    version_added: 3.7.0
+    author:
+        - Dom Del Nano (@ddelnano) <ddelnano@gmail.com>
+        - Samori Gorse (@shinuza) <samorigorse@gmail.com>
+    requirements:
+        - jsonrpc_websocket >= 3.0
+    description:
+        - Get inventory hosts from a Xen Orchestra deployment.
+        - 'Uses a configuration file as an inventory source, it must end in C(.xen_orchestra.yml) or C(.xen_orchestra.yaml).'
+    extends_documentation_fragment:
+        - constructed
+        - inventory_cache
+    options:
+        plugin:
+            description: The name of this plugin, it should always be set to C(community.general.xen_orchestra) for this plugin to recognize it as it's own.
+            required: yes
+            choices: ['community.general.xen_orchestra']
+            type: str
+        api_host:
+            description:
+                - API host to XOA API.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_API_HOST) will be used instead.
+            default: '192.168.1.123'
+            type: str
+            env:
+                - name: XO_API_HOST
+        user:
+            description:
+                - Xen Orchestra user.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_USER) will be used instead.
+            required: yes
+            type: str
+            env:
+                - name: XO_USER
+        password:
+            description:
+                - Xen Orchestra password.
+                - If the value is not specified in the inventory configuration, the value of environment variable C(XO_PASSWORD) will be used instead.
+            required: yes
+            type: str
+            env:
+                - name: XO_PASSWORD
+        validate_certs:
+            description: Verify SSL certificate if using HTTPS.
+            type: boolean
+            default: true
+        use_ssl:
+            description: Use wss when connecting to the Xen Orchestra API
+            type: boolean
+            default: true
+'''
+
+
+EXAMPLES = '''
+# file must be named xen_orchestra.yaml or xen_orchestra.yml
+simple_config_file:
+    plugin: xen_orchestra
+    api_host: 192.168.1.255
+    user: xo
+    password: xo_pwd
+    validate_certs: true
+    use_ssl: true
+'''
+
+
+HALTED = 'Halted'
+PAUSED = 'Paused'
+RUNNING = 'Running'
+SUSPENDED = 'Suspended'
+POWER_STATES = [RUNNING, HALTED, SUSPENDED, PAUSED]
+HOST_GROUP = 'xo_hosts'
+POOL_GROUP = 'xo_pools'
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
+    ''' Host inventory parser for ansible using XenOrchestra as source. '''
+
+    NAME = 'community.general.xen_orchestra'
+
+    def __init__(self):
+
+        super(InventoryModule, self).__init__()
+
+        # from config
+        self.session = None
+        self.cache_key = None
+        self.use_cache = None
+
+    def _get_objects(self):
+        async def req():
+            server = Server(
+                f'{self.protocol}://{self.xoa_api_host}/api/', ssl=self.validate_certs)
+
+            await server.ws_connect()
+            await server.session.signIn(username=self.xoa_user, password=self.xoa_password)
+
+            vms = await server.xo.getAllObjects(filter={'type': 'VM'})
+            pools = await server.xo.getAllObjects(filter={'type': 'pool'})
+            hosts = await server.xo.getAllObjects(filter={'type': 'host'})
+
+            return {
+                'vms': vms,
+                'pools': pools,
+                'hosts': hosts,
+            }
+
+        return asyncio.get_event_loop().run_until_complete(req())
+
+    def _add_vms(self, vms, hosts, pools):
+        for uuid, vm in vms.items():
+            group = 'with_ip'
+            ip = vm.get('mainIpAddress')
+            host = uuid
+            power_state = vm['power_state'].lower()
+            pool_name = self._pool_group_name_for_uuid(pools, vm['$poolId'])
+            host_name = self._host_group_name_for_uuid(hosts, vm['$container'])
+
+            self.inventory.add_host(host)
+
+            # Grouping by power state
+            self.inventory.add_child(power_state, host)
+
+            # Grouping by host
+            if host_name:
+                self.inventory.add_child(host_name, host)
+
+            # Grouping by pool
+            if pool_name:
+                self.inventory.add_child(pool_name, host)
+
+            # Grouping VMs with an IP together
+            if ip is None:
+                group = 'without_ip'
+            self.inventory.add_group(group)
+            self.inventory.add_child(group, host)
+
+            # Adding meta
+            self.inventory.set_variable(host, 'uuid', uuid)
+            self.inventory.set_variable(host, 'ip', ip)
+            self.inventory.set_variable(host, 'ansible_host', ip)
+            self.inventory.set_variable(host, 'name_label', vm['name_label'])
+            self.inventory.set_variable(host, 'type', vm['type'])
+            self.inventory.set_variable(host, 'power_state', power_state)
+            self.inventory.set_variable(host, 'cpus', vm["CPUs"]["number"])
+            self.inventory.set_variable(host, 'tags', vm["tags"])
+            self.inventory.set_variable(host, 'memory', vm["memory"]["size"])
+            self.inventory.set_variable(host, 'has_ip', group == 'with_ip')
+            self.inventory.set_variable(
+                host, 'is_managed', vm.get('managementAgentDetected', False))
+            self.inventory.set_variable(
+                host, 'os_version', vm["os_version"])
+
+    def _add_hosts(self, hosts, pools):
+        for host in hosts.values():
+            address = host['address']
+            group_name = self.to_safe("xo_host_{}".format(host['name_label']))
+            pool_name = self._pool_group_name_for_uuid(pools, host['$poolId'])
+
+            self.inventory.add_group(group_name)
+            self.inventory.add_host(address)
+            self.inventory.add_child(HOST_GROUP, address)
+            self.inventory.add_child(pool_name, address)
+
+            self.inventory.set_variable(address, 'enabled', host['enabled'])
+            self.inventory.set_variable(address, 'hostname', host['hostname'])
+            self.inventory.set_variable(address, 'memory', host['memory'])
+            self.inventory.set_variable(address, 'cpus', host['cpus'])
+            self.inventory.set_variable(address, 'type', 'host')
+            self.inventory.set_variable(address, 'tags', host['tags'])
+            self.inventory.set_variable(address, 'version', host['version'])
+            self.inventory.set_variable(
+                address, 'power_state', host['power_state'].lower())
+            self.inventory.set_variable(
+                address, 'product_brand', host['productBrand'])
+
+    def _add_pools(self, pools):
+        for pool in pools.values():
+            group_name = self.to_safe("xo_pool_{}".format(pool['name_label']))
+
+            self.inventory.add_group(group_name)
+
+    # TODO: Refactor
+    def _pool_group_name_for_uuid(self, pools, pool_uuid) -> str:
+        for pool in pools:
+            if pool == pool_uuid:
+                return self.to_safe("xo_pool_{}".format(pools[pool_uuid]['name_label']))
+
+    # TODO: Refactor
+    def _host_group_name_for_uuid(self, hosts, host_uuid) -> str:
+        for host in hosts:
+            if host == host_uuid:
+                return self.to_safe("xo_host_{}".format(hosts[host_uuid]['name_label']))
+
+    def _populate(self, objects):
+        # Prepare general groups
+        self.inventory.add_group(HOST_GROUP)
+        self.inventory.add_group(POOL_GROUP)
+        for group in POWER_STATES:
+            self.inventory.add_group(group.lower())
+
+        self._add_pools(objects['pools'])
+        self._add_hosts(objects['hosts'], objects['pools'])
+        self._add_vms(objects['vms'], objects['hosts'], objects['pools'])
+
+    def to_safe(self, word) -> str:
+        '''Converts 'bad' characters in a string to underscores so they can be used as Ansible groups
+        #> InventoryModule.to_safe("foo-bar baz")
+        'foo_barbaz'
+        '''
+        regex = r"[^A-Za-z0-9\_]"
+        return re.sub(regex, "_", word.replace(" ", "")).lower()
+
+    def verify_file(self, path):
+
+        valid = False
+        if super(InventoryModule, self).verify_file(path):
+            if path.endswith(('xen_orchestra.yaml', 'xen_orchestra.yml')):
+                valid = True
+            else:
+                self.display.vvv(
+                    'Skipping due to inventory source not ending in "xen_orchestra.yaml" nor "xen_orchestra.yml"')
+        return valid
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path)
+
+        # read config from file, this sets 'options'
+        self._read_config_data(path)
+        self.inventory = inventory
+
+        self.protocol = 'wss'
+        self.xoa_api_host = self.get_option('api_host')
+        self.xoa_user = self.get_option('user')
+        self.xoa_password = self.get_option('password')
+        self.cache_key = self.get_cache_key(path)
+        self.use_cache = cache and self.get_option('cache')
+
+        self.validate_certs = self.get_option('validate_certs')
+        if not self.get_option('use_ssl'):
+            self.protocol = 'ws'
+
+        objects = self._get_objects()
+        self._populate(objects)

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -2,16 +2,8 @@
 # Copyright (c) 2021 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import asyncio
-import json
-import os
-import re
-
-from ansible.errors import AnsibleError
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
-
-from jsonrpc_websocket import Server
-
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 DOCUMENTATION = '''
     name: xen_orchestra
@@ -79,6 +71,22 @@ simple_config_file:
     validate_certs: true
     use_ssl: true
 '''
+
+import asyncio
+import json
+import os
+import re
+
+from ansible.errors import AnsibleError
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from distutils.version import LooseVersion
+
+# 3rd party imports
+try:
+    from jsonrpc_websocket import Server
+    JSONRPC_WEBSOCKET = True
+except ImportError:
+    JSONRPC_WEBSOCKET = False
 
 
 HALTED = 'Halted'
@@ -240,6 +248,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return valid
 
     def parse(self, inventory, loader, path, cache=True):
+        if not JSONRPC_WEBSOCKET:
+            raise AnsibleError('This module requires jsonrpc-websocket 3.0.0 or higher: '
+                               'https://pypi.org/project/jsonrpc-websocket/.')
+
         super(InventoryModule, self).parse(inventory, loader, path)
 
         # read config from file, this sets 'options'

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    name: community.general.xen_orchestra
+    name: xen_orchestra
     short_description: Xen Orchestra inventory source
     version_added: 4.1.0
     author:

--- a/tests/unit/plugins/inventory/test_xen_orchestra.py
+++ b/tests/unit/plugins/inventory/test_xen_orchestra.py
@@ -15,208 +15,122 @@ from ansible_collections.community.general.plugins.inventory.xen_orchestra impor
 
 objects = {
     'vms': {
-        '8900449d-44a2-e5f5-f692-a110c758b351':
-            {
-                'type': 'VM',
-                'addresses': {},
-                'CPUs': {'max': 4, 'number': 4}, 'current_operations': {},
-                'memory': {'dynamic': [8589934592, 8589934592], 'static': [134217728, 8589934592], 'size': 8589934592},
-                'installTime': 1626873121, 'name_description': '', 'name_label': 'XCP-NG lab',
-                'os_version': {}, 'parent': '45b83446-23e8-f623-56d7-ea4eb55c2818', 'power_state': 'Running', 'hasVendorDevice': False,
-                'snapshots': ['45b83446-23e8-f623-56d7-ea4eb55c2818', 'e46a28eb-b069-7a5b-91ef-1b2f002e6c78', '52ae0c8b-7be8-9eb1-f2d1-f37f806f2429'], 'startDelay': 0, 'startTime': 1633076244, 'secureBoot': False, 'tags': [],
-                'VIFs': ['7a8a9d85-a547-db0a-f101-be9bb16e94a1'], 'virtualizationMode': 'hvm', 'xenTools': False, 'managementAgentDetected': False, 'pvDriversDetected': False, '$container': '222d8594-9426-468a-ad69-7a6f02330fa3',
-                '$VBDs': ['2c0525d1-15b0-6c5a-10e7-a86418aa42cc', 'aa56c52b-63cc-49c1-1fd4-81ed330685d8'],
-                'VGPUs': [],
-                '$VGPUs': [],
-                'vga': 'cirrus', 'videoram': 4,
-                'id': '8900449d-44a2-e5f5-f692-a110c758b351',
-                'uuid': '8900449d-44a2-e5f5-f692-a110c758b351',
-                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
-                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
-            },
         '0e64588-2bea-2d82-e922-881654b0a48f':
             {
                 'type': 'VM',
                 'addresses': {},
-                'auto_poweron': False,
-                'CPUs': {'max': 1, 'number': 1}, 'current_operations': {},
-                'expNestedHvm': False,
-                'high_availability': '',
+                'CPUs': {'max': 4, 'number': 4},
                 'memory': {'dynamic': [1073741824, 2147483648], 'static': [536870912, 4294967296], 'size': 2147483648},
-                'installTime': 1599049252,
                 'name_description': '',
-                'name_label': 'rajaa - XS 7.1',
+                'name_label': 'XCP-NG lab 2',
                 'os_version': {},
                 'parent': 'd3af89b2-d846-0874-6acb-031ccf11c560',
-                'power_state': 'Halted',
-                'hasVendorDevice': False,
-                'snapshots': ['d3af89b2-d846-0874-6acb-031ccf11c560'],
-                'startDelay': 0,
-                'startTime': None,
-                'secureBoot': False,
+                'power_state': 'Running',
                 'tags': [],
-                'VIFs': ['889ea35b-a0f9-2d07-eacf-345d3e45664b'],
-                'virtualizationMode': 'hvm',
-                '$container': '355ee47d-ff4c-4924-3db2-fd86ae629676',
-                '$VBDs': ['1131abdd-99f7-548f-c727-26fe7626f890', 'b21a2342-cc1d-38b0-ebb9-f2c22d5051c5'],
-                'VGPUs': [],
-                '$VGPUs': [],
-                'vga': 'std',
-                'videoram': '8',
                 'id': '0e645898-2bea-2d82-e922-881654b0a48f',
                 'uuid': '0e645898-2bea-2d82-e922-881654b0a48f',
-                '$pool': '355ee47d-ff4c-4924-3db2-fd86ae629676',
-                '$poolId': '355ee47d-ff4c-4924-3db2-fd86ae629676'
+                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$container': '222d8594-9426-468a-ad69-7a6f02330fa3'
             },
         'b0d25e70-019d-6182-2f7c-b0f5d8ef9331':
             {
                 'type': 'VM',
                 'addresses': {'0/ipv4/0': '192.168.1.55', '1/ipv4/0': '10.0.90.1'},
-                'auto_poweron': False,
                 'CPUs': {'max': 4, 'number': 4},
-                'current_operations': {},
-                'expNestedHvm': False, 'mainIpAddress': '192.168.1.55',
+                'mainIpAddress': '192.168.1.55',
                 'memory': {'dynamic': [2147483648, 2147483648], 'static': [134217728, 2147483648], 'size': 2147483648},
-                'installTime': None,
                 'name_description': '',
-                'name_label': 'SamTest PfSense',
+                'name_label': 'XCP-NG lab 3',
                 'os_version': {'name': 'FreeBSD 11.3-STABLE', 'uname': '11.3-STABLE', 'distro': 'FreeBSD'},
                 'power_state': 'Halted',
-                'hasVendorDevice': False,
-                'snapshots': [],
-                'startDelay': 0,
-                'startTime': None,
-                'secureBoot': False,
                 'tags': [],
-                'VIFs': ['92e4825d-78c8-a2db-925e-d934059942f5', '5ffc904e-6b15-fe6e-c1da-efe9168ff0c0'],
-                'virtualizationMode': 'hvm',
-                '$container': '355ee47d-ff4c-4924-3db2-fd86ae629676',
-                '$VBDs': ['2e318246-1248-5035-8aa1-bee8672a09fe', 'a41cf8ef-01b2-9899-6a6d-1e35e026ae3b'],
-                'VGPUs': [],
-                '$VGPUs': [],
-                'vga': 'cirrus',
-                'videoram': 4,
-                'coresPerSocket': 4,
                 'id': 'b0d25e70-019d-6182-2f7c-b0f5d8ef9331',
                 'uuid': 'b0d25e70-019d-6182-2f7c-b0f5d8ef9331',
-                '$pool': '355ee47d-ff4c-4924-3db2-fd86ae629676',
-                '$poolId': '355ee47d-ff4c-4924-3db2-fd86ae629676'
+                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$container': 'c96ec4dd-28ac-4df4-b73c-4371bd202728',
             }
     },
     'pools': {
-            '3d315997-73bd-5a74-8ca7-289206cb03ab': {
-                'current_operations': {},
-                'HA_enabled': False,
-                'master': '222d8594-9426-468a-ad69-7a6f02330fa3',
-                'tags': [],
-                'name_description': '',
-                'name_label': 'Storage Lab',
-                'xosanPackInstallationTime': None,
-                'cpus': {'cores': 120, 'sockets': 6},
-                'zstdSupported': True,
-                'id': '3d315997-73bd-5a74-8ca7-289206cb03ab',
-                'type': 'pool',
-                'uuid': '3d315997-73bd-5a74-8ca7-289206cb03ab',
-                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
-                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'},
-            'bb538461-80ce-c712-1083-699dd8b8163f': {
-                'current_operations': {},
-                'default_SR': '63b86645-2fc2-2497-8e58-1dcd7c86939b',
-                'HA_enabled': False,
-                'master': 'b181faa0-e9c4-4e26-a029-463d726a63c0',
-                'tags': [],
-                'name_description': '',
-                'name_label': 'runx prod',
-                'xosanPackInstallationTime': None,
-                'otherConfig': {'memory-ratio-hvm': '0.25', 'memory-ratio-pv': '0.25'},
-                'cpus': {'cores': 4, 'sockets': 4},
-                'zstdSupported': True,
-                'id': 'bb538461-80ce-c712-1083-699dd8b8163f',
-                'type': 'pool',
-                'uuid': 'bb538461-80ce-c712-1083-699dd8b8163f',
-                '$pool': 'bb538461-80ce-c712-1083-699dd8b8163f',
-                '$poolId': 'bb538461-80ce-c712-1083-699dd8b8163f'
-            },
-            '682fdbf8-df62-e0d9-3f3c-266624e092d1': {
-                'current_operations': {},
-                'default_SR': '040ad5c2-d9a6-bd98-fd38-97807d24d4fb',
-                'HA_enabled': False,
-                'master': 'a450c97c-4b40-482f-afc9-86153e6135cd',
-                'tags': [],
-                'name_description': '',
-                'name_label': 'runx prod 2',
-                'xosanPackInstallationTime': None,
-                'otherConfig': {'memory-ratio-hvm': '0.25', 'memory-ratio-pv': '0.25'},
-                'cpus': {'cores': 2, 'sockets': 2},
-                'zstdSupported': True,
-                'id': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
-                'type': 'pool',
-                'uuid': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
-                '$pool': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
-                '$poolId': '682fdbf8-df62-e0d9-3f3c-266624e092d1'
-            },
+        '3d315997-73bd-5a74-8ca7-289206cb03ab': {
+            'master': '222d8594-9426-468a-ad69-7a6f02330fa3',
+            'tags': [],
+            'name_description': '',
+            'name_label': 'Storage Lab',
+            'cpus': {'cores': 120, 'sockets': 6},
+            'id': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+            'type': 'pool',
+            'uuid': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+            '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+            '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+        }
     },
     'hosts': {
         'c96ec4dd-28ac-4df4-b73c-4371bd202728': {
-            'CPUs': {
-                'cpu_count': '40',
-                'socket_count': '2', 'vendor': 'GenuineIntel', 'speed': '1699.998', 'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
-                'family': '6', 'model': '62', 'stepping': '4'
-            },
-            'address': '172.16.210.14',
-            'build': 'release/stockholm/master/7',
-            'chipset_info': {'iommu': True},
-            'enabled': True,
-            'controlDomain': 'bc557b9a-9c97-4829-87c1-6765b857e9e5',
-            'cpus': {'cores': 40, 'sockets': 2},
-            'current_operations': {},
-            'hostname': 'r620-s1',
-            'iscsiIqn': 'iqn.2020-03.com.example:d71399bd', 'zstdSupported': True,
-            'license_server': {'address': 'localhost', 'port': '27000'},
-            'license_expiry': None,
-            'logging': {},
-            'name_description': 'Default install',
-            'name_label': 'R620-S1',
-            'memory': {'usage': 45283590144, 'size': 137391292416},
-            'multipathing': False,
-            'patches': [],
-            'powerOnMode': '',
-            'power_state': 'Running',
-            'startTime': 1625749690, 'supplementalPacks': [], 'agentStartTime': 1625749776, 'rebootRequired': False, 'tags': [], 'version': '8.2.0', 'productBrand': 'XCP-ng', 'hvmCapable': True, 'certificates': [],
-            'id': 'c96ec4dd-28ac-4df4-b73c-4371bd202728',
             'type': 'host',
-                    'uuid': 'c96ec4dd-28ac-4df4-b73c-4371bd202728', '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab', '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
-        },
-        'ddcd3461-7052-4f5e-932c-e1ed75c192d6': {
+            'uuid': 'c96ec4dd-28ac-4df4-b73c-4371bd202728',
+            'enabled': True,
             'CPUs': {
                 'cpu_count': '40',
                 'socket_count': '2',
                 'vendor': 'GenuineIntel',
-                'speed': '1700.007', 'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
+                'speed': '1699.998',
+                'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
+                'family': '6',
+                'model': '62',
+                'stepping': '4'
+            },
+            'address': '172.16.210.14',
+            'build': 'release/stockholm/master/7',
+            'cpus': {'cores': 40, 'sockets': 2},
+            'hostname': 'r620-s1',
+            'name_description': 'Default install',
+            'name_label': 'R620-S1',
+            'memory': {'usage': 45283590144, 'size': 137391292416},
+            'power_state': 'Running',
+            'tags': [],
+            'version': '8.2.0',
+            'productBrand': 'XCP-ng',
+            'id': 'c96ec4dd-28ac-4df4-b73c-4371bd202728',
+            '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+            '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+        },
+        '222d8594-9426-468a-ad69-7a6f02330fa3': {
+            'type': 'host',
+            'uuid': '222d8594-9426-468a-ad69-7a6f02330fa3',
+            'enabled': True,
+            'CPUs': {
+                'cpu_count': '40',
+                'socket_count': '2',
+                'vendor': 'GenuineIntel',
+                'speed': '1700.007',
+                'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
                 'family': '6',
                 'model': '62',
                 'stepping': '4'
             },
             'address': '172.16.210.16',
             'build': 'release/stockholm/master/7',
-            'chipset_info': {'iommu': True}, 'enabled': True, 'controlDomain': 'e9e1922f-ca2b-4259-9e0a-9b11277e276d',
             'cpus': {'cores': 40, 'sockets': 2},
-            'current_operations': {},
-            'hostname': 'r620-s3',
-            'iscsiIqn': 'iqn.2020-03.com.example:964057e9', 'zstdSupported': True,
+            'hostname': 'r620-s2',
             'name_description': 'Default install',
-            'name_label': 'R620-S3',
-            'memory': {'usage': 10636521472, 'size': 137391292416}, 'multipathing': False,
-            'powerOnMode': '', 'power_state': 'Running', 'startTime': 1625154580, 'supplementalPacks': [],
-            'agentStartTime': 1635336654, 'rebootRequired': False, 'tags': [], 'version': '8.2.0', 'productBrand': 'XCP-ng', 'hvmCapable': True,
-            'certificates': [],
+            'name_label': 'R620-S2',
+            'memory': {'usage': 10636521472, 'size': 137391292416},
+            'power_state': 'Running',
+            'tags': ['foo', 'bar', 'baz'],
+            'version': '8.2.0',
+            'productBrand': 'XCP-ng',
             'id': '222d8594-9426-468a-ad69-7a6f02330fa3',
-            'type': 'host',
-                    'uuid': '222d8594-9426-468a-ad69-7a6f02330fa3',
-                    '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab', '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+            '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+            '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
         }
     }
 }
+
+
+def serialize_groups(groups):
+    return list(map(str, groups))
 
 
 @ pytest.fixture(scope="module")
@@ -232,6 +146,52 @@ def test_verify_file_bad_config(inventory):
 
 def test_populate(inventory):
     inventory._populate(objects)
-    print(inventory.inventory.serialize())
+    actual = sorted(inventory.inventory.hosts.keys())
+    expected = sorted(['c96ec4dd-28ac-4df4-b73c-4371bd202728', '222d8594-9426-468a-ad69-7a6f02330fa3',
+                       '0e64588-2bea-2d82-e922-881654b0a48f', 'b0d25e70-019d-6182-2f7c-b0f5d8ef9331'])
 
-    assert 'foo' in inventory.inventory.groups
+    assert actual == expected
+
+    # Host with ip assertions
+    host_with_ip = inventory.inventory.get_host(
+        'b0d25e70-019d-6182-2f7c-b0f5d8ef9331')
+    host_with_ip_vars = host_with_ip.vars
+
+    assert host_with_ip_vars['ansible_host'] == '192.168.1.55'
+    assert host_with_ip_vars['power_state'] == 'halted'
+    assert host_with_ip_vars['type'] == 'VM'
+
+    assert host_with_ip in inventory.inventory.groups['with_ip'].hosts
+
+    # Host without ip
+    host_without_ip = inventory.inventory.get_host(
+        '0e64588-2bea-2d82-e922-881654b0a48f')
+    host_without_ip_vars = host_without_ip.vars
+
+    assert host_without_ip_vars['ansible_host'] is None
+    assert host_without_ip_vars['power_state'] == 'running'
+
+    assert host_without_ip in inventory.inventory.groups['without_ip'].hosts
+
+    assert host_with_ip in inventory.inventory.groups['xo_host_r620_s1'].hosts
+    assert host_without_ip in inventory.inventory.groups['xo_host_r620_s2'].hosts
+
+    r620_s1 = inventory.inventory.get_host(
+        'c96ec4dd-28ac-4df4-b73c-4371bd202728')
+    r620_s2 = inventory.inventory.get_host(
+        '222d8594-9426-468a-ad69-7a6f02330fa3')
+
+    assert r620_s1.vars['address'] == '172.16.210.14'
+    assert r620_s1.vars['tags'] == []
+    assert r620_s2.vars['address'] == '172.16.210.16'
+    assert r620_s2.vars['tags'] == ['foo', 'bar', 'baz']
+
+    storage_lab = inventory.inventory.groups['xo_pool_storage_lab']
+
+    # Check that hosts are in their corresponding pool
+    assert r620_s1 in storage_lab.hosts
+    assert r620_s2 in storage_lab.hosts
+
+    # Check that hosts are in their corresponding pool
+    assert host_without_ip in storage_lab.hosts
+    assert host_with_ip in storage_lab.hosts

--- a/tests/unit/plugins/inventory/test_xen_orchestra.py
+++ b/tests/unit/plugins/inventory/test_xen_orchestra.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, Jeffrey van Pelt <jeff@vanpelt.one>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# The API responses used in these tests were recorded from PVE version 6.2.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.inventory.data import InventoryData
+from ansible_collections.community.general.plugins.inventory.xen_orchestra import InventoryModule
+
+objects = {
+    'vms': {
+        '8900449d-44a2-e5f5-f692-a110c758b351':
+            {
+                'type': 'VM',
+                'addresses': {},
+                'CPUs': {'max': 4, 'number': 4}, 'current_operations': {},
+                'memory': {'dynamic': [8589934592, 8589934592], 'static': [134217728, 8589934592], 'size': 8589934592},
+                'installTime': 1626873121, 'name_description': '', 'name_label': 'XCP-NG lab',
+                'os_version': {}, 'parent': '45b83446-23e8-f623-56d7-ea4eb55c2818', 'power_state': 'Running', 'hasVendorDevice': False,
+                'snapshots': ['45b83446-23e8-f623-56d7-ea4eb55c2818', 'e46a28eb-b069-7a5b-91ef-1b2f002e6c78', '52ae0c8b-7be8-9eb1-f2d1-f37f806f2429'], 'startDelay': 0, 'startTime': 1633076244, 'secureBoot': False, 'tags': [],
+                'VIFs': ['7a8a9d85-a547-db0a-f101-be9bb16e94a1'], 'virtualizationMode': 'hvm', 'xenTools': False, 'managementAgentDetected': False, 'pvDriversDetected': False, '$container': '222d8594-9426-468a-ad69-7a6f02330fa3',
+                '$VBDs': ['2c0525d1-15b0-6c5a-10e7-a86418aa42cc', 'aa56c52b-63cc-49c1-1fd4-81ed330685d8'],
+                'VGPUs': [],
+                '$VGPUs': [],
+                'vga': 'cirrus', 'videoram': 4,
+                'id': '8900449d-44a2-e5f5-f692-a110c758b351',
+                'uuid': '8900449d-44a2-e5f5-f692-a110c758b351',
+                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+            },
+        '0e64588-2bea-2d82-e922-881654b0a48f':
+            {
+                'type': 'VM',
+                'addresses': {},
+                'auto_poweron': False,
+                'CPUs': {'max': 1, 'number': 1}, 'current_operations': {},
+                'expNestedHvm': False,
+                'high_availability': '',
+                'memory': {'dynamic': [1073741824, 2147483648], 'static': [536870912, 4294967296], 'size': 2147483648},
+                'installTime': 1599049252,
+                'name_description': '',
+                'name_label': 'rajaa - XS 7.1',
+                'os_version': {},
+                'parent': 'd3af89b2-d846-0874-6acb-031ccf11c560',
+                'power_state': 'Halted',
+                'hasVendorDevice': False,
+                'snapshots': ['d3af89b2-d846-0874-6acb-031ccf11c560'],
+                'startDelay': 0,
+                'startTime': None,
+                'secureBoot': False,
+                'tags': [],
+                'VIFs': ['889ea35b-a0f9-2d07-eacf-345d3e45664b'],
+                'virtualizationMode': 'hvm',
+                '$container': '355ee47d-ff4c-4924-3db2-fd86ae629676',
+                '$VBDs': ['1131abdd-99f7-548f-c727-26fe7626f890', 'b21a2342-cc1d-38b0-ebb9-f2c22d5051c5'],
+                'VGPUs': [],
+                '$VGPUs': [],
+                'vga': 'std',
+                'videoram': '8',
+                'id': '0e645898-2bea-2d82-e922-881654b0a48f',
+                'uuid': '0e645898-2bea-2d82-e922-881654b0a48f',
+                '$pool': '355ee47d-ff4c-4924-3db2-fd86ae629676',
+                '$poolId': '355ee47d-ff4c-4924-3db2-fd86ae629676'
+            },
+        'b0d25e70-019d-6182-2f7c-b0f5d8ef9331':
+            {
+                'type': 'VM',
+                'addresses': {'0/ipv4/0': '192.168.1.55', '1/ipv4/0': '10.0.90.1'},
+                'auto_poweron': False,
+                'CPUs': {'max': 4, 'number': 4},
+                'current_operations': {},
+                'expNestedHvm': False, 'mainIpAddress': '192.168.1.55',
+                'memory': {'dynamic': [2147483648, 2147483648], 'static': [134217728, 2147483648], 'size': 2147483648},
+                'installTime': None,
+                'name_description': '',
+                'name_label': 'SamTest PfSense',
+                'os_version': {'name': 'FreeBSD 11.3-STABLE', 'uname': '11.3-STABLE', 'distro': 'FreeBSD'},
+                'power_state': 'Halted',
+                'hasVendorDevice': False,
+                'snapshots': [],
+                'startDelay': 0,
+                'startTime': None,
+                'secureBoot': False,
+                'tags': [],
+                'VIFs': ['92e4825d-78c8-a2db-925e-d934059942f5', '5ffc904e-6b15-fe6e-c1da-efe9168ff0c0'],
+                'virtualizationMode': 'hvm',
+                '$container': '355ee47d-ff4c-4924-3db2-fd86ae629676',
+                '$VBDs': ['2e318246-1248-5035-8aa1-bee8672a09fe', 'a41cf8ef-01b2-9899-6a6d-1e35e026ae3b'],
+                'VGPUs': [],
+                '$VGPUs': [],
+                'vga': 'cirrus',
+                'videoram': 4,
+                'coresPerSocket': 4,
+                'id': 'b0d25e70-019d-6182-2f7c-b0f5d8ef9331',
+                'uuid': 'b0d25e70-019d-6182-2f7c-b0f5d8ef9331',
+                '$pool': '355ee47d-ff4c-4924-3db2-fd86ae629676',
+                '$poolId': '355ee47d-ff4c-4924-3db2-fd86ae629676'
+            }
+    },
+    'pools': {
+            '3d315997-73bd-5a74-8ca7-289206cb03ab': {
+                'current_operations': {},
+                'HA_enabled': False,
+                'master': '222d8594-9426-468a-ad69-7a6f02330fa3',
+                'tags': [],
+                'name_description': '',
+                'name_label': 'Storage Lab',
+                'xosanPackInstallationTime': None,
+                'cpus': {'cores': 120, 'sockets': 6},
+                'zstdSupported': True,
+                'id': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                'type': 'pool',
+                'uuid': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab',
+                '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'},
+            'bb538461-80ce-c712-1083-699dd8b8163f': {
+                'current_operations': {},
+                'default_SR': '63b86645-2fc2-2497-8e58-1dcd7c86939b',
+                'HA_enabled': False,
+                'master': 'b181faa0-e9c4-4e26-a029-463d726a63c0',
+                'tags': [],
+                'name_description': '',
+                'name_label': 'runx prod',
+                'xosanPackInstallationTime': None,
+                'otherConfig': {'memory-ratio-hvm': '0.25', 'memory-ratio-pv': '0.25'},
+                'cpus': {'cores': 4, 'sockets': 4},
+                'zstdSupported': True,
+                'id': 'bb538461-80ce-c712-1083-699dd8b8163f',
+                'type': 'pool',
+                'uuid': 'bb538461-80ce-c712-1083-699dd8b8163f',
+                '$pool': 'bb538461-80ce-c712-1083-699dd8b8163f',
+                '$poolId': 'bb538461-80ce-c712-1083-699dd8b8163f'
+            },
+            '682fdbf8-df62-e0d9-3f3c-266624e092d1': {
+                'current_operations': {},
+                'default_SR': '040ad5c2-d9a6-bd98-fd38-97807d24d4fb',
+                'HA_enabled': False,
+                'master': 'a450c97c-4b40-482f-afc9-86153e6135cd',
+                'tags': [],
+                'name_description': '',
+                'name_label': 'runx prod 2',
+                'xosanPackInstallationTime': None,
+                'otherConfig': {'memory-ratio-hvm': '0.25', 'memory-ratio-pv': '0.25'},
+                'cpus': {'cores': 2, 'sockets': 2},
+                'zstdSupported': True,
+                'id': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
+                'type': 'pool',
+                'uuid': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
+                '$pool': '682fdbf8-df62-e0d9-3f3c-266624e092d1',
+                '$poolId': '682fdbf8-df62-e0d9-3f3c-266624e092d1'
+            },
+    },
+    'hosts': {
+        'c96ec4dd-28ac-4df4-b73c-4371bd202728': {
+            'CPUs': {
+                'cpu_count': '40',
+                'socket_count': '2', 'vendor': 'GenuineIntel', 'speed': '1699.998', 'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
+                'family': '6', 'model': '62', 'stepping': '4'
+            },
+            'address': '172.16.210.14',
+            'build': 'release/stockholm/master/7',
+            'chipset_info': {'iommu': True},
+            'enabled': True,
+            'controlDomain': 'bc557b9a-9c97-4829-87c1-6765b857e9e5',
+            'cpus': {'cores': 40, 'sockets': 2},
+            'current_operations': {},
+            'hostname': 'r620-s1',
+            'iscsiIqn': 'iqn.2020-03.com.example:d71399bd', 'zstdSupported': True,
+            'license_server': {'address': 'localhost', 'port': '27000'},
+            'license_expiry': None,
+            'logging': {},
+            'name_description': 'Default install',
+            'name_label': 'R620-S1',
+            'memory': {'usage': 45283590144, 'size': 137391292416},
+            'multipathing': False,
+            'patches': [],
+            'powerOnMode': '',
+            'power_state': 'Running',
+            'startTime': 1625749690, 'supplementalPacks': [], 'agentStartTime': 1625749776, 'rebootRequired': False, 'tags': [], 'version': '8.2.0', 'productBrand': 'XCP-ng', 'hvmCapable': True, 'certificates': [],
+            'id': 'c96ec4dd-28ac-4df4-b73c-4371bd202728',
+            'type': 'host',
+                    'uuid': 'c96ec4dd-28ac-4df4-b73c-4371bd202728', '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab', '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+        },
+        'ddcd3461-7052-4f5e-932c-e1ed75c192d6': {
+            'CPUs': {
+                'cpu_count': '40',
+                'socket_count': '2',
+                'vendor': 'GenuineIntel',
+                'speed': '1700.007', 'modelname': 'Intel(R) Xeon(R) CPU E5-2650L v2 @ 1.70GHz',
+                'family': '6',
+                'model': '62',
+                'stepping': '4'
+            },
+            'address': '172.16.210.16',
+            'build': 'release/stockholm/master/7',
+            'chipset_info': {'iommu': True}, 'enabled': True, 'controlDomain': 'e9e1922f-ca2b-4259-9e0a-9b11277e276d',
+            'cpus': {'cores': 40, 'sockets': 2},
+            'current_operations': {},
+            'hostname': 'r620-s3',
+            'iscsiIqn': 'iqn.2020-03.com.example:964057e9', 'zstdSupported': True,
+            'name_description': 'Default install',
+            'name_label': 'R620-S3',
+            'memory': {'usage': 10636521472, 'size': 137391292416}, 'multipathing': False,
+            'powerOnMode': '', 'power_state': 'Running', 'startTime': 1625154580, 'supplementalPacks': [],
+            'agentStartTime': 1635336654, 'rebootRequired': False, 'tags': [], 'version': '8.2.0', 'productBrand': 'XCP-ng', 'hvmCapable': True,
+            'certificates': [],
+            'id': '222d8594-9426-468a-ad69-7a6f02330fa3',
+            'type': 'host',
+                    'uuid': '222d8594-9426-468a-ad69-7a6f02330fa3',
+                    '$pool': '3d315997-73bd-5a74-8ca7-289206cb03ab', '$poolId': '3d315997-73bd-5a74-8ca7-289206cb03ab'
+        }
+    }
+}
+
+
+@ pytest.fixture(scope="module")
+def inventory():
+    r = InventoryModule()
+    r.inventory = InventoryData()
+    return r
+
+
+def test_verify_file_bad_config(inventory):
+    assert inventory.verify_file('foobar.xen_orchestra.yml') is False
+
+
+def test_populate(inventory):
+    inventory._populate(objects)
+    print(inventory.inventory.serialize())
+
+    assert 'foo' in inventory.inventory.groups


### PR DESCRIPTION
##### SUMMARY

This adds an ansible inventory plugins that lists and group by types the following assets:

- Virtual machines
- Hosts
- Pools

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
xen_orchestra

##### ADDITIONAL INFORMATION
As vm's are not guaranteed to have an ip [1], I opted to use the assets uuid's instead, as they are consistent across all asset types.
This is lacking tests, although I have a fair understanding of what kind of tests need to be added to this PR, I don't get how to run them. 😄 
Also: I will cleanup the commit history as needed.

[1] A vm without the xen tools or a vm in a `Shutdown` state will not have an ip.
