### PR TITLE
interfaces_file - fixed dup options bug

### DIFF
--- a/changelogs/fragments/3862-interfaces-file-fix-dup-option.yaml
+++ b/changelogs/fragments/3862-interfaces-file-fix-dup-option.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - interfaces_file - fixed the check for existing option in interface (https://github.com/ansible-collections/community.general/issues/3841).

--- a/plugins/modules/system/interfaces_file.py
+++ b/plugins/modules/system/interfaces_file.py
@@ -253,7 +253,7 @@ def set_interface_option(module, lines, iface, option, raw_value, state, address
             last_line_dict = iface_lines[-1]
             return add_option_after_line(option, value, iface, lines, last_line_dict, iface_options, address_family)
 
-        if option in ["pre-up", "up", "down", "post-up"] and all(ito for ito in target_options if ito['value'] != value):
+        if option in ["pre-up", "up", "down", "post-up"] and all(ito['value'] != value for ito in target_options):
             return add_option_after_line(option, value, iface, lines, target_options[-1], iface_options, address_family)
 
         # if more than one option found edit the last one

--- a/tests/integration/targets/interfaces_file/files/interfaces_ff_3841
+++ b/tests/integration/targets/interfaces_file/files/interfaces_ff_3841
@@ -1,0 +1,7 @@
+iface eth0 inet static
+  address   1.2.3.4
+  netmask   255.255.255.0
+  gateway   1.2.3.1
+  up route add -net 1.2.3.4 netmask 255.255.255.0 gw 1.2.3.1 eth0
+  up ip addr add 4.3.2.1/32 dev eth0
+  down ip addr add 4.3.2.1/32 dev eth0

--- a/tests/integration/targets/interfaces_file/tasks/main.yml
+++ b/tests/integration/targets/interfaces_file/tasks/main.yml
@@ -2,6 +2,7 @@
 - name:
   set_fact:
     interfaces_testfile: '{{ remote_tmp_dir }}/interfaces'
+    interfaces_testfile_3841: '{{ remote_tmp_dir }}/interfaces_3841'
 
 - name: Copy interfaces file
   copy:
@@ -31,3 +32,32 @@
 - assert:
     that:
     - ifile_2 is not changed
+
+- name: 3841 - copy interfaces file
+  copy:
+    src: 'files/interfaces_ff_3841'
+    dest: '{{ interfaces_testfile_3841 }}'
+
+- name: 3841 - floating_ip_interface_up_ip 2a01:a:b:c::1/64 dev eth0
+  interfaces_file:
+    option: up
+    iface: eth0
+    dest: "{{ interfaces_testfile_3841 }}"
+    value: 'ip addr add 2a01:a:b:c::1/64 dev eth0'
+    state: present
+  register: ifile_3841_a
+
+- name: 3841 - floating_ip_interface_up_ip 2a01:a:b:c::1/64 dev eth0 (again)
+  interfaces_file:
+    option: up
+    iface: eth0
+    dest: "{{ interfaces_testfile_3841 }}"
+    value: 'ip addr add 2a01:a:b:c::1/64 dev eth0'
+    state: present
+  register: ifile_3841_b
+
+- name: 3841 - check assertions
+  assert:
+    that:
+      - ifile_3841_a is changed
+      - ifile_3841_b is not changed


### PR DESCRIPTION
##### SUMMARY
The code that checked whether the existing option already existed was flawed. Fixed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3841 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/system/interfaces_file.py
