### PR TITLE
[WIP] osx_defaults: Add dict support

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1052,7 +1052,7 @@ files:
     maintainers: agaffney
   $modules/system/osx_defaults.py:
     notify: chris-short
-    maintainers: $team_macos notok
+    maintainers: $team_macos notok aiotter
     labels: macos osx_defaults
     keywords: brew cask darwin homebrew macosx macports osx
   $modules/system/pam_limits.py:

--- a/plugins/modules/system/osx_defaults.py
+++ b/plugins/modules/system/osx_defaults.py
@@ -266,8 +266,12 @@ class OSXDefaults(object):
                     element.append(key_element)
                     value_element = object_to_element(value)
                     element.append(value_element)
+            elif isinstance(obj, list):
+                element = ElementTree.Element('array')
+                for item in obj:
+                    element.append(object_to_element(item))
             else:
-                raise OSXDefaultsException("Invalid dict value. Value must be one of: bool, datetime, dict, float, int, str")
+                raise OSXDefaultsException("Invalid dict value. Value must be one of: bool, datetime, dict, float, int, list, str")
             return element
         return ElementTree.tostring(object_to_element(value))
 


### PR DESCRIPTION
##### SUMMARY
Add dict support to osx_default.
Fixes #238.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
osx_defaults.py

##### ADDITIONAL INFORMATION
Example usage:
```yaml
- osx_defaults:
    domain: com.apple.finder
    key: FXInfoPanesExpanded
    type: dict
    value: {General: true, OpenWith: true}
    state: present

- osx_defaults:
    domain: com.apple.finder
    key: FXInfoPanesExpanded
    dict_add: MetaData
    type: bool
    value: yes
    state: present
```

CAUTION: This PR contains a bug. To make it fixed, I need some help. For more detail: https://github.com/ansible-collections/community.general/issues/238#issuecomment-924625506