### PR TITLE
MH decorators - added decorators for check_mode

### DIFF
--- a/changelogs/fragments/3849-mh-check-mode-decos.yaml
+++ b/changelogs/fragments/3849-mh-check-mode-decos.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - module_helper module utils - added decorators ``check_mode_skip`` and ``check_mode_skip_returns`` for skipping methods when ``check_mode=True`` (https://github.com/ansible-collections/community.general/pull/3849).

--- a/plugins/module_utils/mh/deco.py
+++ b/plugins/module_utils/mh/deco.py
@@ -52,3 +52,36 @@ def module_fails_on_exception(func):
             self.module.fail_json(msg=msg, exception=traceback.format_exc(),
                                   output=self.output, vars=self.vars.output(), **self.output)
     return wrapper
+
+
+def check_mode_skip(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if not self.module.check_mode:
+            return func(self, *args, **kwargs)
+    return wrapper
+
+
+def check_mode_skip_returns(callable=None, value=None):
+
+    def deco(func):
+        if callable is not None:
+            @wraps(func)
+            def wrapper_callable(self, *args, **kwargs):
+                if self.module.check_mode:
+                    return callable(self, *args, **kwargs)
+                return func(self, *args, **kwargs)
+            return wrapper_callable
+
+        if value is not None:
+            @wraps(func)
+            def wrapper_value(self, *args, **kwargs):
+                if self.module.check_mode:
+                    return value
+                return func(self, *args, **kwargs)
+            return wrapper_value
+
+    if callable is None and value is None:
+        return check_mode_skip
+
+    return deco

--- a/tests/integration/targets/module_helper/library/msimple.py
+++ b/tests/integration/targets/module_helper/library/msimple.py
@@ -30,30 +30,39 @@ EXAMPLES = ""
 RETURN = ""
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import ModuleHelper
+from ansible_collections.community.general.plugins.module_utils.mh.deco import check_mode_skip
 
 
 class MSimple(ModuleHelper):
     output_params = ('a', 'b', 'c')
     module = dict(
         argument_spec=dict(
-            a=dict(type='int'),
+            a=dict(type='int', default=0),
             b=dict(type='str'),
             c=dict(type='str'),
         ),
+        supports_check_mode=True,
     )
 
     def __init_module__(self):
         self.vars.set('value', None)
         self.vars.set('abc', "abc", diff=True)
 
+    @check_mode_skip
+    def process_a3_bc(self):
+        if self.vars.a == 3:
+            self.vars['b'] = str(self.vars.b) * 3
+            self.vars['c'] = str(self.vars.c) * 3
+
     def __run__(self):
-        if (0 if self.vars.a is None else self.vars.a) >= 100:
+        if self.vars.a >= 100:
             raise Exception("a >= 100")
         if self.vars.c == "abc change":
             self.vars['abc'] = "changed abc"
         if self.vars.get('a', 0) == 2:
             self.vars['b'] = str(self.vars.b) * 2
             self.vars['c'] = str(self.vars.c) * 2
+        self.process_a3_bc()
 
 
 def main():

--- a/tests/integration/targets/module_helper/tasks/msimple.yml
+++ b/tests/integration/targets/module_helper/tasks/msimple.yml
@@ -1,7 +1,7 @@
 # (c) 2021, Alexei Znamensky
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: test msimple 1
+- name: test msimple (set a=80)
   msimple:
     a: 80
   register: simple1
@@ -55,3 +55,30 @@
       - simple4.c == "abc change"
       - simple4.abc == "changed abc"
       - simple4 is changed
+
+- name: test msimple 5a
+  msimple:
+    a: 3   # should triple b and c
+    b: oh
+    c: my
+  register: simple5a
+
+- name: test msimple 5b
+  check_mode: true
+  msimple:
+    a: 3   # should triple b and c
+    b: oh
+    c: my
+  register: simple5b
+
+- name: assert simple5
+  assert:
+    that:
+      - simple5a.a == 3
+      - simple5a.b == "ohohoh"
+      - simple5a.c == "mymymy"
+      - simple5a is not changed
+      - simple5b.a == 3
+      - simple5b.b == "oh"
+      - simple5b.c == "my"
+      - simple5b is not changed


### PR DESCRIPTION
##### SUMMARY
Added decorators `check_mode_skip` and `check_mode_skip_returns` for skipping methods when `check_mode=True`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/deco.py
