### PR TITLE
proxmox - fixing onboot parameter causing module failure when not defined

### DIFF
--- a/changelogs/fragments/3874-proxmox-fix-onboot-param.yml
+++ b/changelogs/fragments/3874-proxmox-fix-onboot-param.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox - fixed ``onboot`` parameter causing module failures when undefined
+    (https://github.com/ansible-collections/community.general/issues/3844).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -54,6 +54,17 @@ def proxmox_to_ansible_bool(value):
     return True if value == 1 else False
 
 
+def ansible_to_proxmox_bool(value):
+    '''Convert Ansible representation of a boolean to be proxmox-friendly'''
+    if value is None:
+        return None
+
+    if not isinstance(value, bool):
+        raise ValueError("%s must be of type bool not %s" % (value, type(value)))
+
+    return 1 if value else 0
+
+
 class ProxmoxAnsible(object):
     """Base class for Proxmox modules"""
     def __init__(self, module):

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -359,6 +359,10 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.common.text.converters import to_native
 
+from ansible_collections.community.general.plugins.module_utils.proxmox import (
+    ansible_to_proxmox_bool
+)
+
 
 VZ_TYPE = None
 
@@ -605,14 +609,14 @@ def main():
                             netif=module.params['netif'],
                             mounts=module.params['mounts'],
                             ip_address=module.params['ip_address'],
-                            onboot=int(module.params['onboot']),
+                            onboot=ansible_to_proxmox_bool(module.params['onboot']),
                             cpuunits=module.params['cpuunits'],
                             nameserver=module.params['nameserver'],
                             searchdomain=module.params['searchdomain'],
-                            force=int(module.params['force']),
+                            force=ansible_to_proxmox_bool(module.params['force']),
                             pubkey=module.params['pubkey'],
                             features=",".join(module.params['features']) if module.params['features'] is not None else None,
-                            unprivileged=int(module.params['unprivileged']),
+                            unprivileged=ansible_to_proxmox_bool(module.params['unprivileged']),
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])
 


### PR DESCRIPTION
##### SUMMARY
Preventing type casting `None` to `int` for all bool options in the Proxmox module (LXC).

Fixes #3844

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox.py

##### ADDITIONAL INFORMATION
- Implemented conversion function in module_utils for reuse in other Proxmox modules.
