### PR TITLE
[opentelemetry][callback] enrich stacktrace errors

### DIFF
--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -241,12 +241,7 @@ class OpenTelemetrySource(object):
             res = host_data.result._result
             rc = res.get('rc', 0)
             if host_data.status == 'failed':
-                if res.get('exception') is not None:
-                    message = res['exception'].strip().split('\n')[-1]
-                elif 'msg' in res:
-                    message = res['msg']
-                else:
-                    message = 'failed'
+                message = self.get_error_message(res)
                 status = Status(status_code=StatusCode.ERROR, description=message)
                 # Record an exception with the task message
                 span.record_exception(BaseException(message))
@@ -275,6 +270,16 @@ class OpenTelemetrySource(object):
         else:
             if attributeValue is not None:
                 span.set_attribute(attributeName, attributeValue)
+
+    def get_error_message(self, res):
+        message = ''
+        if res.get('exception') is not None:
+            message = res['exception'].strip().split('\n')[-1]
+        elif 'msg' in res:
+            message = res['msg']
+        else:
+            message = 'failed'
+        return message
 
 
 class CallbackModule(CallbackBase):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -244,7 +244,7 @@ class OpenTelemetrySource(object):
                 message = self.get_error_message(res)
                 status = Status(status_code=StatusCode.ERROR, description=message)
                 # Record an exception with the task message
-                span.record_exception(BaseException(message))
+                span.record_exception(BaseException(self.enrich_error_message(res)))
             elif host_data.status == 'skipped':
                 if 'skip_reason' in res:
                     message = res['skip_reason']
@@ -280,6 +280,12 @@ class OpenTelemetrySource(object):
         else:
             message = 'failed'
         return message
+
+    def enrich_error_message(self, res):
+        message = res.get('msg', 'failed')
+        exception = res.get('exception', None)
+        stderr = res.get('stderr', None)
+        return ('message: "{}"\nexception: "{}"\nstderr: "{}"').format(message, exception, stderr)
 
 
 class CallbackModule(CallbackBase):

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -112,3 +112,45 @@ class TestOpentelemetry(unittest.TestCase):
 
         result = self.opentelemetry.get_error_message(res_data)
         self.assertEqual(result, 'failed')
+
+    def test_enrich_error_message(self):
+        res_data = OrderedDict()
+        res_data['exception'] = 'my-exception'
+        res_data['msg'] = 'my-msg'
+        res_data['stderr'] = 'my-stderr'
+
+        result = self.opentelemetry.enrich_error_message(res_data)
+        self.assertEqual(result, 'message: "my-msg"\nexception: "my-exception"\nstderr: "my-stderr"')
+
+    def test_get_error_message_without_msg(self):
+        res_data = OrderedDict()
+        res_data['exception'] = 'my-exception'
+        res_data['stderr'] = 'my-stderr'
+
+        result = self.opentelemetry.enrich_error_message(res_data)
+        self.assertEqual(result, 'message: "failed"\nexception: "my-exception"\nstderr: "my-stderr"')
+
+    def test_get_error_message_without_msg(self):
+        res_data = OrderedDict()
+        res_data['msg'] = 'my-msg'
+        res_data['stderr'] = 'my-stderr'
+
+        result = self.opentelemetry.enrich_error_message(res_data)
+        self.assertEqual(result, 'message: "my-msg"\nexception: "None"\nstderr: "my-stderr"')
+
+    def test_get_error_message_without_stderr(self):
+        res_data = OrderedDict()
+        res_data['exception'] = 'my-exception'
+        res_data['msg'] = 'my-msg'
+
+        result = self.opentelemetry.enrich_error_message(res_data)
+        self.assertEqual(result, 'message: "my-msg"\nexception: "my-exception"\nstderr: "None"')
+
+    def test_get_error_message_with_multiple_line_stderr(self):
+        res_data = OrderedDict()
+        res_data['exception'] = 'my-exception'
+        res_data['msg'] = 'my-msg'
+        res_data['stderr'] = '\nmake[1]: Entering directory \n.No space left on device'
+
+        result = self.opentelemetry.enrich_error_message(res_data)
+        self.assertEqual(result, 'message: "my-msg"\nexception: "my-exception"\nstderr: "\nmake[1]: Entering directory \n.No space left on device"')

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -91,3 +91,24 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(host_data.uuid, 'include')
         self.assertEqual(host_data.name, 'include')
         self.assertEqual(host_data.status, 'ok')
+
+    def test_get_error_message_with_exception(self):
+        res_data = OrderedDict()
+        res_data['exception'] = 'my-exception'
+        res_data['msg'] = 'my-msg'
+
+        result = self.opentelemetry.get_error_message(res_data)
+        self.assertEqual(result, 'my-exception')
+
+    def test_get_error_message_without_exception(self):
+        res_data = OrderedDict()
+        res_data['msg'] = 'my-msg'
+
+        result = self.opentelemetry.get_error_message(res_data)
+        self.assertEqual(result, 'my-msg')
+
+    def test_get_error_message_without_exception_and_msg(self):
+        res_data = OrderedDict()
+
+        result = self.opentelemetry.get_error_message(res_data)
+        self.assertEqual(result, 'failed')


### PR DESCRIPTION
##### SUMMARY

This proposal enriches the stacktrace information with the below fields from the failed task:
-`stderr`
- `exception`
- `msg`.

In order to help with the troubleshooting.

I refactored just a bit some logic to add more UTs.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`plugins/callback/opentelemetry.py`

##### ADDITIONAL INFORMATION

Given the playbook:

```yaml
---
- name: Echo
  hosts: localhost
  connection: local

  tasks:
  - name: Print debug message
    debug:
      msg: Hello, world!

  - name: install versions of ruby via rbenv
    command: bash -lc 'foo bar'
```

Then the output in Kibana (it could be Jaeger or any other tool) was:

![image](https://user-images.githubusercontent.com/2871786/135718231-02489dd6-c4c0-4e72-a044-5b4fe001c0d4.png)

![image](https://user-images.githubusercontent.com/2871786/135718242-cbaba221-c094-4eb8-a69e-f0b4b8df8b96.png)


And with this proposal is:

![image](https://user-images.githubusercontent.com/2871786/135718316-c61da444-518f-45a1-816a-719b2511fdd4.png)

![image](https://user-images.githubusercontent.com/2871786/135718333-78bdcee8-e1a0-4631-8ddd-af984b943447.png)



