### PR TITLE
fix modules' output by using publish_cmd

### DIFF
--- a/changelogs/fragments/3655-use-publish_cmd.yaml
+++ b/changelogs/fragments/3655-use-publish_cmd.yaml
@@ -1,4 +1,4 @@
 bugfixes:
     - ansible_galaxy_install - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
     - pipx - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
-    - snap_alias - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
+    - snap_alias - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).

--- a/changelogs/fragments/3655-use-publish_cmd.yaml
+++ b/changelogs/fragments/3655-use-publish_cmd.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-    - ansible_galaxy_install - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
+    - ansible_galaxy_install - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
     - pipx - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
     - snap_alias - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).

--- a/changelogs/fragments/3655-use-publish_cmd.yaml
+++ b/changelogs/fragments/3655-use-publish_cmd.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+    - ansible_galaxy_install - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
+    - pipx - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
+    - snap_alias - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).

--- a/changelogs/fragments/3655-use-publish_cmd.yaml
+++ b/changelogs/fragments/3655-use-publish_cmd.yaml
@@ -1,4 +1,4 @@
 bugfixes:
     - ansible_galaxy_install - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
-    - pipx - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
+    - pipx - the output value ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).
     - snap_alias - the output valeu ``cmd_args`` was bringing the intermediate command used to gather the state, instead of the command that actually performed the state change (https://github.com/ansible-collections/community.general/pull/3655).

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -238,7 +238,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
     def _list_element(self, _type, path_re, elem_re):
         params = ({'type': _type}, {'galaxy_cmd': 'list'}, 'dest')
         elems = self.run_command(params=params,
-                                 publish_rc=False, publish_out=False, publish_err=False,
+                                 publish_rc=False, publish_out=False, publish_err=False, publish_cmd=False,
                                  process_output=self._process_output_list,
                                  check_rc=False)
         elems_dict = {}

--- a/plugins/modules/packaging/language/pipx.py
+++ b/plugins/modules/packaging/language/pipx.py
@@ -197,7 +197,7 @@ class PipX(CmdStateModuleHelper):
             return results
 
         installed = self.run_command(params=[{'_list': True}], process_output=process_list,
-                                     publish_rc=False, publish_out=False, publish_err=False)
+                                     publish_rc=False, publish_out=False, publish_err=False, publish_cmd=False)
 
         if self.vars.name is not None:
             app_list = installed.get(self.vars.name)

--- a/plugins/modules/packaging/os/snap_alias.py
+++ b/plugins/modules/packaging/os/snap_alias.py
@@ -134,7 +134,7 @@ class SnapAlias(CmdStateModuleHelper):
             return results
 
         return self.run_command(params=[{'state': 'info'}, 'name'], check_rc=True,
-                                publish_rc=False, publish_out=False, publish_err=False,
+                                publish_rc=False, publish_out=False, publish_err=False, publish_cmd=False,
                                 process_output=process_get_aliases)
 
     def _get_aliases_for(self, name):


### PR DESCRIPTION
##### SUMMARY
These three modules have the same mechanics: they run a "state gathering" function before and after executing the actual command. Because we lacked the `publish_cmd` option in `MH.run_command()`, the output value `cmd_args` would always contain the arguments of the *after*-state-gathering call. Instead, what made sense was to show the command actually executed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/packaging/language/ansible_galaxy_install.py
plugins/modules/packaging/language/pipx.py
plugins/modules/packaging/os/snap_alias.py
