### PR TITLE
linode: support cache in Linode dynamic inventory

### DIFF
--- a/changelogs/fragments/4179-linode-inventory-cache.yaml
+++ b/changelogs/fragments/4179-linode-inventory-cache.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - linode inventory plugin - add support for caching inventory results (https://github.com/ansible-collections/community.general/pull/4179).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for caching results from the Linode dynamic inventory plugin.

Because the Linode API module uses non-serializable custom classes, I store the raw JSON response from the API in the cache and recreate the `Instance` objects when reading from cache.
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
linode
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I've confirmed that the inventory works as expected both with cache disabled and with it enabled. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
