### PR TITLE
gitlab: clean up modules and utils

### DIFF
--- a/changelogs/fragments/3694-gitlab-cleanup.yml
+++ b/changelogs/fragments/3694-gitlab-cleanup.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab - clean up modules and utils (https://github.com/ansible-collections/community.general/pull/3694)
+  - gitlab - clean up modules and utils (https://github.com/ansible-collections/community.general/pull/3694).

--- a/changelogs/fragments/3694-gitlab-cleanup.yml
+++ b/changelogs/fragments/3694-gitlab-cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab - clean up modules and utils (https://github.com/ansible-collections/community.general/pull/3694)

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -30,30 +30,6 @@ except Exception:
     HAS_GITLAB_PACKAGE = False
 
 
-def request(module, api_url, project, path, access_token, private_token, rawdata='', method='GET'):
-    url = "%s/v4/projects/%s%s" % (api_url, quote_plus(project), path)
-    headers = {}
-    if access_token:
-        headers['Authorization'] = "Bearer %s" % access_token
-    else:
-        headers['Private-Token'] = private_token
-
-    headers['Accept'] = "application/json"
-    headers['Content-Type'] = "application/json"
-
-    response, info = fetch_url(module=module, url=url, headers=headers, data=rawdata, method=method)
-    status = info['status']
-    content = ""
-    if response:
-        content = response.read()
-    if status == 204:
-        return True, content
-    elif status == 200 or status == 201:
-        return True, json.loads(content)
-    else:
-        return False, str(status) + ": " + content
-
-
 def findProject(gitlab_instance, identifier):
     try:
         project = gitlab_instance.projects.get(identifier)

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -30,7 +30,7 @@ except Exception:
     HAS_GITLAB_PACKAGE = False
 
 
-def findProject(gitlab_instance, identifier):
+def find_project(gitlab_instance, identifier):
     try:
         project = gitlab_instance.projects.get(identifier)
     except Exception as e:
@@ -43,7 +43,7 @@ def findProject(gitlab_instance, identifier):
     return project
 
 
-def findGroup(gitlab_instance, identifier):
+def find_group(gitlab_instance, identifier):
     try:
         project = gitlab_instance.groups.get(identifier)
     except Exception as e:
@@ -52,7 +52,7 @@ def findGroup(gitlab_instance, identifier):
     return project
 
 
-def gitlabAuthentication(module):
+def gitlab_authentication(module):
     gitlab_url = module.params['api_url']
     validate_certs = module.params['validate_certs']
     gitlab_user = module.params['api_username']

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -133,13 +133,13 @@ class GitLabDeployKey(object):
     def __init__(self, module, gitlab_instance):
         self._module = module
         self._gitlab = gitlab_instance
-        self.deployKeyObject = None
+        self.deploy_key_object = None
 
     '''
     @param project Project object
     @param key_title Title of the key
     @param key_key String of the key
-    @param key_can_push Option of the deployKey
+    @param key_can_push Option of the deploy_key
     @param options Deploy key options
     '''
     def create_or_update_deploy_key(self, project, key_title, key_key, options):
@@ -148,29 +148,29 @@ class GitLabDeployKey(object):
         # note: unfortunately public key cannot be updated directly by
         #   GitLab REST API, so for that case we need to delete and
         #   than recreate the key
-        if self.deployKeyObject and self.deployKeyObject.key != key_key:
+        if self.deploy_key_object and self.deploy_key_object.key != key_key:
             if not self._module.check_mode:
-                self.deployKeyObject.delete()
-            self.deployKeyObject = None
+                self.deploy_key_object.delete()
+            self.deploy_key_object = None
 
         # Because we have already call exists_deploy_key in main()
-        if self.deployKeyObject is None:
-            deployKey = self.create_deploy_key(project, {
+        if self.deploy_key_object is None:
+            deploy_key = self.create_deploy_key(project, {
                 'title': key_title,
                 'key': key_key,
                 'can_push': options['can_push']})
             changed = True
         else:
-            changed, deployKey = self.update_deploy_key(self.deployKeyObject, {
+            changed, deploy_key = self.update_deploy_key(self.deploy_key_object, {
                 'can_push': options['can_push']})
 
-        self.deployKeyObject = deployKey
+        self.deploy_key_object = deploy_key
         if changed:
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully created or updated the deploy key %s" % key_title)
 
             try:
-                deployKey.save()
+                deploy_key.save()
             except Exception as e:
                 self._module.fail_json(msg="Failed to update deploy key: %s " % e)
             return True
@@ -179,53 +179,53 @@ class GitLabDeployKey(object):
 
     '''
     @param project Project Object
-    @param arguments Attributes of the deployKey
+    @param arguments Attributes of the deploy_key
     '''
     def create_deploy_key(self, project, arguments):
         if self._module.check_mode:
             return True
 
         try:
-            deployKey = project.keys.create(arguments)
+            deploy_key = project.keys.create(arguments)
         except (gitlab.exceptions.GitlabCreateError) as e:
             self._module.fail_json(msg="Failed to create deploy key: %s " % to_native(e))
 
-        return deployKey
+        return deploy_key
 
     '''
-    @param deployKey Deploy Key Object
-    @param arguments Attributes of the deployKey
+    @param deploy_key Deploy Key Object
+    @param arguments Attributes of the deploy_key
     '''
-    def update_deploy_key(self, deployKey, arguments):
+    def update_deploy_key(self, deploy_key, arguments):
         changed = False
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(deployKey, arg_key) != arguments[arg_key]:
-                    setattr(deployKey, arg_key, arguments[arg_key])
+                if getattr(deploy_key, arg_key) != arguments[arg_key]:
+                    setattr(deploy_key, arg_key, arguments[arg_key])
                     changed = True
 
-        return (changed, deployKey)
+        return (changed, deploy_key)
 
     '''
     @param project Project object
     @param key_title Title of the key
     '''
     def find_deploy_key(self, project, key_title):
-        deployKeys = project.keys.list(all=True)
-        for deployKey in deployKeys:
-            if (deployKey.title == key_title):
-                return deployKey
+        deploy_keys = project.keys.list(all=True)
+        for deploy_key in deploy_keys:
+            if (deploy_key.title == key_title):
+                return deploy_key
 
     '''
     @param project Project object
     @param key_title Title of the key
     '''
     def exists_deploy_key(self, project, key_title):
-        # When project exists, object will be stored in self.projectObject.
-        deployKey = self.find_deploy_key(project, key_title)
-        if deployKey:
-            self.deployKeyObject = deployKey
+        # When project exists, object will be stored in self.project_object.
+        deploy_key = self.find_deploy_key(project, key_title)
+        if deploy_key:
+            self.deploy_key_object = deploy_key
             return True
         return False
 
@@ -233,7 +233,7 @@ class GitLabDeployKey(object):
         if self._module.check_mode:
             return True
 
-        return self.deployKeyObject.delete()
+        return self.deploy_key_object.delete()
 
 
 def main():
@@ -280,10 +280,10 @@ def main():
     if project is None:
         module.fail_json(msg="Failed to create deploy key: project %s doesn't exists" % project_identifier)
 
-    deployKey_exists = gitlab_deploy_key.exists_deploy_key(project, key_title)
+    deploy_key_exists = gitlab_deploy_key.exists_deploy_key(project, key_title)
 
     if state == 'absent':
-        if deployKey_exists:
+        if deploy_key_exists:
             gitlab_deploy_key.delete_deploy_key()
             module.exit_json(changed=True, msg="Successfully deleted deploy key %s" % key_title)
         else:
@@ -293,10 +293,10 @@ def main():
         if gitlab_deploy_key.create_or_update_deploy_key(project, key_title, key_keyfile, {'can_push': key_can_push}):
 
             module.exit_json(changed=True, msg="Successfully created or updated the deploy key %s" % key_title,
-                             deploy_key=gitlab_deploy_key.deployKeyObject._attrs)
+                             deploy_key=gitlab_deploy_key.deploy_key_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the deploy key %s" % key_title,
-                             deploy_key=gitlab_deploy_key.deployKeyObject._attrs)
+                             deploy_key=gitlab_deploy_key.deploy_key_object._attrs)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -169,7 +169,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, gitlab_authentication
 
 
 class GitLabGroup(object):
@@ -181,7 +181,7 @@ class GitLabGroup(object):
     '''
     @param group Group object
     '''
-    def getGroupId(self, group):
+    def get_group_id(self, group):
         if group is not None:
             return group.id
         return None
@@ -191,12 +191,12 @@ class GitLabGroup(object):
     @param parent Parent group full path
     @param options Group options
     '''
-    def createOrUpdateGroup(self, name, parent, options):
+    def create_or_update_group(self, name, parent, options):
         changed = False
 
         # Because we have already call userExists in main()
         if self.groupObject is None:
-            parent_id = self.getGroupId(parent)
+            parent_id = self.get_group_id(parent)
 
             payload = {
                 'name': name,
@@ -211,10 +211,10 @@ class GitLabGroup(object):
                 payload['description'] = options['description']
             if options.get('require_two_factor_authentication'):
                 payload['require_two_factor_authentication'] = options['require_two_factor_authentication']
-            group = self.createGroup(payload)
+            group = self.create_group(payload)
             changed = True
         else:
-            changed, group = self.updateGroup(self.groupObject, {
+            changed, group = self.update_group(self.groupObject, {
                 'name': name,
                 'description': options['description'],
                 'visibility': options['visibility'],
@@ -240,7 +240,7 @@ class GitLabGroup(object):
     '''
     @param arguments Attributes of the group
     '''
-    def createGroup(self, arguments):
+    def create_group(self, arguments):
         if self._module.check_mode:
             return True
 
@@ -255,7 +255,7 @@ class GitLabGroup(object):
     @param group Group Object
     @param arguments Attributes of the group
     '''
-    def updateGroup(self, group, arguments):
+    def update_group(self, group, arguments):
         changed = False
 
         for arg_key, arg_value in arguments.items():
@@ -266,7 +266,7 @@ class GitLabGroup(object):
 
         return (changed, group)
 
-    def deleteGroup(self):
+    def delete_group(self):
         group = self.groupObject
 
         if len(group.projects.list()) >= 1:
@@ -285,9 +285,9 @@ class GitLabGroup(object):
     @param name Name of the groupe
     @param full_path Complete path of the Group including parent group path. <parent_path>/<group_path>
     '''
-    def existsGroup(self, project_identifier):
+    def exists_group(self, project_identifier):
         # When group/user exists, object will be stored in self.groupObject.
-        group = findGroup(self._gitlab, project_identifier)
+        group = find_group(self._gitlab, project_identifier)
         if group:
             self.groupObject = group
             return True
@@ -339,7 +339,7 @@ def main():
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
 
     # Define default group_path based on group_name
     if group_path is None:
@@ -349,23 +349,23 @@ def main():
 
     parent_group = None
     if parent_identifier:
-        parent_group = findGroup(gitlab_instance, parent_identifier)
+        parent_group = find_group(gitlab_instance, parent_identifier)
         if not parent_group:
             module.fail_json(msg="Failed create GitLab group: Parent group doesn't exists")
 
-        group_exists = gitlab_group.existsGroup(parent_group.full_path + '/' + group_path)
+        group_exists = gitlab_group.exists_group(parent_group.full_path + '/' + group_path)
     else:
-        group_exists = gitlab_group.existsGroup(group_path)
+        group_exists = gitlab_group.exists_group(group_path)
 
     if state == 'absent':
         if group_exists:
-            gitlab_group.deleteGroup()
+            gitlab_group.delete_group()
             module.exit_json(changed=True, msg="Successfully deleted group %s" % group_name)
         else:
             module.exit_json(changed=False, msg="Group deleted or does not exists")
 
     if state == 'present':
-        if gitlab_group.createOrUpdateGroup(group_name, parent_group, {
+        if gitlab_group.create_or_update_group(group_name, parent_group, {
                                             "path": group_path,
                                             "description": description,
                                             "visibility": group_visibility,

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -176,7 +176,7 @@ class GitLabGroup(object):
     def __init__(self, module, gitlab_instance):
         self._module = module
         self._gitlab = gitlab_instance
-        self.groupObject = None
+        self.group_object = None
 
     '''
     @param group Group object
@@ -195,7 +195,7 @@ class GitLabGroup(object):
         changed = False
 
         # Because we have already call userExists in main()
-        if self.groupObject is None:
+        if self.group_object is None:
             parent_id = self.get_group_id(parent)
 
             payload = {
@@ -214,7 +214,7 @@ class GitLabGroup(object):
             group = self.create_group(payload)
             changed = True
         else:
-            changed, group = self.update_group(self.groupObject, {
+            changed, group = self.update_group(self.group_object, {
                 'name': name,
                 'description': options['description'],
                 'visibility': options['visibility'],
@@ -224,7 +224,7 @@ class GitLabGroup(object):
                 'require_two_factor_authentication': options['require_two_factor_authentication'],
             })
 
-        self.groupObject = group
+        self.group_object = group
         if changed:
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully created or updated the group %s" % name)
@@ -267,7 +267,7 @@ class GitLabGroup(object):
         return (changed, group)
 
     def delete_group(self):
-        group = self.groupObject
+        group = self.group_object
 
         if len(group.projects.list()) >= 1:
             self._module.fail_json(
@@ -286,10 +286,10 @@ class GitLabGroup(object):
     @param full_path Complete path of the Group including parent group path. <parent_path>/<group_path>
     '''
     def exists_group(self, project_identifier):
-        # When group/user exists, object will be stored in self.groupObject.
+        # When group/user exists, object will be stored in self.group_object.
         group = find_group(self._gitlab, project_identifier)
         if group:
-            self.groupObject = group
+            self.group_object = group
             return True
         return False
 
@@ -374,9 +374,9 @@ def main():
                                             "subgroup_creation_level": subgroup_creation_level,
                                             "require_two_factor_authentication": require_two_factor_authentication,
                                             }):
-            module.exit_json(changed=True, msg="Successfully created or updated the group %s" % group_name, group=gitlab_group.groupObject._attrs)
+            module.exit_json(changed=True, msg="Successfully created or updated the group %s" % group_name, group=gitlab_group.group_object._attrs)
         else:
-            module.exit_json(changed=False, msg="No need to update the group %s" % group_name, group=gitlab_group.groupObject._attrs)
+            module.exit_json(changed=False, msg="No need to update the group %s" % group_name, group=gitlab_group.group_object._attrs)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -366,14 +366,14 @@ def main():
 
     if state == 'present':
         if gitlab_group.create_or_update_group(group_name, parent_group, {
-                                               "path": group_path,
-                                               "description": description,
-                                               "visibility": group_visibility,
-                                               "project_creation_level": project_creation_level,
-                                               "auto_devops_enabled": auto_devops_enabled,
-                                               "subgroup_creation_level": subgroup_creation_level,
-                                               "require_two_factor_authentication": require_two_factor_authentication,
-                                               }):
+            "path": group_path,
+            "description": description,
+            "visibility": group_visibility,
+            "project_creation_level": project_creation_level,
+            "auto_devops_enabled": auto_devops_enabled,
+            "subgroup_creation_level": subgroup_creation_level,
+            "require_two_factor_authentication": require_two_factor_authentication,
+        }):
             module.exit_json(changed=True, msg="Successfully created or updated the group %s" % group_name, group=gitlab_group.group_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the group %s" % group_name, group=gitlab_group.group_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -366,14 +366,14 @@ def main():
 
     if state == 'present':
         if gitlab_group.create_or_update_group(group_name, parent_group, {
-                                            "path": group_path,
-                                            "description": description,
-                                            "visibility": group_visibility,
-                                            "project_creation_level": project_creation_level,
-                                            "auto_devops_enabled": auto_devops_enabled,
-                                            "subgroup_creation_level": subgroup_creation_level,
-                                            "require_two_factor_authentication": require_two_factor_authentication,
-                                            }):
+                                               "path": group_path,
+                                               "description": description,
+                                               "visibility": group_visibility,
+                                               "project_creation_level": project_creation_level,
+                                               "auto_devops_enabled": auto_devops_enabled,
+                                               "subgroup_creation_level": subgroup_creation_level,
+                                               "require_two_factor_authentication": require_two_factor_authentication,
+                                               }):
             module.exit_json(changed=True, msg="Successfully created or updated the group %s" % group_name, group=gitlab_group.group_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the group %s" % group_name, group=gitlab_group.group_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -155,7 +155,7 @@ RETURN = r''' # '''
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
 
 import traceback
 
@@ -300,7 +300,7 @@ def main():
         purge_users = [access_level_int[level] for level in purge_users]
 
     # connect to gitlab server
-    gl = gitlabAuthentication(module)
+    gl = gitlab_authentication(module)
 
     group = GitLabGroup(module, gl)
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -288,7 +288,7 @@ def main():
         'reporter': gitlab.REPORTER_ACCESS,
         'developer': gitlab.DEVELOPER_ACCESS,
         'maintainer': gitlab.MAINTAINER_ACCESS,
-        'owner': gitlab.OWNER_ACCESS
+        'owner': gitlab.OWNER_ACCESS,
     }
 
     gitlab_group = module.params['gitlab_group']

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -170,9 +170,13 @@ class GitlabGroupVariables(object):
     def create_variable(self, key, value, masked, protected, variable_type):
         if self._module.check_mode:
             return
-        return self.group.variables.create({"key": key, "value": value,
-                                            "masked": masked, "protected": protected,
-                                            "variable_type": variable_type})
+        return self.group.variables.create({
+            "key": key,
+            "value": value,
+            "masked": masked,
+            "protected": protected,
+            "variable_type": variable_type,
+        })
 
     def update_variable(self, key, var, value, masked, protected, variable_type):
         if var.value == value and var.protected == protected and var.masked == masked and var.variable_type == variable_type:
@@ -226,11 +230,14 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
             existing_variables[index] = None
 
             if state == 'present':
-                single_change = this_gitlab.update_variable(key,
-                                                            gitlab_keys[index],
-                                                            value, masked,
-                                                            protected,
-                                                            variable_type)
+                single_change = this_gitlab.update_variable(
+                    key,
+                    gitlab_keys[index],
+                    value,
+                    masked,
+                    protected,
+                    variable_type,
+                )
                 change = single_change or change
                 if single_change:
                     return_value['updated'].append(key)

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -144,7 +144,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
 
 
 class GitlabGroupVariables(object):
@@ -291,7 +291,7 @@ def main():
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
 
     this_gitlab = GitlabGroupVariables(module=module, gitlab_instance=gitlab_instance)
 

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -183,7 +183,7 @@ class GitLabHook(object):
     def __init__(self, module, gitlab_instance):
         self._module = module
         self._gitlab = gitlab_instance
-        self.hookObject = None
+        self.hook_object = None
 
     '''
     @param project Project Object
@@ -195,7 +195,7 @@ class GitLabHook(object):
         changed = False
 
         # Because we have already call userExists in main()
-        if self.hookObject is None:
+        if self.hook_object is None:
             hook = self.create_hook(project, {
                 'url': hook_url,
                 'push_events': options['push_events'],
@@ -211,7 +211,7 @@ class GitLabHook(object):
                 'token': options['token']})
             changed = True
         else:
-            changed, hook = self.update_hook(self.hookObject, {
+            changed, hook = self.update_hook(self.hook_object, {
                 'push_events': options['push_events'],
                 'push_events_branch_filter': options['push_events_branch_filter'],
                 'issues_events': options['issues_events'],
@@ -224,7 +224,7 @@ class GitLabHook(object):
                 'enable_ssl_verification': options['enable_ssl_verification'],
                 'token': options['token']})
 
-        self.hookObject = hook
+        self.hook_object = hook
         if changed:
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url)
@@ -279,10 +279,10 @@ class GitLabHook(object):
     @param hook_url Url to call on event
     '''
     def exists_hook(self, project, hook_url):
-        # When project exists, object will be stored in self.projectObject.
+        # When project exists, object will be stored in self.project_object.
         hook = self.find_hook(project, hook_url)
         if hook:
-            self.hookObject = hook
+            self.hook_object = hook
             return True
         return False
 
@@ -290,7 +290,7 @@ class GitLabHook(object):
         if self._module.check_mode:
             return True
 
-        return self.hookObject.delete()
+        return self.hook_object.delete()
 
 
 def main():
@@ -378,9 +378,9 @@ def main():
                                           "enable_ssl_verification": enable_ssl_verification,
                                           "token": hook_token}):
 
-            module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url, hook=gitlab_hook.hookObject._attrs)
+            module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url, hook=gitlab_hook.hook_object._attrs)
         else:
-            module.exit_json(changed=False, msg="No need to update the hook %s" % hook_url, hook=gitlab_hook.hookObject._attrs)
+            module.exit_json(changed=False, msg="No need to update the hook %s" % hook_url, hook=gitlab_hook.hook_object._attrs)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -366,17 +366,17 @@ def main():
 
     if state == 'present':
         if gitlab_hook.create_or_update_hook(project, hook_url, {
-                                          "push_events": push_events,
-                                          "push_events_branch_filter": push_events_branch_filter,
-                                          "issues_events": issues_events,
-                                          "merge_requests_events": merge_requests_events,
-                                          "tag_push_events": tag_push_events,
-                                          "note_events": note_events,
-                                          "job_events": job_events,
-                                          "pipeline_events": pipeline_events,
-                                          "wiki_page_events": wiki_page_events,
-                                          "enable_ssl_verification": enable_ssl_verification,
-                                          "token": hook_token}):
+                                             "push_events": push_events,
+                                             "push_events_branch_filter": push_events_branch_filter,
+                                             "issues_events": issues_events,
+                                             "merge_requests_events": merge_requests_events,
+                                             "tag_push_events": tag_push_events,
+                                             "note_events": note_events,
+                                             "job_events": job_events,
+                                             "pipeline_events": pipeline_events,
+                                             "wiki_page_events": wiki_page_events,
+                                             "enable_ssl_verification": enable_ssl_verification,
+                                             "token": hook_token}):
 
             module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url, hook=gitlab_hook.hook_object._attrs)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -209,7 +209,7 @@ class GitLabHook(object):
                 'wiki_page_events': options['wiki_page_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
                 'token': options['token'],
-                })
+            })
             changed = True
         else:
             changed, hook = self.update_hook(self.hook_object, {
@@ -224,7 +224,7 @@ class GitLabHook(object):
                 'wiki_page_events': options['wiki_page_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
                 'token': options['token'],
-                })
+            })
 
         self.hook_object = hook
         if changed:
@@ -368,18 +368,18 @@ def main():
 
     if state == 'present':
         if gitlab_hook.create_or_update_hook(project, hook_url, {
-                                             "push_events": push_events,
-                                             "push_events_branch_filter": push_events_branch_filter,
-                                             "issues_events": issues_events,
-                                             "merge_requests_events": merge_requests_events,
-                                             "tag_push_events": tag_push_events,
-                                             "note_events": note_events,
-                                             "job_events": job_events,
-                                             "pipeline_events": pipeline_events,
-                                             "wiki_page_events": wiki_page_events,
-                                             "enable_ssl_verification": enable_ssl_verification,
-                                             "token": hook_token,
-                                             }):
+            "push_events": push_events,
+            "push_events_branch_filter": push_events_branch_filter,
+            "issues_events": issues_events,
+            "merge_requests_events": merge_requests_events,
+            "tag_push_events": tag_push_events,
+            "note_events": note_events,
+            "job_events": job_events,
+            "pipeline_events": pipeline_events,
+            "wiki_page_events": wiki_page_events,
+            "enable_ssl_verification": enable_ssl_verification,
+            "token": hook_token,
+        }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url, hook=gitlab_hook.hook_object._attrs)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -208,7 +208,8 @@ class GitLabHook(object):
                 'pipeline_events': options['pipeline_events'],
                 'wiki_page_events': options['wiki_page_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
-                'token': options['token']})
+                'token': options['token'],
+                })
             changed = True
         else:
             changed, hook = self.update_hook(self.hook_object, {
@@ -222,7 +223,8 @@ class GitLabHook(object):
                 'pipeline_events': options['pipeline_events'],
                 'wiki_page_events': options['wiki_page_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
-                'token': options['token']})
+                'token': options['token'],
+                })
 
         self.hook_object = hook
         if changed:
@@ -376,7 +378,8 @@ def main():
                                              "pipeline_events": pipeline_events,
                                              "wiki_page_events": wiki_page_events,
                                              "enable_ssl_verification": enable_ssl_verification,
-                                             "token": hook_token}):
+                                             "token": hook_token,
+                                             }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the hook %s" % hook_url, hook=gitlab_hook.hook_object._attrs)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -237,7 +237,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, findProject, gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, find_project, gitlab_authentication
 
 
 class GitLabProject(object):
@@ -251,7 +251,7 @@ class GitLabProject(object):
     @param namespace Namespace Object (User or Group)
     @param options Options of the project
     '''
-    def createOrUpdateProject(self, project_name, namespace, options):
+    def create_or_update_project(self, project_name, namespace, options):
         changed = False
         project_options = {
             'name': project_name,
@@ -280,11 +280,11 @@ class GitLabProject(object):
             })
             if options['initialize_with_readme']:
                 project_options['initialize_with_readme'] = options['initialize_with_readme']
-            project_options = self.getOptionsWithValue(project_options)
-            project = self.createProject(namespace, project_options)
+            project_options = self.get_options_with_value(project_options)
+            project = self.create_project(namespace, project_options)
             changed = True
         else:
-            changed, project = self.updateProject(self.projectObject, project_options)
+            changed, project = self.update_project(self.projectObject, project_options)
 
         self.projectObject = project
         if changed:
@@ -302,7 +302,7 @@ class GitLabProject(object):
     @param namespace Namespace Object (User or Group)
     @param arguments Attributes of the project
     '''
-    def createProject(self, namespace, arguments):
+    def create_project(self, namespace, arguments):
         if self._module.check_mode:
             return True
 
@@ -317,7 +317,7 @@ class GitLabProject(object):
     '''
     @param arguments Attributes of the project
     '''
-    def getOptionsWithValue(self, arguments):
+    def get_options_with_value(self, arguments):
         ret_arguments = dict()
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
@@ -329,7 +329,7 @@ class GitLabProject(object):
     @param project Project Object
     @param arguments Attributes of the project
     '''
-    def updateProject(self, project, arguments):
+    def update_project(self, project, arguments):
         changed = False
 
         for arg_key, arg_value in arguments.items():
@@ -340,7 +340,7 @@ class GitLabProject(object):
 
         return (changed, project)
 
-    def deleteProject(self):
+    def delete_project(self):
         if self._module.check_mode:
             return True
 
@@ -352,9 +352,9 @@ class GitLabProject(object):
     @param namespace User/Group object
     @param name Name of the project
     '''
-    def existsProject(self, namespace, path):
+    def exists_project(self, namespace, path):
         # When project exists, object will be stored in self.projectObject.
-        project = findProject(self._gitlab, namespace.full_path + '/' + path)
+        project = find_project(self._gitlab, namespace.full_path + '/' + path)
         if project:
             self.projectObject = project
             return True
@@ -433,7 +433,7 @@ def main():
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
 
     # Set project_path to project_name if it is empty.
     if project_path is None:
@@ -444,7 +444,7 @@ def main():
     namespace = None
     namespace_id = None
     if group_identifier:
-        group = findGroup(gitlab_instance, group_identifier)
+        group = find_group(gitlab_instance, group_identifier)
         if group is None:
             module.fail_json(msg="Failed to create project: group %s doesn't exists" % group_identifier)
 
@@ -466,17 +466,17 @@ def main():
 
     if not namespace:
         module.fail_json(msg="Failed to find the namespace for the project")
-    project_exists = gitlab_project.existsProject(namespace, project_path)
+    project_exists = gitlab_project.exists_project(namespace, project_path)
 
     if state == 'absent':
         if project_exists:
-            gitlab_project.deleteProject()
+            gitlab_project.delete_project()
             module.exit_json(changed=True, msg="Successfully deleted project %s" % project_name)
         module.exit_json(changed=False, msg="Project deleted or does not exists")
 
     if state == 'present':
 
-        if gitlab_project.createOrUpdateProject(project_name, namespace, {
+        if gitlab_project.create_or_update_project(project_name, namespace, {
                                                 "path": project_path,
                                                 "description": project_description,
                                                 "initialize_with_readme": initialize_with_readme,

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -477,26 +477,26 @@ def main():
     if state == 'present':
 
         if gitlab_project.create_or_update_project(project_name, namespace, {
-                                                "path": project_path,
-                                                "description": project_description,
-                                                "initialize_with_readme": initialize_with_readme,
-                                                "issues_enabled": issues_enabled,
-                                                "merge_requests_enabled": merge_requests_enabled,
-                                                "merge_method": merge_method,
-                                                "wiki_enabled": wiki_enabled,
-                                                "snippets_enabled": snippets_enabled,
-                                                "visibility": visibility,
-                                                "import_url": import_url,
-                                                "lfs_enabled": lfs_enabled,
-                                                "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
-                                                "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
-                                                "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
-                                                "packages_enabled": packages_enabled,
-                                                "remove_source_branch_after_merge": remove_source_branch_after_merge,
-                                                "squash_option": squash_option,
-                                                "ci_config_path": ci_config_path,
-                                                "shared_runners_enabled": shared_runners_enabled,
-                                                }):
+                                                   "path": project_path,
+                                                   "description": project_description,
+                                                   "initialize_with_readme": initialize_with_readme,
+                                                   "issues_enabled": issues_enabled,
+                                                   "merge_requests_enabled": merge_requests_enabled,
+                                                   "merge_method": merge_method,
+                                                   "wiki_enabled": wiki_enabled,
+                                                   "snippets_enabled": snippets_enabled,
+                                                   "visibility": visibility,
+                                                   "import_url": import_url,
+                                                   "lfs_enabled": lfs_enabled,
+                                                   "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
+                                                   "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
+                                                   "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
+                                                   "packages_enabled": packages_enabled,
+                                                   "remove_source_branch_after_merge": remove_source_branch_after_merge,
+                                                   "squash_option": squash_option,
+                                                   "ci_config_path": ci_config_path,
+                                                   "shared_runners_enabled": shared_runners_enabled,
+                                                   }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)
         module.exit_json(changed=False, msg="No need to update the project %s" % project_name, project=gitlab_project.project_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -244,7 +244,7 @@ class GitLabProject(object):
     def __init__(self, module, gitlab_instance):
         self._module = module
         self._gitlab = gitlab_instance
-        self.projectObject = None
+        self.project_object = None
 
     '''
     @param project_name Name of the project
@@ -273,7 +273,7 @@ class GitLabProject(object):
             'shared_runners_enabled': options['shared_runners_enabled'],
         }
         # Because we have already call userExists in main()
-        if self.projectObject is None:
+        if self.project_object is None:
             project_options.update({
                 'path': options['path'],
                 'import_url': options['import_url'],
@@ -284,9 +284,9 @@ class GitLabProject(object):
             project = self.create_project(namespace, project_options)
             changed = True
         else:
-            changed, project = self.update_project(self.projectObject, project_options)
+            changed, project = self.update_project(self.project_object, project_options)
 
-        self.projectObject = project
+        self.project_object = project
         if changed:
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name)
@@ -344,7 +344,7 @@ class GitLabProject(object):
         if self._module.check_mode:
             return True
 
-        project = self.projectObject
+        project = self.project_object
 
         return project.delete()
 
@@ -353,10 +353,10 @@ class GitLabProject(object):
     @param name Name of the project
     '''
     def exists_project(self, namespace, path):
-        # When project exists, object will be stored in self.projectObject.
+        # When project exists, object will be stored in self.project_object.
         project = find_project(self._gitlab, namespace.full_path + '/' + path)
         if project:
-            self.projectObject = project
+            self.project_object = project
             return True
         return False
 
@@ -498,8 +498,8 @@ def main():
                                                 "shared_runners_enabled": shared_runners_enabled,
                                                 }):
 
-            module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.projectObject._attrs)
-        module.exit_json(changed=False, msg="No need to update the project %s" % project_name, project=gitlab_project.projectObject._attrs)
+            module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)
+        module.exit_json(changed=False, msg="No need to update the project %s" % project_name, project=gitlab_project.project_object._attrs)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -477,26 +477,26 @@ def main():
     if state == 'present':
 
         if gitlab_project.create_or_update_project(project_name, namespace, {
-                                                   "path": project_path,
-                                                   "description": project_description,
-                                                   "initialize_with_readme": initialize_with_readme,
-                                                   "issues_enabled": issues_enabled,
-                                                   "merge_requests_enabled": merge_requests_enabled,
-                                                   "merge_method": merge_method,
-                                                   "wiki_enabled": wiki_enabled,
-                                                   "snippets_enabled": snippets_enabled,
-                                                   "visibility": visibility,
-                                                   "import_url": import_url,
-                                                   "lfs_enabled": lfs_enabled,
-                                                   "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
-                                                   "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
-                                                   "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
-                                                   "packages_enabled": packages_enabled,
-                                                   "remove_source_branch_after_merge": remove_source_branch_after_merge,
-                                                   "squash_option": squash_option,
-                                                   "ci_config_path": ci_config_path,
-                                                   "shared_runners_enabled": shared_runners_enabled,
-                                                   }):
+            "path": project_path,
+            "description": project_description,
+            "initialize_with_readme": initialize_with_readme,
+            "issues_enabled": issues_enabled,
+            "merge_requests_enabled": merge_requests_enabled,
+            "merge_method": merge_method,
+            "wiki_enabled": wiki_enabled,
+            "snippets_enabled": snippets_enabled,
+            "visibility": visibility,
+            "import_url": import_url,
+            "lfs_enabled": lfs_enabled,
+            "allow_merge_on_skipped_pipeline": allow_merge_on_skipped_pipeline,
+            "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
+            "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
+            "packages_enabled": packages_enabled,
+            "remove_source_branch_after_merge": remove_source_branch_after_merge,
+            "squash_option": squash_option,
+            "ci_config_path": ci_config_path,
+            "shared_runners_enabled": shared_runners_enabled,
+        }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)
         module.exit_json(changed=False, msg="No need to update the project %s" % project_name, project=gitlab_project.project_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -176,7 +176,7 @@ RETURN = r''' # '''
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
 
 import traceback
 
@@ -317,7 +317,7 @@ def main():
         purge_users = [access_level_int[level] for level in purge_users]
 
     # connect to gitlab server
-    gl = gitlabAuthentication(module)
+    gl = gitlab_authentication(module)
 
     project = GitLabProjectMembers(module, gl)
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -172,7 +172,7 @@ class GitlabProjectVariables(object):
         var = {
             "key": key, "value": value,
             "masked": masked, "protected": protected,
-            "variable_type": variable_type
+            "variable_type": variable_type,
         }
         if environment_scope is not None:
             var["environment_scope"] = environment_scope

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -143,7 +143,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
 
 
 class GitlabProjectVariables(object):
@@ -300,7 +300,7 @@ def main():
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
 
     this_gitlab = GitlabProjectVariables(module=module, gitlab_instance=gitlab_instance)
 

--- a/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
@@ -87,7 +87,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
 
 
 class GitlabProtectedBranch(object):
@@ -179,7 +179,7 @@ def main():
         module.fail_json(msg="community.general.gitlab_proteched_branch requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
                              " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
     this_gitlab = GitlabProtectedBranch(module=module, project=project, gitlab_instance=gitlab_instance)
 
     p_branch = this_gitlab.protected_branch_exist(name=name)

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -217,7 +217,8 @@ class GitLabRunner(object):
                 'locked': options['locked'],
                 'run_untagged': options['run_untagged'],
                 'maximum_timeout': options['maximum_timeout'],
-                'tag_list': options['tag_list']})
+                'tag_list': options['tag_list'],
+                })
             changed = True
         else:
             changed, runner = self.update_runner(self.runner_object, {
@@ -226,7 +227,8 @@ class GitLabRunner(object):
                 'run_untagged': options['run_untagged'],
                 'maximum_timeout': options['maximum_timeout'],
                 'access_level': options['access_level'],
-                'tag_list': options['tag_list']})
+                'tag_list': options['tag_list'],
+                })
 
         self.runner_object = runner
         if changed:
@@ -395,7 +397,8 @@ def main():
                                                  "locked": runner_locked,
                                                  "access_level": access_level,
                                                  "maximum_timeout": maximum_timeout,
-                                                 "registration_token": registration_token}):
+                                                 "registration_token": registration_token,
+                                                 }):
             module.exit_json(changed=True, runner=gitlab_runner.runner_object._attrs,
                              msg="Successfully created or updated the runner %s" % runner_description)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -203,13 +203,13 @@ class GitLabRunner(object):
         # See https://gitlab.com/gitlab-org/gitlab-ce/issues/60774
         # for group runner token access
         self._runners_endpoint = project.runners if project else gitlab_instance.runners
-        self.runnerObject = None
+        self.runner_object = None
 
     def create_or_update_runner(self, description, options):
         changed = False
 
         # Because we have already call userExists in main()
-        if self.runnerObject is None:
+        if self.runner_object is None:
             runner = self.create_runner({
                 'description': description,
                 'active': options['active'],
@@ -220,7 +220,7 @@ class GitLabRunner(object):
                 'tag_list': options['tag_list']})
             changed = True
         else:
-            changed, runner = self.update_runner(self.runnerObject, {
+            changed, runner = self.update_runner(self.runner_object, {
                 'active': options['active'],
                 'locked': options['locked'],
                 'run_untagged': options['run_untagged'],
@@ -228,7 +228,7 @@ class GitLabRunner(object):
                 'access_level': options['access_level'],
                 'tag_list': options['tag_list']})
 
-        self.runnerObject = runner
+        self.runner_object = runner
         if changed:
             if self._module.check_mode:
                 self._module.exit_json(changed=True, msg="Successfully created or updated the runner %s" % description)
@@ -302,11 +302,11 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def exists_runner(self, description, owned=False):
-        # When runner exists, object will be stored in self.runnerObject.
+        # When runner exists, object will be stored in self.runner_object.
         runner = self.find_runner(description, owned)
 
         if runner:
-            self.runnerObject = runner
+            self.runner_object = runner
             return True
         return False
 
@@ -314,7 +314,7 @@ class GitLabRunner(object):
         if self._module.check_mode:
             return True
 
-        runner = self.runnerObject
+        runner = self.runner_object
 
         return runner.delete()
 
@@ -396,10 +396,10 @@ def main():
                                               "access_level": access_level,
                                               "maximum_timeout": maximum_timeout,
                                               "registration_token": registration_token}):
-            module.exit_json(changed=True, runner=gitlab_runner.runnerObject._attrs,
+            module.exit_json(changed=True, runner=gitlab_runner.runner_object._attrs,
                              msg="Successfully created or updated the runner %s" % runner_description)
         else:
-            module.exit_json(changed=False, runner=gitlab_runner.runnerObject._attrs,
+            module.exit_json(changed=False, runner=gitlab_runner.runner_object._attrs,
                              msg="No need to update the runner %s" % runner_description)
 
 

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -218,7 +218,7 @@ class GitLabRunner(object):
                 'run_untagged': options['run_untagged'],
                 'maximum_timeout': options['maximum_timeout'],
                 'tag_list': options['tag_list'],
-                })
+            })
             changed = True
         else:
             changed, runner = self.update_runner(self.runner_object, {
@@ -228,7 +228,7 @@ class GitLabRunner(object):
                 'maximum_timeout': options['maximum_timeout'],
                 'access_level': options['access_level'],
                 'tag_list': options['tag_list'],
-                })
+            })
 
         self.runner_object = runner
         if changed:
@@ -391,14 +391,14 @@ def main():
 
     if state == 'present':
         if gitlab_runner.create_or_update_runner(runner_description, {
-                                                 "active": runner_active,
-                                                 "tag_list": tag_list,
-                                                 "run_untagged": run_untagged,
-                                                 "locked": runner_locked,
-                                                 "access_level": access_level,
-                                                 "maximum_timeout": maximum_timeout,
-                                                 "registration_token": registration_token,
-                                                 }):
+            "active": runner_active,
+            "tag_list": tag_list,
+            "run_untagged": run_untagged,
+            "locked": runner_locked,
+            "access_level": access_level,
+            "maximum_timeout": maximum_timeout,
+            "registration_token": registration_token,
+        }):
             module.exit_json(changed=True, runner=gitlab_runner.runner_object._attrs,
                              msg="Successfully created or updated the runner %s" % runner_description)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -389,13 +389,13 @@ def main():
 
     if state == 'present':
         if gitlab_runner.create_or_update_runner(runner_description, {
-                                              "active": runner_active,
-                                              "tag_list": tag_list,
-                                              "run_untagged": run_untagged,
-                                              "locked": runner_locked,
-                                              "access_level": access_level,
-                                              "maximum_timeout": maximum_timeout,
-                                              "registration_token": registration_token}):
+                                                 "active": runner_active,
+                                                 "tag_list": tag_list,
+                                                 "run_untagged": run_untagged,
+                                                 "locked": runner_locked,
+                                                 "access_level": access_level,
+                                                 "maximum_timeout": maximum_timeout,
+                                                 "registration_token": registration_token}):
             module.exit_json(changed=True, runner=gitlab_runner.runner_object._attrs,
                              msg="Successfully created or updated the runner %s" % runner_description)
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -681,7 +681,8 @@ def main():
                                              "isadmin": user_isadmin,
                                              "external": user_external,
                                              "identities": user_identities,
-                                             "overwrite_identities": overwrite_identities}):
+                                             "overwrite_identities": overwrite_identities,
+                                             }):
             module.exit_json(changed=True, msg="Successfully created or updated the user %s" % user_username, user=gitlab_user.user_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the user %s" % user_username, user=gitlab_user.user_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -238,7 +238,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import findGroup, gitlabAuthentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, gitlab_authentication
 
 
 class GitLabUser(object):
@@ -258,13 +258,13 @@ class GitLabUser(object):
     @param username Username of the user
     @param options User options
     '''
-    def createOrUpdateUser(self, username, options):
+    def create_or_update_user(self, username, options):
         changed = False
         potentionally_changed = False
 
         # Because we have already call userExists in main()
         if self.userObject is None:
-            user = self.createUser({
+            user = self.create_user({
                 'name': options['name'],
                 'username': username,
                 'password': options['password'],
@@ -277,7 +277,7 @@ class GitLabUser(object):
             })
             changed = True
         else:
-            changed, user = self.updateUser(
+            changed, user = self.update_user(
                 self.userObject, {
                     # add "normal" parameters here, put uncheckable
                     # params in the dict below
@@ -313,7 +313,7 @@ class GitLabUser(object):
 
         # Assign ssh keys
         if options['sshkey_name'] and options['sshkey_file']:
-            key_changed = self.addSshKeyToUser(user, {
+            key_changed = self.add_ssh_key_to_user(user, {
                 'name': options['sshkey_name'],
                 'file': options['sshkey_file'],
                 'expires_at': options['sshkey_expires_at']})
@@ -321,7 +321,7 @@ class GitLabUser(object):
 
         # Assign group
         if options['group_path']:
-            group_changed = self.assignUserToGroup(user, options['group_path'], options['access_level'])
+            group_changed = self.assign_user_to_group(user, options['group_path'], options['access_level'])
             changed = changed or group_changed
 
         self.userObject = user
@@ -341,7 +341,7 @@ class GitLabUser(object):
     '''
     @param group User object
     '''
-    def getUserId(self, user):
+    def get_user_id(self, user):
         if user is not None:
             return user.id
         return None
@@ -350,7 +350,7 @@ class GitLabUser(object):
     @param user User object
     @param sshkey_name Name of the ssh key
     '''
-    def sshKeyExists(self, user, sshkey_name):
+    def ssh_key_exists(self, user, sshkey_name):
         keyList = map(lambda k: k.title, user.keys.list())
 
         return sshkey_name in keyList
@@ -359,8 +359,8 @@ class GitLabUser(object):
     @param user User object
     @param sshkey Dict containing sshkey infos {"name": "", "file": "", "expires_at": ""}
     '''
-    def addSshKeyToUser(self, user, sshkey):
-        if not self.sshKeyExists(user, sshkey['name']):
+    def add_ssh_key_to_user(self, user, sshkey):
+        if not self.ssh_key_exists(user, sshkey['name']):
             if self._module.check_mode:
                 return True
 
@@ -381,7 +381,7 @@ class GitLabUser(object):
     @param group Group object
     @param user_id Id of the user to find
     '''
-    def findMember(self, group, user_id):
+    def find_member(self, group, user_id):
         try:
             member = group.members.get(user_id)
         except gitlab.exceptions.GitlabGetError:
@@ -392,8 +392,8 @@ class GitLabUser(object):
     @param group Group object
     @param user_id Id of the user to check
     '''
-    def memberExists(self, group, user_id):
-        member = self.findMember(group, user_id)
+    def member_exists(self, group, user_id):
+        member = self.find_member(group, user_id)
 
         return member is not None
 
@@ -402,8 +402,8 @@ class GitLabUser(object):
     @param user_id Id of the user to check
     @param access_level GitLab access_level to check
     '''
-    def memberAsGoodAccessLevel(self, group, user_id, access_level):
-        member = self.findMember(group, user_id)
+    def member_as_good_access_level(self, group, user_id, access_level):
+        member = self.find_member(group, user_id)
 
         return member.access_level == access_level
 
@@ -412,8 +412,8 @@ class GitLabUser(object):
     @param group_path Complete path of the Group including parent group path. <parent_path>/<group_path>
     @param access_level GitLab access_level to assign
     '''
-    def assignUserToGroup(self, user, group_identifier, access_level):
-        group = findGroup(self._gitlab, group_identifier)
+    def assign_user_to_group(self, user, group_identifier, access_level):
+        group = find_group(self._gitlab, group_identifier)
 
         if self._module.check_mode:
             return True
@@ -421,16 +421,16 @@ class GitLabUser(object):
         if group is None:
             return False
 
-        if self.memberExists(group, self.getUserId(user)):
-            member = self.findMember(group, self.getUserId(user))
-            if not self.memberAsGoodAccessLevel(group, member.id, self.ACCESS_LEVEL[access_level]):
+        if self.member_exists(group, self.get_user_id(user)):
+            member = self.find_member(group, self.get_user_id(user))
+            if not self.member_as_good_access_level(group, member.id, self.ACCESS_LEVEL[access_level]):
                 member.access_level = self.ACCESS_LEVEL[access_level]
                 member.save()
                 return True
         else:
             try:
                 group.members.create({
-                    'user_id': self.getUserId(user),
+                    'user_id': self.get_user_id(user),
                     'access_level': self.ACCESS_LEVEL[access_level]})
             except gitlab.exceptions.GitlabCreateError as e:
                 self._module.fail_json(msg="Failed to assign user to group: %s" % to_native(e))
@@ -441,7 +441,7 @@ class GitLabUser(object):
     @param user User object
     @param arguments User attributes
     '''
-    def updateUser(self, user, arguments, uncheckable_args):
+    def update_user(self, user, arguments, uncheckable_args):
         changed = False
 
         for arg_key, arg_value in arguments.items():
@@ -449,7 +449,7 @@ class GitLabUser(object):
 
             if av is not None:
                 if arg_key == "identities":
-                    changed = self.addIdentities(user, av, uncheckable_args['overwrite_identities']['value'])
+                    changed = self.add_identities(user, av, uncheckable_args['overwrite_identities']['value'])
 
                 elif getattr(user, arg_key) != av:
                     setattr(user, arg_value.get('setter', arg_key), av)
@@ -466,7 +466,7 @@ class GitLabUser(object):
     '''
     @param arguments User attributes
     '''
-    def createUser(self, arguments):
+    def create_user(self, arguments):
         if self._module.check_mode:
             return True
 
@@ -478,7 +478,7 @@ class GitLabUser(object):
         try:
             user = self._gitlab.users.create(arguments)
             if identities:
-                self.addIdentities(user, identities)
+                self.add_identities(user, identities)
 
         except (gitlab.exceptions.GitlabCreateError) as e:
             self._module.fail_json(msg="Failed to create user: %s " % to_native(e))
@@ -490,10 +490,10 @@ class GitLabUser(object):
     @param identites List of identities to be added/updated
     @param overwrite_identities Overwrite user identities with identities passed to this module
     '''
-    def addIdentities(self, user, identities, overwrite_identities=False):
+    def add_identities(self, user, identities, overwrite_identities=False):
         changed = False
         if overwrite_identities:
-            changed = self.deleteIdentities(user, identities)
+            changed = self.delete_identities(user, identities)
 
         for identity in identities:
             if identity not in user.identities:
@@ -508,7 +508,7 @@ class GitLabUser(object):
     @param user User object
     @param identites List of identities to be added/updated
     '''
-    def deleteIdentities(self, user, identities):
+    def delete_identities(self, user, identities):
         changed = False
         for identity in user.identities:
             if identity not in identities:
@@ -520,7 +520,7 @@ class GitLabUser(object):
     '''
     @param username Username of the user
     '''
-    def findUser(self, username):
+    def find_user(self, username):
         users = self._gitlab.users.list(search=username)
         for user in users:
             if (user.username == username):
@@ -529,9 +529,9 @@ class GitLabUser(object):
     '''
     @param username Username of the user
     '''
-    def existsUser(self, username):
+    def exists_user(self, username):
         # When user exists, object will be stored in self.userObject.
-        user = self.findUser(username)
+        user = self.find_user(username)
         if user:
             self.userObject = user
             return True
@@ -540,11 +540,11 @@ class GitLabUser(object):
     '''
     @param username Username of the user
     '''
-    def isActive(self, username):
-        user = self.findUser(username)
+    def is_active(self, username):
+        user = self.find_user(username)
         return user.attributes['state'] == 'active'
 
-    def deleteUser(self):
+    def delete_user(self):
         if self._module.check_mode:
             return True
 
@@ -552,7 +552,7 @@ class GitLabUser(object):
 
         return user.delete()
 
-    def blockUser(self):
+    def block_user(self):
         if self._module.check_mode:
             return True
 
@@ -560,7 +560,7 @@ class GitLabUser(object):
 
         return user.block()
 
-    def unblockUser(self):
+    def unblock_user(self):
         if self._module.check_mode:
             return True
 
@@ -636,38 +636,38 @@ def main():
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
-    gitlab_instance = gitlabAuthentication(module)
+    gitlab_instance = gitlab_authentication(module)
 
     gitlab_user = GitLabUser(module, gitlab_instance)
-    user_exists = gitlab_user.existsUser(user_username)
+    user_exists = gitlab_user.exists_user(user_username)
     if user_exists:
-        user_is_active = gitlab_user.isActive(user_username)
+        user_is_active = gitlab_user.is_active(user_username)
     else:
         user_is_active = False
 
     if state == 'absent':
         if user_exists:
-            gitlab_user.deleteUser()
+            gitlab_user.delete_user()
             module.exit_json(changed=True, msg="Successfully deleted user %s" % user_username)
         else:
             module.exit_json(changed=False, msg="User deleted or does not exists")
 
     if state == 'blocked':
         if user_exists and user_is_active:
-            gitlab_user.blockUser()
+            gitlab_user.block_user()
             module.exit_json(changed=True, msg="Successfully blocked user %s" % user_username)
         else:
             module.exit_json(changed=False, msg="User already blocked or does not exists")
 
     if state == 'unblocked':
         if user_exists and not user_is_active:
-            gitlab_user.unblockUser()
+            gitlab_user.unblock_user()
             module.exit_json(changed=True, msg="Successfully unblocked user %s" % user_username)
         else:
             module.exit_json(changed=False, msg="User is not blocked or does not exists")
 
     if state == 'present':
-        if gitlab_user.createOrUpdateUser(user_username, {
+        if gitlab_user.create_or_update_user(user_username, {
                                           "name": user_name,
                                           "password": user_password,
                                           "reset_password": user_reset_password,

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -668,20 +668,20 @@ def main():
 
     if state == 'present':
         if gitlab_user.create_or_update_user(user_username, {
-                                          "name": user_name,
-                                          "password": user_password,
-                                          "reset_password": user_reset_password,
-                                          "email": user_email,
-                                          "sshkey_name": user_sshkey_name,
-                                          "sshkey_file": user_sshkey_file,
-                                          "sshkey_expires_at": user_sshkey_expires_at,
-                                          "group_path": group_path,
-                                          "access_level": access_level,
-                                          "confirm": confirm,
-                                          "isadmin": user_isadmin,
-                                          "external": user_external,
-                                          "identities": user_identities,
-                                          "overwrite_identities": overwrite_identities}):
+                                             "name": user_name,
+                                             "password": user_password,
+                                             "reset_password": user_reset_password,
+                                             "email": user_email,
+                                             "sshkey_name": user_sshkey_name,
+                                             "sshkey_file": user_sshkey_file,
+                                             "sshkey_expires_at": user_sshkey_expires_at,
+                                             "group_path": group_path,
+                                             "access_level": access_level,
+                                             "confirm": confirm,
+                                             "isadmin": user_isadmin,
+                                             "external": user_external,
+                                             "identities": user_identities,
+                                             "overwrite_identities": overwrite_identities}):
             module.exit_json(changed=True, msg="Successfully created or updated the user %s" % user_username, user=gitlab_user.user_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the user %s" % user_username, user=gitlab_user.user_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -252,7 +252,8 @@ class GitLabUser(object):
             'developer': gitlab.DEVELOPER_ACCESS,
             'master': gitlab.MAINTAINER_ACCESS,
             'maintainer': gitlab.MAINTAINER_ACCESS,
-            'owner': gitlab.OWNER_ACCESS}
+            'owner': gitlab.OWNER_ACCESS,
+        }
 
     '''
     @param username Username of the user
@@ -668,21 +669,21 @@ def main():
 
     if state == 'present':
         if gitlab_user.create_or_update_user(user_username, {
-                                             "name": user_name,
-                                             "password": user_password,
-                                             "reset_password": user_reset_password,
-                                             "email": user_email,
-                                             "sshkey_name": user_sshkey_name,
-                                             "sshkey_file": user_sshkey_file,
-                                             "sshkey_expires_at": user_sshkey_expires_at,
-                                             "group_path": group_path,
-                                             "access_level": access_level,
-                                             "confirm": confirm,
-                                             "isadmin": user_isadmin,
-                                             "external": user_external,
-                                             "identities": user_identities,
-                                             "overwrite_identities": overwrite_identities,
-                                             }):
+            "name": user_name,
+            "password": user_password,
+            "reset_password": user_reset_password,
+            "email": user_email,
+            "sshkey_name": user_sshkey_name,
+            "sshkey_file": user_sshkey_file,
+            "sshkey_expires_at": user_sshkey_expires_at,
+            "group_path": group_path,
+            "access_level": access_level,
+            "confirm": confirm,
+            "isadmin": user_isadmin,
+            "external": user_external,
+            "identities": user_identities,
+            "overwrite_identities": overwrite_identities,
+        }):
             module.exit_json(changed=True, msg="Successfully created or updated the user %s" % user_username, user=gitlab_user.user_object._attrs)
         else:
             module.exit_json(changed=False, msg="No need to update the user %s" % user_username, user=gitlab_user.user_object._attrs)

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -245,7 +245,7 @@ class GitLabUser(object):
     def __init__(self, module, gitlab_instance):
         self._module = module
         self._gitlab = gitlab_instance
-        self.userObject = None
+        self.user_object = None
         self.ACCESS_LEVEL = {
             'guest': gitlab.GUEST_ACCESS,
             'reporter': gitlab.REPORTER_ACCESS,
@@ -263,7 +263,7 @@ class GitLabUser(object):
         potentionally_changed = False
 
         # Because we have already call userExists in main()
-        if self.userObject is None:
+        if self.user_object is None:
             user = self.create_user({
                 'name': options['name'],
                 'username': username,
@@ -278,7 +278,7 @@ class GitLabUser(object):
             changed = True
         else:
             changed, user = self.update_user(
-                self.userObject, {
+                self.user_object, {
                     # add "normal" parameters here, put uncheckable
                     # params in the dict below
                     'name': {'value': options['name']},
@@ -324,7 +324,7 @@ class GitLabUser(object):
             group_changed = self.assign_user_to_group(user, options['group_path'], options['access_level'])
             changed = changed or group_changed
 
-        self.userObject = user
+        self.user_object = user
         if (changed or potentionally_changed) and not self._module.check_mode:
             try:
                 user.save()
@@ -530,10 +530,10 @@ class GitLabUser(object):
     @param username Username of the user
     '''
     def exists_user(self, username):
-        # When user exists, object will be stored in self.userObject.
+        # When user exists, object will be stored in self.user_object.
         user = self.find_user(username)
         if user:
-            self.userObject = user
+            self.user_object = user
             return True
         return False
 
@@ -548,7 +548,7 @@ class GitLabUser(object):
         if self._module.check_mode:
             return True
 
-        user = self.userObject
+        user = self.user_object
 
         return user.delete()
 
@@ -556,7 +556,7 @@ class GitLabUser(object):
         if self._module.check_mode:
             return True
 
-        user = self.userObject
+        user = self.user_object
 
         return user.block()
 
@@ -564,7 +564,7 @@ class GitLabUser(object):
         if self._module.check_mode:
             return True
 
-        user = self.userObject
+        user = self.user_object
 
         return user.unblock()
 
@@ -682,9 +682,9 @@ def main():
                                           "external": user_external,
                                           "identities": user_identities,
                                           "overwrite_identities": overwrite_identities}):
-            module.exit_json(changed=True, msg="Successfully created or updated the user %s" % user_username, user=gitlab_user.userObject._attrs)
+            module.exit_json(changed=True, msg="Successfully created or updated the user %s" % user_username, user=gitlab_user.user_object._attrs)
         else:
-            module.exit_json(changed=False, msg="No need to update the user %s" % user_username, user=gitlab_user.userObject._attrs)
+            module.exit_json(changed=False, msg="No need to update the user %s" % user_username, user=gitlab_user.user_object._attrs)
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
@@ -55,11 +55,11 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
     def test_deploy_key_exist(self):
         project = self.gitlab_instance.projects.get(1)
 
-        rvalue = self.moduleUtil.existsDeployKey(project, "Public key")
+        rvalue = self.moduleUtil.exists_deploy_key(project, "Public key")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsDeployKey(project, "Private key")
+        rvalue = self.moduleUtil.exists_deploy_key(project, "Private key")
 
         self.assertEqual(rvalue, False)
 
@@ -68,7 +68,7 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
     def test_create_deploy_key(self):
         project = self.gitlab_instance.projects.get(1)
 
-        deploy_key = self.moduleUtil.createDeployKey(project, {"title": "Public key",
+        deploy_key = self.moduleUtil.create_deploy_key(project, {"title": "Public key",
                                                                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM"
                                                                "4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxc"
                                                                "KDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfD"
@@ -82,15 +82,15 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
     @with_httmock(resp_create_project_deploy_key)
     def test_update_deploy_key(self):
         project = self.gitlab_instance.projects.get(1)
-        deployKey = self.moduleUtil.findDeployKey(project, "Public key")
+        deployKey = self.moduleUtil.find_deploy_key(project, "Public key")
 
-        changed, newDeploy_key = self.moduleUtil.updateDeployKey(deployKey, {"title": "Private key"})
+        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deployKey, {"title": "Private key"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newDeploy_key), ProjectKey)
         self.assertEqual(newDeploy_key.title, "Private key")
 
-        changed, newDeploy_key = self.moduleUtil.updateDeployKey(deployKey, {"title": "Private key"})
+        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deployKey, {"title": "Private key"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newDeploy_key.title, "Private key")
@@ -101,8 +101,8 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
     def test_delete_deploy_key(self):
         project = self.gitlab_instance.projects.get(1)
 
-        self.moduleUtil.existsDeployKey(project, "Public key")
+        self.moduleUtil.exists_deploy_key(project, "Public key")
 
-        rvalue = self.moduleUtil.deleteDeployKey()
+        rvalue = self.moduleUtil.delete_deploy_key()
 
         self.assertEqual(rvalue, None)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
@@ -82,15 +82,15 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
     @with_httmock(resp_create_project_deploy_key)
     def test_update_deploy_key(self):
         project = self.gitlab_instance.projects.get(1)
-        deployKey = self.moduleUtil.find_deploy_key(project, "Public key")
+        deploy_key = self.moduleUtil.find_deploy_key(project, "Public key")
 
-        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deployKey, {"title": "Private key"})
+        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deploy_key, {"title": "Private key"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newDeploy_key), ProjectKey)
         self.assertEqual(newDeploy_key.title, "Private key")
 
-        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deployKey, {"title": "Private key"})
+        changed, newDeploy_key = self.moduleUtil.update_deploy_key(deploy_key, {"title": "Private key"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newDeploy_key.title, "Private key")

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_deploy_key.py
@@ -69,10 +69,10 @@ class TestGitlabDeployKey(GitlabModuleTestCase):
         project = self.gitlab_instance.projects.get(1)
 
         deploy_key = self.moduleUtil.create_deploy_key(project, {"title": "Public key",
-                                                               "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM"
-                                                               "4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxc"
-                                                               "KDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfD"
-                                                               "zpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="})
+                                                                 "key": "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM"
+                                                                 "4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxc"
+                                                                 "KDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfD"
+                                                                 "zpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0="})
 
         self.assertEqual(type(deploy_key), ProjectKey)
         self.assertEqual(deploy_key.title, "Public key")

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -71,7 +71,8 @@ class TestGitlabGroup(GitlabModuleTestCase):
                                               'description': "An interesting group",
                                               'project_creation_level': "developer",
                                               'subgroup_creation_level': "maintainer",
-                                              'require_two_factor_authentication': True})
+                                              'require_two_factor_authentication': True,
+                                              })
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "Foobar Group")
@@ -88,7 +89,8 @@ class TestGitlabGroup(GitlabModuleTestCase):
                                               'path': "bar-foo",
                                               'parent_id': 1,
                                               'project_creation_level': "noone",
-                                              'require_two_factor_authentication': True})
+                                              'require_two_factor_authentication': True,
+                                              })
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "BarFoo Group")
@@ -104,7 +106,8 @@ class TestGitlabGroup(GitlabModuleTestCase):
         changed, newGroup = self.moduleUtil.update_group(group, {'name': "BarFoo Group",
                                                                  'visibility': "private",
                                                                  'project_creation_level': "maintainer",
-                                                                 'require_two_factor_authentication': True})
+                                                                 'require_two_factor_authentication': True,
+                                                                 })
 
         self.assertEqual(changed, True)
         self.assertEqual(newGroup.name, "BarFoo Group")

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -67,11 +67,11 @@ class TestGitlabGroup(GitlabModuleTestCase):
     @with_httmock(resp_create_group)
     def test_create_group(self):
         group = self.moduleUtil.create_group({'name': "Foobar Group",
-                                             'path': "foo-bar",
-                                             'description': "An interesting group",
-                                             'project_creation_level': "developer",
-                                             'subgroup_creation_level': "maintainer",
-                                             'require_two_factor_authentication': True})
+                                              'path': "foo-bar",
+                                              'description': "An interesting group",
+                                              'project_creation_level': "developer",
+                                              'subgroup_creation_level': "maintainer",
+                                              'require_two_factor_authentication': True})
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "Foobar Group")
@@ -85,10 +85,10 @@ class TestGitlabGroup(GitlabModuleTestCase):
     @with_httmock(resp_create_subgroup)
     def test_create_subgroup(self):
         group = self.moduleUtil.create_group({'name': "BarFoo Group",
-                                             'path': "bar-foo",
-                                             'parent_id': 1,
-                                             'project_creation_level': "noone",
-                                             'require_two_factor_authentication': True})
+                                              'path': "bar-foo",
+                                              'parent_id': 1,
+                                              'project_creation_level': "noone",
+                                              'require_two_factor_authentication': True})
 
         self.assertEqual(type(group), Group)
         self.assertEqual(group.name, "BarFoo Group")
@@ -102,9 +102,9 @@ class TestGitlabGroup(GitlabModuleTestCase):
     def test_update_group(self):
         group = self.gitlab_instance.groups.get(1)
         changed, newGroup = self.moduleUtil.update_group(group, {'name': "BarFoo Group",
-                                                                'visibility': "private",
-                                                                'project_creation_level': "maintainer",
-                                                                'require_two_factor_authentication': True})
+                                                                 'visibility': "private",
+                                                                 'project_creation_level': "maintainer",
+                                                                 'require_two_factor_authentication': True})
 
         self.assertEqual(changed, True)
         self.assertEqual(newGroup.name, "BarFoo Group")

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -122,7 +122,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
     def test_delete_group(self):
         self.moduleUtil.exists_group(1)
 
-        print(self.moduleUtil.groupObject.projects)
+        print(self.moduleUtil.group_object.projects)
 
         rvalue = self.moduleUtil.delete_group()
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_group.py
@@ -54,19 +54,19 @@ class TestGitlabGroup(GitlabModuleTestCase):
 
     @with_httmock(resp_get_group)
     def test_exist_group(self):
-        rvalue = self.moduleUtil.existsGroup(1)
+        rvalue = self.moduleUtil.exists_group(1)
 
         self.assertEqual(rvalue, True)
 
     @with_httmock(resp_get_missing_group)
     def test_exist_group(self):
-        rvalue = self.moduleUtil.existsGroup(1)
+        rvalue = self.moduleUtil.exists_group(1)
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_create_group)
     def test_create_group(self):
-        group = self.moduleUtil.createGroup({'name': "Foobar Group",
+        group = self.moduleUtil.create_group({'name': "Foobar Group",
                                              'path': "foo-bar",
                                              'description': "An interesting group",
                                              'project_creation_level': "developer",
@@ -84,7 +84,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
 
     @with_httmock(resp_create_subgroup)
     def test_create_subgroup(self):
-        group = self.moduleUtil.createGroup({'name': "BarFoo Group",
+        group = self.moduleUtil.create_group({'name': "BarFoo Group",
                                              'path': "bar-foo",
                                              'parent_id': 1,
                                              'project_creation_level': "noone",
@@ -101,7 +101,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
     @with_httmock(resp_get_group)
     def test_update_group(self):
         group = self.gitlab_instance.groups.get(1)
-        changed, newGroup = self.moduleUtil.updateGroup(group, {'name': "BarFoo Group",
+        changed, newGroup = self.moduleUtil.update_group(group, {'name': "BarFoo Group",
                                                                 'visibility': "private",
                                                                 'project_creation_level': "maintainer",
                                                                 'require_two_factor_authentication': True})
@@ -112,7 +112,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
         self.assertEqual(newGroup.project_creation_level, "maintainer")
         self.assertEqual(newGroup.require_two_factor_authentication, True)
 
-        changed, newGroup = self.moduleUtil.updateGroup(group, {'name': "BarFoo Group"})
+        changed, newGroup = self.moduleUtil.update_group(group, {'name': "BarFoo Group"})
 
         self.assertEqual(changed, False)
 
@@ -120,10 +120,10 @@ class TestGitlabGroup(GitlabModuleTestCase):
     @with_httmock(resp_find_group_project)
     @with_httmock(resp_delete_group)
     def test_delete_group(self):
-        self.moduleUtil.existsGroup(1)
+        self.moduleUtil.exists_group(1)
 
         print(self.moduleUtil.groupObject.projects)
 
-        rvalue = self.moduleUtil.deleteGroup()
+        rvalue = self.moduleUtil.delete_group()
 
         self.assertEqual(rvalue, None)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_hook.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_hook.py
@@ -55,11 +55,11 @@ class TestGitlabHook(GitlabModuleTestCase):
     def test_hook_exist(self):
         project = self.gitlab_instance.projects.get(1)
 
-        rvalue = self.moduleUtil.existsHook(project, "http://example.com/hook")
+        rvalue = self.moduleUtil.exists_hook(project, "http://example.com/hook")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsHook(project, "http://gitlab.com/hook")
+        rvalue = self.moduleUtil.exists_hook(project, "http://gitlab.com/hook")
 
         self.assertEqual(rvalue, False)
 
@@ -68,7 +68,7 @@ class TestGitlabHook(GitlabModuleTestCase):
     def test_create_hook(self):
         project = self.gitlab_instance.projects.get(1)
 
-        hook = self.moduleUtil.createHook(project, {"url": "http://example.com/hook"})
+        hook = self.moduleUtil.create_hook(project, {"url": "http://example.com/hook"})
 
         self.assertEqual(type(hook), ProjectHook)
         self.assertEqual(hook.url, "http://example.com/hook")
@@ -77,15 +77,15 @@ class TestGitlabHook(GitlabModuleTestCase):
     @with_httmock(resp_find_project_hook)
     def test_update_hook(self):
         project = self.gitlab_instance.projects.get(1)
-        hook = self.moduleUtil.findHook(project, "http://example.com/hook")
+        hook = self.moduleUtil.find_hook(project, "http://example.com/hook")
 
-        changed, newHook = self.moduleUtil.updateHook(hook, {"url": "http://gitlab.com/hook"})
+        changed, newHook = self.moduleUtil.update_hook(hook, {"url": "http://gitlab.com/hook"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newHook), ProjectHook)
         self.assertEqual(newHook.url, "http://gitlab.com/hook")
 
-        changed, newHook = self.moduleUtil.updateHook(hook, {"url": "http://gitlab.com/hook"})
+        changed, newHook = self.moduleUtil.update_hook(hook, {"url": "http://gitlab.com/hook"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newHook.url, "http://gitlab.com/hook")
@@ -96,8 +96,8 @@ class TestGitlabHook(GitlabModuleTestCase):
     def test_delete_hook(self):
         project = self.gitlab_instance.projects.get(1)
 
-        self.moduleUtil.existsHook(project, "http://example.com/hook")
+        self.moduleUtil.exists_hook(project, "http://example.com/hook")
 
-        rvalue = self.moduleUtil.deleteHook()
+        rvalue = self.moduleUtil.delete_hook()
 
         self.assertEqual(rvalue, None)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_project.py
@@ -59,11 +59,11 @@ class TestGitlabProject(GitlabModuleTestCase):
     def test_project_exist(self):
         group = self.gitlab_instance.groups.get(1)
 
-        rvalue = self.moduleUtil.existsProject(group, "diaspora-client")
+        rvalue = self.moduleUtil.exists_project(group, "diaspora-client")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsProject(group, "missing-project")
+        rvalue = self.moduleUtil.exists_project(group, "missing-project")
 
         self.assertEqual(rvalue, False)
 
@@ -71,7 +71,7 @@ class TestGitlabProject(GitlabModuleTestCase):
     @with_httmock(resp_create_project)
     def test_create_project(self):
         group = self.gitlab_instance.groups.get(1)
-        project = self.moduleUtil.createProject(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id})
+        project = self.moduleUtil.create_project(group, {"name": "Diaspora Client", "path": "diaspora-client", "namespace_id": group.id})
 
         self.assertEqual(type(project), Project)
         self.assertEqual(project.name, "Diaspora Client")
@@ -80,13 +80,13 @@ class TestGitlabProject(GitlabModuleTestCase):
     def test_update_project(self):
         project = self.gitlab_instance.projects.get(1)
 
-        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name"})
+        changed, newProject = self.moduleUtil.update_project(project, {"name": "New Name"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newProject), Project)
         self.assertEqual(newProject.name, "New Name")
 
-        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name"})
+        changed, newProject = self.moduleUtil.update_project(project, {"name": "New Name"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newProject.name, "New Name")
@@ -98,14 +98,14 @@ class TestGitlabProject(GitlabModuleTestCase):
         # merge_method should be 'merge' by default
         self.assertEqual(project.merge_method, "merge")
 
-        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name", "merge_method": "rebase_merge"})
+        changed, newProject = self.moduleUtil.update_project(project, {"name": "New Name", "merge_method": "rebase_merge"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newProject), Project)
         self.assertEqual(newProject.name, "New Name")
         self.assertEqual(newProject.merge_method, "rebase_merge")
 
-        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name", "merge_method": "rebase_merge"})
+        changed, newProject = self.moduleUtil.update_project(project, {"name": "New Name", "merge_method": "rebase_merge"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newProject.name, "New Name")
@@ -117,8 +117,8 @@ class TestGitlabProject(GitlabModuleTestCase):
     def test_delete_project(self):
         group = self.gitlab_instance.groups.get(1)
 
-        self.moduleUtil.existsProject(group, "diaspora-client")
+        self.moduleUtil.exists_project(group, "diaspora-client")
 
-        rvalue = self.moduleUtil.deleteProject()
+        rvalue = self.moduleUtil.delete_project()
 
         self.assertEqual(rvalue, None)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
@@ -54,28 +54,28 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     def test_runner_exist_all(self):
-        rvalue = self.moduleUtil.existsRunner("test-1-20150125")
+        rvalue = self.moduleUtil.exists_runner("test-1-20150125")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsRunner("test-3-00000000")
+        rvalue = self.moduleUtil.exists_runner("test-3-00000000")
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     def test_runner_exist_owned(self):
-        rvalue = self.moduleUtil.existsRunner("test-1-20201214", True)
+        rvalue = self.moduleUtil.exists_runner("test-1-20201214", True)
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsRunner("test-3-00000000", True)
+        rvalue = self.moduleUtil.exists_runner("test-3-00000000", True)
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_create_runner)
     def test_create_runner(self):
-        runner = self.moduleUtil.createRunner({"token": "token", "description": "test-1-20150125"})
+        runner = self.moduleUtil.create_runner({"token": "token", "description": "test-1-20150125"})
 
         self.assertEqual(type(runner), Runner)
         self.assertEqual(runner.description, "test-1-20150125")
@@ -83,15 +83,15 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     def test_update_runner(self):
-        runner = self.moduleUtil.findRunner("test-1-20150125")
+        runner = self.moduleUtil.find_runner("test-1-20150125")
 
-        changed, newRunner = self.moduleUtil.updateRunner(runner, {"description": "Runner description"})
+        changed, newRunner = self.moduleUtil.update_runner(runner, {"description": "Runner description"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newRunner), Runner)
         self.assertEqual(newRunner.description, "Runner description")
 
-        changed, newRunner = self.moduleUtil.updateRunner(runner, {"description": "Runner description"})
+        changed, newRunner = self.moduleUtil.update_runner(runner, {"description": "Runner description"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newRunner.description, "Runner description")
@@ -100,8 +100,8 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_get_runner)
     @with_httmock(resp_delete_runner)
     def test_delete_runner(self):
-        self.moduleUtil.existsRunner("test-1-20150125")
+        self.moduleUtil.exists_runner("test-1-20150125")
 
-        rvalue = self.moduleUtil.deleteRunner()
+        rvalue = self.moduleUtil.delete_runner()
 
         self.assertEqual(rvalue, None)

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_user.py
@@ -61,17 +61,17 @@ class TestGitlabUser(GitlabModuleTestCase):
 
     @with_httmock(resp_find_user)
     def test_exist_user(self):
-        rvalue = self.moduleUtil.existsUser("john_smith")
+        rvalue = self.moduleUtil.exists_user("john_smith")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.existsUser("paul_smith")
+        rvalue = self.moduleUtil.exists_user("paul_smith")
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_find_user)
     def test_find_user(self):
-        user = self.moduleUtil.findUser("john_smith")
+        user = self.moduleUtil.find_user("john_smith")
 
         self.assertEqual(type(user), User)
         self.assertEqual(user.name, "John Smith")
@@ -79,7 +79,7 @@ class TestGitlabUser(GitlabModuleTestCase):
 
     @with_httmock(resp_create_user)
     def test_create_user(self):
-        user = self.moduleUtil.createUser({'email': 'john@example.com', 'password': 's3cur3s3cr3T',
+        user = self.moduleUtil.create_user({'email': 'john@example.com', 'password': 's3cur3s3cr3T',
                                            'username': 'john_smith', 'name': 'John Smith'})
         self.assertEqual(type(user), User)
         self.assertEqual(user.name, "John Smith")
@@ -89,7 +89,7 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_update_user(self):
         user = self.gitlab_instance.users.get(1)
 
-        changed, newUser = self.moduleUtil.updateUser(
+        changed, newUser = self.moduleUtil.update_user(
             user,
             {'name': {'value': "Jack Smith"}, "is_admin": {'value': "true", 'setter': 'admin'}}, {}
         )
@@ -98,11 +98,11 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(newUser.name, "Jack Smith")
         self.assertEqual(newUser.admin, "true")
 
-        changed, newUser = self.moduleUtil.updateUser(user, {'name': {'value': "Jack Smith"}}, {})
+        changed, newUser = self.moduleUtil.update_user(user, {'name': {'value': "Jack Smith"}}, {})
 
         self.assertEqual(changed, False)
 
-        changed, newUser = self.moduleUtil.updateUser(
+        changed, newUser = self.moduleUtil.update_user(
             user,
             {}, {
                 'skip_reconfirmation': {'value': True},
@@ -118,8 +118,8 @@ class TestGitlabUser(GitlabModuleTestCase):
     @with_httmock(resp_find_user)
     @with_httmock(resp_delete_user)
     def test_delete_user(self):
-        self.moduleUtil.existsUser("john_smith")
-        rvalue = self.moduleUtil.deleteUser()
+        self.moduleUtil.exists_user("john_smith")
+        rvalue = self.moduleUtil.delete_user()
 
         self.assertEqual(rvalue, None)
 
@@ -128,10 +128,10 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_sshkey_exist(self):
         user = self.gitlab_instance.users.get(1)
 
-        exist = self.moduleUtil.sshKeyExists(user, "Public key")
+        exist = self.moduleUtil.ssh_key_exists(user, "Public key")
         self.assertEqual(exist, True)
 
-        notExist = self.moduleUtil.sshKeyExists(user, "Private key")
+        notExist = self.moduleUtil.ssh_key_exists(user, "Private key")
         self.assertEqual(notExist, False)
 
     @with_httmock(resp_get_user)
@@ -140,7 +140,7 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_create_sshkey(self):
         user = self.gitlab_instance.users.get(1)
 
-        rvalue = self.moduleUtil.addSshKeyToUser(user, {
+        rvalue = self.moduleUtil.add_ssh_key_to_user(user, {
             'name': "Public key",
             'file': "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJe"
                     "jgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4"
@@ -148,7 +148,7 @@ class TestGitlabUser(GitlabModuleTestCase):
             'expires_at': ""})
         self.assertEqual(rvalue, False)
 
-        rvalue = self.moduleUtil.addSshKeyToUser(user, {
+        rvalue = self.moduleUtil.add_ssh_key_to_user(user, {
             'name': "Private key",
             'file': "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA1YotVDm2mAyk2tPt4E7AHm01sS6JZmcU"
                     "dRuSuA5zszUJzYPPUSRAX3BCgTqLqYx//UuVncK7YqLVSbbwjKR2Ez5lISgCnVfLVEXzwhv+"
@@ -163,7 +163,7 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_find_member(self):
         group = self.gitlab_instance.groups.get(1)
 
-        user = self.moduleUtil.findMember(group, 1)
+        user = self.moduleUtil.find_member(group, 1)
         self.assertEqual(user.username, "raymond_smith")
 
     @with_httmock(resp_get_user)
@@ -176,8 +176,8 @@ class TestGitlabUser(GitlabModuleTestCase):
         group = self.gitlab_instance.groups.get(1)
         user = self.gitlab_instance.users.get(1)
 
-        rvalue = self.moduleUtil.assignUserToGroup(user, group.id, "developer")
+        rvalue = self.moduleUtil.assign_user_to_group(user, group.id, "developer")
         self.assertEqual(rvalue, False)
 
-        rvalue = self.moduleUtil.assignUserToGroup(user, group.id, "guest")
+        rvalue = self.moduleUtil.assign_user_to_group(user, group.id, "guest")
         self.assertEqual(rvalue, True)


### PR DESCRIPTION
##### SUMMARY

This cleans up the gitlab modules a bit to consistently use snake_case conventions (which is used in the newer modules, core utils, and python-gitlab). No functional change, but it's a small first step toward de-duplicating some of the code in those modules. It might help with implementing things like https://github.com/ansible-collections/community.general/issues/3669 in other modules.

I'm not sure if you accept these style-only PRs but thought I'd try. In case the PR is a bit cumbersome to review I split it into these commits (I can also split the PR):
- b04c5639 gitlab: use snake_case consistently in variables
- 92e03bd5 gitlab: use snake_case consistently in methods and functions
- 10f9a127 gitlab: remove dead code in module_utils

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab

##### ADDITIONAL INFORMATION

Not sure where the `request()` in utils came from but it is not used. It looks like a copy of the bitbucket helper, or maybe was there before `python-gitlab` was introduced. Also I'm aware a lot of the code could still be de-duplicated from those modules but didn't want to start with a huge PR.

Also wasn't quite sure how to label this but there's no "chore"/"style" issue type :grinning: 