### PR TITLE
Fix local port regex in listen_ports_facts

### DIFF
--- a/changelogs/fragments/4092-fix_local_ports_regex_listen_ports_facts.yaml
+++ b/changelogs/fragments/4092-fix_local_ports_regex_listen_ports_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - listen_ports_facts - local port regex was not handling well ipv6 only binding. Fixes the regex for ss

--- a/changelogs/fragments/4092-fix_local_ports_regex_listen_ports_facts.yaml
+++ b/changelogs/fragments/4092-fix_local_ports_regex_listen_ports_facts.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - listen_ports_facts - local port regex was not handling well ipv6 only binding. Fixes the regex for ss
+  - listen_ports_facts - local port regex was not handling well IPv6 only binding. Fixes the regex for ``ss`` (https://github.com/ansible-collections/community.general/pull/4092).

--- a/plugins/modules/system/listen_ports_facts.py
+++ b/plugins/modules/system/listen_ports_facts.py
@@ -197,7 +197,7 @@ def netStatParse(raw):
 
 def ss_parse(raw):
     results = list()
-    regex_conns = re.compile(pattern=r'\[?(.+?)\]?:([0-9]+)')
+    regex_conns = re.compile(pattern=r'\[?(.+?)\]?:([0-9]+)$')
     regex_pid = re.compile(pattern=r'"(.*?)",pid=(\d+)')
 
     lines = raw.splitlines()


### PR DESCRIPTION
##### SUMMARY
This PR fix the bug reported in #4091 by fixing the regex used to parse ss local connection entry
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
listen_ports_facts

```
