### PR TITLE
[stable-2] Remove CentOS 8 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -268,8 +268,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34
@@ -294,8 +292,6 @@ stages:
         parameters:
           testFormat: 2.11/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: openSUSE 15 py3
@@ -313,8 +309,6 @@ stages:
         parameters:
           testFormat: 2.10/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
             - name: openSUSE 15 py3
@@ -332,8 +326,6 @@ stages:
         parameters:
           testFormat: 2.9/linux/{0}
           targets:
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 31
               test: fedora31
             - name: openSUSE 15 py3


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/news-for-maintainers/issues/3. For our old stable branches, this looks like the easiest route. For the newer ones, we try #4132 first.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
