### PR TITLE
Add lookup which allows to query whether an action is available

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -174,7 +174,7 @@ files:
   $lookups/:
     labels: lookups
   $lookups/cartesian.py: {}
-  $lookups/check_target:
+  $lookups/check_action.py:
     maintainers: felixfontein
   $lookups/chef_databag.py: {}
   $lookups/consul_kv.py: {}

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -174,6 +174,8 @@ files:
   $lookups/:
     labels: lookups
   $lookups/cartesian.py: {}
+  $lookups/check_target:
+    maintainers: felixfontein
   $lookups/chef_databag.py: {}
   $lookups/consul_kv.py: {}
   $lookups/credstash.py: {}

--- a/plugins/lookup/check_action.py
+++ b/plugins/lookup/check_action.py
@@ -11,7 +11,12 @@ version_added: "4.0.0"
 short_description: Check whether a module or action plugin is available
 description:
   - This lookup allows to query whether a module or action plugin is available under a given name.
-  - Please note that this lookup does B(not) consider the C(collections) keyword.
+  - Please note that this lookup does B(not) consider the C(collections) keyword. It looks up
+    module or action plugin names the same way as ansible does when the C(collections) keyword is
+    not present. So for modules or action plugins in collections, it is best to use their FQCN.
+    Short names should only be used for local modules or action plugins, for modules and action
+    plugins included with ansible-core, or for modules and action plugins that have a short name
+    redirect included for backwards compatibility in ansible-core.
 options:
   _terms:
     description:
@@ -25,7 +30,7 @@ options:
 EXAMPLES = """
 - name: Check whether community.general.ufw is available.
   ansible.builtin.debug:
-    msg: "We can use ufw: {{ lookup('felixfontein.acme.check_action', 'community.general.ufw) }}"
+    msg: "We can use ufw: {{ lookup('community.general.check_action', 'community.general.ufw') }}"
 """
 
 RETURN = """

--- a/plugins/lookup/check_action.py
+++ b/plugins/lookup/check_action.py
@@ -1,0 +1,61 @@
+# (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+name: check_collection
+author: Felix Fontein (@felixfontein)
+version_added: "4.0.0"
+short_description: Check whether a module or action plugin is available
+description:
+  - This lookup allows to query whether a module or action plugin is available under a given name.
+  - Please note that this lookup does B(not) consider the C(collections) keyword.
+options:
+  _terms:
+    description:
+      - The short names or FQCNs for the modules or action plugins to check for.
+      - For example C(file) or C(community.general.ufw).
+    type: list
+    elements: str
+    required: true
+"""
+
+EXAMPLES = """
+- name: Check whether community.general.ufw is available.
+  ansible.builtin.debug:
+    msg: "We can use ufw: {{ lookup('felixfontein.acme.check_action', 'community.general.ufw) }}"
+"""
+
+RETURN = """
+  _raw:
+    description:
+      - For every action name provided in the input, C(true) indicates that the action is available,
+        and C(false) indicates that it is not available.
+    type: list
+    elements: bool
+"""
+
+from ansible.plugins.loader import action_loader, module_loader
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        result = []
+        self.set_options(var_options=variables, direct=kwargs)
+
+        for term in terms:
+            found = False
+            for loader in (action_loader, module_loader):
+                data = loader.find_plugin(term)
+                # Ansible 2.9 returns a tuple
+                if isinstance(data, tuple):
+                    data = data[0]
+                if data is not None:
+                    found = True
+                    break
+            result.append(found)
+
+        return result

--- a/tests/integration/targets/lookup_check_action/aliases
+++ b/tests/integration/targets/lookup_check_action/aliases
@@ -1,0 +1,1 @@
+shippable/cloud/group3

--- a/tests/integration/targets/lookup_check_action/aliases
+++ b/tests/integration/targets/lookup_check_action/aliases
@@ -1,1 +1,1 @@
-shippable/cloud/group3
+shippable/posix/group3

--- a/tests/integration/targets/lookup_check_action/collections/ansible_collections/testns/testcoll/galaxy.yml
+++ b/tests/integration/targets/lookup_check_action/collections/ansible_collections/testns/testcoll/galaxy.yml
@@ -1,0 +1,7 @@
+namespace: testns
+name: testcoll
+version: 0.0.1
+authors:
+  - Ansible (https://github.com/ansible)
+description: null
+tags: [community]

--- a/tests/integration/targets/lookup_check_action/collections/ansible_collections/testns/testcoll/plugins/modules/collection_module.py
+++ b/tests/integration/targets/lookup_check_action/collections/ansible_collections/testns/testcoll/plugins/modules/collection_module.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: collection_module
+short_description: Test collection module
+description:
+  - This is a test module in a local collection.
+author: "Felix Fontein (@felixfontein)"
+options: {}
+'''
+
+EXAMPLES = ''' # '''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    AnsibleModule(argument_spec={}).exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_check_action/library/local_module.py
+++ b/tests/integration/targets/lookup_check_action/library/local_module.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: local_module
+short_description: Test local module
+description:
+  - This is a test module locally next to a playbook.
+author: "Felix Fontein (@felixfontein)"
+options: {}
+'''
+
+EXAMPLES = ''' # '''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    AnsibleModule(argument_spec={}).exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lookup_check_action/runme.sh
+++ b/tests/integration/targets/lookup_check_action/runme.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export ANSIBLE_TEST_PREFER_VENV=1  # see https://github.com/ansible/ansible/pull/73000#issuecomment-757012395; can be removed once Ansible 2.9 and ansible-base 2.10 support has been dropped
+source virtualenv.sh
+
+# The collection loader ignores paths which have more than one ansible_collections in it.
+# That's why we have to copy this directory to a temporary place and run the test there.
+
+# Create temporary folder
+TEMPDIR=$(mktemp --directory)
+trap "{ rm -rf ${TEMPDIR}; }" EXIT
+
+cp -r . "${TEMPDIR}"
+cd "${TEMPDIR}"
+
+ansible-playbook runme.yml "$@"

--- a/tests/integration/targets/lookup_check_action/runme.sh
+++ b/tests/integration/targets/lookup_check_action/runme.sh
@@ -9,7 +9,7 @@ source virtualenv.sh
 # That's why we have to copy this directory to a temporary place and run the test there.
 
 # Create temporary folder
-TEMPDIR=$(mktemp --directory)
+TEMPDIR=$(mktemp -d)
 trap '{ rm -rf ${TEMPDIR}; }' EXIT
 
 cp -r . "${TEMPDIR}"

--- a/tests/integration/targets/lookup_check_action/runme.sh
+++ b/tests/integration/targets/lookup_check_action/runme.sh
@@ -10,7 +10,7 @@ source virtualenv.sh
 
 # Create temporary folder
 TEMPDIR=$(mktemp --directory)
-trap "{ rm -rf ${TEMPDIR}; }" EXIT
+trap '{ rm -rf ${TEMPDIR}; }' EXIT
 
 cp -r . "${TEMPDIR}"
 cd "${TEMPDIR}"

--- a/tests/integration/targets/lookup_check_action/runme.yml
+++ b/tests/integration/targets/lookup_check_action/runme.yml
@@ -1,0 +1,25 @@
+- hosts: localhost
+  tasks:
+    - name: Test check_action
+      assert:
+        that:
+          # Modules/actions that do not exist
+          - query('community.general.check_action', 'foo_bar') == [false]
+          - query('community.general.check_action', 'foo.bar.baz') == [false]
+          # Short name and FQCN for builtin and other collections
+          - query('community.general.check_action', 'file') == [true]
+          - query('community.general.check_action', 'set_fact') == [true]
+          - query('community.general.check_action', 'ansible.builtin.file') == [true]
+          - query('community.general.check_action', 'ansible.builtin.set_fact') == [true]
+          - query('community.general.check_action', 'ansible.builtin.foo_bar') == [false]
+          - query('community.general.check_action', 'community.crypto.acme_certificate') == [true]
+          - query('community.general.check_action', 'community.crypto.openssl_privatekey_pipe') == [true]
+          - query('community.general.check_action', 'community.crypto.foo_bar') == [false]
+          # Modules from this collection (that exist or not)
+          - query('community.general.check_action', 'community.general.ufw') == [true]
+          - query('community.general.check_action', 'community.general.foooo_really_does_not_exist') == [false]
+          # Local module
+          - query('community.general.check_action', 'local_module') == [true]
+          # Local collection module (that exist or not)
+          - query('community.general.check_action', 'testns.testcoll.collection_module') == [true]
+          - query('community.general.check_action', 'testns.testcoll.foobar') == [false]


### PR DESCRIPTION
##### SUMMARY
This can be very useful for roles and playbooks to check whether a (dynamic) dependency is around *before* trying to use it.

(See https://github.com/felixfontein/ansible-acme/pull/20 for a use-case.)

##### ISSUE TYPE
- New Plugin Pull Request

##### COMPONENT NAME
check_action
