### PR TITLE
passwordstore: Prevent using path as password

### DIFF
--- a/changelogs/fragments/4192-improve-passwordstore-consistency.yml
+++ b/changelogs/fragments/4192-improve-passwordstore-consistency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - passwordstore lookup plugin - prevent returning path names as passwords by accident (https://github.com/ansible-collections/community.general/issues/4185, https://github.com/ansible-collections/community.general/pull/4192).


### PR DESCRIPTION
##### SUMMARY
Given a password stored in _path/to/secret_, requesting the password
_path/to_ will literally return `path/to`. This can lead to using
weak passwords by accident/mess up logic in code, based on the
state of the password store.

This is worked around by applying the same logic `pass` uses:
If a password was returned, check if there is a .gpg file it could
have come from. If not, treat it as missing.

Fixes ansible-collections/community.general#4185

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
passwordstore
plugins/lookup/passwordstore

##### ADDITIONAL INFORMATION
See:
- ansible-collections/community.general#4185

