### PR TITLE
fix dummy interface bug

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1367,16 +1367,15 @@ class Nmcli(object):
             if setting_type is bool:
                 # Convert all bool options to yes/no.
                 convert_func = self.bool_to_string
-            if detect_change:
-                if setting in ('vlan.id', 'vxlan.id'):
-                    # Convert VLAN/VXLAN IDs to text when detecting changes.
-                    convert_func = to_text
-                elif setting == self.mtu_setting:
-                    # MTU is 'auto' by default when detecting changes.
-                    convert_func = self.mtu_to_string
+            if detect_change and setting in ('vlan.id', 'vxlan.id'):
+                # Convert VLAN/VXLAN IDs to text when detecting changes.
+                convert_func = to_text
             elif setting_type is list:
                 # Convert lists to strings for nmcli create/modify commands.
                 convert_func = self.list_to_string
+            if setting == self.mtu_setting:
+                # MTU is 'auto' by default
+                convert_func = self.mtu_to_string
 
             if callable(convert_func):
                 options[setting] = convert_func(options[setting])


### PR DESCRIPTION
##### SUMMARY
connection_options work differently when detecting changes for 802-3-ethernet.mtu parameter. It causes problems with applying mtu setting.
Fixes #3612

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py

##### ADDITIONAL INFORMATION
I guess it's better not to devide two scenarious(detect_change true and false) in terms of 802-3-ethernet.mtu and apply auto mtu by default. This change causes setting 802-3-ethernet.mtu to "auto" when mtu parameter not specified for dummy,ethernet,team-slave types, but it looks like right decision in this case. Correct me if i'm wrong.
