### PR TITLE
Actually expand ~ in yarn global install folder

### DIFF
--- a/changelogs/fragments/4048-expand-tilde-in-yarn-global-install-folder.yaml
+++ b/changelogs/fragments/4048-expand-tilde-in-yarn-global-install-folder.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - yarn - fix missing `~` expansion in yarn global install folder which resulted in incorrect task status
+  - yarn - fix missing ``~`` expansion in yarn global install folder which resulted in incorrect task status (https://github.com/ansible-collections/community.general/issues/4045, https://github.com/ansible-collections/community.general/pull/4048).

--- a/changelogs/fragments/4048-expand-tilde-in-yarn-global-install-folder.yaml
+++ b/changelogs/fragments/4048-expand-tilde-in-yarn-global-install-folder.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yarn - fix missing `~` expansion in yarn global install folder which resulted in incorrect task status

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -163,7 +163,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 class Yarn(object):
 
-    DEFAULT_GLOBAL_INSTALLATION_PATH = '~/.config/yarn/global'
+    DEFAULT_GLOBAL_INSTALLATION_PATH = os.path.expanduser('~/.config/yarn/global')
 
     def __init__(self, module, **kwargs):
         self.module = module

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -24,6 +24,7 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
+plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -23,6 +23,7 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
+plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -18,6 +18,7 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
+plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -18,6 +18,7 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
+plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -18,6 +18,7 @@ plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undo
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/packaging/language/composer.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
+plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/apt_rpm.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0
 plugins/modules/packaging/os/homebrew_cask.py validate-modules:parameter-invalid   # invalid alias - removed in 5.0.0


### PR DESCRIPTION
##### SUMMARY
As suggested [here](https://github.com/ansible-collections/community.general/issues/4045#issuecomment-1013936277), I'm making this change to fix the issue with `yarn` module ran with `global: true` always reporting its status as 'changed'

Related: #4045 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yarn

##### ADDITIONAL INFORMATION
```paste below
...
```
