### PR TITLE
Restrict redis to < 4.1.0 for ansible-base 2.10

### DIFF
--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -23,6 +23,7 @@ esac
 ansible-test env --timeout "${timeout}" --color -v
 
 if [ "$2" == "2.10" ]; then
+    sed -i -E 's/^redis($| .*)/redis < 4.1.0/g' tests/unit/requirements.txt
     sed -i -E 's/^python-gitlab($| .*)/python-gitlab < 2.10.1 ; python_version >= '\'3.6\''/g' tests/unit/requirements.txt
     echo "python-gitlab ; python_version < '3.6'" >> tests/unit/requirements.txt
 fi


### PR DESCRIPTION
##### SUMMARY
Fixes CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
