### PR TITLE
Fixed typo in homebrew documentation

### DIFF
--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -132,10 +132,10 @@ EXAMPLES = '''
     name: homebrew/cask/foo
     state: present
 
-- name: Use ignored-pinned option while upgrading all
+- name: Use ignore-pinned option while upgrading all
   community.general.homebrew:
     upgrade_all: yes
-    upgrade_options: ignored-pinned
+    upgrade_options: ignore-pinned
 '''
 
 RETURN = '''


### PR DESCRIPTION
Fixed typo in community.general.homebrew documentation
