### PR TITLE
proxmox: Add clone parameter

### DIFF
--- a/changelogs/fragments/3930-proxmox-add-clone.yaml
+++ b/changelogs/fragments/3930-proxmox-add-clone.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - add ``clone`` parameter.

--- a/changelogs/fragments/3930-proxmox-add-clone.yaml
+++ b/changelogs/fragments/3930-proxmox-add-clone.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - add ``clone`` parameter.
+  - proxmox - add ``clone`` parameter (https://github.com/ansible-collections/community.general/pull/3930).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -746,24 +746,7 @@ def main():
             module.fail_json(msg="Pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
         try:
-            create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, clone,
-                            cores=module.params['cores'],
-                            pool=module.params['pool'],
-                            password=module.params['password'],
-                            hostname=module.params['hostname'],
-                            netif=module.params['netif'],
-                            mounts=module.params['mounts'],
-                            ip_address=module.params['ip_address'],
-                            onboot=ansible_to_proxmox_bool(module.params['onboot']),
-                            cpuunits=module.params['cpuunits'],
-                            nameserver=module.params['nameserver'],
-                            searchdomain=module.params['searchdomain'],
-                            force=ansible_to_proxmox_bool(module.params['force']),
-                            pubkey=module.params['pubkey'],
-                            features=",".join(module.params['features']) if module.params['features'] is not None else None,
-                            unprivileged=ansible_to_proxmox_bool(module.params['unprivileged']),
-                            description=module.params['description'],
-                            hookscript=module.params['hookscript'])
+            create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, clone)
 
             module.exit_json(changed=True, msg="Cloned VM %s from %s" % (vmid, clone))
         except Exception as e:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -313,7 +313,7 @@ EXAMPLES = r'''
 
 - name: >
     Create a linked clone of the template container with id 100. The newly created container with be a
-    linked clone, because no storage parameter is defined.
+    linked clone, because no storage parameter is defined
   community.general.proxmox:
     vmid: 201
     node: uk-mc02

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -674,7 +674,7 @@ def main():
                 module.fail_json(msg="ostemplate '%s' not exists on node %s and storage %s"
                                  % (module.params['ostemplate'], node, template_store))
         except Exception as e:
-            module.fail_json(msg="pre-creation checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
+            module.fail_json(msg="Pre-creation checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
         try:
             create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, clone,
@@ -697,9 +697,9 @@ def main():
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])
 
-            module.exit_json(changed=True, msg="deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
+            module.exit_json(changed=True, msg="Deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
         except Exception as e:
-            module.fail_json(msg="creation of %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
+            module.fail_json(msg="Creation of %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
 
     # Clone a container
     elif state == 'present' and clone is not None:
@@ -712,7 +712,7 @@ def main():
             if not get_instance(proxmox, clone):
                 module.exit_json(changed=False, msg="Container to be cloned does not exist")
         except Exception as e:
-            module.fail_json(msg="pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
+            module.fail_json(msg="Pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
         try:
             create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, clone,
@@ -734,9 +734,9 @@ def main():
                             description=module.params['description'],
                             hookscript=module.params['hookscript'])
 
-            module.exit_json(changed=True, msg="cloned VM %s from %s" % (vmid, clone))
+            module.exit_json(changed=True, msg="Cloned VM %s from %s" % (vmid, clone))
         except Exception as e:
-            module.fail_json(msg="cloning %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
+            module.fail_json(msg="Cloning %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
 
     elif state == 'started':
         try:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -442,15 +442,16 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
 
     if clone is not None:
         # Only accept parameters that are compatible with the clone endpoint
-        valid_clone_parameters = ['hostname', 'pool', 'storage']
+        # TODO: Don't accept 'storage' parameters when cloning a template
+        #valid_clone_parameters = ['hostname', 'pool', 'storage']
+        valid_clone_parameters = ['hostname', 'pool']
         clone_parameters = {}
         for param in valid_clone_parameters:
             if module.params[param] is not None:
                 clone_parameters[param] = module.params[param]
 
-        #taskid = getattr(proxmox_node, VZ_TYPE).clone.post(vmid=kwargs['clone'], newid=vmid, **clone_parameters)
-        #taskid = getattr(proxmox_node, VZ_TYPE).post("{vmid}/clone".format(vmid=kwargs['clone']), newid=vmid, **clone_parameters)
-        taskid = proxmox_node.lxc(clone).clone.post(newid=vmid, **clone_parameters)
+        # TODO: Check if openvz VZ_TYPE also supports this endpoint
+        taskid = getattr(proxmox_node, VZ_TYPE)(clone).clone.post(newid=vmid, **clone_parameters)
     else:
         taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)
 
@@ -693,8 +694,7 @@ def main():
                             features=",".join(module.params['features']) if module.params['features'] is not None else None,
                             unprivileged=ansible_to_proxmox_bool(module.params['unprivileged']),
                             description=module.params['description'],
-                            hookscript=module.params['hookscript'],
-                            clone=module.params['clone'])
+                            hookscript=module.params['hookscript'])
 
             module.exit_json(changed=True, msg="cloned VM %s from %s" % (vmid, clone))
         except Exception as e:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: proxmox
-short_description: management of container instances in Proxmox VE cluster
+short_description: management of instances in Proxmox VE cluster
 description:
   - allows you to create/delete/stop instances in Proxmox VE cluster
   - Starting in Ansible 2.1, it automatically detects containerization type (lxc for PVE 4, openvz for older)
@@ -427,7 +427,6 @@ def get_instance(proxmox, vmid):
 
 
 def content_check(proxmox, node, ostemplate, template_store):
-    """Check if the given ostemplate actually exists in the template store of a node."""
     return [True for cnt in proxmox.nodes(node).storage(template_store).content.get() if cnt['volid'] == ostemplate]
 
 

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -174,6 +174,7 @@ options:
       - If I(storage) is not set, a linked clone is created when cloning a template, or a full clone is created when cloning a normal container.
         If I(storage) is set, a full clone will always be made.
     type: int
+    version_added: 4.3.0
 author: Sergei Antipov (@UnderGreen)
 extends_documentation_fragment:
   - community.general.proxmox.documentation

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -313,6 +313,18 @@ EXAMPLES = r'''
     clone: 100
     hostname: clone.example.org
 
+- name: >
+    Create a full clone of the container with id 100.
+  community.general.proxmox:
+    vmid: 201
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    clone: 100
+    hostname: clone.example.org
+    storage: local
+
 - name: Start container
   community.general.proxmox:
     vmid: 100

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -323,8 +323,7 @@ EXAMPLES = r'''
     clone: 100
     hostname: clone.example.org
 
-- name: >
-    Create a full clone of the container with id 100.
+- name: Create a full clone of the container with id 100
   community.general.proxmox:
     vmid: 201
     node: uk-mc02

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -172,7 +172,7 @@ options:
       - ID of the container to be cloned.
       - I(description), I(hostname), and I(pool) will be copied from the cloned container if not specified.
       - The type of clone created is defined by the I(clone_type) parameter.
-      - This operator is only supported for Proxmox clusters that use LXC containerization (PVE version >= 4)
+      - This operator is only supported for Proxmox clusters that use LXC containerization (PVE version >= 4).
     type: int
     version_added: 4.3.0
   clone_type:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -556,9 +556,14 @@ def main():
             proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults']),
             clone=dict(type='int'),
         ),
-        required_if=[('state', 'present', ['node', 'hostname', 'ostemplate'])],
+        required_if=[
+          ('state', 'present', ['node', 'hostname']),
+          ('state', 'present', ('clone', 'ostemplate'), True), # Require one of clone and ostemplate. Together with mutually_exclusive this ensures that we
+                                                               # either clone a container or create a new one from a template file.
+        ],
         required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('api_password', 'api_token_id')],
+        mutually_exclusive=[('clone', 'ostemplate')], # Creating a new container is done either by cloning an existing one, or based on a template.
     )
 
     if not HAS_PROXMOXER:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -621,8 +621,7 @@ def main():
                                                                   # either clone a container or create a new one from a template file.
         ],
         required_together=[
-            ('api_token_id', 'api_token_secret'),
-            ('clone', 'clone_type')
+            ('api_token_id', 'api_token_secret')
         ],
         required_one_of=[('api_password', 'api_token_id')],
         mutually_exclusive=[('clone', 'ostemplate')],  # Creating a new container is done either by cloning an existing one, or based on a template.

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -695,7 +695,7 @@ def main():
     if state == 'present' and clone is None:
         try:
             if get_instance(proxmox, vmid) and not module.params['force']:
-                module.exit_json(changed=False, msg="VM with vmid %s is already exists" % vmid)
+                module.exit_json(changed=False, msg="VM with vmid = %s is already exists" % vmid)
             # If no vmid was passed, there cannot be another VM named 'hostname'
             if not module.params['vmid'] and get_vmid(proxmox, hostname) and not module.params['force']:
                 module.exit_json(changed=False, msg="VM with hostname %s already exists and has ID number %s" % (hostname, get_vmid(proxmox, hostname)[0]))
@@ -736,7 +736,7 @@ def main():
     elif state == 'present' and clone is not None:
         try:
             if get_instance(proxmox, vmid) and not module.params['force']:
-                module.exit_json(changed=False, msg="VM with vmid %s is already exists" % vmid)
+                module.exit_json(changed=False, msg="VM with vmid = %s is already exists" % vmid)
             # If no vmid was passed, there cannot be another VM named 'hostname'
             if not module.params['vmid'] and get_vmid(proxmox, hostname) and not module.params['force']:
                 module.exit_json(changed=False, msg="VM with hostname %s already exists and has ID number %s" % (hostname, get_vmid(proxmox, hostname)[0]))

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -404,6 +404,7 @@ def get_instance(proxmox, vmid):
 
 
 def content_check(proxmox, node, ostemplate, template_store):
+    """Check if the given ostemplate actually exists in the template store of a node."""
     return [True for cnt in proxmox.nodes(node).storage(template_store).content.get() if cnt['volid'] == ostemplate]
 
 

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -630,7 +630,10 @@ def main():
             elif not content_check(proxmox, node, module.params['ostemplate'], template_store):
                 module.fail_json(msg="ostemplate '%s' not exists on node %s and storage %s"
                                  % (module.params['ostemplate'], node, template_store))
+        except Exception as e:
+            module.fail_json(msg="pre-creation checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
+        try:
             create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout,
                             cores=module.params['cores'],
                             pool=module.params['pool'],

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -628,7 +628,7 @@ def main():
     if state == 'present' and clone is None:
         try:
             if get_instance(proxmox, vmid) and not module.params['force']:
-                module.exit_json(changed=False, msg="VM with vmid = %s is already exists" % vmid)
+                module.exit_json(changed=False, msg="VM with vmid %s is already exists" % vmid)
             # If no vmid was passed, there cannot be another VM named 'hostname'
             if not module.params['vmid'] and get_vmid(proxmox, hostname) and not module.params['force']:
                 module.exit_json(changed=False, msg="VM with hostname %s already exists and has ID number %s" % (hostname, get_vmid(proxmox, hostname)[0]))
@@ -669,10 +669,12 @@ def main():
     elif state == 'present' and clone is not None:
         try:
             if get_instance(proxmox, vmid) and not module.params['force']:
-                module.exit_json(changed=False, msg="VM with vmid = %s is already exists" % vmid)
+                module.exit_json(changed=False, msg="VM with vmid %s is already exists" % vmid)
             # If no vmid was passed, there cannot be another VM named 'hostname'
             if not module.params['vmid'] and get_vmid(proxmox, hostname) and not module.params['force']:
                 module.exit_json(changed=False, msg="VM with hostname %s already exists and has ID number %s" % (hostname, get_vmid(proxmox, hostname)[0]))
+            if not get_instance(proxmox, clone):
+                module.exit_json(changed=False, msg="Container to be cloned does not exist")
         except Exception as e:
             module.fail_json(msg="pre-clone checks of {VZ_TYPE} VM {vmid} failed with exception: {e}".format(VZ_TYPE=VZ_TYPE, vmid=vmid, e=e))
 
@@ -699,7 +701,6 @@ def main():
             module.exit_json(changed=True, msg="cloned VM %s from %s" % (vmid, clone))
         except Exception as e:
             module.fail_json(msg="cloning %s VM %s failed with exception: %s" % (VZ_TYPE, vmid, e))
-
 
     elif state == 'started':
         try:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -463,7 +463,7 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
             # Not cloning a template, but also no defined storage. This isn't possible.
             module.fail_json(changed=False, msg="Cloned container is not a template, storage needs to be specified.")
 
-        clone_parameters = { }
+        clone_parameters = {}
         clone_parameters['full'] = create_full_copy
         for param in valid_clone_parameters:
             if module.params[param] is not None:
@@ -576,13 +576,13 @@ def main():
             clone=dict(type='int'),
         ),
         required_if=[
-          ('state', 'present', ['node', 'hostname']),
-          ('state', 'present', ('clone', 'ostemplate'), True), # Require one of clone and ostemplate. Together with mutually_exclusive this ensures that we
-                                                               # either clone a container or create a new one from a template file.
+            ('state', 'present', ['node', 'hostname']),
+            ('state', 'present', ('clone', 'ostemplate'), True),  # Require one of clone and ostemplate. Together with mutually_exclusive this ensures that we
+                                                                  # either clone a container or create a new one from a template file.
         ],
         required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('api_password', 'api_token_id')],
-        mutually_exclusive=[('clone', 'ostemplate')], # Creating a new container is done either by cloning an existing one, or based on a template.
+        mutually_exclusive=[('clone', 'ostemplate')],  # Creating a new container is done either by cloning an existing one, or based on a template.
     )
 
     if not HAS_PROXMOXER:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -171,7 +171,7 @@ options:
     description:
       - ID of the container to be cloned.
       - I(description), I(hostname), and I(pool) will be copied from the cloned container if not specified.
-      - The type of clone created is defined by the I(clone-type) parameter.
+      - The type of clone created is defined by the I(clone_type) parameter.
       - This operator is only supported for Proxmox clusters that use LXC containerization (PVE version >= 4)
     type: int
     version_added: 4.3.0


### PR DESCRIPTION
##### SUMMARY
This PR adds a 'clone' parameter to the proxmox module to clone a container. The implementation is based on the clone option in the proxmox_kvm module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox

##### WIP
A small todo list of things which I already know I should do:
- [ ] ~Check if the older OpenVZ type also supports the clone API operation just like the LXC one. If not, make sure that the clone operation is only used with LXC-enabled proxmox nodes.~ Not solved, just ignored: it now fails when using this on a node that does not use LXC. A note is added in the documentation.
- [x] Actually test out the code
- [x] Check development conventions
- [x] Check documentation conventions
- [x] Add changelog fragment
- [x] Change the `required_if[('state', 'present' ...` accordingly
- [x] Check if cloned container is a template or not (if not, a 'storage' parameter can't be passed/should be ignored)
- [x] Add extra examples