### PR TITLE
Temporarily disable ansible_galaxy_install tests due to Galaxy failures

### DIFF
--- a/tests/integration/targets/ansible_galaxy_install/aliases
+++ b/tests/integration/targets/ansible_galaxy_install/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group3
 skip/python2.6
 context/controller  # While this is not really true, this module mainly is run on the controller, *and* needs access to the ansible-galaxy CLI tool
+disabled  # FIXME


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/galaxy/issues/2302

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
