### PR TITLE
Enable ansibullbot notifications in issues and PRs

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1,3 +1,4 @@
+notifications: true
 automerge: true
 files:
   plugins/:


### PR DESCRIPTION
##### SUMMARY

The more recent version of Ansibullbot defaults notifications to false.
We need to set it to true so it can notify contributors and maintainers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
botmeta
