### PR TITLE
[modules/cloud/misc/proxmox_kvm] Adding EFI disk support

### DIFF
--- a/changelogs/fragments/4106-proxmox-efidisk0-support.yaml
+++ b/changelogs/fragments/4106-proxmox-efidisk0-support.yaml
@@ -1,5 +1,3 @@
 ---
 minor_changes:
-  - Added efidisk0 support when creating VM with OVMF UEFI BIOS
-bugfixes:
-  - Fixes VM created with OVMF BIOS are invalid (https://github.com/ansible-collections/community.general/issues/1638)
+  - proxmox_kvm - added EFI disk support when creating VM with OVMF UEFI BIOS with new ``efidisk0`` option (https://github.com/ansible-collections/community.general/pull/4106, https://github.com/ansible-collections/community.general/issues/1638).

--- a/changelogs/fragments/4106-proxmox-efidisk0-support.yaml
+++ b/changelogs/fragments/4106-proxmox-efidisk0-support.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Added efidisk0 support when creating VM with OVMF UEFI BIOS
+bugfixes:
+  - Fixes VM created with OVMF BIOS are invalid (https://github.com/ansible-collections/community.general/issues/1638)

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -946,7 +946,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         # check sanity of efidisk0 option, pre-enrolled-keys=1 should not be set with efitype=2m
         if 'efidisk0' in kwargs:
             re_efi = re.compile(r'efitype=2m.*pre-enrolled-keys=1|pre-enrolled-keys=1.*efitype=2m')
-            if re_efi.match(kwargs['efidisk0']):
+            if re_efi.match(kwargs['efidisk0']) is not None:
                 self.module.fail_json(msg='efitype=2m cannont be set with pre-enrolled-keys=1. ')
 
         if update:
@@ -1190,8 +1190,8 @@ def main():
                 module.fail_json(msg="node '%s' does not exist in cluster" % node)
 
             # Merge efi option into efidisk0
-            if ('efidisk0' in module.params) and ('efi' in module.params):
-                module.params['efidisk0'] += module.params['efi']
+            if ('efidisk0' in module.params) and ('efi' in module.params) and (module.params['efi'] is not None):
+                module.params['efidisk0'] += "," + module.params['efi']
 
             proxmox.create_vm(vmid, newid, node, name, memory, cpu, cores, sockets, update,
                               acpi=module.params['acpi'],
@@ -1209,7 +1209,7 @@ def main():
                               cpuunits=module.params['cpuunits'],
                               description=module.params['description'],
                               digest=module.params['digest'],
-                              efidiskO=module.params['efidisk0'],
+                              efidisk0=module.params['efidisk0'],
                               force=module.params['force'],
                               freeze=module.params['freeze'],
                               hostpci=module.params['hostpci'],

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -845,7 +845,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             urlencoded_ssh_keys = quote(kwargs['sshkeys'], safe='')
             kwargs['sshkeys'] = str(urlencoded_ssh_keys)
 
-        # If update, don't update disk (virtio, ide, sata, scsi) and network interface
+        # If update, don't update disk (virtio, efidisk0, ide, sata, scsi) and network interface
         # pool parameter not supported by qemu/<vmid>/config endpoint on "update" (PVE 6.2) - only with "create"
         if update:
             if 'virtio' in kwargs:
@@ -856,6 +856,8 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                 del kwargs['scsi']
             if 'ide' in kwargs:
                 del kwargs['ide']
+            if 'efidisk0' in kwargs:
+                del kwargs['efidisk0']
             if 'net' in kwargs:
                 del kwargs['net']
             if 'force' in kwargs:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -130,7 +130,7 @@ options:
        Standard Secure Boot keys(C(1)) or not (C(0)). It also enables Secure Boot by default if set to C(1).
       - Cannot be set if efidisk0 is not set.
     type: str
-    version_added: 4.4.0
+    version_added: 4.5.0
   efidisk0:
     description:
       - Specify volume to use as EFI disk.
@@ -138,7 +138,7 @@ options:
       - C(storage) is the storage identifier where to create the disk.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
     type: str
-    version_added: 4.4.0
+    version_added: 4.5.0
   force:
     description:
       - Allow to force stop VM.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -553,6 +553,30 @@ EXAMPLES = '''
     bios: ovmf
     efidisk0: 'VMs_LVM:1,format=qcow2,efitype=4m,pre-enrolled_keys=1'
 
+- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot disabled by default
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    sata:
+      sata0: 'VMs_LVM:10,format=raw'
+    bios: ovmf
+    efidisk0: 'VMs_LVM_thin:1,format=raw,efitype=4m,pre-enrolled_keys=0'
+
+- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot enabled by default
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    sata:
+      sata0: 'VMs_LVM:10,format=raw'
+    bios: ovmf
+    efidisk0: 'VMs_LVM:1,format=qcow2,efitype=4m,pre-enrolled_keys=1'
+
 - name: >
     Clone VM with only source VM name.
     The VM source is spynal.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -935,13 +935,11 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             if 'storage' in kwargs['efidisk0']:
                 efidisk0_str += kwargs['efidisk0'].get('storage') + ':1,'
                 kwargs['efidisk0'].pop('storage')
-            for k in list(kwargs['efidisk0'].keys()):
-                if 'pre_enrolled_keys' == k:
-                    efidisk0_str += hyphen_re.sub('-', k) + "=" + str(int(kwargs['efidisk0'].get(k))) + ','
-                else:
-                    efidisk0_str += hyphen_re.sub('-', k) + "=" + str(kwargs['efidisk0'].get(k)) + ','
-            # copy the string minus the last coma
-            kwargs['efidisk0'] = efidisk0_str[:-1]
+            # Join other elements from the dict as key=value using commas as separator, replacing any underscore in key
+            # by hyphens (needed for pre_enrolled_keys to pre-enrolled_keys)
+            efidisk0_str += ','.join([hyphen_re.sub('-', k) + "=" + str(v) for k, v in kwargs['efidisk0'].items()
+                                      if 'storage' != k])
+            kwargs['efidisk0'] = efidisk0_str
 
         # Convert all dict in kwargs to elements.
         # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n]

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -123,12 +123,13 @@ options:
   efidisk0:
     description:
       - Specify volume to use as EFI disk.
-      - Values allowed are - C("storage:1,format=value,efitype=4m,pre-enrolled-keys=0|1")
+      - Values allowed are - C("storage:1,format=value,efitype=4m,pre-enrolled-keys=0|1").
       - C(storage) is the storage identifier where to create the disk.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
       - C(pre-enrolled_keys) specifies if the efidisk should come pre-loaded with distribution-specific and Microsoft
        Standard Secure Boot keys(C(1)) or not (C(0)). It also enables Secure Boot by default if set to C(1).
     type: str
+    version_added: 4.4.0
   force:
     description:
       - Allow to force stop VM.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -528,6 +528,30 @@ EXAMPLES = '''
       virtio2: 'VMs:5,format=raw'
     cores: 4
     vcpus: 2
+    
+- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot disabled by default
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    sata:
+      sata0: 'VMs_LVM:10,format=raw'
+    bios: ovmf
+    efidisk0: 'VMs_LVM_thin:1,format=raw,efitype=4m,pre-enrolled_keys=0'
+    
+- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot enabled by default
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf
+    sata:
+      sata0: 'VMs_LVM:10,format=raw'
+    bios: ovmf
+    efidisk0: 'VMs_LVM:1,format=qcow2,efitype=4m,pre-enrolled_keys=1'
 
 - name: >
     Clone VM with only source VM name.

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -528,7 +528,7 @@ EXAMPLES = '''
       virtio2: 'VMs:5,format=raw'
     cores: 4
     vcpus: 2
-    
+
 - name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot disabled by default
   community.general.proxmox_kvm:
     api_user: root@pam
@@ -540,7 +540,7 @@ EXAMPLES = '''
       sata0: 'VMs_LVM:10,format=raw'
     bios: ovmf
     efidisk0: 'VMs_LVM_thin:1,format=raw,efitype=4m,pre-enrolled_keys=0'
-    
+
 - name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot enabled by default
   community.general.proxmox_kvm:
     api_user: root@pam

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -936,7 +936,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                 efidisk0_str += kwargs['efidisk0'].get('storage') + ':1,'
                 kwargs['efidisk0'].pop('storage')
             # Join other elements from the dict as key=value using commas as separator, replacing any underscore in key
-            # by hyphens (needed for pre_enrolled_keys to pre-enrolled_keys)
+            # by hyphens (needed for pre_enrolled_keys to pre-enrolled-keys)
             efidisk0_str += ','.join([hyphen_re.sub('-', k) + "=" + str(v) for k, v in kwargs['efidisk0'].items()
                                       if 'storage' != k])
             kwargs['efidisk0'] = efidisk0_str
@@ -1226,10 +1226,6 @@ def main():
                 module.fail_json(msg='node, name is mandatory for creating/updating vm')
             elif not proxmox.get_node(node):
                 module.fail_json(msg="node '%s' does not exist in cluster" % node)
-
-            # Merge efi option into efidisk0
-            if ('efidisk0' in module.params) and ('efi' in module.params) and (module.params['efi'] is not None):
-                module.params['efidisk0'] += "," + module.params['efi']
 
             proxmox.create_vm(vmid, newid, node, name, memory, cpu, cores, sockets, update,
                               acpi=module.params['acpi'],

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -126,7 +126,7 @@ options:
       - Values allowed are - C("storage:1,format=value,efitype=4m,pre-enrolled-keys=0|1").
       - C(storage) is the storage identifier where to create the disk.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
-      - C(pre-enrolled_keys) specifies if the efidisk should come pre-loaded with distribution-specific and Microsoft
+      - C(pre-enrolled-keys) specifies if the efidisk should come pre-loaded with distribution-specific and Microsoft
        Standard Secure Boot keys(C(1)) or not (C(0)). It also enables Secure Boot by default if set to C(1).
     type: str
     version_added: 4.4.0

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -120,6 +120,15 @@ options:
       - Specify if to prevent changes if current configuration file has different SHA1 digest.
       - This can be used to prevent concurrent modifications.
     type: str
+  efidisk0:
+    description:
+      - Specify volume to use as EFI disk.
+      - Values allowed are - C("storage:1,format=value,efitype=4m,pre-enrolled-keys=0|1")
+      - C(storage) is the storage identifier where to create the disk.
+      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
+      - C(pre-enrolled_keys) specifies if the efidisk should come pre-loaded with distribution-specific and Microsoft
+       Standard Secure Boot keys(C(1)) or not (C(0)). It also enables Secure Boot by default if set to C(1).
+    type: str
   force:
     description:
       - Allow to force stop VM.
@@ -960,6 +969,7 @@ def main():
         delete=dict(type='str'),
         description=dict(type='str'),
         digest=dict(type='str'),
+        efidisk0=dict(type='str'),
         force=dict(type='bool'),
         format=dict(type='str', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk', 'unspecified']),
         freeze=dict(type='bool'),
@@ -1149,6 +1159,7 @@ def main():
                               cpuunits=module.params['cpuunits'],
                               description=module.params['description'],
                               digest=module.params['digest'],
+                              efidiskO=module.params['efidisk0'],
                               force=module.params['force'],
                               freeze=module.params['freeze'],
                               hostpci=module.params['hostpci'],


### PR DESCRIPTION
##### SUMMARY
- Fixes #1638
- When creating OVMF UEFI VMs, a EFI disk isn't created as well, leaving the user to manually add it through other means (i.e. Proxmox VE GUI or command line). This PR aims to correct this point by adding an `efidisk0` parameter to the module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm.py

##### ADDITIONAL INFORMATION
I added the `efidisk0` parameter to the module, since it is already supported by the underlying proxmoxer interface the module uses to communicate with Proxmox VE API. This change actually involves only adding the correct parameter to the module, and passing it directly to the `create_vm` method since it already handles and undefined number of arguments. The parameter is also removed when updating a VM as are other parameters that handle disks.

As per [Proxmox VE documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_virtual_machines_settings) recommandations I've made the setting required if the `bios` parameter is set to `ovmf` rather than `seabios`, though that can be easily changed back to the original behaviour.
