### PR TITLE
Enable deprecaded message for ignore_volatile_options

### DIFF
--- a/changelogs/fragments/3429-enable_deprecaded_message_for_ignore_volatile_option.yml
+++ b/changelogs/fragments/3429-enable_deprecaded_message_for_ignore_volatile_option.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "lxd_container - enable deprecated message if ``ignore_volatile_options`` are True. (https://github.com/ansible-collections/community.general/pull/3429)."

--- a/changelogs/fragments/3429-enable_deprecaded_message_for_ignore_volatile_option.yml
+++ b/changelogs/fragments/3429-enable_deprecaded_message_for_ignore_volatile_option.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - "lxd_container - enable deprecated message if ``ignore_volatile_options`` are True. (https://github.com/ansible-collections/community.general/pull/3429)."
+  - "lxd_container - the current default value ``true`` of ``ignore_volatile_options`` is deprecated and will change to ``false`` in community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/3429)."

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -43,10 +43,9 @@ options:
           - If set to C(true), options starting with C(volatile.) are ignored. As a result,
             they are reapplied for each execution.
           - This default behavior can be changed by setting this option to C(false).
-          - The default value C(true) will be deprecated in community.general 4.0.0,
-            and will change to C(false) in community.general 5.0.0.
+          - The default value C(true) will be deprecated in community.general 5.0.0,
+            and will change to C(false) in community.general 6.0.0.
         type: bool
-        default: true
         required: false
         version_added: 3.7.0
     profiles:
@@ -674,7 +673,6 @@ def main():
             ),
             ignore_volatile_options=dict(
                 type='bool',
-                default=True
             ),
             devices=dict(
                 type='dict',
@@ -729,13 +727,15 @@ def main():
         supports_check_mode=False,
     )
 
-    if module.params['ignore_volatile_options'] is True:
+    if module.params['ignore_volatile_options'] is None:
+        module.params['ignore_volatile_options'] = True
         module.deprecate(
             'If the keyword "volatile" is used in a playbook in the config'
             'section, a "changed" message will appear with every run, even without a change'
             'to the playbook.'
             'This will change in the future. Please test your scripts'
-            'by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
+            'by "ignore_volatile_options: false". To keep the old behavior, set that option explicitly to "true"',
+            version='6.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -730,11 +730,12 @@ def main():
     )
 
     if module.params['ignore_volatile_options'] is True:
-        module.deprecate('If the keyword "volatile" is used in a playbook in the config'
-        'section, a "changed" message will appear with every run, even without a change'
-        'to the playbook.'
-        'This will change in the future. Please test your scripts'
-        'by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
+        module.deprecate(
+            'If the keyword "volatile" is used in a playbook in the config'
+            'section, a "changed" message will appear with every run, even without a change'
+            'to the playbook.'
+            'This will change in the future. Please test your scripts'
+            'by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -43,7 +43,7 @@ options:
           - If set to C(true), options starting with C(volatile.) are ignored. As a result,
             they are reapplied for each execution.
           - This default behavior can be changed by setting this option to C(false).
-          - The default value C(true) will be deprecated in community.general 5.0.0,
+          - The current default value C(true) is deprecated since community.general 4.0.0,
             and will change to C(false) in community.general 6.0.0.
         type: bool
         required: false

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -728,13 +728,13 @@ def main():
         ),
         supports_check_mode=False,
     )
-    # if module.params['ignore_volatile_options'] is None:
-    #     module.params['ignore_volatile_options'] = True
-    #     module.deprecate(
-    #         'If the keyword "volatile" is used in a playbook in the config section, a
-    #         "changed" message will appear with every run, even without a change to the playbook.
-    #         This will change in the future.
-    #         Please test your scripts by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
+
+    if module.params['ignore_volatile_options'] is True:
+        module.deprecate('If the keyword "volatile" is used in a playbook in the config'
+        'section, a "changed" message will appear with every run, even without a change'
+        'to the playbook.'
+        'This will change in the future. Please test your scripts'
+        'by "ignore_volatile_options: false"', version='5.0.0', collection_name='community.general')
     lxd_manage = LXDContainerManagement(module=module)
     lxd_manage.run()
 


### PR DESCRIPTION
##### SUMMARY
Enable deprecated message if ignore_volatile_options is set to true.

This patch should not be ported back to previous versions .

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lxd_container
