### PR TITLE
CI: Stick to community.crypto 1.x.y for ubuntu1604

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -87,9 +87,13 @@ if [ "${script}" != "sanity" ] || [ "${test}" == "sanity/extra" ]; then
 fi
 
 if [ "${script}" != "sanity" ] && [ "${script}" != "units" ]; then
+    CRYPTO_BRANCH=main
+    if [ "${script}" == "linux" ] && [[ "${test}" =~ "ubuntu1604/" ]]; then
+        CRYPTO_BRANCH=stable-1
+    fi
     # To prevent Python dependencies on other collections only install other collections for integration tests
     retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/posix"
-    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
+    retry git clone --depth=1 --branch "${CRYPTO_BRANCH}" --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
     # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
     # retry ansible-galaxy -vvv collection install ansible.posix
     # retry ansible-galaxy -vvv collection install community.crypto


### PR DESCRIPTION
##### SUMMARY
community.crypto 2.0.0 requires a new enough cryptography library, which Ubuntu 16.04 does not have.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
