### PR TITLE
provide more fitting description for runner timeout

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -92,7 +92,7 @@ options:
     type: str
   maximum_timeout:
     description:
-      - The maximum time that a runner has to run a specific job.
+      - The maximum time that a runner has to complete a specific job.
     required: False
     default: 3600
     type: int

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -92,7 +92,7 @@ options:
     type: str
   maximum_timeout:
     description:
-      - The maximum timeout that a runner has to pick up a specific job.
+      - The maximum time that a runner has to run a specific job.
     required: False
     default: 3600
     type: int


### PR DESCRIPTION
##### SUMMARY
Fixes #3623 and provides a more fitting description for the `maximum_timeout` parameter of the `community.general.gitlab_runner` module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
gitlab_runner.py

##### ADDITIONAL INFORMATION
I'm happy to change the wording and simply provided a first possible improvement to discuss further.