### PR TITLE
Update locale_gen.py

### DIFF
--- a/plugins/modules/system/locale_gen.py
+++ b/plugins/modules/system/locale_gen.py
@@ -46,6 +46,7 @@ LOCALE_NORMALIZATION = {
     ".utf8": ".UTF-8",
     ".eucjp": ".EUC-JP",
     ".iso885915": ".ISO-8859-15",
+    ".iso88591": ".ISO-8859-1",
     ".cp1251": ".CP1251",
     ".koi8r": ".KOI8-R",
     ".armscii8": ".ARMSCII-8",


### PR DESCRIPTION
##### SUMMARY
I have some old terminals which don't support ISO-8859-15, but this module doesn't recognize ISO-8859-1 as a valid encoding.  This PR adds it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.locale_gen

