### PR TITLE
[stable-3] nios_next_network lookup: remove default for required=true option

### DIFF
--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -48,7 +48,6 @@ options:
         - The CIDR of the network to retrieve the next network from next available network within the
           specified container. Also, Requested CIDR must be specified and greater than the parent CIDR.
       required: True
-      default: 24
     num:
       description: The number of network addresses to return from network-container
       required: false


### PR DESCRIPTION
##### SUMMARY
This is currently breaking stable-3's CI.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nios_next_network lookup
