### PR TITLE
Proxmox inventory plugin - Fix tags parsing

### DIFF
--- a/changelogs/fragments/4378-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/4378-proxmox-inventory-tags.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - proxmox inventory plugin - fixed the ``tags_parsed`` field when Proxmox
-    returns a single space for the ``tags`` entry.
+    returns a single space for the ``tags`` entry (https://github.com/ansible-collections/community.general/pull/4378).

--- a/changelogs/fragments/4378-proxmox-inventory-tags.yml
+++ b/changelogs/fragments/4378-proxmox-inventory-tags.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox inventory plugin - fixed the ``tags_parsed`` field when Proxmox
+    returns a single space for the ``tags`` entry.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -323,8 +323,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
                 # Additional field containing parsed tags as list
                 if config == 'tags':
-                    parsed_key = self.to_safe('%s%s' % (key, "_parsed"))
-                    properties[parsed_key] = [tag.strip() for tag in value.split(",")]
+                    stripped_value = value.strip()
+                    if stripped_value:
+                        parsed_key = key + "_parsed"
+                        properties[parsed_key] = [tag.strip() for tag in stripped_value.split(",")]
 
                 # The first field in the agent string tells you whether the agent is enabled
                 # the rest of the comma separated string is extra config for the agent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In some cases the Proxmox API returns a tags string that consists in a single space (typically after trying to clear tags using `qm set <vmid> --tags ""`). The Proxmox inventory plugin parsed that into a single, empty tag. This PR fixes that problem.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Proxmox inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

  * Strip the initial string then check whether it actually contains something before extracting it to a list of tags.
  * Do not call `_to_safe` on the concatenation of a known safe string and a string that was already made safe.

<!--- Paste verbatim command output below, e.g. before and after your change -->
  * Output before changes
```
    "proxmox_tags": " ",
    "proxmox_tags_parsed": [          
        ""
    ],
```
  * Output after changes
```paste below
    "proxmox_tags": " ",
```
