### PR TITLE
Fix filesystem tests (so they run on their own)

### DIFF
--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -8,7 +8,7 @@
     state: present
   # xfsprogs on OpenSUSE requires Python 3, skip this for our newer Py2 OpenSUSE builds
   when: not (item == 'xfsprogs' and ansible_os_family == 'Suse' and ansible_python.version.major == 2 and ansible_distribution_major_version|int != 42)
-  with_items:
+  loop:
     - e2fsprogs
     - xfsprogs
 
@@ -32,12 +32,11 @@
 
 - name: "Install btrfs progs (OpenSuse)"
   ansible.builtin.package:
-    name: '{{ item }}'
+    name:
+      - python{{ ansible_python.version.major }}-xml
+      - btrfsprogs
     state: present
   when: ansible_os_family == 'Suse'
-  with_items:
-    - python{{ ansible_python.version.major }}-xml
-    - btrfsprogs
 
 - name: "Install reiserfs utils (Fedora)"
   ansible.builtin.package:
@@ -100,10 +99,9 @@
 
 - name: "Install dosfstools and lvm2 (Linux)"
   ansible.builtin.package:
-    name: '{{ item }}'
-  with_items:
-    - dosfstools
-    - lvm2
+    name:
+      - dosfstools
+      - lvm2
   when: ansible_system == 'Linux'
 
 - name: "Install fatresize and get version"

--- a/tests/integration/targets/filesystem/tasks/setup.yml
+++ b/tests/integration/targets/filesystem/tasks/setup.yml
@@ -45,9 +45,11 @@
   when:
     - ansible_distribution == 'Fedora' and (ansible_facts.distribution_major_version | int < 35)
 
-- name: "Install reiserfs (OpenSuse)"
+- name: "Install reiserfs and util-linux-systemd (for findmnt) (OpenSuse)"
   ansible.builtin.package:
-    name: reiserfs
+    name:
+      - reiserfs
+      - util-linux-systemd
     state: present
   when:
     - ansible_os_family == 'Suse'


### PR DESCRIPTION
##### SUMMARY
Right now the filesystem tests don't run on their own on OpenSuSE; they need the cloud_init_data_facts tests to run first. (These install `cloud-init`, which has `util-linux-systemd` as a dependency, and that contains the `findmnt` CLI tool which the `filesystem` tests need.)

(Fixes the issue seen here: https://github.com/ansible-collections/community.general/pull/3936#pullrequestreview-838926693)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
filesystem
