### PR TITLE
Drop CentOS 8 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -324,8 +324,6 @@ stages:
           targets:
             - name: CentOS 6
               test: centos6
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 34
               test: fedora34
             - name: openSUSE 15 py3


### PR DESCRIPTION
##### SUMMARY
Similar PRs for stable-1 and stable-2 are #4134 and #4135. For stable-3 and stable-4, hotfixes are in place: #4137 and #4138. I think it's better to drop it from `main`'s CI as this will end up as the next major release of community.general.

See also ansible-collections/news-for-maintainers#3.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
