### PR TITLE
fix  scaleway_user_data

### DIFF
--- a/changelogs/fragments/3940_fix_contenttype_scaleway_user_data.yml
+++ b/changelogs/fragments/3940_fix_contenttype_scaleway_user_data.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - scaleway_user_data - fix double-quote added where no double-quote is needed to user data in scaleway's server (Content-type -> Content-Type).

--- a/changelogs/fragments/3940_fix_contenttype_scaleway_user_data.yml
+++ b/changelogs/fragments/3940_fix_contenttype_scaleway_user_data.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - scaleway_user_data - fix double-quote added where no double-quote is needed to user data in scaleway's server (Content-type -> Content-Type).
+  - scaleway_user_data - fix double-quote added where no double-quote is needed to user data in scaleway's server (``Content-type`` -> ``Content-Type``) (https://github.com/ansible-collections/community.general/pull/3940).

--- a/plugins/modules/cloud/scaleway/scaleway_user_data.py
+++ b/plugins/modules/cloud/scaleway/scaleway_user_data.py
@@ -75,7 +75,7 @@ def patch_user_data(compute_api, server_id, key, value):
     compute_api.module.debug("Starting patching user_data attributes")
 
     path = "servers/%s/user_data/%s" % (server_id, key)
-    response = compute_api.patch(path=path, data=value, headers={"Content-type": "text/plain"})
+    response = compute_api.patch(path=path, data=value, headers={"Content-Type": "text/plain"})
     if not response.ok:
         msg = 'Error during user_data patching: %s %s' % (response.status_code, response.body)
         compute_api.module.fail_json(msg=msg)


### PR DESCRIPTION
##### SUMMARY
Fix the key named Content-type in Content-Type

Bug fixed:
In file who do the HTTP request  ( module_utils/scaleway.py , ligne 130 ), it's "Content-Type" ( with big T) in the key.
The send fonction ( in module_utils/scaleway.py ) found default value ( application/json )  instead of "text/plain" and do jsonify  and the cloud-init send to server is ususable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
scaleway_user_data

##### ADDITIONAL INFORMATION
Reproduce:
Test to put a cloud-init value in a scaleway's server and see it on the serveur with scw-userdata cloud-init:  you will see double-quote at the begin and the end

With the fix: no unexpected "

