### PR TITLE
nmcli: amended the routing-rules4 key values as list

### DIFF
--- a/changelogs/fragments/3395-nmcli-needs-type.yml
+++ b/changelogs/fragments/3395-nmcli-needs-type.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nmcli - modify existing 'routing_rules4' type as 'list' with elements='str' (https://github.com/ansible-collections/community.general/issues/3395)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1470,6 +1470,7 @@ class Nmcli(object):
         elif setting in ('ipv4.dns',
                          'ipv4.dns-search',
                          'ipv4.routes',
+                         'ipv4.routing-rules',
                          'ipv4.route-metric'
                          'ipv6.dns',
                          'ipv6.dns-search',
@@ -1602,6 +1603,10 @@ class Nmcli(object):
                     conn_info[key] = [s.strip() for s in raw_value.split(';')]
                 elif key_type == list:
                     conn_info[key] = [s.strip() for s in raw_value.split(',')]
+                elif key_type == 'ipv4.routing-rules':
+                    conn_info[key] = [s.strip() for s in raw_value.split(';')]
+                elif key_type == list:
+                    conn_info[key] = [s.strip() for s in raw_value.split(',')]
                 else:
                     m_enum = p_enum_value.match(raw_value)
                     if m_enum is not None:
@@ -1685,6 +1690,15 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
+                if key == 'ipv4.routing-rules' and current_value is not None:
+                    # ipv4.routes do not have same options and show_connection() format
+                    # options: ['10.11.0.0/24 10.10.0.2', '10.12.0.0/24 10.10.0.2 200']
+                    # show_connection(): ['{ ip = 10.11.0.0/24, nh = 10.10.0.2 }', '{ ip = 10.12.0.0/24, nh = 10.10.0.2, mt = 200 }']
+                    # Need to convert in order to compare both
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
+                                     route) for route in current_value]
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
+                
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1697,8 +1697,7 @@ class Nmcli(object):
                     # Need to convert in order to compare both
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
-                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
-                
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]                
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()


### PR DESCRIPTION
"routing_rules4" module argument is only accepting single value. In order to accept multiple values, we need to accept "routing_rules4" module argument values as list.

SUMMARY

The "routing_rules4" module argument  currently accepting only 'str' values. In the event of adding multiple entries, we need to amend "routing_rules4" module argument as list.

ISSUE TYPE
- Feature Pull Request

COMPONENT NAME
nmcli

ADDITIONAL INFORMATION

In plugins/modules/net_tools/nmcli.py#L1473, L1601 and L1693, added the routing_rules4 module argument to accept values as list. 

BEFORE:
fatal: [192.168.235.157]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": true,
            "conn_name": "ens192",
            "dhcp_client_id": null,
            "dns4": null,
            "dns4_ignore_auto": false,
            "dns4_search": null,
            "dns6": null,
            "dns6_ignore_auto": false,
            "dns6_search": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": 15,
            "gw4": null,
            "gw4_ignore_auto": false,
            "gw6": null,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ifname": "ens192",
            "ignore_unsupported_suboptions": false,
            "ingress": null,
            "ip4": "192.168.235.157",
            "ip6": null,
            "ip_tunnel_dev": null,
            "ip_tunnel_input_key": null,
            "ip_tunnel_local": null,
            "ip_tunnel_output_key": null,
            "ip_tunnel_remote": null,
            "mac": null,
            "master": null,
            "maxage": 20,
            "may_fail4": false,
            "method4": "manual",
            "method6": "disabled",
            "miimon": null,
            "mode": "balance-rr",
            "mtu": null,
            "never_default4": false,
            "path_cost": 100,
            "primary": null,
            "priority": 128,
            "route_metric4": null,
            "routes4": null,
            "routing_rules4": "['priority 32745 from 10.10.10.1/32  lookup 103', 'priority 32746 from 1.1.1.0/24  lookup 103']",
            "runner": "roundrobin",
            "runner_hwaddr_policy": null,
            "slavepriority": 32,
            "ssid": null,
            "state": "present",
            "stp": true,
            "type": "ethernet",
            "updelay": null,
            "vlandev": null,
            "vlanid": null,
            "vxlan_id": null,
            "vxlan_local": null,
            "vxlan_remote": null,
            "wifi": null,
            "wifi_sec": null,
            "zone": null
        }
    },
    "msg": "Error: failed to modify ipv4.routing-rules: unsupported key \"['priority\".\n",
    "name": "ens192",
    "rc": 2
}

AFTER: 
changed: [192.168.235.157] => {
    "Exists": "Connections do exist so we are modifying them",
    "changed": true,
    "conn_name": "ens192",
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": true,
            "conn_name": "ens192",
            "dhcp_client_id": null,
            "dns4": null,
            "dns4_ignore_auto": false,
            "dns4_search": null,
            "dns6": null,
            "dns6_ignore_auto": false,
            "dns6_search": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": 15,
            "gsm": null,
            "gw4": null,
            "gw4_ignore_auto": false,
            "gw6": null,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ifname": "ens192",
            "ignore_unsupported_suboptions": false,
            "ingress": null,
            "ip4": "4.4.4.4",
            "ip6": null,
            "ip_tunnel_dev": null,
            "ip_tunnel_input_key": null,
            "ip_tunnel_local": null,
            "ip_tunnel_output_key": null,
            "ip_tunnel_remote": null,
            "mac": null,
            "master": null,
            "maxage": 20,
            "may_fail4": false,
            "method4": "manual",
            "method6": "disabled",
            "miimon": null,
            "mode": "balance-rr",
            "mtu": null,
            "never_default4": false,
            "path_cost": 100,
            "primary": null,
            "priority": 128,
            "route_metric4": null,
            "routes4": [
                "0.0.0.0/0 4.4.4.254 104 table=103"
            ],
            "routing_rules4": [
                " priority 32744 from 10.10.10.1/32 lookup 101",
                "priority 32745 from 1.1.1.0/24 lookup 101"
            ],
            "runner": "roundrobin",
            "runner_hwaddr_policy": null,
            "slavepriority": 32,
            "ssid": null,
            "state": "present",
            "stp": true,
            "type": "ethernet",
            "updelay": null,
            "vlandev": null,
            "vlanid": null,
            "vxlan_id": null,
            "vxlan_local": null,
            "vxlan_remote": null,
            "wifi": null,
            "wifi_sec": null,
            "zone": null
        }
    },
    "state": "present"
}
