### PR TITLE
proxmox: Fix error on VM clone (#4278)

### DIFF
--- a/changelogs/fragments/4306-proxmox-fix-error-on-vm-clone.yml
+++ b/changelogs/fragments/4306-proxmox-fix-error-on-vm-clone.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox_kvm: Fix error in check when creating or cloning"

--- a/changelogs/fragments/4306-proxmox-fix-error-on-vm-clone.yml
+++ b/changelogs/fragments/4306-proxmox-fix-error-on-vm-clone.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "proxmox_kvm: Fix error in check when creating or cloning"
+  - "proxmox_kvm - fix error in check when creating or cloning (https://github.com/ansible-collections/community.general/pull/4306)."

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1205,12 +1205,12 @@ def main():
         proxmox.get_vm(vmid)
 
         # Ensure the choosen VM name doesn't already exist when cloning
-        existing_vmid = proxmox.get_vmid(name, choose_first_if_multiple=True)
+        existing_vmid = proxmox.get_vmid(name, ignore_missing=True, choose_first_if_multiple=True)
         if existing_vmid:
             module.exit_json(changed=False, vmid=existing_vmid, msg="VM with name <%s> already exists" % name)
 
         # Ensure the choosen VM id doesn't already exist when cloning
-        if proxmox.get_vm(newid, ignore_errors=True):
+        if proxmox.get_vm(newid, ignore_missing=True):
             module.exit_json(changed=False, vmid=vmid, msg="vmid %s with VM name %s already exists" % (newid, name))
 
     if delete is not None:


### PR DESCRIPTION


##### SUMMARY
Incorrect parameters for `get_vmid()` and `get_vm()` caused failures when
cloning VMs.

Fixes #4278

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
proxmox_kvm module failed to create or clone VMs due to incorrect function parameters.

There is already a PR (4287) for this, but it only fixes the new VM case, clone still fails. This PR fixes the clone case as well.

```
TASK [gitlab-runner-ephemeral-prepare : Clone VM] ******************************
Tuesday 01 March 2022  09:33:42 +0000 (0:00:00.029)       0:00:00.050 ********* 
fatal: [freebsd-builder01.isnic.is -> localhost]: FAILED! => changed=false 
  msg: No VM with name freebsd-builder01.isnic.is-temp found
```
