### PR TITLE
Fix random_words lookup tests

### DIFF
--- a/tests/integration/targets/lookup_random_words/test.yml
+++ b/tests/integration/targets/lookup_random_words/test.yml
@@ -8,7 +8,7 @@
       result2: "{{ query('community.general.random_words', min_length=5, max_length=5) }}"
       result3: "{{ query('community.general.random_words', delimiter='!') }}"
       result4: "{{ query('community.general.random_words', numwords=3, delimiter='-', case='capitalize') }}"
-      result5: "{{ query('community.general.random_words', numwords=3, delimiter='') }}"
+      result5: "{{ query('community.general.random_words', min_length=5, max_length=5, numwords=3, delimiter='') }}"
 
   - name: Check results
     assert:
@@ -25,4 +25,4 @@
         - result4[0] | regex_findall("[A-Z]") | length == 3
         - result4[0].count("-") == 2
         - result5 | length == 1
-        - result5[0] | length >= 18
+        - result5[0] | length == 15


### PR DESCRIPTION
##### SUMMARY
The last test failed this night: https://dev.azure.com/ansible/community.general/_build/results?buildId=28400&view=logs&j=c7ffc934-fbed-562a-6e45-fd1f90b7af39&t=ce367ec3-f892-585f-7ff6-26f664cc2334

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
random_words lookup
