### PR TITLE
Move Proxmox `HAS_PROXMOXER` check into `module_utils`.

### DIFF
--- a/changelogs/fragments/4030-proxmox-has-proxmoxer.yml
+++ b/changelogs/fragments/4030-proxmox-has-proxmoxer.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Move Proxmox `HAS_PROXMOXER` check into `module_utils`.

--- a/changelogs/fragments/4030-proxmox-has-proxmoxer.yml
+++ b/changelogs/fragments/4030-proxmox-has-proxmoxer.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Move Proxmox `HAS_PROXMOXER` check into `module_utils`.
+  - proxmox modules - move ``HAS_PROXMOXER`` check into ``module_utils`` (https://github.com/ansible-collections/community.general/pull/4030).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -68,6 +68,9 @@ def ansible_to_proxmox_bool(value):
 class ProxmoxAnsible(object):
     """Base class for Proxmox modules"""
     def __init__(self, module):
+        if not HAS_PROXMOXER:
+            module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
+
         self.module = module
         self.proxmox_api = self._connect()
         # Test token validity

--- a/plugins/modules/cloud/misc/proxmox_domain_info.py
+++ b/plugins/modules/cloud/misc/proxmox_domain_info.py
@@ -76,7 +76,7 @@ proxmox_domains:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+    proxmox_auth_argument_spec, ProxmoxAnsible)
 
 
 class ProxmoxDomainInfoAnsible(ProxmoxAnsible):
@@ -113,9 +113,6 @@ def main():
     result = dict(
         changed=False
     )
-
-    if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
     proxmox = ProxmoxDomainInfoAnsible(module)
     domain = module.params['domain']

--- a/plugins/modules/cloud/misc/proxmox_group_info.py
+++ b/plugins/modules/cloud/misc/proxmox_group_info.py
@@ -73,7 +73,7 @@ proxmox_groups:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+    proxmox_auth_argument_spec, ProxmoxAnsible)
 
 
 class ProxmoxGroupInfoAnsible(ProxmoxAnsible):
@@ -123,9 +123,6 @@ def main():
     result = dict(
         changed=False
     )
-
-    if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
     proxmox = ProxmoxGroupInfoAnsible(module)
     group = module.params['group']

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -197,7 +197,7 @@ def main():
     )
 
     if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib('python-proxmoxer'),
+        module.fail_json(msg=missing_required_lib('proxmoxer'),
                          exception=PROXMOXER_IMP_ERR)
 
     state = module.params['state']

--- a/plugins/modules/cloud/misc/proxmox_storage_info.py
+++ b/plugins/modules/cloud/misc/proxmox_storage_info.py
@@ -111,7 +111,7 @@ proxmox_storages:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR, proxmox_to_ansible_bool)
+    proxmox_auth_argument_spec, ProxmoxAnsible, proxmox_to_ansible_bool)
 
 
 class ProxmoxStorageInfoAnsible(ProxmoxAnsible):
@@ -169,9 +169,6 @@ def main():
     result = dict(
         changed=False
     )
-
-    if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
     proxmox = ProxmoxStorageInfoAnsible(module)
     storage = module.params['storage']

--- a/plugins/modules/cloud/misc/proxmox_tasks_info.py
+++ b/plugins/modules/cloud/misc/proxmox_tasks_info.py
@@ -116,7 +116,7 @@ msg:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+    proxmox_auth_argument_spec, ProxmoxAnsible)
 
 
 class ProxmoxTaskInfoAnsible(ProxmoxAnsible):
@@ -163,9 +163,6 @@ def main():
         supports_check_mode=True)
     result = dict(changed=False)
 
-    if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib(
-            'proxmoxer'), exception=PROXMOXER_IMP_ERR)
     proxmox = ProxmoxTaskInfoAnsible(module)
     upid = module.params['task']
     node = module.params['node']

--- a/plugins/modules/cloud/misc/proxmox_user_info.py
+++ b/plugins/modules/cloud/misc/proxmox_user_info.py
@@ -156,7 +156,7 @@ proxmox_users:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
-    proxmox_auth_argument_spec, ProxmoxAnsible, proxmox_to_ansible_bool, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+    proxmox_auth_argument_spec, ProxmoxAnsible, proxmox_to_ansible_bool)
 
 
 class ProxmoxUserInfoAnsible(ProxmoxAnsible):
@@ -231,9 +231,6 @@ def main():
     result = dict(
         changed=False
     )
-
-    if not HAS_PROXMOXER:
-        module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
     proxmox = ProxmoxUserInfoAnsible(module)
     domain = module.params['domain']

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_tasks_info.py
@@ -12,6 +12,7 @@ import pytest
 import json
 
 from ansible_collections.community.general.plugins.modules.cloud.misc import proxmox_tasks_info
+import ansible_collections.community.general.plugins.module_utils.proxmox as proxmox_utils
 from ansible_collections.community.general.plugins.module_utils.proxmox import ProxmoxAnsible
 from ansible_collections.community.general.tests.unit.compat.mock import MagicMock, patch
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import (
@@ -144,7 +145,7 @@ def test_get_tasks(connect_mock, capfd, mocker):
         return m
 
     connect_mock.side_effect = f
-    proxmox_tasks_info.HAS_PROXMOXER = True
+    proxmox_utils.HAS_PROXMOXER = True
 
     with pytest.raises(SystemExit):
         proxmox_tasks_info.main()
@@ -170,7 +171,7 @@ def test_get_single_task(connect_mock, capfd, mocker):
         return m
 
     connect_mock.side_effect = f
-    proxmox_tasks_info.HAS_PROXMOXER = True
+    proxmox_utils.HAS_PROXMOXER = True
 
     with pytest.raises(SystemExit):
         proxmox_tasks_info.main()
@@ -197,7 +198,7 @@ def test_get_non_existent_task(connect_mock, capfd, mocker):
         return m
 
     connect_mock.side_effect = f
-    proxmox_tasks_info.HAS_PROXMOXER = True
+    proxmox_utils.HAS_PROXMOXER = True
 
     with pytest.raises(SystemExit):
         proxmox_tasks_info.main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Simplify code by moving Proxmox `HAS_PROXMOXER` check into `module_utils`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Extracted from https://github.com/ansible-collections/community.general/pull/4027.