### PR TITLE
Allow Proxmox Snapshot Restoring

### DIFF
--- a/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
+++ b/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).

--- a/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
+++ b/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - proxmox - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).
+  - proxmox - fixed timeout value to correctly relfect time in seconds

--- a/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
+++ b/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - proxmox - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).
+  - proxmox_snap - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).
   - proxmox_snap - fixed timeout value to correctly relfect time in seconds (https://github.com/ansible-collections/community.general/pull/4377).

--- a/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
+++ b/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - proxmox - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).
-  - proxmox - fixed timeout value to correctly relfect time in seconds
+  - proxmox_snap - fixed timeout value to correctly relfect time in seconds (https://github.com/ansible-collections/community.general/pull/4377).

--- a/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
+++ b/changelogs/fragments/4377-allow-proxmox-snapshot-restoring.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - proxmox_snap - add restore snapshot option (https://github.com/ansible-collections/community.general/pull/4377).
-  - proxmox_snap - fixed timeout value to correctly relfect time in seconds (https://github.com/ansible-collections/community.general/pull/4377).
+  - proxmox_snap - fixed timeout value to correctly reflect time in seconds. The timeout was off by one second (https://github.com/ansible-collections/community.general/pull/4377).

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -102,7 +103,9 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec,
+                                                                                ProxmoxAnsible, HAS_PROXMOXER,
+                                                                                PROXMOXER_IMP_ERR)
 
 
 class ProxmoxSnapAnsible(ProxmoxAnsible):
@@ -123,8 +126,9 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
-                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(
+                    msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
+                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -140,8 +144,9 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
-                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(
+                    msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
+                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -157,8 +162,9 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
-                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(
+                    msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
+                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -215,7 +221,8 @@ def main():
                     module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
 
         except Exception as e:
-            module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(
+                msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
     elif state == 'absent':
         try:
@@ -236,7 +243,8 @@ def main():
                         module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
 
         except Exception as e:
-            module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(
+                msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
     elif state == 'rollback':
         try:
             snap_exist = False
@@ -256,8 +264,9 @@ def main():
                         module.exit_json(changed=True, msg="Snapshot %s rolled back" % snapname)
 
         except Exception as e:
-            module.fail_json(msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(
+                msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
 
-if __name__ == '__main__':4
+if __name__ == '__main__':
     main()

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -122,12 +122,12 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
             status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
             if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
-            timeout -= 1
             if timeout == 0:
                 self.module.fail_json(msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
                                       self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
+            timeout -= 1
         return False
 
     def snapshot_remove(self, vm, vmid, timeout, snapname, force):
@@ -139,12 +139,12 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
             status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
             if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
-            timeout -= 1
             if timeout == 0:
                 self.module.fail_json(msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
                                       self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
+            timeout -= 1
         return False
 
     def snapshot_rollback(self, vm, vmid, timeout, snapname):
@@ -156,12 +156,12 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
             status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
             if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
-            timeout -= 1
             if timeout == 0:
                 self.module.fail_json(msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
                                       self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
+            timeout -= 1
         return False
 
 
@@ -249,12 +249,11 @@ def main():
 
             if not snap_exist:
                 module.exit_json(changed=False, msg="Snapshot %s does not exist" % snapname)
-            else:
-                if proxmox.snapshot_rollback(vm, vmid, timeout, snapname):
-                    if module.check_mode:
-                        module.exit_json(changed=False, msg="Snapshot %s would be rolled back" % snapname)
-                    else:
-                        module.exit_json(changed=True, msg="Snapshot %s rolled back" % snapname)
+            if proxmox.snapshot_rollback(vm, vmid, timeout, snapname):
+                if module.check_mode:
+                    module.exit_json(changed=True, msg="Snapshot %s would be rolled back" % snapname)
+                else:
+                    module.exit_json(changed=True, msg="Snapshot %s rolled back" % snapname)
 
         except Exception as e:
             module.fail_json(msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -28,7 +28,7 @@ options:
   state:
     description:
      - Indicate desired state of the instance snapshot.
-    choices: ['present', 'absent']
+    choices: ['present', 'absent', 'rollback']
     default: present
     type: str
   force:
@@ -84,6 +84,15 @@ EXAMPLES = r'''
     vmid: 100
     state: absent
     snapname: pre-updates
+
+- name: Rollback container snapshot
+  community.general.proxmox_snap:
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    vmid: 100
+    state: rollback
+    snapname: pre-updates
 '''
 
 RETURN = r'''#'''
@@ -137,6 +146,23 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
             time.sleep(1)
         return False
 
+    def snapshot_rollback(self, vm, vmid, timeout, snapname):
+        if self.module.check_mode:
+            return True
+
+        taskid = self.snapshot(vm, vmid)(snapname).post("rollback")
+        while timeout:
+            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
+                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+                return True
+            timeout -= 1
+            if timeout == 0:
+                self.module.fail_json(msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+
+            time.sleep(1)
+        return False
+
 
 def main():
     module_args = proxmox_auth_argument_spec()
@@ -144,7 +170,7 @@ def main():
         vmid=dict(required=False),
         hostname=dict(),
         timeout=dict(type='int', default=30),
-        state=dict(default='present', choices=['present', 'absent']),
+        state=dict(default='present', choices=['present', 'absent', 'rollback']),
         description=dict(type='str'),
         snapname=dict(type='str', default='ansible_snap'),
         force=dict(type='bool', default='no'),
@@ -211,7 +237,27 @@ def main():
 
         except Exception as e:
             module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+    elif state == 'rollback':
+        try:
+            snap_exist = False
+
+            for i in proxmox.snapshot(vm, vmid).get():
+                if i['name'] == snapname:
+                    snap_exist = True
+                    continue
+
+            if not snap_exist:
+                module.exit_json(changed=False, msg="Snapshot %s does not exist" % snapname)
+            else:
+                if proxmox.snapshot_rollback(vm, vmid, timeout, snapname):
+                    if module.check_mode:
+                        module.exit_json(changed=False, msg="Snapshot %s would be rolled back" % snapname)
+                    else:
+                        module.exit_json(changed=True, msg="Snapshot %s rolled back" % snapname)
+
+        except Exception as e:
+            module.fail_json(msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':4
     main()

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -29,6 +29,7 @@ options:
   state:
     description:
      - Indicate desired state of the instance snapshot.
+     - The C(rollback) value was added in community.general 4.7.0.
     choices: ['present', 'absent', 'rollback']
     default: present
     type: str

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -5,7 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -104,9 +103,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec,
-                                                                                ProxmoxAnsible, HAS_PROXMOXER,
-                                                                                PROXMOXER_IMP_ERR)
+from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
 
 
 class ProxmoxSnapAnsible(ProxmoxAnsible):
@@ -127,9 +124,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
-                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(msg='Reached timeout while waiting for creating VM snapshot. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -145,9 +141,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
-                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(msg='Reached timeout while waiting for removing VM snapshot. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -163,9 +158,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 return True
             timeout -= 1
             if timeout == 0:
-                self.module.fail_json(
-                    msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
-                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+                self.module.fail_json(msg='Reached timeout while waiting for rolling back VM snapshot. Last line in task before timeout: %s' %
+                                      self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
 
             time.sleep(1)
         return False
@@ -222,8 +216,7 @@ def main():
                     module.exit_json(changed=True, msg="Snapshot %s created" % snapname)
 
         except Exception as e:
-            module.fail_json(
-                msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(msg="Creating snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
     elif state == 'absent':
         try:
@@ -244,8 +237,7 @@ def main():
                         module.exit_json(changed=True, msg="Snapshot %s removed" % snapname)
 
         except Exception as e:
-            module.fail_json(
-                msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(msg="Removing snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
     elif state == 'rollback':
         try:
             snap_exist = False
@@ -265,8 +257,7 @@ def main():
                         module.exit_json(changed=True, msg="Snapshot %s rolled back" % snapname)
 
         except Exception as e:
-            module.fail_json(
-                msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
+            module.fail_json(msg="Rollback of snapshot %s of VM %s failed with exception: %s" % (snapname, vmid, to_native(e)))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -119,8 +119,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
         else:
             taskid = self.snapshot(vm, vmid).post(snapname=snapname, description=description, vmstate=int(vmstate))
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
+            if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
             timeout -= 1
             if timeout == 0:
@@ -136,8 +136,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
 
         taskid = self.snapshot(vm, vmid).delete(snapname, force=int(force))
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
+            if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
             timeout -= 1
             if timeout == 0:
@@ -153,8 +153,8 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
 
         taskid = self.snapshot(vm, vmid)(snapname).post("rollback")
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
+            if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
             timeout -= 1
             if timeout == 0:

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -13,7 +13,7 @@ module: proxmox_snap
 short_description: Snapshot management of instances in Proxmox VE cluster
 version_added: 2.0.0
 description:
-  - Allows you to create/delete snapshots from instances in Proxmox VE cluster.
+  - Allows you to create/delete/restore snapshots from instances in Proxmox VE cluster.
   - Supports both KVM and LXC, OpenVZ has not been tested, as it is no longer supported on Proxmox VE.
 options:
   hostname:
@@ -54,7 +54,7 @@ options:
     type: int
   snapname:
     description:
-      - Name of the snapshot that has to be created.
+      - Name of the snapshot that has to be created/deleted/restored.
     default: 'ansible_snap'
     type: str
 

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -28,7 +28,7 @@ options:
   state:
     description:
      - Indicate desired state of the instance snapshot.
-     - The C(rollback) value was added in community.general 4.7.0.
+     - The C(rollback) value was added in community.general 4.8.0.
     choices: ['present', 'absent', 'rollback']
     default: present
     type: str

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -111,4 +111,6 @@ def test_rollback_snapshot_check_mode(connect_mock, capfd, mocker):
 
     out, err = capfd.readouterr()
     assert not err
-    assert not json.loads(out)['changed']
+    output = json.loads(out)
+    assert not output['changed']
+    assert output['msg'] == "Snapshot test does not exist"

--- a/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/cloud/misc/test_proxmox_snap.py
@@ -91,3 +91,24 @@ def test_remove_snapshot_check_mode(connect_mock, capfd, mocker):
     out, err = capfd.readouterr()
     assert not err
     assert not json.loads(out)['changed']
+
+
+@patch('ansible_collections.community.general.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
+def test_rollback_snapshot_check_mode(connect_mock, capfd, mocker):
+    set_module_args({"hostname": "test-lxc",
+                     "api_user": "root@pam",
+                     "api_password": "secret",
+                     "api_host": "127.0.0.1",
+                     "state": "rollback",
+                     "snapname": "test",
+                     "timeout": "1",
+                     "force": True,
+                     "_ansible_check_mode": True})
+    proxmox_utils.HAS_PROXMOXER = True
+    connect_mock.side_effect = lambda: fake_api(mocker)
+    with pytest.raises(SystemExit) as results:
+        proxmox_snap.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    assert not json.loads(out)['changed']


### PR DESCRIPTION

SUMMARY

Allows the restoration of a proxmox snapshot
ISSUE TYPE

    Feature Pull Request

COMPONENT NAME

This Change allows restoring a snapshot in Proxmox
ADDITIONAL INFORMATION

This is the result of [https://github.com/ansible-collections/community.general/pull/4375](https://github.com/ansible-collections/community.general/pull/4375)
I did not mark `snapname` as required, as it has a default value and the behaviour didn't change. Or should i still mark it as required?