### PR TITLE
Adding while loop to wait for cluster container creation

### DIFF
--- a/changelogs/fragments/4039-cluster-container-wait.yml
+++ b/changelogs/fragments/4039-cluster-container-wait.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Adds a wait period when creating clustered containers for when the task is still Running and not immediately jump to success. This would error out when the task was still running."

--- a/changelogs/fragments/4039-cluster-container-wait.yml
+++ b/changelogs/fragments/4039-cluster-container-wait.yml
@@ -1,4 +1,2 @@
 minor_changes:
-  - "lxc_container module - adds wait_for_container parameter to the lxc_container module. This is a bool true or false. If true it will wait till the running task reports success as the status. Defaults to false. Not required."
-bugfixes:
-  - "lxd inventory plugin, lxd_container module, lxd_profile module - adds a wait period (if specified in wait_for_container) when creating clustered containers for when the task is still running and not immediately jump to success. This would error out when the task was still running (https://github.com/ansible-collections/community.general/pull/4039)."
+  - "lxc_container - added ``wait_for_container`` parameter. If ``true`` the module will wait until the running task reports success as the status (https://github.com/ansible-collections/community.general/pull/4039)."

--- a/changelogs/fragments/4039-cluster-container-wait.yml
+++ b/changelogs/fragments/4039-cluster-container-wait.yml
@@ -1,2 +1,4 @@
+minor_changes:
+  - "lxc_container module - adds wait_for_container parameter to the lxc_container module. This is a bool true or false. If true it will wait till the running task reports success as the status. Defaults to false. Not required."
 bugfixes:
-  - "Adds a wait period when creating clustered containers for when the task is still Running and not immediately jump to success. This would error out when the task was still running."
+  - "lxd inventory plugin, lxd_container module, lxd_profile module - adds a wait period (if specified in wait_for_container) when creating clustered containers for when the task is still running and not immediately jump to success. This would error out when the task was still running (https://github.com/ansible-collections/community.general/pull/4039)."

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -75,13 +75,14 @@ class LXDClient(object):
         else:
             raise LXDClientException('URL scheme must be unix: or https:')
 
-    def do(self, method, url, body_json=None, ok_error_codes=None, timeout=None):
+    def do(self, method, url, body_json=None, ok_error_codes=None, timeout=None, wait_for_container=None):
         resp_json = self._send_request(method, url, body_json=body_json, ok_error_codes=ok_error_codes, timeout=timeout)
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
-            while resp_json['metadata']['status'] == 'Running':
-                resp_json = self._send_request('GET', url)
+            if wait_for_container:
+                while resp_json['metadata']['status'] == 'Running':
+                    resp_json = self._send_request('GET', url)
             if resp_json['metadata']['status'] != 'Success':
                 self._raise_err_from_json(resp_json)
         return resp_json

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -80,6 +80,8 @@ class LXDClient(object):
         if resp_json['type'] == 'async':
             url = '{0}/wait'.format(resp_json['operation'])
             resp_json = self._send_request('GET', url)
+            while resp_json['metadata']['status'] == 'Running':
+                resp_json = self._send_request('GET', url)
             if resp_json['metadata']['status'] != 'Success':
                 self._raise_err_from_json(resp_json)
         return resp_json

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -126,11 +126,11 @@ options:
         type: bool
     wait_for_container:
         description:
-            - If this is true, the tasks will wait till the task reports a
-              Success status when performing container operations
-        required: false
+            - If set to C(true), the tasks will wait till the task reports a
+              success status when performing container operations.
         default: false
         type: bool
+        version_added: 4.4.0
     force_stop:
         description:
           - If this is true, the C(lxd_container) forces to stop the instance

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -124,6 +124,13 @@ options:
         required: false
         default: false
         type: bool
+    wait_for_container:
+        description:
+            - If this is true, the tasks will wait till the task reports a
+              Success status when performing container operations
+        required: false
+        default: false
+        type: bool
     force_stop:
         description:
           - If this is true, the C(lxd_container) forces to stop the instance
@@ -414,6 +421,7 @@ class LXDContainerManagement(object):
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
         self.target = self.module.params['target']
+        self.wait_for_container = self.module.params['wait_for_container']
 
         self.type = self.module.params['type']
 
@@ -487,9 +495,9 @@ class LXDContainerManagement(object):
         config = self.config.copy()
         config['name'] = self.name
         if self.target:
-            self.client.do('POST', '{0}?{1}'.format(self.api_endpoint, urlencode(dict(target=self.target))), config)
+            self.client.do('POST', '{0}?{1}'.format(self.api_endpoint, urlencode(dict(target=self.target))), config, wait_for_container=self.wait_for_container)
         else:
-            self.client.do('POST', self.api_endpoint, config)
+            self.client.do('POST', self.api_endpoint, config, wait_for_container=self.wait_for_container)
         self.actions.append('create')
 
     def _start_instance(self):
@@ -744,6 +752,10 @@ def main():
                 type='str',
                 default='container',
                 choices=['container', 'virtual-machine'],
+            ),
+            wait_for_container=dict(
+                type='bool',
+                default=False
             ),
             wait_for_ipv4_addresses=dict(
                 type='bool',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.general/issues/3999

In a cluster scenario where the node running the Ansible creates a container on another node in the cluster, the playbook would fail because the `Status != Success` it was equal to running because the container wasn't created yet and took a bit. This will keep checking the status while it is running and then proceed once it is no longer listed as running.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxd module_util

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

If the containers are all created on the node which the Ansible is executing on, the problem will never show itself. 

See this discussion too: https://discuss.linuxcontainers.org/t/lxd-cluster-launch-command-creates-container-on-different-node-is-it-possible-to-disable-this-by-default/8389/8

Related: https://github.com/ansible/ansible/issues/53426#issuecomment-655624197

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
