### PR TITLE
redfish_command: example command has wrong arg

### DIFF
--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -307,7 +307,7 @@ EXAMPLES = '''
     community.general.redfish_command:
       category: Systems
       command: SetOneTimeBoot
-      bootnext: BiosSetup
+      boot_next: BiosSetup
       boot_override_mode: Legacy
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"


### PR DESCRIPTION
Example command arg `boot_next` missing the underscore.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3710

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add the underscore to make the arg `bootnext` valid `boot_next`.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
