### PR TITLE
datadog: Add missing priority

### DIFF
--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -153,6 +153,11 @@ options:
         type: bool
         default: yes
         version_added: 1.3.0
+    priority:
+        description:
+         - Integer from 1 (high) to 5 (low) indicating alert severity.
+         type: str
+         default: no
 '''
 
 EXAMPLES = '''
@@ -239,6 +244,7 @@ def main():
             evaluation_delay=dict(),
             id=dict(),
             include_tags=dict(required=False, default=True, type='bool'),
+            priority=dict(),
         )
     )
 
@@ -298,6 +304,7 @@ def _post_monitor(module, options):
                       name=_fix_template_vars(module.params['name']),
                       message=_fix_template_vars(module.params['notification_message']),
                       escalation_message=_fix_template_vars(module.params['escalation_message']),
+                      priority=module.params['priority'],
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
@@ -322,6 +329,7 @@ def _update_monitor(module, monitor, options):
                       name=_fix_template_vars(module.params['name']),
                       message=_fix_template_vars(module.params['notification_message']),
                       escalation_message=_fix_template_vars(module.params['escalation_message']),
+                      priority=module.params['priority'],
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -157,7 +157,6 @@ options:
         description:
           - Integer from 1 (high) to 5 (low) indicating alert severity.
         type: int
-        choices: [1, 2, 3, 4, 5]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -155,9 +155,8 @@ options:
         version_added: 1.3.0
     priority:
         description:
-         - Integer from 1 (high) to 5 (low) indicating alert severity.
+          - Integer from 1 (high) to 5 (low) indicating alert severity.
          type: str
-         default: no
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -157,6 +157,7 @@ options:
         description:
           - Integer from 1 (high) to 5 (low) indicating alert severity.
         type: str
+        choices: [1, 2, 3, 4, 5]
 '''
 
 EXAMPLES = '''
@@ -243,7 +244,7 @@ def main():
             evaluation_delay=dict(),
             id=dict(),
             include_tags=dict(required=False, default=True, type='bool'),
-            priority=dict(),
+            priority=dict(type='int'),
         )
     )
 

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -157,6 +157,7 @@ options:
         description:
           - Integer from 1 (high) to 5 (low) indicating alert severity.
         type: int
+        version_added: 4.6.0
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -156,7 +156,7 @@ options:
     priority:
         description:
           - Integer from 1 (high) to 5 (low) indicating alert severity.
-         type: str
+        type: str
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -156,7 +156,7 @@ options:
     priority:
         description:
           - Integer from 1 (high) to 5 (low) indicating alert severity.
-        type: str
+        type: int
         choices: [1, 2, 3, 4, 5]
 '''
 


### PR DESCRIPTION
##### SUMMARY
Add a missing property for priority in datadog monitor module


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
datadog_monitor
`priority=module.params['priority'],`
