### PR TITLE
nmcli - fixing idempotency bug for 'dummy' connections and 'mtu' option

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1373,6 +1373,7 @@ class Nmcli(object):
                     convert_func = to_text
                 elif setting == self.mtu_setting:
                     # MTU is 'auto' by default when detecting changes.
+                    # The above does not hold for 'dummy' connections when MTU is undefined.
                     convert_func = self.mtu_to_string
             elif setting_type is list:
                 # Convert lists to strings for nmcli create/modify commands.
@@ -1420,12 +1421,12 @@ class Nmcli(object):
     def mtu_setting(self):
         return '802-3-ethernet.mtu'
 
-    @staticmethod
-    def mtu_to_string(mtu):
+    def mtu_to_string(self, mtu):
+        if self.type == 'dummy' and mtu is None:
+            return ''
         if not mtu:
             return 'auto'
-        else:
-            return to_text(mtu)
+        return to_text(mtu)
 
     @property
     def slave_conn_type(self):


### PR DESCRIPTION
##### SUMMARY
Dummy connections do not default `802-3-ethernet.mtu` to `auto` if no value is explicitly provided. This is in contrast to other connection types which requires an additional check.

Fixes #3612 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py

##### ADDITIONAL INFORMATION
- Tested against the `ethernet` connection type to confirm that null `mtu` __does__ result in `auto` being set in that case and this is specific to `dummy` connections