### PR TITLE
xfs_quota: use project name when setting a new project to a mount

### DIFF
--- a/plugins/modules/system/xfs_quota.py
+++ b/plugins/modules/system/xfs_quota.py
@@ -293,7 +293,7 @@ def main():
                         break
 
         if not prj_set and not module.check_mode:
-            cmd = "project -s"
+            cmd = "project -s %s" % name
             rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
             if rc != 0:
                 result["cmd"] = cmd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When setting new project to a mount point project name has to be supplied in the command. This was missing and therefore adding new project never worked.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.general.xfs_quota

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To reproduce:

Check that there are no quotas set:
```
xfs_quota -x -c 'df -h'
```

Try enabling quota on mounted XFS filesystem

```
ansible -m xfs_quota -a 'type=project name=varlog mountpoint=/var'
```

Then check again, and observe that no project quota flag is set.

<!--- Paste verbatim command output below, e.g. before and after your change -->
