### PR TITLE
Copy the permissions along with file for jboss module

### DIFF
--- a/changelogs/fragments/3426-copy-permissions-along-with-file-for-jboss-module.yml
+++ b/changelogs/fragments/3426-copy-permissions-along-with-file-for-jboss-module.yml
@@ -1,6 +1,6 @@
 bugfixes:
   - jboss - fix the deployment file permission issue when Jboss server is running 
     under non-root user. The deployment file is copied with file content only. The 
-    file permission is set to 440 and belongs to root user. When the
-    JBossI(Wildfly) server is running under non-root user, it is unable to read
-    the deployment file. (https://github.com/ansible-collections/community.general/pull/3426)
+    file permission is set to ``440`` and belongs to root user. When the
+    JBoss ``WildFly`` server is running under non-root user, it is unable to read
+    the deployment file (https://github.com/ansible-collections/community.general/pull/3426).

--- a/changelogs/fragments/3426-copy-permissions-along-with-file-for-jboss-module.yml
+++ b/changelogs/fragments/3426-copy-permissions-along-with-file-for-jboss-module.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - jboss - fix the deployment file permission issue when Jboss server is running 
+    under non-root user. The deployment file is copied with file content only. The 
+    file permission is set to 440 and belongs to root user. When the
+    JBossI(Wildfly) server is running under non-root user, it is unable to read
+    the deployment file. (https://github.com/ansible-collections/community.general/pull/3426)

--- a/plugins/modules/web_infrastructure/jboss.py
+++ b/plugins/modules/web_infrastructure/jboss.py
@@ -142,7 +142,7 @@ def main():
             # Clean up old failed deployment
             os.remove(os.path.join(deploy_path, "%s.failed" % deployment))
 
-        shutil.copyfile(src, os.path.join(deploy_path, deployment))
+        module.preserved_copy(src, os.path.join(deploy_path, deployment))
         while not deployed:
             deployed = is_deployed(deploy_path, deployment)
             if is_failed(deploy_path, deployment):
@@ -153,7 +153,7 @@ def main():
     if state == 'present' and deployed:
         if module.sha1(src) != module.sha1(os.path.join(deploy_path, deployment)):
             os.remove(os.path.join(deploy_path, "%s.deployed" % deployment))
-            shutil.copyfile(src, os.path.join(deploy_path, deployment))
+            module.preserved_copy(src, os.path.join(deploy_path, deployment))
             deployed = False
             while not deployed:
                 deployed = is_deployed(deploy_path, deployment)


### PR DESCRIPTION



##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The deployment file is copied with file content only. The file
permission is set to 440 and belongs to root user. When the
JBossI(Wildfly) server is running under non root account, it can't read
the deployment file.

With is fix, the correct permission can be set from previous task for JBoss
server to pickup the deployment file.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Jboss

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
