### PR TITLE
xen_orchestra: replace usage of packaging.version with distutils.version.LooseVersion

### DIFF
--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -74,7 +74,7 @@ simple_config_file:
 import json
 import ssl
 
-from packaging import version
+from distutils.version import LooseVersion
 
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
@@ -85,7 +85,7 @@ try:
     import websocket
     from websocket import create_connection
 
-    if version.parse(websocket.__version__) <= version.parse('1.0.0'):
+    if LooseVersion(websocket.__version__) <= LooseVersion('1.0.0'):
         raise ImportError
 except ImportError as e:
     HAS_WEBSOCKET = False


### PR DESCRIPTION
##### SUMMARY
Currenly xen_orchestra breaks the sanity tests (https://github.com/ansible-collections/community.general/runs/4272234512) since it uses `packaging.version`, which is not available everywhere.

Replacing it by `distutils.version.LooseVersion`, which we commonly use to compare versions and which is available everywhere.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xen_orchestra
