### PR TITLE
opentelemetry: enrich services for jenkins, hetzner or jira

### DIFF
--- a/changelogs/fragments/4105-opentelemetry_plugin-enrich_jira_hetzner_jenkins_services.yaml
+++ b/changelogs/fragments/4105-opentelemetry_plugin-enrich_jira_hetzner_jenkins_services.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-    - opentelemetry_plugin - enrich service when using the ``jenkins``, ``hetzner`` or ``jira`` (https://github.com/ansible-collections/community.general/pull/4105).
+    - opentelemetry_plugin - enrich service when using the ``jenkins``, ``hetzner`` or ``jira`` modules (https://github.com/ansible-collections/community.general/pull/4105).

--- a/changelogs/fragments/4105-opentelemetry_plugin-enrich_jira_hetzner_jenkins_services.yaml
+++ b/changelogs/fragments/4105-opentelemetry_plugin-enrich_jira_hetzner_jenkins_services.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - opentelemetry_plugin - enrich service when using the ``jenkins``, ``hetzner`` or ``jira`` (https://github.com/ansible-collections/community.general/pull/4105).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -319,7 +319,7 @@ class OpenTelemetrySource(object):
     @staticmethod
     def url_from_args(args):
         # the order matters
-        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url", "registry_url")
+        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url", "registry_url", "endpoint", "uri", "updates_url", "name", "source")
         for arg in url_args:
             if args is not None and args.get(arg):
                 return args.get(arg)

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -319,7 +319,7 @@ class OpenTelemetrySource(object):
     @staticmethod
     def url_from_args(args):
         # the order matters
-        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url", "registry_url", "endpoint", "uri", "updates_url", "name", "source")
+        url_args = ("url", "api_url", "baseurl", "repo", "server_url", "chart_repo_url", "registry_url", "endpoint", "uri", "updates_url")
         for arg in url_args:
             if args is not None and args.get(arg):
                 return args.get(arg)


### PR DESCRIPTION
##### SUMMARY

Enrich the span metadata for those ansible tasks that interact with:

- https://docs.ansible.com/ansible/latest/collections/community/general/jira_module.html#parameter-uri
- https://docs.ansible.com/ansible/latest/collections/hetzner/hcloud/hcloud_server_module.html#parameter-endpoint
- https://docs.ansible.com/ansible/latest/collections/community/general/jenkins_plugin_module.html#parameter-updates_url


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`callback/opentelemetry.py`

##### ADDITIONAL INFORMATION
