### PR TITLE
gem: Fixes #3779 installing updated gem using gem_source

### DIFF
--- a/changelogs/fragments/4172-gem-source.yaml
+++ b/changelogs/fragments/4172-gem-source.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - gem - fix version handling when using ``gem_source``
+    (https://github.com/ansible-collections/community.general/issues/3779).

--- a/plugins/modules/packaging/language/gem.py
+++ b/plugins/modules/packaging/language/gem.py
@@ -319,7 +319,7 @@ def main():
 
     if module.params['gem_source']:
         filename = os.path.basename(module.params['gem_source'])
-        match = re.match(r".*(\d+\.\d+\.\d+)", filename)
+        match = re.match(r".*-(\d+\.\d+\.\d+)", filename)
         if match:
             module.params['version'] = match.group(1)
         else:

--- a/plugins/modules/packaging/language/gem.py
+++ b/plugins/modules/packaging/language/gem.py
@@ -133,9 +133,8 @@ EXAMPLES = '''
     state: present
 '''
 
+import os
 import re
-
-from pathlib import PurePosixPath
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -319,7 +318,7 @@ def main():
         module.fail_json(msg="install_dir requires user_install=false")
 
     if module.params['gem_source']:
-        filename = PurePosixPath(module.params['gem_source']).name
+        filename = os.path.basename(module.params['gem_source'])
         match = re.match(r".*(\d+\.\d+\.\d+)", filename)
         if match:
             module.params['version'] = match.group(1)

--- a/plugins/modules/packaging/language/gem.py
+++ b/plugins/modules/packaging/language/gem.py
@@ -135,6 +135,8 @@ EXAMPLES = '''
 
 import re
 
+from pathlib import PurePosixPath
+
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -316,7 +318,14 @@ def main():
     if module.params['user_install'] and module.params['install_dir']:
         module.fail_json(msg="install_dir requires user_install=false")
 
-    if not module.params['gem_source']:
+    if module.params['gem_source']:
+        filename = PurePosixPath(module.params['gem_source']).name
+        match = re.match(r".*(\d+\.\d+\.\d+)", filename)
+        if match:
+            module.params['version'] = match.group(1)
+        else:
+            module.fail_json(msg="Unable to parse version from gem_source")
+    else:
         module.params['gem_source'] = module.params['name']
 
     changed = False


### PR DESCRIPTION
##### SUMMARY

When specifying the `gem_source`, Ansible currently only checks to see if a gem with the same module is installed. If it is, the task returns OK even though the version of the file specified by the `gem_source` is not installed.

Modify `modules/packaging/language/gem.py` so when `gem_source` is specified, the `gem_version` will be set to the version
specified in the filename of the gem given by `gem_source`. This will cause Ansible to correctly install the specified version of the gem when it is missing, even when another version is installed.

This fixes #3779, though in a manner different then the author of that issue suggested.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gem