### PR TITLE
Revert "Temporarily disable yaml callback tests. (#3651)"

### DIFF
--- a/tests/integration/targets/callback_yaml/aliases
+++ b/tests/integration/targets/callback_yaml/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group1
 needs/target/callback
-disabled  # FIXME (https://github.com/ansible-collections/community.general/pull/3643)


### PR DESCRIPTION
##### SUMMARY
This reverts commit 2324f350bcb257bc1ac39cee8ae734aa9acb96b9, and re-enables the yaml callback tests. This is possible since https://github.com/ansible/ansible/pull/76186 has been merged.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
yaml callback tests
