### PR TITLE
Fixed - TypeError: unexpected keyword argument

### DIFF
--- a/changelogs/fragments/3649-proxmox_group_info_TypeError.yml
+++ b/changelogs/fragments/3649-proxmox_group_info_TypeError.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - fix  - proxmox_group_info.py - error "TypeError: get_group() got an unexpected keyword argument 'group'\r\n'" if a group parameter is used. Issue is an argument naming conflict. After changing the argument name to 'groupid', as used in method ProxmoxGroupInfoAnsible::get_group, testing a Proxmox group name is working now. (https://github.com/ansible-collections/community.general/pull/3649)
+  - proxmox_group_info - fix module crash if a ``group`` parameter is used (https://github.com/ansible-collections/community.general/pull/3649).

--- a/changelogs/fragments/3649-proxmox_group_info_TypeError.yml
+++ b/changelogs/fragments/3649-proxmox_group_info_TypeError.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix  - proxmox_group_info.py - error "TypeError: get_group() got an unexpected keyword argument 'group'\r\n'" if a group parameter is used. Issue is an argument naming conflict. After changing the argument name to 'groupid', as used in method ProxmoxGroupInfoAnsible::get_group, testing a Proxmox group name is working now. (https://github.com/ansible-collections/community.general/pull/3649)

--- a/plugins/modules/cloud/misc/proxmox_group_info.py
+++ b/plugins/modules/cloud/misc/proxmox_group_info.py
@@ -131,7 +131,7 @@ def main():
     group = module.params['group']
 
     if group:
-        groups = [proxmox.get_group(group=group)]
+        groups = [proxmox.get_group(groupid=group)]
     else:
         groups = proxmox.get_groups()
     result['proxmox_groups'] = [group.group for group in groups]


### PR DESCRIPTION
- File proxmox_group_info.py creates the error "TypeError: 
  get_group() got an unexpected keyword argument \'group\'\r\n'" if a
  group parameter is used.
  Issue is an argument naming conflict. After changing the argument 
  name to 'groupid', as used in method ProxmoxGroupInfoAnsible::get_group,
  testing a Proxmox group name is working now.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
