### PR TITLE
xfconf - using aggregated base class

### DIFF
--- a/changelogs/fragments/3919-xfconf-baseclass.yaml
+++ b/changelogs/fragments/3919-xfconf-baseclass.yaml
@@ -1,0 +1,2 @@
+minor_changed:
+    - xfconf - minor refactor on the base class for the module (https://github.com/ansible-collections/community.general/pull/3919).

--- a/changelogs/fragments/3919-xfconf-baseclass.yaml
+++ b/changelogs/fragments/3919-xfconf-baseclass.yaml
@@ -1,2 +1,2 @@
-minor_changed:
+minor_changes:
     - xfconf - minor refactor on the base class for the module (https://github.com/ansible-collections/community.general/pull/3919).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -128,7 +128,7 @@ RETURN = '''
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import (
-    ModuleHelper, CmdMixin, StateMixin, ArgFormat, ModuleHelperException
+    CmdStateModuleHelper, ArgFormat, ModuleHelperException
 )
 
 
@@ -151,7 +151,7 @@ class XFConfException(Exception):
     pass
 
 
-class XFConfProperty(CmdMixin, StateMixin, ModuleHelper):
+class XFConfProperty(CmdStateModuleHelper):
     change_params = 'value',
     diff_params = 'value',
     output_params = ('property', 'channel', 'value')


### PR DESCRIPTION
##### SUMMARY
Using `CmdStateModuleHelper` as base class, instead of explicitly importing `CmdMixin`, `StateMixin` and `ModuleHelper`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/xfconf.py
