### PR TITLE
Portage: remove gentoolkit requirement for portage's python module

### DIFF
--- a/changelogs/fragments/3870-portage-prefer-pymodule.yml
+++ b/changelogs/fragments/3870-portage-prefer-pymodule.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - portage - Make the module work on systems without the non-system package
+    gentoolkit. If possible, use the ansible interpreter's 'portage' module.
+    (https://github.com/ansible-collections/community.general/pull/3870)

--- a/plugins/modules/packaging/os/portage.py
+++ b/plugins/modules/packaging/os/portage.py
@@ -262,7 +262,9 @@ def query_set(module, set, action):
             module.fail_json(msg='set %s cannot be removed' % set)
         return False
 
-    world_sets_path = '/var/lib/portage/world_sets'
+    # When providing ROOT via ansible enviroment, portage.root may return a
+    # portage._LegacyGlobalProxy instance. Force it to be a string.
+    world_sets_path = os.path.join(str(portage.root), portage.const.WORLD_SETS_FILE)
     if not os.path.exists(world_sets_path):
         return False
 

--- a/plugins/modules/packaging/os/portage.py
+++ b/plugins/modules/packaging/os/portage.py
@@ -174,7 +174,7 @@ options:
     type: bool
     default: no
 
-requirements: [ gentoolkit ]
+requirements: [ portage ]
 author:
     - "William L Thomson Jr (@wltjr)"
     - "Yap Sok Ann (@sayap)"
@@ -231,6 +231,8 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
+import portage
+
 
 def query_package(module, package, action):
     if package.startswith('@'):
@@ -239,10 +241,8 @@ def query_package(module, package, action):
 
 
 def query_atom(module, atom, action):
-    cmd = '%s list %s' % (module.equery_path, atom)
-
-    rc, out, err = module.run_command(cmd)
-    return rc == 0
+    installed = portage.vartree().dbapi.match(atom)
+    return bool(installed)
 
 
 def query_set(module, set, action):
@@ -287,7 +287,7 @@ def sync_repositories(module, webrsync=False):
         module.fail_json(msg='could not sync package repositories')
 
 
-# Note: In the 3 functions below, equery is done one-by-one, but emerge is done
+# Note: In the 3 functions below, package query is done one-by-one, but emerge is done
 # in one go. If that is not desirable, split the packages into multiple tasks
 # instead of joining them together with comma.
 
@@ -506,7 +506,6 @@ def main():
     )
 
     module.emerge_path = module.get_bin_path('emerge', required=True)
-    module.equery_path = module.get_bin_path('equery', required=True)
 
     p = module.params
 


### PR DESCRIPTION
##### SUMMARY
The package `app-portage/gentoolkit` is not a requirement for a working Gentoo/portage installation (i.e. the package is not provided in any `system` set). This prevents those hosts from using an otherwise usable module, and forces administrators who wish to use it to install an extra package (by some other method).

Switch the portage ansible module to use the portage python module for checking if a package is installed. This allows ansible to work on more hosts without workarounds.

Since a working python installation is required for portage to work, this does not add an extra, optional dependency.


##### ISSUE TYPE
- Bug Fix Pull Request

##### COMPONENT NAME
portage

##### ADDITIONAL INFORMATION
Before this change:
```json
host | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3.9"
    },
    "changed": false,
    "msg": "Failed to find required executable \"equery\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin"
}
```

After this change:
```json
host | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3.9"
    },
    "changed": true,
    "cmd": [
        "/usr/bin/emerge",
        "--noreplace",
        "--update",
        "--ask=n",
        "--pretend",
        "gentoolkit"
    ],
    "msg": "Packages would be installed.",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "\nThese are the packages that would be merged, in order:\n\nCalculating dependencies  .... done!\n[binary  N     ] app-portage/gentoolkit-0.5.1-r1-1  USE=\"-test\" PYTHON_TARGETS=\"python3_9 (-pypy3) -python3_8 (-python3_10)\" \n",
    "stdout_lines": [
        "",
        "These are the packages that would be merged, in order:",
        "",
        "Calculating dependencies  .... done!",
        "[binary  N     ] app-portage/gentoolkit-0.5.1-r1-1  USE=\"-test\" PYTHON_TARGETS=\"python3_9 (-pypy3) -python3_8 (-python3_10)\" "
    ]
}
```