### PR TITLE
homebrew: detect already installed cask using homebrew

### DIFF
--- a/changelogs/fragments/864-homebrew-cask-install.yml
+++ b/changelogs/fragments/864-homebrew-cask-install.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- homebrew - detect already installed cask using homebrew command to maintain idempotency (https://github.com/ansible-collections/community.general/issues/864).

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -471,20 +471,33 @@ class Homebrew(object):
             self.message = 'Invalid package: {0}.'.format(self.current_package)
             raise HomebrewException(self.message)
 
-        cmd = [
-            "{brew_path}".format(brew_path=self.brew_path),
-            "info",
-            self.current_package,
-        ]
-        rc, out, err = self.module.run_command(cmd)
-        for line in out.split('\n'):
-            if (
-                re.search(r'Built from source', line)
-                or re.search(r'Poured from bottle', line)
-            ):
+        if "homebrew/cask" in self.current_package:
+            cmd = [
+                "{brew_path}".format(brew_path=self.brew_path),
+                "ls", "--cask",
+                self.current_package,
+            ]
+            rc, out, err = self.module.run_command(cmd)
+            if rc == 0:
                 return True
+            return False
+        else:
+            cmd = [
+                "{brew_path}".format(brew_path=self.brew_path),
+                "info",
+                self.current_package,
+            ]
 
-        return False
+            rc, out, err = self.module.run_command(cmd)
+
+            for line in out.split('\n'):
+                if (
+                    re.search(r'Built from source', line)
+                    or re.search(r'Poured from bottle', line)
+                ):
+                    return True
+
+            return False
 
     def _current_package_is_outdated(self):
         if not self.valid_package(self.current_package):

--- a/tests/integration/targets/homebrew/tasks/install_package.yml
+++ b/tests/integration/targets/homebrew/tasks/install_package.yml
@@ -7,44 +7,11 @@
 # Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: Find brew binary
-  command: which brew
-  register: brew_which
-  when: ansible_distribution in ['MacOSX']
-
-- name: Get owner of brew binary
-  stat:
-    path: "{{ brew_which.stdout }}"
-  register: brew_stat
-  when: ansible_distribution in ['MacOSX']
-
-#- name: Use ignored-pinned option while upgrading all
-#  homebrew:
-#    upgrade_all: yes
-#    upgrade_options: ignore-pinned
-#  become: yes
-#  become_user: "{{ brew_stat.stat.pw_name }}"
-#  register: upgrade_option_result
-#  environment:
-#    HOMEBREW_NO_AUTO_UPDATE: True
-
-#- assert:
-#    that:
-#      - upgrade_option_result.changed
-
-- include_tasks: install_package.yml
-  vars:
-    package_name: "{{ item }}"
-  with_items:
-    - gnu-tar
-
-- set_fact:
-    package_name: homebrew/cask/1clipboard
-
 - name: Make sure {{ package_name }} package is not installed
   homebrew:
     name: "{{ package_name }}"
     state: absent
+    update_homebrew: no
   become: yes
   become_user: "{{ brew_stat.stat.pw_name }}"
 
@@ -52,6 +19,7 @@
   homebrew:
     name: "{{ package_name }}"
     state: present
+    update_homebrew: no
   become: yes
   become_user: "{{ brew_stat.stat.pw_name }}"
   register: package_result
@@ -64,6 +32,33 @@
   homebrew:
     name: "{{ package_name }}"
     state: present
+    update_homebrew: no
+  become: yes
+  become_user: "{{ brew_stat.stat.pw_name }}"
+  register: package_result
+
+- assert:
+    that:
+      - not package_result.changed
+
+- name: Uninstall {{ package_name }} package using homebrew
+  homebrew:
+    name: "{{ package_name }}"
+    state: absent
+    update_homebrew: no
+  become: yes
+  become_user: "{{ brew_stat.stat.pw_name }}"
+  register: package_result
+
+- assert:
+    that:
+      - package_result.changed
+
+- name: Again uninstall {{ package_name }} package using homebrew
+  homebrew:
+    name: "{{ package_name }}"
+    state: absent
+    update_homebrew: no
   become: yes
   become_user: "{{ brew_stat.stat.pw_name }}"
   register: package_result


### PR DESCRIPTION
##### SUMMARY

In order to maintain idempotency, detect already installed cask using
``brew ls`` command.

Fixes: #864

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/864-homebrew-cask-install.yml
plugins/modules/packaging/os/homebrew.py
tests/integration/targets/homebrew/tasks/install_package.yml
tests/integration/targets/homebrew/tasks/main.yml
