### PR TITLE
Make pfexec become usable for illumos

### DIFF
--- a/changelogs/fragments/3671-illumos-pfexec.yml
+++ b/changelogs/fragments/3671-illumos-pfexec.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "become_pfexec - remove superflous quotes preventing exe wrap from working as expected, fixes #3671, see https://github.com/ansible-collections/community.general/issues/3671#issuecomment-1174906473"

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -102,4 +102,4 @@ class BecomeModule(BecomeBase):
 
         flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')
-        return '%s %s %s' % (exe, flags, self._build_success_command(cmd, shell, noexe = noexe))
+        return '%s %s %s' % (exe, flags, self._build_success_command(cmd, shell, noexe=noexe))

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -102,4 +102,4 @@ class BecomeModule(BecomeBase):
 
         flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')
-        return '%s %s %s' % (exe, flags, self._build_success_command(cmd, shell))
+        return '%s %s %s' % (exe, flags, self._build_success_command(cmd, shell, noexe = noexe))

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -100,6 +100,6 @@ class BecomeModule(BecomeBase):
 
         exe = self.get_option('become_exe')
 
-        flags = '' #self.get_option('become_flags')
+        flags = self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')
-        return '%s %s /usr/bin/sh -c %s' % (exe, flags, self._build_success_command(cmd, shell, noexe=noexe))
+        return '%s %s %s' % (exe, flags, self._build_success_command(cmd, shell))

--- a/plugins/become/pfexec.py
+++ b/plugins/become/pfexec.py
@@ -100,6 +100,6 @@ class BecomeModule(BecomeBase):
 
         exe = self.get_option('become_exe')
 
-        flags = self.get_option('become_flags')
+        flags = '' #self.get_option('become_flags')
         noexe = not self.get_option('wrap_exe')
-        return '%s %s "%s"' % (exe, flags, self._build_success_command(cmd, shell, noexe=noexe))
+        return '%s %s /usr/bin/sh -c %s' % (exe, flags, self._build_success_command(cmd, shell, noexe=noexe))

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -32,7 +32,7 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s echo %s; %s''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec(mocker, parser, reset_cli_args):
@@ -54,7 +54,7 @@ def test_pfexec(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s 'echo %s; %s' ''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec_varoptions(mocker, parser, reset_cli_args):
@@ -79,4 +79,4 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s 'echo %s; %s' ''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -32,7 +32,7 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s echo %s; %s''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match("""%s %s 'echo %s; %s'""" % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec(mocker, parser, reset_cli_args):
@@ -54,7 +54,7 @@ def test_pfexec(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s 'echo %s; %s' ''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match("""%s %s 'echo %s; %s'""" % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec_varoptions(mocker, parser, reset_cli_args):
@@ -79,4 +79,4 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s 'echo %s; %s' ''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match("""%s %s 'echo %s; %s'""" % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None

--- a/tests/unit/plugins/become/test_pfexec.py
+++ b/tests/unit/plugins/become/test_pfexec.py
@@ -32,7 +32,7 @@ def test_pfexec_basic(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec(mocker, parser, reset_cli_args):
@@ -54,7 +54,7 @@ def test_pfexec(mocker, parser, reset_cli_args):
     var_options = {}
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
 
 
 def test_pfexec_varoptions(mocker, parser, reset_cli_args):
@@ -79,4 +79,4 @@ def test_pfexec_varoptions(mocker, parser, reset_cli_args):
     }
     cmd = call_become_plugin(task, var_options, cmd=default_cmd, executable=default_exe)
     print(cmd)
-    assert re.match('''%s %s "'echo %s; %s'"''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None
+    assert re.match('''%s %s 'echo %s; %s'''' % (pfexec_exe, pfexec_flags, success, default_cmd), cmd) is not None


### PR DESCRIPTION
##### SUMMARY
Pfexec become does not work for illumos
fixes #3671

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/become/pfexec.py

##### ADDITIONAL INFORMATION
Changed quoting and command composition in analogy to standard su become

