### PR TITLE
Support IPMI encryption key parameter in ipmi_boot

### DIFF
--- a/changelogs/fragments/3702-ipmi-encryption-key.yml
+++ b/changelogs/fragments/3702-ipmi-encryption-key.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - ipmi_boot: add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).
-  - ipmi_power: add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).
+  - ipmi_boot - add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).
+  - ipmi_power - add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).

--- a/changelogs/fragments/3702-ipmi-encryption-key.yml
+++ b/changelogs/fragments/3702-ipmi-encryption-key.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ipmi_boot: add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).
+  - ipmi_power: add support for user-specified IPMI encryption key (https://github.com/ansible-collections/community.general/issues/3698).

--- a/plugins/modules/remote_management/ipmi/ipmi_boot.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_boot.py
@@ -40,6 +40,7 @@ options:
       - Encryption key to connect to the BMC in hex format.
     required: false
     type: str
+    version_added: 4.1.0
   bootdev:
     description:
       - Set boot device to use on next reboot

--- a/plugins/modules/remote_management/ipmi/ipmi_boot.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_boot.py
@@ -126,6 +126,7 @@ EXAMPLES = '''
 '''
 
 import traceback
+import binascii
 
 PYGHMI_IMP_ERR = None
 try:
@@ -169,10 +170,13 @@ def main():
     if state == 'absent' and bootdev == 'default':
         module.fail_json(msg="The bootdev 'default' cannot be used with state 'absent'.")
 
-    if module.params['key']:
-        key = bytes.fromhex(module.params['key'])
-    else:
-        key = None
+    try:
+        if module.params['key']:
+            key = binascii.unhexlify(module.params['key'])
+        else:
+            key = None
+    except Exception as e:
+        module.fail_json(msg="Unable to convert 'key' from hex string.")
 
     # --- run command ---
     try:

--- a/plugins/modules/remote_management/ipmi/ipmi_boot.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_boot.py
@@ -145,7 +145,7 @@ def main():
             port=dict(default=623, type='int'),
             user=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
-            key=dict(required=False, type='str', no_log=True),
+            key=dict(type='str', no_log=True),
             state=dict(default='present', choices=['present', 'absent']),
             bootdev=dict(required=True, choices=['network', 'hd', 'floppy', 'safe', 'optical', 'setup', 'default']),
             persistent=dict(default=False, type='bool'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3698 

This is a very naive PoC on how passing an IPMI encryption key to the `ipmi_boot` module could work. Similar change is needed in the `ipmi_power` module.

I would like feedback on if this is feasible - especially on things like portability. I am not sure it works on all Python versions and so on.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipmi_boot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
no change to output
```
