### PR TITLE
jira - Add support for Bearer token auth

### DIFF
--- a/changelogs/fragments/3838-jira-token.yaml
+++ b/changelogs/fragments/3838-jira-token.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-    - jira - Add support for Bearer token auth (https://github.com/ansible-collections/community.general/pull/3838).
+    - jira - add support for Bearer token auth (https://github.com/ansible-collections/community.general/pull/3838).

--- a/changelogs/fragments/3838-jira-token.yaml
+++ b/changelogs/fragments/3838-jira-token.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - jira - Add support for Bearer token auth (https://github.com/ansible-collections/community.general/pull/3838).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -36,15 +36,22 @@ options:
 
   username:
     type: str
-    required: true
+    required: false
     description:
-      - The username to log-in with.
+      - The username to log-in with. Must be used with password.  Mutually exclusive with token.
 
   password:
     type: str
-    required: true
+    required: false
     description:
-      - The password to log-in with.
+      - The password to log-in with. Must be used with username.  Mutually exclusive with token.
+
+  token:
+    type: str
+    description:
+      - The personal access token to log-in with.
+      - Mutually exclusive with I(username) and I(password).
+    version_added: 4.2.0
 
   project:
     type: str
@@ -206,7 +213,7 @@ options:
             done.
 
 notes:
-  - "Currently this only works with basic-auth."
+  - "Currently this only works with basic-auth, or tokens."
   - "To use with JIRA Cloud, pass the login e-mail as the I(username) and the API token as I(password)."
 
 author:
@@ -408,8 +415,9 @@ class JIRA(StateModuleHelper):
                 choices=['attach', 'create', 'comment', 'edit', 'update', 'fetch', 'transition', 'link', 'search'],
                 aliases=['command'], required=True
             ),
-            username=dict(type='str', required=True),
-            password=dict(type='str', required=True, no_log=True),
+            username=dict(type='str'),
+            password=dict(type='str', no_log=True),
+            token=dict(type='str', no_log=True),
             project=dict(type='str', ),
             summary=dict(type='str', ),
             description=dict(type='str', ),
@@ -432,6 +440,17 @@ class JIRA(StateModuleHelper):
             validate_certs=dict(default=True, type='bool'),
             account_id=dict(type='str'),
         ),
+        mutually_exclusive=[
+            ['username', 'token'],
+            ['password', 'token'],
+            ['assignee', 'account_id'],
+        ],
+        required_together=[
+            ['username', 'password'],
+        ],
+        required_one_of=[
+            ['username', 'token'],
+        ],
         required_if=(
             ('operation', 'attach', ['issue', 'attachment']),
             ('operation', 'create', ['project', 'issuetype', 'summary']),
@@ -441,7 +460,6 @@ class JIRA(StateModuleHelper):
             ('operation', 'link', ['linktype', 'inwardissue', 'outwardissue']),
             ('operation', 'search', ['jql']),
         ),
-        mutually_exclusive=[('assignee', 'account_id')],
         supports_check_mode=False
     )
 
@@ -642,23 +660,30 @@ class JIRA(StateModuleHelper):
         if data and content_type == 'application/json':
             data = json.dumps(data)
 
+       headers = {}
+       if isinstance(additional_headers, dict):
+           headers = additional_headers.copy()
+
         # NOTE: fetch_url uses a password manager, which follows the
         # standard request-then-challenge basic-auth semantics. However as
         # JIRA allows some unauthorised operations it doesn't necessarily
         # send the challenge, so the request occurs as the anonymous user,
         # resulting in unexpected results. To work around this we manually
-        # inject the basic-auth header up-front to ensure that JIRA treats
+        # inject the auth header up-front to ensure that JIRA treats
         # the requests as authorized for this user.
-        auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
-                                                 errors='surrogate_or_strict')))
 
-        headers = {}
-        if isinstance(additional_headers, dict):
-            headers = additional_headers.copy()
-        headers.update({
-            "Content-Type": content_type,
-            "Authorization": "Basic %s" % auth,
-        })
+        if self.vars.token is not None:
+            headers.update({
+                "Content-Type": content_type,
+                "Authorization": "Bearer %s" % self.vars.token,
+            })
+        else:
+            auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
+                                                        errors='surrogate_or_strict')))
+            headers.update({
+                "Content-Type": content_type,
+                "Authorization": "Basic %s" % auth,
+            })
 
         response, info = fetch_url(
             self.module, url, data=data, method=method, timeout=self.vars.timeout, headers=headers

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -660,9 +660,9 @@ class JIRA(StateModuleHelper):
         if data and content_type == 'application/json':
             data = json.dumps(data)
 
-       headers = {}
-       if isinstance(additional_headers, dict):
-           headers = additional_headers.copy()
+        headers = {}
+        if isinstance(additional_headers, dict):
+            headers = additional_headers.copy()
 
         # NOTE: fetch_url uses a password manager, which follows the
         # standard request-then-challenge basic-auth semantics. However as

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -43,7 +43,6 @@ options:
 
   password:
     type: str
-    required: false
     description:
       - The password to log-in with.
       - Must be used with I(username).  Mutually exclusive with I(token).

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -679,7 +679,7 @@ class JIRA(StateModuleHelper):
             })
         else:
             auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(self.vars.username, self.vars.password),
-                                                        errors='surrogate_or_strict')))
+                                                     errors='surrogate_or_strict')))
             headers.update({
                 "Content-Type": content_type,
                 "Authorization": "Basic %s" % auth,

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -38,13 +38,15 @@ options:
     type: str
     required: false
     description:
-      - The username to log-in with. Must be used with password.  Mutually exclusive with token.
+      - The username to log-in with.
+      - Must be used with I(password). Mutually exclusive with I(token).
 
   password:
     type: str
     required: false
     description:
-      - The password to log-in with. Must be used with username.  Mutually exclusive with token.
+      - The password to log-in with.
+      - Must be used with I(username).  Mutually exclusive with I(token).
 
   token:
     type: str

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -36,7 +36,6 @@ options:
 
   username:
     type: str
-    required: false
     description:
       - The username to log-in with.
       - Must be used with I(password). Mutually exclusive with I(token).


### PR DESCRIPTION
* jira - Add support for Bearer token auth

* added changelog fragment

Co-authored-by: Felix Fontein <felix@fontein.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
    Allow the use of personal access tokens with JIRA

    username and passwords are currently "required".
    If token is set, then the Authorization header is changed
    to use:

        Authorization: Bearer <token>

    instead of the previous:

        Authorization: Basic <base64 encoding of user:pass>

    If the policy of the JIRA instance prohibits the use of BasicAuth
    for API calls, this would be a method to allow users to use the
    ansible module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
jira

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
