### PR TITLE
[stable-1] Fix CI

### DIFF
--- a/tests/integration/targets/inventory_kubevirt/runme.sh
+++ b/tests/integration/targets/inventory_kubevirt/runme.sh
@@ -23,7 +23,7 @@ source virtualenv.sh
 python --version
 pip --version
 pip show setuptools
-pip install openshift -c constraints.txt
+pip install 'openshift<0.13.0' -c constraints.txt
 
 ./server.py &
 


### PR DESCRIPTION
##### SUMMARY
stable-1's CI is currently broken due to `openshift == 0.13.0` doing something wrong. Let's stick to `openshift < 0.13.0` since this branch is EOL soon anyway.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
