### PR TITLE
nmcli: amended the routing-rules4 key values as list

### DIFF
--- a/changelogs/fragments/3395-nmcli-needs-type.yml
+++ b/changelogs/fragments/3395-nmcli-needs-type.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nmcli - modify existing 'routing_rules4' type as 'list' with elements='str' (https://github.com/ansible-collections/community.general/issues/3395)."

--- a/changelogs/fragments/3395-nmcli-needs-type.yml
+++ b/changelogs/fragments/3395-nmcli-needs-type.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - "nmcli - modify existing 'routing_rules4' type as 'list' with elements='str' (https://github.com/ansible-collections/community.general/issues/3395)."

--- a/changelogs/fragments/3401-nmcli-needs-type.yml
+++ b/changelogs/fragments/3401-nmcli-needs-type.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "nmcli - the option ``routing_rules4`` can now specified as a list of strings, instead of as a single string (https://github.com/ansible-collections/community.general/issues/3401)."
+  - "nmcli - the option ``routing_rules4`` can now be specified as a list of strings, instead of as a single string (https://github.com/ansible-collections/community.general/issues/3401)."

--- a/changelogs/fragments/3401-nmcli-needs-type.yml
+++ b/changelogs/fragments/3401-nmcli-needs-type.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+minor_changes:
   - "nmcli - amended 'routing_rules4' type as 'list' with elements 'str' (https://github.com/ansible-collections/community.general/issues/3401)."

--- a/changelogs/fragments/3401-nmcli-needs-type.yml
+++ b/changelogs/fragments/3401-nmcli-needs-type.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "nmcli - amended 'routing_rules4' type as 'list' with elements 'str' (https://github.com/ansible-collections/community.general/issues/3401)."
+  - "nmcli - the option ``routing_rules4`` can now specified as a list of strings, instead of as a single string (https://github.com/ansible-collections/community.general/issues/3401)."

--- a/changelogs/fragments/3401-nmcli-needs-type.yml
+++ b/changelogs/fragments/3401-nmcli-needs-type.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "nmcli - amended 'routing_rules4' type as 'list' with elements 'str' (https://github.com/ansible-collections/community.general/issues/3401)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -101,7 +101,7 @@ options:
         description:
             - Is the same as in an C(ip route add) command, except always requires specifying a priority.
         type: list
-        element: str
+        elements: str
         version_added: 3.3.0
     never_default4:
         description:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -100,7 +100,8 @@ options:
     routing_rules4:
         description:
             - Is the same as in an C(ip route add) command, except always requires specifying a priority.
-        type: str
+        type: list
+        element: str
         version_added: 3.3.0
     never_default4:
         description:
@@ -1603,10 +1604,6 @@ class Nmcli(object):
                     conn_info[key] = [s.strip() for s in raw_value.split(';')]
                 elif key_type == list:
                     conn_info[key] = [s.strip() for s in raw_value.split(',')]
-                elif key_type == 'ipv4.routing-rules':
-                    conn_info[key] = [s.strip() for s in raw_value.split(';')]
-                elif key_type == list:
-                    conn_info[key] = [s.strip() for s in raw_value.split(',')]
                 else:
                     m_enum = p_enum_value.match(raw_value)
                     if m_enum is not None:
@@ -1690,14 +1687,6 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
-                if key == 'ipv4.routing-rules' and current_value is not None:
-                    # ipv4.routing-rules do not have same options and show_connection() format
-                    # options: ['10.11.0.0/24 10.10.0.2', '10.12.0.0/24 10.10.0.2 200']
-                    # show_connection(): ['{ ip = 10.11.0.0/24, nh = 10.10.0.2 }', '{ ip = 10.12.0.0/24, nh = 10.10.0.2, mt = 200 }']
-                    # Need to convert in order to compare both
-                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
-                                     rules) for rules in current_value]
-                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', rules) for rules in current_value]
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()
@@ -1771,7 +1760,7 @@ def main():
             gw4_ignore_auto=dict(type='bool', default=False),
             routes4=dict(type='list', elements='str'),
             route_metric4=dict(type='int'),
-            routing_rules4=dict(type='str'),
+            routing_rules4=dict(type='list', elements='str'),
             never_default4=dict(type='bool', default=False),
             dns4=dict(type='list', elements='str'),
             dns4_search=dict(type='list', elements='str'),

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1470,6 +1470,7 @@ class Nmcli(object):
         elif setting in ('ipv4.dns',
                          'ipv4.dns-search',
                          'ipv4.routes',
+                         'ipv4.routing-rules',
                          'ipv4.route-metric'
                          'ipv6.dns',
                          'ipv6.dns-search',
@@ -1602,6 +1603,10 @@ class Nmcli(object):
                     conn_info[key] = [s.strip() for s in raw_value.split(';')]
                 elif key_type == list:
                     conn_info[key] = [s.strip() for s in raw_value.split(',')]
+                elif key_type == 'ipv4.routing-rules':
+                    conn_info[key] = [s.strip() for s in raw_value.split(';')]
+                elif key_type == list:
+                    conn_info[key] = [s.strip() for s in raw_value.split(',')]
                 else:
                     m_enum = p_enum_value.match(raw_value)
                     if m_enum is not None:
@@ -1685,6 +1690,15 @@ class Nmcli(object):
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
+                if key == 'ipv4.routing-rules' and current_value is not None:
+                    # ipv4.routes do not have same options and show_connection() format
+                    # options: ['10.11.0.0/24 10.10.0.2', '10.12.0.0/24 10.10.0.2 200']
+                    # show_connection(): ['{ ip = 10.11.0.0/24, nh = 10.10.0.2 }', '{ ip = 10.12.0.0/24, nh = 10.10.0.2, mt = 200 }']
+                    # Need to convert in order to compare both
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
+                                     route) for route in current_value]
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
+                
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1697,8 +1697,7 @@ class Nmcli(object):
                     # Need to convert in order to compare both
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
                                      route) for route in current_value]
-                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
-                
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]                
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1691,13 +1691,13 @@ class Nmcli(object):
                                      route) for route in current_value]
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]
                 if key == 'ipv4.routing-rules' and current_value is not None:
-                    # ipv4.routes do not have same options and show_connection() format
+                    # ipv4.routing-rules do not have same options and show_connection() format
                     # options: ['10.11.0.0/24 10.10.0.2', '10.12.0.0/24 10.10.0.2 200']
                     # show_connection(): ['{ ip = 10.11.0.0/24, nh = 10.10.0.2 }', '{ ip = 10.12.0.0/24, nh = 10.10.0.2, mt = 200 }']
                     # Need to convert in order to compare both
                     current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+),\s*mt\s*=\s*([^} ]+)\s*}', r'\1 \2 \3',
-                                     route) for route in current_value]
-                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', route) for route in current_value]                
+                                     rules) for rules in current_value]
+                    current_value = [re.sub(r'^{\s*ip\s*=\s*([^, ]+),\s*nh\s*=\s*([^} ]+)\s*}', r'\1 \2', rules) for rules in current_value]
                 if key == self.mac_setting:
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -122,6 +122,37 @@ ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
 """
 
+TESTCASE_GENERIC_MODIFY_ROUTING_RULES = [
+    {
+        'type': 'generic',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'generic_non_existant',
+        'ip4': '10.10.10.10/24',
+        'gw4': '10.10.10.1',
+        'routing_rules4': ['priority 5 from 10.0.0.0/24 table 5000', 'priority 10 from 10.0.1.0/24 table 5001'],
+        'state': 'present',
+        '_ansible_check_mode': False,
+    },
+]
+
+TESTCASE_GENERIC_MODIFY_ROUTING_RULES_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              generic_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.routing-rules:                     priority 5 from 10.0.0.0/24 table 5000, priority 10 from 10.0.1.0/24 table 5001
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+"""
+
+
 TESTCASE_GENERIC_DNS4_SEARCH = [
     {
         'type': 'generic',
@@ -739,6 +770,13 @@ def mocked_generic_connection_unchanged(mocker):
 
 
 @pytest.fixture
+def mocked_generic_connection_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_GENERIC_MODIFY_ROUTING_RULES_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
 def mocked_generic_connection_dns_search_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
@@ -1024,6 +1062,7 @@ def test_generic_connection_modify(mocked_generic_connection_modify, capfd):
     assert results['changed']
 
 
+
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
 def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd):
     """
@@ -1037,6 +1076,26 @@ def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd
     assert not results.get('failed')
     assert not results['changed']
 
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_MODIFY_ROUTING_RULES, indirect=['patch_ansible_module'])
+def test_generic_connection_modify_routing_rules4(mocked_generic_connection_create, capfd):
+    """
+    Test : Generic connection modified with routing-rules4
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    
+    assert 'ipv4.routing-rules' in args[0]
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_create_dns_search(mocked_generic_connection_create, capfd):

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1060,6 +1060,7 @@ def test_generic_connection_modify(mocked_generic_connection_modify, capfd):
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+    
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
 def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd):
@@ -1073,6 +1074,7 @@ def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
+    
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_MODIFY_ROUTING_RULES, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_routing_rules4(mocked_generic_connection_create, capfd):
@@ -1092,6 +1094,7 @@ def test_generic_connection_modify_routing_rules4(mocked_generic_connection_crea
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+    
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_create_dns_search(mocked_generic_connection_create, capfd):
@@ -1112,6 +1115,7 @@ def test_generic_connection_create_dns_search(mocked_generic_connection_create, 
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+    
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_dns_search(mocked_generic_connection_create, capfd):

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1060,7 +1060,7 @@ def test_generic_connection_modify(mocked_generic_connection_modify, capfd):
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
-    
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
 def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd):
@@ -1074,7 +1074,7 @@ def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
-    
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_MODIFY_ROUTING_RULES, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_routing_rules4(mocked_generic_connection_create, capfd):
@@ -1094,7 +1094,7 @@ def test_generic_connection_modify_routing_rules4(mocked_generic_connection_crea
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
-    
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_create_dns_search(mocked_generic_connection_create, capfd):
@@ -1115,7 +1115,7 @@ def test_generic_connection_create_dns_search(mocked_generic_connection_create, 
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
-    
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_dns_search(mocked_generic_connection_create, capfd):

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1061,8 +1061,6 @@ def test_generic_connection_modify(mocked_generic_connection_modify, capfd):
     assert not results.get('failed')
     assert results['changed']
 
-
-
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC, indirect=['patch_ansible_module'])
 def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd):
     """
@@ -1076,7 +1074,6 @@ def test_generic_connection_unchanged(mocked_generic_connection_unchanged, capfd
     assert not results.get('failed')
     assert not results['changed']
 
-
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_MODIFY_ROUTING_RULES, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_routing_rules4(mocked_generic_connection_create, capfd):
     """
@@ -1089,7 +1086,6 @@ def test_generic_connection_modify_routing_rules4(mocked_generic_connection_crea
     arg_list = nmcli.Nmcli.execute_command.call_args_list
     args, kwargs = arg_list[0]
 
-    
     assert 'ipv4.routing-rules' in args[0]
 
     out, err = capfd.readouterr()
@@ -1116,7 +1112,6 @@ def test_generic_connection_create_dns_search(mocked_generic_connection_create, 
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
-
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GENERIC_DNS4_SEARCH, indirect=['patch_ansible_module'])
 def test_generic_connection_modify_dns_search(mocked_generic_connection_create, capfd):


### PR DESCRIPTION

SUMMARY

Amended the 'routing-rules4'  module argument to accept key values as list. Currently it is accepting only 'str' values. In the event of adding multiple values to be added, 'routing-rules4' key needs to accept values as list.


ISSUE TYPE

- Feature Pull Request


COMPONENT NAME

nmcli

ADDITIONAL INFORMATION

In plugins/modules/net_tools/nmcli.py#L1774 - routing_rules4=dict(type='str') . For adding multiple entries to routing-rules, we need to accept values as list.


BEFORE:
fatal: [192.168.235.157]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": true,
            "conn_name": "ens192",
            "dhcp_client_id": null,
            "dns4": null,
            "dns4_ignore_auto": false,
            "dns4_search": null,
            "dns6": null,
            "dns6_ignore_auto": false,
            "dns6_search": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": 15,
            "gw4": null,
            "gw4_ignore_auto": false,
            "gw6": null,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ifname": "ens192",
            "ignore_unsupported_suboptions": false,
            "ingress": null,
            "ip4": "192.168.235.157",
            "ip6": null,
            "ip_tunnel_dev": null,
            "ip_tunnel_input_key": null,
            "ip_tunnel_local": null,
            "ip_tunnel_output_key": null,
            "ip_tunnel_remote": null,
            "mac": null,
            "master": null,
            "maxage": 20,
            "may_fail4": false,
            "method4": "manual",
            "method6": "disabled",
            "miimon": null,
            "mode": "balance-rr",
            "mtu": null,
            "never_default4": false,
            "path_cost": 100,
            "primary": null,
            "priority": 128,
            "route_metric4": null,
            "routes4": null,
            "routing_rules4": "['priority 32745 from 10.10.10.1/32  lookup 103', 'priority 32746 from 1.1.1.0/24  lookup 103']",
            "runner": "roundrobin",
            "runner_hwaddr_policy": null,
            "slavepriority": 32,
            "ssid": null,
            "state": "present",
            "stp": true,
            "type": "ethernet",
            "updelay": null,
            "vlandev": null,
            "vlanid": null,
            "vxlan_id": null,
            "vxlan_local": null,
            "vxlan_remote": null,
            "wifi": null,
            "wifi_sec": null,
            "zone": null
        }
    },
    "msg": "Error: failed to modify ipv4.routing-rules: unsupported key \"['priority\".\n",
    "name": "ens192",
    "rc": 2
}

AFTER: 
changed: [192.168.235.157] => {
    "Exists": "Connections do exist so we are modifying them",
    "changed": true,
    "conn_name": "ens192",
    "invocation": {
        "module_args": {
            "ageingtime": 300,
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": true,
            "conn_name": "ens192",
            "dhcp_client_id": null,
            "dns4": null,
            "dns4_ignore_auto": false,
            "dns4_search": null,
            "dns6": null,
            "dns6_ignore_auto": false,
            "dns6_search": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": 15,
            "gsm": null,
            "gw4": null,
            "gw4_ignore_auto": false,
            "gw6": null,
            "gw6_ignore_auto": false,
            "hairpin": true,
            "hellotime": 2,
            "ifname": "ens192",
            "ignore_unsupported_suboptions": false,
            "ingress": null,
            "ip4": "4.4.4.4",
            "ip6": null,
            "ip_tunnel_dev": null,
            "ip_tunnel_input_key": null,
            "ip_tunnel_local": null,
            "ip_tunnel_output_key": null,
            "ip_tunnel_remote": null,
            "mac": null,
            "master": null,
            "maxage": 20,
            "may_fail4": false,
            "method4": "manual",
            "method6": "disabled",
            "miimon": null,
            "mode": "balance-rr",
            "mtu": null,
            "never_default4": false,
            "path_cost": 100,
            "primary": null,
            "priority": 128,
            "route_metric4": null,
            "routes4": [
                "0.0.0.0/0 4.4.4.254 104 table=103"
            ],
            "routing_rules4": [
                " priority 32744 from 10.10.10.1/32 lookup 101",
                "priority 32745 from 1.1.1.0/24 lookup 101"
            ],
            "runner": "roundrobin",
            "runner_hwaddr_policy": null,
            "slavepriority": 32,
            "ssid": null,
            "state": "present",
            "stp": true,
            "type": "ethernet",
            "updelay": null,
            "vlandev": null,
            "vlanid": null,
            "vxlan_id": null,
            "vxlan_local": null,
            "vxlan_remote": null,
            "wifi": null,
            "wifi_sec": null,
            "zone": null
        }
    },
    "state": "present"
}

