### PR TITLE
[WIP] ssh_config: Add 'forwardagent' option

### DIFF
--- a/plugins/modules/system/ssh_config.py
+++ b/plugins/modules/system/ssh_config.py
@@ -76,6 +76,10 @@ options:
     description:
       - Sets the C(ProxyCommand) option.
     type: str
+  forwardagent:
+    description:
+      - Sets the C(ForwardAgent) option.
+    type: str
   ssh_config_file:
     description:
       - SSH config file.
@@ -201,6 +205,7 @@ class SSHConfig():
             strict_host_key_checking=self.params.get('strict_host_key_checking'),
             user_known_hosts_file=self.params.get('user_known_hosts_file'),
             proxycommand=self.params.get('proxycommand'),
+            forwardagent=self.params.get('forwardagent'),
         )
 
         config_changed = False
@@ -288,6 +293,7 @@ def main():
             identity_file=dict(type='path'),
             port=dict(type='str'),
             proxycommand=dict(type='str', default=None),
+            forwardagent=dict(type='str', default=None),
             remote_user=dict(type='str'),
             ssh_config_file=dict(default=None, type='path'),
             state=dict(type='str', default='present', choices=['present', 'absent']),

--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -219,3 +219,6 @@
       - short_name.hosts_added == ["full"]
       - short_name.hosts_changed == []
       - short_name.hosts_removed == []
+
+- name: Include integration tests for additional options (e.g. proxycommand)
+  include: 'options.yml'

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -3,6 +3,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
+    forwardagent: yes
     state: present
   register: options_add
   check_mode: yes
@@ -30,6 +31,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
+    forwardagent: yes
     state: present
   register: options_add
 
@@ -46,6 +48,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
+    forwardagent: yes
     state: present
   register: options_add_again
 
@@ -66,12 +69,14 @@
   assert:
     that:
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
+      - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
+    forwardagent: no
     state: present
   register: options_update
 
@@ -90,6 +95,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
+    forwardagent: no
     state: present
   register: options_update
 
@@ -111,6 +117,7 @@
   assert:
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
+      - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Delete a host
   community.general.ssh_config:
@@ -151,4 +158,5 @@
   assert:
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
+      - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
 

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -3,7 +3,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
-    forwardagent: yes
+    forwardagent: "yes"
     state: present
   register: options_add
   check_mode: yes
@@ -31,7 +31,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
-    forwardagent: yes
+    forwardagent: "yes"
     state: present
   register: options_add
 
@@ -48,7 +48,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
-    forwardagent: yes
+    forwardagent: "yes"
     state: present
   register: options_add_again
 
@@ -76,7 +76,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
-    forwardagent: no
+    forwardagent: "no"
     state: present
   register: options_update
 
@@ -95,7 +95,7 @@
     ssh_config_file: "{{ ssh_config_test }}"
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
-    forwardagent: no
+    forwardagent: "no"
     state: present
   register: options_update
 

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -159,4 +159,3 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
-

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -1,0 +1,154 @@
+- name: Options - Add in check mode
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    proxycommand: "ssh jumphost.example.com -W %h:%p"
+    state: present
+  register: options_add
+  check_mode: yes
+
+- name: Options - Check if changes are made in check mode
+  assert:
+    that:
+      - options_add.changed
+      - "'options.example.com' in options_add.hosts_added"
+      - options_add.hosts_changed is defined
+      - options_add.hosts_removed is defined
+
+- name: "Options - Get content of {{ ssh_config_test }}"
+  slurp:
+    src: "{{ ssh_config_test }}"
+  register: slurp_ssh_config
+
+- name: "Verify that nothign was added to {{ ssh_config_test }} during change mode"
+  assert:
+    that:
+      - "'options.example.com' not in slurp_ssh_config['content'] | b64decode"
+
+- name: Options - Add a host
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    proxycommand: "ssh jumphost.example.com -W %h:%p"
+    state: present
+  register: options_add
+
+- name: Options - Check if changes are made
+  assert:
+    that:
+      - options_add.changed
+      - "'options.example.com' in options_add.hosts_added"
+      - options_add.hosts_changed is defined
+      - options_add.hosts_removed is defined
+
+- name: Options - Add same host again for idempotency
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    proxycommand: "ssh jumphost.example.com -W %h:%p"
+    state: present
+  register: options_add_again
+
+- name: Options - Check for idempotency
+  assert:
+    that:
+      - not options_add_again.changed
+      - options_add.hosts_changed is defined
+      - options_add.hosts_removed is defined
+      - options_add.hosts_added is defined
+
+- name: "Options - Get content of {{ ssh_config_test }}"
+  slurp:
+    src: "{{ ssh_config_test }}"
+  register: slurp_ssh_config
+
+- name: "Verify that {{ ssh_config_test }} contains added options"
+  assert:
+    that:
+      - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
+
+- name: Options - Update host
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    proxycommand: "ssh new-jumphost.example.com -W %h:%p"
+    state: present
+  register: options_update
+
+- name: Options - Check for update operation
+  assert:
+    that:
+      - options_update.changed
+      - options_update.hosts_changed is defined
+      - "'options.example.com' in options_update.hosts_changed"
+      - options_update.hosts_removed is defined
+      - options_update.hosts_added is defined
+      - options_update.hosts_change_diff is defined
+
+- name: Options - Update host again
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    proxycommand: "ssh new-jumphost.example.com -W %h:%p"
+    state: present
+  register: options_update
+
+- name: Options - Check update operation for idempotency
+  assert:
+    that:
+      - not options_update.changed
+      - options_update.hosts_changed is defined
+      - options_update.hosts_removed is defined
+      - options_update.hosts_added is defined
+      - options_update.hosts_change_diff is defined
+
+- name: "Options - Get content of {{ ssh_config_test }}"
+  slurp:
+    src: "{{ ssh_config_test }}"
+  register: slurp_ssh_config
+
+- name: "Verify that {{ ssh_config_test }} contains changed options"
+  assert:
+    that:
+      - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
+
+- name: Options - Delete a host
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    state: absent
+  register: options_delete
+
+- name: Options - Check if host was removed
+  assert:
+    that:
+      - options_delete.changed
+      - "'options.example.com' in options_delete.hosts_removed"
+      - options_delete.hosts_changed is defined
+      - options_delete.hosts_added is defined
+
+- name: Options - Delete same host again for idempotency
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "options.example.com"
+    state: absent
+  register: options_delete_again
+
+- name: Options - Check delete operation for idempotency
+  assert:
+    that:
+      - not options_delete_again.changed
+      - options_delete_again.hosts_changed is defined
+      - options_delete_again.hosts_removed is defined
+      - options_delete_again.hosts_added is defined
+
+- name: "Options - Get content of {{ ssh_config_test }}"
+  slurp:
+    src: "{{ ssh_config_test }}"
+  register: slurp_ssh_config
+
+- name: "Verify that {{ ssh_config_test }} does not contains deleted options"
+  assert:
+    that:
+      - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
New feature to set `ForwardAgent` option via `ssh_config` module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2473 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ssh_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The Change allows to set `ForwardAgent` Option to either `yes` or `no`.