### PR TITLE
npm: add support for `production` flag when using `ci`

### DIFF
--- a/changelogs/fragments/4299-npm-add-production-with-ci-flag.yml
+++ b/changelogs/fragments/4299-npm-add-production-with-ci-flag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - npm - add ability to use production flag when ci is set (https://github.com/ansible-collections/community.general/pull/4299).

--- a/changelogs/fragments/4299-npm-add-production-with-ci-flag.yml
+++ b/changelogs/fragments/4299-npm-add-production-with-ci-flag.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - npm - add ability to use production flag when ci is set (https://github.com/ansible-collections/community.general/pull/4299).
+  - npm - add ability to use ``production`` flag when ``ci`` is set (https://github.com/ansible-collections/community.general/pull/4299).

--- a/plugins/modules/packaging/language/npm.py
+++ b/plugins/modules/packaging/language/npm.py
@@ -175,7 +175,7 @@ class Npm(object):
 
             if self.glbl:
                 cmd.append('--global')
-            if self.production and ('install' in cmd or 'update' in cmd):
+            if self.production and ('install' in cmd or 'update' in cmd or 'ci' in cmd):
                 cmd.append('--production')
             if self.ignore_scripts:
                 cmd.append('--ignore-scripts')

--- a/tests/unit/plugins/modules/packaging/language/test_npm.py
+++ b/tests/unit/plugins/modules/packaging/language/test_npm.py
@@ -188,3 +188,75 @@ class NPMModuleTestCase(ModuleTestCase):
             call(['/testbin/npm', 'list', '--json', '--long', '--global'], check_rc=False, cwd=None),
             call(['/testbin/npm', 'uninstall', '--global', 'coffee-script'], check_rc=True, cwd=None),
         ])
+
+    def test_present_package_json(self):
+        set_module_args({
+            'global': 'true',
+            'state': 'present'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'install', '--global'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_package_json_production(self):
+        set_module_args({
+            'production': 'true',
+            'global': 'true',
+            'state': 'present',
+        })
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'install', '--global', '--production'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_package_json_ci(self):
+        set_module_args({
+            'ci': 'true',
+            'global': 'true',
+            'state': 'present'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'ci', '--global'], check_rc=True, cwd=None),
+        ])
+
+    def test_present_package_json_ci_production(self):
+        set_module_args({
+            'ci': 'true',
+            'production': 'true',
+            'global': 'true',
+            'state': 'present'
+        })
+        self.module_main_command.side_effect = [
+            (0, '{}', ''),
+            (0, '{}', ''),
+        ]
+
+        result = self.module_main(AnsibleExitJson)
+
+        self.assertTrue(result['changed'])
+        self.module_main_command.assert_has_calls([
+            call(['/testbin/npm', 'ci', '--global', '--production'], check_rc=True, cwd=None),
+        ])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
npm supports using `--production` with the `npm ci` command
see [npm ci](https://docs.npmjs.com/cli/v8/commands/npm-ci) and [npm install](https://docs.npmjs.com/cli/v8/commands/npm-install) documentation
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
npm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
- name: run npm ci with production flag
  community.general.npm:
    path: npm_with_package_json
    ci: true
    production: true
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# before change
npm ci

# after change
npm ci --production
```
