### PR TITLE
yaml callback: fix for devel changes

### DIFF
--- a/changelogs/fragments/3642-yaml-callback-devel.yml
+++ b/changelogs/fragments/3642-yaml-callback-devel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "yaml callback plugin - make compatible with changes to ansible-core's ``devel`` branch (https://github.com/ansible-collections/community.general/pull/3642)."

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -32,7 +32,12 @@ from ansible.module_utils.six import string_types
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.callback import CallbackBase, strip_internal_keys, module_response_deepcopy
 from ansible.plugins.callback.default import CallbackModule as Default
-from ansible.utils.unsafe_proxy import NativeJinjaUnsafeText
+
+try:
+    from ansible.utils.unsafe_proxy import NativeJinjaUnsafeText
+except ImportError:
+    # Ansible 2.9 and ansible-base 2.10 do not have this yet
+    NativeJinjaUnsafeText = None
 
 
 # from http://stackoverflow.com/a/15423007/115478
@@ -72,7 +77,7 @@ class MyDumper(AnsibleDumper):
 def sanitize(value):
     if isinstance(value, Mapping):
         return dict((sanitize(k), sanitize(v)) for k, v in value.items())
-    if isinstance(value, NativeJinjaUnsafeText):
+    if NativeJinjaUnsafeText is not None and isinstance(value, NativeJinjaUnsafeText):
         return str(value)
     if isinstance(value, string_types):
         return value

--- a/tests/integration/targets/callback_yaml/aliases
+++ b/tests/integration/targets/callback_yaml/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group1
 needs/target/callback
-disabled  # FIXME (https://github.com/ansible-collections/community.general/pull/3643)


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/commit/26707a3c6bd1bc72f59ce6efb188e94c4f58ce86 broke the YAML callback; see for example https://dev.azure.com/ansible/community.general/_build/results?buildId=28400&view=logs&j=1d520954-9606-5520-b594-0b935de5aeca&t=cbeffed3-49d8-5f25-fa26-6591d04d4a87.

Basically the test fails because the YAML callback errors out:
```
[WARNING]: Failure using method (v2_runner_on_ok) in callback plugin (<ansible_collections.community.general.plugins.callback.yaml.CallbackModule object at 0x12345>): ('cannot
represent an object', "'line 1\n\n  line 2\n\n  line 3\n\n  '\n")
```
(Not visible in CI unfortunately...)

CC @mkrizek @sivel since my PR might have unwanted side-effects :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yaml callback
