### PR TITLE
Fix module failure due to itertools.izip_longest

### DIFF
--- a/changelogs/fragments/4206-imc-rest-module.yaml
+++ b/changelogs/fragments/4206-imc-rest-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - imc_rest - fixes the module failure due to the usage of itertools.izip_longest which is not available in Python 3. (https://github.com/ansible-collections/community.general/issues/4206)

--- a/changelogs/fragments/4206-imc-rest-module.yaml
+++ b/changelogs/fragments/4206-imc-rest-module.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - imc_rest - fixes the module failure due to the usage of itertools.izip_longest which is not available in Python 3. (https://github.com/ansible-collections/community.general/issues/4206)
+  - imc_rest - fixes the module failure due to the usage of ``itertools.izip_longest`` which is not available in Python 3 (https://github.com/ansible-collections/community.general/issues/4206).

--- a/plugins/modules/remote_management/imc/imc_rest.py
+++ b/plugins/modules/remote_management/imc/imc_rest.py
@@ -283,6 +283,7 @@ except ImportError:
     HAS_XMLJSON_COBRA = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.six.moves import zip_longest
 from ansible.module_utils.urls import fetch_url
 
 
@@ -318,7 +319,7 @@ def merge(one, two):
         return copy
 
     elif isinstance(one, list) and isinstance(two, list):
-        return [merge(alpha, beta) for (alpha, beta) in itertools.izip_longest(one, two)]
+        return [merge(alpha, beta) for (alpha, beta) in zip_longest(one, two)]
 
     return one if two is None else two
 

--- a/plugins/modules/remote_management/imc/imc_rest.py
+++ b/plugins/modules/remote_management/imc/imc_rest.py
@@ -261,7 +261,6 @@ output:
 '''
 
 import datetime
-import itertools
 import os
 import traceback
 from functools import partial


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #4206
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
imc_rest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Fixes module failure due to the usage of itertools.izip_longest which is missing in Python 3.
Used ansible.module_utils.six.moves.zip_longest which is works in both Python 2 and 3.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
