### PR TITLE
Install nios test requirements

### DIFF
--- a/tests/integration/targets/prepare_nios_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_nios_tests/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install
+  pip:
+    name: infoblox-client


### PR DESCRIPTION
##### SUMMARY
@mattclay mentioned on IRC that ansible-test will stop installing them automatically (currently the dependencies are coming from https://github.com/ansible/ansible/blob/c3fc8fb99a409d7555c1587697a3cfd78b7f3eb9/test/lib/ansible_test/_data/requirements/integration.cloud.nios.txt).

CC @anagha-infoblox

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
nios integration tests
