### PR TITLE
ldap: added documentation as requested

### DIFF
--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -38,7 +38,7 @@ options:
     version_added: 2.0.0
   server_uri:
     description:
-      - The uri parameter may be a comma- or whitespace-separated list of URIs containing only the schema, the host, and the port fields.
+      - The I(server_uri) parameter may be a comma- or whitespace-separated list of URIs containing only the schema, the host, and the port fields.
       - The default value lets the underlying LDAP client library look for a UNIX domain socket in its default location.
       - Note that when using multiple URIs you cannot determine to which URI your client gets connected.
       - For URIs containing additional fields, particularly when using commas, behavior is undefined.

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -38,8 +38,10 @@ options:
     version_added: 2.0.0
   server_uri:
     description:
-      - A URI to the LDAP server.
+      - The uri parameter may be a comma- or whitespace-separated list of URIs containing only the schema, the host, and the port fields.
       - The default value lets the underlying LDAP client library look for a UNIX domain socket in its default location.
+      - Note that when using multiple URIs you cannot determine to which URI your client gets connected.
+      - For URIs containing additional fields, particularly when using commas, behavior is undefined.
     type: str
     default: ldapi:///
   start_tls:


### PR DESCRIPTION
##### SUMMARY
The documentation for `server_uri` parameter in ldap modules describes how to use multiple URIs.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1659 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
plugins/doc_fragments/ldap.py
