### PR TITLE
[stable-2] Replace devel with stable-2.12 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,14 +54,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_12
+    displayName: Sanity 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.12/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -108,14 +108,14 @@ stages:
             - test: 3
             - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_12
+    displayName: Units 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.12/units/{0}/1
           targets:
             - test: 2.6
             - test: 2.7
@@ -174,13 +174,13 @@ stages:
             - test: 3.8
 
 ## Remote
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: Remote_2_12
+    displayName: Remote 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.12/{0}
           targets:
             - name: macOS 11.1
               test: macos/11.1
@@ -255,13 +255,13 @@ stages:
             - 2
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_12
+    displayName: Docker 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.12/linux/{0}
           targets:
             - name: CentOS 6
               test: centos6
@@ -342,14 +342,14 @@ stages:
             - 3
 
 ### Cloud
-  - stage: Cloud_devel
-    displayName: Cloud devel
+  - stage: Cloud_2_12
+    displayName: Cloud 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/cloud/{0}/1
+          testFormat: 2.12/cloud/{0}/1
           targets:
             - test: 3.8
   - stage: Cloud_2_11
@@ -386,23 +386,23 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
+      - Sanity_2_12
       - Sanity_2_9
       - Sanity_2_10
       - Sanity_2_11
-      - Units_devel
+      - Units_2_12
       - Units_2_9
       - Units_2_10
       - Units_2_11
-      - Remote_devel
+      - Remote_2_12
       - Remote_2_9
       - Remote_2_10
       - Remote_2_11
-      - Docker_devel
+      - Docker_2_12
       - Docker_2_9
       - Docker_2_10
       - Docker_2_11
-      - Cloud_devel
+      - Cloud_2_12
       - Cloud_2_9
       - Cloud_2_10
       - Cloud_2_11

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11 and ansible-core 2.12 releases. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Replace devel with stable-2.12 in CI for the stable-2 branch. Only stable-3 and devel will keep testing devel for now.

(This is similar to what we did for stable-1 after stable-2.11 was formed, there devel was replaced by stable-2.11.)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
