### PR TITLE
pacman: don't always return changed w/ update_cache

### DIFF
--- a/changelogs/fragments/4318-pacman-restore-old-changed-behavior.yml
+++ b/changelogs/fragments/4318-pacman-restore-old-changed-behavior.yml
@@ -1,7 +1,8 @@
 bugfixes:
   - pacman - when the ``update_cache`` option is combined with another option
     such as ``upgrade``, report ``changed`` based on the actions performed by
-    the latter option. Previously a task combining these options would always
+    the latter option. This was the behavior in community.general 4.4.0 and before.
+    In community.general 4.5.0, a task combining these options would always
     report ``changed``
     (https://github.com/ansible-collections/community.general/pull/4318).
 

--- a/changelogs/fragments/4318-pacman-restore-old-changed-behavior.yml
+++ b/changelogs/fragments/4318-pacman-restore-old-changed-behavior.yml
@@ -1,0 +1,11 @@
+bugfixes:
+  - pacman - when the ``update_cache`` option is combined with another option
+    such as ``upgrade``, report ``changed`` based on the actions performed by
+    the latter option. Previously a task combining these options would always
+    report ``changed``
+    (https://github.com/ansible-collections/community.general/pull/4318).
+
+known_issues:
+   - pacman - ``update_cache`` cannot differentiate between up to date and
+     outdated package lists and will report ``changed`` in both situations
+     (https://github.com/ansible-collections/community.general/pull/4318).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -271,6 +271,12 @@ class Pacman(object):
             if not (self.m.params["name"] or self.m.params["upgrade"]):
                 self.success()
 
+        # Avoid shadowing lack of changes in the following stages
+        # so that update_cache: yes doesn't always return changed
+        # TODO: remove this when update_cache is tweaked to report its real
+        # changed status (i.e. no changed if package lists were up to date)
+        self.changed = False
+
         self.inventory = self._build_inventory()
         if self.m.params["upgrade"]:
             self.upgrade()


### PR DESCRIPTION
##### SUMMARY

Restores the `changed` behavior before the recent refactoring (https://github.com/ansible-collections/community.general/pull/3907).

Allows the following to return changed only when packages were upgraded:

```
- pacman:
  update_cache: yes
  upgrade: yes
```

And the following to return changed only when the foo package wasn't at the latest version:

```
- pacman:
  name: foo
  state: latest
  update_cache: yes
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pacman