### PR TITLE
fix gitlab_deploy_key task in check mode

### DIFF
--- a/changelogs/fragments/3622-fix-gitlab-deploy-key-check-mode.yml
+++ b/changelogs/fragments/3622-fix-gitlab-deploy-key-check-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_deploy_key - fix the SSH Deploy Key being deleted accidentally while running task in check mode (https://github.com/ansible-collections/community.general/issues/3621, https://github.com/ansible-collections/community.general/pull/3622).

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -149,7 +149,8 @@ class GitLabDeployKey(object):
         #   GitLab REST API, so for that case we need to delete and
         #   than recreate the key
         if self.deployKeyObject and self.deployKeyObject.key != key_key:
-            self.deployKeyObject.delete()
+            if not self._module.check_mode:
+                self.deployKeyObject.delete()
             self.deployKeyObject = None
 
         # Because we have already call existsDeployKey in main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Running check mode used to accidentally delete the existing ssh key.
This PR fixes it by making sure not to delete an existing key even if it doesn't match
the new value.

Fixes #3621

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_deploy_key

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #3621

Output before and after is still the same:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

TASK [myrole : Add the deploy key to Gitlab repo] **************************************************************************************************************************************
changed: [myhost.example.com -> localhost]
```

The difference is, module doesn't issue the Delete Key operation which fixes the problem.