### PR TITLE
[WIP] [modules/cloud/misc/proxmox_kvm] Refactor of hostpci[n], ide[n], net[n], sata[n], scsi[n], virtio[n] options into lists of dicts instead of dicts of str

### DIFF
--- a/changelogs/fragments/4188-proxmox_kvm-options-refactor.yaml
+++ b/changelogs/fragments/4188-proxmox_kvm-options-refactor.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - proxmox_kvm - refactor of several options to tranform them into dicts instead of strings (https://github.com/ansible-collections/community.general/pull/4188)

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -87,6 +87,7 @@ def ansible_dict_to_proxmox_string(kv_dict):
             del kv_dict['']
         return ','.join([k + '=' + str(v) for k, v in kv_dict.items()])
 
+
 class ProxmoxAnsible(object):
     """Base class for Proxmox modules"""
     def __init__(self, module):

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -67,6 +67,26 @@ def ansible_to_proxmox_bool(value):
     return 1 if value else 0
 
 
+def proxmox_string_to_ansible_dict(string):
+    """Convert a comma separated string of key=value pairs that is obtained from the API or from params to a dict in
+     the format of {key: value}. For some API endpoints, the first part contains just the value and no key. In this case
+     the resulting dict will have a key that is the empty string ('') whose value is the verbatim value from the API"""
+    return dict(pair.split('=') if '=' in pair else ['', pair] for pair in string.split(','))
+
+
+def ansible_dict_to_proxmox_string(kv_dict):
+    """Convert a dict in the format of {key: value} in a strnig that the PVE API can understand, namely a comma
+     separated string of key=value pairs. Developer is responsible for the dict having the correct key/values pairs. In
+     case the API expects the first argument not to have a key (for instance storage definitions usually start with the
+     volume specification) then use an empty string ('') as the key, the function will output it as the first part of
+     the string"""
+    if isinstance(kv_dict, dict):
+        join_list = []
+        if '' in kv_dict:
+            join_list.append(kv_dict[''])
+            del kv_dict['']
+        return ','.join([k + '=' + str(v) for k, v in kv_dict.items()])
+
 class ProxmoxAnsible(object):
     """Base class for Proxmox modules"""
     def __init__(self, module):

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -204,7 +204,7 @@ options:
       - Enable/disable hugepages memory.
     type: str
     choices: ['any', '2', '1024']
-  ide:
+  ide_dictstr:
     description:
       - A hash/dictionary of volume used as IDE hard disk or CD-ROM. C(ide='{"key":"value", "key":"value"}').
       - Keys allowed are - C(ide[n]) where 0 ≤ n ≤ 3.
@@ -215,6 +215,199 @@ options:
         Administrator Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for
         the latest version, tables 3 to 14) to find out format supported by the provided storage backend.
     type: dict
+    aliases:
+      - ide
+  ide_listdict:
+    description:
+      - to be written
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - to be written
+        type: str
+        choices: ['ide0', 'ide1', 'ide2', 'ide3']
+      storage:
+        description:
+          - to be written
+        type: str
+      size_in_gb:
+        description:
+          - to be written
+        type: float
+      aio:
+        description:
+          - to be written
+        type: str
+        choices: ['native', 'threads', 'io_uring']
+      backup:
+        description:
+          - to be written
+        type: bool
+      bps:
+        description:
+          - to be written
+        type: int
+      bps_max_length:
+        description:
+          - to be written
+        type: int
+      bps_rd:
+        description:
+          - to be written
+        type: int
+      bps_rd_max_length:
+        description:
+          - to be written
+        type: int
+      bps_wr:
+        description:
+          - to be written
+        type: int
+      bps_wr_max_length:
+        description:
+          - to be written
+        type: int
+      cache:
+        description:
+          - to be written
+        type: str
+        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
+      cyls:
+        description:
+          - to be written
+        type: int
+      detect_zeroes:
+        description:
+          - to be written
+        type: bool
+      discard:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'on']
+      format:
+        description:
+          - to be written
+        type: str
+        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
+      heads:
+        description:
+          - to be written
+        type: int
+      iops:
+        description:
+          - to be written
+        type: int
+      iops_max:
+        description:
+          - to be written
+        type: int
+      iops_max_length:
+        description:
+          - to be written
+        type: int
+      iops_rd:
+        description:
+          - to be written
+        type: int
+      iops_rd_max:
+        description:
+          - to be written
+        type: int
+      iops_rd_max_length:
+        description:
+          - to be written
+        type: int
+      iops_wr:
+        description:
+          - to be written
+        type: int
+      iops_wr_max:
+        description:
+          - to be written
+        type: int
+      iops_wr_max_length:
+        description:
+          - to be written
+        type: int
+      mbps:
+        description:
+          - to be written
+        type: int
+      mbps_max:
+        description:
+          - to be written
+        type: int
+      mbps_rd:
+        description:
+          - to be written
+        type: int
+      mbps_rd_max:
+        description:
+          - to be written
+        type: int
+      mbps_wr:
+        description:
+          - to be written
+        type: int
+      mbps_wr_max:
+        description:
+          - to be written
+        type: int
+      media:
+        description:
+          - to be written
+        type: str
+        choices: ['disk', 'cdrom']
+      model:
+        description:
+          - to be written
+        type: str
+      replicate:
+        description:
+          - to be written
+        type: bool
+      rerror:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'report', 'stop']
+      secs:
+        description:
+          - to be written
+        type: int
+      serial:
+        description:
+          - to be written
+        type: str
+      shared:
+        description:
+          - to be written
+        type: bool
+      size:
+        description:
+          - to be written
+        type: str
+      snapshot:
+        description:
+          - to be written
+        type: bool
+      trans:
+        description:
+          - to be written
+        type: str
+        choices: ['none', 'lba', 'auto']
+      werror:
+        description:
+          - to be written
+        type: str
+        choices: ['enospc', 'ignore', 'report', 'stop']
+      wwn:
+        description:
+          - to be written
+        type: str
   ipconfig:
     description:
       - 'cloud-init: Set the IP configuration.'
@@ -338,7 +531,7 @@ options:
     description:
       - Revert a pending change.
     type: str
-  sata:
+  sata_dictstr:
     description:
       - A hash/dictionary of volume used as sata hard disk or CD-ROM. C(sata='{"key":"value", "key":"value"}').
       - Keys allowed are - C(sata[n]) where 0 ≤ n ≤ 5.
@@ -349,7 +542,200 @@ options:
         Administrator Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for
         the latest version, tables 3 to 14) to find out format supported by the provided storage backend.
     type: dict
-  scsi:
+    aliases:
+      - sata
+  sata_listdict:
+    description:
+      - to be written
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - to be written
+        type: str
+        choices: ['sata0', 'sata1', 'sata2', 'sata3', 'sata4', 'sata5']
+      storage:
+        description:
+          - to be written
+        type: str
+      size_in_gb:
+        description:
+          - to be written
+        type: float
+      aio:
+        description:
+          - to be written
+        type: str
+        choices: ['native', 'threads', 'io_uring']
+      backup:
+        description:
+          - to be written
+        type: bool
+      bps:
+        description:
+          - to be written
+        type: int
+      bps_max_length:
+        description:
+          - to be written
+        type: int
+      bps_rd:
+        description:
+          - to be written
+        type: int
+      bps_rd_max_length:
+        description:
+          - to be written
+        type: int
+      bps_wr:
+        description:
+          - to be written
+        type: int
+      bps_wr_max_length:
+        description:
+          - to be written
+        type: int
+      cache:
+        description:
+          - to be written
+        type: str
+        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
+      cyls:
+        description:
+          - to be written
+        type: int
+      detect_zeroes:
+        description:
+          - to be written
+        type: bool
+      discard:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'on']
+      format:
+        description:
+          - to be written
+        type: str
+        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
+      heads:
+        description:
+          - to be written
+        type: int
+      iops:
+        description:
+          - to be written
+        type: int
+      iops_max:
+        description:
+          - to be written
+        type: int
+      iops_max_length:
+        description:
+          - to be written
+        type: int
+      iops_rd:
+        description:
+          - to be written
+        type: int
+      iops_rd_max:
+        description:
+          - to be written
+        type: int
+      iops_rd_max_length:
+        description:
+          - to be written
+        type: int
+      iops_wr:
+        description:
+          - to be written
+        type: int
+      iops_wr_max:
+        description:
+          - to be written
+        type: int
+      iops_wr_max_length:
+        description:
+          - to be written
+        type: int
+      mbps:
+        description:
+          - to be written
+        type: int
+      mbps_max:
+        description:
+          - to be written
+        type: int
+      mbps_rd:
+        description:
+          - to be written
+        type: int
+      mbps_rd_max:
+        description:
+          - to be written
+        type: int
+      mbps_wr:
+        description:
+          - to be written
+        type: int
+      mbps_wr_max:
+        description:
+          - to be written
+        type: int
+      media:
+        description:
+          - to be written
+        type: str
+        choices: ['disk', 'cdrom']
+      replicate:
+        description:
+          - to be written
+        type: bool
+      rerror:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'report', 'stop']
+      secs:
+        description:
+          - to be written
+        type: int
+      serial:
+        description:
+          - to be written
+        type: str
+      shared:
+        description:
+          - to be written
+        type: bool
+      size:
+        description:
+          - to be written
+        type: str
+      snapshot:
+        description:
+          - to be written
+        type: bool
+      ssd:
+        description:
+          - to be written
+        type: bool
+      trans:
+        description:
+          - to be written
+        type: str
+        choices: ['none', 'lba', 'auto']
+      werror:
+        description:
+          - to be written
+        type: str
+        choices: ['enospc', 'ignore', 'report', 'stop']
+      wwn:
+        description:
+          - to be written
+        type: str
+  scsi_dictstr:
     description:
       - A hash/dictionary of volume used as SCSI hard disk or CD-ROM. C(scsi='{"key":"value", "key":"value"}').
       - Keys allowed are - C(sata[n]) where 0 ≤ n ≤ 13.
@@ -360,6 +746,213 @@ options:
         Administrator Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for
         the latest version, tables 3 to 14) to find out format supported by the provided storage backend.
     type: dict
+    aliases:
+      - scsi
+  scsi_listdict:
+    description:
+      - to be written
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - to be written
+        type: str
+        choices: ['scsi0', 'scsi1', 'scsi2', 'scsi3', 'scsi4', 'scsi5', 'scsi6', 'scsi7', 'scsi8', 'scsi9', 'scsi10',
+        'scsi11', 'scsi12', 'scsi13', 'scsi14', 'scsi15', 'scsi16', 'scsi17', 'scsi18', 'scsi19', 'scsi20', 'scsi21',
+        'scsi22', 'scsi23', 'scsi24', 'scsi25', 'scsi26', 'scsi27', 'scsi28', 'scsi29', 'scsi30']
+      storage:
+        description:
+          - to be written
+        type: str
+      size_in_gb:
+        description:
+          - to be written
+        type: float
+      aio:
+        description:
+          - to be written
+        type: str
+        choices: ['native', 'threads', 'io_uring']
+      backup:
+        description:
+          - to be written
+        type: bool
+      bps:
+        description:
+          - to be written
+        type: int
+      bps_max_length:
+        description:
+          - to be written
+        type: int
+      bps_rd:
+        description:
+          - to be written
+        type: int
+      bps_rd_max_length:
+        description:
+          - to be written
+        type: int
+      bps_wr:
+        description:
+          - to be written
+        type: int
+      bps_wr_max_length:
+        description:
+          - to be written
+        type: int
+      cache:
+        description:
+          - to be written
+        type: str
+        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
+      cyls:
+        description:
+          - to be written
+        type: int
+      detect_zeroes:
+        description:
+          - to be written
+        type: bool
+      discard:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'on']
+      format:
+        description:
+          - to be written
+        type: str
+        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
+      heads:
+        description:
+          - to be written
+        type: int
+      iops:
+        description:
+          - to be written
+        type: int
+      iops_max:
+        description:
+          - to be written
+        type: int
+      iops_max_length:
+        description:
+          - to be written
+        type: int
+      iops_rd:
+        description:
+          - to be written
+        type: int
+      iops_rd_max:
+        description:
+          - to be written
+        type: int
+      iops_rd_max_length:
+        description:
+          - to be written
+        type: int
+      iops_wr:
+        description:
+          - to be written
+        type: int
+      iops_wr_max:
+        description:
+          - to be written
+        type: int
+      iops_wr_max_length:
+        description:
+          - to be written
+        type: int
+      mbps:
+        description:
+          - to be written
+        type: int
+      mbps_max:
+        description:
+          - to be written
+        type: int
+      mbps_rd:
+        description:
+          - to be written
+        type: int
+      mbps_rd_max:
+        description:
+          - to be written
+        type: int
+      mbps_wr:
+        description:
+          - to be written
+        type: int
+      mbps_wr_max:
+        description:
+          - to be written
+        type: int
+      media:
+        description:
+          - to be written
+        type: str
+        choices: ['disk', 'cdrom']
+      queues:
+        description:
+          - to be written
+        type: int
+      replicate:
+        description:
+          - to be written
+        type: bool
+      rerror:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'report', 'stop']
+      ro:
+        description:
+          - to be writtent
+        type: bool
+      scsibloc:
+        description:
+          - to be written
+        type: bool
+      secs:
+        description:
+          - to be written
+        type: int
+      serial:
+        description:
+          - to be written
+        type: str
+      shared:
+        description:
+          - to be written
+        type: bool
+      size:
+        description:
+          - to be written
+        type: str
+      snapshot:
+        description:
+          - to be written
+        type: bool
+      ssd:
+        description:
+          - to be written
+        type: bool
+      trans:
+        description:
+          - to be written
+        type: str
+        choices: ['none', 'lba', 'auto']
+      werror:
+        description:
+          - to be written
+        type: str
+        choices: ['enospc', 'ignore', 'report', 'stop']
+      wwn:
+        description:
+          - to be written
+        type: str
   scsihw:
     description:
       - Specifies the SCSI controller model.
@@ -481,7 +1074,7 @@ options:
       - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(std).
     type: str
     choices: ['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']
-  virtio:
+  virtio_dictstr:
     description:
       - A hash/dictionary of volume used as VIRTIO hard disk. C(virtio='{"key":"value", "key":"value"}').
       - Keys allowed are - C(virto[n]) where 0 ≤ n ≤ 15.
@@ -492,6 +1085,200 @@ options:
         Administrator Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html)
         for the latest version, tables 3 to 14) to find out format supported by the provided storage backend.
     type: dict
+    aliases:
+      - virtio
+  virtio_listdict:
+    description:
+      - to be written
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - to be written
+        type: str
+        choices: ['virtio0', 'virtio1', 'virtio2', 'virtio3', 'virtio4', 'virtio5', 'virtio6', 'virtio7', 'virtio8',
+        'virtio9', 'virtio10', 'virtio11', 'virtio12', 'virtio13', 'virtio14', 'virtio15']
+      storage:
+        description:
+          - to be written
+        type: str
+      size_in_gb:
+        description:
+          - to be written
+        type: float
+      aio:
+        description:
+          - to be written
+        type: str
+        choices: ['native', 'threads', 'io_uring']
+      backup:
+        description:
+          - to be written
+        type: bool
+      bps:
+        description:
+          - to be written
+        type: int
+      bps_max_length:
+        description:
+          - to be written
+        type: int
+      bps_rd:
+        description:
+          - to be written
+        type: int
+      bps_rd_max_length:
+        description:
+          - to be written
+        type: int
+      bps_wr:
+        description:
+          - to be written
+        type: int
+      bps_wr_max_length:
+        description:
+          - to be written
+        type: int
+      cache:
+        description:
+          - to be written
+        type: str
+        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
+      cyls:
+        description:
+          - to be written
+        type: int
+      detect_zeroes:
+        description:
+          - to be written
+        type: bool
+      discard:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'on']
+      format:
+        description:
+          - to be written
+        type: str
+        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
+      heads:
+        description:
+          - to be written
+        type: int
+      iops:
+        description:
+          - to be written
+        type: int
+      iops_max:
+        description:
+          - to be written
+        type: int
+      iops_max_length:
+        description:
+          - to be written
+        type: int
+      iops_rd:
+        description:
+          - to be written
+        type: int
+      iops_rd_max:
+        description:
+          - to be written
+        type: int
+      iops_rd_max_length:
+        description:
+          - to be written
+        type: int
+      iops_wr:
+        description:
+          - to be written
+        type: int
+      iops_wr_max:
+        description:
+          - to be written
+        type: int
+      iops_wr_max_length:
+        description:
+          - to be written
+        type: int
+      mbps:
+        description:
+          - to be written
+        type: int
+      mbps_max:
+        description:
+          - to be written
+        type: int
+      mbps_rd:
+        description:
+          - to be written
+        type: int
+      mbps_rd_max:
+        description:
+          - to be written
+        type: int
+      mbps_wr:
+        description:
+          - to be written
+        type: int
+      mbps_wr_max:
+        description:
+          - to be written
+        type: int
+      media:
+        description:
+          - to be written
+        type: str
+        choices: ['disk', 'cdrom']
+      replicate:
+        description:
+          - to be written
+        type: bool
+      rerror:
+        description:
+          - to be written
+        type: str
+        choices: ['ignore', 'report', 'stop']
+      ro:
+        description:
+          - to be written
+        type: bool
+      secs:
+        description:
+          - to be written
+        type: int
+      serial:
+        description:
+          - to be written
+        type: str
+      shared:
+        description:
+          - to be written
+        type: bool
+      size:
+        description:
+          - to be written
+        type: str
+      snapshot:
+        description:
+          - to be written
+        type: bool
+      trans:
+        description:
+          - to be written
+        type: str
+        choices: ['none', 'lba', 'auto']
+      werror:
+        description:
+          - to be written
+        type: str
+        choices: ['enospc', 'ignore', 'report', 'stop']
+      wwn:
+        description:
+          - to be written
+        type: str
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.
@@ -952,6 +1739,20 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                                       if 'storage' != k])
             kwargs['efidisk0'] = efidisk0_str
 
+        # Flatten ide_listdict, sata_listdic, scsi_listdict, virtio_listdict into {name: str} dicts and push them to
+        # kwargs, and then deleting the original *_listdicts as they are not understood by PVE API
+        for key in ['ide_listdict', 'sata_listdict', 'scsi_listdict', 'virtio_listdict']:
+            if key in kwargs.keys():
+                for item in kwargs[key]:
+                    dict_key = item['name']
+                    # Storage backend and volume has to be first, and has to look like <storage>:<size>
+                    flattened_str = item['storage'] + ':' + str(item['size_in_gb']) + ','
+                    # Add remaining options as key=value, using commas as separator
+                    flattened_str += ','.join([k + '=' + str(v) for k, v in item.items() if k not in ['name', 'storage',
+                                                                                                      'size_in_gb']])
+                    kwargs.update({dict_key: flattened_str})
+                del kwargs[key]
+
         # Convert all dict in kwargs to elements.
         # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n]
         for k in list(kwargs.keys()):
@@ -1037,6 +1838,73 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
 def main():
     module_args = proxmox_auth_argument_spec()
+    format_arg_spec = dict(type='str', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk'])
+    common_storage_arg_spec = dict(storage=dict(type='str'),
+                                   size_in_gb=dict(type='float'),
+                                   aio=dict(type='str', choices=['native', 'threads', 'io_uring']),
+                                   backup=dict(type='bool'),
+                                   bps=dict(type='int'),
+                                   bps_max_length=dict(type='int'),
+                                   bps_rd=dict(type='int'),
+                                   bps_rd_max_length=dict(type='int'),
+                                   bps_wr=dict(type='int'),
+                                   bps_wr_max_length=dict(type='int'),
+                                   cache=dict(type='str', choices=['directsync', 'none', 'unsafe',
+                                                                   'writeback', 'writethrough']),
+                                   cyls=dict(type='int'),
+                                   detect_zeroes=dict(type='bool'),
+                                   discard=dict(type='str', choices=['ignore', 'on']),
+                                   format=format_arg_spec,
+                                   heads=dict(type='int'),
+                                   iops=dict(type='int'),
+                                   iops_max=dict(type='int'),
+                                   iops_max_length=dict(type='int'),
+                                   iops_rd=dict(type='int'),
+                                   iops_rd_max=dict(type='int'),
+                                   iops_rd_max_length=dict(type='int'),
+                                   iops_wr=dict(type='int'),
+                                   iops_wr_max=dict(type='int'),
+                                   iops_wr_max_length=dict(type='int'),
+                                   mbps=dict(type='int'),
+                                   mbps_max=dict(type='int'),
+                                   mbps_rd=dict(type='int'),
+                                   mbps_rd_max=dict(type='int'),
+                                   mbps_wr=dict(type='int'),
+                                   mbps_wr_max=dict(type='int'),
+                                   media=dict(type='str', choices=['cdrom', 'disk']),
+                                   replicate=dict(type='bool'),
+                                   rerror=dict(type='str', choices=['ignore', 'report', 'stop']),
+                                   secs=dict(type='int'),
+                                   serial=dict(type='str'),
+                                   shared=dict(type='bool'),
+                                   size=dict(type='str'),
+                                   snapshot=dict(type='bool'),
+                                   trans=dict(type='str', choices=['none', 'lba', 'auto']),
+                                   werror=dict(type='str', choices=['enospc', 'ignore', 'report', 'stop']),
+                                   wwn=dict(type='str')
+                                   )
+    ide_storage_arg_spec = common_storage_arg_spec.copy()
+    ide_storage_arg_spec.update(dict(
+        name=dict(type='str', choices=['ide' + str(n) for n in range(0, 4)]),
+        model=dict(type='str')
+    ))
+    sata_storage_arg_spec = common_storage_arg_spec.copy()
+    sata_storage_arg_spec.update(dict(
+        name=dict(type='str', choices=['sata' + str(n) for n in range(0, 6)]),
+        ssd=dict(type='bool')
+    ))
+    scsi_storage_arg_spec = sata_storage_arg_spec.copy()
+    scsi_storage_arg_spec.update(dict(
+        name=dict(type='str', choices=['scsi' + str(n) for n in range(0, 31)]),
+        queues=dict(type='int'),
+        ro=dict(type='bool'),
+        scsibloc=dict(type='bool'),
+    ))
+    virtio_storage_arg_spec = common_storage_arg_spec.copy()
+    virtio_storage_arg_spec.update(dict(
+        name=dict(type='str', choices=['virtio' + str(n) for n in range(0, 16)]),
+        ro=dict(type='bool'),
+    ))
     kvm_args = dict(
         acpi=dict(type='bool'),
         agent=dict(type='bool'),
@@ -1072,7 +1940,11 @@ def main():
         hostpci=dict(type='dict'),
         hotplug=dict(type='str'),
         hugepages=dict(choices=['any', '2', '1024']),
-        ide=dict(type='dict'),
+        ide_dictstr=dict(type='dict', aliases=['ide']),
+        ide_listdict=dict(type='list',
+                          elements='dict',
+                          options=ide_storage_arg_spec
+                          ),
         ipconfig=dict(type='dict'),
         keyboard=dict(type='str'),
         kvm=dict(type='bool'),
@@ -1096,8 +1968,14 @@ def main():
         protection=dict(type='bool'),
         reboot=dict(type='bool'),
         revert=dict(type='str'),
-        sata=dict(type='dict'),
-        scsi=dict(type='dict'),
+        sata_dictstr=dict(type='dict', aliases=['sata']),
+        sata_listdict=dict(type='list',
+                           elements='dict',
+                           options=sata_storage_arg_spec),
+        scsi_dictstr=dict(type='dict', aliases=['scsi']),
+        scsi_listdict=dict(type='list',
+                           elements='dict',
+                           options=scsi_storage_arg_spec),
         scsihw=dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
         serial=dict(type='dict'),
         searchdomains=dict(type='list', elements='str'),
@@ -1120,7 +1998,11 @@ def main():
         update=dict(type='bool', default=False),
         vcpus=dict(type='int'),
         vga=dict(choices=['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
-        virtio=dict(type='dict'),
+        virtio_dictstr=dict(type='dict', aliases=['virtio']),
+        virtio_listdict=dict(type='list',
+                             elements='dict',
+                             options=virtio_storage_arg_spec
+                             ),
         vmid=dict(type='int'),
         watchdog=dict(),
         proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults']),
@@ -1129,7 +2011,10 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        mutually_exclusive=[('delete', 'revert'), ('delete', 'update'), ('revert', 'update'), ('clone', 'update'), ('clone', 'delete'), ('clone', 'revert')],
+        mutually_exclusive=[('delete', 'revert'), ('delete', 'update'), ('revert', 'update'), ('clone', 'update'),
+                            ('clone', 'delete'), ('clone', 'revert'), ('ide_dictstr', 'ide_listdict'),
+                            ('sata_dictstr', 'sata_listdict'), ('scsi_dictstr', 'scsi_listdict'),
+                            ('virtio_dictstr', 'virtio_listdict')],
         required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
         required_if=[('state', 'present', ['node'])],
@@ -1260,7 +2145,8 @@ def main():
                               hostpci=module.params['hostpci'],
                               hotplug=module.params['hotplug'],
                               hugepages=module.params['hugepages'],
-                              ide=module.params['ide'],
+                              ide=module.params['ide_dictstr'],
+                              ide_listdict=module.params['ide_listdict'],
                               ipconfig=module.params['ipconfig'],
                               keyboard=module.params['keyboard'],
                               kvm=module.params['kvm'],
@@ -1278,8 +2164,10 @@ def main():
                               pool=module.params['pool'],
                               protection=module.params['protection'],
                               reboot=module.params['reboot'],
-                              sata=module.params['sata'],
-                              scsi=module.params['scsi'],
+                              sata=module.params['sata_dictstr'],
+                              sata_listdict=module.params['sata_lsit_dict'],
+                              scsi=module.params['scsi_dictstr'],
+                              scsi_listdict=module.params['scsi_listdict'],
                               scsihw=module.params['scsihw'],
                               serial=module.params['serial'],
                               shares=module.params['shares'],

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -228,135 +228,139 @@ options:
           - to be written
         type: str
         choices: ['ide0', 'ide1', 'ide2', 'ide3']
-      storage:
+      storage : &storage_option_storage
         description:
           - to be written
         type: str
-      size_in_gb:
+      size_in_gb : &storage_option_size_in_gb
         description:
           - to be written
         type: float
-      aio:
+      aio : &storage_option_aio
         description:
           - to be written
         type: str
         choices: ['native', 'threads', 'io_uring']
-      backup:
+      backup : &storage_option_backup
         description:
           - to be written
         type: bool
-      bps:
+      bps : &storage_option_bps
         description:
           - to be written
         type: int
-      bps_max_length:
+      bps_max_length : &storage_option_bps_max_length
         description:
           - to be written
         type: int
-      bps_rd:
+      bps_rd : &storage_option_bps_rd
         description:
           - to be written
         type: int
-      bps_rd_max_length:
+      bps_rd_max_length : &storage_option_bps_rd_max_length
         description:
           - to be written
         type: int
-      bps_wr:
+      bps_wr : &storage_option_bps_wr
         description:
           - to be written
         type: int
-      bps_wr_max_length:
+      bps_wr_max_length : &storage_option_bps_wr_max_length
         description:
           - to be written
         type: int
-      cache:
+      cache : &storage_option_cache
         description:
           - to be written
         type: str
         choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
-      cyls:
+      cyls : &storage_option_cyls
         description:
           - to be written
         type: int
-      detect_zeroes:
+      detect_zeroes : &storage_option_detect_zeroes
         description:
           - to be written
         type: bool
-      discard:
+      discard : &storage_option_discard
         description:
           - to be written
         type: str
         choices: ['ignore', 'on']
-      format:
+      file : &storage_option_file
+        description:
+          - to be written
+        type: str
+      format : &storage_option_format
         description:
           - to be written
         type: str
         choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
-      heads:
+      heads : &storage_option_heads
         description:
           - to be written
         type: int
-      iops:
+      iops : &storage_option_iops
         description:
           - to be written
         type: int
-      iops_max:
+      iops_max : &storage_option_iops_max
         description:
           - to be written
         type: int
-      iops_max_length:
+      iops_max_length : &storage_option_iops_max_length
         description:
           - to be written
         type: int
-      iops_rd:
+      iops_rd : &storage_option_iops_rd
         description:
           - to be written
         type: int
-      iops_rd_max:
+      iops_rd_max : &storage_option_iops_rd_max
         description:
           - to be written
         type: int
-      iops_rd_max_length:
+      iops_rd_max_length : &storage_option_iops_rd_max_length
         description:
           - to be written
         type: int
-      iops_wr:
+      iops_wr : &storage_option_iops_wr
         description:
           - to be written
         type: int
-      iops_wr_max:
+      iops_wr_max : &storage_option_iops_wr_max
         description:
           - to be written
         type: int
-      iops_wr_max_length:
+      iops_wr_max_length : &storage_option_iops_wr_max_length
         description:
           - to be written
         type: int
-      mbps:
+      mbps : &storage_option_mbps
         description:
           - to be written
         type: int
-      mbps_max:
+      mbps_max : &storage_option_mbps_max
         description:
           - to be written
         type: int
-      mbps_rd:
+      mbps_rd : &storage_option_mbps_rd
         description:
           - to be written
         type: int
-      mbps_rd_max:
+      mbps_rd_max : &storage_option_mbps_rd_max
         description:
           - to be written
         type: int
-      mbps_wr:
+      mbps_wr : &storage_option_mbps_wr
         description:
           - to be written
         type: int
-      mbps_wr_max:
+      mbps_wr_max : &storage_option_mbps_wr_max
         description:
           - to be written
         type: int
-      media:
+      media : &storage_option_media
         description:
           - to be written
         type: str
@@ -365,49 +369,50 @@ options:
         description:
           - to be written
         type: str
-      replicate:
+      replicate : &storage_option_replicate
         description:
           - to be written
         type: bool
-      rerror:
+      rerror : &storage_option_rerror
         description:
           - to be written
         type: str
         choices: ['ignore', 'report', 'stop']
-      secs:
+      secs : &storage_option_secs
         description:
           - to be written
         type: int
-      serial:
+      serial : &storage_option_serial
         description:
           - to be written
         type: str
-      shared:
+      shared : &storage_option_shared
         description:
           - to be written
         type: bool
-      size:
+      size : &storage_option_size
         description:
           - to be written
         type: str
-      snapshot:
+      snapshot : &storage_option_snapshot
         description:
           - to be written
         type: bool
-      trans:
+      trans : &storage_option_trans
         description:
           - to be written
         type: str
         choices: ['none', 'lba', 'auto']
-      werror:
+      werror : &storage_option_werror
         description:
           - to be written
         type: str
         choices: ['enospc', 'ignore', 'report', 'stop']
-      wwn:
+      wwn : &storage_option_wwn
         description:
           - to be written
         type: str
+    version_added: 5.0.0
   ipconfig:
     description:
       - 'cloud-init: Set the IP configuration.'
@@ -555,186 +560,54 @@ options:
           - to be written
         type: str
         choices: ['sata0', 'sata1', 'sata2', 'sata3', 'sata4', 'sata5']
-      storage:
-        description:
-          - to be written
-        type: str
-      size_in_gb:
-        description:
-          - to be written
-        type: float
-      aio:
-        description:
-          - to be written
-        type: str
-        choices: ['native', 'threads', 'io_uring']
-      backup:
-        description:
-          - to be written
-        type: bool
-      bps:
-        description:
-          - to be written
-        type: int
-      bps_max_length:
-        description:
-          - to be written
-        type: int
-      bps_rd:
-        description:
-          - to be written
-        type: int
-      bps_rd_max_length:
-        description:
-          - to be written
-        type: int
-      bps_wr:
-        description:
-          - to be written
-        type: int
-      bps_wr_max_length:
-        description:
-          - to be written
-        type: int
-      cache:
-        description:
-          - to be written
-        type: str
-        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
-      cyls:
-        description:
-          - to be written
-        type: int
-      detect_zeroes:
-        description:
-          - to be written
-        type: bool
-      discard:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'on']
-      format:
-        description:
-          - to be written
-        type: str
-        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
-      heads:
-        description:
-          - to be written
-        type: int
-      iops:
-        description:
-          - to be written
-        type: int
-      iops_max:
-        description:
-          - to be written
-        type: int
-      iops_max_length:
-        description:
-          - to be written
-        type: int
-      iops_rd:
-        description:
-          - to be written
-        type: int
-      iops_rd_max:
-        description:
-          - to be written
-        type: int
-      iops_rd_max_length:
-        description:
-          - to be written
-        type: int
-      iops_wr:
-        description:
-          - to be written
-        type: int
-      iops_wr_max:
-        description:
-          - to be written
-        type: int
-      iops_wr_max_length:
-        description:
-          - to be written
-        type: int
-      mbps:
-        description:
-          - to be written
-        type: int
-      mbps_max:
-        description:
-          - to be written
-        type: int
-      mbps_rd:
-        description:
-          - to be written
-        type: int
-      mbps_rd_max:
-        description:
-          - to be written
-        type: int
-      mbps_wr:
-        description:
-          - to be written
-        type: int
-      mbps_wr_max:
-        description:
-          - to be written
-        type: int
-      media:
-        description:
-          - to be written
-        type: str
-        choices: ['disk', 'cdrom']
-      replicate:
-        description:
-          - to be written
-        type: bool
-      rerror:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'report', 'stop']
-      secs:
-        description:
-          - to be written
-        type: int
-      serial:
-        description:
-          - to be written
-        type: str
-      shared:
-        description:
-          - to be written
-        type: bool
-      size:
-        description:
-          - to be written
-        type: str
-      snapshot:
-        description:
-          - to be written
-        type: bool
+      storage: *storage_option_storage
+      size_in_gb: *storage_option_size_in_gb
+      aio: *storage_option_aio
+      backup: *storage_option_backup
+      bps: *storage_option_bps
+      bps_max_length: *storage_option_bps_max_length
+      bps_rd: *storage_option_bps_rd
+      bps_rd_max_length: *storage_option_bps_max_length
+      bps_wr: *storage_option_bps_wr
+      bps_wr_max_length: *storage_option_wr_max_length
+      cache: *storage_option_cache
+      cyls: *storage_option_cyls
+      detect_zeroes: *storage_option_detect_zeroes
+      discard: *storage_option_discard
+      file: *storage_option_file
+      format: *storage_option_format
+      heads: *storage_option_heads
+      iops: *storage_option_iops
+      iops_max: *storage_option_iops_max
+      iops_max_length: *storage_option_iops_max_length
+      iops_rd: *storage_option_iops_rd
+      iops_rd_max: *storage_option_iops_rd_max
+      iops_rd_max_length: *storage_option_iops_rd_max_length
+      iops_wr: *storage_option_iops_wr
+      iops_wr_max: *storage_option_iops_wr_max
+      iops_wr_max_length: *storage_option_iops_wr_max_length
+      mbps: *storage_option_mbps
+      mbps_max: *storage_option_mbps_max
+      mbps_rd: *storage_option_mbps_rd
+      mbps_rd_max: *storage_option_mbps_rd_max
+      mbps_wr: *storage_mbps_wr
+      mbps_wr_max: *storage_mbps_wr_max
+      media: *storage_option_media
+      replicate: *storage_option_replicate
+      rerror: *storage_option_rerror
+      secs: *storage_option_secs
+      serial: *storage_option_serial
+      shared: *storage_option_shared
+      size: *storage_option_size
+      snapshot: *storage_option_snapshot
       ssd:
         description:
           - to be written
         type: bool
-      trans:
-        description:
-          - to be written
-        type: str
-        choices: ['none', 'lba', 'auto']
-      werror:
-        description:
-          - to be written
-        type: str
-        choices: ['enospc', 'ignore', 'report', 'stop']
-      wwn:
-        description:
-          - to be written
-        type: str
+      trans: *storage_option_trans
+      werror: *storage_option_werror
+      wwn: *storage_option_wwn
+    version_added: 5.0.0
   scsi_dictstr:
     description:
       - A hash/dictionary of volume used as SCSI hard disk or CD-ROM. C(scsi='{"key":"value", "key":"value"}').
@@ -761,198 +634,66 @@ options:
         choices: ['scsi0', 'scsi1', 'scsi2', 'scsi3', 'scsi4', 'scsi5', 'scsi6', 'scsi7', 'scsi8', 'scsi9', 'scsi10',
         'scsi11', 'scsi12', 'scsi13', 'scsi14', 'scsi15', 'scsi16', 'scsi17', 'scsi18', 'scsi19', 'scsi20', 'scsi21',
         'scsi22', 'scsi23', 'scsi24', 'scsi25', 'scsi26', 'scsi27', 'scsi28', 'scsi29', 'scsi30']
-      storage:
-        description:
-          - to be written
-        type: str
-      size_in_gb:
-        description:
-          - to be written
-        type: float
-      aio:
-        description:
-          - to be written
-        type: str
-        choices: ['native', 'threads', 'io_uring']
-      backup:
-        description:
-          - to be written
-        type: bool
-      bps:
-        description:
-          - to be written
-        type: int
-      bps_max_length:
-        description:
-          - to be written
-        type: int
-      bps_rd:
-        description:
-          - to be written
-        type: int
-      bps_rd_max_length:
-        description:
-          - to be written
-        type: int
-      bps_wr:
-        description:
-          - to be written
-        type: int
-      bps_wr_max_length:
-        description:
-          - to be written
-        type: int
-      cache:
-        description:
-          - to be written
-        type: str
-        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
-      cyls:
-        description:
-          - to be written
-        type: int
-      detect_zeroes:
-        description:
-          - to be written
-        type: bool
-      discard:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'on']
-      format:
-        description:
-          - to be written
-        type: str
-        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
-      heads:
-        description:
-          - to be written
-        type: int
-      iops:
-        description:
-          - to be written
-        type: int
-      iops_max:
-        description:
-          - to be written
-        type: int
-      iops_max_length:
-        description:
-          - to be written
-        type: int
-      iops_rd:
-        description:
-          - to be written
-        type: int
-      iops_rd_max:
-        description:
-          - to be written
-        type: int
-      iops_rd_max_length:
-        description:
-          - to be written
-        type: int
-      iops_wr:
-        description:
-          - to be written
-        type: int
-      iops_wr_max:
-        description:
-          - to be written
-        type: int
-      iops_wr_max_length:
-        description:
-          - to be written
-        type: int
-      mbps:
-        description:
-          - to be written
-        type: int
-      mbps_max:
-        description:
-          - to be written
-        type: int
-      mbps_rd:
-        description:
-          - to be written
-        type: int
-      mbps_rd_max:
-        description:
-          - to be written
-        type: int
-      mbps_wr:
-        description:
-          - to be written
-        type: int
-      mbps_wr_max:
-        description:
-          - to be written
-        type: int
-      media:
-        description:
-          - to be written
-        type: str
-        choices: ['disk', 'cdrom']
+      storage: *storage_option_storage
+      size_in_gb: *storage_option_size_in_gb
+      aio: *storage_option_aio
+      backup: *storage_option_backup
+      bps: *storage_option_bps
+      bps_max_length: *storage_option_bps_max_length
+      bps_rd: *storage_option_bps_rd
+      bps_rd_max_length: *storage_option_bps_rd_max_length
+      bps_wr: *storage_option_bps_wr
+      bps_wr_max_length: *storage_option_bps_wr_max_length
+      cache: *storage_option_cache
+      cyls: *storage_option_cyls
+      detect_zeroes: *storage_option_detect_zeroes
+      discard: *storage_option_discard
+      file: *storage_option_file
+      format: *storage_option_format
+      heads: *storage_option_heads
+      iops: *storage_option_iops
+      iops_max: *storage_option_iops_max
+      iops_max_length: *storage_option_iops_max_length
+      iops_rd: *storage_option_iops_rd
+      iops_rd_max: *storage_option_iops_rd_max
+      iops_rd_max_length: *storage_option_iops_rd_max_length
+      iops_wr: *storage_option_iops_wr
+      iops_wr_max: *storage_option_iops_wr_max
+      iops_wr_max_length: *storage_option_iops_wr_max_length
+      mbps: *storage_option_mbps
+      mbps_max: *storage_option_mbps_max
+      mbps_rd: *storage_option_mbps_rd
+      mbps_rd_max: *storage_option_mbps_rd_max
+      mbps_wr: *storage_option_mbps_wr
+      mbps_wr_max: *storage_option_mbps_wr_max
+      media: *storage_option_media
       queues:
         description:
           - to be written
         type: int
-      replicate:
-        description:
-          - to be written
-        type: bool
-      rerror:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'report', 'stop']
+      replicate: *storage_option_replicate
+      rerror: *storage_option_rerror
       ro:
         description:
-          - to be writtent
+          - to be written
         type: bool
       scsibloc:
         description:
           - to be written
         type: bool
-      secs:
-        description:
-          - to be written
-        type: int
-      serial:
-        description:
-          - to be written
-        type: str
-      shared:
-        description:
-          - to be written
-        type: bool
-      size:
-        description:
-          - to be written
-        type: str
-      snapshot:
-        description:
-          - to be written
-        type: bool
+      secs: *storage_option_secs
+      serial: *storage_option_serial
+      shared: *storage_option_shared
+      size: *storage_option_size
+      snapshot: *storage_option_snapshot
       ssd:
         description:
           - to be written
         type: bool
-      trans:
-        description:
-          - to be written
-        type: str
-        choices: ['none', 'lba', 'auto']
-      werror:
-        description:
-          - to be written
-        type: str
-        choices: ['enospc', 'ignore', 'report', 'stop']
-      wwn:
-        description:
-          - to be written
-        type: str
+      trans: *storage_option_trans
+      werror: *storage_option_werror
+      wwn: *storage_option_wwn
+    version_added: 5.0.0
   scsihw:
     description:
       - Specifies the SCSI controller model.
@@ -1099,186 +840,54 @@ options:
         type: str
         choices: ['virtio0', 'virtio1', 'virtio2', 'virtio3', 'virtio4', 'virtio5', 'virtio6', 'virtio7', 'virtio8',
         'virtio9', 'virtio10', 'virtio11', 'virtio12', 'virtio13', 'virtio14', 'virtio15']
-      storage:
-        description:
-          - to be written
-        type: str
-      size_in_gb:
-        description:
-          - to be written
-        type: float
-      aio:
-        description:
-          - to be written
-        type: str
-        choices: ['native', 'threads', 'io_uring']
-      backup:
-        description:
-          - to be written
-        type: bool
-      bps:
-        description:
-          - to be written
-        type: int
-      bps_max_length:
-        description:
-          - to be written
-        type: int
-      bps_rd:
-        description:
-          - to be written
-        type: int
-      bps_rd_max_length:
-        description:
-          - to be written
-        type: int
-      bps_wr:
-        description:
-          - to be written
-        type: int
-      bps_wr_max_length:
-        description:
-          - to be written
-        type: int
-      cache:
-        description:
-          - to be written
-        type: str
-        choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
-      cyls:
-        description:
-          - to be written
-        type: int
-      detect_zeroes:
-        description:
-          - to be written
-        type: bool
-      discard:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'on']
-      format:
-        description:
-          - to be written
-        type: str
-        choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
-      heads:
-        description:
-          - to be written
-        type: int
-      iops:
-        description:
-          - to be written
-        type: int
-      iops_max:
-        description:
-          - to be written
-        type: int
-      iops_max_length:
-        description:
-          - to be written
-        type: int
-      iops_rd:
-        description:
-          - to be written
-        type: int
-      iops_rd_max:
-        description:
-          - to be written
-        type: int
-      iops_rd_max_length:
-        description:
-          - to be written
-        type: int
-      iops_wr:
-        description:
-          - to be written
-        type: int
-      iops_wr_max:
-        description:
-          - to be written
-        type: int
-      iops_wr_max_length:
-        description:
-          - to be written
-        type: int
-      mbps:
-        description:
-          - to be written
-        type: int
-      mbps_max:
-        description:
-          - to be written
-        type: int
-      mbps_rd:
-        description:
-          - to be written
-        type: int
-      mbps_rd_max:
-        description:
-          - to be written
-        type: int
-      mbps_wr:
-        description:
-          - to be written
-        type: int
-      mbps_wr_max:
-        description:
-          - to be written
-        type: int
-      media:
-        description:
-          - to be written
-        type: str
-        choices: ['disk', 'cdrom']
-      replicate:
-        description:
-          - to be written
-        type: bool
-      rerror:
-        description:
-          - to be written
-        type: str
-        choices: ['ignore', 'report', 'stop']
+      storage: *storage_option_storage
+      size_in_gb: *storage_option_size_in_gb
+      aio: *storage_option_aio
+      backup: *storage_option_backup
+      bps: *storage_option_bps
+      bps_max_length: *storage_option_bps_max_length
+      bps_rd: *storage_option_bps_rd
+      bps_rd_max_length: *storage_option_bps_rd_max_length
+      bps_wr: *storage_option_bps_wr
+      bps_wr_max_length: *storage_option_bps_wr_max_length
+      cache: *storage_option_cache
+      cyls: *storage_option_cyls
+      detect_zeroes: *storage_option_detect_zeroes
+      discard: *storage_option_discard
+      file: *storage_option_file
+      format: *storage_option_format
+      heads: *storage_option_heads
+      iops: *storage_option_iops
+      iops_max: *storage_option_iops_max
+      iops_max_length: *storage_option_iops_max_length
+      iops_rd: *storage_option_iops_rd
+      iops_rd_max: *storage_option_iops_rd_max
+      iops_rd_max_length: *storage_option_iops_rd_max_length
+      iops_wr: *storage_option_iops_wr
+      iops_wr_max: *storage_option_iops_wr_max
+      iops_wr_max_length: *storage_option_iops_wr_max_length
+      mbps: *storage_option_mbps
+      mbps_max: *storage_option_mbps_max
+      mbps_rd: *storage_option_mbps_rd
+      mbps_rd_max: *storage_option_mbps_rd_max
+      mbps_wr: *storage_option_mbps_wr
+      mbps_wr_max: *storage_option_mbps_wr_max
+      media: *storage_option_media
+      replicate: *storage_option_replicate
+      rerror: *storage_option_rerror
       ro:
         description:
           - to be written
         type: bool
-      secs:
-        description:
-          - to be written
-        type: int
-      serial:
-        description:
-          - to be written
-        type: str
-      shared:
-        description:
-          - to be written
-        type: bool
-      size:
-        description:
-          - to be written
-        type: str
-      snapshot:
-        description:
-          - to be written
-        type: bool
-      trans:
-        description:
-          - to be written
-        type: str
-        choices: ['none', 'lba', 'auto']
-      werror:
-        description:
-          - to be written
-        type: str
-        choices: ['enospc', 'ignore', 'report', 'stop']
-      wwn:
-        description:
-          - to be written
-        type: str
+      secs: *storage_option_secs
+      serial: *storage_option_serial
+      shared: *storage_option_shared
+      size: *storage_option_size
+      snapshot: *storage_option_snapshot
+      trans: *storage_option_trans
+      werror: *storage_option_werror
+      wwn: *storage_option_wwn
+    version_added: 5.0.0
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.
@@ -1675,6 +1284,102 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
         proxmox_node = self.proxmox_api.nodes(node)
 
+        module_params = self.module.params
+
+        update = module_params['update']
+        vmid = module_params['vmid']
+        newid = module_params['newid']
+        clone = module_params['clone']
+
+        create_params = dict(
+            node=module_params['node'],
+            vmid=module_params['vmid'],
+            acpi=module_params['acpi'],
+            agent=module_params['agent'],
+            arch=module_params['arch'],
+            args=module_params['args'],
+            audio0=module_params['audio0'],
+            autostart=module_params['autostart'],
+            background_delay=module_params['background_delay'],
+            balloon=module_params['balloon'],
+            bios=module_params['bios'],
+            boot=module_params['boot'],
+            bootdisk=module_params['bootdisk'],
+            cdrom=module_params['cdrom'],
+            cicustom=module_params['cicustom'],
+            cipassword=module_params['cipassword'],
+            citype=module_params['citype'],
+            ciuser=module_params['ciuser'],
+            cores=module_params['cores'],
+            cpu=module_params['cpu'],
+            cpulimit=module_params['cpulimit'],
+            cpuunits=module_params['cpuunits'],
+            delete=module_params['delete'],
+            description=module_params['description'],
+            digest=module_params['digest'],
+            efidisk0=module_params['efidisk0'],
+            force=module_params['force'],
+            freeze=module_params['freeze'],
+            hookscript=module_params['hookscript'],
+            hostpci=module_params['hostpci'],
+            hotplug=module_params['hotplug'],
+            hugepages=module_params['hugepages'],
+            ide_dictstr=module_params['ide_dictstr'],
+            ide_listdict=module_params['ide_listdict'],
+            ipconfig=module_params['ipconfig'],
+            ivshmem=module_params['ivshmem'],
+            keephugepages=module_params['keephugepages'],
+            keyboard=module_params['keyboard'],
+            kvm=module_params['kvm'],
+            localtime=module_params['localtime'],
+            lock=module_params['lock'],
+            machine=module_params['machine'],
+            memory=module_params['memory'],
+            migrate_downtime=module_params['migrate_downtime'],
+            migrate_speed=module_params['migrate_speed'],
+            name=module_params['name'],
+            nameserver=module_params['nameserver'],
+            net=module_params['net'],
+            numa=module_params['numa_enabled'],
+            numas=module_params['numa'],
+            onboot=module_params['onboot'],
+            ostype=module_params['ostype'],
+            parallel=module_params['parallel'],
+            protection=module_params['protection'],
+            reboot=module_params['reboot'],
+            revert=module_params['revert'],
+            rng0=module_params['rng0'],
+            sata_dictstr=module_params['sata_dictstr'],
+            sata_listdict=module_params['sata_listdict'],
+            scsi_dictstr=module_params['scsi_dictstr'],
+            scsi_listdict=module_params['scsi_listdict'],
+            scsihw=module_params['scsihw'],
+            searchdomain=module_params['searchdomain'],
+            serial=module_params['serial'],
+            shares=module_params['shares'],
+            skiplock=module_params['skiplock'],
+            smbios1=module_params['smbios'],
+            smp=module_params['smp'],
+            sockets=module_params['sockets'],
+            spice_enhancements=module_params['spice_enhancements'],
+            sshkeys=module_params['sshkeys'],
+            startdate=module_params['startdate'],
+            startup=module_params['startup'],
+            tablet=module_params['tablet'],
+            tags=module_params['tags'],
+            tdf=module_params['tdf'],
+            template=module_params['template'],
+            unused=module_params['unused'],
+            usb=module_params['usb'],
+            vcpus=module_params['vcpus'],
+            vga=module_params['vga'],
+            virtio_dictstr=module_params['virtio_dictstr'],
+            virtio_listdict=module_params['virtio_listdict'],
+            vmgenid=module_params['vmgenid'],
+            vmstatestorage=module_params['vmstatestorage'],
+            watchdog=module_params['watchdog']
+        )
+
         # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
         kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
         kwargs.update(dict([k, int(v)] for k, v in kwargs.items() if isinstance(v, bool)))
@@ -1871,6 +1576,7 @@ def main():
                                    cyls=dict(type='int'),
                                    detect_zeroes=dict(type='bool'),
                                    discard=dict(type='str', choices=['ignore', 'on']),
+                                   file=dict(type='str'),
                                    format=format_arg_spec,
                                    heads=dict(type='int'),
                                    iops=dict(type='int'),
@@ -1960,7 +1666,8 @@ def main():
         ide_dictstr=dict(type='dict', aliases=['ide']),
         ide_listdict=dict(type='list',
                           elements='dict',
-                          options=ide_storage_arg_spec
+                          options=ide_storage_arg_spec,
+                          mutually_exclusive=[('file', 'size_in_gb')],
                           ),
         ipconfig=dict(type='dict'),
         keyboard=dict(type='str'),
@@ -1988,11 +1695,15 @@ def main():
         sata_dictstr=dict(type='dict', aliases=['sata']),
         sata_listdict=dict(type='list',
                            elements='dict',
-                           options=sata_storage_arg_spec),
+                           options=sata_storage_arg_spec,
+                           mutually_exclusive=[('file', 'size_in_gb')],
+                           ),
         scsi_dictstr=dict(type='dict', aliases=['scsi']),
         scsi_listdict=dict(type='list',
                            elements='dict',
-                           options=scsi_storage_arg_spec),
+                           options=scsi_storage_arg_spec,
+                           mutually_exclusive=[('file', 'size_in_gb')],
+                           ),
         scsihw=dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
         serial=dict(type='dict'),
         searchdomains=dict(type='list', elements='str'),
@@ -2018,7 +1729,8 @@ def main():
         virtio_dictstr=dict(type='dict', aliases=['virtio']),
         virtio_listdict=dict(type='list',
                              elements='dict',
-                             options=virtio_storage_arg_spec
+                             options=virtio_storage_arg_spec,
+                             mutually_exclusive=[('file', 'size_in_gb')],
                              ),
         vmid=dict(type='int'),
         watchdog=dict(),

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -569,7 +569,7 @@ options:
       bps_rd: *storage_option_bps_rd
       bps_rd_max_length: *storage_option_bps_max_length
       bps_wr: *storage_option_bps_wr
-      bps_wr_max_length: *storage_option_wr_max_length
+      bps_wr_max_length: *storage_option_bps_wr_max_length
       cache: *storage_option_cache
       cyls: *storage_option_cyls
       detect_zeroes: *storage_option_detect_zeroes
@@ -590,8 +590,8 @@ options:
       mbps_max: *storage_option_mbps_max
       mbps_rd: *storage_option_mbps_rd
       mbps_rd_max: *storage_option_mbps_rd_max
-      mbps_wr: *storage_mbps_wr
-      mbps_wr_max: *storage_mbps_wr_max
+      mbps_wr: *storage_option_mbps_wr
+      mbps_wr_max: *storage_option_mbps_wr_max
       media: *storage_option_media
       replicate: *storage_option_replicate
       rerror: *storage_option_rerror

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -223,194 +223,215 @@ options:
     type: list
     elements: dict
     suboptions:
-      name:
+      name: &storage_option_name
         description:
-          - to be written
+          - API name of the disk device that is going to be added.
+          - Should be C(ide(n)) with C(n) between 0 and 3 included.
         type: str
         choices: ['ide0', 'ide1', 'ide2', 'ide3']
       storage : &storage_option_storage
         description:
-          - to be written
+          - C(storage) is the storage identifier where to create the disk.
         type: str
       size_in_gb : &storage_option_size_in_gb
         description:
-          - to be written
+          - Disk size in GB in order to create a new volume.
+          - Mutually exclusive with C(file).
         type: float
-      aio : &storage_option_aio
+      aio: &storage_option_aio
         description:
-          - to be written
+          - "Indicate which Async I/O driver is used for the VM:"
+          - C(native) is Linux AIO,
+          - C(threads) makes use of thread pools,
+          - C(io_uring) is developped to give better performance that traditional Linux AIO.
         type: str
         choices: ['native', 'threads', 'io_uring']
       backup : &storage_option_backup
         description:
-          - to be written
+          - Whether this disk should be included when making a backup of the VM.
         type: bool
       bps : &storage_option_bps
         description:
-          - to be written
+          - Sets the maximum read/write speed for this disk in bytes per seconds.
         type: int
       bps_max_length : &storage_option_bps_max_length
         description:
-          - to be written
+          - Sets the maximum length of I/O bursts in seconds.
         type: int
       bps_rd : &storage_option_bps_rd
         description:
-          - to be written
+          - Sets the maximum read speed in bytes per second.
         type: int
       bps_rd_max_length : &storage_option_bps_rd_max_length
         description:
-          - to be written
+          - Sets the maximum length of read I/O bursts in seconds.
         type: int
       bps_wr : &storage_option_bps_wr
         description:
-          - to be written
+          - Sets the maximum write speed in bytes per second.
         type: int
       bps_wr_max_length : &storage_option_bps_wr_max_length
         description:
-          - to be written
+          - Sets the maximum length of write I/O bursts in seconds.
         type: int
       cache : &storage_option_cache
         description:
-          - to be written
+          - Controls how the host cache is used to access block data.
         type: str
         choices: ['directsync', 'none', 'unsafe', 'writeback', 'writethrough']
       cyls : &storage_option_cyls
         description:
-          - to be written
+          - Force the drive's physical geometry to have a specific cylinder count.
         type: int
       detect_zeroes : &storage_option_detect_zeroes
         description:
-          - to be written
+          - Controls whether to detect and try to optimize writes of zeroes.
         type: bool
       discard : &storage_option_discard
         description:
-          - to be written
+          - Controls whether to pass discard/trim requests to the underlying storage.
         type: str
         choices: ['ignore', 'on']
       file : &storage_option_file
         description:
-          - to be written
+          - Indicate a file that contains the disk if you want to reuse an existing volume
+          - Mutually exclusive with C(size_in_gb)
         type: str
       format : &storage_option_format
         description:
-          - to be written
+          - The drive's backing file's data format. Please refer to the Proxmox VE
+            Administrator Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html)
+            for the latest version, tables 3 to 14) to find out format supported by the provided storage backend.
         type: str
         choices: ['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk']
       heads : &storage_option_heads
         description:
-          - to be written
+          - Force the drive's physical geometry to have a specific head count.
         type: int
       iops : &storage_option_iops
         description:
-          - to be written
+          - Sets the maximum read/write I/O in operations per second.
         type: int
       iops_max : &storage_option_iops_max
         description:
-          - to be written
+          - Sets the maximum unthrottled read/write I/O pool in operations per second.
         type: int
       iops_max_length : &storage_option_iops_max_length
         description:
-          - to be written
+          - Sets the maximum length of I/O bursts in seconds.
         type: int
       iops_rd : &storage_option_iops_rd
         description:
-          - to be written
+          - Sets the maximum read I/O in operations per second.
         type: int
       iops_rd_max : &storage_option_iops_rd_max
         description:
-          - to be written
+          - Sets the maximum unthrottled read I/O pool in operations per second.
         type: int
       iops_rd_max_length : &storage_option_iops_rd_max_length
         description:
-          - to be written
+          - Sets the maximum length of read I/O bursts in seconds.
         type: int
       iops_wr : &storage_option_iops_wr
         description:
-          - to be written
+          - Sets the maximum write I/O in operations per second.
         type: int
       iops_wr_max : &storage_option_iops_wr_max
         description:
-          - to be written
+          - Sets the maximum unthrottled write I/O pool in operations per second.
         type: int
       iops_wr_max_length : &storage_option_iops_wr_max_length
         description:
-          - to be written
+          - Sets the maximum length of write I/O bursts in seconds.
         type: int
       mbps : &storage_option_mbps
         description:
-          - to be written
+          - Sets maximum read/write speed in megabytes per second.
         type: int
       mbps_max : &storage_option_mbps_max
         description:
-          - to be written
+          - Maximum unthrottled read/write pool in megabytes per second.
         type: int
       mbps_rd : &storage_option_mbps_rd
         description:
-          - to be written
+          - Sets maximum read speed in megabytes per second.
         type: int
       mbps_rd_max : &storage_option_mbps_rd_max
         description:
-          - to be written
+          - Maximum unthrottled read pool in megabytes per second.
         type: int
       mbps_wr : &storage_option_mbps_wr
         description:
-          - to be written
+          - Sets maximum write speed in megabytes per second.
         type: int
       mbps_wr_max : &storage_option_mbps_wr_max
         description:
-          - to be written
+          - Sets maximum write speed in megabytes per second.
         type: int
       media : &storage_option_media
         description:
-          - to be written
+          - Indicate if the volume should be considered as a VM disk (C(disk)) or an optical drive (C(cdrom))
         type: str
         choices: ['disk', 'cdrom']
       model:
         description:
-          - to be written
+          - The drive's reported model name, url-encoded, up to 40 bytes long.
         type: str
       replicate : &storage_option_replicate
         description:
-          - to be written
+          - Whether the drive should considered for replication jobs.
         type: bool
       rerror : &storage_option_rerror
         description:
-          - to be written
+          - Specify which action to take on read errors.
+          - C(ignore) will ignore the error and try to continue.
+          - C(stop) will pause the VM.
+          - C(report) will report the error to the guest.
         type: str
         choices: ['ignore', 'report', 'stop']
       secs : &storage_option_secs
         description:
-          - to be written
+          - Force the drive's physical geometry to have a specific sector count.
         type: int
       serial : &storage_option_serial
         description:
-          - to be written
+          - The drive's reported serial number, url-encoded, up to 20 bytes long.
         type: str
       shared : &storage_option_shared
         description:
-          - to be written
+          - Mark this locally-managed volume as available on all nodes.
+          - "WARNING: This option does not share the volume automatically, it assumes it is shared already."
         type: bool
       size : &storage_option_size
         description:
-          - to be written
+          - Disk size. This is purely informational and has no effect.
         type: str
       snapshot : &storage_option_snapshot
         description:
-          - to be written
+          - Controls qemu's snapshot mode feature. If activated, changes made to the disk are temporary and will be
+            discarded when the VM is shutdown.
+        type: bool
+      ssd: &storage_option_ssd
+        description:
+          - Whether to expose this drive as an SSD, rather than a rotational hard disk.
         type: bool
       trans : &storage_option_trans
         description:
-          - to be written
+          - Force disk geometry bios translation mode.
         type: str
         choices: ['none', 'lba', 'auto']
       werror : &storage_option_werror
         description:
-          - to be written
+          - Specify which action to take on write errors.
+          - C(ignore) will ignore the error and try to continue?
+          - C(stop) will pause the VM.
+          - C(report) will report the error to the guest.
+          - C(enospc) will pause the VM only is the host disk is full and report the error to the guest otherwise.
         type: str
         choices: ['enospc', 'ignore', 'report', 'stop']
       wwn : &storage_option_wwn
         description:
-          - to be written
+          - The drive's worldwide name, encoded as 16 bytes hex string, prefixed by I(0x).
         type: str
     version_added: 5.0.0
   ipconfig:
@@ -557,7 +578,8 @@ options:
     suboptions:
       name:
         description:
-          - to be written
+          - API name of the disk device that is going to be added.
+          - Should be C(sata(n)) with C(n) between 0 and 5 included.
         type: str
         choices: ['sata0', 'sata1', 'sata2', 'sata3', 'sata4', 'sata5']
       storage: *storage_option_storage
@@ -600,10 +622,7 @@ options:
       shared: *storage_option_shared
       size: *storage_option_size
       snapshot: *storage_option_snapshot
-      ssd:
-        description:
-          - to be written
-        type: bool
+      ssd: *storage_option_ssd
       trans: *storage_option_trans
       werror: *storage_option_werror
       wwn: *storage_option_wwn
@@ -629,7 +648,8 @@ options:
     suboptions:
       name:
         description:
-          - to be written
+          - API name of the disk device that is going to be added.
+          - Should be C(scsi(n)) with C(n) between 0 and 30 included.
         type: str
         choices: ['scsi0', 'scsi1', 'scsi2', 'scsi3', 'scsi4', 'scsi5', 'scsi6', 'scsi7', 'scsi8', 'scsi9', 'scsi10',
         'scsi11', 'scsi12', 'scsi13', 'scsi14', 'scsi15', 'scsi16', 'scsi17', 'scsi18', 'scsi19', 'scsi20', 'scsi21',
@@ -669,27 +689,26 @@ options:
       media: *storage_option_media
       queues:
         description:
-          - to be written
+          - Number of queues.
+          - Must be greater than 2
         type: int
       replicate: *storage_option_replicate
       rerror: *storage_option_rerror
-      ro:
+      ro: &storage_option_ro
         description:
-          - to be written
+          - Whether the drive is read-only.
         type: bool
-      scsibloc:
+      scsiblock:
         description:
-          - to be written
+          - Whether to use scsi-block for full passthrough of host block device.
+          - WARNING can lead to I/O errors in combination with low memory or high memory fragmentation
         type: bool
       secs: *storage_option_secs
       serial: *storage_option_serial
       shared: *storage_option_shared
       size: *storage_option_size
       snapshot: *storage_option_snapshot
-      ssd:
-        description:
-          - to be written
-        type: bool
+      ssd: *storage_option_ssd
       trans: *storage_option_trans
       werror: *storage_option_werror
       wwn: *storage_option_wwn
@@ -836,7 +855,8 @@ options:
     suboptions:
       name:
         description:
-          - to be written
+          - API name of the disk device that is going to be added.
+          - Should be C(virtio(n)) with C(n) between 0 and 15 included.
         type: str
         choices: ['virtio0', 'virtio1', 'virtio2', 'virtio3', 'virtio4', 'virtio5', 'virtio6', 'virtio7', 'virtio8',
         'virtio9', 'virtio10', 'virtio11', 'virtio12', 'virtio13', 'virtio14', 'virtio15']
@@ -875,10 +895,7 @@ options:
       media: *storage_option_media
       replicate: *storage_option_replicate
       rerror: *storage_option_rerror
-      ro:
-        description:
-          - to be written
-        type: bool
+      ro: *storage_option_ro
       secs: *storage_option_secs
       serial: *storage_option_serial
       shared: *storage_option_shared
@@ -1520,20 +1537,19 @@ def main():
                                    )
     ide_storage_arg_spec = common_storage_arg_spec.copy()
     ide_storage_arg_spec.update(dict(
-        name=dict(type='str', choices=['ide' + str(n) for n in range(0, 4)]),
-        model=dict(type='str')
+        name=dict(type='str', choices=['ide' + str(n) for n in range(0, 4)]), model=dict(type='str'), ssd=dict(type='bool')
     ))
     sata_storage_arg_spec = common_storage_arg_spec.copy()
     sata_storage_arg_spec.update(dict(
-        name=dict(type='str', choices=['sata' + str(n) for n in range(0, 6)]),
-        ssd=dict(type='bool')
+        name=dict(type='str', choices=['sata' + str(n) for n in range(0, 6)]), ssd=dict(type='bool')
     ))
     scsi_storage_arg_spec = sata_storage_arg_spec.copy()
     scsi_storage_arg_spec.update(dict(
         name=dict(type='str', choices=['scsi' + str(n) for n in range(0, 31)]),
         queues=dict(type='int'),
         ro=dict(type='bool'),
-        scsibloc=dict(type='bool'),
+        scsiblock=dict(type='bool'),
+        ssd=dict(type='bool')
     ))
     virtio_storage_arg_spec = common_storage_arg_spec.copy()
     virtio_storage_arg_spec.update(dict(


### PR DESCRIPTION
##### SUMMARY
Some options of this module are `dict` of `str` which are sent verbatim to the PVE API. Unfortunately, if the user makes a mistake in those strings, the API will error out with:
```
400 Bad Request: Parameter verification failed.
```
which isn't very informative about where the error occured. This PR offers to tackle this problem by converting these `dict` of `str` into `lists` of `dict` and provide adequate documentation for each of the suboptions. This will also provide better clarity and readability to users while hopefully not having too big an impact on maintaining the module.

**THIS PR INTRODUCES BREAKING CHANGES**

Here is a proposed todo list which can evolve as this PR is written:

- [x] Create storage (`ide, sata, scsi, virtio`) arg_specs

- [x] Create stub documentation for storage options

- [x] Write adequate documentation for storage suboptions using the [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) and the [Proxmox VE API documentation](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/config)

- [ ] Modify examples to comply with new storage definition

- [x] Add logic to flatten `storage` lists of `dict` into `str` that are understood by the API

- [x] Add logic to populate new lists of `dict` from old `dict` of `str` for `storage` options 

- [ ] Create `hostpci` arg_specs

- [ ] Create stub documentation for `hostpci` options

- [ ] Write adequate documentation for `hostpci` suboptions using the [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) and the [Proxmox VE API documentation](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/config)

- [ ] Add logic to flatten `hostpci` lists of `dict` into `str` that are understood by the API

- [ ] Add logic to populate new lists of `dict` from old `dict` of `str` for `hostpci` options 

- [ ] Modify examples to comply with new `hostpci` option definition

- [ ] Create `net` arg_specs

- [ ] Create stub documentation for `net` options

- [ ] Write adequate documentation for net suboptions using the [Proxmox VE Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html) and the [Proxmox VE API documentation](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/config)

- [ ] Modify examples to comply with new `net` option definition

- [ ] Add logic to flatten net lists of `dict` into `str` that are understood by the API

- [ ] Add logic to populate new lists of `dict` from old `dict` of `str` for `net` options 

- [ ] Find a way to check converted old to new arguments against argument spec

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm.py

##### ADDITIONAL INFORMATION
As outlined in PR #4106 a `dict` instead of a `str` for API options offers better readability and clarity for the user, while not adding too big an overhead for the maintainer. This also simplifies error catching, as the API error message doesn't indicate where the error occured. This approach would help catching some of those errors before even sending them through the API, and offering clearer error messages to the user.

For now, I've renamed the corresponding options, and left an alias for the old option, as this PR would introduce breaking changes. I thought this could be added in 5.0.0 or perhaps in 6.0.0 so that it would leave enough time for users to get to know the new syntax.

I welcome any comment you may have to improve this PR.