### PR TITLE
`mail`: add `Date` and `Message-ID` headers

### DIFF
--- a/changelogs/fragments/4056-add-missing-mail-headers.yml
+++ b/changelogs/fragments/4056-add-missing-mail-headers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mail callback plugin - add ``Message-ID`` and ``Date`` headers (https://github.com/ansible-collections/community.general/issues/4055, https://github.com/ansible-collections/community.general/pull/4056).

--- a/plugins/callback/mail.py
+++ b/plugins/callback/mail.py
@@ -59,6 +59,7 @@ notes:
 import json
 import os
 import re
+import email.utils
 import smtplib
 
 from ansible.module_utils.six import string_types
@@ -100,10 +101,12 @@ class CallbackModule(CallbackBase):
 
         smtp = smtplib.SMTP(self.smtphost, port=self.smtpport)
 
-        content = 'From: %s\n' % self.sender
+        content = 'Date: %s\n' % email.utils.formatdate()
+        content += 'From: %s\n' % self.sender
         content += 'To: %s\n' % self.to
         if self.cc:
             content += 'Cc: %s\n' % self.cc
+        content += 'Message-ID: %s\n' % email.utils.make_msgid()
         content += 'Subject: %s\n\n' % subject.strip()
         content += body
 


### PR DESCRIPTION
##### SUMMARY

* Fixes #4055
* Adds the [mandatory `Date:` email header](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.1)
* Adds the [recommended `Message-ID:` email header](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.4)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`community.general.mail` callback plugin

##### ADDITIONAL INFORMATION

~~This PR will conflict with #4026 and will need to be re-written once #4026 will be merged.~~ PR rebased