### PR TITLE
Allow the use of personal access tokens with JIRA

### DIFF
--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -417,7 +417,7 @@ class JIRA(StateModuleHelper):
             ),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True, no_log=True),
-            token=dict(type='str', required=False, no_log=True),
+            token=dict(type='str', no_log=True),
             project=dict(type='str', ),
             summary=dict(type='str', ),
             description=dict(type='str', ),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -443,6 +443,7 @@ class JIRA(StateModuleHelper):
         mutually_exclusive=[
             ['username', 'token'],
             ['password', 'token'],
+            ['assignee', 'account_id'],
         ],
         required_together=[
             ['username', 'password'],
@@ -459,7 +460,6 @@ class JIRA(StateModuleHelper):
             ('operation', 'link', ['linktype', 'inwardissue', 'outwardissue']),
             ('operation', 'search', ['jql']),
         ),
-        mutually_exclusive=[('assignee', 'account_id')],
         supports_check_mode=False
     )
 

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -36,15 +36,15 @@ options:
 
   username:
     type: str
-    required: true
+    required: false
     description:
-      - The username to log-in with.
+      - The username to log-in with. Must be used with password.  Mutually exclusive with token.
 
   password:
     type: str
-    required: true
+    required: false
     description:
-      - The password to log-in with.
+      - The password to log-in with. Must be used with username.  Mutually exclusive with token.
 
   token:
     type: str
@@ -440,6 +440,16 @@ class JIRA(StateModuleHelper):
             validate_certs=dict(default=True, type='bool'),
             account_id=dict(type='str'),
         ),
+        mutually_exclusive=[
+            ['username', 'token'],
+            ['password', 'token'],
+        ],
+        required_together=[
+            ['username', 'password'],
+        ],
+        required_one_of=[
+            ['username', 'token'],
+        ],
         required_if=(
             ('operation', 'attach', ['issue', 'attachment']),
             ('operation', 'create', ['project', 'issuetype', 'summary']),

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -660,25 +660,26 @@ class JIRA(StateModuleHelper):
         if data and content_type == 'application/json':
             data = json.dumps(data)
 
+       headers = {}
+        if isinstance(additional_headers, dict):
+            headers = additional_headers.copy()
+
         # NOTE: fetch_url uses a password manager, which follows the
         # standard request-then-challenge basic-auth semantics. However as
         # JIRA allows some unauthorised operations it doesn't necessarily
         # send the challenge, so the request occurs as the anonymous user,
         # resulting in unexpected results. To work around this we manually
-        # inject the basic-auth header up-front to ensure that JIRA treats
+        # inject the auth header up-front to ensure that JIRA treats
         # the requests as authorized for this user.
-        auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
-                                                 errors='surrogate_or_strict')))
 
-        headers = {}
-        if isinstance(additional_headers, dict):
-            headers = additional_headers.copy()
-        if self.vars.token is not None:
+         if self.vars.token is not None:
             headers.update({
                 "Content-Type": content_type,
                 "Authorization": "Bearer %s" % self.vars.token,
             })
         else:
+           auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
+                                                        errors='surrogate_or_strict')))
             headers.update({
                 "Content-Type": content_type,
                 "Authorization": "Basic %s" % auth,

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -661,8 +661,8 @@ class JIRA(StateModuleHelper):
             data = json.dumps(data)
 
        headers = {}
-        if isinstance(additional_headers, dict):
-            headers = additional_headers.copy()
+       if isinstance(additional_headers, dict):
+           headers = additional_headers.copy()
 
         # NOTE: fetch_url uses a password manager, which follows the
         # standard request-then-challenge basic-auth semantics. However as
@@ -672,13 +672,13 @@ class JIRA(StateModuleHelper):
         # inject the auth header up-front to ensure that JIRA treats
         # the requests as authorized for this user.
 
-         if self.vars.token is not None:
+        if self.vars.token is not None:
             headers.update({
                 "Content-Type": content_type,
                 "Authorization": "Bearer %s" % self.vars.token,
             })
         else:
-           auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
+            auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
                                                         errors='surrogate_or_strict')))
             headers.update({
                 "Content-Type": content_type,

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -51,6 +51,7 @@ options:
     required: false
     description:
       - The personal access token to log-in with.
+      - Mutually exclusive with I(username) and I(password).
     version_added: 4.2.0
 
   project:

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -48,7 +48,6 @@ options:
 
   token:
     type: str
-    required: false
     description:
       - The personal access token to log-in with.
       - Mutually exclusive with I(username) and I(password).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -46,6 +46,12 @@ options:
     description:
       - The password to log-in with.
 
+  token:
+    type: str
+    required: false
+    description:
+      - The personal access token to log-in with.
+
   project:
     type: str
     required: false
@@ -206,7 +212,7 @@ options:
             done.
 
 notes:
-  - "Currently this only works with basic-auth."
+  - "Currently this only works with basic-auth, or tokens."
   - "To use with JIRA Cloud, pass the login e-mail as the I(username) and the API token as I(password)."
 
 author:
@@ -410,6 +416,7 @@ class JIRA(StateModuleHelper):
             ),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True, no_log=True),
+            token=dict(type='str', required=False, no_log=True),
             project=dict(type='str', ),
             summary=dict(type='str', ),
             description=dict(type='str', ),
@@ -655,10 +662,16 @@ class JIRA(StateModuleHelper):
         headers = {}
         if isinstance(additional_headers, dict):
             headers = additional_headers.copy()
-        headers.update({
-            "Content-Type": content_type,
-            "Authorization": "Basic %s" % auth,
-        })
+        if self.vars.token is not None:
+            headers.update({
+                "Content-Type": content_type,
+                "Authorization": "Bearer %s" % self.vars.token,
+            })
+        else:
+            headers.update({
+                "Content-Type": content_type,
+                "Authorization": "Basic %s" % auth,
+            })
 
         response, info = fetch_url(
             self.module, url, data=data, method=method, timeout=self.vars.timeout, headers=headers

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -51,6 +51,7 @@ options:
     required: false
     description:
       - The personal access token to log-in with.
+    version_added: 4.2.0
 
   project:
     type: str


### PR DESCRIPTION
username and passwords are currently "required".
If token is set, then the Authorization header is changed
to use:

    Authorization: Bearer <token>

instead of the previous:

    Authorization: Basic <base64 encoding of user:pass>

If the policy of the JIRA instance prohibits the use of BasicAuth
for API calls, this would be a method to allow users to use the
ansible module.

##### SUMMARY
If your JIRA administrator disallows the use of BasicAuth and enforces a PAT only policy,
this change allows for token to be set (optionally) which will change the Authorization header to use the token.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jira

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
