### PR TITLE
passwordstore: Add configurable locking

### DIFF
--- a/changelogs/fragments/4194-configurable-passwordstore-locking.yml
+++ b/changelogs/fragments/4194-configurable-passwordstore-locking.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - passwordstore lookup plugin - add configurable ``lock`` and ``locktimeout`` options to avoid race conditions in itself and in the ``pass`` utility it calls. By default, the plugin now locks on write operations (https://github.com/ansible-collections/community.general/pull/4194).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -98,7 +98,7 @@ DOCUMENTATION = '''
       locktimeout:
         description:
           - Lock timeout applied when I(lock) is not C(none).
-          - Time with a unit suffix, "s", "m", "h" for seconds, minutes, and hours. So, e.g, C(900s) equals C(15m).
+          - Time with a unit suffix, C(s), C(m), C(h) for seconds, minutes, and hours, respectively. For example, C(900s) equals C(15m).
           - Correlates with C(pinentry-timeout) in C(~/.gnupg/gpg-agent.conf), see C(man gpg-agent) for details.
         ini:
           - section: passwordstore_lookup


### PR DESCRIPTION
##### SUMMARY
Passwordstore cannot be accessed safely in parallel, which causes
various issues:

- When accessing the same path, multiple different secrets are
  returned when the secret didn't exist (missing=create).
- When accessing the same _or different_ paths, multiple pinentry
  dialogs will be spawned by gpg-agent sequentially, having to enter
  the password for the same gpg key multiple times in a row.
- Due to issues in gpg dependencies, accessing gpg-agent in parallel
  is not reliable, causing plays to fail (this can be fixed by adding
  `auto-expand-secmem` to _~/.gnupg/gpg-agent.conf_ though).

These problems have been described in various github issues in the past,
e.g., https://github.com/ansible/ansible/issues/23816 and https://github.com/ansible/ansible/issues/27277.

This cannot be worked around in playbooks by users in a non-error-prone
way.

It is addressed by adding new configuration options:

- lock:
  - readwrite: Lock all operations
  - write: Only lock write operations (default)
  - none: Disable locking
- locktimeout: Time to wait for getting a lock (s/m/h suffix)
  (defaults to 15m)

These options can also be set in ansible.cfg, e.g.:

    [passwordstore_lookup]
    lock=readwrite
    locktimeout=30s

Also, add a note about modifying gpg-agent.conf.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
passwordstore
plugins/lookup/passwordstore

##### ADDITIONAL INFORMATION
See also #4192 for a discussion that lead to this PR.
