### PR TITLE
Fix nrdp string arguments without an encoding

### DIFF
--- a/changelogs/fragments/3909-nrdp_fix_string_args_without_encoding.yaml
+++ b/changelogs/fragments/3909-nrdp_fix_string_args_without_encoding.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-    - nrdp - fix nrdp callback error ``string arguments without an encoding`` (https://github.com/ansible-collections/community.general/issues/3903).
+    - nrdp callback plugin - fix error ``string arguments without an encoding`` (https://github.com/ansible-collections/community.general/issues/3903).

--- a/changelogs/fragments/3909-nrdp_fix_string_args_without_encoding.yaml
+++ b/changelogs/fragments/3909-nrdp_fix_string_args_without_encoding.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - nrdp - fix nrdp callback error ``string arguments without an encoding`` (https://github.com/ansible-collections/community.general/issues/3903).

--- a/plugins/callback/nrdp.py
+++ b/plugins/callback/nrdp.py
@@ -70,6 +70,7 @@ import os
 import json
 
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.urls import open_url
 from ansible.plugins.callback import CallbackBase
 
@@ -143,7 +144,7 @@ class CallbackModule(CallbackBase):
         body = {
             'cmd': 'submitcheck',
             'token': self.token,
-            'XMLDATA': bytes(xmldata)
+            'XMLDATA': to_bytes(xmldata)
         }
 
         try:


### PR DESCRIPTION
##### SUMMARY
Fixes #3903 nrdp string arguments without an encoding

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nrdp callback

##### ADDITIONAL INFORMATION
Uses to_bytes from ansible.module_utils.common.text.converters to convert string to bytes.