### PR TITLE
puppet: Add documentation and remove deprecation for show_diff, keep deprecation for alias show-diff

### DIFF
--- a/changelogs/fragments/3980-puppet-show_diff.yml
+++ b/changelogs/fragments/3980-puppet-show_diff.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - puppet - remove deprecation for ``show_diff`` parameter (https://github.com/ansible-collections/community.general/pull/3980).
+  - puppet - remove deprecation for ``show_diff`` parameter. Its alias ``show-diff`` is still deprecated and will be removed in community.general 7.0.0 (https://github.com/ansible-collections/community.general/pull/3980).

--- a/changelogs/fragments/3980-puppet-show_diff.yml
+++ b/changelogs/fragments/3980-puppet-show_diff.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - puppet - add documentation for parameter ``show_diff`` and remove deprecation warning (https://github.com/ansible-collections/community.general/pull/3980).
+  - puppet - remove deprecation for ``show_diff`` parameter (https://github.com/ansible-collections/community.general/pull/3980).

--- a/changelogs/fragments/3980-puppet-show_diff.yml
+++ b/changelogs/fragments/3980-puppet-show_diff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - puppet - add documentation for parameter ``show_diff`` and remove deprecation warning (https://github.com/ansible-collections/community.general/pull/3980).

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -179,7 +179,9 @@ def main():
             manifest=dict(type='str'),
             noop=dict(type='bool'),
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
-            show_diff=dict(type='bool', default=False, aliases=['show-diff']),
+            show_diff=dict(
+                type='bool', default=False, aliases=['show-diff'],
+                deprecated_aliases=[dict(name='show-diff', version='7.0.0', collection_name='community.general')])),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -94,10 +94,11 @@ options:
     default: false
   show_diff:
     description:
-      - Wether to print file changes details
+      - Whether to print file changes details
+      - Alias C(show-diff) has been deprecated and will be removed in community.general 7.0.0.
+    aliases: ['show-diff']
     type: bool
     default: false
-    aliases: [show-diff]
 requirements:
 - puppet
 author:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -181,6 +181,7 @@ def main():
             manifest=dict(type='str'),
             noop=dict(type='bool'),
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
+            # The following is not related to Ansible's diff; see https://github.com/ansible-collections/community.general/pull/3980#issuecomment-1005666154
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
                 deprecated_aliases=[dict(name='show-diff', version='7.0.0', collection_name='community.general')]),

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -97,6 +97,7 @@ options:
       - Wether to print file changes details
     type: bool
     default: false
+    aliases: [show-diff]
 requirements:
 - puppet
 author:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -182,7 +182,7 @@ def main():
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             show_diff=dict(
                 type='bool', default=False, aliases=['show-diff'],
-                deprecated_aliases=[dict(name='show-diff', version='7.0.0', collection_name='community.general')])),
+                deprecated_aliases=[dict(name='show-diff', version='7.0.0', collection_name='community.general')]),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -92,6 +92,11 @@ options:
       - Enable full debugging.
     type: bool
     default: false
+  show_diff:
+    description:
+      - Wether to print file changes details
+    type: bool
+    default: false
 requirements:
 - puppet
 author:
@@ -174,9 +179,7 @@ def main():
             manifest=dict(type='str'),
             noop=dict(type='bool'),
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
-            show_diff=dict(
-                type='bool', default=False, aliases=['show-diff'],
-                removed_in_version='7.0.0', removed_from_collection='community.general'),
+            show_diff=dict(type='bool', default=False, aliases=['show-diff']),
             facts=dict(type='dict'),
             facter_basename=dict(type='str', default='ansible'),
             environment=dict(type='str'),

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -47,6 +47,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -47,7 +47,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
-plugins/modules/system/puppet.py use-argspec-type-path
+plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -48,8 +48,6 @@ plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -47,8 +47,6 @@ plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -46,6 +46,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -46,7 +46,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
-plugins/modules/system/puppet.py use-argspec-type-path
+plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -42,8 +42,6 @@ plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -41,7 +41,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
-plugins/modules/system/puppet.py use-argspec-type-path
+plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -41,6 +41,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -42,8 +42,6 @@ plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:doc-default-does-not-match-spec  # show_diff is not documented
-plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -41,7 +41,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
-plugins/modules/system/puppet.py use-argspec-type-path
+plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -41,6 +41,7 @@ plugins/modules/system/gconftool2.py validate-modules:parameter-state-invalid-ch
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/system/parted.py validate-modules:parameter-state-invalid-choice
+plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice  # state get removed in 5.0.0

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -36,6 +36,7 @@ plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
+plugins/modules/system/puppet.py use-argspec-type-path
 plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -37,7 +37,6 @@ plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
 plugins/modules/system/puppet.py use-argspec-type-path
-plugins/modules/system/puppet.py validate-modules:parameter-type-not-in-doc
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -36,7 +36,7 @@ plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/source_control/github/github_deploy_key.py validate-modules:parameter-invalid
 plugins/modules/system/iptables_state.py validate-modules:undocumented-parameter
-plugins/modules/system/puppet.py use-argspec-type-path
+plugins/modules/system/puppet.py validate-modules:parameter-invalid  # invalid alias - removed in 7.0.0
 plugins/modules/system/ssh_config.py use-argspec-type-path # Required since module uses other methods to specify path
 plugins/modules/system/xfconf.py validate-modules:return-syntax-error
 plugins/modules/web_infrastructure/jenkins_plugin.py use-argspec-type-path


### PR DESCRIPTION
First, I'm new to this contribution thing and although I'm trying to follow the PR quick start guide I wouldn't be surprised if I'm not doing everything according to standards, so please be forgiving :)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/ansible-collections/community.general/pull/1927 introduced deprecation for the `show_diff` parameter on the puppet module, it seems due to it being undocumented.

Since I believe it's worthwhile for a user to have the possibility to get change details when running puppet (not by default obviously, due to potential security concerns), I'm trying here to fix the documentation for that parameter to then be able to remove the deprecation.

Worth noting I haven't been able to run the sanity check yet (as described in the quick start guide):
```
[...]ansible_collections/community/general (puppet/show_diff) $ ansible-test sanity plugins/modules/system/puppet.py --docker -v
Traceback (most recent call last):
  File "~/.local/bin/ansible-test", line 69, in <module>
    main(context)
  File "~/.local/bin/ansible-test", line 38, in main
    generate_dockerfile(context)
  File "~/.local/bin/ansible-test", line 17, in generate_dockerfile
    resource_string("ansible_test","resources/Dockerfile.j2")
  File "~/.local/lib/python3.6/site-packages/jinja2/environment.py", line 1195, in __new__
    return env.from_string(source, template_class=cls)
  File "~/.local/lib/python3.6/site-packages/jinja2/environment.py", line 1092, in from_string
    return cls.from_code(self, self.compile(source), gs, None)
  File "~/.local/lib/python3.6/site-packages/jinja2/environment.py", line 750, in compile
    source = self._generate(source, name, filename, defer_init=defer_init)
  File "~/.local/lib/python3.6/site-packages/jinja2/environment.py", line 684, in _generate
    optimized=self.optimized,
  File "~/.local/lib/python3.6/site-packages/jinja2/compiler.py", line 112, in generate
    raise TypeError("Can't compile non template nodes")
TypeError: Can't compile non template nodes
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Puppet
