### PR TITLE
chore: add deprecation warning for gitlab group membership

### DIFF
--- a/changelogs/fragments/3451-gitlab-group-member-deprecate-name-and-path.yml
+++ b/changelogs/fragments/3451-gitlab-group-member-deprecate-name-and-path.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - gitlab_group_members - Setting ``gitlab_group`` to ``name`` or ``path`` is deprecated. Use ``full_path`` instead (https://github.com/ansible-collections/community.general/pull/3451).

--- a/changelogs/fragments/3451-gitlab-group-member-deprecate-name-and-path.yml
+++ b/changelogs/fragments/3451-gitlab-group-member-deprecate-name-and-path.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - gitlab_group_members - Setting ``gitlab_group`` to ``name`` or ``path`` is deprecated. Use ``full_path`` instead (https://github.com/ansible-collections/community.general/pull/3451).
+  - gitlab_group_members - setting ``gitlab_group`` to ``name`` or ``path`` is deprecated. Use ``full_path`` instead (https://github.com/ansible-collections/community.general/pull/3451).

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -186,8 +186,9 @@ class GitLabGroup(object):
                 return group.id
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
-                self._module.deprecate(msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.",
-                version="6.0.0", collection_name="community.general")
+                self._module.deprecate(
+                    msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.",
+                    version="6.0.0", collection_name="community.general")
                 return group.id
 
     # get all members in a group

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -185,6 +185,7 @@ class GitLabGroup(object):
                 return group.id
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
+                module.deprecate()
                 return group.id
 
     # get all members in a group

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -186,7 +186,8 @@ class GitLabGroup(object):
                 return group.id
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
-                self._module.deprecate(msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.", version="6.0.0", collection_name="community.general" )
+                self._module.deprecate(msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.",
+                version="6.0.0", collection_name="community.general")
                 return group.id
 
     # get all members in a group

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -27,7 +27,8 @@ options:
         type: str
     gitlab_group:
         description:
-            - The name of the GitLab group the member is added to/removed from.
+            - The C(full_path) of the GitLab group the member is added to/removed from.
+            - Setting this to C(name) or C(path) is deprecated and will be removed in community.general 6.0.0. Use C(full_path) instead.
         required: true
         type: str
     gitlab_user:

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -185,7 +185,7 @@ class GitLabGroup(object):
                 return group.id
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
-                module.deprecate()
+                self._module.deprecate(msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.", version="6.0.0", collection_name="community.general" )
                 return group.id
 
     # get all members in a group

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -187,7 +187,7 @@ class GitLabGroup(object):
         for group in groups:
             if group.path == gitlab_group or group.name == gitlab_group:
                 self._module.deprecate(
-                    msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead.",
+                    msg="Setting 'gitlab_group' to 'name' or 'path' is deprecated. Use 'full_path' instead",
                     version="6.0.0", collection_name="community.general")
                 return group.id
 


### PR DESCRIPTION
##### SUMMARY

Follow up PR on #3400 to deprecate direct usage of `name` and `path` as discussed in https://github.com/ansible-collections/community.general/pull/3400#issuecomment-927293690

Fixes #3386

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

gitlab_group_members

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/community.general/pull/3400#issuecomment-927293690
