### PR TITLE
lxd_container: support lxd instance types

### DIFF
--- a/changelogs/fragments/3661-lxd_container-add-vm-support.yml
+++ b/changelogs/fragments/3661-lxd_container-add-vm-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lxd_container - manipulate the API endpoint to create instances of type container or virtual-machine.
+  - lxd_container - adds ``type`` option which also allows to operate on virtual machines and not just containers (https://github.com/ansible-collections/community.general/pull/3661).

--- a/changelogs/fragments/3661-lxd_container-add-vm-support.yml
+++ b/changelogs/fragments/3661-lxd_container-add-vm-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lxd_container - manipulate the API endpoint to create instances of type container or virtual-machine.

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -392,7 +392,7 @@ ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
-    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source', 'type'
+    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source'
 ]
 
 

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -246,6 +246,7 @@ EXAMPLES = '''
       community.general.lxd_container:
         name: mycontainer
         state: absent
+        type: container
 
 # An example for restarting a container
 - hosts: localhost
@@ -255,6 +256,7 @@ EXAMPLES = '''
       community.general.lxd_container:
         name: mycontainer
         state: restarted
+        type: container
 
 # An example for restarting a container using https to connect to the LXD server
 - hosts: localhost
@@ -312,6 +314,26 @@ EXAMPLES = '''
           mode: pull
           alias: ubuntu/xenial/amd64
         target: node02
+
+# An example for creating a virtual machine
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Create container on another node
+      community.general.lxd_container:
+        name: new-vm-1
+        type: virtual-machine
+        state: started
+        ignore_volatile_options: true
+        wait_for_ipv4_addresses: true
+        profiles: ["default"]
+        source:
+          protocol: simplestreams
+          type: image
+          mode: pull
+          server: https://images.linuxcontainers.org
+          alias: debian/11
+        timeout: 600
 '''
 
 RETURN = '''

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -32,8 +32,7 @@ options:
           - 'The config for the instance (for example C({"limits.cpu": "2"})).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
           - If the instance already exists and its "config" values in metadata
-            obtained from GET <api_endpoint>/<name>
-            U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
+            obtained from the LXD API U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#instances-containers-and-virtual-machines)
             are different, this module tries to apply the configurations.
           - The keys starting with C(volatile.) are ignored for this comparison when I(ignore_volatile_options=true).
         type: dict

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -341,7 +341,7 @@ EXAMPLES = '''
 
 RETURN = '''
 addresses:
-  description: Mapping from the network device name to a list of IPv4 addresses in the instance
+  description: Mapping from the network device name to a list of IPv4 addresses in the instance.
   returned: when state is started or restarted
   type: dict
   sample: {"eth0": ["10.155.92.191"]}
@@ -419,7 +419,7 @@ class LXDContainerManagement(object):
 
         # LXD Rest API provides additional endpoints for creating containers and virtual-machines.
         self.api_endpoint = None
-        if self.type == 'container' or self.type is None:
+        if self.type == 'container':
             self.api_endpoint = '/1.0/containers'
         elif self.type == 'virtual-machine':
             self.api_endpoint = '/1.0/virtual-machines'

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -634,8 +634,7 @@ class LXDContainerManagement(object):
             self._needs_to_change_instance_config('config') or
             self._needs_to_change_instance_config('ephemeral') or
             self._needs_to_change_instance_config('devices') or
-            self._needs_to_change_instance_config('profiles') or
-            self._needs_to_change_instance_config('type')
+            self._needs_to_change_instance_config('profiles')
         )
 
     def _apply_instance_configs(self):
@@ -645,7 +644,6 @@ class LXDContainerManagement(object):
             'config': old_metadata['config'],
             'devices': old_metadata['devices'],
             'profiles': old_metadata['profiles'],
-            'type': old_metadata['type'],
         }
 
         if self._needs_to_change_instance_config('architecture'):
@@ -659,11 +657,6 @@ class LXDContainerManagement(object):
             body_json['devices'] = self.config['devices']
         if self._needs_to_change_instance_config('profiles'):
             body_json['profiles'] = self.config['profiles']
-        if self._needs_to_change_instance_config('type') and self.type != self.old_instance_json['metadata']['type']:
-            self.module.fail_json(rc=1,
-                                  msg="Failed to update the instance name '{0}'. The parameter 'type' is immutable and cannot be changed."
-                                      " The last provided value '{1}' mismatch the current one '{2}'".
-                                      format(self.name, self.type, self.old_instance_json['metadata']['type']))
 
         self.client.do('PUT', '{0}/{1}'.format(self.api_endpoint, self.name), body_json=body_json)
         self.actions.append('apply_instance_configs')

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -21,24 +21,17 @@ options:
           - Name of an instance.
         type: str
         required: true
-    api_endpoint:
-        description:
-          - The LXD Rest API endpoint to create containers oder virtual-machines.
-            It can be set to "/1.0/instances" for creating instances of type container or virtual-machine.
-          - If the LXD server version is older than 3.19, then this should be set to "/1.0/containers".
-        type: str
-        required: false
     architecture:
         description:
-          - 'The architecture for the container (for example C(x86_64) or C(i686)).
+          - 'The architecture for the instance (for example C(x86_64) or C(i686)).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
         type: str
         required: false
     config:
         description:
-          - 'The config for the container (for example C({"limits.cpu": "2"})).
+          - 'The config for the instance (for example C({"limits.cpu": "2"})).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
-          - If the container already exists and its "config" values in metadata
+          - If the instance already exists and its "config" values in metadata
             obtained from GET <api_endpoint>/<name>
             U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#10containersname)
             are different, this module tries to apply the configurations.
@@ -57,25 +50,25 @@ options:
         version_added: 3.7.0
     profiles:
         description:
-          - Profile to be used by the container.
+          - Profile to be used by the instance.
         type: list
         elements: str
     devices:
         description:
-          - 'The devices for the container
+          - 'The devices for the instance
             (for example C({ "rootfs": { "path": "/dev/kvm", "type": "unix-char" }})).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
         type: dict
         required: false
     ephemeral:
         description:
-          - Whether or not the container is ephemeral (for example C(true) or C(false)).
+          - Whether or not the instance is ephemeral (for example C(true) or C(false)).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).
         required: false
         type: bool
     source:
         description:
-          - 'The source for the container
+          - 'The source for the instance
             (e.g. { "type": "image",
                     "mode": "pull",
                     "server": "https://images.linuxcontainers.org",
@@ -93,45 +86,45 @@ options:
           - absent
           - frozen
         description:
-          - Define the state of a container.
+          - Define the state of an instance.
         required: false
         default: started
         type: str
     target:
         description:
-          - For cluster deployments. Will attempt to create a container on a target node.
-            If container exists elsewhere in a cluster, then container will not be replaced or moved.
+          - For cluster deployments. Will attempt to create an instance on a target node.
+            If the instance exists elsewhere in a cluster, then it will not be replaced or moved.
             The name should respond to same name of the node you see in C(lxc cluster list).
         type: str
         required: false
         version_added: 1.0.0
     timeout:
         description:
-          - A timeout for changing the state of the container.
+          - A timeout for changing the state of the instance.
           - This is also used as a timeout for waiting until IPv4 addresses
-            are set to the all network interfaces in the container after
+            are set to the all network interfaces in the instance after
             starting or restarting.
         required: false
         default: 30
         type: int
     type:
         description:
-          - Instance type can be either "container" or "virtual-machine".
+          - Instance type can be either C(virtual-machine) or C(container).
         required: false
         default: container
         type: str
     wait_for_ipv4_addresses:
         description:
           - If this is true, the C(lxd_container) waits until IPv4 addresses
-            are set to the all network interfaces in the container after
+            are set to the all network interfaces in the instance after
             starting or restarting.
         required: false
         default: false
         type: bool
     force_stop:
         description:
-          - If this is true, the C(lxd_container) forces to stop the container
-            when it stops or restarts the container.
+          - If this is true, the C(lxd_container) forces to stop the instance
+            when it stops or restarts the instance.
         required: false
         default: false
         type: bool
@@ -173,18 +166,18 @@ options:
         required: false
         type: str
 notes:
-  - Containers must have a unique name. If you attempt to create a container
+  - Instances can be a container or a virtual machine, both of them must have unique name. If you attempt to create an instance
     with a name that already existed in the users namespace the module will
     simply return as "unchanged".
-  - There are two ways to run commands in containers, using the command
+  - There are two ways to run commands inside a container or virtual machine, using the command
     module or using the ansible lxd connection plugin bundled in Ansible >=
-    2.1, the later requires python to be installed in the container which can
+    2.1, the later requires python to be installed in the instance which can
     be done with the command module.
-  - You can copy a file from the host to the container
+  - You can copy a file from the host to the instance
     with the Ansible M(ansible.builtin.copy) and M(ansible.builtin.template) module and the `lxd` connection plugin.
     See the example below.
-  - You can copy a file in the created container to the localhost
-    with `command=lxc file pull container_name/dir/filename filename`.
+  - You can copy a file in the created instance to the localhost
+    with `command=lxc file pull instance_name/dir/filename filename`.
     See the first example below.
 '''
 
@@ -323,12 +316,12 @@ EXAMPLES = '''
 
 RETURN = '''
 addresses:
-  description: Mapping from the network device name to a list of IPv4 addresses in the container
+  description: Mapping from the network device name to a list of IPv4 addresses in the instance
   returned: when state is started or restarted
   type: dict
   sample: {"eth0": ["10.155.92.191"]}
 old_state:
-  description: The old state of the container
+  description: The old state of the instance
   returned: when state is started or restarted
   type: str
   sample: "stopped"
@@ -338,7 +331,7 @@ logs:
   type: list
   sample: "(too long to be placed here)"
 actions:
-  description: List of actions performed for the container.
+  description: List of actions performed for the instance.
   returned: success
   type: list
   sample: '["create", "start"]'
@@ -374,7 +367,7 @@ ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
-    'api_endpoint', 'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source', 'type'
+    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source', 'type'
 ]
 
 
@@ -397,8 +390,18 @@ class LXDContainerManagement(object):
         self.addresses = None
         self.target = self.module.params['target']
 
-        self.api_endpoint = self.module.params['api_endpoint']
         self.type = self.module.params['type']
+
+        # LXD Rest API provides additional endpoints for creating containers and virtual-machines.
+        self.api_endpoint = None
+        if self.type == 'container' or self.type is None:
+            self.api_endpoint = '/1.0/containers'
+        elif self.type == 'virtual-machine':
+            self.api_endpoint = '/1.0/virtual-machines'
+        else:
+            self.module.fail_json(msg="Validation error: "
+                                      "'type' parameter must be 'container' or 'virtual-machine'. "
+                                      "The current value is '{}'".format(self.type))
 
         self.key_file = self.module.params.get('client_key')
         if self.key_file is None:
@@ -435,20 +438,20 @@ class LXDContainerManagement(object):
             if param_val is not None:
                 self.config[attr] = param_val
 
-    def _get_container_json(self):
+    def _get_instance_json(self):
         return self.client.do(
             'GET', '{0}/{1}'.format(self.api_endpoint, self.name),
             ok_error_codes=[404]
         )
 
-    def _get_container_state_json(self):
+    def _get_instance_state_json(self):
         return self.client.do(
             'GET', '{0}/{1}/state'.format(self.api_endpoint, self.name),
             ok_error_codes=[404]
         )
 
     @staticmethod
-    def _container_json_to_module_state(resp_json):
+    def _instance_json_to_module_state(resp_json):
         if resp_json['type'] == 'error':
             return 'absent'
         return ANSIBLE_LXD_STATES[resp_json['metadata']['status']]
@@ -459,7 +462,7 @@ class LXDContainerManagement(object):
             body_json['force'] = True
         return self.client.do('PUT', '{0}/{1}/state'.format(self.api_endpoint, self.name), body_json=body_json)
 
-    def _create_container(self):
+    def _create_instance(self):
         config = self.config.copy()
         config['name'] = self.name
         if self.target:
@@ -468,34 +471,34 @@ class LXDContainerManagement(object):
             self.client.do('POST', self.api_endpoint, config)
         self.actions.append('create')
 
-    def _start_container(self):
+    def _start_instance(self):
         self._change_state('start')
         self.actions.append('start')
 
-    def _stop_container(self):
+    def _stop_instance(self):
         self._change_state('stop', self.force_stop)
         self.actions.append('stop')
 
-    def _restart_container(self):
+    def _restart_instance(self):
         self._change_state('restart', self.force_stop)
         self.actions.append('restart')
 
-    def _delete_container(self):
+    def _delete_instance(self):
         self.client.do('DELETE', '{0}/{1}'.format(self.api_endpoint, self.name))
         self.actions.append('delete')
 
-    def _freeze_container(self):
+    def _freeze_instance(self):
         self._change_state('freeze')
         self.actions.append('freeze')
 
-    def _unfreeze_container(self):
+    def _unfreeze_instance(self):
         self._change_state('unfreeze')
         self.actions.append('unfreez')
 
-    def _container_ipv4_addresses(self, ignore_devices=None):
+    def _instance_ipv4_addresses(self, ignore_devices=None):
         ignore_devices = ['lo'] if ignore_devices is None else ignore_devices
 
-        resp_json = self._get_container_state_json()
+        resp_json = self._get_instance_state_json()
         network = resp_json['metadata']['network'] or {}
         network = dict((k, v) for k, v in network.items() if k not in ignore_devices) or {}
         addresses = dict((k, [a['address'] for a in v['addresses'] if a['family'] == 'inet']) for k, v in network.items()) or {}
@@ -510,7 +513,7 @@ class LXDContainerManagement(object):
             due = datetime.datetime.now() + datetime.timedelta(seconds=self.timeout)
             while datetime.datetime.now() < due:
                 time.sleep(1)
-                addresses = self._container_ipv4_addresses()
+                addresses = self._instance_ipv4_addresses()
                 if self._has_all_ipv4_addresses(addresses):
                     self.addresses = addresses
                     return
@@ -520,72 +523,72 @@ class LXDContainerManagement(object):
 
     def _started(self):
         if self.old_state == 'absent':
-            self._create_container()
-            self._start_container()
+            self._create_instance()
+            self._start_instance()
         else:
             if self.old_state == 'frozen':
-                self._unfreeze_container()
+                self._unfreeze_instance()
             elif self.old_state == 'stopped':
-                self._start_container()
-            if self._needs_to_apply_container_configs():
-                self._apply_container_configs()
+                self._start_instance()
+            if self._needs_to_apply_instance_configs():
+                self._apply_instance_configs()
         if self.wait_for_ipv4_addresses:
             self._get_addresses()
 
     def _stopped(self):
         if self.old_state == 'absent':
-            self._create_container()
+            self._create_instance()
         else:
             if self.old_state == 'stopped':
-                if self._needs_to_apply_container_configs():
-                    self._start_container()
-                    self._apply_container_configs()
-                    self._stop_container()
+                if self._needs_to_apply_instance_configs():
+                    self._start_instance()
+                    self._apply_instance_configs()
+                    self._stop_instance()
             else:
                 if self.old_state == 'frozen':
-                    self._unfreeze_container()
-                if self._needs_to_apply_container_configs():
-                    self._apply_container_configs()
-                self._stop_container()
+                    self._unfreeze_instance()
+                if self._needs_to_apply_instance_configs():
+                    self._apply_instance_configs()
+                self._stop_instance()
 
     def _restarted(self):
         if self.old_state == 'absent':
-            self._create_container()
-            self._start_container()
+            self._create_instance()
+            self._start_instance()
         else:
             if self.old_state == 'frozen':
-                self._unfreeze_container()
-            if self._needs_to_apply_container_configs():
-                self._apply_container_configs()
-            self._restart_container()
+                self._unfreeze_instance()
+            if self._needs_to_apply_instance_configs():
+                self._apply_instance_configs()
+            self._restart_instance()
         if self.wait_for_ipv4_addresses:
             self._get_addresses()
 
     def _destroyed(self):
         if self.old_state != 'absent':
             if self.old_state == 'frozen':
-                self._unfreeze_container()
+                self._unfreeze_instance()
             if self.old_state != 'stopped':
-                self._stop_container()
-            self._delete_container()
+                self._stop_instance()
+            self._delete_instance()
 
     def _frozen(self):
         if self.old_state == 'absent':
-            self._create_container()
-            self._start_container()
-            self._freeze_container()
+            self._create_instance()
+            self._start_instance()
+            self._freeze_instance()
         else:
             if self.old_state == 'stopped':
-                self._start_container()
-            if self._needs_to_apply_container_configs():
-                self._apply_container_configs()
-            self._freeze_container()
+                self._start_instance()
+            if self._needs_to_apply_instance_configs():
+                self._apply_instance_configs()
+            self._freeze_instance()
 
-    def _needs_to_change_container_config(self, key):
+    def _needs_to_change_instance_config(self, key):
         if key not in self.config:
             return False
         if key == 'config' and self.ignore_volatile_options:  # the old behavior is to ignore configurations by keyword "volatile"
-            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
+            old_configs = dict((k, v) for k, v in self.old_instance_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
                 if k not in old_configs:
                     return True
@@ -593,7 +596,7 @@ class LXDContainerManagement(object):
                     return True
             return False
         elif key == 'config':  # next default behavior
-            old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items())
+            old_configs = dict((k, v) for k, v in self.old_instance_json['metadata'][key].items())
             for k, v in self.config['config'].items():
                 if k not in old_configs:
                     return True
@@ -601,21 +604,21 @@ class LXDContainerManagement(object):
                     return True
             return False
         else:
-            old_configs = self.old_container_json['metadata'][key]
+            old_configs = self.old_instance_json['metadata'][key]
             return self.config[key] != old_configs
 
-    def _needs_to_apply_container_configs(self):
+    def _needs_to_apply_instance_configs(self):
         return (
-            self._needs_to_change_container_config('architecture') or
-            self._needs_to_change_container_config('config') or
-            self._needs_to_change_container_config('ephemeral') or
-            self._needs_to_change_container_config('devices') or
-            self._needs_to_change_container_config('profiles') or
-            self._needs_to_change_container_config('type')
+            self._needs_to_change_instance_config('architecture') or
+            self._needs_to_change_instance_config('config') or
+            self._needs_to_change_instance_config('ephemeral') or
+            self._needs_to_change_instance_config('devices') or
+            self._needs_to_change_instance_config('profiles') or
+            self._needs_to_change_instance_config('type')
         )
 
-    def _apply_container_configs(self):
-        old_metadata = self.old_container_json['metadata']
+    def _apply_instance_configs(self):
+        old_metadata = self.old_instance_json['metadata']
         body_json = {
             'architecture': old_metadata['architecture'],
             'config': old_metadata['config'],
@@ -624,25 +627,25 @@ class LXDContainerManagement(object):
             'type': old_metadata['type'],
         }
 
-        if self._needs_to_change_container_config('architecture'):
+        if self._needs_to_change_instance_config('architecture'):
             body_json['architecture'] = self.config['architecture']
-        if self._needs_to_change_container_config('config'):
+        if self._needs_to_change_instance_config('config'):
             for k, v in self.config['config'].items():
                 body_json['config'][k] = v
-        if self._needs_to_change_container_config('ephemeral'):
+        if self._needs_to_change_instance_config('ephemeral'):
             body_json['ephemeral'] = self.config['ephemeral']
-        if self._needs_to_change_container_config('devices'):
+        if self._needs_to_change_instance_config('devices'):
             body_json['devices'] = self.config['devices']
-        if self._needs_to_change_container_config('profiles'):
+        if self._needs_to_change_instance_config('profiles'):
             body_json['profiles'] = self.config['profiles']
-        if self._needs_to_change_container_config('type') and self.type != self.old_container_json['metadata']['type']:
+        if self._needs_to_change_instance_config('type') and self.type != self.old_instance_json['metadata']['type']:
             self.module.fail_json(rc=1,
                                   msg="Failed to update the instance name '{0}'. The parameter 'type' is immutable and cannot be changed."
                                       " The last provided value '{1}' mismatch the current one '{2}'".
-                                      format(self.name, self.type, self.old_container_json['metadata']['type']))
+                                      format(self.name, self.type, self.old_instance_json['metadata']['type']))
 
         self.client.do('PUT', '{0}/{1}'.format(self.api_endpoint, self.name), body_json=body_json)
-        self.actions.append('apply_container_configs')
+        self.actions.append('apply_instance_configs')
 
     def run(self):
         """Run the main method."""
@@ -652,8 +655,8 @@ class LXDContainerManagement(object):
                 self.client.authenticate(self.trust_password)
             self.ignore_volatile_options = self.module.params.get('ignore_volatile_options')
 
-            self.old_container_json = self._get_container_json()
-            self.old_state = self._container_json_to_module_state(self.old_container_json)
+            self.old_instance_json = self._get_instance_json()
+            self.old_state = self._instance_json_to_module_state(self.old_instance_json)
             action = getattr(self, LXD_ANSIBLE_STATES[self.state])
             action()
 
@@ -723,9 +726,6 @@ def main():
                 type='int',
                 default=30
             ),
-            api_endpoint=dict(
-                type='str',
-            ),
             type=dict(
                 type='str',
                 default='container'
@@ -767,17 +767,6 @@ def main():
             'to the playbook.'
             'This will change in the future. Please test your scripts'
             'by "ignore_volatile_options: false". To keep the old behavior, set that option explicitly to "true"',
-            version='6.0.0', collection_name='community.general')
-
-    if module.params['api_endpoint'] is None:
-        if module.params['type'] == 'virtual-machine':
-            module.params['api_endpoint'] = '/1.0/virtual-machines'
-        else:
-            module.params['api_endpoint'] = '/1.0/containers'
-        module.deprecate(
-            'The LXD Rest API has implemented a new endpoint, which supports containers and virtual-machines.'
-            ' If the LXD server version is greater than or equal to 3.19, make sure to change the API endpoint by setting "api_endpoint: /1.0/instances".'
-            ' To keep the old behavior, set that option explicitly to "/1.0/containers"',
             version='6.0.0', collection_name='community.general')
 
     lxd_manage = LXDContainerManagement(module=module)

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -346,7 +346,7 @@ addresses:
   type: dict
   sample: {"eth0": ["10.155.92.191"]}
 old_state:
-  description: The old state of the instance
+  description: The old state of the instance.
   returned: when state is started or restarted
   type: str
   sample: "stopped"

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -422,7 +422,7 @@ class LXDContainerManagement(object):
         else:
             self.module.fail_json(msg="Validation error: "
                                       "'type' parameter must be 'container' or 'virtual-machine'. "
-                                      "The current value is '{}'".format(self.type))
+                                      "The current value is '{0}'".format(self.type))
 
         self.key_file = self.module.params.get('client_key')
         if self.key_file is None:

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -111,7 +111,11 @@ options:
           - Instance type can be either C(virtual-machine) or C(container).
         required: false
         default: container
+        choices:
+          - container
+          - virtual-machine
         type: str
+        version_added: 4.1.0
     wait_for_ipv4_addresses:
         description:
           - If this is true, the C(lxd_container) waits until IPv4 addresses
@@ -419,10 +423,6 @@ class LXDContainerManagement(object):
             self.api_endpoint = '/1.0/containers'
         elif self.type == 'virtual-machine':
             self.api_endpoint = '/1.0/virtual-machines'
-        else:
-            self.module.fail_json(msg="Validation error: "
-                                      "'type' parameter must be 'container' or 'virtual-machine'. "
-                                      "The current value is '{0}'".format(self.type))
 
         self.key_file = self.module.params.get('client_key')
         if self.key_file is None:
@@ -749,7 +749,8 @@ def main():
             ),
             type=dict(
                 type='str',
-                default='container'
+                default='container',
+                choices=['container', 'virtual-machine'],
             ),
             wait_for_ipv4_addresses=dict(
                 type='bool',

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -643,7 +643,7 @@ class LXDContainerManagement(object):
             'architecture': old_metadata['architecture'],
             'config': old_metadata['config'],
             'devices': old_metadata['devices'],
-            'profiles': old_metadata['profiles'],
+            'profiles': old_metadata['profiles']
         }
 
         if self._needs_to_change_instance_config('architecture'):


### PR DESCRIPTION
##### SUMMARY

This MR adds support to lxd_container module to deploy either containers or virtual-machines. For that it was necessary to create two new parameters `api_endpoint` and `type`:

* `api_endpoint`: is required in order to be backwards compatible with old LXD servers, which does not support the new API endpoint `/1.0/virtual-machines` or `/1.0/instances` (implemented in [lxd 3.19](https://discuss.linuxcontainers.org/t/lxd-3-19-has-been-released/6529))
* `type`: there is two different types of instances, “container” or “virtual-machine”

It is related to:
* https://github.com/ansible-collections/community.general/pull/3519

It is a different approach of an open MR:
* https://github.com/ansible-collections/community.general/pull/3480

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lxd_container

##### ADDITIONAL INFORMATION

The old functionality has not changed. Additionally I've tested the changes only with the latest LXD version 4.19.
* it is possible to create virtual-machine or container
* if an instance already exists and someone tries to update its "type" from `container` to `virtual-machine` or vice-versa, it fails with a warning, otherwise I was only getting changed as status, which is not correct.