### PR TITLE
Fix linode inventory filtering

### DIFF
--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -181,26 +181,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for linode_group in self.linode_groups:
             self.inventory.add_group(linode_group)
 
-    def _filter_by_config(self, regions, types, tags):
-        """Filter instances by user specified configuration."""
-        if regions:
-            self.instances = [
-                instance for instance in self.instances
-                if instance.region.id in regions
-            ]
-
-        if types:
-            self.instances = [
-                instance for instance in self.instances
-                if instance.type.id in types
-            ]
-
-        if tags:
-            self.instances = [
-                instance for instance in self.instances
-                if any(tag in instance.tags for tag in tags)
-            ]
-
     def _add_instances_to_groups(self):
         """Add instance names to their dynamic inventory groups."""
         for instance in self.instances:
@@ -247,60 +227,32 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
         return data
 
-    def _validate_option(self, name, desired_type, option_value):
-        """Validate user specified configuration data against types."""
-        if isinstance(option_value, string_types) and desired_type == list:
-            option_value = [option_value]
-
-        if option_value is None:
-            option_value = desired_type()
-
-        if not isinstance(option_value, desired_type):
-            raise AnsibleParserError(
-                'The option %s (%s) must be a %s' % (
-                    name, option_value, desired_type
-                )
-            )
-
-        return option_value
-
-    def _get_query_options(self, config_data):
-        """Get user specified query options from the configuration."""
-        options = {
-            'regions': {
-                'type_to_be': list,
-                'value': config_data.get('regions', [])
-            },
-            'types': {
-                'type_to_be': list,
-                'value': config_data.get('types', [])
-            },
-            'tags': {
-                'type_to_be': list,
-                'value': config_data.get('tags', [])
-            },
-        }
-
-        for name in options:
-            options[name]['value'] = self._validate_option(
-                name,
-                options[name]['type_to_be'],
-                options[name]['value']
-            )
-
-        regions = options['regions']['value']
-        types = options['types']['value']
-        tags = options['tags']['value']
-
-        return regions, types, tags
-
     def _cacheable_inventory(self):
         return [i._raw_json for i in self.instances]
 
-    def populate(self, config_data):
+    def populate(self):
         strict = self.get_option('strict')
-        regions, types, tags = self._get_query_options(config_data)
-        self._filter_by_config(regions, types, tags)
+
+        regions = self.get_option('regions')
+        if regions:
+            self.instances = [
+                instance for instance in self.instances
+                if instance.region.id in regions
+            ]
+
+        types = self.get_option('types')
+        if types:
+            self.instances = [
+                instance for instance in self.instances
+                if instance.type.id in types
+            ]
+
+        tags = self.get_option('tags')
+        if tags:
+            self.instances = [
+                instance for instance in self.instances
+                if any(tag in instance.tags for tag in tags)
+            ]
 
         self._add_groups()
         self._add_instances_to_groups()
@@ -339,8 +291,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not HAS_LINODE:
             raise AnsibleError('the Linode dynamic inventory plugin requires linode_api4.')
 
-        config_data = self._read_config_data(path)
-        self._consume_options(config_data)
+        self._read_config_data(path)
 
         cache_key = self.get_cache_key(path)
 
@@ -363,4 +314,4 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if update_cache:
             self._cache[cache_key] = self._cacheable_inventory()
 
-        self.populate(config_data)
+        self.populate()


### PR DESCRIPTION
##### SUMMARY

There was a regression introduced in the addition of caching. The
`_consume_options` method was added and provided the `config_data`
dictionary. This `pop`s every entry, resulting in an empty `config_data`
dict, which was then reused and expected to be populated.

After reviewing, `_consume_data` doesn't need to be called. Also, once
the `_read_config_data` method has been called, we no longer need the
`config_data` dict, and can instead use the `get_option` method
throughout.

Once those were removed, the filtering function seemed a bit odd, since
we were no longer using the file. I used that opportunity to move the
filter calls into the populate function directly.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

community.general.linode