### PR TITLE
[plugins/callback/syslog_json.py] use v2 api, add option to skip sysl…

### DIFF
--- a/changelogs/fragments/4223-syslog-json-skip-syslog-option.yml
+++ b/changelogs/fragments/4223-syslog-json-skip-syslog-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - syslog_json - add option to skip logging of ``gather_facts`` playbook task; use v2 callback api (https://github.com/ansible-collections/community.general/pull/4223).
+  - syslog_json - add option to skip logging of ``gather_facts`` playbook tasks; use v2 callback API (https://github.com/ansible-collections/community.general/pull/4223).

--- a/changelogs/fragments/4223-syslog-json-skip-syslog-option.yml
+++ b/changelogs/fragments/4223-syslog-json-skip-syslog-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - syslog_json - add option to skip logging of ``gather_facts`` playbook task; use v2 callback api (https://github.com/ansible-collections/community.general/pull/4223).

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -50,6 +50,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_setup
+        version_added: 4.5.0
 '''
 
 import os

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -44,7 +44,7 @@ DOCUMENTATION = '''
       setup:
         description: Log setup tasks.
         env:
-          - name: SYSLOG_SETUP
+          - name: ANSIBLE_SYSLOG_SETUP
         type: bool
         default: true
         ini:

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -42,7 +42,7 @@ DOCUMENTATION = '''
           - section: callback_syslog_json
             key: syslog_facility
       setup:
-        description: log setup tasks
+        description: Log setup tasks.
         env:
           - name: SYSLOG_SETUP
         type: bool

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -41,6 +41,15 @@ DOCUMENTATION = '''
         ini:
           - section: callback_syslog_json
             key: syslog_facility
+      setup:
+        description: log setup tasks
+        env:
+          - name: SYSLOG_SETUP
+        type: bool
+        default: true
+        ini:
+          - section: callback_syslog_json
+            key: syslog_setup
 '''
 
 import os
@@ -86,23 +95,36 @@ class CallbackModule(CallbackBase):
         self.logger.addHandler(self.handler)
         self.hostname = socket.gethostname()
 
-    def runner_on_failed(self, host, res, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        res = result._result
+        host = result._host.get_name()
         self.logger.error('%s ansible-command: task execution FAILED; host: %s; message: %s', self.hostname, host, self._dump_results(res))
 
-    def runner_on_ok(self, host, res):
-        self.logger.info('%s ansible-command: task execution OK; host: %s; message: %s', self.hostname, host, self._dump_results(res))
+    def v2_runner_on_ok(self, result):
+        res = result._result
+        host = result._host.get_name()
+        if result._task.action != "gather_facts" or self.get_option("setup"):
+            self.logger.info('%s ansible-command: task execution OK; host: %s; message: %s', self.hostname, host, self._dump_results(res))
 
-    def runner_on_skipped(self, host, item=None):
+    def v2_runner_on_skipped(self, result):
+        host = result._host.get_name()
         self.logger.info('%s ansible-command: task execution SKIPPED; host: %s; message: %s', self.hostname, host, 'skipped')
 
-    def runner_on_unreachable(self, host, res):
+    def v2_runner_on_unreachable(self, result):
+        res = result._result
+        host = result._host.get_name()
         self.logger.error('%s ansible-command: task execution UNREACHABLE; host: %s; message: %s', self.hostname, host, self._dump_results(res))
 
-    def runner_on_async_failed(self, host, res, jid):
+    def v2_runner_on_async_failed(self, result):
+        res = result._result
+        host = result._host.get_name()
+        jid = result._result.get('ansible_job_id')
         self.logger.error('%s ansible-command: task execution FAILED; host: %s; message: %s', self.hostname, host, self._dump_results(res))
 
-    def playbook_on_import_for_host(self, host, imported_file):
+    def v2_playbook_on_import_for_host(self, result, imported_file):
+        host = result._host.get_name()
         self.logger.info('%s ansible-command: playbook IMPORTED; host: %s; message: imported file %s', self.hostname, host, imported_file)
 
-    def playbook_on_not_import_for_host(self, host, missing_file):
+    def v2_playbook_on_not_import_for_host(self, result, missing_file):
+        host = result._host.get_name()
         self.logger.info('%s ansible-command: playbook NOT IMPORTED; host: %s; message: missing file %s', self.hostname, host, missing_file)


### PR DESCRIPTION
[plugins/callback/syslog_json.py]  use v2 api, add option to skip syslog on gather_facts

##### SUMMARY
syslog_json callback plugin fails during gather_facts on playbooks that run on hosts with many facts, as the syslog message exceeds OS limits. An option should be added to skip syslog on the gather_facts task.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/callback/syslog_json.py

##### ADDITIONAL INFORMATION

Easiest way to reproduce this issue is to run playbook with -vvv and with callback_syslog_json enabled.

```
--- Logging error ---                                                                                                                                                                        
Traceback (most recent call last):                                                                                                                                                           
  File "/usr/lib64/python3.6/logging/handlers.py", line 942, in emit                                                                                                                         
    self.socket.sendto(msg, self.address)                                                                                                                                                    
OSError: [Errno 90] Message too long
<snip>
```