### PR TITLE
Ensuring command options are applied during build_plan

### DIFF
--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -323,14 +323,19 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
-    plan_command = [command[0], 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', plan_path]
+    plan_command = [command.pop(0), 'plan', '-input=false', '-no-color', '-detailed-exitcode', '-out', plan_path]
+
+    for c in command:
+        plan_command.insert(2,c)
 
     for t in targets:
         plan_command.extend(['-target', t])
 
+    plan_command.extend(variables_args)
+
     plan_command.extend(_state_args(state_file))
 
-    rc, out, err = module.run_command(plan_command + variables_args, cwd=project_path)
+    rc, out, err = module.run_command(plan_command, cwd=project_path)
 
     if rc == 0:
         # no changes


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
State: Planned does not use other command options such as lock: true or lock_timeout: 10
This proposed change includes all command options in planning stage to ensure no options are missed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce this issue:
Set Terraform module with State: plan 
Set lock_timout 
Run the task on a already locked state file
It will not wait for the lock to be removed and fail directly

