### PR TITLE
filesize: fix alpine linux sparse file

### DIFF
--- a/changelogs/fragments/4288-fix-4259-support-busybox-dd.yml
+++ b/changelogs/fragments/4288-fix-4259-support-busybox-dd.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - filesize - add support for busybox dd implementation, that is used by default on Alpine linux
+    (https://github.com/ansible-collections/community.general/pull/4288,
+    https://github.com/ansible-collections/community.general/issues/4259).

--- a/plugins/modules/files/filesize.py
+++ b/plugins/modules/files/filesize.py
@@ -83,7 +83,7 @@ options:
       - Whether or not the file to create should be a sparse file.
       - This option is effective only on newly created files, or when growing a
         file, only for the bytes to append.
-      - This option is not supported on OpenBSD, Solaris and AIX.
+      - This option is not supported on OS or filesystems not supporting sparse files.
       - I(force=true) and I(sparse=true) are mutually exclusive.
     type: bool
     default: false
@@ -129,6 +129,10 @@ seealso:
   - name: dd(1) manpage for NetBSD
     description: Manual page of the NetBSD's dd implementation.
     link: https://man.netbsd.org/dd.1
+
+  - name: busybox(1) manpage for Linux
+    description: Manual page of the GNU/Linux's busybox, that provides its own dd implementation.
+    link: https://www.unix.com/man-page/linux/1/busybox
 '''
 
 EXAMPLES = r'''
@@ -377,12 +381,10 @@ def complete_dd_cmdline(args, dd_cmd):
         return list()
 
     bs = args['size_spec']['blocksize']
-    conv = list()
 
     # For sparse files (create, truncate, grow): write count=0 block.
     if args['sparse']:
         seek = args['size_spec']['blocks']
-        conv += ['sparse']
     elif args['force'] or not os.path.exists(args['path']):     # Create file
         seek = 0
     elif args['size_diff'] < 0:                                 # Truncate file
@@ -394,8 +396,6 @@ def complete_dd_cmdline(args, dd_cmd):
 
     count = args['size_spec']['blocks'] - seek
     dd_cmd += ['bs=%s' % str(bs), 'seek=%s' % str(seek), 'count=%s' % str(count)]
-    if conv:
-        dd_cmd += ['conv=%s' % ','.join(conv)]
 
     return dd_cmd
 

--- a/plugins/modules/files/filesize.py
+++ b/plugins/modules/files/filesize.py
@@ -83,7 +83,7 @@ options:
       - Whether or not the file to create should be a sparse file.
       - This option is effective only on newly created files, or when growing a
         file, only for the bytes to append.
-      - This option is not supported on OS or filesystems not supporting sparse files.
+      - This option is not supported on OSes or filesystems not supporting sparse files.
       - I(force=true) and I(sparse=true) are mutually exclusive.
     type: bool
     default: false

--- a/tests/integration/targets/filesize/tasks/main.yml
+++ b/tests/integration/targets/filesize/tasks/main.yml
@@ -29,7 +29,6 @@
       include_tasks: sparse.yml
       when:
         - not (ansible_os_family == 'Darwin' and ansible_distribution_version is version('11', '<'))
-        - not (ansible_os_family == 'Alpine')  # TODO figure out why it fails
 
     - name: Include tasks to test playing with symlinks
       include_tasks: symlinks.yml


### PR DESCRIPTION
##### SUMMARY

~~I don't know why the module fails to create sparse files on Alpine linux, so I start by re-enabling these tests, to catch the error and then fix it.~~

Update 1: Alpine linux is mainly based on busybox, and its dd applet doesn't support `conv=sparse` flag. Although this flag is not needed since a `count=0` already does the job as expected. Removing it could also extend support for sparse files to OpenBSD, Solaris and AIX (their native dd implementations don't support `conv=sparse` too)


Fixes #4259

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

filesize

##### ADDITIONAL INFORMATION