### PR TITLE
python_requirements_info - fail when version operator used without version

### DIFF
--- a/changelogs/fragments/3785-python_requirements_info-versionless-op.yaml
+++ b/changelogs/fragments/3785-python_requirements_info-versionless-op.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - python_requirements_info - fails if version operator used without version (https://github.com/ansible-collections/community.general/pull/3785).

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -121,7 +121,7 @@ def main():
             python_version=sys.version,
             python_system_path=sys.path,
         )
-    pkg_dep_re = re.compile(r'(^[a-zA-Z][a-zA-Z0-9_-]+)(==|[><]=?)?([0-9.]+)?$')
+    pkg_dep_re = re.compile(r'(^[a-zA-Z][a-zA-Z0-9_-]+)(?:(==|[><]=?)([0-9.]+))?$')
 
     results = dict(
         not_found=[],
@@ -134,11 +134,8 @@ def main():
         if not match:
             module.fail_json(msg="Failed to parse version requirement '{0}'. Must be formatted like 'ansible>2.6'".format(dep))
         pkg, op, version = match.groups()
-        if op:
-          if op not in operations:
+        if op is not None and op not in operations:
             module.fail_json(msg="Failed to parse version requirement '{0}'. Operator must be one of >, <, <=, >=, or ==".format(dep))
-          if not version:
-            module.fail_json(msg="Failed to parse version requirement '{0}'. Operator requires a version number".format(dep))
         try:
             existing = pkg_resources.get_distribution(pkg).version
         except pkg_resources.DistributionNotFound:

--- a/plugins/modules/system/python_requirements_info.py
+++ b/plugins/modules/system/python_requirements_info.py
@@ -131,11 +131,14 @@ def main():
 
     for dep in (module.params.get('dependencies') or []):
         match = pkg_dep_re.match(dep)
-        if match is None:
+        if not match:
             module.fail_json(msg="Failed to parse version requirement '{0}'. Must be formatted like 'ansible>2.6'".format(dep))
         pkg, op, version = match.groups()
-        if op is not None and op not in operations:
+        if op:
+          if op not in operations:
             module.fail_json(msg="Failed to parse version requirement '{0}'. Operator must be one of >, <, <=, >=, or ==".format(dep))
+          if not version:
+            module.fail_json(msg="Failed to parse version requirement '{0}'. Operator requires a version number".format(dep))
         try:
             existing = pkg_resources.get_distribution(pkg).version
         except pkg_resources.DistributionNotFound:

--- a/tests/integration/targets/python_requirements_info/tasks/main.yml
+++ b/tests/integration/targets/python_requirements_info/tasks/main.yml
@@ -25,3 +25,15 @@
     that:
       - "'installed' in dep_info.valid.pip"
       - "'notreal' in dep_info.not_found"
+
+- name: wrong specs
+  python_requirements_info:
+    dependencies:
+      - ansible<
+  register: wrong_spec1
+  ignore_errors: true
+
+- name: ensure wrong specs return error
+  assert:
+    that:
+      - wrong_spec1 is failed


### PR DESCRIPTION
##### SUMMARY
Module does not complain when a python package requirement is passed with a version operator but no version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/python_requirements_info.py

