### PR TITLE
homebrew_cask: reinstall when force is install option

### DIFF
--- a/changelogs/fragments/3703-force-install-homebrew-cask.yml
+++ b/changelogs/fragments/3703-force-install-homebrew-cask.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew_cask - fix force install operation (https://github.com/ansible-collections/community.general/issues/3703).

--- a/plugins/modules/packaging/os/homebrew_cask.py
+++ b/plugins/modules/packaging/os/homebrew_cask.py
@@ -102,6 +102,12 @@ EXAMPLES = '''
     state: present
     install_options: 'debug,appdir=/Applications'
 
+- name: Install cask with force option
+  community.general.homebrew_cask:
+    name: alfred
+    state: present
+    install_options: force
+
 - name: Allow external app
   community.general.homebrew_cask:
     name: alfred
@@ -600,7 +606,7 @@ class HomebrewCask(object):
             self.message = 'Invalid cask: {0}.'.format(self.current_cask)
             raise HomebrewCaskException(self.message)
 
-        if self._current_cask_is_installed():
+        if '--force' not in self.install_options and self._current_cask_is_installed():
             self.unchanged_count += 1
             self.message = 'Cask already installed: {0}'.format(
                 self.current_cask,

--- a/tests/integration/targets/homebrew_cask/aliases
+++ b/tests/integration/targets/homebrew_cask/aliases
@@ -1,0 +1,6 @@
+shippable/posix/group1
+skip/aix
+skip/freebsd
+skip/rhel
+skip/docker
+skip/python2.6

--- a/tests/integration/targets/homebrew_cask/defaults/main.yml
+++ b/tests/integration/targets/homebrew_cask/defaults/main.yml
@@ -1,1 +1,1 @@
-cask: moonlight
+cask: bitcoin-core

--- a/tests/integration/targets/homebrew_cask/defaults/main.yml
+++ b/tests/integration/targets/homebrew_cask/defaults/main.yml
@@ -1,1 +1,1 @@
-cask: bitcoin-core
+cask: brooklyn

--- a/tests/integration/targets/homebrew_cask/defaults/main.yml
+++ b/tests/integration/targets/homebrew_cask/defaults/main.yml
@@ -1,0 +1,1 @@
+cask: moonlight

--- a/tests/integration/targets/homebrew_cask/tasks/main.yml
+++ b/tests/integration/targets/homebrew_cask/tasks/main.yml
@@ -1,0 +1,52 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Test code for the homebrew_cask module.
+# Copyright: (c) 2022, Joseph Torcasso <jtorcass@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+  - block:
+      - name: Install cask
+        homebrew_cask:
+          name: "{{ cask }}"
+          state: present
+        register: cask_install_result
+
+      - assert:
+          that:
+            - cask_install_result is changed
+            - "'Cask installed' in cask_install_result.msg"
+
+      - name: Install cask (idempotence)
+        homebrew_cask:
+          name: "{{ cask }}"
+          state: present
+        register: cask_install_result
+
+      - assert:
+          that:
+            - cask_install_result is not changed
+            - "'Cask installed' not in cask_install_result.msg"
+            - "'Cask already installed' in cask_install_result.msg"
+
+      - name: Install cask with force install option
+        homebrew_cask:
+          name: "{{ cask }}"
+          state: present
+          install_options: force
+        register: cask_install_result
+
+      - assert:
+          that:
+            - cask_install_result is changed
+            - "'Cask installed' in cask_install_result.msg"
+
+    always:
+      - name: Delete cask
+        homebrew_cask:
+          name: "{{ cask }}"
+          state: absent
+          install_options: force
+        ignore_errors: yes

--- a/tests/integration/targets/homebrew_cask/tasks/main.yml
+++ b/tests/integration/targets/homebrew_cask/tasks/main.yml
@@ -7,11 +7,24 @@
 # Copyright: (c) 2022, Joseph Torcasso <jtorcass@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+  - name: Find brew binary
+    command: which brew
+    register: brew_which
+    when: ansible_distribution in ['MacOSX']
+
+  - name: Get owner of brew binary
+    stat:
+      path: "{{ brew_which.stdout }}"
+    register: brew_stat
+    when: ansible_distribution in ['MacOSX']
+
   - block:
       - name: Install cask
         homebrew_cask:
           name: "{{ cask }}"
           state: present
+        become: yes
+        become_user: "{{ brew_stat.stat.pw_name }}"
         register: cask_install_result
 
       - assert:
@@ -23,6 +36,8 @@
         homebrew_cask:
           name: "{{ cask }}"
           state: present
+        become: yes
+        become_user: "{{ brew_stat.stat.pw_name }}"
         register: cask_install_result
 
       - assert:
@@ -36,6 +51,8 @@
           name: "{{ cask }}"
           state: present
           install_options: force
+        become: yes
+        become_user: "{{ brew_stat.stat.pw_name }}"
         register: cask_install_result
 
       - assert:
@@ -49,4 +66,6 @@
           name: "{{ cask }}"
           state: absent
           install_options: force
+        become: yes
+        become_user: "{{ brew_stat.stat.pw_name }}"
         ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Per [suggestion](https://github.com/ansible-collections/community.general/issues/3703#issuecomment-1020909235), fixed bug that prevented force install of homebrew casks and added integration tests.

Fixes #3703 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask
