### PR TITLE
Allow YAML docs in plugins/test/ and plugins/filters/

### DIFF
--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -26,6 +26,11 @@ def main():
     skip_directories = (
     )
 
+    yaml_directories = (
+        'plugins/test/',
+        'plugins/filter/',
+    )
+
     for path in paths:
         if path in skip_paths:
             continue
@@ -34,6 +39,9 @@ def main():
             continue
 
         ext = os.path.splitext(path)[1]
+
+        if ext in ('.yml', ) and any(path.startswith(yaml_directory) for yaml_directory in yaml_directories):
+            continue
 
         if ext not in allowed_extensions:
             print('%s: extension must be one of: %s' % (path, ', '.join(allowed_extensions)))


### PR DESCRIPTION
##### SUMMARY
Preparation for https://github.com/ansible/ansible/pull/74963. Will fix extra sanity test failures in #4203.

(I only support `.yml` and not `.yaml` so we stick to one extension in this collection :) )

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
