### PR TITLE
Allow complex values in variables parameter of terraform module

### DIFF
--- a/changelogs/fragments/4281-terraform-complex-variables.yml
+++ b/changelogs/fragments/4281-terraform-complex-variables.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - terraform - fix ``variable`` handling to allow complex values (https://github.com/ansible-collections/community.general/pull/4281)
+  - terraform - fix ``variable`` handling to allow complex values (https://github.com/ansible-collections/community.general/pull/4281).

--- a/changelogs/fragments/4281-terraform-complex-variables.yml
+++ b/changelogs/fragments/4281-terraform-complex-variables.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - terraform - fix ``variable`` handling to allow complex values (https://github.com/ansible-collections/community.general/pull/4281)

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -443,7 +443,7 @@ def main():
     for k, v in variables.items():
         variables_args.extend([
             '-var',
-            '{0}={1}'.format(k, v)
+            '{0}={1}'.format(k, json.dumps(v))
         ])
     if variables_files:
         for f in variables_files:


### PR DESCRIPTION
Signed-off-by: Webster Mudge <wmudge@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow complex, i.e. lists and dictionaries, values in the `variables` parameter of the `terraform` module. Without this minor patch, complex values will fail due to formatting issues, i.e. `Single quotes are not valid. Use double quotes (\") to enclose strings.`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.general.terraform
