### PR TITLE
Fix detection of installed cargo packages with hyphens in name

### DIFF
--- a/changelogs/fragments/4052-fix-detection-of-installed-cargo-packages-with-hyphens.yaml
+++ b/changelogs/fragments/4052-fix-detection-of-installed-cargo-packages-with-hyphens.yaml
@@ -1,2 +1,3 @@
 bugfixes:
   - cargo - fix incorrectly reported changed status for packages with a name containing a hyphen (https://github.com/ansible-collections/community.general/issues/4044, https://github.com/ansible-collections/community.general/pull/4052).
+  - cargo - fix detection of outdated packages when ``state=latest`` (https://github.com/ansible-collections/community.general/pull/4052).

--- a/changelogs/fragments/4052-fix-detection-of-installed-cargo-packages-with-hyphens.yaml
+++ b/changelogs/fragments/4052-fix-detection-of-installed-cargo-packages-with-hyphens.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cargo - fix incorrectly reported changed status for packages with a name containing a hyphen (https://github.com/ansible-collections/community.general/issues/4044, https://github.com/ansible-collections/community.general/pull/4052).

--- a/plugins/modules/packaging/language/cargo.py
+++ b/plugins/modules/packaging/language/cargo.py
@@ -112,7 +112,7 @@ class Cargo(object):
         cmd = ["install", "--list"]
         data, dummy = self._exec(cmd, True, False, False)
 
-        package_regex = re.compile(r"^(\w+) v(.+):$")
+        package_regex = re.compile(r"^([\w\-]+) v(.+):$")
         installed = {}
         for line in data.splitlines():
             package_info = package_regex.match(line)

--- a/plugins/modules/packaging/language/cargo.py
+++ b/plugins/modules/packaging/language/cargo.py
@@ -136,7 +136,7 @@ class Cargo(object):
         installed_version = self.get_installed().get(name)
 
         cmd = ["search", name, "--limit", "1"]
-        data = self._exec(cmd, True, False, False)
+        data, dummy = self._exec(cmd, True, False, False)
 
         match = re.search(r'"(.+)"', data)
         if match:

--- a/plugins/modules/packaging/language/cargo.py
+++ b/plugins/modules/packaging/language/cargo.py
@@ -140,7 +140,7 @@ class Cargo(object):
 
         match = re.search(r'"(.+)"', data)
         if match:
-            latest_version = match[1]
+            latest_version = match.group(1)
 
         return installed_version != latest_version
 

--- a/tests/integration/targets/cargo/tasks/test_version.yml
+++ b/tests/integration/targets/cargo/tasks/test_version.yml
@@ -5,11 +5,23 @@
     version: 0.1.0
   register: install_helloworld_010
 
+- name: Install application helloworld-yliu 0.1.0 (idempotent)
+  community.general.cargo:
+    name: helloworld-yliu
+    version: 0.1.0
+  register: install_helloworld_010_idem
+
 - name: Upgrade helloworld-yliu 0.1.0
   community.general.cargo:
     name: helloworld-yliu
     state: latest
   register: upgrade_helloworld_010
+
+- name: Upgrade helloworld-yliu 0.1.0 (idempotent)
+  community.general.cargo:
+    name: helloworld-yliu
+    state: latest
+  register: upgrade_helloworld_010_idem
 
 - name: Downgrade helloworld-yliu 0.1.0
   community.general.cargo:
@@ -17,9 +29,18 @@
     version: 0.1.0
   register: downgrade_helloworld_010
 
-- name: Check assertions helloworld-yliu 0.1.0
+- name: Downgrade helloworld-yliu 0.1.0 (idempotent)
+  community.general.cargo:
+    name: helloworld-yliu
+    version: 0.1.0
+  register: downgrade_helloworld_010_idem
+
+- name: Check assertions helloworld-yliu
   assert:
     that:
         - install_helloworld_010 is changed
+        - install_helloworld_010_idem is not changed
         - upgrade_helloworld_010 is changed
+        - upgrade_helloworld_010_idem is not changed
         - downgrade_helloworld_010 is changed
+        - downgrade_helloworld_010_idem is not changed


### PR DESCRIPTION
##### SUMMARY
Per [the suggestion here](https://github.com/ansible-collections/community.general/issues/4044#issuecomment-1013936673), I included `-` in the character set detected by the regex and it in fact fixes the issue. I've also double-checked that this will cover the full character set and it is the case.

Fixes #4044 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cargo

##### ADDITIONAL INFORMATION
Output before the change can be found in #4044.

Output after the change:
```paste below
$ ansible-playbook example_playbook.yaml
ansible-playbook [core 2.12.1]
  config file = None
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ans/lib/python3.8/site-packages/ansible
  ansible collection location = /home/ubuntu/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/ubuntu/ans/bin/ansible-playbook
  python version = 3.8.5 (default, Jan 27 2021, 15:41:15) [GCC 9.3.0]
  jinja version = 3.0.3
  libyaml = True
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
Loading collection community.general from /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general
Loading callback plugin default of type stdout, v2.0 from /home/ubuntu/ans/lib/python3.8/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: example_playbook.yaml ************************************************
Positional arguments: example_playbook.yaml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('all',)
inventory: ('/etc/ansible/hosts',)
forks: 5
1 plays in example_playbook.yaml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/ubuntu/example_playbook.yaml:1
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710 `" && echo ansible-tmp-1642444760.0748374-431-6785503882710="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible/modules/setup.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-425houd_b4a/tmp5l9uv3ob TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710/AnsiballZ_setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642444760.0748374-431-6785503882710/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [community.general.cargo] *************************************************
task path: /home/ubuntu/example_playbook.yaml:4
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581 `" && echo ansible-tmp-1642444762.2701924-549-171960837065581="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general/plugins/modules/cargo.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-425houd_b4a/tmp0dgp5dud TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581/AnsiballZ_cargo.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642444762.2701924-549-171960837065581/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "name": [
                "git-interactive-rebase-tool"
            ],
            "path": null,
            "state": "present",
            "version": null
        }
    },
    "stderr": "    Updating crates.io index\n  Installing git-interactive-rebase-tool v2.1.0\n   Compiling libc v0.2.112\n   Compiling cfg-if v1.0.0\n   Compiling autocfg v1.0.1\n   Compiling pkg-config v0.3.24\n   Compiling log v0.4.14\n   Compiling tinyvec_macros v0.1.0\n   Compiling matches v0.1.9\n   Compiling parking_lot_core v0.8.5\n   Compiling arrayvec v0.4.12\n   Compiling bitflags v1.3.2\n   Compiling percent-encoding v2.1.0\n   Compiling unicode-bidi v0.3.7\n   Compiling smallvec v1.8.0\n   Compiling scopeguard v1.1.0\n   Compiling unicode-width v0.1.9\n   Compiling nodrop v0.1.14\n   Compiling anyhow v1.0.52\n   Compiling lazy_static v1.4.0\n   Compiling vec_map v0.8.2\n   Compiling ansi_term v0.12.1\n   Compiling strsim v0.8.0\n   Compiling itoa v0.4.8\n   Compiling xi-unicode v0.3.0\n   Compiling unicode-segmentation v1.8.0\n   Compiling instant v0.1.12\n   Compiling num-traits v0.2.14\n   Compiling num-integer v0.1.44\n   Compiling tinyvec v1.5.1\n   Compiling form_urlencoded v1.0.1\n   Compiling lock_api v0.4.5\n   Compiling textwrap v0.11.0\n   Compiling unicode-normalization v0.1.19\n   Compiling num-format v0.4.0\n   Compiling jobserver v0.1.24\n   Compiling signal-hook-registry v1.4.0\n   Compiling mio v0.7.14\n   Compiling time v0.1.44\n   Compiling atty v0.2.14\n   Compiling cc v1.0.72\n   Compiling idna v0.2.3\n   Compiling parking_lot v0.11.2\n   Compiling signal-hook v0.1.17\n   Compiling clap v2.34.0\n   Compiling chrono v0.4.19\n   Compiling url v2.2.2\n   Compiling crossterm v0.19.0\n   Compiling libz-sys v1.1.3\n   Compiling libgit2-sys v0.12.26+1.3.0\n   Compiling git2 v0.13.25\n   Compiling git-interactive-rebase-tool v2.1.0\n    Finished release [optimized] target(s) in 1m 52s\n  Installing /home/ubuntu/.cargo/bin/interactive-rebase-tool\n   Installed package `git-interactive-rebase-tool v2.1.0` (executable `interactive-rebase-tool`)\n",
    "stderr_lines": [
        "    Updating crates.io index",
        "  Installing git-interactive-rebase-tool v2.1.0",
        "   Compiling libc v0.2.112",
        "   Compiling cfg-if v1.0.0",
        "   Compiling autocfg v1.0.1",
        "   Compiling pkg-config v0.3.24",
        "   Compiling log v0.4.14",
        "   Compiling tinyvec_macros v0.1.0",
        "   Compiling matches v0.1.9",
        "   Compiling parking_lot_core v0.8.5",
        "   Compiling arrayvec v0.4.12",
        "   Compiling bitflags v1.3.2",
        "   Compiling percent-encoding v2.1.0",
        "   Compiling unicode-bidi v0.3.7",
        "   Compiling smallvec v1.8.0",
        "   Compiling scopeguard v1.1.0",
        "   Compiling unicode-width v0.1.9",
        "   Compiling nodrop v0.1.14",
        "   Compiling anyhow v1.0.52",
        "   Compiling lazy_static v1.4.0",
        "   Compiling vec_map v0.8.2",
        "   Compiling ansi_term v0.12.1",
        "   Compiling strsim v0.8.0",
        "   Compiling itoa v0.4.8",
        "   Compiling xi-unicode v0.3.0",
        "   Compiling unicode-segmentation v1.8.0",
        "   Compiling instant v0.1.12",
        "   Compiling num-traits v0.2.14",
        "   Compiling num-integer v0.1.44",
        "   Compiling tinyvec v1.5.1",
        "   Compiling form_urlencoded v1.0.1",
        "   Compiling lock_api v0.4.5",
        "   Compiling textwrap v0.11.0",
        "   Compiling unicode-normalization v0.1.19",
        "   Compiling num-format v0.4.0",
        "   Compiling jobserver v0.1.24",
        "   Compiling signal-hook-registry v1.4.0",
        "   Compiling mio v0.7.14",
        "   Compiling time v0.1.44",
        "   Compiling atty v0.2.14",
        "   Compiling cc v1.0.72",
        "   Compiling idna v0.2.3",
        "   Compiling parking_lot v0.11.2",
        "   Compiling signal-hook v0.1.17",
        "   Compiling clap v2.34.0",
        "   Compiling chrono v0.4.19",
        "   Compiling url v2.2.2",
        "   Compiling crossterm v0.19.0",
        "   Compiling libz-sys v1.1.3",
        "   Compiling libgit2-sys v0.12.26+1.3.0",
        "   Compiling git2 v0.13.25",
        "   Compiling git-interactive-rebase-tool v2.1.0",
        "    Finished release [optimized] target(s) in 1m 52s",
        "  Installing /home/ubuntu/.cargo/bin/interactive-rebase-tool",
        "   Installed package `git-interactive-rebase-tool v2.1.0` (executable `interactive-rebase-tool`)"
    ],
    "stdout": "",
    "stdout_lines": []
}

TASK [community.general.cargo] *************************************************
task path: /home/ubuntu/example_playbook.yaml:7
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819 `" && echo ansible-tmp-1642444875.5450938-3159-270875935772819="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general/plugins/modules/cargo.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-425houd_b4a/tmp18m3kgr0 TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819/AnsiballZ_cargo.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642444875.5450938-3159-270875935772819/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "name": [
                "exa"
            ],
            "path": null,
            "state": "present",
            "version": null
        }
    },
    "stderr": "    Updating crates.io index\n  Installing exa v0.10.1\n   Compiling libc v0.2.112\n   Compiling pkg-config v0.3.24\n   Compiling unicode-width v0.1.9\n   Compiling tinyvec_macros v0.1.0\n   Compiling matches v0.1.9\n   Compiling log v0.4.14\n   Compiling unicode-bidi v0.3.7\n   Compiling cfg-if v1.0.0\n   Compiling percent-encoding v2.1.0\n   Compiling byteorder v1.4.3\n   Compiling bitflags v1.3.2\n   Compiling lazy_static v1.4.0\n   Compiling natord v1.0.9\n   Compiling ansi_term v0.12.1\n   Compiling glob v0.3.0\n   Compiling scoped_threadpool v0.1.9\n   Compiling number_prefix v0.4.0\n   Compiling tinyvec v1.5.1\n   Compiling pad v0.1.6\n   Compiling term_grid v0.1.7\n   Compiling form_urlencoded v1.0.1\n   Compiling unicode-normalization v0.1.19\n   Compiling jobserver v0.1.24\n   Compiling locale v0.2.2\n   Compiling term_size v0.3.2\n   Compiling num_cpus v1.13.1\n   Compiling users v0.11.0\n   Compiling cc v1.0.72\n   Compiling idna v0.2.3\n   Compiling datetime v0.5.2\n   Compiling url v2.2.2\n   Compiling zoneinfo_compiled v0.5.1\n   Compiling exa v0.10.1\n   Compiling libz-sys v1.1.3\n   Compiling libgit2-sys v0.12.26+1.3.0\n   Compiling git2 v0.13.25\n    Finished release [optimized] target(s) in 1m 32s\n  Installing /home/ubuntu/.cargo/bin/exa\n   Installed package `exa v0.10.1` (executable `exa`)\n",
    "stderr_lines": [
        "    Updating crates.io index",
        "  Installing exa v0.10.1",
        "   Compiling libc v0.2.112",
        "   Compiling pkg-config v0.3.24",
        "   Compiling unicode-width v0.1.9",
        "   Compiling tinyvec_macros v0.1.0",
        "   Compiling matches v0.1.9",
        "   Compiling log v0.4.14",
        "   Compiling unicode-bidi v0.3.7",
        "   Compiling cfg-if v1.0.0",
        "   Compiling percent-encoding v2.1.0",
        "   Compiling byteorder v1.4.3",
        "   Compiling bitflags v1.3.2",
        "   Compiling lazy_static v1.4.0",
        "   Compiling natord v1.0.9",
        "   Compiling ansi_term v0.12.1",
        "   Compiling glob v0.3.0",
        "   Compiling scoped_threadpool v0.1.9",
        "   Compiling number_prefix v0.4.0",
        "   Compiling tinyvec v1.5.1",
        "   Compiling pad v0.1.6",
        "   Compiling term_grid v0.1.7",
        "   Compiling form_urlencoded v1.0.1",
        "   Compiling unicode-normalization v0.1.19",
        "   Compiling jobserver v0.1.24",
        "   Compiling locale v0.2.2",
        "   Compiling term_size v0.3.2",
        "   Compiling num_cpus v1.13.1",
        "   Compiling users v0.11.0",
        "   Compiling cc v1.0.72",
        "   Compiling idna v0.2.3",
        "   Compiling datetime v0.5.2",
        "   Compiling url v2.2.2",
        "   Compiling zoneinfo_compiled v0.5.1",
        "   Compiling exa v0.10.1",
        "   Compiling libz-sys v1.1.3",
        "   Compiling libgit2-sys v0.12.26+1.3.0",
        "   Compiling git2 v0.13.25",
        "    Finished release [optimized] target(s) in 1m 32s",
        "  Installing /home/ubuntu/.cargo/bin/exa",
        "   Installed package `exa v0.10.1` (executable `exa`)"
    ],
    "stdout": "",
    "stdout_lines": []
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


$ ansible-playbook example_playbook.yaml
ansible-playbook [core 2.12.1]
  config file = None
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ans/lib/python3.8/site-packages/ansible
  ansible collection location = /home/ubuntu/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/ubuntu/ans/bin/ansible-playbook
  python version = 3.8.5 (default, Jan 27 2021, 15:41:15) [GCC 9.3.0]
  jinja version = 3.0.3
  libyaml = True
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
Loading collection community.general from /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general
Loading callback plugin default of type stdout, v2.0 from /home/ubuntu/ans/lib/python3.8/site-packages/ansible/plugins/callback/default.py
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: example_playbook.yaml ************************************************
Positional arguments: example_playbook.yaml
verbosity: 4
connection: smart
timeout: 10
become_method: sudo
tags: ('all',)
inventory: ('/etc/ansible/hosts',)
forks: 5
1 plays in example_playbook.yaml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/ubuntu/example_playbook.yaml:1
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488 `" && echo ansible-tmp-1642445006.7256258-5766-215880989514488="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible/modules/setup.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-5757qc_3misj/tmp478duw7l TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488/AnsiballZ_setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642445006.7256258-5766-215880989514488/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [community.general.cargo] *************************************************
task path: /home/ubuntu/example_playbook.yaml:4
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598 `" && echo ansible-tmp-1642445009.07285-5906-29746697006598="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general/plugins/modules/cargo.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-5757qc_3misj/tmp80vlkx1p TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598/AnsiballZ_cargo.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.07285-5906-29746697006598/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "name": [
                "git-interactive-rebase-tool"
            ],
            "path": null,
            "state": "present",
            "version": null
        }
    },
    "stderr": null,
    "stderr_lines": [],
    "stdout": null,
    "stdout_lines": []
}

TASK [community.general.cargo] *************************************************
task path: /home/ubuntu/example_playbook.yaml:7
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<127.0.0.1> EXEC /bin/sh -c 'echo ~ubuntu && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/ubuntu/.ansible/tmp `"&& mkdir "` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783 `" && echo ansible-tmp-1642445009.479031-5933-75669393458783="` echo /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783 `" ) && sleep 0'
Using module file /home/ubuntu/ans/lib/python3.8/site-packages/ansible_collections/community/general/plugins/modules/cargo.py
<127.0.0.1> PUT /home/ubuntu/.ansible/tmp/ansible-local-5757qc_3misj/tmp0pp9yver TO /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783/AnsiballZ_cargo.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783/ /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/ubuntu/ans/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783/AnsiballZ_cargo.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1642445009.479031-5933-75669393458783/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "name": [
                "exa"
            ],
            "path": null,
            "state": "present",
            "version": null
        }
    },
    "stderr": null,
    "stderr_lines": [],
    "stdout": null,
    "stdout_lines": []
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
