### PR TITLE
`mail`: fix the encoding of the mail senders and recipients name

### DIFF
--- a/changelogs/fragments/4061-fix-mail-recipient-encoding.yml
+++ b/changelogs/fragments/4061-fix-mail-recipient-encoding.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mail callback plugin - fix encoding of the name of sender and recipient (https://github.com/ansible-collections/community.general/issues/4060, https://github.com/ansible-collections/community.general/pull/4061).


### PR DESCRIPTION
##### SUMMARY

* Fixes #4060 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`community.general.mail` callback plugin

##### ADDITIONAL INFORMATION

This PR will conflict with #4026 and will need to be re-written once #4026 will be merged.