### PR TITLE
slack - use UTF-8 charset in content-type header

### DIFF
--- a/changelogs/fragments/3933-slack-charset-header.yaml
+++ b/changelogs/fragments/3933-slack-charset-header.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - slack - add ``charset`` to HTTP headers to avoid Slack API warning (https://github.com/ansible-collections/community.general/issues/3932).

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -346,7 +346,7 @@ def build_payload_for_slack(text, channel, thread_id, username, icon_url, icon_e
 
 def get_slack_message(module, token, channel, ts):
     headers = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=UTF-8',
         'Accept': 'application/json',
         'Authorization': 'Bearer ' + token
     }
@@ -383,7 +383,7 @@ def do_notify_slack(module, domain, token, payload):
         slack_uri = OLD_SLACK_INCOMING_WEBHOOK % (domain, token)
 
     headers = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=UTF-8',
         'Accept': 'application/json',
     }
     if use_webapi:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #3932

Add `charset=UTF-8` to the `Content-type` header to avoid warnings from the Slack API.  
~~It is a naive implementation, but UTF-8 should be a pretty good/universal choice in my opinion. A more complete implementation might have a configurable charset but really shouldn't everyone be using UTF-8?~~

Edit: The Slack API only accepts UTF-8 ("all messages must use UTF-8 encoding") so there is no need for further flexibility and the hardcoding to UTF-8 should be right.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
slack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:
```paste below
[...]
    ok: true
    response_metadata:
      warnings:
      - missing_charset
    ts: '1640000150.000000'
    warning: missing_charset
[...]
```

After:
```
[...]
    ok: true
    ts: '1640000150.000000'
[...]
```

Fixes the `missing_charset` warning.