### PR TITLE
feat: sudoers module supports runas parameter with default of root

### DIFF
--- a/changelogs/fragments/4380-sudoers-runas-parameter.yml
+++ b/changelogs/fragments/4380-sudoers-runas-parameter.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - sudoers - add support for 'runas' parameter
+    (https://github.com/ansible-collections/community.general/issues/4379).

--- a/changelogs/fragments/4380-sudoers-runas-parameter.yml
+++ b/changelogs/fragments/4380-sudoers-runas-parameter.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - sudoers - add support for 'runas' parameter
+  - sudoers - add support for ``runas`` parameter
     (https://github.com/ansible-collections/community.general/issues/4379).

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -44,8 +44,8 @@ options:
   runas:
     description:
       - Specify the target user the command(s) will run as.
-    default: root
     type: str
+    version_added: 4.7.0
   sudoers_path:
     description:
       - The path which sudoers config files will be managed in.
@@ -154,8 +154,8 @@ class Sudoers(object):
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''
-        runas = self.runas
-        return "{owner} ALL=({runas}) {nopasswd} {commands}\n".format(owner=owner, runas=runas, nopasswd=nopasswd_str, commands=commands_str)
+        runas_str = '(' + self.runas + ')' if self.runas is not None else '' 
+        return "{owner} ALL={runas}{nopasswd} {commands}\n".format(owner=owner, runas=runas_str, nopasswd=nopasswd_str, commands=commands_str)
 
     def run(self):
         if self.state == 'absent' and self.exists():
@@ -185,7 +185,7 @@ def main():
         },
         'runas': {
             'type': 'str',
-            'default': 'root',
+            'default': None,
         },
         'sudoers_path': {
             'type': 'str',

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -154,7 +154,7 @@ class Sudoers(object):
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''
-        runas_str = '(' + self.runas + ')' if self.runas is not None else '' 
+        runas_str = '(' + self.runas + ')' if self.runas is not None else ''
         return "{owner} ALL={runas}{nopasswd} {commands}\n".format(owner=owner, runas=runas_str, nopasswd=nopasswd_str, commands=commands_str)
 
     def run(self):

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -154,7 +154,7 @@ class Sudoers(object):
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''
-        runas_str = '(' + self.runas + ')' if self.runas is not None else ''
+        runas_str = '({runas})'.format(runas=self.runas) if self.runas is not None else ''
         return "{owner} ALL={runas}{nopasswd} {commands}\n".format(owner=owner, runas=runas_str, nopasswd=nopasswd_str, commands=commands_str)
 
     def run(self):

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -41,6 +41,11 @@ options:
       - Whether a password will be required to run the sudo'd command.
     default: true
     type: bool
+  runas:
+    description:
+      - Specify the target user the command(s) will run as.
+    default: root
+    type: str
   sudoers_path:
     description:
       - The path which sudoers config files will be managed in.
@@ -68,6 +73,14 @@ EXAMPLES = '''
     state: present
     user: backup
     commands: /usr/local/bin/backup
+
+- name: Allow the bob user to run any commands as alice with sudo -u alice
+  community.general.sudoers:
+    name: bob-do-as-alice
+    state: present
+    user: bob
+    runas: alice
+    commands: ANY
 
 - name: >-
     Allow the monitoring group to run sudo /usr/local/bin/gather-app-metrics
@@ -108,6 +121,7 @@ class Sudoers(object):
         self.group = module.params['group']
         self.state = module.params['state']
         self.nopassword = module.params['nopassword']
+        self.runas = module.params['runas']
         self.sudoers_path = module.params['sudoers_path']
         self.file = os.path.join(self.sudoers_path, self.name)
         self.commands = module.params['commands']
@@ -140,7 +154,8 @@ class Sudoers(object):
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''
-        return "{owner} ALL={nopasswd} {commands}\n".format(owner=owner, nopasswd=nopasswd_str, commands=commands_str)
+        runas = self.runas
+        return "{owner} ALL=({runas}) {nopasswd} {commands}\n".format(owner=owner, runas=runas, nopasswd=nopasswd_str, commands=commands_str)
 
     def run(self):
         if self.state == 'absent' and self.exists():
@@ -167,6 +182,10 @@ def main():
         'nopassword': {
             'type': 'bool',
             'default': True,
+        },
+        'runas': {
+            'type': 'str',
+            'default': 'root',
         },
         'sudoers_path': {
             'type': 'str',

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -102,6 +102,21 @@
     src: "{{ alt_sudoers_path }}/my-sudo-rule-5"
   register: rule_5_contents
 
+- name: Create rule to runas another user
+  community.general.sudoers:
+    name: my-sudo-rule-6
+    state: present
+    user: alice
+    commands: /usr/local/bin/command
+    runas: bob
+    sudoers_path: "{{ alt_sudoers_path }}"
+  register: rule_6
+
+- name: Grab contents of my-sudo-rule-6 (in alternative directory)
+  ansible.builtin.slurp:
+    src: "{{ alt_sudoers_path }}/my-sudo-rule-6"
+  register: rule_6_contents
+
 
 - name: Revoke rule 1
   community.general.sudoers:
@@ -128,11 +143,13 @@
 - name: Check contents
   ansible.builtin.assert:
     that:
-      - "rule_1_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_2_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command1, /usr/local/bin/command2\n'"
-      - "rule_3_contents['content'] | b64decode == 'alice ALL= /usr/local/bin/command\n'"
-      - "rule_4_contents['content'] | b64decode == '%students ALL=NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_5_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_1_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_2_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command1, /usr/local/bin/command2\n'"
+      - "rule_3_contents['content'] | b64decode == 'alice ALL=(root)  /usr/local/bin/command\n'"
+      - "rule_4_contents['content'] | b64decode == '%students ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_5_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_6_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_6_contents['content'] | b64decode == 'alice ALL=(bob) NOPASSWD: /usr/local/bin/command\n'"
 
 - name: Check stats
   ansible.builtin.assert:

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -143,12 +143,12 @@
 - name: Check contents
   ansible.builtin.assert:
     that:
-      - "rule_1_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_2_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command1, /usr/local/bin/command2\n'"
-      - "rule_3_contents['content'] | b64decode == 'alice ALL=(root)  /usr/local/bin/command\n'"
-      - "rule_4_contents['content'] | b64decode == '%students ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_5_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_6_contents['content'] | b64decode == 'alice ALL=(bob) NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_1_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_2_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command1, /usr/local/bin/command2\n'"
+      - "rule_3_contents['content'] | b64decode == 'alice ALL= /usr/local/bin/command\n'"
+      - "rule_4_contents['content'] | b64decode == '%students ALL=NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_5_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_6_contents['content'] | b64decode == 'alice ALL=(bob)NOPASSWD: /usr/local/bin/command\n'"
 
 - name: Check stats
   ansible.builtin.assert:

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -109,12 +109,12 @@
     user: alice
     commands: /usr/local/bin/command
     runas: bob
-    sudoers_path: "{{ alt_sudoers_path }}"
+    sudoers_path: "{{ sudoers_path }}"
   register: rule_6
 
 - name: Grab contents of my-sudo-rule-6 (in alternative directory)
   ansible.builtin.slurp:
-    src: "{{ alt_sudoers_path }}/my-sudo-rule-6"
+    src: "{{ sudoers_path }}/my-sudo-rule-6"
   register: rule_6_contents
 
 
@@ -148,7 +148,6 @@
       - "rule_3_contents['content'] | b64decode == 'alice ALL=(root)  /usr/local/bin/command\n'"
       - "rule_4_contents['content'] | b64decode == '%students ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
       - "rule_5_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
-      - "rule_6_contents['content'] | b64decode == 'alice ALL=(root) NOPASSWD: /usr/local/bin/command\n'"
       - "rule_6_contents['content'] | b64decode == 'alice ALL=(bob) NOPASSWD: /usr/local/bin/command\n'"
 
 - name: Check stats


### PR DESCRIPTION
##### SUMMARY
Adds `runas` parameter to the sudoers module. 
Also allows for clearer and more consistent sudo rule format.

Fixes https://github.com/ansible-collections/community.general/issues/4379

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
Adds `runas` parameter to the sudoers module. 

##### ADDITIONAL INFORMATION
There are two parts to this. 
1. Add the `runas` parameter to allow commands to be run as a user other than root. 
  - NOTE: This should also allow for specifying **any** string supported by sudoers  as specified in the `Runas_Spec` section of the sudoers manpage. For example `runas: ALL` to allow running as any user.
  
To specify a rule to allow alice to run a command as the user bob:
```
- name: Allow alice to run a command as bob
  community.general.sudoers:
    name: my-sudo-rule
    state: present
    user: alice
    commands: /usr/local/bin/command
    runas: bob
```
Should return:
```
alice ALL=(bob) NOPASSWD: /usr/local/bin/command
```

2. When `runas` is not specified, it will default to 'root' and will explicitly declare that in the resulting sudo rule

```
- name: Sudo rule to allow alice to run commands
  community.general.sudoers:
    name: my-sudo-rule
    state: present
    user: alice
    commands: /usr/local/bin/command
```

The current module returns:
```
alice ALL=NOPASSWD: /usr/local/bin/command
```

With this change it should return:
```
alice ALL=(root) NOPASSWD: /usr/local/bin/command
```

The current output of the sudoers module, while syntactically correct, is ambiguous. By not specifying the user to run as, it might give the impression that the command can be 'run as' any user, but it actually only allows running as root. This change makes it clearer by explicitly defining the user the command can be run as.


