### PR TITLE
ldap_entry - Recursive deletion

### DIFF
--- a/changelogs/fragments/4355-ldap-recursive-delete.yml
+++ b/changelogs/fragments/4355-ldap-recursive-delete.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - ldap_entry - add support for recursive deletion
-    (https://github.com/ansible-collections/community.general/issues/3613)
+    (https://github.com/ansible-collections/community.general/issues/3613).

--- a/changelogs/fragments/4355-ldap-recursive-delete.yml
+++ b/changelogs/fragments/4355-ldap-recursive-delete.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ldap_entry - add support for recursive deletion
+    (https://github.com/ansible-collections/community.general/issues/3613)

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -55,6 +55,7 @@ options:
         whole branch must be deleted.
     type: bool
     default: false
+    version_added: 4.6.0
 extends_documentation_fragment:
 - community.general.ldap.documentation
 

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -49,6 +49,12 @@ options:
     choices: [present, absent]
     default: present
     type: str
+  recursive:
+    description:
+      - If I(state=delete), a flag indicating whether a single entry or the
+        whole branch must be deleted.
+    type: bool
+    default: false
 extends_documentation_fragment:
 - community.general.ldap.documentation
 
@@ -110,6 +116,7 @@ from ansible_collections.community.general.plugins.module_utils.ldap import Ldap
 LDAP_IMP_ERR = None
 try:
     import ldap.modlist
+    import ldap.controls
 
     HAS_LDAP = True
 except ImportError:
@@ -131,6 +138,8 @@ class LdapEntry(LdapGeneric):
         # Load attributes
         if self.state == 'present':
             self.attrs = self._load_attrs()
+        else:
+            self.recursive = self.module.params['recursive']
 
     def _load_attrs(self):
         """ Turn attribute's value to array. """
@@ -158,12 +167,29 @@ class LdapEntry(LdapGeneric):
         return action
 
     def delete(self):
-        """ If self.dn exists, returns a callable that will delete it. """
+        """ If self.dn exists, returns a callable that will delete either
+        the item itself if the recursive option is not set or the whole branch
+        if it is. """
         def _delete():
             self.connection.delete_s(self.dn)
 
+        def _delete_recursive():
+            """ Attempt recurive deletion using the subtree-delete control.
+            If that fails, do it manually. """
+            try:
+                subtree_delete = ldap.controls.ValueLessRequestControl('1.2.840.113556.1.4.805')
+                self.connection.delete_ext_s(self.dn, serverctrls=[subtree_delete])
+            except ldap.NOT_ALLOWED_ON_NONLEAF:
+                search = self.connection.search_s(self.dn, ldap.SCOPE_SUBTREE, attrlist=('dn',))
+                search.reverse()
+                for dn, _ in search:
+                    self.connection.delete_s(dn)
+
         if self._is_entry_present():
-            action = _delete
+            if self.recursive:
+                action = _delete_recursive
+            else:
+                action = _delete
         else:
             action = None
 
@@ -186,6 +212,7 @@ def main():
             attributes=dict(default={}, type='dict'),
             objectClass=dict(type='list', elements='str'),
             state=dict(default='present', choices=['present', 'absent']),
+            recursive=dict(default=False, type='bool'),
         ),
         required_if=[('state', 'present', ['objectClass'])],
         supports_check_mode=True,

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -131,6 +131,7 @@ class LdapEntry(LdapGeneric):
 
         # Shortcuts
         self.state = self.module.params['state']
+        self.recursive = self.module.params['recursive']
 
         # Add the objectClass into the list of attributes
         self.module.params['attributes']['objectClass'] = (
@@ -139,8 +140,6 @@ class LdapEntry(LdapGeneric):
         # Load attributes
         if self.state == 'present':
             self.attrs = self._load_attrs()
-        else:
-            self.recursive = self.module.params['recursive']
 
     def _load_attrs(self):
         """ Turn attribute's value to array. """

--- a/plugins/modules/net_tools/ldap/ldap_entry.py
+++ b/plugins/modules/net_tools/ldap/ldap_entry.py
@@ -182,8 +182,8 @@ class LdapEntry(LdapGeneric):
             except ldap.NOT_ALLOWED_ON_NONLEAF:
                 search = self.connection.search_s(self.dn, ldap.SCOPE_SUBTREE, attrlist=('dn',))
                 search.reverse()
-                for dn, _ in search:
-                    self.connection.delete_s(dn)
+                for entry in search:
+                    self.connection.delete_s(entry[0])
 
         if self._is_entry_present():
             if self.recursive:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
  * Fixes #3613
  * Recursive deletion can be enabled with the `recursive` option. It is disabled by default.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ldap_entry

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

  * The initial issue is a bug report, however I filed this PR as a Feature as the LDAP delete requests actually works as intended and the PR adds a new option.
  * When enabled, deletion is attempted by sending a single delete request with the Subtree Delete control (`1.2.840.113556.1.4.805`). If that request fails with the `NOT_ALLOWED_ON_NONLEAF` error, the code tries deleting the whole branch in reverse order by running a search then sending individual delete requests.
  * Example usage : 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
community.general.ldap_entry:
  server_uri: ldapi:///
  bind_dn: ...
  bind_pw: ...
  dn: ou=people,dc=example,dc=org
  state: absent
  recursive: true
```
