### PR TITLE
ansible_galaxy_install: added no_deps option

### DIFF
--- a/changelogs/fragments/4240-ansible_galaxy_install-no_deps.yml
+++ b/changelogs/fragments/4240-ansible_galaxy_install-no_deps.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible_galaxy_install - added option ``no_deps`` to the module (https://github.com/ansible-collections/community.general/issues/4174).

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -55,7 +55,8 @@ options:
     type: path
   no_deps:
     description:
-      - Refrain from installing dependencies
+      - Refrain from installing dependencies.
+    version_added: 4.5.0
     type: bool
     default: false
   force:

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -53,6 +53,11 @@ options:
         Please notice that C(ansible-galaxy) will not install collections with I(type=both), when I(requirements_file)
         contains both roles and collections and I(dest) is specified.
     type: path
+  no_deps:
+    description:
+      - Refrain from installing dependencies
+    type: bool
+    default: false
   force:
     description:
       - Force overwriting an existing role or collection.
@@ -178,7 +183,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
     ansible_version = None
     is_ansible29 = None
 
-    output_params = ('type', 'name', 'dest', 'requirements_file', 'force')
+    output_params = ('type', 'name', 'dest', 'requirements_file', 'force', 'no_deps')
     module = dict(
         argument_spec=dict(
             type=dict(type='str', choices=('collection', 'role', 'both'), required=True),
@@ -186,6 +191,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
             requirements_file=dict(type='path'),
             dest=dict(type='path'),
             force=dict(type='bool', default=False),
+            no_deps=dict(type='bool', default=False),
             ack_ansible29=dict(type='bool', default=False),
         ),
         mutually_exclusive=[('name', 'requirements_file')],
@@ -201,6 +207,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
         requirements_file=dict(fmt=('-r', '{0}'),),
         dest=dict(fmt=('-p', '{0}'),),
         force=dict(fmt="--force", style=ArgFormat.BOOLEAN),
+        no_deps=dict(fmt="--no-deps", style=ArgFormat.BOOLEAN),
     )
     force_lang = "en_US.UTF-8"
     check_rc = True
@@ -293,7 +300,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
             self._setup29()
         else:
             self._setup210plus()
-        params = ('type', {'galaxy_cmd': 'install'}, 'force', 'dest', 'requirements_file', 'name')
+        params = ('type', {'galaxy_cmd': 'install'}, 'force', 'no_deps', 'dest', 'requirements_file', 'name')
         self.run_command(params=params)
 
     def process_command_output(self, rc, out, err):


### PR DESCRIPTION
##### SUMMARY
Added option `no_deps` to the module, translating into the CLI option `--no-deps`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #4174

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/packaging/language/ansible_galaxy_install.py
