### PR TITLE
Better handling of base64-encoded values in xattr module

### DIFF
--- a/changelogs/fragments/3675-xattr-handle-base64-values.yml
+++ b/changelogs/fragments/3675-xattr-handle-base64-values.yml
@@ -1,4 +1,3 @@
 bugfixes:
   - xattr - fix exception caused by ``_run_xattr()`` raising a ``ValueError``
     due to a mishandling of base64-encoded value (https://github.com/ansible-collections/community.general/issues/3673).
-

--- a/changelogs/fragments/3675-xattr-handle-base64-values.yml
+++ b/changelogs/fragments/3675-xattr-handle-base64-values.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - xattr - fix exception caused by ``_run_xattr()`` raising a ``ValueError``
+    due to a mishandling of base64-encoded value (https://github.com/ansible-collections/community.general/issues/3673).
+

--- a/plugins/modules/files/xattr.py
+++ b/plugins/modules/files/xattr.py
@@ -158,7 +158,7 @@ def _run_xattr(module, cmd, check_rc=True):
         if line.startswith('#') or line == '':
             pass
         elif '=' in line:
-            (key, val) = line.split('=', maxsplit=1)
+            (key, val) = line.split('=', 1)
             result[key] = val.strip('"')
         else:
             result[line] = ''

--- a/plugins/modules/files/xattr.py
+++ b/plugins/modules/files/xattr.py
@@ -158,7 +158,7 @@ def _run_xattr(module, cmd, check_rc=True):
         if line.startswith('#') or line == '':
             pass
         elif '=' in line:
-            (key, val) = line.split('=')
+            (key, val) = line.split('=', maxsplit=1)
             result[key] = val.strip('"')
         else:
             result[line] = ''


### PR DESCRIPTION
Fix an exception in xattr module when existing extended attribute's value contains non-printable characters and the base64-encoded string contains a '=' sign

##### SUMMARY
xattr module tries to split the output of getfattr with the '=' sign, without taking into consideration that a base64-encoded value can have '=' sign itself. The patch introduces a maxsplit to prevent the value from being splitted.
Fixes #3673

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
xattr


```
