### PR TITLE
[WIP] Add --apply-live option for rpm-ostree module

### DIFF
--- a/plugins/modules/packaging/os/rpm_ostree_pkg.py
+++ b/plugins/modules/packaging/os/rpm_ostree_pkg.py
@@ -185,6 +185,7 @@ def main():
             apply_live=dict(
                 required=False,
                 type='bool',
+                default=False,
             )
         ),
     )

--- a/plugins/modules/packaging/os/rpm_ostree_pkg.py
+++ b/plugins/modules/packaging/os/rpm_ostree_pkg.py
@@ -142,7 +142,7 @@ class RpmOstreePkg:
             results['packages'].append(pkg)
             
         # Append apply-live
-        if self.apply_live and self.state not in ('absent'):
+        if self.apply_live and self.state not in ('absent', ):
             cmd.append('--apply-live')
 
         rc, out, err = self.module.run_command(cmd)

--- a/plugins/modules/packaging/os/rpm_ostree_pkg.py
+++ b/plugins/modules/packaging/os/rpm_ostree_pkg.py
@@ -36,8 +36,7 @@ options:
       description:
       - Stage packages and overlay them on the running system tree.
       - Corresponds to the C(--apply-live) option. Default behavior C(no). If set to C(yes), overlays the requested package(s) to the live system.
-      required: false
-      default: "no"
+      default: false
       type: bool
 author:
 - Dusty Mabe (@dustymabe)

--- a/plugins/modules/packaging/os/rpm_ostree_pkg.py
+++ b/plugins/modules/packaging/os/rpm_ostree_pkg.py
@@ -38,6 +38,7 @@ options:
       - Corresponds to the C(--apply-live) option. Default behavior C(no). If set to C(yes), overlays the requested package(s) to the live system.
       default: false
       type: bool
+      version_added: '4.2.0'
 author:
 - Dusty Mabe (@dustymabe)
 - Abhijeet Kasurde (@Akasurde)

--- a/plugins/modules/packaging/os/rpm_ostree_pkg.py
+++ b/plugins/modules/packaging/os/rpm_ostree_pkg.py
@@ -35,7 +35,7 @@ options:
     apply_live:
       description:
       - Stage packages and overlay them on the running system tree.
-      - Corresponds to the C(--apply-live) option. Default behavior (C(no)); C(yes) overlays the requested package(s) to the live system.
+      - Corresponds to the C(--apply-live) option. Default behavior C(no). If set to C(yes), overlays the requested package(s) to the live system.
       required: false
       default: "no"
       type: bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds feature requested in #3670

Appends the `--apply-live` option to `rpm-ostree install` operations when the module option `apply_live` is set to a true value. This only applies to install operations as the option is not available to uninstall operations.

This does introduce a complexity in the case where files need to be overwritten as there is no option to allow overwrites when the action is performed in this manner, this could potentially have an additional command segment to include the option in an `rpm-ostree ex apply-live --allow-replacement` operation as a catch for the error the module throws.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

rpm_ostree_pkg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Testing playbook:

```yaml
- name: "Test roles and tasklists against testing nodes"
  hosts: rpi-edge-fw
  become: true
  tasks:
    - name: Install dhtest
      community.general.rpm_ostree_pkg:
        name: dhtest
        state: present
        apply_live: true
```

Play output:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [Test roles and tasklists against testing nodes] **************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************
Wednesday 15 December 2021  16:47:20 -0500 (0:00:00.030)       0:00:00.030 **** 
ok: [rpi-edge-fw]

TASK [Install dhtest] **********************************************************************************************************************************************************
Wednesday 15 December 2021  16:47:22 -0500 (0:00:02.151)       0:00:02.181 **** 
changed: [rpi-edge-fw]

PLAY RECAP *********************************************************************************************************************************************************************
rpi-edge-fw: ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

Wednesday 15 December 2021  16:47:46 -0500 (0:00:24.403)       0:00:26.585 **** 
=============================================================================== 
Install dhtest --------------------------------------------------------------------------------------------------------------------------------------------------------- 24.40s
Gathering Facts --------------------------------------------------------------------------------------------------------------------------------------------------------- 2.15s
```

Output of `rpm-ostree status` on testing VM.

```none
  fedora:fedora/x86_64/coreos/stable
                   Version: 35.20211029.3.0 (2021-11-17T23:45:08Z)
                BaseCommit: ccdac241ed4b83b55e4d72e864923679c00a15804fbea7d1e638e67c2a08dd5c
                    Commit: 94b6e05a44fddc1881cf414725ea191fd152bf251b2f167385dd171bbe00ffd4
              GPGSignature: Valid signature by 787EA6AE1147EEE56C40B30CDB4639719867C58F
                      Diff: 1 added
           LayeredPackages: python3 dhtest

● fedora:fedora/x86_64/coreos/stable
                   Version: 35.20211029.3.0 (2021-11-17T23:45:08Z)
          BootedBaseCommit: ccdac241ed4b83b55e4d72e864923679c00a15804fbea7d1e638e67c2a08dd5c
                    Commit: d08463be49815a7f55a666041d67f235f6ccaac028eeb333d0d60723c9b0f22d
                LiveCommit: 94b6e05a44fddc1881cf414725ea191fd152bf251b2f167385dd171bbe00ffd4
                  LiveDiff: 1 added
              GPGSignature: Valid signature by 787EA6AE1147EEE56C40B30CDB4639719867C58F
           LayeredPackages: python3
                  Unlocked: transient

  fedora:fedora/x86_64/coreos/stable
                   Version: 35.20211029.3.0 (2021-11-17T23:45:08Z)
                BaseCommit: ccdac241ed4b83b55e4d72e864923679c00a15804fbea7d1e638e67c2a08dd5c
                    Commit: ab209b14809d98e7f7cfb432c0852ffd1de8cc395766cf1fd025c0a152862005
              GPGSignature: Valid signature by 787EA6AE1147EEE56C40B30CDB4639719867C58F
           LayeredPackages: python3
```

Output of `which dhtest` on testing VM: `/usr/bin/dhtest`
