### PR TITLE
gitlab_runner: Make owned and project mutually exclusive

### DIFF
--- a/changelogs/fragments/4136-gitlab_runner-make-project-owned-mutually-exclusive.yml
+++ b/changelogs/fragments/4136-gitlab_runner-make-project-owned-mutually-exclusive.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'gitlab_runner - make ``project`` and ``owned`` mutually exclusive (https://github.com/ansible-collections/community.general/pull/4136).'

--- a/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/gitlab.py
@@ -17,8 +17,9 @@ import gitlab
 
 
 class FakeAnsibleModule(object):
-    def __init__(self):
+    def __init__(self, module_params=None):
         self.check_mode = False
+        self.params = module_params if module_params else {}
 
     def fail_json(self, **args):
         pass

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
@@ -65,11 +65,11 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     def test_runner_exist_owned(self):
-        rvalue = self.moduleUtil.exists_runner("test-1-20201214", True)
+        rvalue = self.moduleUtil.exists_runner("test-1-20201214", False)
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.exists_runner("test-3-00000000", True)
+        rvalue = self.moduleUtil.exists_runner("test-3-00000000", False)
 
         self.assertEqual(rvalue, False)
 

--- a/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
+++ b/tests/unit/plugins/modules/source_control/gitlab/test_gitlab_runner.py
@@ -19,7 +19,8 @@ def _dummy(x):
 
 pytestmark = []
 try:
-    from .gitlab import (GitlabModuleTestCase,
+    from .gitlab import (FakeAnsibleModule,
+                         GitlabModuleTestCase,
                          python_version_match_requirement,
                          resp_find_runners_all,
                          resp_find_runners_list, resp_get_runner,
@@ -49,33 +50,34 @@ class TestGitlabRunner(GitlabModuleTestCase):
     def setUp(self):
         super(TestGitlabRunner, self).setUp()
 
-        self.moduleUtil = GitLabRunner(module=self.mock_module, gitlab_instance=self.gitlab_instance)
+        self.module_util_all = GitLabRunner(module=FakeAnsibleModule({"owned": False}), gitlab_instance=self.gitlab_instance)
+        self.module_util_owned = GitLabRunner(module=FakeAnsibleModule({"owned": True}), gitlab_instance=self.gitlab_instance)
 
     @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     def test_runner_exist_all(self):
-        rvalue = self.moduleUtil.exists_runner("test-1-20150125")
+        rvalue = self.module_util_all.exists_runner("test-1-20150125")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.exists_runner("test-3-00000000")
+        rvalue = self.module_util_all.exists_runner("test-3-00000000")
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     def test_runner_exist_owned(self):
-        rvalue = self.moduleUtil.exists_runner("test-1-20201214", False)
+        rvalue = self.module_util_owned.exists_runner("test-1-20201214")
 
         self.assertEqual(rvalue, True)
 
-        rvalue = self.moduleUtil.exists_runner("test-3-00000000", False)
+        rvalue = self.module_util_owned.exists_runner("test-3-00000000")
 
         self.assertEqual(rvalue, False)
 
     @with_httmock(resp_create_runner)
     def test_create_runner(self):
-        runner = self.moduleUtil.create_runner({"token": "token", "description": "test-1-20150125"})
+        runner = self.module_util_all.create_runner({"token": "token", "description": "test-1-20150125"})
 
         self.assertEqual(type(runner), Runner)
         self.assertEqual(runner.description, "test-1-20150125")
@@ -83,15 +85,15 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_find_runners_all)
     @with_httmock(resp_get_runner)
     def test_update_runner(self):
-        runner = self.moduleUtil.find_runner("test-1-20150125")
+        runner = self.module_util_all.find_runner("test-1-20150125")
 
-        changed, newRunner = self.moduleUtil.update_runner(runner, {"description": "Runner description"})
+        changed, newRunner = self.module_util_all.update_runner(runner, {"description": "Runner description"})
 
         self.assertEqual(changed, True)
         self.assertEqual(type(newRunner), Runner)
         self.assertEqual(newRunner.description, "Runner description")
 
-        changed, newRunner = self.moduleUtil.update_runner(runner, {"description": "Runner description"})
+        changed, newRunner = self.module_util_all.update_runner(runner, {"description": "Runner description"})
 
         self.assertEqual(changed, False)
         self.assertEqual(newRunner.description, "Runner description")
@@ -100,8 +102,8 @@ class TestGitlabRunner(GitlabModuleTestCase):
     @with_httmock(resp_get_runner)
     @with_httmock(resp_delete_runner)
     def test_delete_runner(self):
-        self.moduleUtil.exists_runner("test-1-20150125")
+        self.module_util_all.exists_runner("test-1-20150125")
 
-        rvalue = self.moduleUtil.delete_runner()
+        rvalue = self.module_util_all.delete_runner()
 
         self.assertEqual(rvalue, None)


### PR DESCRIPTION
##### SUMMARY
This PR follows previous discussion in #3965.

Currently, `project` and `owned=no` can be used together, which leads to GitLab API error response.

This PR sets `owned` and `project` parameters as `mutually_exclusive`, since the concept of `owned` runner has no meaning for project runners.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner

##### ADDITIONAL INFORMATION
This PR also rename internal `owned` variable to `list_all_shared_runners`, for the same reason (`owned` has no meaning for project runners, which was confusing).