### PR TITLE
Added new feature for ansible_user and ansible_port in Icinga2 inventory source

### DIFF
--- a/changelogs/fragments/4088-add-constructed-interface-for-icinga2-inventory.yml
+++ b/changelogs/fragments/4088-add-constructed-interface-for-icinga2-inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - icinga2 inventory plugin - Implemented constructed interface for icinga2 inventory plugin (https://github.com/ansible-collections/community.general/pull/4088).

--- a/changelogs/fragments/4088-add-constructed-interface-for-icinga2-inventory.yml
+++ b/changelogs/fragments/4088-add-constructed-interface-for-icinga2-inventory.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - icinga2 inventory plugin - Implemented constructed interface for icinga2 inventory plugin (https://github.com/ansible-collections/community.general/pull/4088).
+  - icinga2 inventory plugin - implemented constructed interface (https://github.com/ansible-collections/community.general/pull/4088).

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -232,10 +232,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                                         host_attrs['state'])
             self.inventory.set_variable(host_name, 'state_type',
                                         host_attrs['state_type'])
-            if host_attrs['vars'] != None:
-                if host_attrs['vars'].get('ansible_user') != None:
+            if host_attrs['vars'] is not None:
+                if host_attrs['vars'].get('ansible_user') is not None:
                     self.inventory.set_variable(host_name, 'ansible_user', host_attrs['vars'].get('ansible_user'))
-                if host_attrs['vars'].get('ansible_port') != None:
+                if host_attrs['vars'].get('ansible_port') is not None:
                     self.inventory.set_variable(host_name, 'ansible_port', host_attrs['vars'].get('ansible_port'))
         return groups_dict
 

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -232,14 +232,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                                         host_attrs['state'])
             self.inventory.set_variable(host_name, 'state_type',
                                         host_attrs['state_type'])
-            try:
-                self.inventory.set_variable(host_name, 'ansible_user', host_attrs['vars']['ansible_user'])
-            except:
-                pass
-            try:
-                self.inventory.set_variable(host_name, 'ansible_port', host_attrs['vars']['ansible_port'])
-            except:
-                pass
+            if host_attrs['vars'] != None:
+                if host_attrs['vars'].get('ansible_user') != None:
+                    self.inventory.set_variable(host_name, 'ansible_user', host_attrs['vars'].get('ansible_user'))
+                if host_attrs['vars'].get('ansible_port') != None:
+                    self.inventory.set_variable(host_name, 'ansible_port', host_attrs['vars'].get('ansible_port'))
         return groups_dict
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -232,7 +232,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                                         host_attrs['state'])
             self.inventory.set_variable(host_name, 'state_type',
                                         host_attrs['state_type'])
-            if host_attrs['vars'] is not None:
+            if host_attrs.get('vars') is not None:
                 if host_attrs['vars'].get('ansible_user') is not None:
                     self.inventory.set_variable(host_name, 'ansible_user', host_attrs['vars'].get('ansible_user'))
                 if host_attrs['vars'].get('ansible_port') is not None:

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -19,6 +19,14 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
         - constructed
     options:
+      strict:
+        version_added: 4.4.0
+      compose:
+        version_added: 4.4.0
+      groups:
+        version_added: 4.4.0
+      keyed_groups:
+        version_added: 4.4.0
       plugin:
         description: Name of the plugin.
         required: true

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -78,7 +78,7 @@ compose:
 
   # set 'ansible_user' and 'ansible_port' from icinga2 host vars
   ansible_user: icinga2_attributes.vars.ansible_user
-  ansible_port: icinga2_attributes.vars.ansible_port
+  ansible_port: icinga2_attributes.vars.ansible_port | default(22)
 '''
 
 import json

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -70,7 +70,7 @@ groups:
   webservers: inventory_hostname.startswith('web')
 
   # using icinga2 template
-  databaseservers: "'db-template' in (icinga2.templates|list)"
+  databaseservers: "'db-template' in (icinga2_attributes.templates|list)"
 
 compose:
   # set all icinga2 attributes to a host variable 'icinga2_attrs'

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -73,9 +73,12 @@ groups:
   databaseservers: "'db-template' in (icinga2.templates|list)"
 
 compose:
+  # set all icinga2 attributes to a host variable 'icinga2_attrs'
+  icinga2_attrs: icinga2_attributes
+
   # set 'ansible_user' and 'ansible_port' from icinga2 host vars
-  ansible_user: icinga2.vars.ansible_user
-  ansible_port: icinga2.vars.ansible_port
+  ansible_user: icinga2_attributes.vars.ansible_user
+  ansible_port: icinga2_attributes.vars.ansible_port
 '''
 
 import json
@@ -251,9 +254,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                                         host_attrs['state'])
             self.inventory.set_variable(host_name, 'state_type',
                                         host_attrs['state_type'])
-            # Adds all attributes to a host variable 'icinga2'
-            self.inventory.set_variable(host_name, 'icinga2', host_attrs)
-            self._apply_constructable(host_name, self.inventory.get_host(host_name).get_vars())
+            # Adds all attributes to a variable 'icinga2_attributes'
+            construct_vars = dict(self.inventory.get_host(host_name).get_vars())
+            construct_vars['icinga2_attributes'] = host_attrs
+            self._apply_constructable(host_name, construct_vars)
         return groups_dict
 
     def parse(self, inventory, loader, path, cache=True):

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -180,7 +180,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         """Query for all hosts """
         self.display.vvv("Querying Icinga2 for inventory")
         query_args = {
-            "attrs": ["address", "display_name", "state_type", "state", "groups"],
+            "attrs": ["address", "display_name", "state_type", "state", "groups", "vars"],
         }
         if self.host_filter is not None:
             query_args['host_filter'] = self.host_filter
@@ -232,6 +232,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                                         host_attrs['state'])
             self.inventory.set_variable(host_name, 'state_type',
                                         host_attrs['state_type'])
+            try:
+                self.inventory.set_variable(host_name, 'ansible_user', host_attrs['vars']['ansible_user'])
+            except:
+                pass
+            try:
+                self.inventory.set_variable(host_name, 'ansible_port', host_attrs['vars']['ansible_port'])
+            except:
+                pass
         return groups_dict
 
     def parse(self, inventory, loader, path, cache=True):

--- a/tests/unit/plugins/inventory/test_icinga2.py
+++ b/tests/unit/plugins/inventory/test_icinga2.py
@@ -75,6 +75,7 @@ def query_hosts(hosts=None, attrs=None, joins=None, host_filter=None):
     ]
     return json_host_data
 
+
 def get_option(option):
     if option == 'groups':
         return {}
@@ -86,6 +87,7 @@ def get_option(option):
         return False
     else:
         return None
+
 
 def test_populate(inventory, mocker):
     # module settings

--- a/tests/unit/plugins/inventory/test_icinga2.py
+++ b/tests/unit/plugins/inventory/test_icinga2.py
@@ -75,6 +75,17 @@ def query_hosts(hosts=None, attrs=None, joins=None, host_filter=None):
     ]
     return json_host_data
 
+def get_option(option):
+    if option == 'groups':
+        return {}
+    elif option == 'keyed_groups':
+        return []
+    elif option == 'compose':
+        return {}
+    elif option == 'strict':
+        return False
+    else:
+        return None
 
 def test_populate(inventory, mocker):
     # module settings
@@ -86,6 +97,7 @@ def test_populate(inventory, mocker):
     # bypass authentication and API fetch calls
     inventory._check_api = mocker.MagicMock(side_effect=check_api)
     inventory._query_hosts = mocker.MagicMock(side_effect=query_hosts)
+    inventory.get_option = mocker.MagicMock(side_effect=get_option)
     inventory._populate()
 
     # get different hosts


### PR DESCRIPTION
##### SUMMARY
This change allows us to take `ansible_user` and `ansible_port` from Icinga2 Host objects if they are configured and contain the variables `vars.ansible_user` and` vars.ansible_port`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.icinga2

##### ADDITIONAL INFORMATION
Example:
```
object Host "host-1" {
    ...
    vars.ansible_user = "myuser"
    vars.ansible_port = "2202"
    ...
}
```