### PR TITLE
proxmox_kvm: add win11 to ostype

### DIFF
--- a/changelogs/fragments/4191-proxmox-add-win11.yml
+++ b/changelogs/fragments/4191-proxmox-add-win11.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kwm - add ``win11`` to ``ostype`` parameter for Windows 11 and Windows Server 2022 support

--- a/changelogs/fragments/4191-proxmox-add-win11.yml
+++ b/changelogs/fragments/4191-proxmox-add-win11.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kwm - add ``win11`` to ``ostype`` parameter for Windows 11 and Windows Server 2022 support
+  - proxmox_kwm - add ``win11`` to ``ostype`` parameter for Windows 11 and Windows Server 2022 support (https://github.com/ansible-collections/community.general/issues/4023, https://github.com/ansible-collections/community.general/pull/4191).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -286,7 +286,7 @@ options:
       - The l26 is Linux 2.6/3.X Kernel.
       - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(l26).
     type: str
-    choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'l24', 'l26', 'solaris']
+    choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'win11', 'l24', 'l26', 'solaris']
   parallel:
     description:
       - A hash/dictionary of map host parallel devices. C(parallel='{"key":"value", "key":"value"}').
@@ -996,7 +996,7 @@ def main():
         numa=dict(type='dict'),
         numa_enabled=dict(type='bool'),
         onboot=dict(type='bool'),
-        ostype=dict(choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'l24', 'l26', 'solaris']),
+        ostype=dict(choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'win11', 'l24', 'l26', 'solaris']),
         parallel=dict(type='dict'),
         pool=dict(type='str'),
         protection=dict(type='bool'),


### PR DESCRIPTION
##### SUMMARY

This PR will add Windows 11/Windows server 2022 to the list of OS types in Proxmox kvm module.

Closes #4023 ([comment](https://github.com/ansible-collections/community.general/issues/4023#issuecomment-1036581772))

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

proxmox_kvm
