### PR TITLE
Add new github_tag module and tests

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -923,6 +923,8 @@ files:
     maintainers: djmattyg007 mgedmin
   $modules/source_control/github/github_deploy_key.py:
     maintainers: bincyber
+  $modules/source_control/github/github_tag.py:
+    maintainers: marknet15
   $modules/source_control/github/github_issue.py:
     maintainers: Akasurde
   $modules/source_control/github/github_key.py:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
    - Make sure that new plugins and modules have tests (unit tests, integration tests, or both); it is preferable to have some tests
      which run in CI.
 
-4. For modules and action plugins, make sure to create your module/plugin in the correct subdirectory, and create a symbolic link
+4. For modules and action plugins, make sure to create your module/plugin in the correct subdirectory, and create a relative symbolic link
    from `plugins/modules/` respectively `plugins/action/` to the actual module/plugin code. (Other plugin types should not use
    subdirectories.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Creating new modules and plugins requires a bit more work than other Pull Reques
      which run in CI.
 
 4. For modules and action plugins, make sure to create your module/plugin in the correct subdirectory, and create a relative symbolic link
-   from `plugins/modules/` respectively `plugins/action/` to the actual module/plugin code. (Other plugin types should not use
+   from `plugins/modules/` respectively `plugins/action/` to the actual module/plugin code for example `ln -s ./sub_dir/module.py ./module.py`. (Other plugin types should not use
    subdirectories.)
 
    - Action plugins need to be accompanied by a module, even if the module file only contains documentation

--- a/plugins/modules/github_tag.py
+++ b/plugins/modules/github_tag.py
@@ -1,0 +1,1 @@
+./plugins/modules/source_control/github/github_tag.py

--- a/plugins/modules/github_tag.py
+++ b/plugins/modules/github_tag.py
@@ -1,0 +1,1 @@
+./source_control/github/github_tag.py

--- a/plugins/modules/github_tag.py
+++ b/plugins/modules/github_tag.py
@@ -1,1 +1,0 @@
-./source_control/github/github_tag.py

--- a/plugins/modules/github_tag.py
+++ b/plugins/modules/github_tag.py
@@ -1,1 +1,0 @@
-./plugins/modules/source_control/github/github_tag.py

--- a/plugins/modules/source_control/github/github_tag.py
+++ b/plugins/modules/source_control/github/github_tag.py
@@ -1,0 +1,270 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Team
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: github_tag
+short_description: Create annotated GitHub tags for use with releases
+description:
+    - Allows for creation of annotated tags, by default a GitHub release only create lightweight tags.
+    - Use this module with the `github_release` module to created a release linked to a annotated tag.
+options:
+    url:
+        description:
+            - Custom GitHub URL for self-hosted enterprise versions.
+        type: str
+    token:
+        description:
+            - GitHub access Token for authenticating.
+            - Mutually exclusive with C(password).
+        type: str
+    username:
+        description:
+            - GitHub account username used for authentication.
+            - This is only needed when not using I(access_token).
+        type: str
+    password:
+        description:
+            - The GitHub account password for the user.
+            - This is only needed when not using I(access_token).
+        type: str
+    organization:
+        description:
+            - Repository organization name.
+        type: str
+        required: true
+    repo:
+        description:
+            - Repository name.
+        type: str
+        required: true
+    branch:
+        description:
+            - Name of the branch to create the tag on.
+        type: str
+        required: true
+    tag:
+        description:
+            - Name of the tag to create.
+        type: str
+        required: true
+    tagger:
+        description:
+            - Name of the tag to create.
+        type: dict
+        suboptions:
+            name:
+                description:
+                    - Name of the tagger
+                type: str
+                required: true
+            email:
+                description:
+                    - Email of the tagger
+                type: str
+                required: true
+        required: true
+    message:
+        description:
+            - Message for the tag to be created with.
+        type: str
+        required: true
+
+author:
+    - "Mark Woolley (@marknet15)"
+version_added: 3.9.0
+requirements:
+    - "github3.py >= 1.0.0"
+'''
+
+EXAMPLES = r'''
+- name: Create a annotated tag
+  community.general.github_tag:
+    token: tokenabc1234567890
+    organization: someorg
+    repo: testrepo
+    branch: main
+    tag: 1.0.0
+    tagger:
+      name: Some User
+      email: some.user@example.com
+    message: Some tag message
+
+'''
+
+RETURN = r'''
+tag:
+    description:
+    - The tag name created
+    - If specified tag already exists, then State is unchanged
+    type: str
+    returned: success
+    sample: 1.1.0
+branch:
+    description:
+    - The branch used for the tag creation
+    type: str
+    returned: success
+    sample: main
+'''
+
+import traceback
+
+GITHUB_IMP_ERR = None
+try:
+    import github3
+
+    HAS_GITHUB3_PACKAGE = True
+except ImportError:
+    GITHUB_IMP_ERR = traceback.format_exc()
+    HAS_GITHUB3_PACKAGE = False
+
+from datetime import datetime
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
+
+
+def authenticate(module):
+    '''
+    Authenticate to either GitHub Cloud or GitHub Enterprise
+    '''
+
+    url = module.params.get('url')
+    username = module.params.get('username')
+    password = module.params.get('password')
+    token = module.params.get('token')
+    login_params = dict()
+
+    if url:
+        login_params['url'] = url
+    else:
+        login_params['user'] = username
+
+    if password:
+        login_params['password'] = password
+    else:
+        login_params['token'] = token
+
+    # login to github
+    try:
+        if url:
+            client = github3.enterprise_login(**login_params)
+        elif password or token:
+            client = github3.login(**login_params)
+        else:
+            client = github3.GitHub()
+
+        # test if actually logged in
+        if password or token:
+            client.me()
+    except github3.exceptions.AuthenticationFailed as e:
+        module.fail_json(msg='Failed to connect to GitHub: %s' % to_native(e),
+                         details="Please check username and password or token "
+                                 "for repository %s" % module.params.get('repo'))
+
+    return client
+
+def get_repo(module, client):
+    '''
+    Check if tag already exists and return repository object
+    '''
+
+    org = module.params.get('organization')
+    repo = module.params.get('repo')
+    tag = module.params.get('tag')
+
+    try:
+        repository = client.repository(org, repo)
+    except (github3.exceptions.ClientError, github3.exceptions.NotFoundError):
+        module.fail_json(msg="Repository %s/%s doesn't exist" % (org, repo))
+
+    tag_exists = False
+
+    for tag_item in repository.tags():
+        if tag_item.name == tag:
+            tag_exists = True
+
+    if tag_exists:
+        return False
+
+    return repository
+
+def create_tag(module, repository):
+    '''
+    Create annotated git tag
+    '''
+
+    branch = module.params.get('branch')
+    tag = module.params.get('tag')
+    tagger = module.params.get('tagger')
+    message = module.params.get('message')
+
+    latest_commit = repository.commit(sha=branch)
+
+    # Currently the github3.py library requires the date to be set,
+    # eventhough not required by API.
+    current_date = datetime.now()
+    tagger['date'] = current_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    tag_params = dict(
+        tag=tag,
+        tagger=tagger,
+        sha=latest_commit.sha,
+        message=message,
+        obj_type="commit"
+    )
+
+    try:
+        new_tag = repository.create_tag(**tag_params)
+    except (github3.exceptions.ClientError, github3.exceptions.UnprocessableEntity) as err:
+        module.fail_json(
+            msg='Failed to create a annotated tag with the following error: %s' % to_native(err))
+
+    return new_tag
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            url=dict(type=str),
+            username=dict(type='str'),
+            password=dict(no_log=True),
+            token=dict(no_log=True),
+            organization=dict(required=True, type='str'),
+            repo=dict(required=True),
+            branch=dict(type='str'),
+            tag=dict(type='str'),
+            tagger=dict(required=True, type='dict'),
+            message=dict(required=True, type='str')
+        ),
+        required_together=[('username', 'password')],
+        required_one_of=[('password', 'token')],
+        mutually_exclusive=[('password', 'token')]
+    )
+
+    if not HAS_GITHUB3_PACKAGE:
+        module.fail_json(msg=missing_required_lib('github3.py >= 1.0.0'),
+                         exception=GITHUB_IMP_ERR)
+
+    client = authenticate(module)
+    repository = get_repo(module, client)
+
+    if not repository:
+        module.exit_json(changed=False, msg="Tag %s already exists." % module.params.get('tag'))
+
+    new_tag = create_tag(module, repository)
+
+    if new_tag:
+        module.exit_json(changed=True, tag=new_tag.tag, branch=module.params.get('branch'))
+    else:
+        module.exit_json(changed=False, tag=None)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/source_control/github/github_tag.py
+++ b/plugins/modules/source_control/github/github_tag.py
@@ -70,9 +70,9 @@ options:
                 type: str
                 required: true
         required: true
-    message:
+    description:
         description:
-            - Message for the tag to be created with.
+            - description message for the tag to be created with.
         type: str
         required: true
 
@@ -94,7 +94,7 @@ EXAMPLES = r'''
     tagger:
       name: Some User
       email: some.user@example.com
-    message: Some tag message
+    description: Some tag description message
 
 '''
 
@@ -170,6 +170,7 @@ def authenticate(module):
 
     return client
 
+
 def get_repo(module, client):
     '''
     Check if tag already exists and return repository object
@@ -195,6 +196,7 @@ def get_repo(module, client):
 
     return repository
 
+
 def create_tag(module, repository):
     '''
     Create annotated git tag
@@ -203,7 +205,7 @@ def create_tag(module, repository):
     branch = module.params.get('branch')
     tag = module.params.get('tag')
     tagger = module.params.get('tagger')
-    message = module.params.get('message')
+    description = module.params.get('description')
 
     latest_commit = repository.commit(sha=branch)
 
@@ -216,7 +218,7 @@ def create_tag(module, repository):
         tag=tag,
         tagger=tagger,
         sha=latest_commit.sha,
-        message=message,
+        message=description,
         obj_type="commit"
     )
 
@@ -232,16 +234,16 @@ def create_tag(module, repository):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            url=dict(type=str),
+            url=dict(type='str'),
             username=dict(type='str'),
             password=dict(no_log=True),
             token=dict(no_log=True),
             organization=dict(required=True, type='str'),
             repo=dict(required=True),
-            branch=dict(type='str'),
-            tag=dict(type='str'),
+            branch=dict(required=True, type='str'),
+            tag=dict(required=True, type='str'),
             tagger=dict(required=True, type='dict'),
-            message=dict(required=True, type='str')
+            description=dict(required=True, type='str')
         ),
         required_together=[('username', 'password')],
         required_one_of=[('password', 'token')],

--- a/plugins/modules/source_control/github/github_tag.py
+++ b/plugins/modules/source_control/github/github_tag.py
@@ -263,7 +263,7 @@ def main():
 
     new_tag = create_tag(module, repository)
 
-    module.exit_json(changed=True, tag=new_tag.tag, branch=module['branch'])
+    module.exit_json(changed=True, tag=new_tag.tag, branch=module.params['branch'])
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/source_control/github/test_github_tag.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_tag.py
@@ -23,7 +23,7 @@ class TestGithubTag(ModuleTestCase):
                     "name": "Test User",
                     "email": "test.user@test.com"
                 },
-                "message": "Test tag",
+                "description": "Test tag",
             })
             github_tag.main()
 
@@ -45,7 +45,7 @@ class TestGithubTag(ModuleTestCase):
                     "name": "Test User",
                     "email": "test.user@test.com"
                 },
-                "message": "Test tag",
+                "description": "Test tag",
                 "url": "https://api.github.com"
             })
             github_tag.main()
@@ -69,7 +69,7 @@ class TestGithubTag(ModuleTestCase):
                     "name": "Test User",
                     "email": "test.user@test.com"
                 },
-                "message": "Test tag",
+                "description": "Test tag",
                 "url": "https://api.github.com"
             })
             github_tag.main()
@@ -95,7 +95,7 @@ class TestGithubTag(ModuleTestCase):
                     "name": "Test User",
                     "email": "test.user@test.com"
                 },
-                "message": "Test tag",
+                "description": "Test tag",
                 "url": "https://api.github.com"
             })
             github_tag.main()

--- a/tests/unit/plugins/modules/source_control/github/test_github_tag.py
+++ b/tests/unit/plugins/modules/source_control/github/test_github_tag.py
@@ -1,0 +1,107 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible_collections.community.general.plugins.modules.source_control.github import github_tag
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import patch
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestGithubTag(ModuleTestCase):
+    def test_mutually_exclusive(self):
+        with self.assertRaises(AnsibleFailJson) as exec_info:
+            set_module_args({
+                "username": "testusername",
+                "password": "testpassword",
+                "token": "abcde12345",
+                "organization": "MyOrganization",
+                "repo": "myrepo",
+                "branch": "main",
+                "tag": "1.0.0",
+                "tagger": {
+                    "name": "Test User",
+                    "email": "test.user@test.com"
+                },
+                "message": "Test tag",
+            })
+            github_tag.main()
+
+        self.assertEqual(
+            exec_info.exception.args[0]['msg'],
+            'parameters are mutually exclusive: password|token',
+        )
+
+    def test_missing_dependency(self):
+        with self.assertRaises(AnsibleFailJson) as exec_info:
+            github_tag.HAS_GITHUB3_PACKAGE = False
+            set_module_args({
+                "token": "mytoken",
+                "organization": "MyOrganization",
+                "repo": "myrepo",
+                "branch": "main",
+                "tag": "1.0.0",
+                "tagger": {
+                    "name": "Test User",
+                    "email": "test.user@test.com"
+                },
+                "message": "Test tag",
+                "url": "https://api.github.com"
+            })
+            github_tag.main()
+
+        self.assertIn("Failed to import the required Python library (github3.py >= 1.0.0)", exec_info.exception.args[0]['msg'])
+
+    @patch.object(github_tag, 'create_tag')
+    @patch.object(github_tag, 'get_repo')
+    @patch.object(github_tag, 'authenticate')
+    def test_create_tag(self, mock_authenticate, mock_get_repo, mock_create_tag):
+        mock_get_repo.return_value.commit = "15a694d58f849a99f14b1cd9f62a92d8fbb85b6e"
+        mock_create_tag.return_value.tag = "1.0.0"
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                "token": "mytoken",
+                "organization": "MyOrganization",
+                "repo": "myrepo",
+                "branch": "main",
+                "tag": "1.0.0",
+                "tagger": {
+                    "name": "Test User",
+                    "email": "test.user@test.com"
+                },
+                "message": "Test tag",
+                "url": "https://api.github.com"
+            })
+            github_tag.main()
+
+        self.assertEqual(exec_info.exception.args[0]['changed'], True)
+        self.assertEqual(exec_info.exception.args[0]['tag'], "1.0.0")
+        self.assertEqual(exec_info.exception.args[0]['branch'], "main")
+
+    @patch.object(github_tag, 'create_tag')
+    @patch.object(github_tag, 'get_repo')
+    @patch.object(github_tag, 'authenticate')
+    def test_create_tag_already_exists(self, mock_authenticate, mock_get_repo, mock_create_tag):
+        mock_get_repo.return_value = False
+        mock_create_tag.return_value.tag = "1.0.0"
+        with self.assertRaises(AnsibleExitJson) as exec_info:
+            set_module_args({
+                "token": "mytoken",
+                "organization": "MyOrganization",
+                "repo": "myrepo",
+                "branch": "main",
+                "tag": "1.0.0",
+                "tagger": {
+                    "name": "Test User",
+                    "email": "test.user@test.com"
+                },
+                "message": "Test tag",
+                "url": "https://api.github.com"
+            })
+            github_tag.main()
+
+        self.assertEqual(exec_info.exception.args[0]['changed'], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -14,6 +14,7 @@ linode_api4 ; python_version > '2.6'  # APIv4
 # requirement for the gitlab and github modules
 python-gitlab
 PyGithub
+github3.py
 httmock
 
 # requirement for maven_artifact module


### PR DESCRIPTION
##### SUMMARY
Currently there is a `github_release` module for creating release objects against a tag, by default when creating a release via the GitHub API it creates only a lightweight tag if no tag currently exists. For this purpose I've created the `github_tag` module to create an annotated tag that can be used before running the `github_release` module.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
github_tag

##### ADDITIONAL INFORMATION
The module utilises the `github3.py` library.
Making use of the following:
https://github3py.readthedocs.io/en/master/api-reference/repos.html#github3.repos.repo.Repository.commit
https://github3py.readthedocs.io/en/master/api-reference/repos.html#github3.repos.repo.Repository.create_tag

I raised https://github.com/sigmavirus24/github3.py/pull/1051 to remove the need for setting `date` on the `commiter` dictionary on the `create_tag` request.

An example tag creation against GitHub cloud task:
```yml
- name: Create a annotated tag
  community.general.github_tag:
    token: tokenabc1234567890
    organization: someorg
    repo: testrepo
    branch: main
    tag: 1.0.0
    tagger:
      name: Some User
      email: some.user@example.com
    message: Some tag message
```

For enterprise versions `url` can be set.

Extra local testing:
- new tag
```
TASK [Create a annotated tag] ************************************************************************************************************************************
task path: /mnt/c/Users/mark.woolley/Documents/GitHub/public/ansible_collections/community/github_test.yml:6
Using module file /mnt/c/Users/mark.woolley/Documents/GitHub/public/ansible_collections/community/general/plugins/modules/source_control/github/github_tag.py
changed: [localhost] => {
    "branch": "master",
    "changed": true,
    "invocation": {
        "module_args": {
            "branch": "master",
            "message": "Some tag message",
            "organization": "mark-woolley",
            "password": null,
            "repo": "test-pipeline",
            "tag": "2.0.1",
            "tagger": {
                "date": "2021-11-01T07:52:55Z",
                "email": "mw@marknet15.com",
                "name": "Mark Woolley"
            },
            "token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "url": "XXXX",
            "username": null
        }
    },
    "tag": "2.0.1"
}
```
- tag already exists:
```
TASK [Create a annotated tag] ************************************************************************************************************************************
task path: /mnt/c/Users/mark.woolley/Documents/GitHub/public/ansible_collections/community/github_test.yml:6
Using module file /mnt/c/Users/mark.woolley/Documents/GitHub/public/ansible_collections/community/general/plugins/modules/source_control/github/github_tag.py
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "branch": "master",
            "message": "Some tag message",
            "organization": "mark-woolley",
            "password": null,
            "repo": "test-pipeline",
            "tag": "2.0.0",
            "tagger": {
                "email": "mw@marknet15.com",
                "name": "Mark Woolley"
            },
            "token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "url": "XXXX",
            "username": null
        }
    },
    "msg": "Tag 2.0.0 already exists."
}
```
