### PR TITLE
Add require_two_factor_authentication property to gitlab group

### DIFF
--- a/changelogs/fragments/3367-add-require_two_factor_authentication-property-to-gitlab-group.yml
+++ b/changelogs/fragments/3367-add-require_two_factor_authentication-property-to-gitlab-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_group - add new property ``require_two_factor_authentication`` (https://github.com/ansible-collections/community.general/pull/3367).

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -82,7 +82,6 @@ options:
     description:
       - Require all users in this group to setup two-factor authentication.
     type: bool
-    default: false
     version_added: 3.7.0
 '''
 
@@ -307,7 +306,7 @@ def main():
         project_creation_level=dict(type='str', choices=['developer', 'maintainer', 'noone']),
         auto_devops_enabled=dict(type='bool'),
         subgroup_creation_level=dict(type='str', choices=['maintainer', 'owner']),
-        require_two_factor_authentication=dict(type='bool', default=False),
+        require_two_factor_authentication=dict(type='bool'),
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -78,6 +78,12 @@ options:
     choices: ["maintainer", "owner"]
     type: str
     version_added: 3.7.0
+  require_two_factor_authentication:
+    description:
+      - Require all users in this group to setup Two-factor authentication.
+    type: bool
+    default: no
+    version_added: 3.7.0
 '''
 
 EXAMPLES = '''
@@ -201,6 +207,7 @@ class GitLabGroup(object):
                 'project_creation_level': options['project_creation_level'],
                 'auto_devops_enabled': options['auto_devops_enabled'],
                 'subgroup_creation_level': options['subgroup_creation_level'],
+                'require_two_factor_authentication': options['require_two_factor_authentication'],
             }
             if options.get('description'):
                 payload['description'] = options['description']
@@ -214,6 +221,7 @@ class GitLabGroup(object):
                 'project_creation_level': options['project_creation_level'],
                 'auto_devops_enabled': options['auto_devops_enabled'],
                 'subgroup_creation_level': options['subgroup_creation_level'],
+                'require_two_factor_authentication': options['require_two_factor_authentication'],
             })
 
         self.groupObject = group
@@ -299,6 +307,7 @@ def main():
         project_creation_level=dict(type='str', choices=['developer', 'maintainer', 'noone']),
         auto_devops_enabled=dict(type='bool'),
         subgroup_creation_level=dict(type='str', choices=['maintainer', 'owner']),
+        require_two_factor_authentication=dict(type='bool', default=False),
     ))
 
     module = AnsibleModule(
@@ -325,6 +334,7 @@ def main():
     project_creation_level = module.params['project_creation_level']
     auto_devops_enabled = module.params['auto_devops_enabled']
     subgroup_creation_level = module.params['subgroup_creation_level']
+    require_two_factor_authentication = module.params['require_two_factor_authentication']
 
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
@@ -361,7 +371,9 @@ def main():
                                             "visibility": group_visibility,
                                             "project_creation_level": project_creation_level,
                                             "auto_devops_enabled": auto_devops_enabled,
-                                            "subgroup_creation_level": subgroup_creation_level}):
+                                            "subgroup_creation_level": subgroup_creation_level,
+                                            "require_two_factor_authentication": require_two_factor_authentication,
+                                            }):
             module.exit_json(changed=True, msg="Successfully created or updated the group %s" % group_name, group=gitlab_group.groupObject._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the group %s" % group_name, group=gitlab_group.groupObject._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -80,9 +80,9 @@ options:
     version_added: 3.7.0
   require_two_factor_authentication:
     description:
-      - Require all users in this group to setup Two-factor authentication.
+      - Require all users in this group to setup two-factor authentication.
     type: bool
-    default: no
+    default: false
     version_added: 3.7.0
 '''
 

--- a/tests/integration/targets/gitlab_group/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group/tasks/main.yml
@@ -97,3 +97,28 @@
   assert:
     that:
       - gitlab_group_state_pcl.group.project_creation_level == "noone"
+
+- name: Cleanup GitLab Group for require_two_factor_authentication Test
+  gitlab_group:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: false
+    api_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    state: absent
+
+- name: Create GitLab Group for project_creation_level Test
+  gitlab_group:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: false
+    api_token: "{{ gitlab_login_token }}"
+    name: ansible_test_group
+    path: ansible_test_group
+    require_two_factor_authentication: true
+    state: present
+  register: gitlab_group_state_rtfa
+
+- name: Test group created with project_creation_level
+  assert:
+    that:
+      - gitlab_group_state_rtfa.group.require_two_factor_authentication == true

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -195,6 +195,7 @@ def resp_get_group(url, request):
                '"web_url": "http://localhost:3000/groups/foo-bar", "request_access_enabled": false,'
                '"full_name": "Foobar Group", "full_path": "foo-bar",'
                '"project_creation_level": "maintainer", "subgroup_creation_level": "maintainer",'
+               '"require_two_factor_authentication": true,'
                '"file_template_project_id": 1, "parent_id": null, "projects": [{"id": 1,"description": null, "default_branch": "master",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
@@ -227,7 +228,8 @@ def resp_create_group(url, request):
                '"web_url": "http://localhost:3000/groups/foo-bar", "request_access_enabled": false,'
                '"full_name": "Foobar Group", "full_path": "foo-bar",'
                '"file_template_project_id": 1, "parent_id": null,'
-               '"project_creation_level": "developer", "subgroup_creation_level": "maintainer"}')
+               '"project_creation_level": "developer", "subgroup_creation_level": "maintainer",'
+               '"require_two_factor_authentication": true}')
     content = content.encode("utf-8")
     return response(200, content, headers, None, 5, request)
 
@@ -241,7 +243,8 @@ def resp_create_subgroup(url, request):
                '"web_url": "http://localhost:3000/groups/foo-bar/bar-foo", "request_access_enabled": false,'
                '"full_name": "BarFoo Group", "full_path": "foo-bar/bar-foo",'
                '"file_template_project_id": 1, "parent_id": 1,'
-               '"project_creation_level": "noone"}')
+               '"project_creation_level": "noone",'
+               '"require_two_factor_authentication": true}')
     content = content.encode("utf-8")
     return response(200, content, headers, None, 5, request)
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -70,7 +70,8 @@ class TestGitlabGroup(GitlabModuleTestCase):
                                              'path': "foo-bar",
                                              'description': "An interesting group",
                                              'project_creation_level': "developer",
-                                             'subgroup_creation_level': "maintainer"})
+                                             'subgroup_creation_level': "maintainer",
+                                             'require_two_factor_authentication': True})
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "Foobar Group")
@@ -78,6 +79,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
         self.assertEqual(group.description, "An interesting group")
         self.assertEqual(group.project_creation_level, "developer")
         self.assertEqual(group.subgroup_creation_level, "maintainer")
+        self.assertEqual(group.require_two_factor_authentication, True)
         self.assertEqual(group.id, 1)
 
     @with_httmock(resp_create_subgroup)
@@ -85,12 +87,14 @@ class TestGitlabGroup(GitlabModuleTestCase):
         group = self.moduleUtil.createGroup({'name': "BarFoo Group",
                                              'path': "bar-foo",
                                              'parent_id': 1,
-                                             'project_creation_level': "noone"})
+                                             'project_creation_level': "noone",
+                                             'require_two_factor_authentication': True})
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "BarFoo Group")
         self.assertEqual(group.full_path, "foo-bar/bar-foo")
         self.assertEqual(group.project_creation_level, "noone")
+        self.assertEqual(group.require_two_factor_authentication, True)
         self.assertEqual(group.id, 2)
         self.assertEqual(group.parent_id, 1)
 
@@ -99,12 +103,14 @@ class TestGitlabGroup(GitlabModuleTestCase):
         group = self.gitlab_instance.groups.get(1)
         changed, newGroup = self.moduleUtil.updateGroup(group, {'name': "BarFoo Group",
                                                                 'visibility': "private",
-                                                                'project_creation_level': "maintainer"})
+                                                                'project_creation_level': "maintainer",
+                                                                'require_two_factor_authentication': True})
 
         self.assertEqual(changed, True)
         self.assertEqual(newGroup.name, "BarFoo Group")
         self.assertEqual(newGroup.visibility, "private")
         self.assertEqual(newGroup.project_creation_level, "maintainer")
+        self.assertEqual(newGroup.require_two_factor_authentication, True)
 
         changed, newGroup = self.moduleUtil.updateGroup(group, {'name': "BarFoo Group"})
 


### PR DESCRIPTION
##### SUMMARY
Enhance existing community.general.gitlab_group to add require_two_factor_authentication property

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_group

##### ADDITIONAL INFORMATION
Has been tested on a our gitlab instance.
