### PR TITLE
Add pre-commit for linting commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,19 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: fix-encoding-pragma
       - id: check-ast
       - id: check-merge-conflict
-      - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+      - id: check-symlinks
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
     hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
-        args:
-          - --max-line-length=160
-          - --ignore=E402,B007
+      - id: rst-backticks
+        types: [file]
+        files: changelogs/fragments/.*\.(yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]
+        args:
+          - --max-line-length=160
+          - --ignore=E402,B007

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,9 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
 
 ## pre-commit
 
-To help ensure high-quality contributions this repository includes a [pre-commit](https://pre-commit.com) configuration which corrects and tests against common issues that would otherwise cause CI to fail. To begin using these pre-commit hooks see the [Installation](#installation) section below.
+To help ensure high-quality contributions this repository includes a [pre-commit](https://pre-commit.com) configuration which
+corrects and tests against common issues that would otherwise cause CI to fail. To begin using these pre-commit hooks see
+the [Installation](#installation) section below.
 
 ### Installation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,3 +79,7 @@ To help ensure high-quality contributions this repository includes a [pre-commit
 ### Installation
 
 Follow the [instructions](https://pre-commit.com/#install) provided with pre-commit and run `pre-commit install` under the repository base. If for any reason you would like to disable the pre-commit hooks run `pre-commit uninstall`.
+
+This is optional to run it locally and the CI will execute it regardless.
+
+You can trigger it locally with `pre-commit run --all-files` or even to run only for a given file `pre-commit run --files YOUR_FILE`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,3 +71,11 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
    listed as `maintainers` will be pinged for new issues and PRs that modify the module/plugin or its tests.
 
    When you add a new plugin/module, we expect that you perform maintainer duty for at least some time after contributing it.
+
+## pre-commit
+
+This particular process will help to evaluate some linting before committing any changes. Therefore you need the pre-commit.
+
+### Installation
+
+Follow <https://pre-commit.com/#install> and `pre-commit install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,6 @@ To help ensure high-quality contributions this repository includes a [pre-commit
 
 Follow the [instructions](https://pre-commit.com/#install) provided with pre-commit and run `pre-commit install` under the repository base. If for any reason you would like to disable the pre-commit hooks run `pre-commit uninstall`.
 
-This is optional to run it locally and the CI will execute it regardless.
+This is optional to run it locally.
 
 You can trigger it locally with `pre-commit run --all-files` or even to run only for a given file `pre-commit run --files YOUR_FILE`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,8 @@ To help ensure high-quality contributions this repository includes a [pre-commit
 corrects and tests against common issues that would otherwise cause CI to fail. To begin using these pre-commit hooks see
 the [Installation](#installation) section below.
 
+This is optional and not required to contribute to this repository.
+
 ### Installation
 
 Follow the [instructions](https://pre-commit.com/#install) provided with pre-commit and run `pre-commit install` under the repository base. If for any reason you would like to disable the pre-commit hooks run `pre-commit uninstall`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,8 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
 
 ## pre-commit
 
-This particular process will help to evaluate some linting before committing any changes. Therefore you need the pre-commit.
+To help ensure high-quality contributions this repository includes a [pre-commit](https://pre-commit.com) configuration which corrects and tests against common issues that would otherwise cause CI to fail. To begin using these pre-commit hooks see the [Installation](#installation) section below.
 
 ### Installation
 
-Follow <https://pre-commit.com/#install> and `pre-commit install`
+Follow the [instructions](https://pre-commit.com/#install) provided with pre-commit and run `pre-commit install` under the repository base. If for any reason you would like to disable the pre-commit hooks run `pre-commit uninstall`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ansible-collections/community.general/main.svg)](https://results.pre-commit.ci/latest/github/ansible-collections/community.general/main)
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ansible-collections/community.general/main.svg)](https://results.pre-commit.ci/latest/github/ansible-collections/community.general/main)
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.
 


### PR DESCRIPTION
##### SUMMARY

I don't know if this is something interesting to be applied to this project, please forgive me if this should be driving in a different form 🙏 

I decided to raise this PR based on my experience when contributing to the ansible collections, If some linting could be done and defined at the project level then I won't need to checkout the `ansible` repository in order to install the needed tools to validate if my contributions were healthy enough.

I didn't use the `ansible` tool chain much at the beginning, so I ended up by interacting with the CI builds to fix the existing linting errors, in addition to some other errors.

I assume this is something to be discussed broadly and maybe somewhere else, I only wanted to explain my motivation to use the pre-commit approach.

Then, what's this PR about?

Enable [pre-commit](https://pre-commit.com/) to help with the local development by running some linting before committing any changes.

This can be by-passed if using  `-n` or `--no-verify` when committing the changes, for instance: `git commit -n -m ....`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION

```bash
$ git commit -m "chore: add new feature xyz"
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/vmartinez/.cache/pre-commit/patch1634237006-32145.
Check python ast.....................................(no files to check)Skipped
Check for merge conflicts................................................Passed
Trim Trailing Whitespace.................................................Passed
flake8...............................................(no files to check)Skipped
[INFO] Restored changes from /Users/vmartinez/.cache/pre-commit/patch1634237006-32145.
[feature/pre-commit-proposal a36a54c3] Add pre-commit for linting commits
```

or even running the `pre-commit` for a specific file:

```bash
$ pre-commit run --files  plugins/callback/opentelemetry.py
Check python ast.........................................................Passed
Check for merge conflicts................................................Passed
Trim Trailing Whitespace.................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

plugins/callback/opentelemetry.py:92:5: F401 'opentelemetry.sdk.trace.export.ConsoleSpanExporter' imported but unused
plugins/callback/opentelemetry.py:92:5: F401 'opentelemetry.sdk.trace.export.SimpleSpanProcessor' imported but unused
plugins/callback/opentelemetry.py:157:9: E722 do not use bare 'except'
plugins/callback/opentelemetry.py:157:9: B001 Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.  Prefer `except Exception:`.  If you're sure what you're doing, be explicit and write `except BaseException:`.
```

Do you want to enable this in the Azure pipelines? If so, https://pre-commit.com/#azure-pipelines-example might help :)