### PR TITLE
xfconf: fix return value documentation to use a valid value for 'type'

### DIFF
--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -107,23 +107,26 @@ RETURN = '''
     - The type of the value that was changed (C(none) for C(get) and C(reset)
       state). Either a single string value or a list of strings for array
       types.
+    - This is a string or a list of strings.
     returned: success
-    type: string or list of strings
+    type: any
     sample: '"int" or ["str", "str", "str"]'
   value:
     description:
     - The value of the preference key after executing the module. Either a
       single string value or a list of strings for array types.
+    - This is a string or a list of strings.
     returned: success
-    type: string or list of strings
+    type: any
     sample: '"192" or ["orange", "yellow", "violet"]'
   previous_value:
     description:
     - The value of the preference key before executing the module (C(none) for
       C(get) state). Either a single string value or a list of strings for array
       types.
+    - This is a string or a list of strings.
     returned: success
-    type: string or list of strings
+    type: any
     sample: '"96" or ["red", "blue", "green"]'
 '''
 


### PR DESCRIPTION
##### SUMMARY
See https://docs.ansible.com/ansible/latest/collections/community/general/xfconf_module.html#authors

antsibull accepts `any`, which ansible-test right now does not accept.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
xfconf
