### PR TITLE
extend open_iscsi to allow rescanning a session to discover new mapped LUN's #3763

### DIFF
--- a/changelogs/fragments/3765-extend-open_iscsi-with-rescan.yml
+++ b/changelogs/fragments/3765-extend-open_iscsi-with-rescan.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - open_iscsi - extended module to allow rescanning of established session for one or all targets. (https://github.com/ansible-collections/community.general/issues/3763)
+  - open_iscsi - extended module to allow rescanning of established session for one or all targets (https://github.com/ansible-collections/community.general/issues/3763).

--- a/changelogs/fragments/3765-extend-open_iscsi-with-rescan.yml
+++ b/changelogs/fragments/3765-extend-open_iscsi-with-rescan.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - open_iscsi - extended module to allow rescanning of established session for one or all targets. (https://github.com/ansible-collections/community.general/issues/3763)

--- a/plugins/modules/system/open_iscsi.py
+++ b/plugins/modules/system/open_iscsi.py
@@ -88,9 +88,11 @@ options:
         default: false
     rescan:
         description:
-        - rescan an established session for discovering new targets.
+        - Rescan an established session for discovering new targets.
+        - When I(target) is ommited, will rescan all sessions.
         type: bool
         default: false
+        version_added: 4.1.0
 
 '''
 
@@ -189,13 +191,15 @@ def iscsi_discover(module, portal, port):
     cmd = [iscsiadm_cmd, '--mode', 'discovery', '--type', 'sendtargets', '--portal', '%s:%s' % (portal, port)]
     module.run_command(cmd, check_rc=True)
 
+
 def iscsi_rescan(module, target=None):
-    if target == None:
+    if target is None:
         cmd = [iscsiadm_cmd, '--mode', 'session', '--rescan']
     else:
         cmd = [iscsiadm_cmd, '--mode', 'node', '--rescan', '-T', target]
     rc, out, err = module.run_command(cmd)
     return out
+
 
 def target_loggedon(module, target, portal=None, port=None):
     cmd = [iscsiadm_cmd, '--mode', 'session']
@@ -441,7 +445,7 @@ def main():
             result['changed'] |= True
             result['automatic_portal_changed'] = True
 
-    if rescan != False:
+    if rescan is not False:
         result['changed'] = True
         result['sessions'] = iscsi_rescan(module, target)
 

--- a/plugins/modules/system/open_iscsi.py
+++ b/plugins/modules/system/open_iscsi.py
@@ -89,7 +89,7 @@ options:
     rescan:
         description:
         - Rescan an established session for discovering new targets.
-        - When I(target) is ommited, will rescan all sessions.
+        - When I(target) is omitted, will rescan all sessions.
         type: bool
         default: false
         version_added: 4.1.0

--- a/plugins/modules/system/open_iscsi.py
+++ b/plugins/modules/system/open_iscsi.py
@@ -86,6 +86,12 @@ options:
         - Whether the list of nodes in the persistent iSCSI database should be returned by the module.
         type: bool
         default: false
+    rescan:
+        description:
+        - rescan an established session for discovering new targets.
+        type: bool
+        default: false
+
 '''
 
 EXAMPLES = r'''
@@ -123,6 +129,11 @@ EXAMPLES = r'''
     login: false
     portal: 10.1.1.250
     auto_portal_startup: false
+    target: iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d
+
+- name: Rescan one or all established sessions to discover new targets (omit target for all sessions)
+  community.general.open_iscsi:
+    rescan: true
     target: iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d
 '''
 
@@ -178,6 +189,13 @@ def iscsi_discover(module, portal, port):
     cmd = [iscsiadm_cmd, '--mode', 'discovery', '--type', 'sendtargets', '--portal', '%s:%s' % (portal, port)]
     module.run_command(cmd, check_rc=True)
 
+def iscsi_rescan(module, target=None):
+    if target == None:
+        cmd = [iscsiadm_cmd, '--mode', 'session', '--rescan']
+    else:
+        cmd = [iscsiadm_cmd, '--mode', 'node', '--rescan', '-T', target]
+    rc, out, err = module.run_command(cmd)
+    return out
 
 def target_loggedon(module, target, portal=None, port=None):
     cmd = [iscsiadm_cmd, '--mode', 'session']
@@ -305,6 +323,7 @@ def main():
             auto_portal_startup=dict(type='bool'),
             discover=dict(type='bool', default=False),
             show_nodes=dict(type='bool', default=False),
+            rescan=dict(type='bool', default=False),
         ),
 
         required_together=[['node_user', 'node_pass'], ['node_user_in', 'node_pass_in']],
@@ -330,6 +349,7 @@ def main():
     automatic_portal = module.params['auto_portal_startup']
     discover = module.params['discover']
     show_nodes = module.params['show_nodes']
+    rescan = module.params['rescan']
 
     check = module.check_mode
 
@@ -420,6 +440,10 @@ def main():
         else:
             result['changed'] |= True
             result['automatic_portal_changed'] = True
+
+    if rescan != False:
+        result['changed'] = True
+        result['sessions'] = iscsi_rescan(module, target)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
According to issue 3767, adding a session rescan flag to add and utilize mapped_luns after login into a portal and target.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
open_iscsi rescan flag

##### ADDITIONAL INFORMATION

``` yaml
      - name: Rescan Targets
        open_iscsi:
          rescan: true
          target: "{{ item.0 }}"
        register: iscsi_rescan
        loop:
          - iqn.1994-05.com.redhat:8c4ea31d28e
        tags:
          - rescan
```
```bash
    TASK [Rescan Targets] ********************************************************************************************************************************************************************
    changed: [node1] => (item=['iqn.1994-05.com.redhat:8c4ea31d28e'])
    changed: [node2] => (item=['iqn.1994-05.com.redhat:8c4ea31d28e'])

    TASK [Output rescan output] **************************************************************************************************************************************************************
    ok: [node1] => {
        "iscsi_rescan": {
            "changed": true,
            "msg": "All items completed",
            "results": [
                {
                    "ansible_loop_var": "item",
                    "changed": true,
                    "failed": false,
                    "invocation": {
                        "module_args": {
                            "auto_node_startup": null,
                            "discover": false,
                            "login": null,
                            "node_auth": "CHAP",
                            "node_pass": null,
                            "node_user": null,
                            "port": "3260",
                            "portal": null,
                            "rescan": true,
                            "show_nodes": false,
                            "target": "iqn.1994-05.com.redhat:8c4ea31d28e'"
                        }
                    },
                    "item": [
                        "iqn.1994-05.com.redhat:8c4ea31d28e"
                    ],
                    "sessions": [
                        "Rescanning session [sid: 3, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.1,3260]",
                        "Rescanning session [sid: 1, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.2,3260]",
                        "Rescanning session [sid: 2, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.3,3260]",
                        ""
                    ]
                }
            ]
        }
    }
    ok: [node2] => {
        "iscsi_rescan": {
            "changed": true,
            "msg": "All items completed",
            "results": [
                {
                    "ansible_loop_var": "item",
                    "changed": true,
                    "failed": false,
                    "invocation": {
                        "module_args": {
                            "auto_node_startup": null,
                            "discover": false,
                            "login": null,
                            "node_auth": "CHAP",
                            "node_pass": null,
                            "node_user": null,
                            "port": "3260",
                            "portal": null,
                            "rescan": true,
                            "show_nodes": false,
                            "target": "iqn.1994-05.com.redhat:8c4ea31d28e"
                        }
                    },
                    "item": [
                        "iqn.1994-05.com.redhat:8c4ea31d28e"
                    ],
                    "sessions": [
                        "Rescanning session [sid: 3, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.1,3260]",
                        "Rescanning session [sid: 2, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.2,3260]",
                        "Rescanning session [sid: 1, target: iqn.1994-05.com.redhat:8c4ea31d28e, portal: 127.0.0.3,3260]",
                        ""
                    ]
                }
            ]
        }
    }
```