### PR TITLE
java_cert - invoke run_command passing list

### DIFF
--- a/changelogs/fragments/3835-java-cert-run-list.yaml
+++ b/changelogs/fragments/3835-java-cert-run-list.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - java_cert - calling ``run_command`` with arguments as ``list`` instead of ``str`` (https://github.com/ansible-collections/community.general/pull/3835).

--- a/plugins/modules/system/java_cert.py
+++ b/plugins/modules/system/java_cert.py
@@ -439,7 +439,7 @@ def delete_cert(module, executable, keystore_path, keystore_pass, alias, keystor
 
 def test_keytool(module, executable):
     ''' Test if keytool is actually executable or not '''
-    module.run_command("%s" % executable, check_rc=True)
+    module.run_command([executable], check_rc=True)
 
 
 def test_keystore(module, keystore_path):


### PR DESCRIPTION
##### SUMMARY
Passing command as list instead of as string.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/java_cert.py