### PR TITLE
opentelemetry: honour ignore errors

### DIFF
--- a/changelogs/fragments/3837-opentelemetry_plugin-honour_ignore_errors.yaml
+++ b/changelogs/fragments/3837-opentelemetry_plugin-honour_ignore_errors.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - opentelemetry_plugin - honour ``ignore_errors`` when a task has failed instead of reporting an error (https://github.com/ansible-collections/community.general/pull/3837).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -462,10 +462,15 @@ class CallbackModule(CallbackBase):
         )
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self.errors += 1
+        if ignore_errors:
+            status = 'ok'
+        else:
+            status = 'failed'
+            self.errors += 1
+
         self.opentelemetry.finish_task(
             self.tasks_data,
-            'failed',
+            status,
             result
         )
 

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -268,6 +268,8 @@ class OpenTelemetrySource(object):
             elif host_data.status == 'skipped':
                 message = res['skip_reason'] if 'skip_reason' in res else 'skipped'
                 status = Status(status_code=StatusCode.UNSET)
+            elif host_data.status == 'ignored':
+                status = Status(status_code=StatusCode.UNSET)
 
         span.set_status(status)
         if isinstance(task_data.args, dict) and "gather_facts" not in task_data.action:
@@ -464,7 +466,7 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         if ignore_errors:
-            status = 'ok'
+            status = 'ignored'
         else:
             status = 'failed'
             self.errors += 1

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # (C) 2021, Victor Martinez <VictorMartinezRubio@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 


### PR DESCRIPTION
##### SUMMARY

Honour the `ignore_errors` when a task has failed with that configuration.

If a task has failed and the `ignore_errors` was set then the span status will be `UNSET`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`opentelemetry`

##### ADDITIONAL INFORMATION

Given the below playbook:

```yaml
---
- name: MyPlabook
  hosts: localhost
  connection: local

  tasks:
  - name: failed_and_ignore_errors
    shell: "exit 1"
    ignore_errors: yes
  - name: success_and_ignore_errors
    shell: "exit 0"
    ignore_errors: yes
```

Before:

![image](https://user-images.githubusercontent.com/2871786/144414674-0b7ee920-681f-467c-a710-43f8759959d2.png)

After:

![image](https://user-images.githubusercontent.com/2871786/144414117-0f04ee0f-d175-46f8-b2c7-53e67b8bd59e.png)

![image](https://user-images.githubusercontent.com/2871786/144593879-6ac21e22-e8c9-4d13-833d-b45199ac81ba.png)
