### PR TITLE
Proxmox inventory plugin - Fix string to dict conversion

### DIFF
--- a/changelogs/fragments/4349-proxmox-inventory-dict-facts.yml
+++ b/changelogs/fragments/4349-proxmox-inventory-dict-facts.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - proxmox - fixed the description field being ignored if it contained a comma
+    (https://github.com/ansible-collections/community.general/issues/4348)
+  - proxmox - always convert strings that follow the ``key=value[,key=value[...]]``
+    form into dictionaries

--- a/changelogs/fragments/4349-proxmox-inventory-dict-facts.yml
+++ b/changelogs/fragments/4349-proxmox-inventory-dict-facts.yml
@@ -1,6 +1,8 @@
 ---
 bugfixes:
-  - proxmox - fixed the description field being ignored if it contained a comma
-    (https://github.com/ansible-collections/community.general/issues/4348)
-  - proxmox - always convert strings that follow the ``key=value[,key=value[...]]``
-    form into dictionaries
+  - proxmox inventory plugin - fixed the ``description`` field being ignored if
+    it contained a comma
+    (https://github.com/ansible-collections/community.general/issues/4348).
+  - proxmox inventory plugin - always convert strings that follow the
+    ``key=value[,key=value[...]]`` form into dictionaries
+    (https://github.com/ansible-collections/community.general/pull/4349).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -307,7 +307,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.inventory.set_variable(name, vmtype_key, vmtype)
 
         plaintext_configs = [
-            'tags',
+            'description',
         ]
 
         for config in ret:
@@ -333,11 +333,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     if agent_iface_value:
                         self.inventory.set_variable(name, agent_iface_key, agent_iface_value)
 
-                if not (isinstance(value, int) or ',' not in value):
+                if config not in plaintext_configs and not isinstance(value, int) and all("=" in v for v in value.split(",")):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed
                     try:
-                        value = dict(key.split("=") for key in value.split(","))
+                        value = dict(key.split("=", 1) for key in value.split(","))
                     except Exception:
                         continue
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

  * Fixes #4348
  * Parses all strings that have the `key=value,key=value,...` form into dicts, unless they are explicitly excluded.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Proxmox inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

  * Re-use the (defined but unused) `plaintext_configs` variable to list configuration entries that should be ignored by the string to dictionary conversion code. At this point, it only contains the `description` string.
  * Convert to a dictionary if the all substrings obtained by splitting off the initial value with commas contain a `=` character
  * Limit substring splitting to a single split, so that a substring containing `a=b=c` will generate an `a` entry with value `b=c`.
  * This changes the output of the plugin in some cases, and might cause incompatibilities, as some of the facts that used to be returned as strings will be converted to dictionaries (facts that don't include a comma but still follow the `key=value` form). Typically, it will turn the following fact :
```
  "proxmox_boot": "order=virtio0",
```
into this :
```
  "proxmox_boot":  {
        "order": "virtio0"
    },
```
