### PR TITLE
mh/mixins/cmd - added publish_cmd parameter to CmdModuleHelper.run_command()

### DIFF
--- a/changelogs/fragments/3648-mh-cmd-publish-cmd.yaml
+++ b/changelogs/fragments/3648-mh-cmd-publish-cmd.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_helper module utils - added feature flag parameter to ``CmdMixin`` to control whether ``cmd_args`` is automatically added to the module output (https://github.com/ansible-collections/community.general/pull/3648).

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -180,7 +180,7 @@ class CmdMixin(object):
         if publish_err:
             self.update_output(stderr=err)
         if publish_cmd:
-            self.update_output(cmd_args=cmd)
+            self.update_output(cmd_args=cmd_args)
         if process_output is None:
             _process = self.process_command_output
         else:

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -158,8 +158,9 @@ class CmdMixin(object):
                     publish_rc=True,
                     publish_out=True,
                     publish_err=True,
+                    publish_cmd=True,
                     *args, **kwargs):
-        self.vars.cmd_args = self._calculate_args(extra_params, params)
+        cmd_args = self._calculate_args(extra_params, params)
         options = dict(self.run_command_fixed_options)
         options['check_rc'] = options.get('check_rc', self.check_rc)
         options.update(kwargs)
@@ -171,13 +172,15 @@ class CmdMixin(object):
             })
             self.update_output(force_lang=self.force_lang)
             options['environ_update'] = env_update
-        rc, out, err = self.module.run_command(self.vars.cmd_args, *args, **options)
+        rc, out, err = self.module.run_command(cmd_args, *args, **options)
         if publish_rc:
             self.update_output(rc=rc)
         if publish_out:
             self.update_output(stdout=out)
         if publish_err:
             self.update_output(stderr=err)
+        if publish_cmd:
+            self.update_output(cmd_args=cmd)
         if process_output is None:
             _process = self.process_command_output
         else:


### PR DESCRIPTION
##### SUMMARY
Adds `publish_cmd` option to `run_command()`, allowing the developer to control whether the command arguments are published in the module result or not. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/mixins/cmd.py
