### PR TITLE
Revert "Allow complex values in variables parameter of terraform module (#4281)"

### DIFF
--- a/changelogs/fragments/4281-terraform-complex-variables.yml
+++ b/changelogs/fragments/4281-terraform-complex-variables.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - terraform - fix ``variable`` handling to allow complex values (https://github.com/ansible-collections/community.general/pull/4281).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -443,7 +443,7 @@ def main():
     for k, v in variables.items():
         variables_args.extend([
             '-var',
-            '{0}={1}'.format(k, json.dumps(v))
+            '{0}={1}'.format(k, v)
         ])
     if variables_files:
         for f in variables_files:


### PR DESCRIPTION
##### SUMMARY
This reverts commit 4cc7f413953606cda79596c7682eac0319936199 (#4281).

First step in fixing #4367.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform
