### PR TITLE
[PR #3784/aae3ae1a backport][stable-3] Fixing ip address without mask bug

### DIFF
--- a/changelogs/fragments/3768-nmcli_fix_changed_when_no_mask_set.yml
+++ b/changelogs/fragments/3768-nmcli_fix_changed_when_no_mask_set.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - nmcli - fix returning "changed" when no mask set for IPv4 or IPv6 addresses on task rerun
+    (https://github.com/ansible-collections/community.general/issues/3768).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -70,7 +70,7 @@ options:
     ip4:
         description:
             - The IPv4 address to this interface.
-            - Use the format C(192.0.2.24/24).
+            - Use the format C(192.0.2.24/24) or C(192.0.2.24).
             - If defined and I(method4) is not specified, automatically set C(ipv4.method) to C(manual).
         type: str
     gw4:
@@ -142,7 +142,7 @@ options:
     ip6:
         description:
             - The IPv6 address to this interface.
-            - Use the format C(abbe::cafe).
+            - Use the format C(abbe::cafe/128 or abbe::cafe).
             - If defined and I(method6) is not specified, automatically set C(ipv6.method) to C(manual).
         type: str
     gw6:
@@ -1240,7 +1240,7 @@ class Nmcli(object):
         # IP address options.
         if self.ip_conn_type and not self.master:
             options.update({
-                'ipv4.addresses': self.ip4,
+                'ipv4.addresses': self.enforce_ipv4_cidr_notation(self.ip4),
                 'ipv4.dhcp-client-id': self.dhcp_client_id,
                 'ipv4.dns': self.dns4,
                 'ipv4.dns-search': self.dns4_search,
@@ -1253,7 +1253,7 @@ class Nmcli(object):
                 'ipv4.never-default': self.never_default4,
                 'ipv4.method': self.ipv4_method,
                 'ipv4.may-fail': self.may_fail4,
-                'ipv6.addresses': self.ip6,
+                'ipv6.addresses': self.enforce_ipv6_cidr_notation(self.ip6),
                 'ipv6.dns': self.dns6,
                 'ipv6.dns-search': self.dns6_search,
                 'ipv6.ignore-auto-dns': self.dns6_ignore_auto,
@@ -1442,6 +1442,22 @@ class Nmcli(object):
             'ipip',
             'sit',
         )
+
+    @staticmethod
+    def enforce_ipv4_cidr_notation(ip4_address):
+        if ip4_address is None or '/' in ip4_address:
+            return ip4_address
+
+        return ip4_address + '/32'
+
+    @staticmethod
+    def enforce_ipv6_cidr_notation(ip6_address):
+        if ip6_address is None:
+            return None
+        elif '/' in ip6_address:
+            return ip6_address
+        else:
+            return ip6_address + '/128'
 
     @staticmethod
     def bool_to_string(boolean):

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -532,6 +532,26 @@ ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
 """
 
+TESTCASE_ETHERNET_STATIC_IP6_ADDRESS_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              ethernet_non_existant
+connection.autoconnect:                 yes
+802-3-ethernet.mtu:                     auto
+ipv6.method:                            manual
+ipv6.addresses:                         2001:db8::cafe/128
+ipv6.gateway:                           2001:db8::cafa
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+ipv6.never-default:                     no
+ipv6.may-fail:                          yes
+ipv6.dns:                               2001:4860:4860::8888,2001:4860:4860::8844
+ipv4.method:                            disabled
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+"""
+
 TESTCASE_WIRELESS = [
     {
         'type': 'wifi',
@@ -637,7 +657,6 @@ ipv4.ignore-auto-routes:                no
 ipv4.never-default:                     no
 ipv4.may-fail:                          yes
 ipv4.dns:                               1.1.1.1,8.8.8.8
-ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
 ipv6.method:                            manual
@@ -841,6 +860,17 @@ def mocked_ethernet_connection_static_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_ETHERNET_STATIC_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
+def mocked_ethernet_connection_with_ipv6_address_static_modify(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_ETHERNET_STATIC_IP6_ADDRESS_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a backport of PR #3784 as merged into main (aae3ae1).

##### SUMMARY
This PR was requested in #3776. So this just fork of branch in #3776 but with bugfix(#3768)

##### ISSUE TYPE
Bugfix Pull Request
##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py

##### ADDITIONAL INFORMATION
Most of information can be find in #3776. I should mention that i forked this way because this fix depends on adding list support in ipv6 parameter. That's why diff contains diff from #3776.

###### Resolved Conflicts
- `ip4` is not a list in `stable-3` so function to enforce cidr notation was made to accept a string.
- Doc updates related to `ip4` as a list were removed.
- Testcases related to `ip4` as a list and other features introduced after `stable-3` were removed.
- Mocks related to removed testcases were removed.