### PR TITLE
Proxmox inventory filters

### DIFF
--- a/changelogs/fragments/4352-proxmox-inventory-filters.yml
+++ b/changelogs/fragments/4352-proxmox-inventory-filters.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - proxmox inventory plugin - add support for client-side jinja filters
+    (https://github.com/ansible-collections/community.general/issues/3553).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -412,6 +412,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # gather vm's on nodes
         self._get_auth()
+        hosts = []
         for node in self._get_nodes():
             if not node.get('node'):
                 continue
@@ -466,14 +467,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # gather vm's in pools
         for pool in self._get_pools():
-            if not pool.get('poolid'):
+            poolid = pool.get('poolid')
+            if not poolid:
                 continue
-            pool_group = self._group('pool_' + pool['poolid'])
+            pool_group = self._group('pool_' + poolid)
             self.inventory.add_group(pool_group)
 
-            for member in self._get_members_per_pool(pool['poolid']):
-                if member.get('name') and not member.get('template'):
-                    self.inventory.add_child(pool_group, member['name'])
+            for member in self._get_members_per_pool(poolid):
+                name = member.get('name')
+                if name and name in hosts and not member.get('template'):
+                    self.inventory.add_child(pool_group, name)
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_REQUESTS:

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -147,6 +147,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.utils.display import Display
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
@@ -158,6 +159,8 @@ try:
     HAS_REQUESTS = True
 except ImportError:
     HAS_REQUESTS = False
+
+display = Display()
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -378,8 +381,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             try:
                 add_host = self._compose(host_filter, properties)
             except Exception as e:  # pylint: disable=broad-except
+                message = "Could not evaluate host filter %s for host %s - %s" % (host_filter, name, to_native(e))
                 if self.strict:
-                    raise AnsibleError("Could not evaluate host filter %s - %s" % (host_filter, to_native(e)))
+                    raise AnsibleError(message)
+                display.warning(message)
             if not add_host:
                 return False
         return True

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -376,17 +376,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         enabled, any error during host filter compositing will lead to an AnsibleError
         being raised, otherwise the filter will be ignored.
         '''
-        add_host = True
         for host_filter in self.host_filters:
             try:
-                add_host = self._compose(host_filter, properties)
+                if not self._compose(host_filter, properties):
+                    return False
             except Exception as e:  # pylint: disable=broad-except
                 message = "Could not evaluate host filter %s for host %s - %s" % (host_filter, name, to_native(e))
                 if self.strict:
                     raise AnsibleError(message)
                 display.warning(message)
-            if not add_host:
-                return False
         return True
 
     def _add_host(self, name, variables):

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -522,7 +522,7 @@ def get_json(url):
         }
 
 
-def get_vm_snapshots(node, vmtype, vmid, name):
+def get_vm_snapshots(node, properties, vmtype, vmid, name):
     return [
         {"description": "",
          "name": "clean",
@@ -537,7 +537,7 @@ def get_vm_snapshots(node, vmtype, vmid, name):
          }]
 
 
-def get_vm_status(node, vmtype, vmid, name):
+def get_vm_status(properties, node, vmtype, vmid, name):
     return True
 
 
@@ -559,6 +559,9 @@ def test_populate(inventory, mocker):
     inventory.proxmox_user = 'root@pam'
     inventory.proxmox_password = 'password'
     inventory.proxmox_url = 'https://localhost:8006'
+    inventory.group_prefix = 'proxmox_'
+    inventory.facts_prefix = 'proxmox_'
+    inventory.strict = False
 
     # bypass authentication and API fetch calls
     inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
@@ -566,6 +569,7 @@ def test_populate(inventory, mocker):
     inventory._get_vm_status = mocker.MagicMock(side_effect=get_vm_status)
     inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
     inventory.get_option = mocker.MagicMock(side_effect=get_option)
+    inventory._can_add_host = mocker.MagicMock(return_value=True)
     inventory._populate()
 
     # get different hosts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR is an attempt at addressing issue #3553 by adding a `filters` option containing a list of Jinja expressions that must all evaluate to a truthy value for the host to be added to the inventory.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
Proxmox inventory component

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
  * While the initial issue was tagged as being a bug, I think it is in fact a new feature, hence my selecting "Feature" as the issue type here.
  * The initial code added the host to the inventory, then set its variables based on what it read from the Proxmox cluster and added it to various groups as soon as the information became available. This is not possible when it is not known whether the host should be added to the inventory in the first place. The modified code gathers all data to a separate dictionary, checks the specified filters based on that, and only then adds the host and its associated variables.
  * The code for both LXC containers and Qemu VMs was refactored into a single loop.
  * There is a slight change of behaviour regarding the addition of a VM/container to the appropriate status-based group (`(prefix)all_running` / `(prefix)all_stopped`). The initial code only assigned the host to one of the groups if the `want_facts` option was being used. However, the status information is part of initial data obtained when listing the VMs and containers. It is therefore possible to assign the host to a group even if facts are not set.
  * When a host filter fails with an exception and the `strict` option is not enabled, a warning will be displayed. I am not really sure this is appropriate.
  * A few changes to the unit test preparations were required for the tests not to crash due to the refactoring.

