### PR TITLE
1password v2

### DIFF
--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -128,7 +128,7 @@ class OnePass(object):
       # Get the 1password cli version
       try:
           rc, out, err = self._run(['--version'], ignore_errors=True)
-          self.cli_version = int(out.decode('utf-8').split('.')[0])
+          self.cli_version = int(to_text(out).split('.')[0])
       except OSError as e:
           if e.errno == errno.ENOENT:
               raise AnsibleLookupError("1Password CLI tool '%s' not installed in path on control machine" % self.cli_path)

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -112,9 +112,9 @@ class OnePass(object):
         self.cli_path = path
         self.get_version()
         if self.cli_version >= 2:
-          config_path = '~/.config/op/config'
+            config_path = '~/.config/op/config'
         else:
-          config_path = '~/.op/config'
+            config_path = '~/.op/config'
         self.config_file_path = os.path.expanduser(config_path)
         self.logged_in = False
         self.token = None
@@ -125,14 +125,14 @@ class OnePass(object):
         self.master_password = None
 
     def get_version(self):
-      # Get the 1password cli version
-      try:
-          rc, out, err = self._run(['--version'], ignore_errors=True)
-          self.cli_version = int(to_text(out).split('.')[0])
-      except OSError as e:
-          if e.errno == errno.ENOENT:
-              raise AnsibleLookupError("1Password CLI tool '%s' not installed in path on control machine" % self.cli_path)
-          raise e
+        # Get the 1password cli version
+        try:
+            rc, out, err = self._run(['--version'], ignore_errors=True)
+            self.cli_version = int(to_text(out).split('.')[0])
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                raise AnsibleLookupError("1Password CLI tool '%s' not installed in path on control machine" % self.cli_path)
+            raise e
 
     def get_token(self):
         # If the config file exists, assume an initial signin has taken place and try basic sign in
@@ -314,6 +314,5 @@ class LookupModule(LookupBase):
 
         values = []
         for term in terms:
-            
             values.append(op.get_field(term, field, section, vault))
         return values


### PR DESCRIPTION
##### SUMMARY
Fixes #4396
Adds support for 1password cli v2. A version check is added before attempting to pull any secrets from 1password to determine the correct commands to run. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup/onepassword.py

##### ADDITIONAL INFORMATION
The logic flow is the same otherwise so use with 1password cli < 2 is unaffected by the changes, if the version is less then 2 the original commands are run, otherwise the v2 commands are used. 

1password cli v2 does not appear to support the `full_login` workflow so an error is thrown if that is attempted, partial login with just the password does work. I don't understand either use case as it would end up with your 1pass secrets in your playbook which seems to defeat the purpose of using an external secret store. 

The onepassword_raw.py lookup was not touched as that simply returns the raw output from 1password, although this will be different for different versions of the cli.
