### PR TITLE
pacman: user --groups instead of --group

### DIFF
--- a/changelogs/fragments/4312-pacman-groups.yml
+++ b/changelogs/fragments/4312-pacman-groups.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - pacman - Use ``--groups`` instead of ``--group``
+    (https://github.com/ansible-collections/community.general/pull/4312).
+
+known_issues:
+   - pacman - Binaries specified in the ``executable`` parameter must support
+     ``--print-format`` in order to be used by this module.
+     In particular, AUR helper ``yay`` is known not to currently support it.

--- a/changelogs/fragments/4312-pacman-groups.yml
+++ b/changelogs/fragments/4312-pacman-groups.yml
@@ -3,6 +3,7 @@ bugfixes:
     (https://github.com/ansible-collections/community.general/pull/4312).
 
 known_issues:
-   - pacman - Binaries specified in the ``executable`` parameter must support
+   - pacman - binaries specified in the ``executable`` parameter must support
      ``--print-format`` in order to be used by this module.
-     In particular, AUR helper ``yay`` is known not to currently support it.
+     In particular, AUR helper ``yay`` is known not to currently support it
+     (https://github.com/ansible-collections/community.general/pull/4312).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -52,7 +52,10 @@ options:
 
     executable:
         description:
-            - Name of binary to use. This can either be C(pacman) or a pacman compatible AUR helper.
+            - Path of the binary to use. This can either be C(pacman) or a pacman compatible AUR helper.
+            - Pacman compatibility is unfortunately ill defined, in particular, this modules makes
+              extensive use of the ``--print-format`` directive which is known not to be implemented by
+              some AUR helpers. (Notably, ``yay``)
             - Beware that AUR helpers might behave unexpectedly and are therefore not recommended.
         default: pacman
         type: str

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -575,7 +575,7 @@ class Pacman(object):
 
         installed_groups = defaultdict(set)
         dummy, stdout, dummy = self.m.run_command(
-            [self.pacman_path, "--query", "--group"], check_rc=True
+            [self.pacman_path, "--query", "--groups"], check_rc=True
         )
         # Format of lines:
         #     base-devel file
@@ -600,7 +600,7 @@ class Pacman(object):
 
         available_groups = defaultdict(set)
         dummy, stdout, dummy = self.m.run_command(
-            [self.pacman_path, "--sync", "--group", "--group"], check_rc=True
+            [self.pacman_path, "--sync", "--groups", "--groups"], check_rc=True
         )
         # Format of lines:
         #     vim-plugins vim-airline

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -54,8 +54,8 @@ options:
         description:
             - Path of the binary to use. This can either be C(pacman) or a pacman compatible AUR helper.
             - Pacman compatibility is unfortunately ill defined, in particular, this modules makes
-              extensive use of the ``--print-format`` directive which is known not to be implemented by
-              some AUR helpers. (Notably, ``yay``)
+              extensive use of the C(--print-format) directive which is known not to be implemented by
+              some AUR helpers (notably, C(yay)).
             - Beware that AUR helpers might behave unexpectedly and are therefore not recommended.
         default: pacman
         type: str


### PR DESCRIPTION
As stated in https://github.com/ansible-collections/community.general/commit/1580f3c2b4876aeb06a0c785a14c5a4e057e843e#commitcomment-67899699 , the new pacman module was using a shorthand option for `--groups` which is accepted by pacman, but not by other programs which have similar CLI interfaces.

This PR uses `--groups` as it should have in the first place.

Question:  should I add a simple integration test that installs yay and proceeds to install a simple package with it using the pacman module?
If so, would it be acceptable to download a fixed version of yay from github, check its checksum and use it for the test?

@felixfontein ^
