### PR TITLE
Update CI matrix to include ansible-core's stable-2.12 branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -220,7 +220,7 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2.12
+  - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
     jobs:
@@ -320,7 +320,7 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Docker_2.12
+  - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
     jobs:
@@ -406,7 +406,7 @@ stages:
           targets:
             - test: 2.7
             - test: 3.9
-  - stage: Cloud_2.12
+  - stage: Cloud_2_12
     displayName: Cloud 2.12
     dependsOn: []
     jobs:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -180,7 +180,7 @@ stages:
           testFormat: 2.10/units/{0}/1
           targets:
             - test: 2.7
-            - test: 3.8
+            - test: 3.6
   - stage: Units_2_9
     displayName: Units 2.9
     dependsOn: []
@@ -266,8 +266,6 @@ stages:
               test: osx/10.11
             - name: macOS 10.15
               test: macos/10.15
-            - name: FreeBSD 12.1
-              test: freebsd/12.1
           groups:
             - 1
             - 2
@@ -330,8 +328,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 34
               test: fedora34
             - name: openSUSE 15 py3
@@ -356,8 +352,6 @@ stages:
               test: fedora33
             - name: openSUSE 15 py2
               test: opensuse15py2
-            - name: Ubuntu 20.04
-              test: ubuntu2004
           groups:
             - 2
             - 3
@@ -384,8 +378,6 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 31
               test: fedora31
             - name: openSUSE 15 py3

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -445,7 +445,7 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.9/cloud/{0}/1
           targets:
-            - test: 2.6
+            - test: 2.7
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -68,6 +68,19 @@ stages:
             - test: 3
             - test: 4
             - test: extra
+  - stage: Sanity_2_12
+    displayName: Sanity 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Test {0}
+          testFormat: 2.12/sanity/{0}
+          targets:
+            - test: 1
+            - test: 2
+            - test: 3
+            - test: 4
   - stage: Sanity_2_11
     displayName: Sanity 2.11
     dependsOn: []
@@ -125,6 +138,22 @@ stages:
             - test: 3.8
             - test: 3.9
             - test: '3.10'
+  - stage: Units_2_12
+    displayName: Units 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.12/units/{0}/1
+          targets:
+            - test: 2.6
+            - test: 2.7
+            - test: 3.5
+            - test: 3.6
+            - test: 3.7
+            - test: 3.8
+            - test: '3.10'
   - stage: Units_2_11
     displayName: Units 2.11
     dependsOn: []
@@ -150,13 +179,8 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.10/units/{0}/1
           targets:
-            - test: 2.6
             - test: 2.7
-            - test: 3.5
-            - test: 3.6
-            - test: 3.7
             - test: 3.8
-            - test: 3.9
   - stage: Units_2_9
     displayName: Units 2.9
     dependsOn: []
@@ -196,6 +220,23 @@ stages:
             - 1
             - 2
             - 3
+  - stage: Remote_2.12
+    displayName: Remote 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/{0}
+          targets:
+            - name: macOS 11.1
+              test: macos/11.1
+            - name: RHEL 8.4
+              test: rhel/8.4
+            - name: FreeBSD 13.0
+              test: freebsd/13.0
+          groups:
+            - 1
+            - 2
   - stage: Remote_2_11
     displayName: Remote 2.11
     dependsOn: []
@@ -204,8 +245,6 @@ stages:
         parameters:
           testFormat: 2.11/{0}
           targets:
-            - name: macOS 11.1
-              test: macos/11.1
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.3
@@ -227,12 +266,6 @@ stages:
               test: osx/10.11
             - name: macOS 10.15
               test: macos/10.15
-            - name: macOS 11.1
-              test: macos/11.1
-            - name: RHEL 7.8
-              test: rhel/7.8
-            - name: RHEL 8.2
-              test: rhel/8.2
             - name: FreeBSD 12.1
               test: freebsd/12.1
           groups:
@@ -248,6 +281,8 @@ stages:
           targets:
             - name: RHEL 8.2
               test: rhel/8.2
+            - name: RHEL 7.8
+              test: rhel/7.8
             - name: FreeBSD 12.0
               test: freebsd/12.0
           groups:
@@ -285,6 +320,28 @@ stages:
             - 1
             - 2
             - 3
+  - stage: Docker_2.12
+    displayName: Docker 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/linux/{0}
+          targets:
+            - name: CentOS 7
+              test: centos7
+            - name: CentOS 8
+              test: centos8
+            - name: Fedora 34
+              test: fedora34
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+          groups:
+            - 1
+            - 2
+            - 3
   - stage: Docker_2_11
     displayName: Docker 2.11
     dependsOn: []
@@ -297,8 +354,8 @@ stages:
               test: centos8
             - name: Fedora 33
               test: fedora33
-            - name: openSUSE 15 py3
-              test: opensuse15
+            - name: openSUSE 15 py2
+              test: opensuse15py2
             - name: Ubuntu 20.04
               test: ubuntu2004
           groups:
@@ -312,12 +369,8 @@ stages:
         parameters:
           testFormat: 2.10/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
-            - name: openSUSE 15 py3
-              test: opensuse15
             - name: Ubuntu 16.04
               test: ubuntu1604
           groups:
@@ -351,6 +404,17 @@ stages:
           nameFormat: Python {0}
           testFormat: devel/cloud/{0}/1
           targets:
+            - test: 2.7
+            - test: 3.9
+  - stage: Cloud_2.12
+    displayName: Cloud 2.12
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.12/cloud/{0}/1
+          targets:
             - test: 3.8
   - stage: Cloud_2_11
     displayName: Cloud 2.11
@@ -361,7 +425,6 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.11/cloud/{0}/1
           targets:
-            - test: 2.7
             - test: 3.6
   - stage: Cloud_2_10
     displayName: Cloud 2.10
@@ -372,7 +435,7 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.10/cloud/{0}/1
           targets:
-            - test: 3.6
+            - test: 3.5
   - stage: Cloud_2_9
     displayName: Cloud 2.9
     dependsOn: []
@@ -382,7 +445,7 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.9/cloud/{0}/1
           targets:
-            - test: 3.6
+            - test: 2.6
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
@@ -390,21 +453,26 @@ stages:
       - Sanity_2_9
       - Sanity_2_10
       - Sanity_2_11
+      - Sanity_2_12
       - Units_devel
       - Units_2_9
       - Units_2_10
       - Units_2_11
+      - Units_2_12
       - Remote_devel
       - Remote_2_9
       - Remote_2_10
       - Remote_2_11
+      - Remote_2_12
       - Docker_devel
       - Docker_2_9
       - Docker_2_10
       - Docker_2_11
+      - Docker_2_12
       - Cloud_devel
       - Cloud_2_9
       - Cloud_2_10
       - Cloud_2_11
+      - Cloud_2_12
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Update CI matrix to include ansible-core's stable-2.12 branch. Reduces testing for older Ansible versions to avoid increasing CI load (too much).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
