### PR TITLE
Improve contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Also, consider taking up a valuable, reviewed, but abandoned pull request which 
 * Do not squash your commits and force-push to your branch if not needed. Reviews of your pull request are much easier with individual commits to comprehend the pull request history. All commits of your pull request branch will be squashed into one commit by GitHub upon merge.
 * Do not add merge commits to your PR. The bot will complain and you will have to rebase ([instructions for rebasing](https://docs.ansible.com/ansible/latest/dev_guide/developing_rebasing.html)) to remove them before your PR can be merged. To avoid that git automatically does merges during pulls, you can configure it to do rebases instead by running `git config pull.rebase true` inside the respository checkout.
 * Make sure your PR includes a [changelog fragment](https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to). (You must not include a fragment for new modules or new plugins, except for test and filter plugins. Also you shouldn't include one for docs-only changes. If you're not sure, simply don't include one, we'll tell you whether one is needed or not :) )
-* Avoid reformatting unrelated parts of the codebase in your PR. Such reformatting make reviewing a lot harder, since it adds a lot of noise to the PR.
+* Avoid reformatting unrelated parts of the codebase in your PR. These types of changes will likely be requested for reversion, create additional work for reviewers, and may cause approval to be delayed.
 
 You can also read [our Quick-start development guide](https://github.com/ansible/community-docs/blob/main/create_pr_quick_start_guide.rst).
 


### PR DESCRIPTION
##### SUMMARY
I'm proposing to add two more points to the contributing instructions:
1. Avoid code reformatting of unrelated parts in PRs;
2. Avoid creating PRs with multiple new plugins/modules.

Both are annoying from a reviewer's point of view. The second is already recommended against somehwere in the Ansible docs, but it's not so easy to find (and I've seen too many PRs which still do it, probably most never found that piece of information).

CC @Ajpantuso @Andersson007 @russoz 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CONTRIBUTING.md
