### PR TITLE
Fixed typo in keycloak_client_rolemapping examples

### DIFF
--- a/changelogs/fragments/4393-keycloak_client_rolemapping_docs.yml
+++ b/changelogs/fragments/4393-keycloak_client_rolemapping_docs.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - keycloak_client_rolemapping - Fixed typo in examples.
+    (https://github.com/ansible-collections/community.general/issues/4392)

--- a/changelogs/fragments/4393-keycloak_client_rolemapping_docs.yml
+++ b/changelogs/fragments/4393-keycloak_client_rolemapping_docs.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - keycloak_client_rolemapping - Fixed typo in examples.
-    (https://github.com/ansible-collections/community.general/issues/4392)

--- a/plugins/modules/identity/keycloak/keycloak_client_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_client_rolemapping.py
@@ -104,7 +104,7 @@ author:
 
 EXAMPLES = '''
 - name: Map a client role to a group, authentication with credentials
-  community.general.keycloak_client_rolemappings:
+  community.general.keycloak_client_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -122,7 +122,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 - name: Map a client role to a group, authentication with token
-  community.general.keycloak_client_rolemappings:
+  community.general.keycloak_client_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -138,7 +138,7 @@ EXAMPLES = '''
   delegate_to: localhost
 
 - name: Unmap client role from a group
-  community.general.keycloak_client_rolemappings:
+  community.general.keycloak_client_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth


### PR DESCRIPTION
##### SUMMARY

Fixed typo in `keycloak_client_rolemapping` examples.

The examples for `keycloak_client_rolemapping` uses a plural `keycloak_client_rolemappings`, instead of the actual name of the module which is singular.

Fixes #4392 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
keycloak_client_rolemapping

##### ADDITIONAL INFORMATION

