### PR TITLE
Temporarily disable Java keytool installation on Archlinux

### DIFF
--- a/tests/integration/targets/setup_java_keytool/tasks/main.yml
+++ b/tests/integration/targets/setup_java_keytool/tasks/main.yml
@@ -8,6 +8,7 @@
       {{
         ansible_os_family not in ['Darwin', 'FreeBSD']
         and not (ansible_distribution == "CentOS" and ansible_distribution_version is version("7.0", "<"))
+        and not (ansible_distribution == "Archlinux")  # TODO
       }}
 
 - name: Include OS-specific variables

--- a/tests/integration/targets/setup_java_keytool/tasks/main.yml
+++ b/tests/integration/targets/setup_java_keytool/tasks/main.yml
@@ -4,11 +4,12 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 - set_fact:
+    # TODO: re-enable Archlinux!
     has_java_keytool: >-
       {{
         ansible_os_family not in ['Darwin', 'FreeBSD']
         and not (ansible_distribution == "CentOS" and ansible_distribution_version is version("7.0", "<"))
-        and not (ansible_distribution == "Archlinux")  # TODO
+        and not (ansible_distribution == "Archlinux")
       }}
 
 - name: Include OS-specific variables


### PR DESCRIPTION
##### SUMMARY
This has been failing for some days, see for example https://dev.azure.com/ansible/community.general/_build/results?buildId=36788&view=logs&j=dbebe795-726f-5309-154b-7ec77aedbab4&t=cd9f0fd2-ffdf-5e93-4772-5c3b02ceb333.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
