### PR TITLE
Fix and rework gitlab_project_variable

### DIFF
--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -3,7 +3,7 @@ bugfixes:
     gitlab_project_variable - allow to set same variable name under different environment scopes.
     Due this change, the return value ``project_variable`` differs from previous version in check mode.
     It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
-  - gitlab_project_variable - fix immutable change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_project_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
   - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -1,5 +1,8 @@
 bugfixes:
-  - gitlab_project_variable - allow to set same variable name under different environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
+  - >
+    gitlab_project_variable - allow to set same variable name under different environment scopes.
+    Due this change, the return value ``project_variable`` differs from previous version in check mode.
+    It was counted ``updated`` values, because it overwrites accidentally environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - fix immutable change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
   - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -4,5 +4,6 @@ bugfixes:
     Due this change, the return value ``project_variable`` differs from previous version in check mode.
     It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_project_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
   - gitlab_project_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -2,7 +2,7 @@ bugfixes:
   - >
     gitlab_project_variable - allow to set same variable name under different environment scopes.
     Due this change, the return value ``project_variable`` differs from previous version in check mode.
-    It was counted ``updated`` values, because it overwrites accidentally environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
+    It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - fix immutable change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
   - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -1,4 +1,6 @@
 bugfixes:
   - gitlab_project_variable - allow to set same variable name under different environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_project_variable - fix immutable change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
   - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_project_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - gitlab_project_variable - allow to set same variable name under different environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
+minor_changes:
+  - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).

--- a/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
+++ b/changelogs/fragments/4038-fix-and-rework-gitlb-project-variable.yml
@@ -5,5 +5,4 @@ bugfixes:
     It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
 minor_changes:
-  - gitlab_project_variable - add diff support (https://github.com/ansible-collections/community.general/issues/4038).
   - gitlab_project_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038).

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -248,8 +248,9 @@ class GitlabProjectVariables(object):
 
     def delete_variable(self, var_obj):
         if self._module.check_mode:
-            return
-        return self.project.variables.delete(var_obj.get('key'))
+            return True
+        self.project.variables.delete(var_obj.get('key'))
+        return True
 
 
 def native_python_main(this_gitlab, purge, requested_variables, state, module):
@@ -296,19 +297,19 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
 
             remove = [x for x in existing_variables if x not in requested_variables]
             for item in remove:
-                if this_gitlab.remove_variable(item):
+                if this_gitlab.delete_variable(item):
                     return_value['removed'].append(item)
 
     elif state == 'absent':
         if not purge:
             remove_requested = [x for x in requested_variables if x not in existing_variables]
             for item in remove_requested:
-                if this_gitlab.remove_variable(item):
+                if this_gitlab.delete_variable(item):
                     return_value['removed'].append(item)
 
         else:
             for item in existing_variables:
-                if this_gitlab.remove_variable(item):
+                if this_gitlab.delete_variable(item):
                     return_value['removed'].append(item)
 
     if len(return_value['added'] + return_value['removed'] + return_value['updated']) > 0:

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -57,7 +57,8 @@ options:
     type: dict
   variables:
     description:
-      - List of dicts
+      - List of dicts.
+    version_added: 4.4.0
     default: []
     type: list
     elements: dict

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -165,13 +165,6 @@ project_variable:
 '''
 
 import traceback
-
-try:
-    import yaml
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
-
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.api import basic_auth_argument_spec
@@ -408,8 +401,8 @@ def main():
         item['name'] = item.pop('key')
 
     diff = dict(
-        before=yaml.safe_dump(before),
-        after=yaml.safe_dump(after)
+        before=before,
+        after=after
     )
 
     raw_return_value['untouched'] = [x for x in before if x in after]

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -58,8 +58,8 @@ options:
   variables:
     version_added: 4.4.0
     description:
-      - A list of dictionries that represents CI/CD variables.
-      - This modules works internal with this sructure, even if the older I(vars) parameter is used.
+      - A list of dictionaries that represents CI/CD variables.
+      - This module works internal with this structure, even if the older I(vars) parameter is used.
     default: []
     type: list
     elements: dict
@@ -68,10 +68,12 @@ options:
         description:
           - The name of the variable.
         type: str
+        required: true
       value:
         description:
           - The variable value.
         type: str
+        required: true
       masked:
         description:
           - Wether variable value is masked or not.
@@ -389,7 +391,14 @@ def main():
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
-        variables=dict(type='list', elements='dict', required=False, default=list(), no_log=True),
+        variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
+            name=dict(type='str', required=True),
+            value=dict(type='str', required=True, no_log=True),
+            masked=dict(type='bool', default=False),
+            protected=dict(type='bool', default=False),
+            environment_scope=dict(type='str', default='*'),
+            variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
+        )),
         state=dict(type='str', default="present", choices=["absent", "present"]),
     )
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -79,7 +79,7 @@ options:
         description:
           - Wether variable value is protected or not.
         type: bool
-        default: true
+        default: false
       variable_type:
         description:
           - Wether a variable is an env or a file.
@@ -231,13 +231,14 @@ class GitlabProjectVariables(object):
 
     def create_variable(self, var_obj):
         if self._module.check_mode:
-            return
+            return True
         var = {
             "key": var_obj.get('key'), "value": var_obj.get('value'),
             "masked": var_obj.get('masked'), "protected": var_obj.get('protected'),
             "variable_type": var_obj.get('variable_type'), "environment_scope": var_obj.get('environment_scope')
         }
-        return self.project.variables.create(var)
+        self.project.variables.create(var)
+        return True
 
     def update_variable(self, var_obj):
         if self._module.check_mode:
@@ -269,7 +270,9 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['key'] = item.pop('name')
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
-            item['protected'] = True
+            item['protected'] = False
+            module.deprecate("The 'protected' attribute will be set to 'True' if not defined.",
+                             version='5.0.0', collection_name='community.general')
         if item.get('masked') is None:
             item['masked'] = False
         if item.get('environment_scope') is None:

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -83,7 +83,7 @@ options:
         default: false
       variable_type:
         description:
-          - Wether a variable is an env or a file.
+          - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
         type: str
         choices: ["env_var", "file"]
         default: env_var

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -283,7 +283,7 @@ def compare(requested_variables, existing_variables, state):
 
         for idx in range(len(requested_variables)):
             if requested_variables[idx] in existing_variables:
-                    untouched.append(requested_variables[idx])
+                untouched.append(requested_variables[idx])
             else:
                 compare_item = {'key': requested_variables[idx].get('name'), 'environment_scope': requested_variables[idx].get('environment_scope', '*')}
                 if compare_item in existing_key_scope_vars:

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -316,7 +316,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
             item['protected'] = False
-            module.deprecate("The 'protected' attribute will be set to 'True' if not defined.",
+            module.deprecate("The 'protected' attribute will be set to 'true' if not defined.",
                              version='5.0.0', collection_name='community.general')
         if item.get('masked') is None:
             item['masked'] = False

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -410,7 +410,7 @@ def main():
             ['api_username', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
-            ['vars', 'variables']
+            ['vars', 'variables'],
         ],
         required_together=[
             ['api_username', 'api_password'],

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -79,22 +79,26 @@ options:
       masked:
         description:
           - Wether variable value is masked or not.
+          - Support for masked values requires GitLab >= 11.10.
         type: bool
         default: false
       protected:
         description:
           - Wether variable value is protected or not.
+          - Support for protected values requires GitLab >= 9.3.
         type: bool
         default: false
       variable_type:
         description:
           - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
+          - Support for I(variable_type) requires GitLab >= 11.11.
         type: str
         choices: ["env_var", "file"]
         default: env_var
       environment_scope:
         description:
           - The scope for the variable.
+          - Support for I(environment_scope) requires GitLab Premium >= 13.11.
         type: str
         default: '*'
 '''
@@ -204,19 +208,17 @@ def vars_to_variables(vars, module):
             )
 
         elif isinstance(value, dict):
-            new_item = {"name": item, "value": value.get('value')}
 
-            if value.get('masked'):
-                new_item['masked'] = value.get('masked')
-
-            if value.get('protected'):
-                new_item['protected'] = value.get('protected')
+            new_item = {
+                "name": item,
+                "value": value.get('value'),
+                "masked": value.get('masked'),
+                "protected": value.get('protected'),
+                "variable_type": value.get('variable_type'),
+            }
 
             if value.get('environment_scope'):
                 new_item['environment_scope'] = value.get('environment_scope')
-
-            if value.get('variable_type'):
-                new_item['variable_type'] = value.get('variable_type')
 
             variables.append(new_item)
 
@@ -297,7 +299,7 @@ def compare(requested_variables, existing_variables, state):
             if var in existing_variables:
                 untouched.append(var)
             else:
-                compare_item = {'key': var.get('name'), 'environment_scope': var.get('environment_scope', '*')}
+                compare_item = {'key': var.get('name'), 'environment_scope': var.get('environment_scope')}
                 if compare_item in existing_key_scope_vars:
                     updated.append(var)
                 else:

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -448,11 +448,6 @@ def main():
         item.pop('project_id')
         item['name'] = item.pop('key')
 
-    diff = dict(
-        before=before,
-        after=after
-    )
-
     untouched_key_name = 'key'
     if not module.check_mode:
         untouched_key_name = 'name'

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -396,15 +396,15 @@ def main():
 
     this_gitlab = GitlabProjectVariables(module=module, gitlab_instance=gitlab_instance)
 
-    change, return_value, before, after = native_python_main(this_gitlab, purge, variables, state, module)
+    change, raw_return_value, before, after = native_python_main(this_gitlab, purge, variables, state, module)
 
     # postprocessing
-    for item in return_value['added']:
-        item['name'] = item.pop('key')
-    for item in return_value['removed']:
-        item['name'] = item.pop('key')
-    for item in return_value['updated']:
-        item['name'] = item.pop('key')
+    added = [x.get('key') for x in raw_return_value['added']]
+    updated = [x.get('key') for x in raw_return_value['updated']]
+    removed = [x.get('key') for x in raw_return_value['removed']]
+    untouched = [x.get('key') for x in raw_return_value['untouched']]
+    return_value = dict(added=added, updated=updated, removed=removed, untouched=untouched)
+
     for item in after:
         item.pop('project_id')
         item['name'] = item.pop('key')

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -375,7 +375,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
     if module.check_mode:
         return_value = dict(added=added, updated=updated, removed=return_value['removed'], untouched=untouched)
 
-    if len(return_value['added'] + return_value['removed'] + return_value['updated']) > 0:
+    if return_value['added'] or return_value['removed'] or return_value['updated']:
         change = True
 
     gitlab_keys = this_gitlab.list_all_project_variables()

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -302,7 +302,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
 
     elif state == 'absent':
         if not purge:
-            remove_requested = [x for x in requested_variables if x not in existing_variables]
+            remove_requested = [x for x in requested_variables if x in existing_variables]
             for item in remove_requested:
                 if this_gitlab.delete_variable(item):
                     return_value['removed'].append(item)

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -212,6 +212,8 @@ def vars_to_variables(vars, module):
             if vars.get(item).get('variable_type'):
                 new_item['variable_type'] = vars.get(item).get('variable_type')
 
+            variables.append(new_item)
+
         else:
             module.fail_json(msg="value must be of type string, integer, float or dict")
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -194,8 +194,8 @@ def vars_to_variables(vars):
     # transform old vars to new variables structure
     variables = list()
     for item in vars.keys():
-        if (isinstance(vars.get(item), str) or
-           isinstance(vars.get(item), int) or
+        if (isinstance(vars.get(item), string_types) or
+           isinstance(vars.get(item), integer_types) or
            isinstance(vars.get(item), float)):
             variables.append(
                 {

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -399,12 +399,6 @@ def main():
     change, raw_return_value, before, after = native_python_main(this_gitlab, purge, variables, state, module)
 
     # postprocessing
-    added = [x.get('key') for x in raw_return_value['added']]
-    updated = [x.get('key') for x in raw_return_value['updated']]
-    removed = [x.get('key') for x in raw_return_value['removed']]
-    untouched = [x.get('key') for x in raw_return_value['untouched']]
-    return_value = dict(added=added, updated=updated, removed=removed, untouched=untouched)
-
     for item in after:
         item.pop('project_id')
         item['name'] = item.pop('key')
@@ -412,11 +406,17 @@ def main():
         item.pop('project_id')
         item['name'] = item.pop('key')
 
-    return_value['untouched'] = [x for x in before if x in after]
     diff = dict(
         before=yaml.safe_dump(before),
         after=yaml.safe_dump(after)
     )
+
+    raw_return_value['untouched'] = [x for x in before if x in after]
+    added = [x.get('key') for x in raw_return_value['added']]
+    updated = [x.get('key') for x in raw_return_value['updated']]
+    removed = [x.get('key') for x in raw_return_value['removed']]
+    untouched = [x.get('name') for x in raw_return_value['untouched']]
+    return_value = dict(added=added, updated=updated, removed=removed, untouched=untouched)
 
     module.exit_json(changed=change, project_variable=return_value, diff=diff)
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -249,7 +249,7 @@ class GitlabProjectVariables(object):
     def delete_variable(self, var_obj):
         if self._module.check_mode:
             return True
-        self.project.variables.delete(var_obj.get('key'))
+        self.project.variables.delete(var_obj.get('key'), filter={'environment_scope': var_obj.get('environment_scope')})
         return True
 
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -324,8 +324,10 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         # key and environment scope are sufficient
         for item in existing_variables:
             item.pop('value')
+            item.pop('variable_type')
         for item in requested_variables:
             item.pop('value')
+            item.pop('variable_type')
 
         if not purge:
             remove_requested = [x for x in requested_variables if x in existing_variables]

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -614,3 +614,33 @@
       - gitlab_project_variable_state.project_variable.untouched|length == 0
       - gitlab_project_variable_state.project_variable.removed|length == 40
       - gitlab_project_variable_state.project_variable.updated|length == 0
+
+- name: same vars, diff scope
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    purge: True
+    variables:
+      - name: SECRET_ACCESS_KEY
+        value: 3214cbad
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: production
+      - name: SECRET_ACCESS_KEY
+        value: hello_world
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: development
+  register: gitlab_project_variable_state
+
+- name: verify two vars
+  assert:
+    that:
+      - gitlab_project_variable_state.changed
+      - gitlab_project_variable_state.project_variable.added|length == 2
+      - gitlab_project_variable_state.project_variable.untouched|length == 0
+      - gitlab_project_variable_state.project_variable.removed|length == 0
+      - gitlab_project_variable_state.project_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -35,8 +35,9 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     project: "{{ gitlab_project_name }}"
-    vars:
-      ACCESS_KEY_ID: checkmode
+    variables:
+      - name: ACCESS_KEY_ID
+        value: checkmode
   register: gitlab_project_variable_state
 
 - name: state must be changed
@@ -455,8 +456,8 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     project: "{{ gitlab_project_name }}"
-    vars:
-      my_test_var:
+    variables:
+      - name: my_test_var
         value: my_test_value
         variable_type: file
     purge: False

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -471,7 +471,8 @@
       - gitlab_project_variable_state.project_variable.untouched|length == 0
       - gitlab_project_variable_state.project_variable.removed|length == 0
       - gitlab_project_variable_state.project_variable.updated|length == 0
-      - gitlab_project_variable_state.project_variable.added[0] == "my_test_var"
+      # VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
+      #- gitlab_project_variable_state.project_variable.added[0] == "my_test_var"
 
 - name: change variable_type attribute
   gitlab_project_variable:


### PR DESCRIPTION
##### SUMMARY
Closes: #1952 
Closes: #4074

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
gitlab_project_variable

##### ADDITIONAL INFORMATION

First tests looks promising.

```yml
    - name: previous way. still works
      community.general.gitlab_project_variable:
        api_url: https://gitlab.com
        api_token: "{{ some_token }}"
        project: markuman/dotfiles
        purge: false
        vars:
          ACCESS_KEY_ID: abc123
          SECRET_ACCESS_KEY:
            value: 3214cbad
            masked: true
            protected: true
            variable_type: env_var
            environment_scope: '*'

    - name: new way, works also
      community.general.gitlab_project_variable:
        api_url: https://gitlab.com
        api_token: "{{ some_token }}"
        project: markuman/dotfiles
        purge: false
        variables:
          - name: ACCESS_KEY_ID
            value: abc123
          - name: SECRET_ACCESS_KEY
            value: 3214cbad
            masked: true
            protected: true
            variable_type: env_var
            environment_scope: '*'
```

What's left is

- [x] append integration test
- [x] `return_value[untouched]` is not handled
- [x] changelog fragment