### PR TITLE
Split up 'Ansible version' in issue templates into ansible-core version + community.general version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,13 +50,27 @@ body:
 
 - type: textarea
   attributes:
-    label: Ansible Version
+    label: Ansible-core Version
     description: >-
       Paste verbatim output from `ansible --version` between
       tripple backticks.
     value: |
       ```console (paste below)
       $ ansible --version
+
+      ```
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Community.general Version
+    description: >-
+      Paste verbatim output from "ansible-galaxy collection list community.general"
+      between tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible-galaxy collection list community.general
 
       ```
   validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -50,7 +50,7 @@ body:
 
 - type: textarea
   attributes:
-    label: Ansible Version
+    label: Ansible-core Version
     description: >-
       Paste verbatim output from `ansible --version` between
       tripple backticks.
@@ -61,6 +61,20 @@ body:
       ```
   validations:
     required: false
+
+- type: textarea
+  attributes:
+    label: Community.general Version
+    description: >-
+      Paste verbatim output from "ansible-galaxy collection list community.general"
+      between tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible-galaxy collection list community.general
+
+      ```
+  validations:
+    required: true
 
 - type: textarea
   attributes:


### PR DESCRIPTION
##### SUMMARY
Split up 'Ansible version' in issue templates into ansible-core version + community.general version. The ansible-core version which most users provide as "Ansible version" (which is also printed by the instructions provided there) isn't really helpful in most cases.

CC @gundalow @Andersson007 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
issue templates
