### PR TITLE
[ufw] Insert or delete biased when deletion enabled - as for append or delete.

### DIFF
--- a/plugins/modules/system/ufw.py
+++ b/plugins/modules/system/ufw.py
@@ -511,12 +511,12 @@ def main():
                                  'interface_in and interface_out')
             # Rules are constructed according to the long format
             #
-            # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
+            # ufw [--dry-run] [route] [delete | insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
             #     [from ADDRESS [port PORT]] [to ADDRESS [port PORT]] \
             #     [proto protocol] [app application] [comment COMMENT]
             cmd.append([module.boolean(params['route']), 'route'])
             cmd.append([module.boolean(params['delete']), 'delete'])
-            if params['insert'] is not None:
+            if params['insert'] is not None and not module.boolean(params['delete']):
                 relative_to_cmd = params['insert_relative_to']
                 if relative_to_cmd == 'zero':
                     insert_to = params['insert']

--- a/tests/unit/plugins/modules/system/test_ufw.py
+++ b/tests/unit/plugins/modules/system/test_ufw.py
@@ -54,6 +54,7 @@ dry_mode_cmd_with_port_700 = {
     "ufw status verbose": ufw_status_verbose_with_port_7000,
     "ufw --version": ufw_version_35,
     "ufw --dry-run allow from any to any port 7000 proto tcp": skippg_adding_existing_rules,
+    "ufw --dry-run insert 1 allow from any to any port 7000 proto tcp": skippg_adding_existing_rules,
     "ufw --dry-run delete allow from any to any port 7000 proto tcp": "",
     "ufw --dry-run delete allow from any to any port 7001 proto tcp": user_rules_with_port_7000,
     "ufw --dry-run route allow in on foo out on bar from 1.1.1.1 port 7000 to 8.8.8.8 port 7001 proto tcp": "",
@@ -170,6 +171,17 @@ class TestUFW(unittest.TestCase):
 
     def test_check_mode_add_rules(self):
         set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7000',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertFalse(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_insert_rules(self):
+        set_module_args({
+            'insert': '1',
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7000',
@@ -318,9 +330,35 @@ class TestUFW(unittest.TestCase):
 
         self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
 
+    def test_check_mode_delete_existing_insert_rules(self):
+
+        set_module_args({
+            'insert': '1',
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7000',
+            'delete': 'yes',
+            '_ansible_check_mode': True,
+        })
+
+        self.assertTrue(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+
     def test_check_mode_delete_not_existing_rules(self):
 
         set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7001',
+            'delete': 'yes',
+            '_ansible_check_mode': True,
+        })
+
+        self.assertFalse(self.__getResult(do_nothing_func_port_7000).exception.args[0]['changed'])
+
+    def test_check_mode_delete_not_existing_insert_rules(self):
+
+        set_module_args({
+            'insert': '1',
             'rule': 'allow',
             'proto': 'tcp',
             'port': '7001',


### PR DESCRIPTION
##### SUMMARY
UFW's rule commands `delete` and `insert` are mutually exclusive. Specifying both insert and delete in a `community.general.ufw` task results in a syntax error. It is proposed, if instead a task containing both insert and delete parameters is biased for deletion when deletion is enabled, then the `insert-or-delete` pattern would operate like the `append-or-delete` pattern does currently, rather than failing with a syntax error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
UFW

##### ADDITIONAL INFORMATION
(1) UFW's rule commands `delete` and `insert` are mutually exclusive. (In fact, they are also mutually exclusive with the `prepend` command, but `prepend` is not currently implemented by `community.general.ufw`):
```
# ufw --version
ufw 0.36

# cat /etc/issue
Ubuntu 20.04.3 LTS \n \l

# ufw --dry-run delete insert 1 allow from any to any port 123 proto tcp
ERROR: Invalid syntax

# ufw --dry-run delete prepend allow from any to any port 123 proto tcp
ERROR: Invalid syntax

# ufw --dry-run insert 1 prepend allow from any to any port 123 proto tcp
ERROR: Invalid syntax
```

(2) Specifying both insert and delete in a `community.general.ufw` task results in a syntax error:
```
  - community.general.ufw:
      delete: 'yes'
      insert: '1' 
      rule: 'allow' 
      proto: 'tcp' 
      port: '123' 

/usr/sbin/ufw --dry-run delete insert 1 allow from any to any port 123 proto tcp
ERROR: Invalid syntax
```

(3) Currently, the `append-or-delete` pattern, either (implicitly) appends the rule or deletes the existing rule when deletion is enabled:
```
  - community.general.ufw:
      delete: '{{ "yes" if (condition) else "no" }}'
      rule: 'allow' 
      proto: 'tcp' 
      port: '123' 
```

(4) It is proposed, if instead a task containing both insert and delete parameters is biased for deletion when deletion is enabled, then the `insert-or-delete` pattern would operate like the `append-or-delete` pattern does currently, rather than failing with a syntax error:
```
  - community.general.ufw:
      delete: '{{ "yes" if (condition) else "no" }}'
      insert: '1'
      rule: 'allow' 
      proto: 'tcp' 
      port: '123' 
```

Please let me know if I've missed anything.

Thanks!

Kind regards,
Greg