### PR TITLE
elastic: honour the ignore_errors

### DIFF
--- a/changelogs/fragments/3839-elastic_plugin-honour_ignore_errors.yaml
+++ b/changelogs/fragments/3839-elastic_plugin-honour_ignore_errors.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - elastic_plugin - honour ``ignore_errors`` when a task has failed instead of reporting an error (https://github.com/ansible-collections/community.general/pull/3839).

--- a/plugins/callback/elastic.py
+++ b/plugins/callback/elastic.py
@@ -374,10 +374,14 @@ class CallbackModule(CallbackBase):
         )
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self.errors += 1
+        if ignore_errors:
+            status = 'ok'
+        else:
+            status = 'failed'
+            self.errors += 1
         self.elastic.finish_task(
             self.tasks_data,
-            'failed',
+            status,
             result
         )
 


### PR DESCRIPTION
##### SUMMARY

Honour the `ignore_errors` when a task has failed with that configuration.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`elastic`

##### ADDITIONAL INFORMATION

Given the below playbook:

```yaml
---
- name: MyPlabook
  hosts: localhost
  connection: local

  tasks:
  - name: failed_and_ignore_errors
    shell: "exit 1"
    ignore_errors: yes
  - name: success_and_ignore_errors
    shell: "exit 0"
    ignore_errors: yes
```

Before:

![image](https://user-images.githubusercontent.com/2871786/144462554-695e01b4-a183-4d81-b696-08ea0c80b43f.png)

After:

![image](https://user-images.githubusercontent.com/2871786/144462497-8e355815-b35e-428f-9826-25c6325a1535.png)


