### PR TITLE
yum_versionlock: Fix entry matching

### DIFF
--- a/changelogs/fragments/4183-fix-yum_versionlock.yaml
+++ b/changelogs/fragments/4183-fix-yum_versionlock.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "yum_versionlock - fix matching of existing entries with names passed to the module. Match yum and dnf lock format (https://github.com/ansible-collections/community.general/pull/4183)."


### PR DESCRIPTION
##### SUMMARY

As an input the module receives names of packages to lock.
Those never matched existing entries and therefore always reported
changes.

For compatibility yum is symlinked to dnf on newer systems,
but versionlock entries defer. Try to parse both formats.
Fixes #2998 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum_versionlock
