### PR TITLE
Fix exception in the `mail` callback plugin

### DIFF
--- a/changelogs/fragments/4026-fix-mail-callback.yml
+++ b/changelogs/fragments/4026-fix-mail-callback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mail callback plugin - fix crash on Python 3 (https://github.com/ansible-collections/community.general/issues/4025, https://github.com/ansible-collections/community.general/pull/4026).

--- a/plugins/callback/mail.py
+++ b/plugins/callback/mail.py
@@ -100,28 +100,21 @@ class CallbackModule(CallbackBase):
 
         smtp = smtplib.SMTP(self.smtphost, port=self.smtpport)
 
-        b_sender = to_bytes(self.sender)
-        b_to = to_bytes(self.to)
-        b_cc = to_bytes(self.cc)
-        b_bcc = to_bytes(self.bcc)
-        b_subject = to_bytes(subject)
-        b_body = to_bytes(body)
-
-        b_content = b'From: %s\n' % b_sender
-        b_content += b'To: %s\n' % b_to
+        content = 'From: %s\n' % self.sender
+        content += 'To: %s\n' % self.to
         if self.cc:
-            b_content += b'Cc: %s\n' % b_cc
-        b_content += b'Subject: %s\n\n' % b_subject
-        b_content += b_body
+            content += 'Cc: %s\n' % self.cc
+        content += 'Subject: %s\n\n' % subject.strip()
+        content += body
 
-        b_addresses = b_to.split(b',')
+        addresses = self.to.split(',')
         if self.cc:
-            b_addresses += b_cc.split(b',')
+            addresses += self.cc.split(',')
         if self.bcc:
-            b_addresses += b_bcc.split(b',')
+            addresses += self.bcc.split(',')
 
-        for b_address in b_addresses:
-            smtp.sendmail(b_sender, b_address, b_content)
+        for address in addresses:
+            smtp.sendmail(self.sender, address, to_bytes(content))
 
         smtp.quit()
 


### PR DESCRIPTION
##### SUMMARY

* Fixes an exception when enabling the `community.general.mail` callback plugin.
* Fixes #4025.
* ~~Add some missing standard mail headers `Date`, `Message-ID`~~ (moved to #4056).
* ~~Fixes encoding issues of non-ascii characters~~ (moved to #4061).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`community.general.mail` callback plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

