### PR TITLE
nmcli: allow editing of MTU for VLAN network types

### DIFF
--- a/changelogs/fragments/4387-nmcli-edit-vlan.yml
+++ b/changelogs/fragments/4387-nmcli-edit-vlan.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - nmcli - allow editing mtu on interfaces of type vlan
+    (https://github.com/ansible-collections/community.general/issues/4387).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1555,6 +1555,7 @@ class Nmcli(object):
             'dummy',
             'ethernet',
             'team-slave',
+            'vlan',
         )
 
     @property


### PR DESCRIPTION
https://github.com/ansible-collections/community.general/issues/4387

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>

##### SUMMARY
nmcli module would silently fail to update MTU for vlan network types, this is
now allowed.

Fixes #4387 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
Assuming an existing base network interface `enp1s0f0` (type `ethernet`) with default MTU 1500 and a VLAN network interface `enp1s0f0.96` (type `vlan`), the following task:

```yaml
 - name: Set VLAN 96 network interface MTU to 1500 after creation
    community.general.nmcli:
      conn_name:  "enp1s0f0.96"
      type:              "vlan"
      vlandev:        "enp1s0f0"
      vlanid:           96
      ip4:               "1.2.3.4"
      mtu:             9000
      state:           "present"
```

should change the output of:

```shell
nmcli conn show enp1s0f0.96 | grep mtu
```

from:

```shell
802-3-ethernet.mtu:                     1500
```

to

```shell
802-3-ethernet.mtu:                     9000
```

