### PR TITLE
[stable-1] Restrict redis to < 4.1.0 for ansible-base 2.10

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -244,4 +244,4 @@ fi
 ansible-test env --dump --show --timeout "${timeout}" --color -v
 
 if [ "${SHIPPABLE_BUILD_ID:-}" ]; then "tests/utils/shippable/check_matrix.py"; fi
-"tests/utils/shippable/${script}.sh" "${test}"
+"tests/utils/shippable/${script}.sh" "${test}" "${ansible_version}"

--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -22,6 +22,10 @@ esac
 
 ansible-test env --timeout "${timeout}" --color -v
 
+if [ "$2" == "2.10" ]; then
+    sed -i -E 's/^redis($| .*)/redis < 4.1.0/g' tests/unit/requirements.txt
+fi
+
 # shellcheck disable=SC2086
 ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
     "${options[@]:+${options[@]}}" \


### PR DESCRIPTION
##### SUMMARY
Backport of #3955 to stable-1.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
