### PR TITLE
Update doc. tss.py (env REQUESTS_CA_BUNDLE)

### DIFF
--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -15,7 +15,7 @@ description:
       Server using token authentication with I(username) and I(password) on
       the REST API at I(base_url).
     - When using self-signed certificates the environment variable
-      I(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
+      C(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
       (in .pem format).
     - e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -16,8 +16,8 @@ description:
       the REST API at I(base_url).
     - When using self-signed certificates the environment variable
       I(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
-      (in .pem format). 
-      e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
+      (in .pem format).
+    - e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 options:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -17,7 +17,7 @@ description:
     - When using self-signed certificates the environment variable
       C(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
       (in C(.pem) format).
-    - e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
+    - For example, C(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 options:

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -16,7 +16,7 @@ description:
       the REST API at I(base_url).
     - When using self-signed certificates the environment variable
       C(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
-      (in .pem format).
+      (in C(.pem) format).
     - e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -14,6 +14,10 @@ description:
     - Uses the Thycotic Secret Server Python SDK to get Secrets from Secret
       Server using token authentication with I(username) and I(password) on
       the REST API at I(base_url).
+    - When using self-signed certificates the environment variable
+      I(REQUESTS_CA_BUNDLE) can be set to a file containing the trusted certificates
+      (in .pem format). 
+      e.g. I(export REQUESTS_CA_BUNDLE='/etc/ssl/certs/ca-bundle.trust.crt').
 requirements:
     - python-tss-sdk - https://pypi.org/project/python-tss-sdk/
 options:


### PR DESCRIPTION
Add a reference to environment variable REQUESTS_CA_BUNDLE to enable using self signed certificates (on-prem server) in documentation.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add a reference to environment variable REQUESTS_CA_BUNDLE to enable using self signed certificates (on-prem server) in documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tss.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
