### PR TITLE
feat(zypper): refreshing repository cache without requiring name

### DIFF
--- a/changelogs/fragments/3605-update-cache-w-o-name.yaml
+++ b/changelogs/fragments/3605-update-cache-w-o-name.yaml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - zypper module - allow ``update_cache`` without package ``name``s (https://github.com/ansible-collections/community.general/pull/3605).
+  - zypper - allow ``update_cache`` without package ``name`` to install
+    (https://github.com/ansible-collections/community.general/pull/3605).

--- a/changelogs/fragments/3605-update-cache-w-o-name.yaml
+++ b/changelogs/fragments/3605-update-cache-w-o-name.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zypper module - allow ``update_cache`` without package ``name``s (https://github.com/ansible-collections/community.general/pull/3605).

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -520,7 +520,7 @@ def main():
             allow_vendor_change=dict(required=False, default=False, type='bool'),
             replacefiles=dict(required=False, default=False, type='bool')
         ),
-        required_one_of=[['pkg', 'update_cache']],
+        required_one_of=[['name', 'update_cache']],
         supports_check_mode=True
     )
 

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -38,7 +38,6 @@ options:
           update the package within the version range given.
         - You can also pass a url or a local path to a rpm file.
         - When using state=latest, this can be '*', which updates all installed packages.
-        required: false
         aliases: [ 'pkg' ]
         type: list
         default: []
@@ -539,11 +538,12 @@ def main():
     name = list(filter(None, name))
 
     # Refresh repositories
-    if update_cache and not module.check_mode:
-        retvals = repo_refresh(module)
+    if update_cache:
+        if not module.check_mode:
+            retvals = repo_refresh(module)
 
-        if retvals['rc'] != 0:
-            module.fail_json(msg="Zypper refresh run failed.", **retvals)
+            if retvals['rc'] != 0:
+                module.fail_json(msg="Zypper refresh run failed.", **retvals)
 
         # If there is nothing else to do, set changed=True
         #  to show the cache was updated and exit

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -313,7 +313,7 @@ def run_zypper(m, cmd):
         'rc': rc,
         'stdout': stdout,
         'stderr': stderr,
-        }
+    }
 
     return dom, retvals
 
@@ -328,7 +328,7 @@ def zypper_ref_results(dom):
 
     return {
         'changed': len(done) > 0,
-        }
+    }
 
 
 def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -310,12 +310,13 @@ def run_zypper(m, cmd):
                     rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
 
     retvals = {
-            'rc': rc,
-            'stdout': stdout,
-            'stderr': stderr,
-            }
+        'rc': rc,
+        'stdout': stdout,
+        'stderr': stderr,
+        }
 
     return dom, retvals
+
 
 def zypper_ref_results(dom):
     "reads dom returned from zypper ref and determines if any repositories were refreshed"
@@ -326,8 +327,9 @@ def zypper_ref_results(dom):
     done = [tag for tag in raw_refresh if tag.hasAttribute('done')]
 
     return {
-            'changed': len(done) > 0,
-            }
+        'changed': len(done) > 0,
+        }
+
 
 def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
     rc, stdout, stderr = m.run_command(cmd, check_rc=False)

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -38,9 +38,10 @@ options:
           update the package within the version range given.
         - You can also pass a url or a local path to a rpm file.
         - When using state=latest, this can be '*', which updates all installed packages.
-        required: true
+        required: false
         aliases: [ 'pkg' ]
         type: list
+        default: []
         elements: str
     state:
         description:
@@ -194,6 +195,10 @@ EXAMPLES = '''
     name: 'nmap'
     state: latest
     replacefiles: true
+
+- name: Refresh repositories without installing/updating any packages
+  community.general.zypper:
+    update_cache: yes
 
 - name: Refresh repositories and update package openssl
   community.general.zypper:

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -298,7 +298,7 @@ def get_installed_state(m, packages):
 
 def run_zypper(m, cmd):
     "run zypper command, parse xml results and return dom and some command metadata"
-    if not set(cmd) | {'-x', '--xmlout'}:
+    if ('-x' not in cmd) or ('--xmlout' not in cmd):
         cmd += '--xmlout'
 
     rc, stdout, stderr = m.run_command(cmd, check_rc=False)

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -396,6 +396,16 @@
       - zypperin1 is changed
       - zypperin2 is not changed
 
+# check for https://github.com/ansible-collections/community.general/issues/3570
+- name: run updatecache without any packages
+  zypper:
+    update_cache: True
+  register: zypper_result_update_cache_only
+
+- assert:
+    that:
+      - zypper_result_update_cache_only is successful
+
 # check for https://github.com/ansible/ansible/issues/20139
 - name: run updatecache
   zypper:

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -397,10 +397,27 @@
       - zypperin2 is not changed
 
 # check for https://github.com/ansible-collections/community.general/issues/3570
+- name: clear repository cache
+  command:
+    cmd: zypper clean -a
+
 - name: update_cache=yes without any packages
   zypper:
     update_cache: True
-  register: zypper_result_update_cache_yes
+  register: zypper_result_update_cache_changed
+
+- name: update_cache=yes again should be unchanged
+  zypper:
+    update_cache: True
+  register: zypper_result_update_cache_unchanged
+
+- assert:
+    that:
+      - zypper_result_update_cache_changed is successful
+      - zypper_result_update_cache_changed is changed
+
+      - zypper_result_update_cache_unchanged is successful
+      - zypper_result_update_cache_changed is not changed
 
 - name: update_cache=no without any packages
   zypper:
@@ -409,8 +426,6 @@
 
 - assert:
     that:
-      - zypper_result_update_cache_yes is successful
-
       - zypper_result_update_cache_no is successful
       - zypper_result_update_cache_no is not changed
 

--- a/tests/integration/targets/zypper/tasks/zypper.yml
+++ b/tests/integration/targets/zypper/tasks/zypper.yml
@@ -397,14 +397,22 @@
       - zypperin2 is not changed
 
 # check for https://github.com/ansible-collections/community.general/issues/3570
-- name: run updatecache without any packages
+- name: update_cache=yes without any packages
   zypper:
     update_cache: True
-  register: zypper_result_update_cache_only
+  register: zypper_result_update_cache_yes
+
+- name: update_cache=no without any packages
+  zypper:
+    update_cache: False
+  register: zypper_result_update_cache_no
 
 - assert:
     that:
-      - zypper_result_update_cache_only is successful
+      - zypper_result_update_cache_yes is successful
+
+      - zypper_result_update_cache_no is successful
+      - zypper_result_update_cache_no is not changed
 
 # check for https://github.com/ansible/ansible/issues/20139
 - name: run updatecache


### PR DESCRIPTION
##### SUMMARY
Allows refreshing repository cache without forcing the user to specify a package `name` to install. This behaviour is in line with other package modules such as `yum` or `apt`.

In the spirit of tring to keep my first PR in this project small, I'm avoiding refactoring the module to make it easier to detect if the cache has actually been updated during the run. For now this code path will always return `changed=True`. I hope to become more familiar with the testing process, the documentation changes required and `zypper` itself so I can confidently contribute the update-awareness changes at a later date.

Fixes #3570 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/packaging/os/zypper.py

##### ADDITIONAL INFORMATION
* The `name` field is no longer strictly required, it will be `[]` by default
* Instead, either `name` or  `update_cache` are required
* After the cache has been updated, we check if a `name` has been provided and if not, exit with `changed=True`

**Before:**
```bash
$ ansible all -i inventory.yml -b -m zypper -a update_cache=true
hostname | FAILED! => {
    "changed": false,
    "msg": "missing required arguments: name"
}
```

**After:**
```bash
$ ansible -i inventory.yml -b -m zypper -a update_cache=yes all
hostname | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "cmd": [
        "/usr/bin/zypper",
        "--quiet",
        "--non-interactive",
        "--xmlout",
        "refresh"
    ],
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "<?xml version='1.0'?>\n<stream>\n</stream>\n",
    "stdout_lines": [
        "<?xml version='1.0'?>",
        "<stream>",
        "</stream>"
    ]
}
```