### PR TITLE
keycloak_client: add default_client_scopes and optional_client_scopes

### DIFF
--- a/changelogs/fragments/4385-keycloak-client-default-optional-scopes.yml
+++ b/changelogs/fragments/4385-keycloak-client-default-optional-scopes.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - keycloak_client - add default_client_scopes and optional_client_scopes parameters.
+  - keycloak_client - add ``default_client_scopes`` and ``optional_client_scopes`` parameters.
     (https://github.com/ansible-collections/community.general/pull/4385).

--- a/changelogs/fragments/4385-keycloak-client-default-optional-scopes.yml
+++ b/changelogs/fragments/4385-keycloak-client-default-optional-scopes.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - keycloak_client - add default_client_scopes and optional_client_scopes parameters.
+    (https://github.com/ansible-collections/community.general/pull/4385).

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -333,6 +333,7 @@ options:
             - defaultClientScopes
         type: list
         elements: str
+        version_added: 4.7.0
 
     optional_client_scopes:
         description:

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -342,6 +342,7 @@ options:
             - optionalClientScopes
         type: list
         elements: str
+        version_added: 4.7.0
 
     protocol_mappers:
         description:

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -326,6 +326,22 @@ options:
             - authenticationFlowBindingOverrides
         version_added: 3.4.0
 
+    default_client_scopes:
+        description:
+            - List of default client scopes.
+        aliases:
+            - defaultClientScopes
+        type: list
+        elements: str
+
+    optional_client_scopes:
+        description:
+            - List of optional client scopes.
+        aliases:
+            - optionalClientScopes
+        type: list
+        elements: str
+
     protocol_mappers:
         description:
             - a list of dicts defining protocol mappers for this client.
@@ -789,6 +805,8 @@ def main():
         authentication_flow_binding_overrides=dict(type='dict', aliases=['authenticationFlowBindingOverrides']),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
         authorization_settings=dict(type='dict', aliases=['authorizationSettings']),
+        default_client_scopes=dict(type='list', elements='str', aliases=['defaultClientScopes']),
+        optional_client_scopes=dict(type='list', elements='str', aliases=['optionalClientScopes']),
     )
 
     argument_spec.update(meta_args)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `default_client_scopes` and `optional_client_scopes` parameters to `keycloak_client`. Partially resolves #2763.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
keycloak_client

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR adds the ability to set default and optional client scopes for a Keycloak client. This is useful for openid-connect clients that have requirements for specific scopes/claims.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
failed: [localhost] ..."msg": "Unsupported parameters for (community.general.keycloak_client) module: default_client_scopes..."...
```
After:
```
ok: [localhost]
```