### PR TITLE
gitlab_project: Add `initialize_with_readme` option

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -50,7 +50,8 @@ options:
     type: str
   initialize_with_readme:
     description:
-      - Will initialize the project with a default README.md.
+      - Will initialize the project with a default C(README.md).
+      - Is only used when the project is created, and ignored otherwise.
     type: bool
     default: no
     version_added: "4.0.0"

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -53,7 +53,7 @@ options:
       - Will initialize the project with a default C(README.md).
       - Is only used when the project is created, and ignored otherwise.
     type: bool
-    default: no
+    default: false
     version_added: "4.0.0"
   issues_enabled:
     description:

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -256,7 +256,6 @@ class GitLabProject(object):
         project_options = {
             'name': project_name,
             'description': options['description'],
-            'initialize_with_readme': options['initialize_with_readme'],
             'issues_enabled': options['issues_enabled'],
             'merge_requests_enabled': options['merge_requests_enabled'],
             'merge_method': options['merge_method'],
@@ -278,6 +277,7 @@ class GitLabProject(object):
             project_options.update({
                 'path': options['path'],
                 'import_url': options['import_url'],
+                'initialize_with_readme': options['initialize_with_readme'],
             })
             project_options = self.getOptionsWithValue(project_options)
             project = self.createProject(namespace, project_options)

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -277,8 +277,9 @@ class GitLabProject(object):
             project_options.update({
                 'path': options['path'],
                 'import_url': options['import_url'],
-                'initialize_with_readme': options['initialize_with_readme'],
             })
+            if options['initialize_with_readme']:
+                project_options['initialize_with_readme'] = options['initialize_with_readme']
             project_options = self.getOptionsWithValue(project_options)
             project = self.createProject(namespace, project_options)
             changed = True

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -48,6 +48,12 @@ options:
     description:
       - An description for the project.
     type: str
+  initialize_with_readme:
+    description:
+      - Will initialize the project with a default README.md.
+    type: bool
+    default: no
+    version_added: "4.0.0"
   issues_enabled:
     description:
       - Whether you want to create issues or not.
@@ -187,6 +193,7 @@ EXAMPLES = r'''
     wiki_enabled: True
     snippets_enabled: True
     import_url: http://git.example.com/example/lab.git
+    initialize_with_readme: True
     state: present
   delegate_to: localhost
 '''
@@ -248,6 +255,7 @@ class GitLabProject(object):
         project_options = {
             'name': project_name,
             'description': options['description'],
+            'initialize_with_readme': options['initialize_with_readme'],
             'issues_enabled': options['issues_enabled'],
             'merge_requests_enabled': options['merge_requests_enabled'],
             'merge_method': options['merge_method'],
@@ -359,6 +367,7 @@ def main():
         name=dict(type='str', required=True),
         path=dict(type='str'),
         description=dict(type='str'),
+        initialize_with_readme=dict(type='bool', default=False),
         issues_enabled=dict(type='bool', default=True),
         merge_requests_enabled=dict(type='bool', default=True),
         merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
@@ -399,6 +408,7 @@ def main():
     project_name = module.params['name']
     project_path = module.params['path']
     project_description = module.params['description']
+    initialize_with_readme = module.params['initialize_with_readme']
     issues_enabled = module.params['issues_enabled']
     merge_requests_enabled = module.params['merge_requests_enabled']
     merge_method = module.params['merge_method']
@@ -467,6 +477,7 @@ def main():
         if gitlab_project.createOrUpdateProject(project_name, namespace, {
                                                 "path": project_path,
                                                 "description": project_description,
+                                                "initialize_with_readme": initialize_with_readme,
                                                 "issues_enabled": issues_enabled,
                                                 "merge_requests_enabled": merge_requests_enabled,
                                                 "merge_method": merge_method,

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -194,7 +194,7 @@ EXAMPLES = r'''
     wiki_enabled: True
     snippets_enabled: True
     import_url: http://git.example.com/example/lab.git
-    initialize_with_readme: True
+    initialize_with_readme: true
     state: present
   delegate_to: localhost
 '''

--- a/tests/integration/targets/gitlab_project/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project/tasks/main.yml
@@ -22,9 +22,9 @@
     validate_certs: False
     login_token: "{{ gitlab_login_token }}"
     name: "{{ gitlab_project_name }}"
+    initialize_with_readme: True
     state: present
   register: gitlab_project_state
-
 
 - assert:
     that:
@@ -38,7 +38,6 @@
     name: "{{ gitlab_project_name }}"
     state: present
   register: gitlab_project_state_again
-
 
 - assert:
     that:

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
@@ -71,16 +71,10 @@ class TestGitlabProject(GitlabModuleTestCase):
     @with_httmock(resp_create_project)
     def test_create_project(self):
         group = self.gitlab_instance.groups.get(1)
-        project = self.moduleUtil.createProject(
-            group,
-            {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id, "initialize_with_readme": True}
-        )
+        project = self.moduleUtil.createProject(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id})
 
         self.assertEqual(type(project), Project)
         self.assertEqual(project.name, "Diaspora Client")
-        self.assertEqual(project.path, "diaspora-client")
-        self.assertEqual(project.namespace_id, group.id)
-        self.assertTrue(project.initialize_with_readme)
 
     @with_httmock(resp_get_project)
     def test_update_project(self):

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
@@ -71,7 +71,10 @@ class TestGitlabProject(GitlabModuleTestCase):
     @with_httmock(resp_create_project)
     def test_create_project(self):
         group = self.gitlab_instance.groups.get(1)
-        project = self.moduleUtil.createProject(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id, "initialize_with_readme": True})
+        project = self.moduleUtil.createProject(
+            group,
+            {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id, "initialize_with_readme": True}
+        )
 
         self.assertEqual(type(project), Project)
         self.assertEqual(project.name, "Diaspora Client")

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
@@ -71,10 +71,13 @@ class TestGitlabProject(GitlabModuleTestCase):
     @with_httmock(resp_create_project)
     def test_create_project(self):
         group = self.gitlab_instance.groups.get(1)
-        project = self.moduleUtil.createProject(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id})
+        project = self.moduleUtil.createProject(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id, "initialize_with_readme": True})
 
         self.assertEqual(type(project), Project)
         self.assertEqual(project.name, "Diaspora Client")
+        self.assertEqual(project.path, "diaspora-client")
+        self.assertEqual(project.namespace_id, group.id)
+        self.assertTrue(project.initialize_with_readme)
 
     @with_httmock(resp_get_project)
     def test_update_project(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `initialize_with_readme` option to `gitlab_project` module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_project

##### ADDITIONAL INFORMATION
This option is available via the API and is helpful when creating projects without having to programmatically initialize it to be able to push up to the repo.
