### PR TITLE
Fix: GitLab API searches always return first found match

### DIFF
--- a/changelogs/fragments/3400-fix-gitLab-api-searches-always-return-first-found-match-3386.yml
+++ b/changelogs/fragments/3400-fix-gitLab-api-searches-always-return-first-found-match-3386.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_group_members - ``get_group_id`` return the group id by matching ``full_path`` or ``name`` (https://github.com/ansible-collections/community.general/pull/3400).

--- a/changelogs/fragments/3400-fix-gitLab-api-searches-always-return-first-found-match-3386.yml
+++ b/changelogs/fragments/3400-fix-gitLab-api-searches-always-return-first-found-match-3386.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_group_members - ``get_group_id`` return the group id by matching ``full_path`` or ``name`` (https://github.com/ansible-collections/community.general/pull/3400).
+  - gitlab_group_members - ``get_group_id`` return the group ID by matching ``full_path``, ``path`` or ``name`` (https://github.com/ansible-collections/community.general/pull/3400).

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -179,9 +179,10 @@ class GitLabGroup(object):
 
     # get group id if group exists
     def get_group_id(self, gitlab_group):
-        group_exists = self._gitlab.groups.list(search=gitlab_group)
-        if group_exists:
-            return group_exists[0].id
+        groups = self._gitlab.groups.list(search=gitlab_group)
+        for group in groups:
+          if group.full_path == gitlab_group or group.name == gitlab_group:
+            return group.id
 
     # get all members in a group
     def get_members_in_a_group(self, gitlab_group_id):

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -181,8 +181,11 @@ class GitLabGroup(object):
     def get_group_id(self, gitlab_group):
         groups = self._gitlab.groups.list(search=gitlab_group)
         for group in groups:
-            if group.full_path == gitlab_group or group.name == gitlab_group:
+            if group.full_path == gitlab_group:
                 return group.id
+        for group in groups:
+            if group.path == gitlab_group or group.name == gitlab_group:
+                return group_id
 
     # get all members in a group
     def get_members_in_a_group(self, gitlab_group_id):

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -181,8 +181,8 @@ class GitLabGroup(object):
     def get_group_id(self, gitlab_group):
         groups = self._gitlab.groups.list(search=gitlab_group)
         for group in groups:
-          if group.full_path == gitlab_group or group.name == gitlab_group:
-            return group.id
+            if group.full_path == gitlab_group or group.name == gitlab_group:
+                return group.id
 
     # get all members in a group
     def get_members_in_a_group(self, gitlab_group_id):

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -185,7 +185,7 @@ class GitLabGroup(object):
                 return group.id
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
-                return group_id
+                return group.id
 
     # get all members in a group
     def get_members_in_a_group(self, gitlab_group_id):


### PR DESCRIPTION
##### SUMMARY

Fixes #3386

`get_group_id` return the group ID by matching `full_path`, `path` or `name`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_group_members

##### ADDITIONAL INFORMATION
Tested with the base of our issue #3386 and our gitlab instance.