### PR TITLE
Fix error when checking if Proxmox VM exists.

### DIFF
--- a/changelogs/fragments/4287-fix-proxmox-vm-chek.yml
+++ b/changelogs/fragments/4287-fix-proxmox-vm-chek.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix error when checking if Proxmox VM exists (https://github.com/ansible-collections/community.general/pull/4287).
+  - proxmox_kvm - fix error when checking whether Proxmox VM exists (https://github.com/ansible-collections/community.general/pull/4287).

--- a/changelogs/fragments/4287-fix-proxmox-vm-chek.yml
+++ b/changelogs/fragments/4287-fix-proxmox-vm-chek.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix error when checking if Proxmox VM exists (https://github.com/ansible-collections/community.general/pull/4287).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1205,7 +1205,7 @@ def main():
         proxmox.get_vm(vmid)
 
         # Ensure the choosen VM name doesn't already exist when cloning
-        existing_vmid = proxmox.get_vmid(name, choose_first_if_multiple=True)
+        existing_vmid = proxmox.get_vmid(name, ignore_missing=True, choose_first_if_multiple=True)
         if existing_vmid:
             module.exit_json(changed=False, vmid=existing_vmid, msg="VM with name <%s> already exists" % name)
 


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/community.general/issues/4278.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_kvm

##### ADDITIONAL INFORMATION

Add `ignore_missing` parameter since we only use this for checking if a VM already exists.