### PR TITLE
Fix dummy interface returning changed

### DIFF
--- a/changelogs/fragments/3625-nmcli_false_changed_mtu_fix.yml
+++ b/changelogs/fragments/3625-nmcli_false_changed_mtu_fix.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - nmcli - fixed falsely reported changed status when ``mtu`` is omitted with ``dummy`` connections
-    (https://github.com/ansible-collections/community.general/issues/3612, https://github.com/ansible-collections/community.general/pull/3625)
+    (https://github.com/ansible-collections/community.general/issues/3612, https://github.com/ansible-collections/community.general/pull/3625).

--- a/changelogs/fragments/3625-nmcli_false_changed_mtu_fix.yml
+++ b/changelogs/fragments/3625-nmcli_false_changed_mtu_fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - nmcli - fixed falsely reported changed status when ``mtu`` is omitted with ``dummy`` connections
+    (https://github.com/ansible-collections/community.general/issues/3612, https://github.com/ansible-collections/community.general/pull/3625)

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1695,7 +1695,7 @@ class Nmcli(object):
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
                     current_value = current_value.strip('"')
-            elif key == self.mtu_setting and self.mtu == None:
+            elif key == self.mtu_setting and self.mtu is None:
                 # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
                 continue
             else:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1705,7 +1705,7 @@ class Nmcli(object):
                 # compare values between two lists
                 if sorted(current_value) != sorted(value):
                     changed = True
-            elif all([key == self.mtu_setting, self.type == 'dummy', current_value is None, value =='auto', self.mtu is None]):
+            elif all([key == self.mtu_setting, self.type == 'dummy', current_value is None, value == 'auto', self.mtu is None]):
                 value = None
             else:
                 if current_value != to_text(value):

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1695,6 +1695,8 @@ class Nmcli(object):
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
                     current_value = current_value.strip('"')
+                if key == self.mtu_setting and self.mtu is None:
+                    self.mtu = 0
             elif key == self.mtu_setting:
                 # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
                 current_value = 'auto'

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1367,15 +1367,16 @@ class Nmcli(object):
             if setting_type is bool:
                 # Convert all bool options to yes/no.
                 convert_func = self.bool_to_string
-            if detect_change and setting in ('vlan.id', 'vxlan.id'):
-                # Convert VLAN/VXLAN IDs to text when detecting changes.
-                convert_func = to_text
+            if detect_change:
+                if setting in ('vlan.id', 'vxlan.id'):
+                    # Convert VLAN/VXLAN IDs to text when detecting changes.
+                    convert_func = to_text
+                elif setting == self.mtu_setting:
+                    # MTU is 'auto' by default when detecting changes.
+                    convert_func = self.mtu_to_string
             elif setting_type is list:
                 # Convert lists to strings for nmcli create/modify commands.
                 convert_func = self.list_to_string
-            if setting == self.mtu_setting:
-                # MTU is 'auto' by default
-                convert_func = self.mtu_to_string
 
             if callable(convert_func):
                 options[setting] = convert_func(options[setting])
@@ -1694,6 +1695,9 @@ class Nmcli(object):
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
                     current_value = current_value.strip('"')
+            elif key == self.mtu_setting and value == 'auto':
+                # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
+                continue
             else:
                 # parameter does not exist
                 current_value = None

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1367,16 +1367,15 @@ class Nmcli(object):
             if setting_type is bool:
                 # Convert all bool options to yes/no.
                 convert_func = self.bool_to_string
-            if detect_change:
-                if setting in ('vlan.id', 'vxlan.id'):
-                    # Convert VLAN/VXLAN IDs to text when detecting changes.
-                    convert_func = to_text
-                elif setting == self.mtu_setting:
-                    # MTU is 'auto' by default when detecting changes.
-                    convert_func = self.mtu_to_string
+            if detect_change and setting in ('vlan.id', 'vxlan.id'):
+                # Convert VLAN/VXLAN IDs to text when detecting changes.
+                convert_func = to_text
             elif setting_type is list:
                 # Convert lists to strings for nmcli create/modify commands.
                 convert_func = self.list_to_string
+            if setting == self.mtu_setting:
+                # MTU is 'auto' by default
+                convert_func = self.mtu_to_string
 
             if callable(convert_func):
                 options[setting] = convert_func(options[setting])

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1697,9 +1697,6 @@ class Nmcli(object):
                     current_value = current_value.strip('"')
                 if key == self.mtu_setting and self.mtu is None:
                     self.mtu = 0
-            elif key == self.mtu_setting:
-                # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
-                current_value = 'auto'
             else:
                 # parameter does not exist
                 current_value = None
@@ -1709,7 +1706,7 @@ class Nmcli(object):
                 if sorted(current_value) != sorted(value):
                     changed = True
             elif all([key == self.mtu_setting, self.type == 'dummy', current_value is None, value =='auto', self.mtu is None]):
-                 value = None
+                value = None
             else:
                 if current_value != to_text(value):
                     changed = True

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1708,6 +1708,8 @@ class Nmcli(object):
                 # compare values between two lists
                 if sorted(current_value) != sorted(value):
                     changed = True
+            elif all([key == self.mtu_setting, self.type == 'dummy', current_value is None, value =='auto', self.mtu is None]):
+                 value = None
             else:
                 if current_value != to_text(value):
                     changed = True

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1695,9 +1695,9 @@ class Nmcli(object):
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
                     current_value = current_value.strip('"')
-            elif key == self.mtu_setting and self.mtu is None:
+            elif key == self.mtu_setting:
                 # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
-                continue
+                current_value = 'auto'
             else:
                 # parameter does not exist
                 current_value = None

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1695,7 +1695,7 @@ class Nmcli(object):
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
                     current_value = current_value.strip('"')
-            elif key == self.mtu_setting and value == 'auto':
+            elif key == self.mtu_setting and self.mtu == None:
                 # if self.mtu_setting parameter doesn't exist, NetworkManager behave like it's set to 'auto'
                 continue
             else:

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -675,6 +675,45 @@ ipv6.method:                            manual
 ipv6.addresses:                         2001:db8::1/128
 """
 
+TESTCASE_DUMMY_STATIC_WITHOUT_MTU_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              dummy_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dns:                               1.1.1.1,8.8.8.8
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+ipv6.method:                            manual
+ipv6.addresses:                         2001:db8::1/128
+"""
+
+TESTCASE_DUMMY_STATIC_WITH_CUSTOM_MTU_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              dummy_non_existant
+connection.autoconnect:                 yes
+802-3-ethernet.mtu:                     1500
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.dns:                               1.1.1.1,8.8.8.8
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+ipv6.method:                            manual
+ipv6.addresses:                         2001:db8::1/128
+"""
+
 
 TESTCASE_GSM = [
     {
@@ -954,6 +993,21 @@ def mocked_dummy_connection_static_unchanged(mocker):
                connection_exists=True,
                execute_return=(0, TESTCASE_DUMMY_STATIC_SHOW_OUTPUT, ""))
 
+@pytest.fixture
+def mocked_dummy_connection_static_without_mtu_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_DUMMY_STATIC_WITHOUT_MTU_SHOW_OUTPUT, ""))
+
+@pytest.fixture
+def mocked_dummy_connection_static_with_custom_mtu_modify(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_DUMMY_STATIC_WITH_CUSTOM_MTU_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
 
 @pytest.fixture
 def mocked_gsm_connection_unchanged(mocker):
@@ -2281,6 +2335,49 @@ def test_dummy_connection_static_unchanged(mocked_dummy_connection_static_unchan
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_DUMMY_STATIC, indirect=['patch_ansible_module'])
+def test_dummy_connection_static_without_mtu_unchanged(mocked_dummy_connection_static_without_mtu_unchanged, capfd):
+    """
+    Test : Dummy connection with static IP configuration and no mtu set unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_DUMMY_STATIC, indirect=['patch_ansible_module'])
+def test_dummy_connection_static_with_custom_mtu_modify(mocked_dummy_connection_static_with_custom_mtu_modify, capfd):
+    """
+    Test : Dummy connection with static IP configuration and no mtu set modify
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+    
+    assert nmcli.Nmcli.execute_command.call_count == 2
+    
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[1]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'modify'
+    assert args[0][3] == 'non_existent_nw_device'
+
+    args_text = list(map(to_text, args[0]))
+    for param in ['802-3-ethernet.mtu', '0']:
+        assert param in args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GSM, indirect=['patch_ansible_module'])

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -993,11 +993,13 @@ def mocked_dummy_connection_static_unchanged(mocker):
                connection_exists=True,
                execute_return=(0, TESTCASE_DUMMY_STATIC_SHOW_OUTPUT, ""))
 
+
 @pytest.fixture
 def mocked_dummy_connection_static_without_mtu_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_DUMMY_STATIC_WITHOUT_MTU_SHOW_OUTPUT, ""))
+
 
 @pytest.fixture
 def mocked_dummy_connection_static_with_custom_mtu_modify(mocker):
@@ -1008,6 +1010,7 @@ def mocked_dummy_connection_static_with_custom_mtu_modify(mocker):
                    (0, TESTCASE_DUMMY_STATIC_WITH_CUSTOM_MTU_SHOW_OUTPUT, ""),
                    (0, "", ""),
                ))
+
 
 @pytest.fixture
 def mocked_gsm_connection_unchanged(mocker):
@@ -2358,9 +2361,9 @@ def test_dummy_connection_static_with_custom_mtu_modify(mocked_dummy_connection_
     """
     with pytest.raises(SystemExit):
         nmcli.main()
-    
+
     assert nmcli.Nmcli.execute_command.call_count == 2
-    
+
     arg_list = nmcli.Nmcli.execute_command.call_args_list
     args, kwargs = arg_list[1]
 
@@ -2377,7 +2380,6 @@ def test_dummy_connection_static_with_custom_mtu_modify(mocked_dummy_connection_
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
-
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_GSM, indirect=['patch_ansible_module'])


### PR DESCRIPTION
##### SUMMARY
connection_options work differently when detecting changes for 802-3-ethernet.mtu parameter. It causes problems with applying mtu setting.
Fixes #3612

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py

##### ADDITIONAL INFORMATION
After little small discussion(#3615) i came out with this change. Basically it shouldn't break previous behavior, but also should fix #3612.
This how it should work: When we try to run playbook with type "dummy" and no mtu parameter setted ansible won't do any changes and also will display no diff, but after you set(any way possible) mtu to some value except 0, next time you gonna run playbook without mtu it will change it to "auto" and will also show diff.
