### PR TITLE
Pass missing vlan-related options (flags, ingress, egress) to nmcli

### DIFF
--- a/changelogs/fragments/3896-nmcli_vlan_missing_options.yaml
+++ b/changelogs/fragments/3896-nmcli_vlan_missing_options.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - nmcli - pass ``flags``, ``ingress``, ``egress`` params to ``nmcli`` (https://github.com/ansible-collections/community.general/issues/1086).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1373,6 +1373,9 @@ class Nmcli(object):
             options.update({
                 'vlan.id': self.vlanid,
                 'vlan.parent': self.vlandev,
+                'vlan.flags' : self.flags,
+                'vlan.ingress' : self.ingress,
+                'vlan.egress' : self.egress
             })
         elif self.type == 'vxlan':
             options.update({

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1375,7 +1375,7 @@ class Nmcli(object):
                 'vlan.parent': self.vlandev,
                 'vlan.flags' : self.flags,
                 'vlan.ingress' : self.ingress,
-                'vlan.egress' : self.egress
+                'vlan.egress' : self.egress,
             })
         elif self.type == 'vxlan':
             options.update({

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1373,9 +1373,9 @@ class Nmcli(object):
             options.update({
                 'vlan.id': self.vlanid,
                 'vlan.parent': self.vlandev,
-                'vlan.flags' : self.flags,
-                'vlan.ingress' : self.ingress,
-                'vlan.egress' : self.egress,
+                'vlan.flags': self.flags,
+                'vlan.ingress': self.ingress,
+                'vlan.egress': self.egress,
             })
         elif self.type == 'vxlan':
             options.update({


### PR DESCRIPTION
Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>

##### SUMMARY
When calling the `nmcli` module, forward the missing options:

- flags
- ingress
- egress

to the corresponding `nmcli` command line options instead of silently ignoring them.

Fixes #1086

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/net_tools/nmcli.py`

##### ADDITIONAL INFORMATION

When calling:

```ansible
- name: Create VLAN network interface 200
  community.general.nmcli:
     conn_name: "enpXXsYYf0.200"
     ifname: "enpXXsYYf0.200"
     type: "vlan"
     vlandev: "enpXXsYYf0"
     vlanid: "200"
     flags: "1"
     ingress: "0:5"
     egress: "0:5"
```

verify that the output of `nmcli conn show enpXXsYYf0.200` shows the expected values for:

```none
vlan.parent:                  enpXXsYYf0
vlan.id:                      200
vlan.flags:                   1 (REORDER_HEADERS)
vlan.ingress-priority-map:    0:5
vlan.egress-priority-map:     0:5
```
