### PR TITLE
fix gitlab_project avatar_path open when undefined bug (#3926)

### DIFF
--- a/changelogs/fragments/3926-fix-gitlab-project-avatar-path.yml
+++ b/changelogs/fragments/3926-fix-gitlab-project-avatar-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab - gitlab_project needs to check for avatar_path before trying to open (https://github.com/ansible-collections/community.general/issues/3926).

--- a/changelogs/fragments/3926-fix-gitlab-project-avatar-path.yml
+++ b/changelogs/fragments/3926-fix-gitlab-project-avatar-path.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - gitlab - gitlab_project needs to check for avatar_path before trying to open (https://github.com/ansible-collections/community.general/issues/3926).

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -299,10 +299,11 @@ class GitLabProject(object):
             project = self.create_project(namespace, project_options)
 
             # add avatar to project
-            try:
-                project.avatar = open(options['avatar_path'], 'rb')
-            except IOError as e:
-                self._module.fail_json(msg='Cannot open {0}: {1}'.format(options['avatar_path'], e))
+            if options['avatar_path']:
+                try:
+                    project.avatar = open(options['avatar_path'], 'rb')
+                except IOError as e:
+                    self._module.fail_json(msg='Cannot open {0}: {1}'.format(options['avatar_path'], e))
 
             changed = True
         else:


### PR DESCRIPTION
##### SUMMARY
Any call to gitlab_project to create with avatar_path undefined will throw an exception

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_project
