### PR TITLE
Bugfix keycloak client do not report changes when there is none

### DIFF
--- a/changelogs/fragments/3609-fix-keycloak-client-diff-bugs-when-sorting.yml
+++ b/changelogs/fragments/3609-fix-keycloak-client-diff-bugs-when-sorting.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - keycloak_client - Update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers``.
-minor_changes:
-  - keycloak_client - Introduce tests and and README to test the module via docker.

--- a/changelogs/fragments/3609-fix-keycloak-client-diff-bugs-when-sorting.yml
+++ b/changelogs/fragments/3609-fix-keycloak-client-diff-bugs-when-sorting.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - keycloak_client - Update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers``.
+minor_changes:
+  - keycloak_client - Introduce tests and and README to test the module via docker.

--- a/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
+++ b/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - keycloak_client - Update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers`` (https://github.com/ansible-collections/community.general/pull/3610).
+minor_changes:
+  - keycloak_client - Introduce tests and and README to test the module via docker (https://github.com/ansible-collections/community.general/pull/3610).

--- a/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
+++ b/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
@@ -1,4 +1,2 @@
 bugfixes:
   - keycloak_client - update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers`` (https://github.com/ansible-collections/community.general/pull/3610).
-minor_changes:
-  - keycloak_client - Introduce tests and and README to test the module via docker (https://github.com/ansible-collections/community.general/pull/3610).

--- a/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
+++ b/changelogs/fragments/3610-fix-keycloak-client-diff-bugs-when-sorting.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - keycloak_client - Update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers`` (https://github.com/ansible-collections/community.general/pull/3610).
+  - keycloak_client - update the check mode to not show differences resulting from sorting and default values relating to the properties, ``redirectUris``, ``attributes``, and ``protocol_mappers`` (https://github.com/ansible-collections/community.general/pull/3610).
 minor_changes:
   - keycloak_client - Introduce tests and and README to test the module via docker (https://github.com/ansible-collections/community.general/pull/3610).

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -692,6 +692,9 @@ def normalise_cr(clientrep):
     :param clientrep: the clientrep dict to be sanitized
     :return: normalised clientrep dict
     """
+    if 'attributes' in clientrep:
+        clientrep['attributes'] = list(sorted(clientrep['attributes']))
+
     if 'redirectUris' in clientrep:
         clientrep['redirectUris'] = list(sorted(clientrep['redirectUris']))
 

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -701,7 +701,7 @@ def normalise_cr(clientrep, remove_ids=False):
         clientrep['redirectUris'] = list(sorted(clientrep['redirectUris']))
 
     if 'protocolMappers' in clientrep:
-        clientrep['protocolMappers'] = sorted(clientrep['protocolMappers'], key=lambda x: (x.get('name'),  x.get('protocol'), x.get('protocolMapper')))
+        clientrep['protocolMappers'] = sorted(clientrep['protocolMappers'], key=lambda x: (x.get('name'), x.get('protocol'), x.get('protocolMapper')))
         for mapper in clientrep['protocolMappers']:
             if remove_ids:
                 mapper.pop('id', None)
@@ -893,7 +893,7 @@ def main():
             if module.check_mode:
                 # We can only compare the current client with the proposed updates we have
                 before_norm = normalise_cr(before_client.copy(), remove_ids=True)
-                desired_norm =  normalise_cr(desired_client.copy(), remove_ids=True)
+                desired_norm = normalise_cr(desired_client.copy(), remove_ids=True)
                 if module._diff:
                     result['diff'] = dict(before=sanitize_cr(before_norm),
                                           after=sanitize_cr(desired_norm))

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -895,8 +895,8 @@ def main():
 
             if module.check_mode:
                 # We can only compare the current client with the proposed updates we have
-                before_norm = normalise_cr(before_client.copy(), remove_ids=True)
-                desired_norm = normalise_cr(desired_client.copy(), remove_ids=True)
+                before_norm = normalise_cr(before_client, remove_ids=True)
+                desired_norm = normalise_cr(desired_client, remove_ids=True)
                 if module._diff:
                     result['diff'] = dict(before=sanitize_cr(before_norm),
                                           after=sanitize_cr(desired_norm))

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -694,6 +694,9 @@ def normalise_cr(clientrep, remove_ids=False):
                        not alert when the ID's of objects are not usually known, (e.g. for protocol_mappers)
     :return: normalised clientrep dict
     """
+    # Avoid the dict passed in to be modified
+    clientrep = clientrep.copy()
+
     if 'attributes' in clientrep:
         clientrep['attributes'] = list(sorted(clientrep['attributes']))
 

--- a/tests/integration/targets/keycloak_client/README.md
+++ b/tests/integration/targets/keycloak_client/README.md
@@ -7,5 +7,5 @@ docker-compose -f tests/integration/targets/keycloak_client/docker-compose.yml r
 docker-compose -f tests/integration/targets/keycloak_client/docker-compose.yml up -d
 
 # 2. Run the integration tests:
-ansible-test integration keycloak_role --allow-unsupported -v
+ansible-test integration keycloak_client --allow-unsupported -v
 ```

--- a/tests/integration/targets/keycloak_client/README.md
+++ b/tests/integration/targets/keycloak_client/README.md
@@ -1,0 +1,11 @@
+The integration test can be performed as follows:
+
+```
+# 1. Start docker-compose:
+docker-compose -f tests/integration/targets/keycloak_client/docker-compose.yml stop
+docker-compose -f tests/integration/targets/keycloak_client/docker-compose.yml rm -f -v
+docker-compose -f tests/integration/targets/keycloak_client/docker-compose.yml up -d
+
+# 2. Run the integration tests:
+ansible-test integration keycloak_role --allow-unsupported -v
+```

--- a/tests/integration/targets/keycloak_client/docker-compose.yml
+++ b/tests/integration/targets/keycloak_client/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.4'
+
+services:
+  postgres:
+    image: postgres:9.6
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+
+  keycloak:
+    image: jboss/keycloak:12.0.4
+    ports:
+      - 8080:8080
+
+    environment:
+      DB_VENDOR: postgres
+      DB_ADDR: postgres
+      DB_DATABASE: postgres
+      DB_USER: postgres
+      DB_SCHEMA: public
+      DB_PASSWORD: postgres
+
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: password

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Delete realm
+  community.general.keycloak_realm: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      id: "{{ realm }}"
+      realm: "{{ realm }}"
+      state: absent
+
+- name: Create realm
+  community.general.keycloak_realm: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      id: "{{ realm }}"
+      realm: "{{ realm }}"
+      state: present
+
+- name: Desire client
+  community.general.keycloak_client: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      realm: "{{ realm }}"
+      client_id: "{{ client_id }}"
+      state: present
+  register: desire_client_not_present
+
+- name: Desire client again with same props
+  community.general.keycloak_client: "{{ auth_args | combine(call_args) }}"
+  vars:
+    call_args:
+      realm: "{{ realm }}"
+      client_id: "{{ client_id }}"
+      state: present
+  register: desire_client_when_present_and_same
+
+- name: Check client again with same props
+  community.general.keycloak_client: "{{ auth_args | combine(call_args) }}"
+  check_mode: yes
+  vars:
+    call_args:
+      realm: "{{ realm }}"
+      client_id: "{{ client_id }}"
+      state: present
+  register: check_client_when_present_and_same
+
+- name: Assert changes not detected in last two tasks (desire when same, and check)
+  assert:
+    that:
+      - desire_client_when_present_and_same is not changed
+      - check_client_when_present_and_same is not changed

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -23,6 +23,7 @@
       client_id: "{{ client_id }}"
       state: present
       redirect_uris: '{{redirect_uris1}}'
+      attributes: '{{client_attributes1}}'
   register: desire_client_not_present
 
 - name: Desire client again with same props
@@ -33,6 +34,7 @@
       client_id: "{{ client_id }}"
       state: present
       redirect_uris: '{{redirect_uris1}}'
+      attributes: '{{client_attributes1}}'
   register: desire_client_when_present_and_same
 
 - name: Check client again with same props
@@ -44,6 +46,7 @@
       client_id: "{{ client_id }}"
       state: present
       redirect_uris: '{{redirect_uris1}}'
+      attributes: '{{client_attributes1}}'
   register: check_client_when_present_and_same
 
 - name: Assert changes not detected in last two tasks (desire when same, and check)

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -24,6 +24,7 @@
       state: present
       redirect_uris: '{{redirect_uris1}}'
       attributes: '{{client_attributes1}}'
+      protocol_mappers: '{{protocol_mappers1}}'
   register: desire_client_not_present
 
 - name: Desire client again with same props
@@ -35,6 +36,7 @@
       state: present
       redirect_uris: '{{redirect_uris1}}'
       attributes: '{{client_attributes1}}'
+      protocol_mappers: '{{protocol_mappers1}}'
   register: desire_client_when_present_and_same
 
 - name: Check client again with same props
@@ -47,6 +49,7 @@
       state: present
       redirect_uris: '{{redirect_uris1}}'
       attributes: '{{client_attributes1}}'
+      protocol_mappers: '{{protocol_mappers1}}'
   register: check_client_when_present_and_same
 
 - name: Assert changes not detected in last two tasks (desire when same, and check)

--- a/tests/integration/targets/keycloak_client/tasks/main.yml
+++ b/tests/integration/targets/keycloak_client/tasks/main.yml
@@ -22,6 +22,7 @@
       realm: "{{ realm }}"
       client_id: "{{ client_id }}"
       state: present
+      redirect_uris: '{{redirect_uris1}}'
   register: desire_client_not_present
 
 - name: Desire client again with same props
@@ -31,6 +32,7 @@
       realm: "{{ realm }}"
       client_id: "{{ client_id }}"
       state: present
+      redirect_uris: '{{redirect_uris1}}'
   register: desire_client_when_present_and_same
 
 - name: Check client again with same props
@@ -41,6 +43,7 @@
       realm: "{{ realm }}"
       client_id: "{{ client_id }}"
       state: present
+      redirect_uris: '{{redirect_uris1}}'
   register: check_client_when_present_and_same
 
 - name: Assert changes not detected in last two tasks (desire when same, and check)

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -19,3 +19,5 @@ redirect_uris1:
   - "http://example.c.com/"
   - "http://example.b.com/"
   - "http://example.a.com/"
+
+client_attributes1: {"backchannel.logout.session.required": true, "backchannel.logout.revoke.offline.tokens": false}

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -14,3 +14,8 @@ auth_args:
   auth_realm: "{{ admin_realm }}"
   auth_username: "{{ admin_user }}"
   auth_password: "{{ admin_password }}"
+
+redirect_uris1:
+  - "http://example.c.com/"
+  - "http://example.b.com/"
+  - "http://example.a.com/"

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -1,0 +1,16 @@
+---
+url: http://localhost:8080/auth
+admin_realm: master
+admin_user: admin
+admin_password: password
+realm: myrealm
+client_id: myclient
+role: myrole
+description_1: desc 1
+description_2: desc 2
+
+auth_args:
+  auth_keycloak_url: "{{ url }}"
+  auth_realm: "{{ admin_realm }}"
+  auth_username: "{{ admin_user }}"
+  auth_password: "{{ admin_password }}"

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -21,3 +21,37 @@ redirect_uris1:
   - "http://example.a.com/"
 
 client_attributes1: {"backchannel.logout.session.required": true, "backchannel.logout.revoke.offline.tokens": false}
+
+protocol_mappers1:
+        - name: 'email'
+          protocol: 'openid-connect'
+          protocolMapper: 'oidc-usermodel-property-mapper'
+          config:
+            "claim.name": "email"
+            "user.attribute": "email"
+            "jsonType.label": "String"
+            "id.token.claim": "true"
+            "access.token.claim": "true"
+            "userinfo.token.claim": "true"
+
+        - name: 'email_verified'
+          protocol: 'openid-connect'
+          protocolMapper: 'oidc-usermodel-property-mapper'
+          config:
+            "claim.name": "email_verified"
+            "user.attribute": "emailVerified"
+            "jsonType.label": "boolean"
+            "id.token.claim": "true"
+            "access.token.claim": "true"
+            "userinfo.token.claim": "true"
+
+        - name: 'family_name'
+          protocol: 'openid-connect'
+          protocolMapper: 'oidc-usermodel-property-mapper'
+          config:
+            "claim.name": "family_name"
+            "user.attribute": "lastName"
+            "jsonType.label": "String"
+            "id.token.claim": "true"
+            "access.token.claim": "true"
+            "userinfo.token.claim": "true"

--- a/tests/integration/targets/keycloak_client/vars/main.yml
+++ b/tests/integration/targets/keycloak_client/vars/main.yml
@@ -23,35 +23,35 @@ redirect_uris1:
 client_attributes1: {"backchannel.logout.session.required": true, "backchannel.logout.revoke.offline.tokens": false}
 
 protocol_mappers1:
-        - name: 'email'
-          protocol: 'openid-connect'
-          protocolMapper: 'oidc-usermodel-property-mapper'
-          config:
-            "claim.name": "email"
-            "user.attribute": "email"
-            "jsonType.label": "String"
-            "id.token.claim": "true"
-            "access.token.claim": "true"
-            "userinfo.token.claim": "true"
+  - name: 'email'
+    protocol: 'openid-connect'
+    protocolMapper: 'oidc-usermodel-property-mapper'
+    config:
+      "claim.name": "email"
+      "user.attribute": "email"
+      "jsonType.label": "String"
+      "id.token.claim": "true"
+      "access.token.claim": "true"
+      "userinfo.token.claim": "true"
 
-        - name: 'email_verified'
-          protocol: 'openid-connect'
-          protocolMapper: 'oidc-usermodel-property-mapper'
-          config:
-            "claim.name": "email_verified"
-            "user.attribute": "emailVerified"
-            "jsonType.label": "boolean"
-            "id.token.claim": "true"
-            "access.token.claim": "true"
-            "userinfo.token.claim": "true"
+  - name: 'email_verified'
+    protocol: 'openid-connect'
+    protocolMapper: 'oidc-usermodel-property-mapper'
+    config:
+      "claim.name": "email_verified"
+      "user.attribute": "emailVerified"
+      "jsonType.label": "boolean"
+      "id.token.claim": "true"
+      "access.token.claim": "true"
+      "userinfo.token.claim": "true"
 
-        - name: 'family_name'
-          protocol: 'openid-connect'
-          protocolMapper: 'oidc-usermodel-property-mapper'
-          config:
-            "claim.name": "family_name"
-            "user.attribute": "lastName"
-            "jsonType.label": "String"
-            "id.token.claim": "true"
-            "access.token.claim": "true"
-            "userinfo.token.claim": "true"
+  - name: 'family_name'
+    protocol: 'openid-connect'
+    protocolMapper: 'oidc-usermodel-property-mapper'
+    config:
+      "claim.name": "family_name"
+      "user.attribute": "lastName"
+      "jsonType.label": "String"
+      "id.token.claim": "true"
+      "access.token.claim": "true"
+      "userinfo.token.claim": "true"


### PR DESCRIPTION
##### SUMMARY
Fixes #3609.

* Updates the module, `keycloak_client` so that `--check` does not report differences that are the result of sorting, default values, and unique internal id's, (e.g. of each `protocol_mappers`)
* Adds a readme and description of how to perform testing using docker.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
See the git history for the steps to reproduce (I used test-driven fixing):
* The first commit introduces a test that does not fail, (because it doesn't have any of the attributes that cause a difference.
* Subsequent commits update the test so that a failure is demonstrated resulting from sorting issues.
* Subsequent commits change the code to fix it.

