### PR TITLE
pacman: improve docs, make sure that packages is always returned, deprecate update_cache behavior

### DIFF
--- a/changelogs/fragments/4330-pacman-packages-update_cache.yml
+++ b/changelogs/fragments/4330-pacman-packages-update_cache.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - "pacman - make sure that ``packages`` is always returned when ``name`` or ``upgrade`` is specified, also if nothing is done
+     (https://github.com/ansible-collections/community.general/pull/4329)."
+deprecated_features:
+  - "pacman - from community.general 5.0.0 on, the ``changed`` status of ``update_cache`` will no longer be ignored if ``name`` or ``upgrade`` is specified.
+     To keep the old behavior, add something like ``register: result`` and ``changed_when: result.packages | length > 0`` to your task
+     (https://github.com/ansible-collections/community.general/pull/4329)."

--- a/changelogs/fragments/4330-pacman-packages-update_cache.yml
+++ b/changelogs/fragments/4330-pacman-packages-update_cache.yml
@@ -1,9 +1,6 @@
 bugfixes:
   - "pacman - make sure that ``packages`` is always returned when ``name`` or ``upgrade`` is specified, also if nothing is done
      (https://github.com/ansible-collections/community.general/pull/4329)."
-minor_changes:
-  - "pacman - add ``cache_updated`` return value to when ``update_cache=true``
-     (https://github.com/ansible-collections/community.general/pull/4329)."
 deprecated_features:
   - "pacman - from community.general 5.0.0 on, the ``changed`` status of ``update_cache`` will no longer be ignored if ``name`` or ``upgrade`` is specified.
      To keep the old behavior, add something like ``register: result`` and ``changed_when: result.packages | length > 0`` to your task

--- a/changelogs/fragments/4330-pacman-packages-update_cache.yml
+++ b/changelogs/fragments/4330-pacman-packages-update_cache.yml
@@ -1,6 +1,9 @@
 bugfixes:
   - "pacman - make sure that ``packages`` is always returned when ``name`` or ``upgrade`` is specified, also if nothing is done
      (https://github.com/ansible-collections/community.general/pull/4329)."
+minor_changes:
+  - "pacman - add ``cache_updated`` return value to when ``update_cache=true``
+     (https://github.com/ansible-collections/community.general/pull/4329)."
 deprecated_features:
   - "pacman - from community.general 5.0.0 on, the ``changed`` status of ``update_cache`` will no longer be ignored if ``name`` or ``upgrade`` is specified.
      To keep the old behavior, add something like ``register: result`` and ``changed_when: result.packages | length > 0`` to your task

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -125,6 +125,15 @@ packages:
     elements: str
     sample: [ package, other-package ]
 
+cache_updated:
+    description:
+        - The changed status of C(pacman -Sy).
+        - Useful when I(name) or I(upgrade=true) are specified next to I(update_cache=true).
+    returned: success, when I(update_cache=true)
+    type: bool
+    sample: false
+    version_added: 4.6.0
+
 stdout:
     description:
         - Output from pacman.
@@ -512,6 +521,7 @@ class Pacman(object):
         if self.m.check_mode:
             self.add_exit_infos("Would have updated the package db")
             self.changed = True
+            self.exit_params["cache_updated"] = True
             return
 
         cmd = [
@@ -526,7 +536,13 @@ class Pacman(object):
 
         rc, stdout, stderr = self.m.run_command(cmd, check_rc=False)
 
+        # TODO: check whether the cache was actually updated
+        # Right now, this only seems to be possible by adding `--debug` and looking
+        # for `.db: response code` and checking whether the response is 304 (not
+        # updated) or something else (likely updated)
+
         self.changed = True
+        self.exit_params["cache_updated"] = True
 
         if rc == 0:
             self.add_exit_infos("Updated package db", stdout=stdout, stderr=stderr)

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -125,15 +125,6 @@ packages:
     elements: str
     sample: [ package, other-package ]
 
-cache_updated:
-    description:
-        - The changed status of C(pacman -Sy).
-        - Useful when I(name) or I(upgrade=true) are specified next to I(update_cache=true).
-    returned: success, when I(update_cache=true)
-    type: bool
-    sample: false
-    version_added: 4.6.0
-
 stdout:
     description:
         - Output from pacman.
@@ -521,7 +512,6 @@ class Pacman(object):
         if self.m.check_mode:
             self.add_exit_infos("Would have updated the package db")
             self.changed = True
-            self.exit_params["cache_updated"] = True
             return
 
         cmd = [
@@ -536,13 +526,7 @@ class Pacman(object):
 
         rc, stdout, stderr = self.m.run_command(cmd, check_rc=False)
 
-        # TODO: check whether the cache was actually updated
-        # Right now, this only seems to be possible by adding `--debug` and looking
-        # for `.db: response code` and checking whether the response is 304 (not
-        # updated) or something else (likely updated)
-
         self.changed = True
-        self.exit_params["cache_updated"] = True
 
         if rc == 0:
             self.add_exit_infos("Updated package db", stdout=stdout, stderr=stderr)

--- a/tests/unit/plugins/modules/packaging/os/test_pacman.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman.py
@@ -325,6 +325,7 @@ class TestPacman:
             P.run()
         self.mock_run_command.call_count == 0
         out = e.value.args[0]
+        assert "packages" not in out
         assert out["changed"]
 
     @pytest.mark.parametrize(
@@ -582,8 +583,9 @@ class TestPacman:
         with pytest.raises(AnsibleExitJson) as e:
             P.run()
         out = e.value.args[0]
-        assert "packages" not in out
+        assert "packages" in out
         assert not out["changed"]
+        assert "packages" in out
         assert "diff" not in out
         self.mock_run_command.call_count == 0
 
@@ -1010,6 +1012,7 @@ class TestPacman:
         if raises == AnsibleExitJson:
             assert out["packages"] == expected_packages
             assert out["changed"]
+            assert "packages" in out
             assert "diff" in out
         else:
             assert out["stdout"] == "stdout"

--- a/tests/unit/plugins/modules/packaging/os/test_pacman.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman.py
@@ -583,7 +583,6 @@ class TestPacman:
         with pytest.raises(AnsibleExitJson) as e:
             P.run()
         out = e.value.args[0]
-        assert "packages" in out
         assert not out["changed"]
         assert "packages" in out
         assert "diff" not in out


### PR DESCRIPTION
##### SUMMARY
1. Improves documentation on return value `packages` and option `update_cache`.
2. Make sure that `packages` is always returned if `name` is specified or `upgrade=true`.
3. Deprecate that `changed` from `upgrade_cache` is ignored when `name` is specified or `upgrade=true`. Provide workaround to keep current behavior.
4. Add `cache_updated` return value (returned when `update_cache=true`).

CC @jraby @foutrelis @aminvakil @artis3n

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
pacman
