### PR TITLE
Allow ldap search to run in check mode always

### DIFF
--- a/plugins/modules/net_tools/ldap/ldap_search.py
+++ b/plugins/modules/net_tools/ldap/ldap_search.py
@@ -106,11 +106,18 @@ def main():
         module.fail_json(msg=missing_required_lib('python-ldap'),
                          exception=LDAP_IMP_ERR)
 
-    if not module.check_mode:
-        try:
-            LdapSearch(module).main()
-        except Exception as exception:
-            module.fail_json(msg="Attribute action failed.", details=to_native(exception))
+    # remove the following and allow to run even in check mode #3619
+    # if not module.check_mode:
+    #     try:
+    #         LdapSearch(module).main()
+    #     except Exception as exception:
+    #         module.fail_json(msg="Attribute action failed.", details=to_native(exception))
+
+    # Run even in check mode #3619
+    try:
+      LdapSearch(module).main()
+    except Exception as exception:
+      module.fail_json(msg="Attribute action failed.", details=to_native(exception))
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
LDAP Search module would not run in check mode unless "check_mode: no" was used. A search does not change anything, therefore running in check mode causes no harm and can help with troubleshooting issues.
Fixes #3619

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ldap_search.py

##### ADDITIONAL INFORMATION
no changed to module options
