### PR TITLE
New Module: Keycloak Default Group

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -538,6 +538,8 @@ files:
     maintainers: Gaetan2907
   $modules/identity/keycloak/keycloak_group.py:
     maintainers: adamgoossens
+  $modules/identity/keycloak/keycloak_default_group.py:
+    maintainers: fynncfchen
   $modules/identity/keycloak/keycloak_identity_provider.py:
     maintainers: laurpaum
   $modules/identity/keycloak/keycloak_realm.py:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1007,6 +1007,34 @@ class KeycloakAPI(object):
         except Exception as e:
             self.module.fail_json(msg="Unable to delete group %s: %s" % (groupid, str(e)))
 
+    def create_default_group(self, groupid, realm="master"):
+        """ Set a Keycloak group as default group under realm.
+
+        :param groupid: group ID.
+        :return: HTTPResponse object on success
+        """
+        default_group_url = URL_DEFAULTGROUP.format(url=self.baseurl, realm=realm, groupid=groupid)
+        try:
+            open_url(default_group_url, method='PUT', headers=self.restheaders,
+                     validate_certs=self.validate_certs)
+        except Exception as e:
+            self.module.fail_json(msg="Could not set default group %s in realm %s: %s"
+                                      % (groupid, realm, str(e)))
+
+    def delete_default_group(self, groupid, realm="master"):
+        """ Remove a Keycloak default group under realm.
+
+        :param groupid: group ID.
+        :return: HTTPResponse object on success
+        """
+        default_group_url = URL_DEFAULTGROUP.format(url=self.baseurl, realm=realm, groupid=groupid)
+        try:
+            open_url(default_group_url, method='DELETE', headers=self.restheaders,
+                     validate_certs=self.validate_certs)
+        except Exception as e:
+            self.module.fail_json(msg="Could not remove default group %s in realm %s: %s"
+                                      % (groupid, realm, str(e)))
+
     def get_realm_roles(self, realm='master'):
         """ Obtains role representations for roles in a realm
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -58,6 +58,8 @@ URL_CLIENTTEMPLATES = "{url}/admin/realms/{realm}/client-templates"
 URL_GROUPS = "{url}/admin/realms/{realm}/groups"
 URL_GROUP = "{url}/admin/realms/{realm}/groups/{groupid}"
 
+URL_DEFAULTGROUP = "{url}/admin/realms/{realm}/default-groups/{groupid}"
+
 URL_CLIENTSCOPES = "{url}/admin/realms/{realm}/client-scopes"
 URL_CLIENTSCOPE = "{url}/admin/realms/{realm}/client-scopes/{id}"
 URL_CLIENTSCOPE_PROTOCOLMAPPERS = "{url}/admin/realms/{realm}/client-scopes/{id}/protocol-mappers/models"

--- a/plugins/modules/identity/keycloak/keycloak_default_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_default_group.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: keycloak_default_group
+
+short_description: Allows administration of Keycloak default groups via Keycloak API
+
+description:
+    - This module allows you to add or remove Keycloak default groups via the Keycloak REST API.
+      It requires access to the REST API via OpenID Connect; the user connecting and the client being
+      used must have the requisite access rights. In a default Keycloak installation, admin-cli
+      and an admin user would work, as would a separate client definition with the scope tailored
+      to your needs and a user having the expected roles.
+
+    - The names of module options are snake_cased versions of the camelCase ones found in the
+      Keycloak API and its documentation at U(https://www.keycloak.org/docs-api/8.0/rest-api/index.html).
+
+    - Attributes are multi-valued in the Keycloak API. All attributes are lists of individual values and will
+      be returned that way by this module. You may pass single values for attributes when calling the module,
+      and this will be translated into a list suitable for the API.
+
+
+options:
+    state:
+        description:
+            - State of the group.
+            - On C(present), the default group will be added if it does not yet exist.
+            - On C(absent), the default group will be removed if it exists.
+        default: 'present'
+        type: str
+        choices:
+            - present
+            - absent
+    realm:
+        type: str
+        description:
+            - They Keycloak realm under which this group resides.
+        default: 'master'
+    id:
+        type: str
+        required: true
+        description:
+            - The unique identifier for this group.
+
+extends_documentation_fragment:
+- community.general.keycloak
+
+
+author:
+    - Fynn Chen (@fynncfchen)
+'''
+
+EXAMPLES = '''
+- name: Add a Keycloak default group, authentication with credentials
+  community.general.keycloak_group:
+    realm: MyCustomRealm
+    id: 27112a16-c847-4def-9140-2b97a1f4108a
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+  delegate_to: localhost
+
+- name: Remove a Keycloak default group, authentication with token
+  community.general.keycloak_group:
+    realm: MyCustomRealm
+    id: 27112a16-c847-4def-9140-2b97a1f4108a
+    state: absent
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    token: TOKEN
+  delegate_to: localhost
+'''
+
+RETURN = '''
+msg:
+    description: Message as to what action was taken.
+    returned: always
+    type: str
+
+end_state:
+    description: Empty.
+    returned: on success
+    type: complex
+
+default_group:
+    description: Empty
+    returned: always
+    type: complex
+'''
+
+from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import KeycloakAPI, camel, \
+    keycloak_argument_spec, get_token, KeycloakError
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """
+    Module execution
+
+    :return:
+    """
+    argument_spec = keycloak_argument_spec()
+
+    meta_args = dict(
+        state=dict(default='present', choices=['present', 'absent']),
+        realm=dict(default='master'),
+        id=dict(type='str', required=True),
+    )
+
+    argument_spec.update(meta_args)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
+                           required_together=([['auth_realm', 'auth_username', 'auth_password']]))
+
+    result = dict(changed=False, msg='', diff={}, default_group={})
+
+    # Obtain access token, initialize API
+    try:
+        connection_header = get_token(module.params)
+    except KeycloakError as e:
+        module.fail_json(msg=str(e))
+
+    kc = KeycloakAPI(module, connection_header)
+
+    realm = module.params.get('realm')
+    state = module.params.get('state')
+    gid = module.params.get('id')
+
+    if state == 'present':
+        # Add to default groups
+        kc.create_default_group(groupid=gid, realm=realm)
+        result['changed'] = True
+        result['end_state'] = {}
+        result['default_group'] = result['end_state']
+        result['msg'] = 'Group {id} has been added to default groups'.format(id=gid)
+        module.exit_json(**result)
+    else:
+        # Remove from default groups
+        kc.delete_default_group(groupid=gid, realm=realm)
+        result['changed'] = True
+        result['end_state'] = {}
+        result['default_group'] = result['end_state']
+        result['msg'] = 'Group {id} has been removed from default groups'.format(id=gid)
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/identity/keycloak/keycloak_default_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_default_group.py
@@ -10,7 +10,9 @@ DOCUMENTATION = '''
 ---
 module: keycloak_default_group
 
-short_description: Allows administration of Keycloak default groups via Keycloak API
+short_description: Administration of Keycloak default groups via Keycloak API
+
+version_added: 4.4.0
 
 description:
     - This module allows you to add or remove Keycloak default groups via the Keycloak REST API.

--- a/plugins/modules/identity/keycloak/keycloak_default_group.py
+++ b/plugins/modules/identity/keycloak/keycloak_default_group.py
@@ -91,11 +91,13 @@ end_state:
     description: Empty.
     returned: on success
     type: complex
+    contains: {}
 
 default_group:
     description: Empty
     returned: always
     type: complex
+    contains: {}
 '''
 
 from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import KeycloakAPI, camel, \

--- a/plugins/modules/keycloak_default_group.py
+++ b/plugins/modules/keycloak_default_group.py
@@ -1,0 +1,1 @@
+./identity/keycloak/keycloak_default_group.py

--- a/tests/unit/plugins/modules/identity/keycloak/test_keycloak_default_group.py
+++ b/tests/unit/plugins/modules/identity/keycloak/test_keycloak_default_group.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from contextlib import contextmanager
+
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import call, patch
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible_collections.community.general.plugins.modules.identity.keycloak import keycloak_default_group
+
+from itertools import count
+
+from ansible.module_utils.six import StringIO
+
+
+@contextmanager
+def patch_keycloak_api(create_default_group, delete_default_group=None):
+    """Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
+
+    Patches the `login` and `_post_json` methods
+
+    Keyword arguments are passed to the mock object that patches `_post_json`
+
+    No arguments are passed to the mock object that patches `login` because no tests require it
+
+    Example::
+
+        with patch_ipa(return_value={}) as (mock_login, mock_post):
+            ...
+    """
+
+    obj = keycloak_default_group.KeycloakAPI
+    with patch.object(obj, 'create_default_group', side_effect=create_default_group) as mock_create_default_group:
+        with patch.object(obj, 'delete_default_group', side_effect=delete_default_group) as mock_delete_default_group:
+            yield mock_create_default_group, mock_delete_default_group
+
+
+def get_response(object_with_future_response, method, get_id_call_count):
+    if callable(object_with_future_response):
+        return object_with_future_response()
+    if isinstance(object_with_future_response, dict):
+        return get_response(
+            object_with_future_response[method], method, get_id_call_count)
+    if isinstance(object_with_future_response, list):
+        call_number = next(get_id_call_count)
+        return get_response(
+            object_with_future_response[call_number], method, get_id_call_count)
+    return object_with_future_response
+
+
+def build_mocked_request(get_id_user_count, response_dict):
+    def _mocked_requests(*args, **kwargs):
+        url = args[0]
+        method = kwargs['method']
+        future_response = response_dict.get(url, None)
+        return get_response(future_response, method, get_id_user_count)
+    return _mocked_requests
+
+
+def create_wrapper(text_as_string):
+    """Allow to mock many times a call to one address.
+    Without this function, the StringIO is empty for the second call.
+    """
+    def _create_wrapper():
+        return StringIO(text_as_string)
+    return _create_wrapper
+
+
+def mock_good_connection():
+    token_response = {
+        'http://keycloak.url/auth/realms/master/protocol/openid-connect/token': create_wrapper('{"access_token": "alongtoken"}'), }
+    return patch(
+        'ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak.open_url',
+        side_effect=build_mocked_request(count(), token_response),
+        autospec=True
+    )
+
+
+class TestKeycloakDefaultGroup(ModuleTestCase):
+    def setUp(self):
+        super(TestKeycloakDefaultGroup, self).setUp()
+        self.module = keycloak_default_group
+
+    def test_create_default_group(self):
+        """Add a default group"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            'validate_certs': True,
+            'state': 'present',
+            'realm': 'my-realm',
+            'id': 'my-default-group',
+        }
+        return_value = [None]
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(create_default_group=return_value, delete_default_group=return_value) \
+                    as (mock_create_default_group, mock_delete_default_group):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_create_default_group.mock_calls), 1)
+        self.assertEqual(len(mock_delete_default_group.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_delete_default_group(self):
+        """Remove a default group"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            'validate_certs': True,
+            'state': 'absent',
+            'realm': 'my-realm',
+            'id': 'my-default-group',
+        }
+        return_value = [None]
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(create_default_group=return_value, delete_default_group=return_value) \
+                    as (mock_create_default_group, mock_delete_default_group):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_create_default_group.mock_calls), 0)
+        self.assertEqual(len(mock_delete_default_group.mock_calls), 1)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add `keycloak_default_group` module to provide add/remove group as default group of the realm.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`keycloak_default_group`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Run unit test:

```
ansible-test units '.*keycloak_default_group.*' --docker --verbose
```

Example:

```yaml
- name: Add a Keycloak default group, authentication with credentials
  community.general.keycloak_group:
    realm: MyCustomRealm
    id: 27112a16-c847-4def-9140-2b97a1f4108a
    state: present
    auth_client_id: admin-cli
    auth_keycloak_url: https://auth.example.com/auth
    auth_realm: master
    auth_username: USERNAME
    auth_password: PASSWORD
  delegate_to: localhost

- name: Remove a Keycloak default group, authentication with token
  community.general.keycloak_group:
    realm: MyCustomRealm
    id: 27112a16-c847-4def-9140-2b97a1f4108a
    state: absent
    auth_client_id: admin-cli
    auth_keycloak_url: https://auth.example.com/auth
    token: TOKEN
  delegate_to: localhost
```
