### PR TITLE
Update Proxmox Inventory Documentation with additional examples

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -114,11 +114,11 @@ groups:
   mailservers: "'mail' in (proxmox_tags_parsed|list)"
 compose:
   ansible_port: 2222
-  
+
 # Using the inventory to allow ansible to connect via the first IP address of the VM / Container
 # (Default is connection by name of QEMU/LXC guests)
-# Note: The false | default('mystr') pattern is necessary due to how compose parses Jinja2.
-#       This would add the variable to every host used by the inventory.
+# Note: my_inv_var demonstrates how to add the variable to every host used by the inventory.
+# my.proxmox.yml
 plugin: community.general.proxmox
 url: http://pve.domain.com:8006
 user: ansible@pve
@@ -126,8 +126,10 @@ password: secure
 validate_certs: false
 want_facts: true
 compose:
-  ansible_host: proxmox_ipconfig0.ip | default(proxmox_net0.ip) | ipaddr('address') 
-  my_inv_var: false | default('inv_var_literal_value',true)
+  ansible_host: proxmox_ipconfig0.ip | default(proxmox_net0.ip) | ipaddr('address')
+  my_inv_var_1: "'my_var1_value'"
+  my_inv_var_2: >
+    "my_var_2_value"
 '''
 
 import re

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -117,7 +117,7 @@ compose:
 
 # Using the inventory to allow ansible to connect via the first IP address of the VM / Container
 # (Default is connection by name of QEMU/LXC guests)
-# Note: my_inv_var demonstrates how to add the variable to every host used by the inventory.
+# Note: my_inv_var demonstrates how to add a string variable to every host used by the inventory.
 # my.proxmox.yml
 plugin: community.general.proxmox
 url: http://pve.domain.com:8006

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -115,8 +115,10 @@ groups:
 compose:
   ansible_port: 2222
   
-# Using the inventory to allow ansible to connect via the first IP address of the VM / Container (Default is connection by name of QEMU/LXC guests)
-# Note: The false | default('mystr') pattern is necessary due to how compose parses Jinja2. This would add the variable to every host used by the inventory
+# Using the inventory to allow ansible to connect via the first IP address of the VM / Container
+# (Default is connection by name of QEMU/LXC guests)
+# Note: The false | default('mystr') pattern is necessary due to how compose parses Jinja2.
+#       This would add the variable to every host used by the inventory.
 plugin: community.general.proxmox
 url: http://pve.domain.com:8006
 user: ansible@pve

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -114,6 +114,18 @@ groups:
   mailservers: "'mail' in (proxmox_tags_parsed|list)"
 compose:
   ansible_port: 2222
+  
+# Using the inventory to allow ansible to connect via the first IP address of the VM / Container (Default is connection by name of QEMU/LXC guests)
+# Note: The false | default('mystr') pattern is necessary due to how compose parses Jinja2. This would add the variable to every host used by the inventory
+plugin: community.general.proxmox
+url: http://pve.domain.com:8006
+user: ansible@pve
+password: secure
+validate_certs: false
+want_facts: true
+compose:
+  ansible_host: proxmox_ipconfig0.ip | default(proxmox_net0.ip) | ipaddr('address') 
+  my_inv_var: false | default('inv_var_literal_value',true)
 '''
 
 import re


### PR DESCRIPTION
##### SUMMARY

#### 1) Added an example to have the plugin return an IP address for a Proxmox guest, instead of the name of the guest (default behavior)

The default behavior of providing the given name from Proxmox as the connection string only works if the name in Proxmox is resolvable by system DNS, which may not be true. I'd like to do a Feature Addition to add this functionality to the actual plugin, but until one exists, having the documentation to support a workaround is much better than nothing.  

#### 2) Added an example to include a string literal to every guest (to support a playbook being able to check for variable presence to identify inventory in use)

There may be occasions in which you are trying to test a playbook or role, and want to make sure that the play you are executing is running against a given inventory (e.g. static vs dynamic, or during development). Having an example of how to add a literal string to each host is helpful, since the default "expected" behavior of `my_var_name: my_var_value` doesn't work, because Jinja2 just tries to interpret my_var_value to a value. Neither does `my_var_name: 'my_var_value'` or `my_var_name: "my_var_value"`. Unless I missed the mark, there is no easy way to add a single key-value pair to a dynamic inventory if the value is a string.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.general.proxmox

