### PR TITLE
interfaces_file - replaced output_dir with remote_tmp_dir in integration test

### DIFF
--- a/tests/integration/targets/interfaces_file/meta/main.yml
+++ b/tests/integration/targets/interfaces_file/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/interfaces_file/tasks/main.yml
+++ b/tests/integration/targets/interfaces_file/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name:
   set_fact:
-    interfaces_testfile: '{{ output_dir }}/interfaces'
+    interfaces_testfile: '{{ remote_tmp_dir }}/interfaces'
 
 - name: Copy interfaces file
   copy:


### PR DESCRIPTION
##### SUMMARY
Replaced `output_dir` with `remote_tmp_dir`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/interfaces_file/meta/main.yml
tests/integration/targets/interfaces_file/tasks/main.yml
