### PR TITLE
zypper: support automatic removal of orphaned dependencies

### DIFF
--- a/changelogs/fragments/4192-zypper-add-clean-deps.yml
+++ b/changelogs/fragments/4192-zypper-add-clean-deps.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zypper - add support for --clean-deps option to remove packages that depend on a package being removed

--- a/changelogs/fragments/4192-zypper-add-clean-deps.yml
+++ b/changelogs/fragments/4192-zypper-add-clean-deps.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - zypper - add support for --clean-deps option to remove packages that depend on a package being removed
+  - zypper - add support for ``--clean-deps`` option to remove packages that depend on a package being removed (https://github.com/ansible-collections/community.general/pull/4195).

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -128,6 +128,13 @@ options:
         description:
           - Adds C(--replacefiles) option to I(zypper) install/update command.
         version_added: '0.2.0'
+    clean_deps:
+        type: bool
+        required: false
+        default: false
+        description:
+          - Adds C(--clean-deps) option to I(zypper) remove command.
+        version_added: '4.5.0'
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -368,6 +375,9 @@ def get_cmd(m, subcommand):
             cmd.append('--oldpackage')
         if m.params['replacefiles']:
             cmd.append('--replacefiles')
+    if subcommand == 'remove':
+        if m.params['clean_deps']:
+            cmd.append('--clean-deps')
     if subcommand == 'dist-upgrade' and m.params['allow_vendor_change']:
         cmd.append('--allow-vendor-change')
     if m.params['extra_args']:
@@ -518,7 +528,8 @@ def main():
             oldpackage=dict(required=False, default=False, type='bool'),
             extra_args=dict(required=False, default=None),
             allow_vendor_change=dict(required=False, default=False, type='bool'),
-            replacefiles=dict(required=False, default=False, type='bool')
+            replacefiles=dict(required=False, default=False, type='bool'),
+            clean_deps=dict(required=False, default=False, type='bool')
         ),
         supports_check_mode=True
     )

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -134,7 +134,7 @@ options:
         default: false
         description:
           - Adds C(--clean-deps) option to I(zypper) remove command.
-        version_added: '4.5.0'
+        version_added: '4.6.0'
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -529,7 +529,7 @@ def main():
             extra_args=dict(required=False, default=None),
             allow_vendor_change=dict(required=False, default=False, type='bool'),
             replacefiles=dict(required=False, default=False, type='bool'),
-            clean_deps=dict(required=False, default=False, type='bool')
+            clean_deps=dict(required=False, default=False, type='bool'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
* zypper: support automatic removal of orphaned dependencies

  - Add support for --clean-deps option during package removal, which
    will clean up packages that were only installed as dependencies
    of the package being removed.

##### SUMMARY

`zypper remove --clean-deps` allows the user to specify that any packages that were installed as dependencies of a package being removed can be removed as well if they aren't required by any other packages.  This feature addition allows the zypper plugin to access this option by defining the `clean_deps` field as `true`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zypper

##### ADDITIONAL INFORMATION

For example, on a newly installed openSUSE or SLE system, the only built-in requirement for the entire `ruby` runtime is yast. It's possible to simply remove yast via a `state: absent` rule, but that only removes yast and any yast modules.  Specifying `clean_deps: true` removes the entire ruby runtime and other packages that were only required by yast.
