### PR TITLE
dconf: Skip processes that disappeared while we inspected them

### DIFF
--- a/changelogs/fragments/4151-dconf-catch-psutil-nosuchprocess.yaml
+++ b/changelogs/fragments/4151-dconf-catch-psutil-nosuchprocess.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "dconf - Skip processes that disappeared while we inspected them (#4151)"
+  - "dconf - skip processes that disappeared while we inspected them (https://github.com/ansible-collections/community.general/issues/4151)."

--- a/changelogs/fragments/4151-dconf-catch-psutil-nosuchprocess.yaml
+++ b/changelogs/fragments/4151-dconf-catch-psutil-nosuchprocess.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dconf - Skip processes that disappeared while we inspected them (#4151)"

--- a/plugins/modules/system/dconf.py
+++ b/plugins/modules/system/dconf.py
@@ -180,9 +180,9 @@ class DBusWrapper(object):
         self.module.debug("Trying to detect existing D-Bus user session for user: %d" % uid)
 
         for pid in psutil.pids():
-            process = psutil.Process(pid)
-            process_real_uid, dummy, dummy = process.uids()
             try:
+                process = psutil.Process(pid)
+                process_real_uid, dummy, dummy = process.uids()
                 if process_real_uid == uid and 'DBUS_SESSION_BUS_ADDRESS' in process.environ():
                     dbus_session_bus_address_candidate = process.environ()['DBUS_SESSION_BUS_ADDRESS']
                     self.module.debug("Found D-Bus user session candidate at address: %s" % dbus_session_bus_address_candidate)
@@ -197,6 +197,9 @@ class DBusWrapper(object):
 
             # This can happen with things like SSH sessions etc.
             except psutil.AccessDenied:
+                pass
+            # Process has disappeared while inspecting it
+            except psutil.NoSuchProcess:
                 pass
 
         self.module.debug("Failed to find running D-Bus user session, will use dbus-run-session")


### PR DESCRIPTION
##### SUMMARY
Original code goes through all the pids for this user, tries to extract the D-Bus session bus address from environment, and ensures it is possible to connect to it.

Since time when pids were listed and a pid is being processed the pid could disappear which means we cannot get additional properties of the process like `uids()` or `environs()`. We could safely skip this process in a hope that there will be another one that still exists and we could inspect it. Similar skipping existed even before this change when one gets `AccessDenied` from `psutil`.

Fixes #4151

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dconf
