### PR TITLE
listen_ports_facts: Added support for ss

### DIFF
--- a/changelogs/fragments/3708-listen_ports_facts-add-ss-support.yml
+++ b/changelogs/fragments/3708-listen_ports_facts-add-ss-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - listen_ports_facts - add support for ``ss`` command besides ``netstat`` (https://github.com/ansible-collections/community.general/pull/3708).

--- a/tests/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/tests/integration/targets/listen_ports_facts/tasks/main.yml
@@ -9,30 +9,25 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: install netstat and netcat on deb
-  apt:
-    name: "{{ item }}"
+  ansible.builtin.package:
+    name:
+      - net-tools
+      - netcat
     state: latest
-  with_items:
-    - net-tools
-    - netcat
   when: ansible_os_family == "Debian"
 
 - name: install netstat and netcat on rh < 7
-  yum:
-    name: "{{ item }}"
+  ansible.builtin.package:
+    name:
+      - net-tools
+      - nc.x86_64
     state: latest
-  with_items:
-    - net-tools
-    - nc.x86_64
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
-- name: install netstat and netcat on rh >= 7
-  yum:
-    name: "{{ item }}"
+- name: install netcat on rh >= 7
+  ansible.builtin.package:
+    name: 'nmap-ncat'
     state: latest
-  with_items:
-    - net-tools
-    - nmap-ncat
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: start UDP server on port 5555
@@ -62,6 +57,16 @@
 - name: Gather listening ports facts
   listen_ports_facts:
   when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+
+- name: Gather listening ports facts explicitly via netstat
+  listen_ports_facts:
+    command: 'netstat'
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7) or ansible_os_family == "Debian"
+
+- name: Gather listening ports facts explicitly via ss
+  listen_ports_facts:
+    command: 'ss'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: check for ansible_facts.udp_listen exists
   assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for command `ss` to module `listen_ports_facts`.

Some distros do not include `netstat` in their base installs anymore, whereas `ss` is included.

Default behaviour is extended to try supported commands one by one until one is existing on the machine.
`netstat` is tried first, as it is the current default and `ss` returns all processes per listen address & port.

A user can override the auto-detection by passing the argument `command` for either `netstat` or `ss`.

Modified integration tests accordingly and tested with them successfully on:
* Debian 9, 10, 11
* Ubuntu 16.04, 18.04, 20.04
* CentOS 7, 8, Stream
* RedHat 7, 8

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
listen_ports_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
<no output changes>
```
