### PR TITLE
ipa_dnszone: add PTR synchronization support for dnszones

### DIFF
--- a/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
+++ b/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
@@ -1,6 +1,2 @@
 minor_changes:
-<<<<<<< HEAD
   - ipa_dnszone - add DNS zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
-=======
-  - ipa - dns zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
->>>>>>> Add changelog fragment

--- a/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
+++ b/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ipa - dns zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).

--- a/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
+++ b/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
@@ -1,2 +1,6 @@
 minor_changes:
+<<<<<<< HEAD
   - ipa_dnszone - add DNS zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
+=======
+  - ipa - dns zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
+>>>>>>> Add changelog fragment

--- a/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
+++ b/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ipa - dns zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
+  - ipa_dnszone - add DNS zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).

--- a/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
+++ b/changelogs/fragments/3374-add-ipa-ptr-sync-support.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - ipa_dnszone - add DNS zone synchronization support (https://github.com/ansible-collections/community.general/pull/3374).
+  - ipa_dnszone - ``dynamicupdate`` is now a boolean parameter, instead of a string parameter accepting ``"true"`` and ``"false"``. Also the module is now idempotent with respect to ``dynamicupdate`` (https://github.com/ansible-collections/community.general/pull/3374).

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -87,6 +87,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.ipa import IPAClient, ipa_argument_spec
 from ansible.module_utils.common.text.converters import to_native
 
+
 class DNSZoneIPAClient(IPAClient):
     def __init__(self, module, host, port, protocol):
         super(DNSZoneIPAClient, self).__init__(module, host, port, protocol)
@@ -157,7 +158,7 @@ def ensure(module, client):
     # state is absent
     else:
         # check for generic zone existence
-        if ipa_dnszone: 
+        if ipa_dnszone:
             changed = True
             if not module.check_mode:
                 client.dnszone_del(zone_name=zone_name)

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -145,8 +145,8 @@ def ensure(module, client):
     if state == 'present':
         if not ipa_dnszone:
 
+            changed = True
             if not module.check_mode:
-                changed = True
                 client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
         elif ipa_dnszone['idnsallowdynupdate'][0] != dynamicupdate.upper() or ipa_dnszone['idnsallowsyncptr'][0] != str(allowsyncptr).upper():
             changed = True

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -29,9 +29,9 @@ options:
   dynamicupdate:
     description: Apply dynamic update to zone
     required: false
-    default: "false"
-    choices: ["false", "true"]
-    type: str
+    default: false
+    choices: [false, true]
+    type: bool
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
     required: false
@@ -148,7 +148,7 @@ def ensure(module, client):
             changed = True
             if not module.check_mode:
                 client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
-        elif ipa_dnszone['idnsallowdynupdate'][0] != dynamicupdate.upper() or ipa_dnszone['idnsallowsyncptr'][0] != str(allowsyncptr).upper():
+        elif ipa_dnszone['idnsallowdynupdate'][0] != str(dynamicupdate).upper() or ipa_dnszone['idnsallowsyncptr'][0] != str(allowsyncptr).upper():
             changed = True
             if not module.check_mode:
                 client.dnszone_mod(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
@@ -170,7 +170,7 @@ def main():
     argument_spec = ipa_argument_spec()
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
-                         dynamicupdate=dict(type='str', required=False, default='false', choices=['true', 'false']),
+                         dynamicupdate=dict(type='bool', required=False, default=False, choices=[True, False]),
                          allowsyncptr=dict(type='bool', required=False, default=False, choices=[True, False]),
                          )
 

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -30,13 +30,11 @@ options:
     description: Apply dynamic update to zone
     required: false
     default: false
-    choices: [false, true]
     type: bool
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
     required: false
     default: false
-    choices: [false, true]
     type: bool
 extends_documentation_fragment:
 - community.general.ipa.documentation
@@ -170,8 +168,8 @@ def main():
     argument_spec = ipa_argument_spec()
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
-                         dynamicupdate=dict(type='bool', required=False, default=False, choices=[True, False]),
-                         allowsyncptr=dict(type='bool', required=False, default=False, choices=[True, False]),
+                         dynamicupdate=dict(type='bool', required=False, default=False),
+                         allowsyncptr=dict(type='bool', required=False, default=False),
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -28,14 +28,13 @@ options:
     type: str
   dynamicupdate:
     description: Apply dynamic update to zone
-    required: false
     default: false
     type: bool
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
-    required: false
     default: false
     type: bool
+    version_added: 4.3.0
 extends_documentation_fragment:
 - community.general.ipa.documentation
 

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -33,11 +33,19 @@ options:
     choices: ["false", "true"]
     type: str
   allowsyncptr:
+<<<<<<< HEAD
     description: Allow synchronization of forward and reverse records in the zone.
     required: false
     default: false
     choices: [false, true]
     type: bool
+=======
+    description: Allow synchronization of forward and reverse records in the zone
+    required: false
+    default: "false"
+    choices: ["false", "true"]
+    type: str
+>>>>>>> Add PTR synchronization support for dnszones
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -58,6 +66,14 @@ EXAMPLES = r'''
     state: present
     zone_name: example.com
     dynamicupdate: true
+
+- name: Ensure dns zone is present and is allowing sync
+  community.general.ipa_dnszone:
+    ipa_host: spider.example.com
+    ipa_pass: Passw0rd!
+    state: present
+    zone_name: example.com
+    allowsyncptr: true
 
 - name: Ensure that dns zone is removed
   community.general.ipa_dnszone:
@@ -135,13 +151,17 @@ def ensure(module, client):
     state = module.params['state']
     dynamicupdate = module.params['dynamicupdate']
     allowsyncptr = module.params['allowsyncptr']
+<<<<<<< HEAD
     changed = False
+=======
+>>>>>>> Add PTR synchronization support for dnszones
 
     # does zone exist with all config params
     ipa_dnszone = client.dnszone_find(zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
 
     if state == 'present':
         if not ipa_dnszone:
+<<<<<<< HEAD
 
             # check for generic zone existence
             if client.dnszone_find(zone_name):
@@ -152,6 +172,11 @@ def ensure(module, client):
                 changed = True
                 if not module.check_mode:
                     client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
+=======
+            changed = True
+            if not module.check_mode:
+                client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
+>>>>>>> Add PTR synchronization support for dnszones
         else:
             changed = False
     # state is absent
@@ -170,7 +195,11 @@ def main():
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
                          dynamicupdate=dict(type='str', required=False, default='false', choices=['true', 'false']),
+<<<<<<< HEAD
                          allowsyncptr=dict(type='bool', required=False, default=False, choices=[True, False]),
+=======
+                         allowsyncptr=dict(type='str', required=False, default='false', choices=['true', 'false']),
+>>>>>>> Add PTR synchronization support for dnszones
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -33,19 +33,11 @@ options:
     choices: ["false", "true"]
     type: str
   allowsyncptr:
-<<<<<<< HEAD
     description: Allow synchronization of forward and reverse records in the zone.
     required: false
     default: false
     choices: [false, true]
     type: bool
-=======
-    description: Allow synchronization of forward and reverse records in the zone
-    required: false
-    default: "false"
-    choices: ["false", "true"]
-    type: str
->>>>>>> Add PTR synchronization support for dnszones
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -151,17 +143,13 @@ def ensure(module, client):
     state = module.params['state']
     dynamicupdate = module.params['dynamicupdate']
     allowsyncptr = module.params['allowsyncptr']
-<<<<<<< HEAD
     changed = False
-=======
->>>>>>> Add PTR synchronization support for dnszones
 
     # does zone exist with all config params
     ipa_dnszone = client.dnszone_find(zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
 
     if state == 'present':
         if not ipa_dnszone:
-<<<<<<< HEAD
 
             # check for generic zone existence
             if client.dnszone_find(zone_name):
@@ -172,11 +160,6 @@ def ensure(module, client):
                 changed = True
                 if not module.check_mode:
                     client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
-=======
-            changed = True
-            if not module.check_mode:
-                client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
->>>>>>> Add PTR synchronization support for dnszones
         else:
             changed = False
     # state is absent
@@ -195,11 +178,7 @@ def main():
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
                          dynamicupdate=dict(type='str', required=False, default='false', choices=['true', 'false']),
-<<<<<<< HEAD
                          allowsyncptr=dict(type='bool', required=False, default=False, choices=[True, False]),
-=======
-                         allowsyncptr=dict(type='str', required=False, default='false', choices=['true', 'false']),
->>>>>>> Add PTR synchronization support for dnszones
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -34,6 +34,7 @@ options:
     type: str
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
+    required: false
     type: boolean
 extends_documentation_fragment:
 - community.general.ipa.documentation
@@ -146,7 +147,7 @@ def main():
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
                          dynamicupdate=dict(type='str', required=False, default='false', choices=['true', 'false']),
-                         allowsyncptr=dict(type='str', required=False, default='false', choices=['true', 'false']),
+                         allowsyncptr=dict(type='bool', required=False),
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -32,6 +32,12 @@ options:
     default: "false"
     choices: ["false", "true"]
     type: str
+  allowsyncptr:
+    description: Allow synchronization of forward and reverse records in the zone
+    required: false
+    default: "false"
+    choices: ["false", "true"]
+    type: str
 extends_documentation_fragment:
 - community.general.ipa.documentation
 
@@ -52,6 +58,14 @@ EXAMPLES = r'''
     state: present
     zone_name: example.com
     dynamicupdate: true
+
+- name: Ensure dns zone is present and is allowing sync
+  community.general.ipa_dnszone:
+    ipa_host: spider.example.com
+    ipa_pass: Passw0rd!
+    state: present
+    zone_name: example.com
+    allowsyncptr: true
 
 - name: Ensure that dns zone is removed
   community.general.ipa_dnszone:
@@ -109,6 +123,7 @@ def ensure(module, client):
     zone_name = module.params['zone_name']
     state = module.params['state']
     dynamicupdate = module.params['dynamicupdate']
+    allowsyncptr = module.params['allowsyncptr']
 
     ipa_dnszone = client.dnszone_find(zone_name)
 
@@ -117,7 +132,7 @@ def ensure(module, client):
         if not ipa_dnszone:
             changed = True
             if not module.check_mode:
-                client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate})
+                client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
         else:
             changed = False
     else:
@@ -134,6 +149,7 @@ def main():
     argument_spec.update(zone_name=dict(type='str', required=True),
                          state=dict(type='str', default='present', choices=['present', 'absent']),
                          dynamicupdate=dict(type='str', required=False, default='false', choices=['true', 'false']),
+                         allowsyncptr=dict(type='str', required=False, default='false', choices=['true', 'false']),
                          )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -34,9 +34,7 @@ options:
     type: str
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
-    default: "false"
-    choices: ["false", "true"]
-    type: str
+    type: boolean
 extends_documentation_fragment:
 - community.general.ipa.documentation
 

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -35,7 +35,7 @@ options:
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
     required: false
-    type: boolean
+    type: bool
 extends_documentation_fragment:
 - community.general.ipa.documentation
 

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -93,37 +93,37 @@ class DNSZoneIPAClient(IPAClient):
         super(DNSZoneIPAClient, self).__init__(module, host, port, protocol)
 
     def dnszone_find(self, zone_name, details=None):
-        itens = {'all': 'true',
+        items = {'all': 'true',
                  'idnsname': zone_name, }
         if details is not None:
-            itens.update(details)
+            items.update(details)
 
         return self._post_json(
             method='dnszone_find',
             name=zone_name,
-            item=itens
+            item=items
         )
 
     def dnszone_add(self, zone_name=None, details=None):
-        itens = {}
+        items = {}
         if details is not None:
-            itens.update(details)
+            items.update(details)
 
         return self._post_json(
             method='dnszone_add',
             name=zone_name,
-            item=itens
+            item=items
         )
 
     def dnszone_mod(self, zone_name=None, details=None):
-        itens = {}
+        items = {}
         if details is not None:
-            itens.update(details)
+            items.update(details)
 
         return self._post_json(
             method='dnszone_mod',
             name=zone_name,
-            item=itens
+            item=items
         )
 
     def dnszone_del(self, zone_name=None, record_name=None, details=None):

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -165,7 +165,7 @@ def ensure(module, client):
     # state is absent
     else:
         # check for generic zone existence
-        if client.dnszone_find(zone_name): 
+        if client.dnszone_find(zone_name):
             changed = True
             if not module.check_mode:
                 client.dnszone_del(zone_name=zone_name)

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -33,7 +33,7 @@ options:
     choices: ["false", "true"]
     type: str
   allowsyncptr:
-    description: Allow synchronization of forward and reverse records in the zone
+    description: Allow synchronization of forward and reverse records in the zone.
     required: false
     default: "false"
     choices: ["false", "true"]

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -34,7 +34,6 @@ options:
     type: str
   allowsyncptr:
     description: Allow synchronization of forward and reverse records in the zone.
-    required: false
     default: "false"
     choices: ["false", "true"]
     type: str

--- a/plugins/modules/identity/ipa/ipa_dnszone.py
+++ b/plugins/modules/identity/ipa/ipa_dnszone.py
@@ -27,7 +27,7 @@ options:
     choices: ["absent", "present"]
     type: str
   dynamicupdate:
-    description: Apply dynamic update to zone
+    description: Apply dynamic update to zone.
     default: false
     type: bool
   allowsyncptr:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1687 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
IPA

##### ADDITIONAL INFORMATION
Allows support for the `idnsallowsyncptr` in the IPA REST API:
```
{
    "id": 0, 
    "method": "dnszone_mod/1", 
    "params": [
        [
            "foo.bar"
        ], 
        {
            "idnsallowsyncptr": true, 
            "version": "2.237"
        }
    ]
}
```
