### PR TITLE
opentelemetry: no_log:true causes exception when generating trace

### DIFF
--- a/changelogs/fragments/4043-fix-no-log-opentelemetry.yml
+++ b/changelogs/fragments/4043-fix-no-log-opentelemetry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opentelemetry - fix generating a trace with a task containing ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/4043).

--- a/changelogs/fragments/4043-fix-no-log-opentelemetry.yml
+++ b/changelogs/fragments/4043-fix-no-log-opentelemetry.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - opentelemetry - fix generating a trace with a task containing ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/4043).
+  - "opentelemetry - fix generating a trace with a task containing ``no_log: true`` (https://github.com/ansible-collections/community.general/pull/4043)."

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -321,7 +321,7 @@ class OpenTelemetrySource(object):
         # the order matters
         url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url")
         for arg in url_args:
-            if args.get(arg):
+            if args is not None and args.get(arg):
                 return args.get(arg)
         return ""
 


### PR DESCRIPTION
##### SUMMARY

The opentelemetry plugin crashes when generating a trace containing a task with `no_log: true` set

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`opentelemetry`

##### ADDITIONAL INFORMATION
Given the below playbook:
```paste below
---
- name: MyPlaybook
  hosts: localhost
  connection: local

  tasks:
  - name: set non secret
    set_fact:
      non_secret_var: hello

  - name: set secret
    set_fact:
      secret_var: ssshhhh
    no_log: true

```
The run produces:
![image](https://user-images.githubusercontent.com/1745970/149629712-a91ae0e8-96d2-46d8-99b0-728d8aaad69a.png)


