### PR TITLE
zypper: disable netcat conflict in tests as one package seems to be no longer available

### DIFF
--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -419,35 +419,35 @@
       - zypper_result_update_cache_check is successful
       - zypper_result_update_cache_check is not changed
 
-- name: ensure no previous netcat package still exists
-  zypper:
-    name:
-      - netcat-openbsd
-      - gnu-netcat
-    state: absent
-
-- name: install netcat-openbsd which conflicts with gnu-netcat
-  zypper:
-    name: netcat-openbsd
-    state: present
-
-- name: try installation of gnu-netcat which should fail due to the conflict
-  zypper:
-    name: gnu-netcat
-    state: present
-  ignore_errors: yes
-  register: zypper_pkg_conflict
-
-- assert:
-    that:
-      - zypper_pkg_conflict is failed
-      - "'conflicts with netcat-openbsd provided' in zypper_pkg_conflict.stdout"
-
-- name: retry installation of gnu-netcat with force_resolution set to choose a resolution
-  zypper:
-    name: gnu-netcat
-    state: present
-    force_resolution: True
+# - name: ensure no previous netcat package still exists
+#   zypper:
+#     name:
+#       - netcat-openbsd
+#       - gnu-netcat
+#     state: absent
+#
+# - name: install netcat-openbsd which conflicts with gnu-netcat
+#   zypper:
+#     name: netcat-openbsd
+#     state: present
+#
+# - name: try installation of gnu-netcat which should fail due to the conflict
+#   zypper:
+#     name: gnu-netcat
+#     state: present
+#   ignore_errors: yes
+#   register: zypper_pkg_conflict
+#
+# - assert:
+#     that:
+#       - zypper_pkg_conflict is failed
+#       - "'conflicts with netcat-openbsd provided' in zypper_pkg_conflict.stdout"
+#
+# - name: retry installation of gnu-netcat with force_resolution set to choose a resolution
+#   zypper:
+#     name: gnu-netcat
+#     state: present
+#    force_resolution: True
 
 - name: duplicate rpms block
   vars:


### PR DESCRIPTION
##### SUMMARY
See https://dev.azure.com/ansible/b24bf3ca-6168-45d7-99e2-bf8029e67c87/_apis/build/builds/25605/logs/1797 or https://dev.azure.com/ansible/b24bf3ca-6168-45d7-99e2-bf8029e67c87/_apis/build/builds/25605/logs/1806:

```
2021-09-25T14:43:55.8137737Z 17:44 TASK [zypper : ensure no previous netcat package still exists] *****************
2021-09-25T14:43:56.1423429Z 17:45 [0;32mok: [testhost] => {"changed": false, "name": ["netcat-openbsd", "gnu-netcat"], "rc": 0, "state": "absent", "update_cache": false}[0m
2021-09-25T14:43:56.1465291Z 17:45 
2021-09-25T14:43:56.1466435Z 17:45 TASK [zypper : install netcat-openbsd which conflicts with gnu-netcat] *********
2021-09-25T14:43:58.5788750Z 17:47 [0;33mchanged: [testhost] => {"changed": true, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+netcat-openbsd"], "name": ["netcat-openbsd"], "rc": 0, "state": "present", "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<install-summary download-size=\"122580\" space-usage-diff=\"335443\" packages-to-change=\"2\">\n<to-install>\n<solvable type=\"package\" name=\"libbsd0\" edition=\"0.8.7-3.3.17\" arch=\"x86_64\" repository=\"repo-oss\" summary=\"Provides useful functions commonly found on BSD systems\">\n<description>This library provides useful functions commonly found on BSD systems, and\nlacking on others like GNU systems, thus making it easier to port projects\nwith strong BSD origins, without needing to embed the same code over and\nover again on each project.</description></solvable>\n<solvable type=\"package\" name=\"netcat-openbsd\" edition=\"1.178-1.24\" arch=\"x86_64\" repository=\"repo-oss\" summary=\"TCP/IP swiss army knife\">\n<description>A simple Unix utility which reads and writes data across network\nconnections using TCP or UDP protocol. It is designed to be a reliable\n&quot;back-end&quot; tool that can be used directly or easily driven by other\nprograms and scripts. At the same time it is a feature-rich network\ndebugging and exploration tool, since it can create almost any kind of\nconnection you would need and has several interesting built-in\ncapabilities.\n\nThis package contains the OpenBSD rewrite of netcat, including support\nfor IPv6, proxies, and Unix sockets.</description></solvable>\n</to-install>\n</install-summary>\n<prompt id=\"0\">\n<text>Continue?</text>\n<option default=\"1\" value=\"y\" desc=\"Yes, accept the summary and proceed with installation/removal of packages.\"/>\n<option value=\"n\" desc=\"No, cancel the operation.\"/>\n<option value=\"v\" desc=\"Toggle display of package versions.\"/>\n<option value=\"a\" desc=\"Toggle display of package architectures.\"/>\n<option value=\"r\" desc=\"Toggle display of repositories from which the packages will be installed.\"/>\n<option value=\"m\" desc=\"Toggle display of package vendor names.\"/>\n<option value=\"d\" desc=\"Toggle between showing all details and as few details as possible.\"/>\n<option value=\"g\" desc=\"View the summary in pager.\"/>\n</prompt>\n<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/libbsd0-0.8.7-3.3.17.x86_64.rpm\" percent=\"-1\" rate=\"-1\"/>\n<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/libbsd0-0.8.7-3.3.17.x86_64.rpm\" rate=\"-1\" done=\"1\"/>\n<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/netcat-openbsd-1.178-1.24.x86_64.rpm\" percent=\"-1\" rate=\"-1\"/>\n<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/netcat-openbsd-1.178-1.24.x86_64.rpm\" rate=\"-1\" done=\"1\"/>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<install-summary download-size=\"122580\" space-usage-diff=\"335443\" packages-to-change=\"2\">", "<to-install>", "<solvable type=\"package\" name=\"libbsd0\" edition=\"0.8.7-3.3.17\" arch=\"x86_64\" repository=\"repo-oss\" summary=\"Provides useful functions commonly found on BSD systems\">", "<description>This library provides useful functions commonly found on BSD systems, and", "lacking on others like GNU systems, thus making it easier to port projects", "with strong BSD origins, without needing to embed the same code over and", "over again on each project.</description></solvable>", "<solvable type=\"package\" name=\"netcat-openbsd\" edition=\"1.178-1.24\" arch=\"x86_64\" repository=\"repo-oss\" summary=\"TCP/IP swiss army knife\">", "<description>A simple Unix utility which reads and writes data across network", "connections using TCP or UDP protocol. It is designed to be a reliable", "&quot;back-end&quot; tool that can be used directly or easily driven by other", "programs and scripts. At the same time it is a feature-rich network", "debugging and exploration tool, since it can create almost any kind of", "connection you would need and has several interesting built-in", "capabilities.", "", "This package contains the OpenBSD rewrite of netcat, including support", "for IPv6, proxies, and Unix sockets.</description></solvable>", "</to-install>", "</install-summary>", "<prompt id=\"0\">", "<text>Continue?</text>", "<option default=\"1\" value=\"y\" desc=\"Yes, accept the summary and proceed with installation/removal of packages.\"/>", "<option value=\"n\" desc=\"No, cancel the operation.\"/>", "<option value=\"v\" desc=\"Toggle display of package versions.\"/>", "<option value=\"a\" desc=\"Toggle display of package architectures.\"/>", "<option value=\"r\" desc=\"Toggle display of repositories from which the packages will be installed.\"/>", "<option value=\"m\" desc=\"Toggle display of package vendor names.\"/>", "<option value=\"d\" desc=\"Toggle between showing all details and as few details as possible.\"/>", "<option value=\"g\" desc=\"View the summary in pager.\"/>", "</prompt>", "<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/libbsd0-0.8.7-3.3.17.x86_64.rpm\" percent=\"-1\" rate=\"-1\"/>", "<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/libbsd0-0.8.7-3.3.17.x86_64.rpm\" rate=\"-1\" done=\"1\"/>", "<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/netcat-openbsd-1.178-1.24.x86_64.rpm\" percent=\"-1\" rate=\"-1\"/>", "<download url=\"http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/netcat-openbsd-1.178-1.24.x86_64.rpm\" rate=\"-1\" done=\"1\"/>", "</stream>"], "update_cache": false}[0m
2021-09-25T14:43:58.5866762Z 17:47 
2021-09-25T14:43:58.5867752Z 17:47 TASK [zypper : try installation of gnu-netcat which should fail due to the conflict] ***
2021-09-25T14:44:00.0664532Z 17:49 [0;31mfatal: [testhost]: FAILED! => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+gnu-netcat"], "msg": "No provider of '+gnu-netcat' found.", "rc": 104, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<message type=\"error\">No provider of &apos;+gnu-netcat&apos; found.</message>\n</stream>\n", "stdout_lines": ["<?xml version='1.0'?>", "<stream>", "<message type=\"error\">No provider of &apos;+gnu-netcat&apos; found.</message>", "</stream>"]}[0m
2021-09-25T14:44:00.0666875Z 17:49 [0;36m...ignoring[0m
2021-09-25T14:44:00.0701671Z 17:49 
2021-09-25T14:44:00.0702260Z 17:49 TASK [zypper : assert] *********************************************************
2021-09-25T14:44:00.1650470Z 17:49 [0;31mfatal: [testhost]: FAILED! => {[0m
2021-09-25T14:44:00.1651474Z 17:49 [0;31m    "assertion": "'conflicts with netcat-openbsd provided' in zypper_pkg_conflict.stdout",[0m
2021-09-25T14:44:00.1652351Z 17:49 [0;31m    "changed": false,[0m
2021-09-25T14:44:00.1653054Z 17:49 [0;31m    "evaluated_to": false,[0m
2021-09-25T14:44:00.1653747Z 17:49 [0;31m    "msg": "Assertion failed"[0m
2021-09-25T14:44:00.1654772Z 17:49 [0;31m}[0m
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zypper
