### PR TITLE
opennebula: fix error message when renaming an image

### DIFF
--- a/changelogs/fragments/3626-fix-one_image-error.yml
+++ b/changelogs/fragments/3626-fix-one_image-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - one_image - fix error message when renaming an image (https://github.com/ansible-collections/community.general/pull/3626).

--- a/plugins/modules/cloud/opennebula/one_image.py
+++ b/plugins/modules/cloud/opennebula/one_image.py
@@ -306,7 +306,7 @@ def rename_image(module, client, image, new_name):
 
     tmp_image = get_image_by_name(module, client, new_name)
     if tmp_image:
-        module.fail_json(msg="Name '" + new_name + "' is already taken by IMAGE with id=" + str(tmp_image.id))
+        module.fail_json(msg="Name '" + new_name + "' is already taken by IMAGE with id=" + str(tmp_image.ID))
 
     if not module.check_mode:
         client.image.rename(image.ID, new_name)


### PR DESCRIPTION
##### SUMMARY

While porting this module to make use of `pyone` I have overlooked one attribute.  Luckily the error only occurs while handling the error condition of trying to rename an image to a name that has already been taken.

Instead of telling the user which image ID already uses that name, the module failed with the following error (along with a huge backtrace):

```
AttributeError: 'IMAGESub' object has no attribute 'id'
```

With this PR the error message is much more obvous again, for example:

```
fatal: [localhost]: FAILED! => changed=false 
  msg: Name 'cloudimg-rocky-8-but-more-awesome' is already taken by IMAGE with id=9357
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
one_image

##### ADDITIONAL INFORMATION

Our team noticed this `by accident` while doing some automated base image creation using the OpenNebula modules.

<details>
  <summary><strong>Example playbook used to reproduce this issue</strong> (click to expand)</summary>

```yaml
---
- hosts: localhost
  connection: local
  gather_facts: no
  module_defaults:
    community.general.one_image:
      api_url: 'https://opennebula.example.com:8633/RPC2'
      api_username: 'oneadmin'
      api_password: 'hackme'

  tasks:
  - name: Ensure our testing images do not exist
    community.general.one_image:
      name: '{{ item }}'
      state: absent
    loop:
      - "cloudimg-rocky-8-but-awesome"
      - "cloudimg-rocky-8-but-more-awesome"
  - meta: end_play

  - name: Clone image
    community.general.one_image:
      name:     "cloudimg-rocky-8"
      new_name: "cloudimg-rocky-8-but-awesome"
      state: cloned
    register: first_image

  - name: Clone image again with a different name
    community.general.one_image:
      name:     "cloudimg-rocky-8"
      new_name: "cloudimg-rocky-8-but-more-awesome"
      state: cloned

  - name: Try to rename the first clone to the name of the second clone (should fail!)
    community.general.one_image:
      id: "{{ first_image.id }}"
      new_name: "cloudimg-rocky-8-but-more-awesome"
      state: renamed
```  

</details>


<details>
  <summary><strong>ansible-playbook output before the fix</strong> (click to expand)</summary>

```
% ANSIBLE_COLLECTIONS_PATHS=~/src/forks/collections ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook ./2021-10-28.one_image_copy_id.yml -v  
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the
implicit localhost does not match 'all'

PLAY [localhost] *************************************************************************

TASK [Ensure our testing images do not exist] ********************************************
ok: [localhost] => (item=cloudimg-rocky-8-but-awesome) => changed=false 
  ansible_loop_var: item
  item: cloudimg-rocky-8-but-awesome
ok: [localhost] => (item=cloudimg-rocky-8-but-more-awesome) => changed=false 
  ansible_loop_var: item
  item: cloudimg-rocky-8-but-more-awesome

TASK [Clone image] ***********************************************************************
changed: [localhost] => changed=true 
  group_id: 0
  group_name: oneadmin
  id: 9354
  name: cloudimg-rocky-8-but-awesome
  running_vms: 0
  state: READY
  used: false
  user_id: 0
  user_name: oneadmin

TASK [Clone image again with a different name] *******************************************
changed: [localhost] => changed=true 
  group_id: 0
  group_name: oneadmin
  id: 9355
  name: cloudimg-rocky-8-but-more-awesome
  running_vms: 0
  state: READY
  used: false
  user_id: 0
  user_name: oneadmin

TASK [Try to rename the first clone to the name of the second clone (should fail!)] ******
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'IMAGESub' object has no attribute 'id'
fatal: [localhost]: FAILED! => changed=false 
  module_stderr: |-
    Traceback (most recent call last):
      File "/home/foxy/.ansible/tmp/ansible-tmp-1635412597.1285481-4647-263250269150364/AnsiballZ_one_image.py", line 102, in <module>
        _ansiballz_main()
      File "/home/foxy/.ansible/tmp/ansible-tmp-1635412597.1285481-4647-263250269150364/AnsiballZ_one_image.py", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/foxy/.ansible/tmp/ansible-tmp-1635412597.1285481-4647-263250269150364/AnsiballZ_one_image.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.one_image', init_globals=None, run_name='__main__', alter_sys=True)
      File "/usr/lib64/python3.8/runpy.py", line 207, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib64/python3.8/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_community.general.one_image_payload_8tgogrb8/ansible_community.general.one_image_payload.zip/ansible_collections/community/general/plugins/modules/one_image.py", line 423, in <module>
      File "/tmp/ansible_community.general.one_image_payload_8tgogrb8/ansible_community.general.one_image_payload.zip/ansible_collections/community/general/plugins/modules/one_image.py", line 414, in main
      File "/tmp/ansible_community.general.one_image_payload_8tgogrb8/ansible_community.general.one_image_payload.zip/ansible_collections/community/general/plugins/modules/one_image.py", line 309, in rename_image
    AttributeError: 'IMAGESub' object has no attribute 'id'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1

PLAY RECAP *******************************************************************************
localhost                  : ok=3    changed=3    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
</details>


<details>
  <summary><strong>ansible-playbook output after the fix</strong> (click to expand)</summary>

```
% ANSIBLE_COLLECTIONS_PATHS=~/src/forks/collections ANSIBLE_STDOUT_CALLBACK=yaml ansible-playbook ./2021-10-28.one_image_copy_id.yml -v
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the
implicit localhost does not match 'all'

PLAY [localhost] *************************************************************************

TASK [Ensure our testing images do not exist] ********************************************
changed: [localhost] => (item=cloudimg-rocky-8-but-awesome) => changed=true 
  ansible_loop_var: item
  item: cloudimg-rocky-8-but-awesome
changed: [localhost] => (item=cloudimg-rocky-8-but-more-awesome) => changed=true 
  ansible_loop_var: item
  item: cloudimg-rocky-8-but-more-awesome

TASK [Clone image] ***********************************************************************
changed: [localhost] => changed=true 
  group_id: 0
  group_name: oneadmin
  id: 9356
  name: cloudimg-rocky-8-but-awesome
  running_vms: 0
  state: READY
  used: false
  user_id: 0
  user_name: oneadmin

TASK [Clone image again with a different name] *******************************************
changed: [localhost] => changed=true 
  group_id: 0
  group_name: oneadmin
  id: 9357
  name: cloudimg-rocky-8-but-more-awesome
  running_vms: 0
  state: READY
  used: false
  user_id: 0
  user_name: oneadmin

TASK [Try to rename the first clone to the name of the second clone (should fail!)] ******
fatal: [localhost]: FAILED! => changed=false 
  msg: Name 'cloudimg-rocky-8-but-more-awesome' is already taken by IMAGE with id=9357

PLAY RECAP *******************************************************************************
localhost                  : ok=3    changed=3    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

</details>