### PR TITLE
3385-nmcli_routing_rules4.yml

### DIFF
--- a/changelogs/fragments/3385-nmcli_remove_routing_rules4.yml
+++ b/changelogs/fragments/3385-nmcli_remove_routing_rules4.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - nmcli - routing_rules4 arguement is currenlty accepting only string elements. In the case of adding multiple entries to routing_rules4, we need to accept values as strings.
-  (https://github.com/ansible-collections/community.general/pull/3385)

--- a/changelogs/fragments/3385-nmcli_remove_routing_rules4.yml
+++ b/changelogs/fragments/3385-nmcli_remove_routing_rules4.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nmcli - routing_rules4 arguement is currenlty accepting only string elements. In the case of adding multiple entries to routing_rules4, we need to accept values as strings.
+  (https://github.com/ansible-collections/community.general/pull/3385)

--- a/changelogs/fragments/3385-nmcli_routing_rules4.yml
+++ b/changelogs/fragments/3385-nmcli_routing_rules4.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - routing_rules4 arguement as accept values as list instead of string (https://github.com/ansible-collections/community.general/pull/3385)


### PR DESCRIPTION
nmcli_routing_rules4.yml

##### SUMMARY

routing_rules4 module argument is currently accepting only string elements. In the case of adding multiple entries to routing_rules4, we need to accept values as strings.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
