### PR TITLE
Add additional auth support to Gitlab (#705)

### DIFF
--- a/changelogs/fragments/705-gitlab-auth-support.yml
+++ b/changelogs/fragments/705-gitlab-auth-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab - add authentication support using oauth_token and job_token (https://github.com/ansible-collections/community.general/issues/705).
+  - gitlab - add more token authentication support with the new options ``api_oauth_token`` and ``api_job_token`` (https://github.com/ansible-collections/community.general/issues/705).

--- a/changelogs/fragments/705-gitlab-auth-support.yml
+++ b/changelogs/fragments/705-gitlab-auth-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab - add authentication support using oauth_token and job_token (https://github.com/ansible-collections/community.general/issues/705).

--- a/plugins/doc_fragments/gitlab.py
+++ b/plugins/doc_fragments/gitlab.py
@@ -11,12 +11,12 @@ class ModuleDocFragment(object):
     # Standard files documentation fragment
     DOCUMENTATION = r'''
 requirements:
-  - requests (python library https://github.com/psf/requests)
+  - requests (Python library U(https://pypi.org/project/requests/))
 
 options:
   api_token:
     description:
-      - GitLab token for logging in.
+      - GitLab access token with API permissions.
     type: str
   api_oauth_token:
     description:

--- a/plugins/doc_fragments/gitlab.py
+++ b/plugins/doc_fragments/gitlab.py
@@ -10,6 +10,9 @@ class ModuleDocFragment(object):
 
     # Standard files documentation fragment
     DOCUMENTATION = r'''
+requirements:
+  - requests (python library https://github.com/psf/requests)
+
 options:
   api_token:
     description:
@@ -19,8 +22,10 @@ options:
     description:
       - GitLab OAuth token for logging in.
     type: str
+    version_added: 4.2.0
   api_job_token:
     description:
       - GitLab CI job token for logging in.
     type: str
+    version_added: 4.2.0
 '''

--- a/plugins/doc_fragments/gitlab.py
+++ b/plugins/doc_fragments/gitlab.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = r'''
+options:
+  api_token:
+    description:
+      - GitLab token for logging in.
+    type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
+'''

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -30,6 +30,17 @@ except Exception:
     HAS_GITLAB_PACKAGE = False
 
 
+def auth_argument_spec(spec=None):
+    arg_spec = (dict(
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
+    ))
+    if spec:
+        arg_spec.update(spec)
+    return arg_spec
+
+
 def find_project(gitlab_instance, identifier):
     try:
         project = gitlab_instance.projects.get(identifier)

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -7,23 +7,23 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 from distutils.version import StrictVersion
 
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.common.text.converters import to_native
 
 try:
     from urllib import quote_plus  # Python 2.X
+    from urlparse import urljoin
 except ImportError:
-    from urllib.parse import quote_plus  # Python 3+
+    from urllib.parse import quote_plus, urljoin  # Python 3+
 
 import traceback
 
 GITLAB_IMP_ERR = None
 try:
     import gitlab
+    import requests
     HAS_GITLAB_PACKAGE = True
 except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
@@ -58,6 +58,8 @@ def gitlab_authentication(module):
     gitlab_user = module.params['api_username']
     gitlab_password = module.params['api_password']
     gitlab_token = module.params['api_token']
+    gitlab_oauth_token = module.params['api_oauth_token']
+    gitlab_job_token = module.params['api_job_token']
 
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
@@ -70,7 +72,16 @@ def gitlab_authentication(module):
             gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, email=gitlab_user, password=gitlab_password,
                                             private_token=gitlab_token, api_version=4)
         else:
-            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, private_token=gitlab_token, api_version=4)
+            # We can create an oauth_token using a username and password
+            # https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-flow
+            if gitlab_user:
+                data = {'grant_type': 'password', 'username': gitlab_user, 'password': gitlab_password}
+                resp = requests.post(urljoin(gitlab_url, "oauth/token"), data=data)
+                resp_data = resp.json()
+                gitlab_oauth_token = resp_data["access_token"]
+
+            gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=validate_certs, private_token=gitlab_token,
+                                            oauth_token=gitlab_oauth_token, job_token=gitlab_job_token, api_version=4)
 
         gitlab_instance.auth()
     except (gitlab.exceptions.GitlabAuthenticationError, gitlab.exceptions.GitlabGetError) as e:

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -87,7 +87,7 @@ def gitlab_authentication(module):
             # https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-flow
             if gitlab_user:
                 data = {'grant_type': 'password', 'username': gitlab_user, 'password': gitlab_password}
-                resp = requests.post(urljoin(gitlab_url, "oauth/token"), data=data)
+                resp = requests.post(urljoin(gitlab_url, "oauth/token"), data=data, verify=validate_certs)
                 resp_data = resp.json()
                 gitlab_oauth_token = resp_data["access_token"]
 

--- a/plugins/modules/source_control/gitlab/gitlab_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_branch.py
@@ -30,7 +30,14 @@ options:
   api_token:
     description:
       - GitLab access token with API permissions.
-    required: true
+    type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
     type: str
   project:
     description:
@@ -120,7 +127,9 @@ class GitlabBranch(object):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         branch=dict(type='str', required=True),
         ref_branch=dict(type='str', required=False),
@@ -132,12 +141,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         required_if=[
             ['state', 'present', ['ref_branch'], True],

--- a/plugins/modules/source_control/gitlab/gitlab_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_branch.py
@@ -17,7 +17,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 2.3.0
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_branch.py
@@ -17,8 +17,10 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 2.3.0
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
   state:
@@ -27,18 +29,6 @@ options:
     default: present
     type: str
     choices: ["present", "absent"]
-  api_token:
-    description:
-      - GitLab access token with API permissions.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - The path or name of the project.
@@ -94,7 +84,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 
 class GitlabBranch(object):
@@ -126,10 +116,8 @@ class GitlabBranch(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         branch=dict(type='str', required=True),
         ref_branch=dict(type='str', required=False),
@@ -140,11 +128,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -14,29 +14,19 @@ DOCUMENTATION = '''
 module: gitlab_deploy_key
 short_description: Manages GitLab project deploy keys.
 description:
-     - Adds, updates and removes project deploy keys
+  - Adds, updates and removes project deploy keys
 author:
   - Marcus Watkins (@marwatk)
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - Id or Full path of project in the form of group/name.
@@ -134,7 +124,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import find_project, gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, find_project, gitlab_authentication
 
 
 class GitLabDeployKey(object):
@@ -246,10 +236,8 @@ class GitLabDeployKey(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         key=dict(type='str', required=True, no_log=False),
@@ -261,11 +249,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -21,7 +21,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/plugins/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -29,6 +29,14 @@ options:
     description:
       - GitLab token for logging in.
     type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
   project:
     description:
       - Id or Full path of project in the form of group/name.
@@ -240,6 +248,8 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         key=dict(type='str', required=True, no_log=False),
@@ -251,13 +261,19 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token']
+            ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password']
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -21,22 +21,12 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   name:
     description:
       - Name of the group you want to create.
@@ -183,7 +173,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, find_group, gitlab_authentication
 
 
 class GitLabGroup(object):
@@ -317,10 +307,8 @@ class GitLabGroup(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         name=dict(type='str', required=True),
         path=dict(type='str'),
         description=dict(type='str'),
@@ -338,11 +326,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -21,7 +21,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -29,6 +29,14 @@ options:
     description:
       - GitLab token for logging in.
     type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
   name:
     description:
       - Name of the group you want to create.
@@ -311,6 +319,8 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         name=dict(type='str', required=True),
         path=dict(type='str'),
         description=dict(type='str'),
@@ -329,12 +339,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -17,7 +17,6 @@ version_added: '1.2.0'
 author: Zainab Alsaffar (@zanssa)
 requirements:
   - python-gitlab python module <= 1.15.0
-  - requests (python library https://github.com/psf/requests)
   - administrator rights on the GitLab server
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -23,7 +23,14 @@ options:
     api_token:
         description:
             - A personal access token to authenticate with the GitLab API.
-        required: true
+        type: str
+    api_oauth_token:
+        description:
+            - GitLab OAuth token for logging in.
+        type: str
+    api_job_token:
+        description:
+            - GitLab CI job token for logging in.
         type: str
     gitlab_group:
         description:
@@ -242,7 +249,9 @@ class GitLabGroup(object):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         gitlab_group=dict(type='str', required=True),
         gitlab_user=dict(type='list', elements='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
@@ -265,13 +274,19 @@ def main():
             ['api_password', 'api_token'],
             ['gitlab_user', 'gitlab_users_access'],
             ['access_level', 'gitlab_users_access'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
             ['gitlab_user', 'access_level'],
         ],
         required_one_of=[
-            ['api_username', 'api_token'],
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token'],
             ['gitlab_user', 'gitlab_users_access'],
         ],
         required_if=[

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -12,85 +12,77 @@ DOCUMENTATION = r'''
 module: gitlab_group_members
 short_description: Manage group members on GitLab Server
 description:
-    - This module allows to add and remove members to/from a group, or change a member's access level in a group on GitLab.
+  - This module allows to add and remove members to/from a group, or change a member's access level in a group on GitLab.
 version_added: '1.2.0'
 author: Zainab Alsaffar (@zanssa)
 requirements:
-    - python-gitlab python module <= 1.15.0
-    - administrator rights on the GitLab server
-extends_documentation_fragment: community.general.auth_basic
+  - python-gitlab python module <= 1.15.0
+  - requests (python library https://github.com/psf/requests)
+  - administrator rights on the GitLab server
+extends_documentation_fragment:
+  - community.general.auth_basic
+  - community.general.gitlab
+
 options:
-    api_token:
-        description:
-            - A personal access token to authenticate with the GitLab API.
+  gitlab_group:
+    description:
+      - The C(full_path) of the GitLab group the member is added to/removed from.
+      - Setting this to C(name) or C(path) is deprecated and will be removed in community.general 6.0.0. Use C(full_path) instead.
+    required: true
+    type: str
+  gitlab_user:
+    description:
+      - A username or a list of usernames to add to/remove from the GitLab group.
+      - Mutually exclusive with I(gitlab_users_access).
+    type: list
+    elements: str
+  access_level:
+    description:
+      - The access level for the user.
+      - Required if I(state=present), user state is set to present.
+      - Mutually exclusive with I(gitlab_users_access).
+    type: str
+    choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
+  gitlab_users_access:
+    description:
+      - Provide a list of user to access level mappings.
+      - Every dictionary in this list specifies a user (by username) and the access level the user should have.
+      - Mutually exclusive with I(gitlab_user) and I(access_level).
+      - Use together with I(purge_users) to remove all users not specified here from the group.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description: A username or a list of usernames to add to/remove from the GitLab group.
         type: str
-    api_oauth_token:
-        description:
-            - GitLab OAuth token for logging in.
-        type: str
-    api_job_token:
-        description:
-            - GitLab CI job token for logging in.
-        type: str
-    gitlab_group:
-        description:
-            - The C(full_path) of the GitLab group the member is added to/removed from.
-            - Setting this to C(name) or C(path) is deprecated and will be removed in community.general 6.0.0. Use C(full_path) instead.
         required: true
-        type: str
-    gitlab_user:
+      access_level:
         description:
-            - A username or a list of usernames to add to/remove from the GitLab group.
-            - Mutually exclusive with I(gitlab_users_access).
-        type: list
-        elements: str
-    access_level:
-        description:
-            - The access level for the user.
-            - Required if I(state=present), user state is set to present.
-            - Mutually exclusive with I(gitlab_users_access).
+          - The access level for the user.
+          - Required if I(state=present), user state is set to present.
         type: str
         choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
-    gitlab_users_access:
-        description:
-            - Provide a list of user to access level mappings.
-            - Every dictionary in this list specifies a user (by username) and the access level the user should have.
-            - Mutually exclusive with I(gitlab_user) and I(access_level).
-            - Use together with I(purge_users) to remove all users not specified here from the group.
-        type: list
-        elements: dict
-        suboptions:
-            name:
-                description: A username or a list of usernames to add to/remove from the GitLab group.
-                type: str
-                required: true
-            access_level:
-                description:
-                    - The access level for the user.
-                    - Required if I(state=present), user state is set to present.
-                type: str
-                choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
-                required: true
-        version_added: 3.6.0
-    state:
-        description:
-            - State of the member in the group.
-            - On C(present), it adds a user to a GitLab group.
-            - On C(absent), it removes a user from a GitLab group.
-        choices: ['present', 'absent']
-        default: 'present'
-        type: str
-    purge_users:
-        description:
-            - Adds/remove users of the given access_level to match the given I(gitlab_user)/I(gitlab_users_access) list.
-              If omitted do not purge orphaned members.
-            - Is only used when I(state=present).
-        type: list
-        elements: str
-        choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
-        version_added: 3.6.0
+        required: true
+    version_added: 3.6.0
+  state:
+    description:
+      - State of the member in the group.
+      - On C(present), it adds a user to a GitLab group.
+      - On C(absent), it removes a user from a GitLab group.
+    choices: ['present', 'absent']
+    default: 'present'
+    type: str
+  purge_users:
+    description:
+      - Adds/remove users of the given access_level to match the given I(gitlab_user)/I(gitlab_users_access) list.
+        If omitted do not purge orphaned members.
+      - Is only used when I(state=present).
+    type: list
+    elements: str
+    choices: ['guest', 'reporter', 'developer', 'maintainer', 'owner']
+    version_added: 3.6.0
 notes:
-    - Supports C(check_mode).
+  - Supports C(check_mode).
 '''
 
 EXAMPLES = r'''
@@ -162,7 +154,7 @@ RETURN = r''' # '''
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 import traceback
 
@@ -248,10 +240,8 @@ class GitLabGroup(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         gitlab_group=dict(type='str', required=True),
         gitlab_user=dict(type='list', elements='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
@@ -271,13 +261,10 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['gitlab_user', 'gitlab_users_access'],
             ['access_level', 'gitlab_users_access'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -22,7 +22,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -35,7 +35,14 @@ options:
   api_token:
     description:
       - GitLab access token with API permissions.
-    required: true
+    type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
     type: str
   group:
     description:
@@ -269,7 +276,9 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         group=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
@@ -281,12 +290,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True
     )

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -22,8 +22,10 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
+  - community.general.gitlab
 
 options:
   state:
@@ -32,18 +34,6 @@ options:
     default: present
     type: str
     choices: ["present", "absent"]
-  api_token:
-    description:
-      - GitLab access token with API permissions.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   group:
     description:
       - The path and name of the group.
@@ -151,7 +141,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 
 class GitlabGroupVariables(object):
@@ -275,10 +265,8 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         group=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
@@ -289,11 +277,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -30,6 +30,14 @@ options:
     description:
       - GitLab token for logging in.
     type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
   project:
     description:
       - Id or Full path of the project in the form of group/name.
@@ -299,6 +307,8 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         hook_url=dict(type='str', required=True),
@@ -319,13 +329,19 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token']
+            ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password']
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -22,7 +22,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -15,29 +15,19 @@ DOCUMENTATION = '''
 module: gitlab_hook
 short_description: Manages GitLab project hooks.
 description:
-     - Adds, updates and removes project hook
+  - Adds, updates and removes project hook
 author:
   - Marcus Watkins (@marwatk)
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - Id or Full path of the project in the form of group/name.
@@ -184,7 +174,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import find_project, gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, find_project, gitlab_authentication
 
 
 class GitLabHook(object):
@@ -305,10 +295,8 @@ class GitLabHook(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"]),
         project=dict(type='str', required=True),
         hook_url=dict(type='str', required=True),
@@ -329,11 +317,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -22,22 +22,12 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   group:
     description:
       - Id or the full path of the group of which this projects belongs to.
@@ -270,7 +260,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, find_project, gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, find_group, find_project, gitlab_authentication
 
 
 class GitLabProject(object):
@@ -407,10 +397,8 @@ class GitLabProject(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         group=dict(type='str'),
         name=dict(type='str', required=True),
         path=dict(type='str'),
@@ -442,11 +430,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
             ['group', 'username'],

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -22,7 +22,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab
@@ -310,11 +309,10 @@ class GitLabProject(object):
             project = self.create_project(namespace, project_options)
 
             # add avatar to project
-            if options['avatar_path']:
-                try:
-                    project.avatar = open(options['avatar_path'], 'rb')
-                except IOError as e:
-                    self._module.fail_json(msg='Cannot open {0}: {1}'.format(options['avatar_path'], e))
+            try:
+                project.avatar = open(options['avatar_path'], 'rb')
+            except IOError as e:
+                self._module.fail_json(msg='Cannot open {0}: {1}'.format(options['avatar_path'], e))
 
             changed = True
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -25,7 +25,14 @@ options:
     api_token:
         description:
             - A personal access token to authenticate with the GitLab API.
-        required: true
+        type: str
+    api_oauth_token:
+        description:
+            - GitLab OAuth token for logging in.
+        type: str
+    api_job_token:
+        description:
+            - GitLab CI job token for logging in.
         type: str
     validate_certs:
         description:
@@ -258,7 +265,9 @@ class GitLabProjectMembers(object):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         gitlab_user=dict(type='list', elements='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
@@ -281,6 +290,12 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
             ['gitlab_user', 'gitlab_users_access'],
             ['access_level', 'gitlab_users_access'],
         ],
@@ -289,7 +304,7 @@ def main():
             ['gitlab_user', 'access_level'],
         ],
         required_one_of=[
-            ['api_username', 'api_token'],
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token'],
             ['gitlab_user', 'gitlab_users_access'],
         ],
         required_if=[

--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -20,7 +20,6 @@ author:
   - Zainab Alsaffar (@zanssa)
 requirements:
   - python-gitlab python module <= 1.15.0
-  - requests (python library https://github.com/psf/requests)
   - owner or maintainer rights to project on the GitLab server
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -14,102 +14,76 @@ module: gitlab_project_members
 short_description: Manage project members on GitLab Server
 version_added: 2.2.0
 description:
-    - This module allows to add and remove members to/from a project, or change a member's access level in a project on GitLab.
+  - This module allows to add and remove members to/from a project, or change a member's access level in a project on GitLab.
 author:
-    - Sergey Mikhaltsov (@metanovii)
-    - Zainab Alsaffar (@zanssa)
+  - Sergey Mikhaltsov (@metanovii)
+  - Zainab Alsaffar (@zanssa)
 requirements:
-    - python-gitlab python module <= 1.15.0
-    - owner or maintainer rights to project on the GitLab server
+  - python-gitlab python module <= 1.15.0
+  - requests (python library https://github.com/psf/requests)
+  - owner or maintainer rights to project on the GitLab server
+extends_documentation_fragment:
+  - community.general.auth_basic
+  - community.general.gitlab
+
 options:
-    api_token:
-        description:
-            - A personal access token to authenticate with the GitLab API.
+  project:
+    description:
+      - The name (or full path) of the GitLab project the member is added to/removed from.
+    required: true
+    type: str
+  gitlab_user:
+    description:
+      - A username or a list of usernames to add to/remove from the GitLab project.
+      - Mutually exclusive with I(gitlab_users_access).
+    type: list
+    elements: str
+  access_level:
+    description:
+      - The access level for the user.
+      - Required if I(state=present), user state is set to present.
+    type: str
+    choices: ['guest', 'reporter', 'developer', 'maintainer']
+  gitlab_users_access:
+    description:
+      - Provide a list of user to access level mappings.
+      - Every dictionary in this list specifies a user (by username) and the access level the user should have.
+      - Mutually exclusive with I(gitlab_user) and I(access_level).
+      - Use together with I(purge_users) to remove all users not specified here from the project.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description: A username or a list of usernames to add to/remove from the GitLab project.
         type: str
-    api_oauth_token:
-        description:
-            - GitLab OAuth token for logging in.
-        type: str
-    api_job_token:
-        description:
-            - GitLab CI job token for logging in.
-        type: str
-    validate_certs:
-        description:
-            - Whether or not to validate TLS/SSL certificates when supplying a HTTPS endpoint.
-            - Should only be set to C(false) if you can guarantee that you are talking to the correct server
-              and no man-in-the-middle attack can happen.
-        default: true
-        type: bool
-    api_username:
-        description:
-            - The username to use for authentication against the API.
-        type: str
-    api_password:
-        description:
-            - The password to use for authentication against the API.
-        type: str
-    api_url:
-        description:
-            - The resolvable endpoint for the API.
-        type: str
-    project:
-        description:
-            - The name (or full path) of the GitLab project the member is added to/removed from.
         required: true
-        type: str
-    gitlab_user:
+      access_level:
         description:
-            - A username or a list of usernames to add to/remove from the GitLab project.
-            - Mutually exclusive with I(gitlab_users_access).
-        type: list
-        elements: str
-    access_level:
-        description:
-            - The access level for the user.
-            - Required if I(state=present), user state is set to present.
+          - The access level for the user.
+          - Required if I(state=present), user state is set to present.
         type: str
         choices: ['guest', 'reporter', 'developer', 'maintainer']
-    gitlab_users_access:
-        description:
-            - Provide a list of user to access level mappings.
-            - Every dictionary in this list specifies a user (by username) and the access level the user should have.
-            - Mutually exclusive with I(gitlab_user) and I(access_level).
-            - Use together with I(purge_users) to remove all users not specified here from the project.
-        type: list
-        elements: dict
-        suboptions:
-            name:
-                description: A username or a list of usernames to add to/remove from the GitLab project.
-                type: str
-                required: true
-            access_level:
-                description:
-                    - The access level for the user.
-                    - Required if I(state=present), user state is set to present.
-                type: str
-                choices: ['guest', 'reporter', 'developer', 'maintainer']
-                required: true
-        version_added: 3.7.0
-    state:
-        description:
-            - State of the member in the project.
-            - On C(present), it adds a user to a GitLab project.
-            - On C(absent), it removes a user from a GitLab project.
-        choices: ['present', 'absent']
-        default: 'present'
-        type: str
-    purge_users:
-        description:
-            - Adds/remove users of the given access_level to match the given I(gitlab_user)/I(gitlab_users_access) list.
-              If omitted do not purge orphaned members.
-            - Is only used when I(state=present).
-        type: list
-        elements: str
-        choices: ['guest', 'reporter', 'developer', 'maintainer']
-        version_added: 3.7.0
+        required: true
+    version_added: 3.7.0
+  state:
+    description:
+      - State of the member in the project.
+      - On C(present), it adds a user to a GitLab project.
+      - On C(absent), it removes a user from a GitLab project.
+    choices: ['present', 'absent']
+    default: 'present'
+    type: str
+  purge_users:
+    description:
+      - Adds/remove users of the given access_level to match the given I(gitlab_user)/I(gitlab_users_access) list.
+        If omitted do not purge orphaned members.
+      - Is only used when I(state=present).
+    type: list
+    elements: str
+    choices: ['guest', 'reporter', 'developer', 'maintainer']
+    version_added: 3.7.0
 notes:
-    - Supports C(check_mode).
+  - Supports C(check_mode).
 '''
 
 EXAMPLES = r'''
@@ -183,7 +157,7 @@ RETURN = r''' # '''
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 import traceback
 
@@ -264,10 +238,8 @@ class GitLabProjectMembers(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         gitlab_user=dict(type='list', elements='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
@@ -289,11 +261,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
             ['gitlab_user', 'gitlab_users_access'],

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -19,7 +19,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -19,8 +19,10 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
   state:
@@ -30,18 +32,6 @@ options:
     default: present
     type: str
     choices: ["present", "absent"]
-  api_token:
-    description:
-      - GitLab access token with API permissions.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - The path and name of the project.
@@ -150,7 +140,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 
 class GitlabProjectVariables(object):
@@ -277,10 +267,8 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
@@ -291,11 +279,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -33,7 +33,14 @@ options:
   api_token:
     description:
       - GitLab access token with API permissions.
-    required: true
+    type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
     type: str
   project:
     description:
@@ -271,7 +278,9 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
@@ -283,12 +292,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True
     )

--- a/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
@@ -17,8 +17,10 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 2.3.0
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
   state:
@@ -27,18 +29,6 @@ options:
     default: present
     type: str
     choices: ["present", "absent"]
-  api_token:
-    description:
-      - GitLab access token with API permissions.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - The path and name of the project.
@@ -94,7 +84,7 @@ except Exception:
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 
 class GitlabProtectedBranch(object):
@@ -148,10 +138,8 @@ class GitlabProtectedBranch(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         name=dict(type='str', required=True),
         merge_access_levels=dict(type='str', default="maintainer", choices=["maintainer", "developer", "nobody"]),
@@ -163,11 +151,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
@@ -30,7 +30,14 @@ options:
   api_token:
     description:
       - GitLab access token with API permissions.
-    required: true
+    type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
     type: str
   project:
     description:
@@ -142,7 +149,9 @@ class GitlabProtectedBranch(object):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(
-        api_token=dict(type='str', required=True, no_log=True),
+        api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         project=dict(type='str', required=True),
         name=dict(type='str', required=True),
         merge_access_levels=dict(type='str', default="maintainer", choices=["maintainer", "developer", "nobody"]),
@@ -155,12 +164,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True
     )

--- a/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_protected_branch.py
@@ -17,7 +17,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 2.3.0
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -39,6 +39,14 @@ options:
     description:
       - Your private token to interact with the GitLab API.
     type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
   project:
     description:
       - ID or full path of the project in the form of group/name.
@@ -325,6 +333,8 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
         owned=dict(type='bool', default=False),
@@ -343,12 +353,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token'],
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token'],
         ],
         required_if=[
             ('state', 'present', ['registration_token']),

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -31,7 +31,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 1.5.0
-  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
   - community.general.auth_basic
   - community.general.gitlab

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -31,22 +31,12 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab >= 1.5.0
+  - requests (python library https://github.com/psf/requests)
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - Your private token to interact with the GitLab API.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   project:
     description:
       - ID or full path of the project in the form of group/name.
@@ -194,7 +184,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
 try:
     cmp
@@ -331,10 +321,8 @@ class GitLabRunner(object):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
         owned=dict(type='bool', default=False),
@@ -352,11 +340,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -28,7 +28,6 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
-  - requests (python library https://github.com/psf/requests)
   - administrator rights on the GitLab server
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -37,6 +37,14 @@ options:
     description:
       - GitLab token for logging in.
     type: str
+  api_oauth_token:
+    description:
+      - GitLab OAuth token for logging in.
+    type: str
+  api_job_token:
+    description:
+      - GitLab CI job token for logging in.
+    type: str
   name:
     description:
       - Name of the user you want to create.
@@ -581,6 +589,8 @@ def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_token=dict(type='str', no_log=True),
+        api_oauth_token=dict(type='str', no_log=True),
+        api_job_token=dict(type='str', no_log=True),
         name=dict(type='str'),
         state=dict(type='str', default="present", choices=["absent", "present", "blocked", "unblocked"]),
         username=dict(type='str', required=True),
@@ -604,12 +614,18 @@ def main():
         mutually_exclusive=[
             ['api_username', 'api_token'],
             ['api_password', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_password', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_password', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
         ],
         required_together=[
             ['api_username', 'api_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
         ],
         supports_check_mode=True,
         required_if=(

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -28,23 +28,13 @@ author:
 requirements:
   - python >= 2.7
   - python-gitlab python module
+  - requests (python library https://github.com/psf/requests)
   - administrator rights on the GitLab server
 extends_documentation_fragment:
-- community.general.auth_basic
+  - community.general.auth_basic
+  - community.general.gitlab
 
 options:
-  api_token:
-    description:
-      - GitLab token for logging in.
-    type: str
-  api_oauth_token:
-    description:
-      - GitLab OAuth token for logging in.
-    type: str
-  api_job_token:
-    description:
-      - GitLab CI job token for logging in.
-    type: str
   name:
     description:
       - Name of the user you want to create.
@@ -246,7 +236,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.community.general.plugins.module_utils.gitlab import find_group, gitlab_authentication
+from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, find_group, gitlab_authentication
 
 
 class GitLabUser(object):
@@ -587,10 +577,8 @@ def sanitize_arguments(arguments):
 
 def main():
     argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
     argument_spec.update(dict(
-        api_token=dict(type='str', no_log=True),
-        api_oauth_token=dict(type='str', no_log=True),
-        api_job_token=dict(type='str', no_log=True),
         name=dict(type='str'),
         state=dict(type='str', default="present", choices=["absent", "present", "blocked", "unblocked"]),
         username=dict(type='str', required=True),
@@ -613,11 +601,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['api_username', 'api_token'],
-            ['api_password', 'api_token'],
             ['api_username', 'api_oauth_token'],
-            ['api_password', 'api_oauth_token'],
             ['api_username', 'api_job_token'],
-            ['api_password', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
         ],


### PR DESCRIPTION
##### SUMMARY
Add the following additional ways to authenticate:
- username/password via oauth_token
- oauth_token
- job_token
Fixes #705

Other small changes:
- removed unused imports from module_utils.gitlab
- fix bug in gitlab_project to check if avatar_path is provided

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

gitlab_branch
gitlab_group_members
gitlab_group_variable
gitlab_project_members
gitlab_project_variable
gitlab_runner
gitlab_deploy_key
gitlab_group
gitlab_hook
gitlab_project
gitlab_protected_branch
gitlab_user

