### PR TITLE
pmem: Add namespace and namespace_append options

### DIFF
--- a/changelogs/fragments/4225-pmem_add_namespace.yaml
+++ b/changelogs/fragments/4225-pmem_add_namespace.yaml
@@ -1,3 +1,0 @@
-minor_changes:
-  - pmem - add ``namespace`` and ``namespace_append`` options to configure the namespace
-    of PMem (https://github.com/ansible-collections/community.general/pull/4225).

--- a/changelogs/fragments/4225-pmem_add_namespace.yaml
+++ b/changelogs/fragments/4225-pmem_add_namespace.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - pmem: - add ``namespace`` and ``namespace_append`` options to configure the namespace
+  - pmem - add ``namespace`` and ``namespace_append`` options to configure the namespace
     of PMem. (https://github.com/ansible-collections/community.general/pull/4225)

--- a/changelogs/fragments/4225-pmem_add_namespace.yaml
+++ b/changelogs/fragments/4225-pmem_add_namespace.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - pmem: - add ``namespace`` and ``namespace_append`` options to configure the namespace
+    of PMem. (https://github.com/ansible-collections/community.general/pull/4225)

--- a/changelogs/fragments/4225-pmem_add_namespace.yaml
+++ b/changelogs/fragments/4225-pmem_add_namespace.yaml
@@ -1,3 +1,3 @@
 minor_changes:
   - pmem - add ``namespace`` and ``namespace_append`` options to configure the namespace
-    of PMem. (https://github.com/ansible-collections/community.general/pull/4225)
+    of PMem (https://github.com/ansible-collections/community.general/pull/4225).

--- a/plugins/modules/storage/pmem/pmem.py
+++ b/plugins/modules/storage/pmem/pmem.py
@@ -105,7 +105,7 @@ options:
   namespace_append:
     description:
      - Enable to append the new namespaces to the system.
-     - The default is C(false) so the all existing namespaces not listed in I{namespace) are removed.
+     - The default is C(false) so the all existing namespaces not listed in I(namespace) are removed.
     type: bool
     default: false
     required: false

--- a/plugins/modules/storage/pmem/pmem.py
+++ b/plugins/modules/storage/pmem/pmem.py
@@ -81,7 +81,6 @@ options:
      - This enables to set the configuration for the namespace of the PMem.
     type: list
     elements: dict
-    version_added: 4.6.0
     suboptions:
       mode:
         description:
@@ -110,7 +109,6 @@ options:
     type: bool
     default: false
     required: false
-    version_added: 4.6.0
 '''
 
 RETURN = r'''
@@ -143,7 +141,6 @@ result:
         namespace:
           description: The list of the detail of namespace.
           type: list
-          version_added: 4.6.0
     sample: [
                 {
                     "appdirect": 111669149696,

--- a/plugins/modules/storage/pmem/pmem.py
+++ b/plugins/modules/storage/pmem/pmem.py
@@ -76,6 +76,41 @@ options:
         description:
           - Percentage of the capacity to reserve (C(0)-C(100)) within the socket ID.
         type: int
+  namespace:
+    description:
+     - This enables to set the configuration for the namespace of the PMem.
+    type: list
+    elements: dict
+    version_added: 4.6.0
+    suboptions:
+      mode:
+        description:
+         - The mode of namespace. The detail of the mode is in the man page of ndctl-create-namespace.
+        type: str
+        required: true
+        choices: ['raw', 'sector', 'fsdax', 'devdax']
+      type:
+        description:
+         - The type of namespace. The detail of the type is in the man page of ndctl-create-namespace.
+        type: str
+        required: false
+        choices: ['pmem', 'blk']
+      size:
+        description:
+          - The size of namespace. This option supports the suffixes "k" or "K" for KiB,
+            "m" or "M" for MiB, "g" or "G" for GiB and "t" or "T" for TiB.
+          - This option is required if multiple namespaces are configured.
+          - If this option is not set, all of the avaiable space of a region is configured.
+        type: str
+        required: false
+  namespace_append:
+    description:
+     - Enable to append the new namespaces to the system.
+     - The default is false so the all existed namespaces are removed by default.
+    type: bool
+    default: false
+    required: false
+    version_added: 4.6.0
 '''
 
 RETURN = r'''
@@ -88,6 +123,7 @@ result:
     description:
      - Shows the value of AppDirect, Memory Mode and Reserved size in bytes.
      - If I(socket) argument is provided, shows the values in each socket with C(socket) which contains the socket ID.
+     - If I(namespace) argument is provided, shows the detail of each namespace.
     returned: success
     type: list
     elements: dict
@@ -104,6 +140,9 @@ result:
         socket:
           description: The socket ID to be configured.
           type: int
+        namespace:
+          description: The list of the detail of namespace.
+          type: list
     sample: [
                 {
                     "appdirect": 111669149696,
@@ -150,6 +189,16 @@ EXAMPLES = r'''
         appdirect: 10
         memorymode: 80
         reserved: 10
+
+- name: Configure the two namespaces.
+  community.general.pmem:
+    namespace:
+      - size: 1GiB
+        type: pmem
+        mode: raw
+      - size: 320MiB
+        type: pmem
+        mode: sector
 '''
 
 import json
@@ -164,6 +213,13 @@ except ImportError:
     XMLTODICT_LIBRARY_IMPORT_ERROR = traceback.format_exc()
 else:
     HAS_XMLTODICT_LIBRARY = True
+
+size_pattn = re.compile(r'([0-9]+) *(TiB|GiB|MiB|KiB|TB|GB|MB|KB|T|G|M|K|B)', re.IGNORECASE)
+tb_pattn = re.compile(r'(T|TiB|TB)', re.IGNORECASE)
+gb_pattn = re.compile(r'(G|GiB|GB)', re.IGNORECASE)
+mb_pattn = re.compile(r'(M|MiB|MB)', re.IGNORECASE)
+kb_pattn = re.compile(r'(K|KiB|KB)', re.IGNORECASE)
+b_pattn = re.compile(r'(B)', re.IGNORECASE)
 
 
 class PersistentMemory(object):
@@ -184,16 +240,31 @@ class PersistentMemory(object):
                         reserved=dict(type='int'),
                     ),
                 ),
+                namespace=dict(
+                    type='list', elements='dict',
+                    options=dict(
+                        mode=dict(required=True, type='str', choices=['raw', 'sector', 'fsdax', 'devdax']),
+                        type=dict(type='str', choices=['pmem', 'blk']),
+                        size=dict(type='str'),
+                    ),
+                ),
+                namespace_append=dict(type='bool', default=False),
             ),
             required_together=(
                 ['appdirect', 'memorymode'],
             ),
             required_one_of=(
-                ['appdirect', 'memorymode', 'socket'],
+                ['appdirect', 'memorymode', 'socket', 'namespace'],
             ),
             mutually_exclusive=(
                 ['appdirect', 'socket'],
                 ['memorymode', 'socket'],
+                ['appdirect', 'namespace'],
+                ['memorymode', 'namespace'],
+                ['socket', 'namespace'],
+                ['appdirect', 'namespace_append'],
+                ['memorymode', 'namespace_append'],
+                ['socket', 'namespace_append'],
             ),
         )
 
@@ -210,6 +281,8 @@ class PersistentMemory(object):
         self.memmode = module.params['memorymode']
         self.reserved = module.params['reserved']
         self.socket = module.params['socket']
+        self.namespace = module.params['namespace']
+        self.namespace_append = module.params['namespace_append']
 
         self.module = module
         self.changed = False
@@ -248,7 +321,96 @@ class PersistentMemory(object):
         command = ['show', '-system', '-capabilities']
         return self.pmem_run_ipmctl(command)
 
+    def pmem_get_region_align_size(self, region):
+        aligns = []
+        for rg in region:
+            if rg['align'] not in aligns:
+                aligns.append(rg['align'])
+
+        return aligns
+
+    def pmem_get_available_region_size(self, region):
+        available_size = []
+        for rg in region:
+            available_size.append(rg['available_size'])
+
+        return available_size
+
+    def pmem_get_available_region_type(self, region):
+        types = []
+        for rg in region:
+            if rg['type'] not in types:
+                types.append(rg['type'])
+
+        return types
+
     def pmem_argument_check(self):
+        def convert_to_bytes(size_str):
+            size = int(size_pattn.match(size_str).group(1))
+            unit = size_pattn.match(size_str).group(2)
+            errmsg = ''
+
+            if tb_pattn.match(unit):
+                mult = 1024**4
+            elif gb_pattn.match(unit):
+                mult = 1024**3
+            elif mb_pattn.match(unit):
+                mult = 1024**2
+            elif kb_pattn.match(unit):
+                mult = 1024**1
+            elif b_pattn.match(unit):
+                mult = 1
+            else:
+                mult = 0
+                errmsg = 'Something wrong while parsing size option: %s' % size_str
+
+            return size * mult, errmsg
+
+        def namespace_check(self):
+            command = ['list', '-R']
+            out = self.pmem_run_ndctl(command)
+            if not out:
+                return 'Available region(s) is not in this system.'
+            region = json.loads(out)
+
+            aligns = self.pmem_get_region_align_size(region)
+            if len(aligns) != 1:
+                return 'Not supported the regions whose alignment size is different.'
+
+            available_size = self.pmem_get_available_region_size(region)
+            types = self.pmem_get_available_region_type(region)
+            for ns in self.namespace:
+                if ns['size']:
+                    if not size_pattn.match(ns['size']):
+                        return 'The format of size: NNN TB|GB|MB|KB|B'
+
+                    size_byte, errmsg = convert_to_bytes(ns['size'])
+                    if errmsg:
+                        return errmsg
+
+                    if size_byte % aligns[0] != 0:
+                        return 'size: %s should be align with %d' % (ns['size'], aligns[0])
+
+                    is_space_enough = False
+                    for i, avail in enumerate(available_size):
+                        if avail > size_byte:
+                            available_size[i] -= size_byte
+                            is_space_enough = True
+                            break
+
+                    if is_space_enough is False:
+                        return 'There is not available region for size: %s' % ns['size']
+
+                    ns['size_byte'] = size_byte
+
+                elif len(self.namespace) != 1:
+                    return 'size option is required to configure multiple namespaces'
+
+                if ns['type'] not in types:
+                    return 'type %s is not supported in this system. Supported type: %s' % (ns['type'], types)
+
+            return None
+
         def percent_check(self, appdirect, memmode, reserved=None):
             if appdirect is None or (appdirect < 0 or appdirect > 100):
                 return 'appdirect percent should be from 0 to 100.'
@@ -278,7 +440,9 @@ class PersistentMemory(object):
 
             return None
 
-        if self.socket is None:
+        if self.namespace:
+            return namespace_check(self)
+        elif self.socket is None:
             return percent_check(self, self.appdirect, self.memmode, self.reserved)
         else:
             ret = socket_id_check(self)
@@ -319,8 +483,10 @@ class PersistentMemory(object):
         self.pmem_run_ipmctl(command)
 
     def pmem_init_env(self):
-        self.pmem_remove_namespaces()
-        self.pmem_delete_goal()
+        if self.namespace is None or (self.namespace and self.namespace_append is False):
+            self.pmem_remove_namespaces()
+        if self.namespace is None:
+            self.pmem_delete_goal()
 
     def pmem_get_capacity(self, skt=None):
         command = ['show', '-d', 'Capacity', '-u', 'B', '-o', 'nvmxml', '-dimm']
@@ -431,6 +597,17 @@ class PersistentMemory(object):
 
         return reboot_required, ret, ''
 
+    def pmem_config_namespaces(self, namespace):
+        command = ['create-namespace', '-m', namespace['mode']]
+        if namespace['type']:
+            command += ['-t', namespace['type']]
+        if 'size_byte' in namespace:
+            command += ['-s', namespace['size_byte']]
+
+        self.pmem_run_ndctl(command)
+
+        return None
+
 
 def main():
 
@@ -445,7 +622,17 @@ def main():
     pmem.pmem_init_env()
     pmem.changed = True
 
-    if pmem.socket is None:
+    if pmem.namespace:
+        for ns in pmem.namespace:
+            pmem.pmem_config_namespaces(ns)
+
+        command = ['list', '-N']
+        out = pmem.pmem_run_ndctl(command)
+        all_ns = json.loads(out)
+
+        pmem.result = all_ns
+        reboot_required = False
+    elif pmem.socket is None:
         reboot_required, ret, errmsg = pmem.pmem_create_memory_allocation()
         if errmsg:
             pmem.module.fail_json(msg=errmsg)

--- a/plugins/modules/storage/pmem/pmem.py
+++ b/plugins/modules/storage/pmem/pmem.py
@@ -106,7 +106,7 @@ options:
   namespace_append:
     description:
      - Enable to append the new namespaces to the system.
-     - The default is false so the all existed namespaces are removed by default.
+     - The default is C(false) so the all existing namespaces not listed in I{namespace) are removed.
     type: bool
     default: false
     required: false

--- a/tests/unit/plugins/modules/storage/pmem/test_pmem.py
+++ b/tests/unit/plugins/modules/storage/pmem/test_pmem.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
+import json
 
 pytest.importorskip('xmltodict')
 
@@ -165,6 +166,102 @@ show_skt = """<?xml version="1.0"?>
  </Socket>
 </SocketList>"""
 
+# ndctl_region: the mock return value of pmem_run_command with:
+# ndctl list -R
+ndctl_region = """[
+  {
+    "dev":"region1",
+    "size":51539607552,
+    "align":16777216,
+    "available_size":50465865728,
+    "max_available_extent":50465865728,
+    "type":"pmem",
+    "iset_id":4694373484956518536,
+    "persistence_domain":"memory_controller"
+  },
+  {
+    "dev":"region0",
+    "size":51539607552,
+    "align":16777216,
+    "available_size":51539607552,
+    "max_available_extent":51539607552,
+    "type":"pmem",
+    "iset_id":4588538894081362056,
+    "persistence_domain":"memory_controller"
+  }
+]"""
+
+# ndctl_region_empty: the mock return value of pmem_run_command with:
+# ndctl list -R
+ndctl_region_empty = ""
+
+# ndctl_without_size: the mock return value of pmem_run_command with:
+# ndctl create-namespace -t pmem -m sector
+ndctl_create_without_size = """{
+  "dev":"namespace1.0",
+  "mode":"sector",
+  "size":"47.95 GiB (51.49 GB)",
+  "uuid":"1aca23a5-941c-4f4a-9d88-e531f0b5a27e",
+  "sector_size":4096,
+  "blockdev":"pmem1s"
+}"""
+
+# ndctl_list_N: the mock return value of pmem_run_command with:
+# ndctl list -N
+ndctl_list_N = """[
+  {
+    "dev":"namespace1.0",
+    "mode":"sector",
+    "size":51488243712,
+    "uuid":"1aca23a5-941c-4f4a-9d88-e531f0b5a27e",
+    "sector_size":4096,
+    "blockdev":"pmem1s"
+  }
+]"""
+
+# ndctl_result_1G: the mock return value of pmem_run_command with:
+# ndctl create-namespace -t pmem -m sector -s 1073741824
+ndctl_create_1G = """{
+  "dev":"namespace0.0",
+  "mode":"sector",
+  "size":"1021.97 MiB (1071.62 MB)",
+  "uuid":"5ba4e51b-3028-4b06-8495-b6834867a9af",
+  "sector_size":4096,
+  "blockdev":"pmem0s"
+}"""
+
+# ndctl_result_640M: the mock return value of pmem_run_command with:
+# ndctl create-namespace -t pmem -m raw -s 671088640
+ndctl_create_640M = """{
+  "dev":"namespace1.0",
+  "mode":"raw",
+  "size":"640.00 MiB (671.09 MB)",
+  "uuid":"5ac1f81d-86e6-4f07-9460-8c4d37027f7a",
+  "sector_size":512,
+  "blockdev":"pmem1"
+}"""
+
+# ndctl_list_N_tow_namespaces: the mock return value of pmem_run_command with:
+# ndctl list -N
+ndctl_list_N_two_namespaces = """[
+  {
+    "dev":"namespace1.0",
+    "mode":"sector",
+    "size":1071616000,
+    "uuid":"afcf050d-3a8b-4f48-88a5-16d7c40ab2d8",
+    "sector_size":4096,
+    "blockdev":"pmem1s"
+  },
+  {
+    "dev":"namespace1.1",
+    "mode":"raw",
+    "size":671088640,
+    "uuid":"fb704339-729b-4cc7-b260-079f2633d84f",
+    "sector_size":512,
+    "blockdev":"pmem1.1"
+  }
+]"""
+
 
 class TestPmem(ModuleTestCase):
     def setUp(self):
@@ -209,6 +306,17 @@ class TestPmem(ModuleTestCase):
             self.assertAlmostEqual(test_result[i]['reserved'], reserved[i])
             if socket:
                 self.assertAlmostEqual(test_result[i]['socket'], i)
+
+    def result_check_ns(self, result, namespace):
+        self.assertTrue(result.exception.args[0]['changed'])
+        self.assertFalse(result.exception.args[0]['reboot_required'])
+
+        test_result = result.exception.args[0]['result']
+        expected = json.loads(namespace)
+
+        for i, notuse in enumerate(test_result):
+            self.assertEqual(test_result[i]['dev'], expected[i]['dev'])
+            self.assertEqual(test_result[i]['size'], expected[i]['size'])
 
     def test_fail_when_required_args_missing(self):
         with self.assertRaises(AnsibleFailJson):
@@ -409,3 +517,190 @@ class TestPmem(ModuleTestCase):
                 pmem_module.main()
             self.result_check(
                 result, True, [12884901888, 12884901888], [94489280512, 94489280512], [164115382272, 164115382272])
+
+    def test_fail_when_namespace_without_mode(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '1GiB',
+                        'type': 'pmem',
+                    },
+                    {
+                        'size': '2GiB',
+                        'type': 'blk',
+                    },
+                ],
+            })
+            pmem_module.main()
+
+    def test_fail_when_region_is_empty(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '1GiB',
+                        'type': 'pmem',
+                        'mode': 'sector',
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region_empty]):
+                pmem_module.main()
+
+    def test_fail_when_namespace_invalid_size(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '1XXX',
+                        'type': 'pmem',
+                        'mode': 'sector',
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region]):
+                pmem_module.main()
+
+    def test_fail_when_size_is_invalid_alignment(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '400MiB',
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                    {
+                        'size': '500MiB',
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region]):
+                pmem_module.main()
+
+    def test_fail_when_blk_is_unsupported_type(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '4GiB',
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                    {
+                        'size': '5GiB',
+                        'type': 'blk',
+                        'mode': 'sector'
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region]):
+                pmem_module.main()
+
+    def test_fail_when_size_isnot_set_to_multiple_namespaces(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                    {
+                        'size': '500GiB',
+                        'type': 'blk',
+                        'mode': 'sector'
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region]):
+                pmem_module.main()
+
+    def test_fail_when_size_of_namespace_over_available(self):
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'namespace': [
+                    {
+                        'size': '400GiB',
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                    {
+                        'size': '500GiB',
+                        'type': 'pmem',
+                        'mode': 'sector'
+                    },
+                ],
+            })
+            with patch(
+                    'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                    side_effect=[ndctl_region]):
+                pmem_module.main()
+
+    def test_when_namespace0_without_size(self):
+        set_module_args({
+            'namespace': [
+                {
+                    'type': 'pmem',
+                    'mode': 'sector'
+                },
+            ],
+        })
+        with patch(
+                'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                side_effect=[ndctl_region, ndctl_create_without_size, ndctl_list_N]):
+            with self.assertRaises(AnsibleExitJson) as result:
+                pmem_module.main()
+            self.result_check_ns(result, ndctl_list_N)
+
+    def test_when_namespace0_with_namespace_append(self):
+        set_module_args({
+            'namespace': [
+                {
+                    'size': '640MiB',
+                    'type': 'pmem',
+                    'mode': 'raw'
+                },
+            ],
+            'namespace_append': True,
+        })
+        with patch(
+                'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                side_effect=[ndctl_region, ndctl_create_640M, ndctl_list_N_two_namespaces]):
+            with self.assertRaises(AnsibleExitJson) as result:
+                pmem_module.main()
+            self.result_check_ns(result, ndctl_list_N_two_namespaces)
+
+    def test_when_namespace0_1GiB_pmem_sector_namespace1_640MiB_pmem_raw(self):
+        set_module_args({
+            'namespace': [
+                {
+                    'size': '1GiB',
+                    'type': 'pmem',
+                    'mode': 'sector'
+                },
+                {
+                    'size': '640MiB',
+                    'type': 'pmem',
+                    'mode': 'raw',
+                },
+            ],
+        })
+        with patch(
+                'ansible_collections.community.general.plugins.modules.storage.pmem.pmem.PersistentMemory.pmem_run_command',
+                side_effect=[ndctl_region, ndctl_create_1G, ndctl_create_640M, ndctl_list_N_two_namespaces]):
+            with self.assertRaises(AnsibleExitJson) as result:
+                pmem_module.main()
+            self.result_check_ns(result, ndctl_list_N_two_namespaces)

--- a/tests/unit/plugins/modules/storage/pmem/test_pmem.py
+++ b/tests/unit/plugins/modules/storage/pmem/test_pmem.py
@@ -523,11 +523,11 @@ class TestPmem(ModuleTestCase):
             set_module_args({
                 'namespace': [
                     {
-                        'size': '1GiB',
+                        'size': '1GB',
                         'type': 'pmem',
                     },
                     {
-                        'size': '2GiB',
+                        'size': '2GB',
                         'type': 'blk',
                     },
                 ],
@@ -539,7 +539,7 @@ class TestPmem(ModuleTestCase):
             set_module_args({
                 'namespace': [
                     {
-                        'size': '1GiB',
+                        'size': '1GB',
                         'type': 'pmem',
                         'mode': 'sector',
                     },
@@ -571,12 +571,12 @@ class TestPmem(ModuleTestCase):
             set_module_args({
                 'namespace': [
                     {
-                        'size': '400MiB',
+                        'size': '400MB',
                         'type': 'pmem',
                         'mode': 'sector'
                     },
                     {
-                        'size': '500MiB',
+                        'size': '500MB',
                         'type': 'pmem',
                         'mode': 'sector'
                     },
@@ -592,12 +592,12 @@ class TestPmem(ModuleTestCase):
             set_module_args({
                 'namespace': [
                     {
-                        'size': '4GiB',
+                        'size': '4GB',
                         'type': 'pmem',
                         'mode': 'sector'
                     },
                     {
-                        'size': '5GiB',
+                        'size': '5GB',
                         'type': 'blk',
                         'mode': 'sector'
                     },
@@ -617,7 +617,7 @@ class TestPmem(ModuleTestCase):
                         'mode': 'sector'
                     },
                     {
-                        'size': '500GiB',
+                        'size': '500GB',
                         'type': 'blk',
                         'mode': 'sector'
                     },
@@ -633,12 +633,12 @@ class TestPmem(ModuleTestCase):
             set_module_args({
                 'namespace': [
                     {
-                        'size': '400GiB',
+                        'size': '400GB',
                         'type': 'pmem',
                         'mode': 'sector'
                     },
                     {
-                        'size': '500GiB',
+                        'size': '500GB',
                         'type': 'pmem',
                         'mode': 'sector'
                     },
@@ -669,7 +669,7 @@ class TestPmem(ModuleTestCase):
         set_module_args({
             'namespace': [
                 {
-                    'size': '640MiB',
+                    'size': '640MB',
                     'type': 'pmem',
                     'mode': 'raw'
                 },
@@ -687,12 +687,12 @@ class TestPmem(ModuleTestCase):
         set_module_args({
             'namespace': [
                 {
-                    'size': '1GiB',
+                    'size': '1GB',
                     'type': 'pmem',
                     'mode': 'sector'
                 },
                 {
-                    'size': '640MiB',
+                    'size': '640MB',
                     'type': 'pmem',
                     'mode': 'raw',
                 },


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add namespace and namespace_append options to pmem module.

- namespace: Configure the namespace of PMem
- namespace_append: Enables to append the new namespaces.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

pmem

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Configure the two namespaces.
  community.general.pmem:
    namespace:
      - size: 1GiB
        type: pmem
        mode: raw
      - size: 320MiB
        type: pmem
        mode: sector
```
