### PR TITLE
gitlab: use gitlab instance runner to create runner

### DIFF
--- a/changelogs/fragments/3935-use-gitlab-instance-runner-to-create-runner.yml
+++ b/changelogs/fragments/3935-use-gitlab-instance-runner-to-create-runner.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'gitlab_runner - use correct API endpoint to create and retrieve project level runners when using ``project`` (https://github.com/ansible-collections/community.general/pull/3965).'

--- a/plugins/modules/source_control/gitlab/gitlab_runner.py
+++ b/plugins/modules/source_control/gitlab/gitlab_runner.py
@@ -248,7 +248,7 @@ class GitLabRunner(object):
             return True
 
         try:
-            runner = self._runners_endpoint.create(arguments)
+            runner = self._gitlab.runners.create(arguments)
         except (gitlab.exceptions.GitlabCreateError) as e:
             self._module.fail_json(msg="Failed to create runner: %s " % to_native(e))
 
@@ -292,10 +292,10 @@ class GitLabRunner(object):
             # object, so we need to handle both
             if hasattr(runner, "description"):
                 if (runner.description == description):
-                    return self._runners_endpoint.get(runner.id)
+                    return self._gitlab.runners.get(runner.id)
             else:
                 if (runner['description'] == description):
-                    return self._runners_endpoint.get(runner['id'])
+                    return self._gitlab.runners.get(runner['id'])
 
     '''
     @param description Description of the runner


### PR DESCRIPTION
##### SUMMARY
When using project it will use project level runner to create runner that based on python-gitlab it will be used for enabling runner and needs a runner_id so for creating a new runner it should use gitlab level runner

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner