### PR TITLE
opentelemetry: enrich service for community.docker.docker_login

### DIFF
--- a/changelogs/fragments/4104-opentelemetry_plugin-enrich_docker_login.yaml
+++ b/changelogs/fragments/4104-opentelemetry_plugin-enrich_docker_login.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - opentelemetry_plugin - enrich service when using the ``docker_login`` (https://github.com/ansible-collections/community.general/pull/4104).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -319,7 +319,7 @@ class OpenTelemetrySource(object):
     @staticmethod
     def url_from_args(args):
         # the order matters
-        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url")
+        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url", "registry_url")
         for arg in url_args:
             if args is not None and args.get(arg):
                 return args.get(arg)


### PR DESCRIPTION
##### SUMMARY

Enrich the span metadata for those ansible tasks that interact with `community.docker.docker_login`.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`callback/opentelemetry.py`

##### ADDITIONAL INFORMATION

Given:

```
---
# This playbook prints a simple debug message
- name: Echo
  hosts: localhost
  connection: local

  tasks:
    - name: Log into DockerHub
      docker_login:
        username: "{{ docker_user }}"
        password: "{{ docker_password }}"
        registry_url: https://index.docker.io/v1/
```

And the ElasticStack, then the Service Maps can see below

![image](https://user-images.githubusercontent.com/2871786/151560497-ab39d322-34c0-42de-a039-c43b08d1f12e.png)
