### PR TITLE
gitlab_project_variable: Allow delete without value

### DIFF
--- a/changelogs/fragments/4150-gitlab-project-variable-absent-fix.yml
+++ b/changelogs/fragments/4150-gitlab-project-variable-absent-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_project_variable - ``value`` is not necessary when deleting variables (https://github.com/ansible-collections/community.general/pull/4150).

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -432,6 +432,9 @@ def main():
         supports_check_mode=True
     )
 
+    if not HAS_GITLAB_PACKAGE:
+        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
+
     purge = module.params['purge']
     var_list = module.params['vars']
     state = module.params['state']
@@ -444,9 +447,6 @@ def main():
     if state == 'present':
         if None in [x.get('value') for x in variables]:
             module.fail_json(msg='value parameter is required in state present')
-
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
 
     gitlab_instance = gitlab_authentication(module)
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -444,7 +444,7 @@ def main():
         variables = module.params['variables']
 
     if state == 'present':
-        if None in [x.get('value') for x in variables]:
+        if any(x['value'] is None for x in variables):
             module.fail_json(msg='value parameter is required in state present')
 
     gitlab_instance = gitlab_authentication(module)

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -74,7 +74,7 @@ options:
       value:
         description:
           - The variable value.
-          - Required when I(state=present).
+          - Required when I(state=fact).
         type: str
       masked:
         description:
@@ -401,23 +401,14 @@ def main():
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
-        variables=dict(
-            type='list',
-            elements='dict',
-            required=False,
-            default=list(),
-            required_if=(
-                ['state', 'present', ('value',)],
-            ),
-            options=dict(
-                name=dict(type='str', required=True),
-                value=dict(type='str', no_log=True),
-                masked=dict(type='bool', default=False),
-                protected=dict(type='bool', default=False),
-                environment_scope=dict(type='str', default='*'),
-                variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
-            )
-        ),
+        variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
+            name=dict(type='str', required=True),
+            value=dict(type='str', no_log=True),
+            masked=dict(type='bool', default=False),
+            protected=dict(type='bool', default=False),
+            environment_scope=dict(type='str', default='*'),
+            variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
+        )),
         state=dict(type='str', default="present", choices=["absent", "present"]),
     )
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -74,8 +74,7 @@ options:
       value:
         description:
           - The variable value.
-          - It is required when I(state) is C(present).
-          - It is not required when I(state) is C(absent).
+          - Required when I(state=present).
         type: str
       masked:
         description:
@@ -402,14 +401,23 @@ def main():
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
-        variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
-            name=dict(type='str', required=True),
-            value=dict(type='str', no_log=True),
-            masked=dict(type='bool', default=False),
-            protected=dict(type='bool', default=False),
-            environment_scope=dict(type='str', default='*'),
-            variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
-        )),
+        variables=dict(
+            type='list',
+            elements='dict',
+            required=False,
+            default=list(),
+            required_if=(
+                ['state', 'present', ('value',)],
+            ),
+            options=dict(
+                name=dict(type='str', required=True),
+                value=dict(type='str', no_log=True),
+                masked=dict(type='bool', default=False),
+                protected=dict(type='bool', default=False),
+                environment_scope=dict(type='str', default='*'),
+                variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
+            )
+        ),
         state=dict(type='str', default="present", choices=["absent", "present"]),
     )
 

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -74,8 +74,9 @@ options:
       value:
         description:
           - The variable value.
+          - It is required when I(state) is C(present).
+          - It is not required when I(state) is C(absent).
         type: str
-        required: true
       masked:
         description:
           - Wether variable value is masked or not.
@@ -403,7 +404,7 @@ def main():
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
-            value=dict(type='str', required=True, no_log=True),
+            value=dict(type='str', no_log=True),
             masked=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),
             environment_scope=dict(type='str', default='*'),
@@ -433,13 +434,16 @@ def main():
 
     purge = module.params['purge']
     var_list = module.params['vars']
+    state = module.params['state']
 
     if var_list:
         variables = vars_to_variables(var_list, module)
     else:
         variables = module.params['variables']
 
-    state = module.params['state']
+    if state == 'present':
+        if None in [x.get('value') for x in variables]:
+            module.fail_json(msg='value parameter is required in state present')
 
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)

--- a/plugins/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_variable.py
@@ -74,7 +74,7 @@ options:
       value:
         description:
           - The variable value.
-          - Required when I(state=fact).
+          - Required when I(state=present).
         type: str
       masked:
         description:

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -227,6 +227,7 @@
     vars:
       ACCESS_KEY_ID:
         environment_scope: testing
+        value: checkmode
   register: gitlab_project_variable_state
 
 - name: state must be changed
@@ -242,6 +243,7 @@
     vars:
       ACCESS_KEY_ID:
         environment_scope: testing
+        value: checkmode
   register: gitlab_project_variable_state
 
 - name: state must not be changed

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -644,3 +644,52 @@
       - gitlab_project_variable_state.project_variable.untouched|length == 0
       - gitlab_project_variable_state.project_variable.removed|length == 0
       - gitlab_project_variable_state.project_variable.updated|length == 0
+
+- name: throw error when state is present but no value is given
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    variables:
+      - name: delete_me
+  register: gitlab_project_variable_state
+  ignore_errors: yes
+
+- name: verify fail
+  assert:
+    that:
+      - gitlab_project_variable_state.failed
+      - gitlab_project_variable_state is not changed
+
+- name: set a new variable to delete is later
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    purge: True
+    variables:
+      - name: delete_me
+        value: ansible
+  register: gitlab_project_variable_state
+
+- name: verify the change
+  assert:
+    that:
+      - gitlab_project_variable_state.changed
+
+- name: delete variable without referencing its value
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    state: absent
+    variables:
+      - name: delete_me
+  register: gitlab_project_variable_state
+
+- name: verify deletion
+  assert:
+    that:
+      - gitlab_project_variable_state.changed
+      - gitlab_project_variable_state.project_variable.removed|length == 0
+      - gitlab_project_variable_state.project_variable.updated|length == 0

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -663,7 +663,7 @@
       - gitlab_project_variable_state.failed
       - gitlab_project_variable_state is not changed
 
-- name: set a new variable to delete is later
+- name: set a new variable to delete it later
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"

--- a/tests/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/tests/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -693,5 +693,4 @@
   assert:
     that:
       - gitlab_project_variable_state.changed
-      - gitlab_project_variable_state.project_variable.removed|length == 0
-      - gitlab_project_variable_state.project_variable.updated|length == 0
+      - gitlab_project_variable_state.project_variable.removed|length == 1


### PR DESCRIPTION
##### SUMMARY

When delete project variables, the value is not necessary.  
It's a bug that was introduced with the new `variables` parameter in 4.4.0  
It works like this before: https://github.com/ansible-collections/community.general/blob/stable-2/plugins/modules/source_control/gitlab/gitlab_project_variable.py#L250

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
gitlab_project_variable

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
