### PR TITLE
Proxmox `local` connection support.

### DIFF
--- a/changelogs/fragments/4027-proxmox-local-backend.yml
+++ b/changelogs/fragments/4027-proxmox-local-backend.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox modules - use ``local`` backend if no ``api_host`` is specified (https://github.com/ansible-collections/community.general/pull/4027).

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -15,19 +15,17 @@ options:
     description:
       - Specify the target host of the Proxmox VE cluster.
     type: str
-    required: true
   api_port:
     description:
       - Specify the target port of the Proxmox VE cluster.
       - Uses the E(PROXMOX_PORT) environment variable if not specified.
     type: int
-    required: false
     version_added: 9.1.0
   api_user:
     description:
       - Specify the user to authenticate with.
     type: str
-    required: true
+    default: root@pam
   api_password:
     description:
       - Specify the password to authenticate with.

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -741,10 +741,7 @@ def get_ansible_module():
             ("state", "present", ("clone", "ostemplate", "update"), True),
         ],
         required_together=[("api_token_id", "api_token_secret")],
-        required_one_of=[
-            ("api_password", "api_token_id"),
-            ("vmid", "hostname"),
-        ],
+        required_one_of=[("vmid", "hostname")],
         mutually_exclusive=[
             # Creating a new container is done either by cloning an existing one, or based on a template.
             ("clone", "ostemplate", "update"),

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -767,7 +767,7 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         required_together=[('api_token_id', 'api_token_secret')],
-        required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
+        required_one_of=[('name', 'vmid')],
         required_if=[
             ('create', 'forced', ['storage']),
             ('state', 'resized', ['size']),

--- a/plugins/modules/proxmox_domain_info.py
+++ b/plugins/modules/proxmox_domain_info.py
@@ -113,7 +113,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
         supports_check_mode=True
     )

--- a/plugins/modules/proxmox_group_info.py
+++ b/plugins/modules/proxmox_group_info.py
@@ -123,7 +123,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
         supports_check_mode=True
     )

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1132,14 +1132,16 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                     self.module.fail_json(msg='%s is not a valid tag' % tag)
             kwargs['tags'] = ",".join(kwargs['tags'])
 
-        # -args and skiplock require root@pam user - but can not use api tokens
-        if self.module.params['api_user'] == "root@pam" and self.module.params['args'] is not None:
-            kwargs['args'] = self.module.params['args']
-        elif self.module.params['api_user'] != "root@pam" and self.module.params['args'] is not None:
-            self.module.fail_json(msg='args parameter require root@pam user. ')
+        # -args and skiplock require root@pam user but cannot use API tokens
+        if self.module.params['api_user'] == 'root@pam':
+            if self.module.params['args'] is not None:
+                kwargs['args'] = self.module.params['args']
+        else:
+            if self.module.params['args'] is not None:
+                self.module.fail_json(msg='args parameter require root@pam user. ')
 
-        if self.module.params['api_user'] != "root@pam" and self.module.params['skiplock'] is not None:
-            self.module.fail_json(msg='skiplock parameter require root@pam user. ')
+            if self.module.params['skiplock'] is not None:
+                self.module.fail_json(msg='skiplock parameter require root@pam user. ')
 
         if update:
             if proxmox_node.qemu(vmid).config.set(name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs) is None:
@@ -1336,7 +1338,7 @@ def main():
         argument_spec=module_args,
         mutually_exclusive=[('delete', 'revert'), ('delete', 'update'), ('revert', 'update'), ('clone', 'update'), ('clone', 'delete'), ('clone', 'revert')],
         required_together=[('api_token_id', 'api_token_secret')],
-        required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
+        required_one_of=[('name', 'vmid')],
         required_if=[('state', 'present', ['node'])],
     )
 

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -922,6 +922,7 @@ msg:
   sample: "VM kropta with vmid = 110 is running"
 """
 
+import json
 import re
 import time
 from ansible.module_utils.six.moves.urllib.parse import quote
@@ -1156,6 +1157,10 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
         else:
             taskid = proxmox_node.qemu.create(vmid=vmid, name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs)
+
+            # FIXME: Workaround for https://forum.proxmox.com/threads/api-bug-pvesh-create-nodes-node-qemu-output-format-json-response-format-broken.111469/.
+            if 'errors' in taskid:
+                taskid = json.loads(taskid['errors'].splitlines()[-1])
 
         if not self.wait_for_task(node, taskid):
             self.module.fail_json(msg='Reached timeout while waiting for creating VM. Last line in task before timeout: %s' %

--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -262,7 +262,7 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         required_together=[('api_token_id', 'api_token_secret')],
-        required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
+        required_one_of=[('name', 'vmid')],
         supports_check_mode=True,
     )
 

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -123,7 +123,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
         supports_check_mode=True,
     )

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -231,11 +231,17 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 # The correct permissions are required only to reconfig mounts.
                 # Not checking now would allow to remove the configuration BUT
                 # fail later, leaving the container in a misconfigured state.
-                if (
-                    self.module.params['api_user'] != 'root@pam'
-                    or not self.module.params['api_password']
+                if not (
+                    self.module.params['api_user'] == 'root@pam' and (
+                        # Either via API and password,
+                        self.module.params['api_password'] or
+                        # or directly via local backend.
+                        not self.module.params['api_host']
+                    )
                 ):
-                    self.module.fail_json(msg='`unbind=True` requires authentication as `root@pam` with `api_password`, API tokens are not supported.')
+                    self.module.fail_json(
+                        msg='`unbind=True` requires authentication as `root@pam` with `api_password` or local backend, API tokens are not supported.'
+                    )
                     return False
                 mountpoints = self._container_mp_get(vm, vmid)
                 vmstatus = self.vmstatus(vm, vmid).current().get()['status']

--- a/plugins/modules/proxmox_storage_info.py
+++ b/plugins/modules/proxmox_storage_info.py
@@ -168,7 +168,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
         mutually_exclusive=[('storage', 'type')],
         supports_check_mode=True

--- a/plugins/modules/proxmox_tasks_info.py
+++ b/plugins/modules/proxmox_tasks_info.py
@@ -164,7 +164,6 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         required_together=[('api_token_id', 'api_token_secret')],
-        required_one_of=[('api_password', 'api_token_id')],
         supports_check_mode=True)
     result = dict(changed=False)
 

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -299,7 +299,6 @@ def main():
     module = AnsibleModule(
         argument_spec=module_args,
         required_together=[('api_token_id', 'api_token_secret'), ('checksum', 'checksum_algorithm')],
-        required_one_of=[('api_password', 'api_token_id')],
         required_if=[('state', 'absent', ['template'])],
         mutually_exclusive=[("src", "url")],
     )

--- a/plugins/modules/proxmox_user_info.py
+++ b/plugins/modules/proxmox_user_info.py
@@ -230,7 +230,6 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
         mutually_exclusive=[('user', 'userid'), ('domain', 'userid')],
         supports_check_mode=True

--- a/tests/unit/plugins/modules/test_proxmox_backup_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_info.py
@@ -17,7 +17,6 @@ from ansible_collections.community.general.plugins.modules import proxmox_backup
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
-    AnsibleFailJson,
     ModuleTestCase,
     set_module_args,
 )

--- a/tests/unit/plugins/modules/test_proxmox_backup_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_info.py
@@ -205,14 +205,6 @@ class TestProxmoxBackupInfoModule(ModuleTestCase):
         self.connect_mock.stop()
         super(TestProxmoxBackupInfoModule, self).tearDown()
 
-    def test_module_fail_when_required_args_missing(self):
-        with pytest.raises(AnsibleFailJson) as exc_info:
-            with set_module_args({}):
-                self.module.main()
-
-        result = exc_info.value.args[0]
-        assert result["msg"] == "missing required arguments: api_host, api_user"
-
     def test_get_all_backups_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
             with set_module_args({

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -450,14 +450,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
         self.connect_mock.stop()
         super(TestProxmoxVmInfoModule, self).tearDown()
 
-    def test_module_fail_when_required_args_missing(self):
-        with pytest.raises(AnsibleFailJson) as exc_info:
-            with set_module_args({}):
-                self.module.main()
-
-        result = exc_info.value.args[0]
-        assert result["msg"] == "missing required arguments: api_host, api_user"
-
     def test_get_lxc_vms_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
             with set_module_args(get_module_args(type="lxc")):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME

proxmox, proxmox_kvm, etc.
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Use the `local` backend when no credential parameters are specified  in order to use SSH instead of the HTTP API.

--

Closes https://github.com/ansible-collections/community.proxmox/issues/38.