### PR TITLE
Updated keycloak.py to allow defining connection timeout value (#4168)

### DIFF
--- a/changelogs/fragments/4168-add-keycloak-url-timeout.yml
+++ b/changelogs/fragments/4168-add-keycloak-url-timeout.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "Keycloak module - added connection timeout parameter when calling server (https://github.com/ansible-collections/community.general/pull/4168)."
+  - "keycloak_* modules - added connection timeout parameter when calling server (https://github.com/ansible-collections/community.general/pull/4168)."

--- a/changelogs/fragments/4168-add-keycloak-url-timeout.yml
+++ b/changelogs/fragments/4168-add-keycloak-url-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Keycloak module - added connection timeout parameter when calling server (https://github.com/ansible-collections/community.general/pull/4168)."

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -61,10 +61,11 @@ options:
             - Verify TLS certificates (do not disable this in production).
         type: bool
         default: yes
-    
+
     connection_timeout:
         description:
-            - Controls the http connections timeout period (in seconds) to keycloak API.
+            - Controls the HTTP connections timeout period (in seconds) to Keycloak API.
         type: int
         default: 10
+        version_added: 4.5.0
 '''

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -61,4 +61,10 @@ options:
             - Verify TLS certificates (do not disable this in production).
         type: bool
         default: yes
+    
+    connection_timeout:
+        description:
+            - Controls the http connections timeout period (in seconds) to keycloak API.
+        type: int
+        default: 10
 '''

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -135,7 +135,7 @@ def get_token(module_params):
         auth_username = module_params.get('auth_username')
         auth_password = module_params.get('auth_password')
         client_secret = module_params.get('auth_client_secret')
-        connection_timeout = module_params.get('connection_timeout');
+        connection_timeout = module_params.get('connection_timeout')
         auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
         temp_payload = {
             'grant_type': 'password',
@@ -541,7 +541,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep), validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
+                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
                                       % (cid, gid, realm, str(e)))
@@ -557,7 +558,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="DELETE", headers=self.restheaders, validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            open_url(available_rolemappings_url, method="DELETE", headers=self.restheaders,
+                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not delete available rolemappings for client %s in group %s, realm %s: %s"
                                       % (cid, gid, realm, str(e)))
@@ -1234,7 +1236,8 @@ class KeycloakAPI(object):
         try:
             authentication_flow = {}
             # Check if the authentication flow exists on the Keycloak serveraders
-            authentications = json.load(open_url(URL_AUTHENTICATION_FLOWS.format(url=self.baseurl, realm=realm), method='GET', headers=self.restheaders, timeout=self.connection_timeout))
+            authentications = json.load(open_url(URL_AUTHENTICATION_FLOWS.format(url=self.baseurl, realm=realm), method='GET',
+                                                 headers=self.restheaders, timeout=self.connection_timeout))
             for authentication in authentications:
                 if authentication["alias"] == alias:
                     authentication_flow = authentication


### PR DESCRIPTION

##### SUMMARY

You can find a summary along with a discussion [here](https://github.com/ansible-collections/community.general/issues/4168) 

**IMPORTANT:** This pull request adds a new parameter to the keycloak module, the `connection_timeout`. 
If provided, it propagates this value as the optional value `timeout` to the `open_url()` calls. By default (if not defined), it inherits the 10 sec default value of the underlying `timeout` parameter. 
We decided to name it `connection_timeout` instead of just `timeout`, because we didn't want to have a naming collision with the task timeout parameter or the network-specific ones, as mentioned [here](https://docs.ansible.com/ansible/latest/network/user_guide/network_debug_troubleshooting.html#command-timeout), but we could rename it into anything else in case this name is not appropriate.
 
The [documentation](https://docs.ansible.com/ansible/latest/collections/community/general/index.html) should also be updated, to include this parameter as an optional to all keycloak plugin calls.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
[keycloak](https://github.com/ansible-collections/community.general/blob/main/plugins/module_utils/identity/keycloak/keycloak.py)

##### ADDITIONAL INFORMATION

