### PR TITLE
jira: Use fields in comment to merge in additional data

### DIFF
--- a/changelogs/fragments/4304-jira-fields-in-comment.yml
+++ b/changelogs/fragments/4304-jira-fields-in-comment.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jira - when creating a comment, ``fields`` is used for additional data (https://github.com/ansible-collections/community.general/pull/4304)
+  - jira - when creating a comment, ``fields`` now is used for additional data (https://github.com/ansible-collections/community.general/pull/4304).

--- a/changelogs/fragments/4304-jira-fields-in-comment.yml
+++ b/changelogs/fragments/4304-jira-fields-in-comment.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jira - when creating a comment, ``fields`` is used for additional data (https://github.com/ansible-collections/community.general/pull/4304)

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -158,6 +158,7 @@ options:
      - This is a free-form data structure that can contain arbitrary data. This is passed directly to the JIRA REST API
        (possibly after merging with other required data, as when passed to create). See examples for more information,
        and the JIRA REST API for the structure required for various fields.
+     - When passed to comment, the data structure is merged at the first level. Useful to add JIRA properties for example.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 
   jql:

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -261,6 +261,20 @@ EXAMPLES = r"""
       type: role
       value: Developers
 
+- name: Comment on issue with property to mark it internal
+  community.general.jira:
+    uri: '{{ server }}'
+    username: '{{ user }}'
+    password: '{{ pass }}'
+    issue: '{{ issue.meta.key }}'
+    operation: comment
+    comment: A comment added by Ansible
+    fields:
+      properties:
+        - key: 'sd.public.comment'
+          value:
+            internal: true
+
 # Assign an existing issue using edit
 - name: Assign an issue using free-form fields
   community.general.jira:
@@ -501,6 +515,10 @@ class JIRA(StateModuleHelper):
         # if comment_visibility is specified restrict visibility
         if self.vars.comment_visibility is not None:
             data['visibility'] = self.vars.comment_visibility
+
+        # Use 'fields' to merge in any additional data
+        if self.vars.fields:
+            data.update(self.vars.fields)
 
         url = self.vars.restbase + '/issue/' + self.vars.issue + '/comment'
         self.vars.meta = self.post(url, data)

--- a/plugins/modules/web_infrastructure/jira.py
+++ b/plugins/modules/web_infrastructure/jira.py
@@ -158,7 +158,7 @@ options:
      - This is a free-form data structure that can contain arbitrary data. This is passed directly to the JIRA REST API
        (possibly after merging with other required data, as when passed to create). See examples for more information,
        and the JIRA REST API for the structure required for various fields.
-     - When passed to comment, the data structure is merged at the first level. Useful to add JIRA properties for example.
+     - When passed to comment, the data structure is merged at the first level since community.general 4.6.0. Useful to add JIRA properties for example.
      - Note that JIRA may not allow changing field values on specific transitions or states.
 
   jql:


### PR DESCRIPTION
##### SUMMARY
The 'fields' parameter could be used to merge in any arbitrary data to a jira comment.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Enhancement of comment creation in community.general.jira.

##### ADDITIONAL INFORMATION
In jira issue creation, the 'fields' parameter is used to pass in any arbitrary data.
We adopted this to work also in jira comment creation.

In our jira service desk environment, we use it to set a property to mark the comment as 'internal'. 
Look at the example I added.

(Some explanation that helped to find the correct property for this:
https://stackoverflow.com/questions/45031475/how-to-create-an-internal-comment-on-a-jira-issue-using-the-jira-cloud-rest-api )

