### PR TITLE
nmcli: Add wireguard connection type support

### DIFF
--- a/changelogs/fragments/3985-nmcli-add-wireguard-connection-type.yml
+++ b/changelogs/fragments/3985-nmcli-add-wireguard-connection-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - add `wireguard` connection type (https://github.com/ansible-collections/community.general/pull/3985).

--- a/changelogs/fragments/3985-nmcli-add-wireguard-connection-type.yml
+++ b/changelogs/fragments/3985-nmcli-add-wireguard-connection-type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - add `wireguard` connection type (https://github.com/ansible-collections/community.general/pull/3985).
+  - nmcli - add ``wireguard`` connection type (https://github.com/ansible-collections/community.general/pull/3985).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -55,9 +55,10 @@ options:
             - Type C(generic) is added in Ansible 2.5.
             - Type C(infiniband) is added in community.general 2.0.0.
             - Type C(gsm) is added in community.general 3.7.0.
-            - Type C(wireguard) is added in community.general x.y.z
+            - Type C(wireguard) is added in community.general 4.3.0
         type: str
-        choices: [ bond, bond-slave, bridge, bridge-slave, dummy, ethernet, generic, gre, infiniband, ipip, sit, team, team-slave, vlan, vxlan, wifi, gsm, wireguard ]
+        choices: [ bond, bond-slave, bridge, bridge-slave, dummy, ethernet, generic, gre, infiniband, ipip, sit, team, team-slave, vlan, vxlan, wifi, gsm,
+            wireguard ]
     mode:
         description:
             - This is the type of device or network connection that you wish to create for a bond or bridge.
@@ -764,7 +765,7 @@ options:
             - 'For instance to configure a listen port:
               C({listen-port: 12345}).'
         type: dict
-        version_added: x.y.z
+        version_added: 4.3.0
         suboptions:
             fwmark:
                 description:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1236,6 +1236,7 @@ class Nmcli(object):
         self.wifi = module.params['wifi']
         self.wifi_sec = module.params['wifi_sec']
         self.gsm = module.params['gsm']
+        self.wireguard = module.params['wireguard']
 
         if self.method4:
             self.ipv4_method = self.method4
@@ -1249,6 +1250,8 @@ class Nmcli(object):
         if self.method6:
             self.ipv6_method = self.method6
         elif self.type == 'dummy' and not self.ip6:
+            self.ipv6_method = 'disabled'
+        elif self.type == 'wireguard' and not self.ip6:
             self.ipv6_method = 'disabled'
         elif self.ip6:
             self.ipv6_method = 'manual'
@@ -1404,6 +1407,12 @@ class Nmcli(object):
                     options.update({
                         'gsm.%s' % name: value,
                     })
+        elif self.type == 'wireguard':
+            if self.wireguard:
+                for name, value in self.wireguard.items():
+                    options.update({
+                        'wireguard.%s' % name: value,
+                    })
         # Convert settings values based on the situation.
         for setting, value in options.items():
             setting_type = self.settings_type(setting)
@@ -1445,6 +1454,7 @@ class Nmcli(object):
             'vlan',
             'wifi',
             'gsm',
+            'wireguard',
         )
 
     @property
@@ -1834,6 +1844,7 @@ def main():
                           'vxlan',
                           'wifi',
                           'gsm',
+                          'wireguard',
                       ]),
             ip4=dict(type='list', elements='str'),
             gw4=dict(type='str'),
@@ -1907,6 +1918,7 @@ def main():
             wifi=dict(type='dict'),
             wifi_sec=dict(type='dict', no_log=True),
             gsm=dict(type='dict'),
+            wireguard=dict(type='dict'),
         ),
         mutually_exclusive=[['never_default4', 'gw4']],
         required_if=[("type", "wifi", [("ssid")])],

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -771,9 +771,8 @@ options:
                 description:
                     - The 32-bit fwmark for outgoing packets.
                     - The use of fwmark is optional and is by default off. Setting it to 0 disables it.
-                    - Note that C(ip4-auto-default-route) or C(ip6-auto-default-route) enabled, implies to automatically choose a fwmark.
+                    - Note that I(wireguard.ip4-auto-default-route) or I(wireguard.ip6-auto-default-route) enabled, implies to automatically choose a fwmark.
                 type: int
-                default: 0
             ip4-auto-default-route:
                 description:
                     - Whether to enable special handling of the IPv4 default route.
@@ -784,20 +783,18 @@ options:
                 type: bool
             ip6-auto-default-route:
                 description:
-                    - Like C(ip4-auto-default-route), but for the IPv6 default route.
+                    - Like I(wireguard.ip4-auto-default-route), but for the IPv6 default route.
                 type: bool
             listen-port:
-                description: The Wireguard connection listen-port. If C(listen-port) is not specified, the port will be chosen randomly when the
+                description: The WireGuard connection listen-port. If not specified, the port will be chosen randomly when the
                     interface comes up.
                 type: int
-                default: 0
             mtu:
                 description:
                     - If non-zero, only transmit packets of the specified size or smaller, breaking larger packets up into multiple fragments.
                     - If zero a default MTU is used. Note that contrary to wg-quick's MTU setting, this does not take into account the current routes
                         at the time of activation.
                 type: int
-                default: 0
             peer-routes:
                 description:
                     - Whether to automatically add routes for the AllowedIPs ranges of the peers.
@@ -808,7 +805,6 @@ options:
                     - Note that if the peer's AllowedIPs is C(0.0.0.0/0) or C(::/0) and the profile's C(ipv4.never-default) or C(ipv6.never-default)
                         setting is enabled, the peer route for this peer won't be added automatically.
                 type: bool
-                default: true
             private-key:
                 description: The 256 bit private-key in base64 encoding.
                 type: str
@@ -1313,9 +1309,7 @@ class Nmcli(object):
 
         if self.method4:
             self.ipv4_method = self.method4
-        elif self.type == 'dummy' and not self.ip4:
-            self.ipv4_method = 'disabled'
-        elif self.type == 'wireguard' and not self.ip4:
+        elif self.type in ('dummy', 'wireguard') and not self.ip4:
             self.ipv4_method = 'disabled'
         elif self.ip4:
             self.ipv4_method = 'manual'
@@ -1324,9 +1318,7 @@ class Nmcli(object):
 
         if self.method6:
             self.ipv6_method = self.method6
-        elif self.type == 'dummy' and not self.ip6:
-            self.ipv6_method = 'disabled'
-        elif self.type == 'wireguard' and not self.ip6:
+        elif self.type in ('dummy', 'wireguard') and not self.ip6:
             self.ipv6_method = 'disabled'
         elif self.ip6:
             self.ipv6_method = 'manual'

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1242,6 +1242,8 @@ class Nmcli(object):
             self.ipv4_method = self.method4
         elif self.type == 'dummy' and not self.ip4:
             self.ipv4_method = 'disabled'
+        elif self.type == 'wireguard' and not self.ip4:
+            self.ipv4_method = 'disabled'
         elif self.ip4:
             self.ipv4_method = 'manual'
         else:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -770,23 +770,24 @@ options:
                 description:
                     - The 32-bit fwmark for outgoing packets.
                     - The use of fwmark is optional and is by default off. Setting it to 0 disables it.
-                    - Note that "ip4-auto-default-route" or "ip6-auto-default-route" enabled, implies to automatically choose a fwmark.
+                    - Note that C(ip4-auto-default-route) or C(ip6-auto-default-route) enabled, implies to automatically choose a fwmark.
                 type: int
                 default: 0
             ip4-auto-default-route:
                 description:
                     - Whether to enable special handling of the IPv4 default route.
-                    - If enabled, the IPv4 default route from wireguard.peer-routes will be placed to a dedicated routing-table and two policy routing
-                        rules will be added.
+                    - If enabled, the IPv4 default route from I(wireguard.peer-routes) will be placed to a dedicated routing-table and two policy
+                        routing rules will be added.
                     - The fwmark number is also used as routing-table for the default-route, and if fwmark is zero, an unused fwmark/table is chosen
                         automatically. This corresponds to what wg-quick does with Table=auto and what WireGuard calls "Improved Rule-based Routing"
                 type: bool
             ip6-auto-default-route:
                 description:
-                    - Like ip4-auto-default-route, but for the IPv6 default route.
+                    - Like C(ip4-auto-default-route), but for the IPv6 default route.
                 type: bool
             listen-port:
-                description: The listen-port. If listen-port is not specified, the port will be chosen randomly when the interface comes up.
+                description: The Wireguard connection listen-port. If C(listen-port) is not specified, the port will be chosen randomly when the
+                    interface comes up.
                 type: int
                 default: 0
             mtu:
@@ -799,19 +800,19 @@ options:
             peer-routes:
                 description:
                     - Whether to automatically add routes for the AllowedIPs ranges of the peers.
-                    - If TRUE (the default), NetworkManager will automatically add routes in the routing tables according to ipv4.route-table and
-                        ipv6.route-table. Usually you want this automatism enabled.
-                    - If FALSE, no such routes are added automatically. In this case, the user may want to configure static routes in ipv4.routes and
-                        ipv6.routes, respectively.
-                    - Note that if the peer's AllowedIPs is "0.0.0.0/0" or "::/0" and the profile's ipv4.never-default or ipv6.never-default setting
-                        is enabled, the peer route for this peer won't be added automatically.
+                    - If C(true) (the default), NetworkManager will automatically add routes in the routing tables according to C(ipv4.route-table) and
+                        C(ipv6.route-table). Usually you want this automatism enabled.
+                    - If C(false), no such routes are added automatically. In this case, the user may want to configure static routes in C(ipv4.routes)
+                        and C(ipv6.routes), respectively.
+                    - Note that if the peer's AllowedIPs is C(0.0.0.0/0) or C(::/0) and the profile's C(ipv4.never-default) or C(ipv6.never-default)
+                        setting is enabled, the peer route for this peer won't be added automatically.
                 type: bool
                 default: true
             private-key:
                 description: The 256 bit private-key in base64 encoding.
                 type: str
             private-key-flags:
-                description: NMSettingSecretFlags indicating how to handle the I(wireguard.private-key) property.
+                description: C(NMSettingSecretFlags) indicating how to handle the I(wireguard.private-key) property.
                 type: int
                 choices: [ 0, 1, 2 ]
 '''


### PR DESCRIPTION
##### SUMMARY
Add `wireguard` connection type support to `nmcli` module

Fixes #3750  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli
