### PR TITLE
Properly parse JSON Lines output from yarn

### DIFF
--- a/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
+++ b/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - yarn - fix incorrect handling of `yarn list` and `yarn global list` output that could result in fatal error
-  - yarn - fix incorrectly reported status when installing a package globally
+  - yarn - fix incorrect handling of `yarn list` and `yarn global list` output that could result in fatal error (https://github.com/ansible-collections/community.general/pull/4050).
+  - yarn - fix incorrectly reported status when installing a package globally (https://github.com/ansible-collections/community.general/issues/4045, https://github.com/ansible-collections/community.general/pull/4050).

--- a/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
+++ b/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - yarn - fix incorrect handling of `yarn list` and `yarn global list` output that could result in fatal error (https://github.com/ansible-collections/community.general/pull/4050).
+  - yarn - fix incorrect handling of ``yarn list`` and ``yarn global list`` output that could result in fatal error (https://github.com/ansible-collections/community.general/pull/4050).
   - yarn - fix incorrectly reported status when installing a package globally (https://github.com/ansible-collections/community.general/issues/4045, https://github.com/ansible-collections/community.general/pull/4050).

--- a/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
+++ b/changelogs/fragments/4050-properly-parse-json-lines-output-from-yarn.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - yarn - fix incorrect handling of `yarn list` and `yarn global list` output that could result in fatal error
+  - yarn - fix incorrectly reported status when installing a package globally

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -244,7 +244,7 @@ class Yarn(object):
         for json_line in result.strip().split('\n'):
             data = json.loads(json_line)
             if self.globally:
-                if data['type'] == 'list':
+                if data['type'] == 'list' and data['data']['type'].startswith('bins-'):
                     # This is a string in format: 'bins-<PACKAGE_NAME>'
                     installed.append(data['data']['type'][5:])
             else:

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -243,12 +243,17 @@ class Yarn(object):
 
         for json_line in result.strip().split('\n'):
             data = json.loads(json_line)
-            if data['type'] == 'tree':
-                dependencies = data['data']['trees']
+            if self.globally:
+                if data['type'] == 'list':
+                    # This is a string in format: 'bins-<PACKAGE_NAME>'
+                    installed.append(data['data']['type'][5:])
+            else:
+                if data['type'] == 'tree':
+                    dependencies = data['data']['trees']
 
-                for dep in dependencies:
-                    name, version = dep['name'].rsplit('@', 1)
-                    installed.append(name)
+                    for dep in dependencies:
+                        name, version = dep['name'].rsplit('@', 1)
+                        installed.append(name)
 
         if self.name not in installed:
             missing.append(self.name)

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -241,16 +241,14 @@ class Yarn(object):
         if error:
             self.module.fail_json(msg=error)
 
-        data = json.loads(result)
-        try:
-            dependencies = data['data']['trees']
-        except KeyError:
-            missing.append(self.name)
-            return installed, missing
+        for json_line in result.strip().split('\n'):
+            data = json.loads(json_line)
+            if data['type'] == 'tree':
+                dependencies = data['data']['trees']
 
-        for dep in dependencies:
-            name, version = dep['name'].rsplit('@', 1)
-            installed.append(name)
+                for dep in dependencies:
+                    name, version = dep['name'].rsplit('@', 1)
+                    installed.append(name)
 
         if self.name not in installed:
             missing.append(self.name)


### PR DESCRIPTION
##### SUMMARY
As [explained here](https://github.com/ansible-collections/community.general/issues/4045#issuecomment-1014585718), yarn's `--json` option returns output in a JSON Lines format and the module did not handle that properly. This fixes that.

While the issue was discovered in #4045, the issue is not necessarily limited to it (though I couldn't come up with anything that would cause it in other cases).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yarn

##### ADDITIONAL INFORMATION
This is not enough to address #4045 and #4048 is still needed to fix the lack of `~` expansion.
