### PR TITLE
ipmi_power: Add machine option to ensure the power state via the remote target address

### DIFF
--- a/changelogs/fragments/3968-ipmi_power-add-machine-option.yaml
+++ b/changelogs/fragments/3968-ipmi_power-add-machine-option.yaml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - ipmi_power - add machine option to ensure the power state via the remote target
+  - ipmi_power - add ``machine`` option to ensure the power state via the remote target
     address (https://github.com/ansible-collections/community.general/pull/3968).

--- a/changelogs/fragments/3968-ipmi_power-add-machine-option.yaml
+++ b/changelogs/fragments/3968-ipmi_power-add-machine-option.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ipmi_power - add machine option to ensure the power state via the remote target
+    address (https://github.com/ansible-collections/community.general/pull/3968).

--- a/plugins/modules/remote_management/ipmi/ipmi_power.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_power.py
@@ -51,13 +51,30 @@ options:
             - reset -- Request system reset without waiting for OS
             - boot -- If system is off, then 'on', else 'reset'"
     choices: ['on', 'off', shutdown, reset, boot]
-    required: true
     type: str
   timeout:
     description:
       - Maximum number of seconds before interrupt request.
     default: 300
     type: int
+  machine:
+    description:
+      - Provide a list of the remote target address for the bridge IPMI request,
+        and the power status.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      targetAddress:
+        description:
+          - Remote target address for the bridge IPMI request.
+        type: int
+      state:
+        description:
+          - Whether to ensure that the machine specified by targetAddress in desired state.
+        choices: ['on', 'off', shutdown, reset, boot]
+        type: str
+
 requirements:
   - "python >= 2.6"
   - pyghmi
@@ -70,6 +87,47 @@ powerstate:
     returned: success
     type: str
     sample: on
+status:
+    description: The current power state of the machine when the machine option is set.
+    returned: success
+    type: list
+    sample: [
+              {
+                "powerstate": "on",
+                "targetAddress': 48,
+              },
+              {
+                "powerstate": "on",
+                "targetAddress": 50,
+              },
+    ]
+
+requirements:
+  - "python >= 2.6"
+  - pyghmi
+author: "Bulat Gaifullin (@bgaifullin) <gaifullinbf@gmail.com>"
+'''
+
+RETURN = '''
+powerstate:
+    description: The current power state of the machine.
+    returned: success
+    type: str
+    sample: on
+status:
+    description: The current power state of the machine when the machine option is set.
+    returned: success
+    type: list
+    sample: [
+              {
+                "powerstate": "on",
+                "targetAddress': 48,
+              },
+              {
+                "powerstate": "on",
+                "targetAddress": 50,
+              },
+    ]
 '''
 
 EXAMPLES = '''
@@ -79,12 +137,34 @@ EXAMPLES = '''
     user: admin
     password: password
     state: on
+
+- name: Ensure machines of which remote target address is 48 and 50 are powered off
+  community.general.ipmi_power:
+    name: test.testdomain.com
+    user: admin
+    password: password
+    state: off
+    machine:
+      - targetAddress: 48
+      - targetAddress: 50
+
+- name: Ensure machine of which remote target address is 48 is powered on, and 50 is powered off
+  community.general.ipmi_power:
+    name: test.testdomain.com
+    user: admin
+    password: password
+    machine:
+      - targetAddress: 48
+        state: on
+      - targetAddress: 50
+        state: off
 '''
 
 import traceback
 import binascii
 
 PYGHMI_IMP_ERR = None
+INVALID_TARGET_ADDRESS = 0x100
 try:
     from pyghmi.ipmi import command
 except ImportError:
@@ -99,13 +179,23 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             port=dict(default=623, type='int'),
-            state=dict(required=True, choices=['on', 'off', 'shutdown', 'reset', 'boot']),
+            state=dict(choices=['on', 'off', 'shutdown', 'reset', 'boot']),
             user=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             key=dict(type='str', no_log=True),
             timeout=dict(default=300, type='int'),
+            machine=dict(
+                type='list', elements='dict',
+                options=dict(
+                    targetAddress=dict(type='int'),
+                    state=dict(type='str', choices=['on', 'off', 'shutdown', 'reset', 'boot']),
+                ),
+            ),
         ),
         supports_check_mode=True,
+        required_one_of=(
+            ['state', 'machine'],
+        ),
     )
 
     if command is None:
@@ -117,13 +207,14 @@ def main():
     password = module.params['password']
     state = module.params['state']
     timeout = module.params['timeout']
+    machine = module.params['machine']
 
     try:
         if module.params['key']:
             key = binascii.unhexlify(module.params['key'])
         else:
             key = None
-    except Exception as e:
+    except Exception:
         module.fail_json(msg="Unable to convert 'key' from hex string.")
 
     # --- run command ---
@@ -133,18 +224,54 @@ def main():
         )
         module.debug('ipmi instantiated - name: "%s"' % name)
 
-        current = ipmi_cmd.get_power()
-        if current['powerstate'] != state:
-            response = {'powerstate': state} if module.check_mode else ipmi_cmd.set_power(state, wait=timeout)
-            changed = True
+        changed = False
+        if not machine:
+            current = ipmi_cmd.get_power()
+            if current['powerstate'] != state:
+                response = {'powerstate': state} if module.check_mode \
+                    else ipmi_cmd.set_power(state, wait=timeout)
+                changed = True
+            else:
+                response = current
+
+            if 'error' in response:
+                module.fail_json(msg=response['error'])
+
+            module.exit_json(changed=changed, **response)
         else:
-            response = current
-            changed = False
+            response = []
+            for entry in machine:
+                taddr = entry['targetAddress']
+                if taddr >= INVALID_TARGET_ADDRESS:
+                    module.fail_json(msg="targetAddress should be set between 0 to 255.")
 
-        if 'error' in response:
-            module.fail_json(msg=response['error'])
+                try:
+                    # bridge_request is supported on pyghmi 1.5.30 and later
+                    current = ipmi_cmd.get_power(bridge_request={"addr": taddr})
+                except TypeError:
+                    module.fail_json(msg="targetAddress isn't supported on this module")
 
-        module.exit_json(changed=changed, **response)
+                if entry['state']:
+                    state = entry['state']
+                elif not state:
+                    module.fail_json(msg="Either state or suboption of machine state should be set.")
+
+                if current['powerstate'] != state:
+                    if module.check_mode:
+                        pass
+                    else:
+                        new = ipmi_cmd.set_power(state, wait=timeout, bridge_request={"addr": taddr})
+                        if 'error' in new:
+                            module.fail_json(msg=response['error'])
+
+                        response.append(
+                            {'targetAddress:': taddr, 'powerstate': new['powerstate']})
+
+                        changed = True
+                else:
+                    response.append({'targetAddress:': taddr, 'powerstate': state})
+
+            module.exit_json(changed=changed, status=response)
     except Exception as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/remote_management/ipmi/ipmi_power.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_power.py
@@ -66,6 +66,7 @@ options:
     required: false
     type: list
     elements: dict
+    version_added: 4.3.0
     suboptions:
       targetAddress:
         description:
@@ -97,6 +98,7 @@ status:
     returned: success and I(machine) is provided
     type: list
     elements: dict
+    version_added: 4.3.0
     contains:
         powerstate:
           description: The current power state of the machine specified by I(targetAddress).

--- a/plugins/modules/remote_management/ipmi/ipmi_power.py
+++ b/plugins/modules/remote_management/ipmi/ipmi_power.py
@@ -94,7 +94,7 @@ status:
     sample: [
               {
                 "powerstate": "on",
-                "targetAddress': 48,
+                "targetAddress": 48,
               },
               {
                 "powerstate": "on",
@@ -121,7 +121,7 @@ status:
     sample: [
               {
                 "powerstate": "on",
-                "targetAddress': 48,
+                "targetAddress": 48,
               },
               {
                 "powerstate": "on",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add bridge IPMI request to the remote target address support to community.general.ipmi_power module.
This PR allows to ensure the power state of the machine(s) which can be reached through the remote target address.
The power state is checked and changed via bridge IPMI request. The IPMI request is supported by pyghmi 1.5.30 and later.
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ipmi_power module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Ensure machine of which remote target address is 48 is powered on, and 50 is powered off
  community.general.ipmi_power:
    name: test.testdomain.com
    user: admin
    password: password
    machine:
      - targetAddress: 48
        state: on
      - targetAddress: 50
        state: off
```
