### PR TITLE
nmcli: Change hairpin default mode

### DIFF
--- a/changelogs/fragments/4320-nmcli-hairpin.yml
+++ b/changelogs/fragments/4320-nmcli-hairpin.yml
@@ -1,2 +1,2 @@
-breaking_changes:
-  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to 'no' in ansible 6.0.0, as this is also the default in nmcli.
+deprecated_features:
+  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to ``no`` in community.general 7.0.0, as this is also the default in nmcli.

--- a/changelogs/fragments/4320-nmcli-hairpin.yml
+++ b/changelogs/fragments/4320-nmcli-hairpin.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to 'no' in ansible 6.0.0, as this is also the default in nmcli.

--- a/changelogs/fragments/4320-nmcli-hairpin.yml
+++ b/changelogs/fragments/4320-nmcli-hairpin.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to ``no`` in community.general 7.0.0, as this is also the default in nmcli.
+  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to ``false`` in community.general 7.0.0, as this is also the default in nmcli (https://github.com/ansible-collections/community.general/pull/4334).

--- a/changelogs/fragments/4320-nmcli-hairpin.yml
+++ b/changelogs/fragments/4320-nmcli-hairpin.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to ``false`` in community.general 7.0.0, as this is also the default in nmcli (https://github.com/ansible-collections/community.general/pull/4334).
+  - nmcli - deprecate default hairpin mode for a bridge. This so we can change it to ``false`` in community.general 7.0.0, as this is also the default in ``nmcli`` (https://github.com/ansible-collections/community.general/pull/4334).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -295,7 +295,7 @@ options:
             - This is only used with 'bridge-slave' - 'hairpin mode' for the slave, which allows frames to be sent back out through the slave the
               frame was received on.
             - The default value is C(true), but that is being deprecated
-              and it will be changed to C(false) in community.general 6.0.0.
+              and it will be changed to C(false) in community.general 7.0.0.
         type: bool
     runner:
         description:
@@ -1346,9 +1346,10 @@ class Nmcli(object):
     @property
     def hairpin(self):
         if self._hairpin is None:
-            self.module.warn(
-                "Parameter 'hairpin' default value will change from true to false in community.general 6.0.0. "
-                "Set the value explicitly to supress this warning."
+            self.module.deprecate(
+                "Parameter 'hairpin' default value will change from true to false in community.general 7.0.0. "
+                "Set the value explicitly to supress this warning.",
+                version='7.0.0', collection_name='community.general',
             )
             # Should be False in 6.0.0 but then that should be in argument_specs
             self._hairpin = True

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1295,7 +1295,7 @@ class Nmcli(object):
         self.hellotime = module.params['hellotime']
         self.maxage = module.params['maxage']
         self.ageingtime = module.params['ageingtime']
-        # hairpin should be back to normal in 6.0.0
+        # hairpin should be back to normal in 7.0.0
         self._hairpin = module.params['hairpin']
         self.path_cost = module.params['path_cost']
         self.mac = module.params['mac']
@@ -1351,7 +1351,7 @@ class Nmcli(object):
                 "Set the value explicitly to supress this warning.",
                 version='7.0.0', collection_name='community.general',
             )
-            # Should be False in 6.0.0 but then that should be in argument_specs
+            # Should be False in 7.0.0 but then that should be in argument_specs
             self._hairpin = True
         return self._hairpin
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -294,8 +294,9 @@ options:
         description:
             - This is only used with 'bridge-slave' - 'hairpin mode' for the slave, which allows frames to be sent back out through the slave the
               frame was received on.
+            - The default value is C(true), but that is being deprecated
+              and it will be changed to C(false) in community.general 6.0.0.
         type: bool
-        default: yes
     runner:
         description:
             - This is the type of device or network connection that you wish to create for a team.
@@ -1294,7 +1295,8 @@ class Nmcli(object):
         self.hellotime = module.params['hellotime']
         self.maxage = module.params['maxage']
         self.ageingtime = module.params['ageingtime']
-        self.hairpin = module.params['hairpin']
+        # hairpin should be back to normal in 6.0.0
+        self._hairpin = module.params['hairpin']
         self.path_cost = module.params['path_cost']
         self.mac = module.params['mac']
         self.runner = module.params['runner']
@@ -1340,6 +1342,17 @@ class Nmcli(object):
             self.ipv6_method = None
 
         self.edit_commands = []
+
+    @property
+    def hairpin(self):
+        if self._hairpin is None:
+            self.module.warn(
+                "Parameter 'hairpin' default value will change from true to false in community.general 6.0.0. "
+                "Set the value explicitly to supress this warning."
+            )
+            # Should be False in 6.0.0 but then that should be in argument_specs
+            self._hairpin = True
+        return self._hairpin
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None):
         if isinstance(cmd, list):
@@ -1983,7 +1996,7 @@ def main():
             hellotime=dict(type='int', default=2),
             maxage=dict(type='int', default=20),
             ageingtime=dict(type='int', default=300),
-            hairpin=dict(type='bool', default=True),
+            hairpin=dict(type='bool'),
             path_cost=dict(type='int', default=100),
             # team specific vars
             runner=dict(type='str', default='roundrobin',


### PR DESCRIPTION
##### SUMMARY
Change default hairpin mode for a bridge.
Plain nmcli/bridge tools defaults to no, but for some reason ansible
defaults to yes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli
