### PR TITLE
Fetch Gitlab runner registration token from API

### DIFF
--- a/changelogs/fragments/3935-add-gitlab-group-runner.yml
+++ b/changelogs/fragments/3935-add-gitlab-group-runner.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - 'gitlab_runner - allow to register group runner (https://github.com/ansible-collections/community.general/pull/3935).'
+bugfixes:
+    - 'gitlab_runner module - fix project/group runner CRUD operations (https://github.com/ansible-collections/community.general/pull/3935).'

--- a/changelogs/fragments/3xxx-fetch-registration-token-from-api.yml
+++ b/changelogs/fragments/3xxx-fetch-registration-token-from-api.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - gitlab_runner - fetch registration token from API.


### PR DESCRIPTION
##### SUMMARY
This PR adds the possibility to retrieve Gitlab runner registration token from instance/group/project API.
It relates to issue #3742.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_runner module

##### ADDITIONAL INFORMATION
Includes PR #3935 code, thus allowing Ansible to retrieve registration token from instance, project or group (group runners usecase added by PR #3935).

:warning: Do not merge before #3935  is merged.
