### PR TITLE
Restrict redis version in CI

### DIFF
--- a/tests/integration/targets/setup_redis_replication/defaults/main.yml
+++ b/tests/integration/targets/setup_redis_replication/defaults/main.yml
@@ -18,7 +18,7 @@ redis_bin:
   CentOS: /usr/bin/redis-server
   FreeBSD: /usr/local/bin/redis-server
 
-redis_module: "{{ (ansible_python_version is version('2.7', '>=')) | ternary('redis', 'redis==2.10.6') }}"
+redis_module: redis
 
 redis_password: PASS
 

--- a/tests/integration/targets/setup_redis_replication/meta/main.yml
+++ b/tests/integration/targets/setup_redis_replication/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
 - setup_pkg_mgr
+- setup_remote_constraints

--- a/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
+++ b/tests/integration/targets/setup_redis_replication/tasks/setup_redis_cluster.yml
@@ -44,6 +44,7 @@
 - name: Install redis module
   pip:
     name: "{{ redis_module }}"
+    extra_args: "-c {{ remote_constraints }}"
     state: present
   notify: cleanup redis
 

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -43,6 +43,9 @@ botocore >= 1.10.0, < 1.14 ; python_version < '2.7' # adds support for the follo
 botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will still install:
+redis == 2.10.6 ; python_version < '2.7'
+redis < 4.0.0 ; python_version >= '2.7' and python_version < '3.6'
+redis ; python_version >= '3.6'
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
Looks like the 4.0.0 release from today requires Python >= 3.6.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
