### PR TITLE
fix alternatives parsing when they are part of a group

### DIFF
--- a/changelogs/fragments/3976-fix-alternatives-parsing.yml
+++ b/changelogs/fragments/3976-fix-alternatives-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - alternatives - fix output parsing for alternatives groups (https://github.com/ansible-collections/community.general/pull/3976).

--- a/plugins/modules/system/alternatives.py
+++ b/plugins/modules/system/alternatives.py
@@ -104,7 +104,7 @@ def main():
         # available alternatives
         current_path_regex = re.compile(r'^\s*link currently points to (.*)$',
                                         re.MULTILINE)
-        alternative_regex = re.compile(r'^(\/.*)\s-\spriority', re.MULTILINE)
+        alternative_regex = re.compile(r'^(\/.*)\s-\s(?:family\s\S+\s)?priority', re.MULTILINE)
 
         match = current_path_regex.search(display_output)
         if match:


### PR DESCRIPTION
##### SUMMARY
Fixes 'alternatives --display' output parsing when an alternative is part of a group.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
alternatives

##### ADDITIONAL INFORMATION
When an alternative is a part of a family (a group with master and slave links), an additional piece of information is present in  'alternatives --display' output , such as:

```
java - status is auto.
 link currently points to /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-2.el8_5.x86_64/jre/bin/java
/usr/lib/jvm/java-11-openjdk-11.0.13.0.8-3.el8_5.x86_64/bin/java - family java-11-openjdk.x86_64 priority 1
 slave alt-java: /usr/lib/jvm/java-11-openjdk-11.0.13.0.8-3.el8_5.x86_64/bin/alt-java
...
/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-2.el8_5.x86_64/jre/bin/java - family java-1.8.0-openjdk.x86_64 priority 1800312
 slave alt-java: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-2.el8_5.x86_64/jre/bin/alt-java
...
Current `best' version is /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-2.el8_5.x86_64/jre/bin/java.
```
Without this fix, ansible never find an existing alternative, and always installs a new one before activating it, breaking the group at the same time.
