### PR TITLE
Update lxd connection to use all documented vars for options

### DIFF
--- a/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
+++ b/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
@@ -1,6 +1,4 @@
 ---
 minor_changes:
-  - lxd connection plugin - fix the lxd connection plugin to have all inventory
-    option vars work. ansible_host, ansible_lxd_remote, and ansible_lxd_project
-    worked prior to this change. ansible_lxd_host, ansible_executable, and
-    ansible_lxd_executable now work with the fix (https://github.com/ansible-collections/community.general/pull/3798).
+  - lxd connection plugin - make sure that ``ansible_lxd_host``, ``ansible_executable``, and
+    ``ansible_lxd_executable`` work (https://github.com/ansible-collections/community.general/pull/3798).

--- a/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
+++ b/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - lxd - fix the lxd connection plugin to have all inventory option vars work (https://github.com/ansible-collections/community.general/pull/3798).

--- a/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
+++ b/changelogs/fragments/3798-fix-lxd-connection-option-vars-support.yml
@@ -1,3 +1,6 @@
 ---
 minor_changes:
-  - lxd - fix the lxd connection plugin to have all inventory option vars work (https://github.com/ansible-collections/community.general/pull/3798).
+  - lxd connection plugin - fix the lxd connection plugin to have all inventory
+    option vars work. ansible_host, ansible_lxd_remote, and ansible_lxd_project
+    worked prior to this change. ansible_lxd_host, ansible_executable, and
+    ansible_lxd_executable now work with the fix (https://github.com/ansible-collections/community.general/pull/3798).

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -89,9 +89,9 @@ class Connection(ConnectionBase):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
             "exec",
-            "%s:%s" % (self.get_option("remote"), self._host),
+            "%s:%s" % (self.get_option("remote"), self.get_option("remote_addr")),
             "--",
-            self._play_context.executable, "-c", cmd
+            self.get_option("executable"), "-c", cmd
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
@@ -126,7 +126,7 @@ class Connection(ConnectionBase):
         local_cmd.extend([
             "file", "push",
             in_path,
-            "%s:%s/%s" % (self.get_option("remote"), self._host, out_path)
+            "%s:%s/%s" % (self.get_option("remote"), self.get_option("remote_addr"), out_path)
         ])
 
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
@@ -145,7 +145,7 @@ class Connection(ConnectionBase):
             local_cmd.extend(["--project", self.get_option("project")])
         local_cmd.extend([
             "file", "pull",
-            "%s:%s/%s" % (self.get_option("remote"), self._host, in_path),
+            "%s:%s/%s" % (self.get_option("remote"), self.get_option("remote_addr"), in_path),
             out_path
         ])
 


### PR DESCRIPTION
##### SUMMARY
The changes below are in attempt to "fix" the mapping of the inventory vars to the LXD connection plugin documented options.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/lxd.py

##### ADDITIONAL INFORMATION

#### STEPS TO REPRODUCE
The following example assumes there exist a VM called 'vm1' that runs LXD, also this LXD instance manages the container 'container1'.

inventory
```shell
vm1:container1 ansible_lxd_remote=x.x.x.x ansible_lxd_host=container1

[lxd_containers]
vm1:container1

[all:vars]
ansible_user=ansible
ansible_ssh_common_args='-o StrictHostKeyChecking=no'
```

playbook
```yaml
---
- name: Check/install python on LXD container nodes
  hosts: lxd_containers
  connection: lxd
  gather_facts: no

  tasks:
    - name: Check if python3 is installed in container
      ansible.builtin.raw: dpkg -s python3
      register: python_install_check
      failed_when: python_install_check.rc not in [0, 1]
      changed_when: false

    - name: Install python3 in container
      ansible.builtin.raw: apt-get install --assume-yes python3
      when: python_install_check.rc == 1

```

output
```shell
ansible-playbook 2.10.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/conner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.9.5 (default, May 11 2021, 08:20:37) [GCC 10.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
script declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
auto declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
Parsed /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python3/dist-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: playbook.yaml ********************************************************
Positional arguments: playbook.yaml
verbosity: 4
connection: smart
timeout: 60
become_method: sudo
become_ask_pass: True
tags: ('all',)
inventory: ('/home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory',)
forks: 5
1 plays in playbook.yaml

PLAY [Check/install python on LXD container nodes] *****************************
META: ran handlers

TASK [Check if python3 is installed in container] ******************************
task path: /home/conner/git/playground/vagrant/ansible/playbook.yaml:10
redirecting (type: connection) ansible.builtin.lxd to community.general.lxd
Loading collection community.general from /home/conner/.ansible/collections/ansible_collections/community/general
[WARNING]: lxd does not support remote_user, using container default: root
<vm1:container1> ESTABLISH LXD CONNECTION FOR USER: root
<vm1:container1> EXEC dpkg -s python3
ok: [vm1:container1] => {
    "changed": false,
    "failed_when_result": false,
    "msg": "non-zero return code",
    "rc": 1,
    "stderr": "Error: Not Found\n",
    "stderr_lines": [
        "Error: Not Found"
    ],
    "stdout": "",
    "stdout_lines": []
}

TASK [Install python3 in container] ********************************************
task path: /home/conner/git/playground/vagrant/ansible/playbook.yaml:16
redirecting (type: connection) ansible.builtin.lxd to community.general.lxd
Loading collection community.general from /home/conner/.ansible/collections/ansible_collections/community/general
[WARNING]: lxd does not support remote_user, using container default: root
<vm1:container1> ESTABLISH LXD CONNECTION FOR USER: root
<vm1:container1> EXEC apt-get install --assume-yes python3
fatal: [vm1:container1]: FAILED! => {
    "changed": true,
    "msg": "non-zero return code",
    "rc": 1,
    "stderr": "Error: Not Found\n",
    "stderr_lines": [
        "Error: Not Found"
    ],
    "stdout": "",
    "stdout_lines": []
}

PLAY RECAP *********************************************************************
vm1:container1        : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 

```

### After applying the following changes, running the same playbook
```shell
ansible-playbook 2.10.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/conner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.9.5 (default, May 11 2021, 08:20:37) [GCC 10.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
script declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
auto declined parsing /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory as it did not pass its verify_file() method
Parsed /home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /usr/lib/python3/dist-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: playbook.yaml ********************************************************
Positional arguments: playbook.yaml
verbosity: 4
connection: smart
timeout: 60
become_method: sudo
become_ask_pass: True
tags: ('all',)
inventory: ('/home/conner/git/playground/vagrant/ansible/vagrant_ansible_inventory',)
forks: 5
1 plays in playbook.yaml

PLAY [Check/install python on LXD container nodes] *****************************
META: ran handlers

TASK [Check if python3 is installed in container] ******************************
task path: /home/conner/git/playground/vagrant/ansible/playbook.yaml:10
redirecting (type: connection) ansible.builtin.lxd to community.general.lxd
Loading collection community.general from /home/conner/.ansible/collections/ansible_collections/community/general
[WARNING]: lxd does not support remote_user, using container default: root
<vm1:container1> ESTABLISH LXD CONNECTION FOR USER: root
<vm1:container1> EXEC dpkg -s python3
ok: [vm1:container1] => {
    "changed": false,
    "failed_when_result": false,
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Package: python3\nStatus: install ok installed\nPriority: optional\nSection: python\nInstalled-Size: 89\nMaintainer: Matthias Klose <doko@debian.org>\nArchitecture: amd64\nMulti-Arch: allowed\nSource: python3-defaults\nVersion: 3.9.2-3\nReplaces: python3-minimal (<< 3.1.2-2)\nProvides: python3-profiler\nDepends: python3.9 (>= 3.9.2-0~), libpython3-stdlib (= 3.9.2-3)\nPre-Depends: python3-minimal (= 3.9.2-3)\nSuggests: python3-doc (>= 3.9.2-3), python3-tk (>= 3.9.2-0~), python3-venv (>= 3.9.2-3)\nDescription: interactive high-level object-oriented language (default python3 version)\n Python, the high-level, interactive object oriented language,\n includes an extensive class library with lots of goodies for\n network programming, system administration, sounds and graphics.\n .\n This package is a dependency package, which depends on Debian's default\n Python 3 version (currently v3.9).\nHomepage: https://www.python.org/\nCnf-Extra-Commands: python\nCnf-Priority-Bonus: 5\n",
    "stdout_lines": [
        "Package: python3",
        "Status: install ok installed",
        "Priority: optional",
        "Section: python",
        "Installed-Size: 89",
        "Maintainer: Matthias Klose <doko@debian.org>",
        "Architecture: amd64",
        "Multi-Arch: allowed",
        "Source: python3-defaults",
        "Version: 3.9.2-3",
        "Replaces: python3-minimal (<< 3.1.2-2)",
        "Provides: python3-profiler",
        "Depends: python3.9 (>= 3.9.2-0~), libpython3-stdlib (= 3.9.2-3)",
        "Pre-Depends: python3-minimal (= 3.9.2-3)",
        "Suggests: python3-doc (>= 3.9.2-3), python3-tk (>= 3.9.2-0~), python3-venv (>= 3.9.2-3)",
        "Description: interactive high-level object-oriented language (default python3 version)",
        " Python, the high-level, interactive object oriented language,",
        " includes an extensive class library with lots of goodies for",
        " network programming, system administration, sounds and graphics.",
        " .",
        " This package is a dependency package, which depends on Debian's default",
        " Python 3 version (currently v3.9).",
        "Homepage: https://www.python.org/",
        "Cnf-Extra-Commands: python",
        "Cnf-Priority-Bonus: 5"
    ]
}

TASK [Install python3 in container] ********************************************
task path: /home/conner/git/playground/vagrant/ansible/playbook.yaml:16
skipping: [vm1:container1] => {
    "changed": false,
    "skip_reason": "Conditional result was False"
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
vm1:container1        : ok=1    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   

```
The main one I wanted to see change was interpolation of \<instance\> (```lxc exec [<remote>:]<instance> ...```) being from ```self.get_option("remote_addr")``` instead of ```self._host```. If an inventory alias is used for a node, then the ```ansible_lxd_host``` inventory variable is ignored entirely. That said, ```ansible_host``` worked ok here vs ```ansible_lxd_host```.

The others are so the other inventory vars can be mapped according to the other documented options. It could also be that it is desired to still make use of the ```play_context```, and that the other specific lxd variables (e.g. ```ansible_lxd_host```, ```ansible_lxd_executable```) are not required.