### PR TITLE
Mattermost: Add sending of attachments

### DIFF
--- a/changelogs/fragments/3946-mattermost_attachments.yml
+++ b/changelogs/fragments/3946-mattermost_attachments.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - mattermost - add the possibility to send attachments instead of text messages. (https://github.com/ansible-collections/community.general/pull/3946)
+  - mattermost - add the possibility to send attachments instead of text messages (https://github.com/ansible-collections/community.general/pull/3946).

--- a/changelogs/fragments/3946-mattermost_attachments.yml
+++ b/changelogs/fragments/3946-mattermost_attachments.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mattermost - add the possibility to send attachments instead of text messages. (https://github.com/ansible-collections/community.general/pull/3946)

--- a/plugins/modules/notification/mattermost.py
+++ b/plugins/modules/notification/mattermost.py
@@ -131,7 +131,7 @@ def main():
             attachments=dict(type='list', elements='dict'),
         ),
         required_one_of=[
-            ('text', 'attachments')
+            ('text', 'attachments'),
         ],
     )
     # init return dict

--- a/plugins/modules/notification/mattermost.py
+++ b/plugins/modules/notification/mattermost.py
@@ -38,7 +38,14 @@ options:
     type: str
     description:
       - Text to send. Note that the module does not handle escaping characters.
-    required: true
+      - Required when I(attachments) is not set.
+  attachments:
+    type: list
+    elements: dict
+    description:
+      - Define a list of attachments.
+      - For more information, see U(https://developers.mattermost.com/integrate/admin-guide/admin-message-attachments/).
+      - Required when I(text) is not set.
   channel:
     type: str
     description:
@@ -76,6 +83,22 @@ EXAMPLES = """
     channel: notifications
     username: 'Ansible on {{ inventory_hostname }}'
     icon_url: http://www.example.com/some-image-file.png
+
+- name: Send attachments message via Mattermost
+  community.general.mattermost:
+    url: http://mattermost.example.com
+    api_key: my_api_key
+    attachments:
+      - text: Display my system load on host A and B
+        color: '#ff00dd'
+        title: System load
+        fields:
+          - title: System A
+            value: "load average: 0,74, 0,66, 0,63"
+            short: True
+          - title: System B
+            value: 'load average: 5,16, 4,64, 2,43'
+            short: True
 """
 
 RETURN = '''
@@ -104,6 +127,7 @@ def main():
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),
             validate_certs=dict(default=True, type='bool'),
+            attachments=dict(type='list', elements='dict'),
         )
     )
     # init return dict
@@ -115,7 +139,7 @@ def main():
 
     # define payload
     payload = {}
-    for param in ['text', 'channel', 'username', 'icon_url']:
+    for param in ['text', 'channel', 'username', 'icon_url', 'attachments']:
         if module.params[param] is not None:
             payload[param] = module.params[param]
 

--- a/plugins/modules/notification/mattermost.py
+++ b/plugins/modules/notification/mattermost.py
@@ -123,7 +123,7 @@ def main():
         argument_spec=dict(
             url=dict(type='str', required=True),
             api_key=dict(type='str', required=True, no_log=True),
-            text=dict(type='str', default=None),
+            text=dict(type='str'),
             channel=dict(type='str', default=None),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),

--- a/plugins/modules/notification/mattermost.py
+++ b/plugins/modules/notification/mattermost.py
@@ -131,7 +131,7 @@ def main():
             attachments=dict(type='list', elements='dict'),
         ),
         required_one_of=[
-          ('text', 'attachments')
+            ('text', 'attachments')
         ],
     )
     # init return dict

--- a/plugins/modules/notification/mattermost.py
+++ b/plugins/modules/notification/mattermost.py
@@ -46,6 +46,7 @@ options:
       - Define a list of attachments.
       - For more information, see U(https://developers.mattermost.com/integrate/admin-guide/admin-message-attachments/).
       - Required when I(text) is not set.
+    version_added: 4.3.0
   channel:
     type: str
     description:
@@ -122,13 +123,16 @@ def main():
         argument_spec=dict(
             url=dict(type='str', required=True),
             api_key=dict(type='str', required=True, no_log=True),
-            text=dict(type='str', required=True),
+            text=dict(type='str', default=None),
             channel=dict(type='str', default=None),
             username=dict(type='str', default='Ansible'),
             icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),
             validate_certs=dict(default=True, type='bool'),
             attachments=dict(type='list', elements='dict'),
-        )
+        ),
+        required_one_of=[
+          ('text', 'attachments')
+        ],
     )
     # init return dict
     result = dict(changed=False, msg="OK")


### PR DESCRIPTION
##### SUMMARY
Add the functionality to send attachments in Mattermost.

Closes: #3944

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mattermost

##### ADDITIONAL INFORMATION

I needed to remove the `required=True` at the `text` element and added additional documentation.
