### PR TITLE
Rework safety check on size arguments for when LV doesn't exist

### DIFF
--- a/changelogs/fragments/3681-lvol-fix-create.yml
+++ b/changelogs/fragments/3681-lvol-fix-create.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes #3665 - allows lvols to be created with arguments prefixed with "+" to preserve old lvol.py behaviour
+  - lvol - allows logical volumes to be created with certain size arguments prefixed with ``+`` to preserve behavior of older versions of this module (https://github.com/ansible-collections/community.general/issues/3665).

--- a/changelogs/fragments/3681-lvol-fix-create.yml
+++ b/changelogs/fragments/3681-lvol-fix-create.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes #3665 - allows lvols to be created with arguments prefixed with "+" to preserve old lvol.py behaviour

--- a/plugins/modules/system/lvol.py
+++ b/plugins/modules/system/lvol.py
@@ -451,7 +451,8 @@ def main():
     if this_lv is None:
         if state == 'present':
             if size_operator is not None:
-                module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % (size_operator, size))
+                if size_operator == "-" or (size_whole not in ["VG", "PVS", "FREE", "ORIGIN", None]):
+                    module.fail_json(msg="Bad size specification of '%s%s' for creating LV" % (size_operator, size))
             # Require size argument except for snapshot of thin volumes
             if (lv or thinpool) and not size:
                 for test_lv in lvs:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #3665 - allows lvols to be created with arguments prefixed with "+", to preserve old lvol.py behaviour
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/system/lvol.py


