### PR TITLE
Fix CI

### DIFF
--- a/tests/unit/plugins/modules/remote_management/oneview/hpe_test_utils.py
+++ b/tests/unit/plugins/modules/remote_management/oneview/hpe_test_utils.py
@@ -38,7 +38,7 @@ class OneViewBaseTest(object):
         testing_module = getattr(oneview_module, testing_module)
         try:
             # Load scenarios from module examples (Also checks if it is a valid yaml)
-            EXAMPLES = yaml.safe_load(testing_module.EXAMPLES, yaml.SafeLoader)
+            EXAMPLES = yaml.safe_load(testing_module.EXAMPLES)
 
         except yaml.scanner.ScannerError:
             message = "Something went wrong while parsing yaml from {0}.EXAMPLES".format(self.testing_class.__module__)
@@ -140,7 +140,7 @@ class OneViewBaseTestCase(object):
 
         try:
             # Load scenarios from module examples (Also checks if it is a valid yaml)
-            self.EXAMPLES = yaml.safe_load(self.testing_module.EXAMPLES, yaml.SafeLoader)
+            self.EXAMPLES = yaml.safe_load(self.testing_module.EXAMPLES)
 
         except yaml.scanner.ScannerError:
             message = "Something went wrong while parsing yaml from {0}.EXAMPLES".format(self.testing_class.__module__)

--- a/tests/unit/plugins/modules/remote_management/oneview/hpe_test_utils.py
+++ b/tests/unit/plugins/modules/remote_management/oneview/hpe_test_utils.py
@@ -38,7 +38,7 @@ class OneViewBaseTest(object):
         testing_module = getattr(oneview_module, testing_module)
         try:
             # Load scenarios from module examples (Also checks if it is a valid yaml)
-            EXAMPLES = yaml.load(testing_module.EXAMPLES, yaml.SafeLoader)
+            EXAMPLES = yaml.safe_load(testing_module.EXAMPLES, yaml.SafeLoader)
 
         except yaml.scanner.ScannerError:
             message = "Something went wrong while parsing yaml from {0}.EXAMPLES".format(self.testing_class.__module__)
@@ -140,7 +140,7 @@ class OneViewBaseTestCase(object):
 
         try:
             # Load scenarios from module examples (Also checks if it is a valid yaml)
-            self.EXAMPLES = yaml.load(self.testing_module.EXAMPLES, yaml.SafeLoader)
+            self.EXAMPLES = yaml.safe_load(self.testing_module.EXAMPLES, yaml.SafeLoader)
 
         except yaml.scanner.ScannerError:
             message = "Something went wrong while parsing yaml from {0}.EXAMPLES".format(self.testing_class.__module__)

--- a/tests/unit/plugins/modules/remote_management/oneview/test_oneview_ethernet_network.py
+++ b/tests/unit/plugins/modules/remote_management/oneview/test_oneview_ethernet_network.py
@@ -132,7 +132,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
         self.resource.update.return_value = data_merged
         self.mock_ov_client.connection_templates.get.return_value = {"uri": "uri"}
 
-        self.mock_ansible_module.params = yaml.load(YAML_PARAMS_WITH_CHANGES)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_PARAMS_WITH_CHANGES)
 
         EthernetNetworkModule().run()
 
@@ -146,7 +146,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
         self.resource.get_by.return_value = [DICT_PARAMS_WITH_CHANGES]
         self.mock_ov_client.connection_templates.get.return_value = {"uri": "uri"}
 
-        self.mock_ansible_module.params = yaml.load(YAML_PARAMS_WITH_CHANGES)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_PARAMS_WITH_CHANGES)
 
         EthernetNetworkModule().run()
 
@@ -165,7 +165,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
         self.mock_ov_client.connection_templates.get.return_value = {
             "bandwidth": DICT_PARAMS_WITH_CHANGES['bandwidth']}
 
-        self.mock_ansible_module.params = yaml.load(YAML_PARAMS_WITH_CHANGES)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_PARAMS_WITH_CHANGES)
 
         EthernetNetworkModule().run()
 
@@ -182,7 +182,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
         self.resource.get_by.return_value = [DEFAULT_ENET_TEMPLATE]
         self.resource.update.return_value = data_merged
 
-        self.mock_ansible_module.params = yaml.load(YAML_PARAMS_WITH_CHANGES)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_PARAMS_WITH_CHANGES)
 
         EthernetNetworkModule().run()
 
@@ -320,7 +320,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
             "max": 1
         }}
 
-        self.mock_ansible_module.params = yaml.load(YAML_RESET_CONNECTION_TEMPLATE)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_RESET_CONNECTION_TEMPLATE)
 
         EthernetNetworkModule().run()
 
@@ -331,7 +331,7 @@ class EthernetNetworkModuleSpec(unittest.TestCase,
     def test_should_fail_when_reset_not_existing_ethernet_network(self):
         self.resource.get_by.return_value = [None]
 
-        self.mock_ansible_module.params = yaml.load(YAML_RESET_CONNECTION_TEMPLATE)
+        self.mock_ansible_module.params = yaml.safe_load(YAML_RESET_CONNECTION_TEMPLATE)
 
         EthernetNetworkModule().run()
 


### PR DESCRIPTION
##### SUMMARY
Currently the `devel` unit tests fail in nightly CI due to PyYAML having removed support for `yaml.load()` without a loader. I replaced the `yaml.load` calls with `yaml.safe_load` in the unit tests to mitigate this.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
