### PR TITLE
pacman: add support for remove_nosave

### DIFF
--- a/changelogs/fragments/4316-pacman-remove-nosave.yml
+++ b/changelogs/fragments/4316-pacman-remove-nosave.yml
@@ -1,3 +1,3 @@
-minor_change:
+minor_changes:
   - pacman - add ``remove_nosave`` parameter to avoid saving modified configuration files as ``.pacsave`` files.
     (https://github.com/ansible-collections/community.general/pull/4316, https://github.com/ansible-collections/community.general/issues/4315).

--- a/changelogs/fragments/4316-pacman-remove-nosave.yml
+++ b/changelogs/fragments/4316-pacman-remove-nosave.yml
@@ -1,0 +1,3 @@
+minor_change:
+  - pacman - add ``remove_nosave`` parameter to avoid saving modified configuration files as ``.pacsave`` files.
+    (https://github.com/ansible-collections/community.general/pull/4316, https://github.com/ansible-collections/community.general/issues/4315).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -54,6 +54,7 @@ options:
         description:
             - When removing packages, do not save modified configuration files as C(.pacsave) files.
               (passes C(--nosave) to pacman)
+        version_added: 4.6.0
         default: no
         type: bool
 

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -45,7 +45,7 @@ options:
         description:
             - When removing packages, forcefully remove them, without any checks.
               Same as C(extra_args="--nodeps --nodeps").
-              When update_cache, force redownload repo databases.
+              When combined with I(update_cache), force a refresh of all package databases.
               Same as C(update_cache_extra_args="--refresh --refresh").
         default: no
         type: bool

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -9,3 +9,4 @@
     # Add more tests here by including more task files:
     - include: 'basic.yml'
     - include: 'package_urls.yml'
+    - include: 'remove_nosave.yml'

--- a/tests/integration/targets/pacman/tasks/remove_nosave.yml
+++ b/tests/integration/targets/pacman/tasks/remove_nosave.yml
@@ -1,0 +1,70 @@
+---
+- vars:
+    package_name: xinetd
+    config_file: /etc/xinetd.conf
+  block:
+    - name: Make sure that {{ package_name }} is not installed
+      pacman:
+        name: '{{ package_name }}'
+        state: absent
+    - name: Make sure {{config_file}}.pacsave file doesn't exist
+      file:
+        path: '{{config_file}}.pacsave'
+        state: absent
+
+    - name: Install {{ package_name }}
+      pacman:
+        name: '{{ package_name }}'
+        state: present
+
+    - name: Modify {{config_file}}
+      blockinfile:
+        path: '{{config_file}}'
+        block: |
+          # something something
+          # on 2 lines
+
+    - name: Remove {{ package_name }} - generate pacsave
+      pacman:
+        name: '{{ package_name }}'
+        state: absent
+    - name: Make sure {{config_file}}.pacsave exists
+      stat:
+        path: '{{config_file}}.pacsave'
+      register: pacsave_st_1
+
+    - assert:
+        that:
+          - pacsave_st_1.stat.exists
+
+    - name: Delete {{config_file}}.pacsave
+      file:
+        path: '{{config_file}}.pacsave'
+        state: absent
+
+    - name: Install {{ package_name }}
+      pacman:
+        name: '{{ package_name }}'
+        state: present
+
+    - name: Modify {{config_file}}
+      blockinfile:
+        path: '{{config_file}}'
+        block: |
+          # something something
+          # on 2 lines
+
+    - name: Remove {{ package_name }} - nosave
+      pacman:
+        name: '{{ package_name }}'
+        remove_nosave: yes
+        state: absent
+
+    - name: Make sure {{config_file}}.pacsave does not exist
+      stat:
+        path: '{{config_file}}.pacsave'
+      register: pacsave_st_2
+
+    - assert:
+        that:
+          - not pacsave_st_2.stat.exists


### PR DESCRIPTION
##### SUMMARY

New parameter: `remove_nosave`
When enabled, will pass `--nosave` to pacman when removing packages.
`--nosave` cannot be used with `--print-format` and thus it couldn't be
passed via extra_args. See #4315

The code adds the option right before the actual removal of the pkgs.

(This is based on an initial diff from @MorphBonehunter)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
pacman
