### PR TITLE
Rework of gitlab_project_variable over gitlab_group_variable

### DIFF
--- a/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
+++ b/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
@@ -2,8 +2,8 @@ bugfixes:
   - >
     gitlab_group_variable - allow to set same variable name under different environment scopes.
     Due this change, the return value ``group_variable`` differs from previous version in check mode.
-    It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
-  - gitlab_group_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
-  - gitlab_group_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/issues/4038).
+    It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/pull/4038).
+  - gitlab_group_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/pull/4038).
+  - gitlab_group_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/pull/4038).
 minor_changes:
-  - gitlab_group_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038 and https://github.com/ansible-collections/community.general/issues/4074).
+  - gitlab_group_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/pull/4038 and https://github.com/ansible-collections/community.general/issues/4074).

--- a/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
+++ b/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
@@ -1,0 +1,9 @@
+bugfixes:
+  - >
+    gitlab_group_variable - allow to set same variable name under different environment scopes.
+    Due this change, the return value ``group_variable`` differs from previous version in check mode.
+    It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_group_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/issues/4038).
+  - gitlab_group_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/issues/4038).
+minor_changes:
+  - gitlab_group_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/issues/4038 and https://github.com/ansible-collections/community.general/issues/4074).

--- a/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
+++ b/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
@@ -5,6 +5,5 @@ bugfixes:
     It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/pull/4038).
   - gitlab_group_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/pull/4038).
   - gitlab_group_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/pull/4038).
-  - gitlab_group_variable - ``value`` is not necessary when deleting variables (https://github.com/ansible-collections/community.general/pull/4150).
 minor_changes:
   - gitlab_group_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/pull/4038 and https://github.com/ansible-collections/community.general/issues/4074).

--- a/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
+++ b/changelogs/fragments/4086-rework_of_gitlab_proyect_variable_over_gitlab_group_variable.yml
@@ -5,5 +5,6 @@ bugfixes:
     It was counting ``updated`` values, because it was accidentally overwriting environment scopes (https://github.com/ansible-collections/community.general/pull/4038).
   - gitlab_group_variable - fix idempotent change behaviour for float and integer variables (https://github.com/ansible-collections/community.general/pull/4038).
   - gitlab_group_variable - add missing documentation about GitLab versions that support ``environment_scope`` and ``variable_type`` (https://github.com/ansible-collections/community.general/pull/4038).
+  - gitlab_group_variable - ``value`` is not necessary when deleting variables (https://github.com/ansible-collections/community.general/pull/4150).
 minor_changes:
   - gitlab_group_variable - new ``variables`` parameter (https://github.com/ansible-collections/community.general/pull/4038 and https://github.com/ansible-collections/community.general/issues/4074).

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -56,6 +56,44 @@ options:
         See GitLab documentation on acceptable values for a masked variable (U(https://docs.gitlab.com/ce/ci/variables/#masked-variables)).
     default: {}
     type: dict
+    variables:
+      version_added: 4.4.0
+      description:
+        - A list of dictionaries that represents CI/CD variables.
+        - This modules works internal with this sructure, even if the older I(vars) parameter is used.
+      default: []
+      type: list
+      elements: dict
+      suboptions:
+        name:
+          description:
+            - The name of the variable
+          type: str
+        value:
+          description:
+            - The variable value
+          type: str
+        masked:
+          description:
+            - Wether variable value is masked or not.
+          type: bool
+          default: false
+        protected:
+          description:
+            - Wether variable value is protected or not.
+          type: bool
+          default: false
+        variable_type:
+          description:
+            - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
+          type: str
+          choices: [ "env_var", "file" ]
+          default: env_var
+        environment_scope:
+          description:
+            - The scope for the variable.
+          type: str
+          default: '*'
 notes:
 - Supports I(check_mode).
 '''
@@ -68,9 +106,15 @@ EXAMPLES = r'''
     api_token: secret_access_token
     group: scodeman/testgroup/
     purge: false
-    vars:
-      ACCESS_KEY_ID: abc123
-      SECRET_ACCESS_KEY: 321cba
+    variables:
+      - name: ACCESS_KEY_ID
+        value: abc123
+      - name: SECRET_ACCESS_KEY
+        value: 3214cbad
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: production
 
 - name: Set or update some CI/CD variables
   community.general.gitlab_group_variable:
@@ -80,11 +124,12 @@ EXAMPLES = r'''
     purge: false
     vars:
       ACCESS_KEY_ID: abc123
-      SECRET_ACCESS_KEY:
+      SECRET_ACCESS_KEY: 321cba
         value: 3214cbad
         masked: true
         protected: true
         variable_type: env_var
+        environment_scope: '*'
 
 - name: Delete one variable
   community.general.gitlab_group_variable:
@@ -125,12 +170,10 @@ group_variable:
 '''
 
 import traceback
-
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six import integer_types
-
 
 GITLAB_IMP_ERR = None
 try:
@@ -142,6 +185,40 @@ except Exception:
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
+def vars_to_variables(vars, module):
+    # transform old vars to new variables structure
+    variables = list()
+    for item in vars.keys():
+        if (isinstance(vars.get(item), string_types) or
+           isinstance(vars.get(item), (integer_types, float))):
+            variables.append(
+                {
+                    "name": item,
+                    "value": str(vars.get(item))
+                }
+            )
+
+        elif isinstance(vars.get(item), dict):
+            new_item = {"name": item, "value": vars.get(item).get('value')}
+
+            if vars.get(item).get('masked'):
+                new_item['masked'] = vars.get(item).get('masked')
+
+            if vars.get(item).get('protected'):
+                new_item['protected'] = vars.get(item).get('protected')
+
+            if vars.get(item).get('environment_scope'):
+                new_item['environment_scope'] = vars.get(item).get('environment_scope')
+
+            if vars.get(item).get('variable_type'):
+                new_item['variable_type'] = vars.get(item).get('variable_type')
+
+            variables.append(new_item)
+
+        else:
+            module.fail_json(msg="value must be of type string, integer, float or dict")
+
+    return variables
 
 class GitlabGroupVariables(object):
 
@@ -163,104 +240,145 @@ class GitlabGroupVariables(object):
             vars_page = self.group.variables.list(page=page_nb)
         return variables
 
-    def create_variable(self, key, value, masked, protected, variable_type):
-        if self._module.check_mode:
-            return
-        return self.group.variables.create({
-            "key": key,
-            "value": value,
-            "masked": masked,
-            "protected": protected,
-            "variable_type": variable_type,
-        })
-
-    def update_variable(self, key, var, value, masked, protected, variable_type):
-        if var.value == value and var.protected == protected and var.masked == masked and var.variable_type == variable_type:
-            return False
-
+    def create_variable(self, var_obj):
         if self._module.check_mode:
             return True
-
-        if var.protected == protected and var.masked == masked and var.variable_type == variable_type:
-            var.value = value
-            var.save()
-            return True
-
-        self.delete_variable(key)
-        self.create_variable(key, value, masked, protected, variable_type)
+        var = {
+            "key": var_obj.get('key'), "value": var_obj.get('value'),
+            "masked": var_obj.get('masked'), "protected": var_obj.get('protected'),
+            "variable_type": var_obj.get('variable_type'), "environment_scope": var_obj.get('environment_scope')
+        }
+        self.group.variables.create(var)
         return True
 
-    def delete_variable(self, key):
+    def update_variable(self, var_obj):
         if self._module.check_mode:
-            return
-        return self.group.variables.delete(key)
+            return True
+        self.delete_variable(var_obj)
+        self.create_variable(var_obj)
+        return True
 
+    def delete_variable(self, var_obj):
+        if self._module.check_mode:
+            return True
+        self.group.variables.delete(var_obj.get('key'), filter={'environment_scope': var_obj.get('environment_scope')})
+        return True
 
-def native_python_main(this_gitlab, purge, var_list, state, module):
+def compare(requested_variables, existing_variables, state):
+    # we need to do this, because it was determined in a previous version - more or less buggy
+    # basically it is not necessary and might results in more/other bugs!
+    # but it is required  and only relevant for check mode!!
+    # logic represents state 'present' when not purge. all other can be derived from that
+    # untouched => equal in both
+    # updated => name and scope are equal
+    # added => name and scope does not exist
+    untouched = list()
+    updated = list()
+    added = list()
+
+    if state == 'present':
+        existing_key_scope_vars = list()
+        for item in existing_variables:
+            existing_key_scope_vars.append({'key': item.get('key'), 'environment_scope': item.get('environment_scope')})
+
+        for idx in range(len(requested_variables)):
+            if requested_variables[idx] in existing_variables:
+                untouched.append(requested_variables[idx])
+            else:
+                compare_item = {'key': requested_variables[idx].get('name'), 'environment_scope': requested_variables[idx].get('environment_scope', '*')}
+                if compare_item in existing_key_scope_vars:
+                    updated.append(requested_variables[idx])
+                else:
+                    added.append(requested_variables[idx])
+
+    return untouched, updated, added
+
+def native_python_main(this_gitlab, purge, requested_variables, state, module):
 
     change = False
     return_value = dict(added=list(), updated=list(), removed=list(), untouched=list())
 
     gitlab_keys = this_gitlab.list_all_group_variables()
-    existing_variables = [x.get_id() for x in gitlab_keys]
+    before = [x.attributes for x in gitlab_keys]
 
-    for key in var_list:
-        if not isinstance(var_list[key], (string_types, integer_types, float, dict)):
-            module.fail_json(msg="Value of %s variable must be of type string, integer, float or dict, passed %s" % (key, var_list[key].__class__.__name__))
+    gitlab_keys = this_gitlab.list_all_group_variables()
+    existing_variables = [x.attributes for x in gitlab_keys]
 
-    for key in var_list:
+    # preprocessing:filter out and enrich before compare
+    for item in existing_variables:
+        item.pop('group_id')
 
-        if isinstance(var_list[key], (string_types, integer_types, float)):
-            value = var_list[key]
-            masked = False
-            protected = False
-            variable_type = 'env_var'
-        elif isinstance(var_list[key], dict):
-            value = var_list[key].get('value')
-            masked = var_list[key].get('masked', False)
-            protected = var_list[key].get('protected', False)
-            variable_type = var_list[key].get('variable_type', 'env_var')
+    for item in requested_variables:
+        item['key'] = item.pop('name')
+        item['value'] = str(item.get('value'))
+        if item.get('protected') is None:
+            item['protected'] = False
+            module.deprecate("The 'protected' attribute will be set to 'True' if not defined.",
+                             version='5.0.0', collection_name='community.general')
+        if item.get('masked') is None:
+            item['masked'] = False
+        if item.get('environment_scope') is None:
+            item['environment_scope'] = '*'
+        if item.get('variable_type') is None:
+            item['variable_type'] = 'env_var'
 
-        if key in existing_variables:
-            index = existing_variables.index(key)
-            existing_variables[index] = None
+    if module.check_mode:
+        untouched, updated, added = compare(requested_variables, existing_variables, state)
 
-            if state == 'present':
-                single_change = this_gitlab.update_variable(
-                    key,
-                    gitlab_keys[index],
-                    value,
-                    masked,
-                    protected,
-                    variable_type,
-                )
-                change = single_change or change
-                if single_change:
-                    return_value['updated'].append(key)
-                else:
-                    return_value['untouched'].append(key)
+    if state == 'present':
+        add_or_update = [x for x in requested_variables if x not in existing_variables]
+        for item in add_or_update:
+            try:
+                if this_gitlab.create_variable(item):
+                    return_value['added'].append(item)
 
-            elif state == 'absent':
-                this_gitlab.delete_variable(key)
-                change = True
-                return_value['removed'].append(key)
+            except Exception:
+                if this_gitlab.update_variable(item):
+                    return_value['updated'].append(item)
 
-        elif key not in existing_variables and state == 'present':
-            this_gitlab.create_variable(key, value, masked, protected, variable_type)
-            change = True
-            return_value['added'].append(key)
+        if purge:
+            # refetch and filter
+            gitlab_keys = this_gitlab.list_all_group_variables()
+            existing_variables = [x.attributes for x in gitlab_keys]
+            for item in existing_variables:
+                item.pop('group_id')
 
-    existing_variables = list(filter(None, existing_variables))
-    if purge:
+            remove = [x for x in existing_variables if x not in requested_variables]
+            for item in remove:
+                if this_gitlab.delete_variable(item):
+                    return_value['removed'].append(item)
+
+    elif state == 'absent':
+        # value does not matter on removing variables.
+        # key and environment scope are sufficient
         for item in existing_variables:
-            this_gitlab.delete_variable(item)
-            change = True
-            return_value['removed'].append(item)
-    else:
-        return_value['untouched'].extend(existing_variables)
+            item.pop('value')
+            item.pop('variable_type')
+        for item in requested_variables:
+            item.pop('value')
+            item.pop('variable_type')
 
-    return change, return_value
+        if not purge:
+            remove_requested = [x for x in requested_variables if x in existing_variables]
+            for item in remove_requested:
+                if this_gitlab.delete_variable(item):
+                    return_value['removed'].append(item)
 
+        else:
+            for item in existing_variables:
+                if this_gitlab.delete_variable(item):
+                    return_value['removed'].append(item)
+
+    if module.check_mode:
+        return_value = dict(added=added, updated=updated, removed=return_value['removed'], untouched=untouched)
+
+    if len(return_value['added'] + return_value['removed'] + return_value['updated']) > 0:
+        change = True
+
+    gitlab_keys = this_gitlab.list_all_group_variables()
+    after = [x.attributes for x in gitlab_keys]
+
+    return change, return_value, before, after
 
 def main():
     argument_spec = basic_auth_argument_spec()
@@ -269,7 +387,8 @@ def main():
         group=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
-        state=dict(type='str', default="present", choices=["absent", "present"])
+        variables=dict(type='list', elements='dict', required=False, default=list(), no_log=True),
+        state=dict(type='str', default="present", choices=["absent", "present"]),
     )
 
     module = AnsibleModule(
@@ -280,6 +399,7 @@ def main():
             ['api_username', 'api_job_token'],
             ['api_token', 'api_oauth_token'],
             ['api_token', 'api_job_token'],
+            ['vars', 'variables']
         ],
         required_together=[
             ['api_username', 'api_password'],
@@ -292,6 +412,12 @@ def main():
 
     purge = module.params['purge']
     var_list = module.params['vars']
+
+    if var_list:
+        variables = vars_to_variables(var_list, module)
+    else:
+        variables = module.params['variables']
+    
     state = module.params['state']
 
     if not HAS_GITLAB_PACKAGE:
@@ -301,7 +427,31 @@ def main():
 
     this_gitlab = GitlabGroupVariables(module=module, gitlab_instance=gitlab_instance)
 
-    changed, return_value = native_python_main(this_gitlab, purge, var_list, state, module)
+    changed, raw_return_value, before, after = native_python_main(this_gitlab, purge, variables, state, module)
+
+        # postprocessing
+    for item in after:
+        item.pop('group_id')
+        item['name'] = item.pop('key')
+    for item in before:
+        item.pop('group_id')
+        item['name'] = item.pop('key')
+
+    diff = dict(
+        before=before,
+        after=after
+    )
+
+    untouched_key_name = 'key'
+    if not module.check_mode:
+        untouched_key_name = 'name'
+        raw_return_value['untouched'] = [x for x in before if x in after]
+
+    added = [x.get('key') for x in raw_return_value['added']]
+    updated = [x.get('key') for x in raw_return_value['updated']]
+    removed = [x.get('key') for x in raw_return_value['removed']]
+    untouched = [x.get(untouched_key_name) for x in raw_return_value['untouched']]
+    return_value = dict(added=added, updated=updated, removed=removed, untouched=untouched)
 
     module.exit_json(changed=changed, group_variable=return_value)
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -76,7 +76,7 @@ options:
         description:
           - The variable value
         type: str
-        required: false
+        required: true
       masked:
         description:
           - Wether variable value is masked or not.
@@ -86,7 +86,7 @@ options:
         description:
           - Wether variable value is protected or not.
         type: bool
-        default: true
+        default: false
       variable_type:
         description:
           - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
@@ -186,7 +186,7 @@ def vars_to_variables(vars, module):
                     "name": item,
                     "value": str(value),
                     "masked": False,
-                    "protected": True,
+                    "protected": False,
                     "variable_type": "env_var",
                 }
             )
@@ -312,7 +312,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['key'] = item.pop('name')
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
-            item['protected'] = True
+            item['protected'] = False
         if item.get('masked') is None:
             item['masked'] = False
         if item.get('environment_scope') is None:
@@ -388,9 +388,9 @@ def main():
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
-            value=dict(type='str', required=False, no_log=True),
+            value=dict(type='str', required=True, no_log=True),
             masked=dict(type='bool', default=False),
-            protected=dict(type='bool', default=True),
+            protected=dict(type='bool', default=False),
             environment_scope=dict(type='str', default='*'),
             variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
         )),

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -59,7 +59,7 @@ options:
     default: {}
     type: dict
   variables:
-    version_added: 4.4.0
+    version_added: 4.5.0
     description:
       - A list of dictionaries that represents CI/CD variables.
       - This modules works internal with this sructure, even if the older I(vars) parameter is used.

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -56,44 +56,44 @@ options:
         See GitLab documentation on acceptable values for a masked variable (U(https://docs.gitlab.com/ce/ci/variables/#masked-variables)).
     default: {}
     type: dict
-    variables:
-      version_added: 4.4.0
-      description:
-        - A list of dictionaries that represents CI/CD variables.
-        - This modules works internal with this sructure, even if the older I(vars) parameter is used.
-      default: []
-      type: list
-      elements: dict
-      suboptions:
-        name:
-          description:
-            - The name of the variable
-          type: str
-        value:
-          description:
-            - The variable value
-          type: str
-        masked:
-          description:
-            - Wether variable value is masked or not.
-          type: bool
-          default: false
-        protected:
-          description:
-            - Wether variable value is protected or not.
-          type: bool
-          default: false
-        variable_type:
-          description:
-            - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
-          type: str
-          choices: [ "env_var", "file" ]
-          default: env_var
-        environment_scope:
-          description:
-            - The scope for the variable.
-          type: str
-          default: '*'
+  variables:
+    version_added: 4.4.0
+    description:
+      - A list of dictionaries that represents CI/CD variables.
+      - This modules works internal with this sructure, even if the older I(vars) parameter is used.
+    default: []
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - The name of the variable
+        type: str
+      value:
+        description:
+          - The variable value
+        type: str
+      masked:
+        description:
+          - Wether variable value is masked or not.
+        type: bool
+        default: false
+      protected:
+        description:
+          - Wether variable value is protected or not.
+        type: bool
+        default: false
+      variable_type:
+        description:
+          - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
+        type: str
+        choices: [ "env_var", "file" ]
+        default: env_var
+      environment_scope:
+        description:
+          - The scope for the variable.
+        type: str
+        default: '*'
 notes:
 - Supports I(check_mode).
 '''

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -71,10 +71,12 @@ options:
         description:
           - The name of the variable
         type: str
+        required: true
       value:
         description:
           - The variable value
         type: str
+        required: false
       masked:
         description:
           - Wether variable value is masked or not.
@@ -84,7 +86,7 @@ options:
         description:
           - Wether variable value is protected or not.
         type: bool
-        default: false
+        default: true
       variable_type:
         description:
           - Wether a variable is an environment variable (C(env_var)) or a file (C(file)).
@@ -184,7 +186,7 @@ def vars_to_variables(vars, module):
                     "name": item,
                     "value": str(value),
                     "masked": False,
-                    "protected": False,
+                    "protected": True,
                     "variable_type": "env_var",
                 }
             )
@@ -242,7 +244,7 @@ class GitlabGroupVariables(object):
             "variable_type": var_obj.get('variable_type'),
         }
         if var_obj.get('environment_scope') is not None:
-          var["environment_scope"] = var_obj.get('environment_scope')
+            var["environment_scope"] = var_obj.get('environment_scope')
 
         self.group.variables.create(var)
         return True
@@ -310,7 +312,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['key'] = item.pop('name')
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
-            item['protected'] = False
+            item['protected'] = True
         if item.get('masked') is None:
             item['masked'] = False
         if item.get('environment_scope') is None:
@@ -386,9 +388,9 @@ def main():
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
-            value=dict(type='str', required=True, no_log=True),
+            value=dict(type='str', required=False, no_log=True),
             masked=dict(type='bool', default=False),
-            protected=dict(type='bool', default=False),
+            protected=dict(type='bool', default=True),
             environment_scope=dict(type='str', default='*'),
             variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
         )),

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -116,21 +116,6 @@ EXAMPLES = r'''
         variable_type: env_var
         environment_scope: production
 
-- name: Set or update some CI/CD variables
-  community.general.gitlab_group_variable:
-    api_url: https://gitlab.com
-    api_token: secret_access_token
-    group: scodeman/testgroup/
-    purge: false
-    vars:
-      ACCESS_KEY_ID: abc123
-      SECRET_ACCESS_KEY: 321cba
-        value: 3214cbad
-        masked: true
-        protected: true
-        variable_type: env_var
-        environment_scope: '*'
-
 - name: Delete one variable
   community.general.gitlab_group_variable:
     api_url: https://gitlab.com
@@ -185,6 +170,7 @@ except Exception:
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import auth_argument_spec, gitlab_authentication
 
+
 def vars_to_variables(vars, module):
     # transform old vars to new variables structure
     variables = list()
@@ -219,6 +205,7 @@ def vars_to_variables(vars, module):
             module.fail_json(msg="value must be of type string, integer, float or dict")
 
     return variables
+
 
 class GitlabGroupVariables(object):
 
@@ -264,6 +251,7 @@ class GitlabGroupVariables(object):
         self.group.variables.delete(var_obj.get('key'), filter={'environment_scope': var_obj.get('environment_scope')})
         return True
 
+
 def compare(requested_variables, existing_variables, state):
     # we need to do this, because it was determined in a previous version - more or less buggy
     # basically it is not necessary and might results in more/other bugs!
@@ -292,6 +280,7 @@ def compare(requested_variables, existing_variables, state):
                     added.append(requested_variables[idx])
 
     return untouched, updated, added
+
 
 def native_python_main(this_gitlab, purge, requested_variables, state, module):
 
@@ -380,6 +369,7 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
 
     return change, return_value, before, after
 
+
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(auth_argument_spec())
@@ -417,7 +407,7 @@ def main():
         variables = vars_to_variables(var_list, module)
     else:
         variables = module.params['variables']
-    
+
     state = module.params['state']
 
     if not HAS_GITLAB_PACKAGE:
@@ -429,7 +419,7 @@ def main():
 
     changed, raw_return_value, before, after = native_python_main(this_gitlab, purge, variables, state, module)
 
-        # postprocessing
+    # postprocessing
     for item in after:
         item.pop('group_id')
         item['name'] = item.pop('key')

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -77,7 +77,6 @@ options:
           - The variable value.
           - Required when I(state=present).
         type: str
-        required: true
       masked:
         description:
           - Wether variable value is masked or not.

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -69,7 +69,7 @@ options:
     suboptions:
       name:
         description:
-          - The name of the variable
+          - The name of the variable.
         type: str
         required: true
       value:

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -74,7 +74,8 @@ options:
         required: true
       value:
         description:
-          - The variable value
+          - The variable value.
+          - Required when I(state=present).
         type: str
         required: true
       masked:
@@ -388,7 +389,7 @@ def main():
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
-            value=dict(type='str', required=True, no_log=True),
+            value=dict(type='str', no_log=True),
             masked=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),
             environment_scope=dict(type='str', default='*'),
@@ -416,18 +417,21 @@ def main():
         supports_check_mode=True
     )
 
+    if not HAS_GITLAB_PACKAGE:
+        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
+
     purge = module.params['purge']
     var_list = module.params['vars']
+    state = module.params['state']
 
     if var_list:
         variables = vars_to_variables(var_list, module)
     else:
         variables = module.params['variables']
 
-    state = module.params['state']
-
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
+    if state == 'present':
+      if any(x['value'] is None for x in variables):
+        module.fail_json(msg='value parameter is required in state present')
 
     gitlab_instance = gitlab_authentication(module)
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_variable.py
@@ -430,8 +430,8 @@ def main():
         variables = module.params['variables']
 
     if state == 'present':
-      if any(x['value'] is None for x in variables):
-        module.fail_json(msg='value parameter is required in state present')
+        if any(x['value'] is None for x in variables):
+            module.fail_json(msg='value parameter is required in state present')
 
     gitlab_instance = gitlab_authentication(module)
 

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -21,9 +21,9 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     group: "{{ gitlab_group_name }}"
-    vars:
-      ACCESS_KEY_ID: checkmode
-  check_mode: yes
+    variables:
+      - name: ACCESS_KEY_ID
+        value: checkmode
   register: gitlab_group_variable_state
 
 - name: check_mode state must be changed
@@ -426,8 +426,8 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     group: "{{ gitlab_group_name }}"
-    vars:
-      my_test_var:
+    variables:
+      - name: my_test_var
         value: my_test_value
         variable_type: file
     purge: False
@@ -582,4 +582,34 @@
       - gitlab_group_variable_state.group_variable.added|length == 0
       - gitlab_group_variable_state.group_variable.untouched|length == 0
       - gitlab_group_variable_state.group_variable.removed|length == 40
+      - gitlab_group_variable_state.group_variable.updated|length == 0
+
+- name: same vars, diff scope
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    purge: True
+    variables:
+      - name: SECRET_ACCESS_KEY
+        value: 3214cbad
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: production
+      - name: SECRET_ACCESS_KEY
+        value: hello_world
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: development
+  register: gitlab_group_variable_state
+
+- name: verify two vars
+  assert:
+    that:
+      - gitlab_group_variable_state.changed
+      - gitlab_group_variable_state.group_variable.added|length == 2
+      - gitlab_group_variable_state.group_variable.untouched|length == 0
+      - gitlab_group_variable_state.group_variable.removed|length == 0
       - gitlab_group_variable_state.group_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -700,3 +700,4 @@
     that:
       - gitlab_group_variable_state.changed
       - gitlab_group_variable_state.group_variable.removed|length == 1
+      

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -21,9 +21,8 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     group: "{{ gitlab_group_name }}"
-    variables:
-      - name: ACCESS_KEY_ID
-        value: checkmode
+    vars:
+      ACCESS_KEY_ID: checkmode
   check_mode: yes
   register: gitlab_group_variable_state
 
@@ -37,8 +36,9 @@
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"
     group: "{{ gitlab_group_name }}"
-    vars:
-      ACCESS_KEY_ID: checkmode
+    variables:
+      - name: ACCESS_KEY_ID
+        value: checkmode
   register: gitlab_group_variable_state
 
 - name: state must be changed
@@ -585,32 +585,33 @@
       - gitlab_group_variable_state.group_variable.removed|length == 40
       - gitlab_group_variable_state.group_variable.updated|length == 0
 
-- name: same vars, diff scope
-  gitlab_group_variable:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_login_token }}"
-    group: "{{ gitlab_group_name }}"
-    purge: True
-    variables:
-      - name: SECRET_ACCESS_KEY
-        value: 3214cbad
-        masked: true
-        protected: true
-        variable_type: env_var
-        environment_scope: production
-      - name: SECRET_ACCESS_KEY
-        value: hello_world
-        masked: true
-        protected: true
-        variable_type: env_var
-        environment_scope: development
-  register: gitlab_group_variable_state
+# This test only works on Premium Gitlab
+# - name: same vars, diff scope
+#   gitlab_group_variable:
+#     api_url: "{{ gitlab_host }}"
+#     api_token: "{{ gitlab_login_token }}"
+#     group: "{{ gitlab_group_name }}"
+#     purge: True
+#     variables:
+#       - name: SECRET_ACCESS_KEY
+#         value: 3214cbad
+#         masked: true
+#         protected: true
+#         variable_type: env_var
+#         environment_scope: production
+#       - name: SECRET_ACCESS_KEY
+#         value: hello_world
+#         masked: true
+#         protected: true
+#         variable_type: env_var
+#         environment_scope: development
+#   register: gitlab_group_variable_state
 
-- name: verify two vars
-  assert:
-    that:
-      - gitlab_group_variable_state.changed
-      - gitlab_group_variable_state.group_variable.added|length == 2
-      - gitlab_group_variable_state.group_variable.untouched|length == 0
-      - gitlab_group_variable_state.group_variable.removed|length == 0
-      - gitlab_group_variable_state.group_variable.updated|length == 0
+# - name: verify two vars
+#   assert:
+#     that:
+#       - gitlab_group_variable_state.changed
+#       - gitlab_group_variable_state.group_variable.added|length == 2
+#       - gitlab_group_variable_state.group_variable.untouched|length == 0
+#       - gitlab_group_variable_state.group_variable.removed|length == 0
+#       - gitlab_group_variable_state.group_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -247,13 +247,13 @@
       ACCESS_KEY_ID:
         environment_scope: testing
         value: checkmode
-  register: gitlab_project_variable_state
+  register: gitlab_group_variable_state
   when: gitlab_premium_tests is defined
 
 - name: state must not be changed
   assert:
     that:
-      - gitlab_project_variable_state is not changed
+      - gitlab_group_variable_state is not changed
   when: gitlab_premium_tests is defined
 
 - name: purge all variables at the beginning

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -220,6 +220,42 @@
     that:
       - gitlab_group_variable_state is not changed
 
+- name: change environment scope
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        environment_scope: testing
+        value: checkmode
+  register: gitlab_group_variable_state
+  when: gitlab_premium_tests is defined
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_group_variable_state is changed
+  when: gitlab_premium_tests is defined
+
+- name: apply again the environment scope change 
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        environment_scope: testing
+        value: checkmode
+  register: gitlab_project_variable_state
+  when: gitlab_premium_tests is defined
+
+- name: state must not be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is not changed
+  when: gitlab_premium_tests is defined
+
 - name: purge all variables at the beginning
   gitlab_group_variable:
     api_url: "{{ gitlab_host }}"
@@ -585,33 +621,82 @@
       - gitlab_group_variable_state.group_variable.removed|length == 40
       - gitlab_group_variable_state.group_variable.updated|length == 0
 
-# This test only works on Premium Gitlab
-# - name: same vars, diff scope
-#   gitlab_group_variable:
-#     api_url: "{{ gitlab_host }}"
-#     api_token: "{{ gitlab_login_token }}"
-#     group: "{{ gitlab_group_name }}"
-#     purge: True
-#     variables:
-#       - name: SECRET_ACCESS_KEY
-#         value: 3214cbad
-#         masked: true
-#         protected: true
-#         variable_type: env_var
-#         environment_scope: production
-#       - name: SECRET_ACCESS_KEY
-#         value: hello_world
-#         masked: true
-#         protected: true
-#         variable_type: env_var
-#         environment_scope: development
-#   register: gitlab_group_variable_state
+- name: same vars, diff scope
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    purge: True
+    variables:
+      - name: SECRET_ACCESS_KEY
+        value: 3214cbad
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: production
+      - name: SECRET_ACCESS_KEY
+        value: hello_world
+        masked: true
+        protected: true
+        variable_type: env_var
+        environment_scope: development
+  register: gitlab_group_variable_state
+  when: gitlab_premium_tests is defined
 
-# - name: verify two vars
-#   assert:
-#     that:
-#       - gitlab_group_variable_state.changed
-#       - gitlab_group_variable_state.group_variable.added|length == 2
-#       - gitlab_group_variable_state.group_variable.untouched|length == 0
-#       - gitlab_group_variable_state.group_variable.removed|length == 0
-#       - gitlab_group_variable_state.group_variable.updated|length == 0
+- name: verify two vars
+  assert:
+    that:
+      - gitlab_group_variable_state.changed
+      - gitlab_group_variable_state.group_variable.added|length == 2
+      - gitlab_group_variable_state.group_variable.untouched|length == 0
+      - gitlab_group_variable_state.group_variable.removed|length == 0
+      - gitlab_group_variable_state.group_variable.updated|length == 0
+  when: gitlab_premium_tests is defined
+
+- name: throw error when state is present but no value is given
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    variables:
+      - name: delete_me
+  register: gitlab_group_variable_state
+  ignore_errors: yes
+
+- name: verify fail
+  assert:
+    that:
+      - gitlab_group_variable_state.failed
+      - gitlab_group_variable_state is not changed
+
+- name: set a new variable to delete it later
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    purge: True
+    variables:
+      - name: delete_me
+        value: ansible
+  register: gitlab_group_variable_state
+
+- name: verify the change
+  assert:
+    that:
+      - gitlab_group_variable_state.changed
+
+- name: delete variable without referencing its value
+  gitlab_group_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    group: "{{ gitlab_group_name }}"
+    state: absent
+    variables:
+      - name: delete_me
+  register: gitlab_group_variable_state
+
+- name: verify deletion
+  assert:
+    that:
+      - gitlab_group_variable_state.changed
+      - gitlab_group_variable_state.group_variable.removed|length == 1

--- a/tests/integration/targets/gitlab_group_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_group_variable/tasks/main.yml
@@ -24,6 +24,7 @@
     variables:
       - name: ACCESS_KEY_ID
         value: checkmode
+  check_mode: yes
   register: gitlab_group_variable_state
 
 - name: check_mode state must be changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Rework on gitlab_project_variable #4038 copied to gitlab_group_variable
Closes: #4074

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

gitlab_group_variable

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Change to support the two kinds of instantiation:

    - name: previous way. still works
      community.general.gitlab_group_variable:
        api_url: https://gitlab.com
        api_token: "{{ some_token }}"
        project: markuman/dotfiles
        purge: false
        vars:
          ACCESS_KEY_ID: abc123
          SECRET_ACCESS_KEY:
            value: 3214cbad
            masked: true
            protected: true
            variable_type: env_var
            environment_scope: '*'

    - name: new way, works also
      community.general.gitlab_group_variable:
        api_url: https://gitlab.com
        api_token: "{{ some_token }}"
        project: markuman/dotfiles
        purge: false
        variables:
          - name: ACCESS_KEY_ID
            value: abc123
          - name: SECRET_ACCESS_KEY
            value: 3214cbad
            masked: true
            protected: true
            variable_type: env_var
            environment_scope: '*'

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
