### PR TITLE
gitlab_user - default admin and external to None and sanitize arguments

### DIFF
--- a/changelogs/fragments/3484-gitlab_user-fix-update.yaml
+++ b/changelogs/fragments/3484-gitlab_user-fix-update.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - gitlab_user - Change defaults for isadmin and external to None, so when these arguments are not specified they do not get used when updating a user. When creating a user the API's default are used.

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -442,6 +442,7 @@ class GitLabUser(object):
     @param arguments User attributes
     '''
     def updateUser(self, user, arguments, uncheckable_args):
+        arguments = sanitize_arguments(arguments)
         changed = False
 
         for arg_key, arg_value in arguments.items():
@@ -451,7 +452,7 @@ class GitLabUser(object):
                 if arg_key == "identities":
                     changed = self.addIdentities(user, av, uncheckable_args['overwrite_identities']['value'])
 
-                elif getattr(user, arg_key) != av:
+                elif av and getattr(user, arg_key) != av:
                     setattr(user, arg_value.get('setter', arg_key), av)
                     changed = True
 
@@ -467,6 +468,7 @@ class GitLabUser(object):
     @param arguments User attributes
     '''
     def createUser(self, arguments):
+        arguments = sanitize_arguments(arguments)
         if self._module.check_mode:
             return True
 
@@ -592,8 +594,8 @@ def main():
         group=dict(type='str'),
         access_level=dict(type='str', default="guest", choices=["developer", "guest", "maintainer", "master", "owner", "reporter"]),
         confirm=dict(type='bool', default=True),
-        isadmin=dict(type='bool', default=False),
-        external=dict(type='bool', default=False),
+        isadmin=dict(type='bool', default=None),
+        external=dict(type='bool', default=None),
         identities=dict(type='list', elements='dict'),
         overwrite_identities=dict(type='bool', default=False),
     ))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When gitlab_username is an admin-account, the task removes the admin privileges as isadmin defaults to false .

See #3483 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_user

