### PR TITLE
Fix 2.9 unit tests

### DIFF
--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -22,6 +22,11 @@ esac
 
 ansible-test env --timeout "${timeout}" --color -v
 
+if [ "$2" == "2.9" ]; then
+    # 1.5.0+ will not install for Python 3.6+ in the 2.9 setting (due to `enum` being installed)
+    echo "pynacl < 1.5.0; python_version >= '3.6'" >> tests/unit/requirements.txt
+fi
+
 if [ "$2" == "2.10" ]; then
     sed -i -E 's/^redis($| .*)/redis < 4.1.0/g' tests/unit/requirements.txt
     sed -i -E 's/^python-gitlab($| .*)/python-gitlab < 2.10.1 ; python_version >= '\'3.6\''/g' tests/unit/requirements.txt

--- a/tests/utils/shippable/units.sh
+++ b/tests/utils/shippable/units.sh
@@ -24,7 +24,7 @@ ansible-test env --timeout "${timeout}" --color -v
 
 if [ "$2" == "2.9" ]; then
     # 1.5.0+ will not install for Python 3.6+ in the 2.9 setting (due to `enum` being installed)
-    echo "pynacl < 1.5.0; python_version >= '3.6'" >> tests/unit/requirements.txt
+    echo "pynacl >= 1.4.0, < 1.5.0; python_version >= '3.6'" >> tests/unit/requirements.txt
 fi
 
 if [ "$2" == "2.10" ]; then


### PR DESCRIPTION
##### SUMMARY
These currently fail for Python 3.6+ due to a new pynacl release (pyGithub depends on it). The problem is (again) that `enum` is installed.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
