### PR TITLE
ipa_service: Add `skip_host_check` option

### DIFF
--- a/changelogs/fragments/4417-ipa_service-add-skip_host_check.yml
+++ b/changelogs/fragments/4417-ipa_service-add-skip_host_check.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ipa_service - add ``skip_host_check`` parameter.
+    (https://github.com/ansible-collections/community.general/pull/4417).

--- a/plugins/modules/identity/ipa/ipa_service.py
+++ b/plugins/modules/identity/ipa/ipa_service.py
@@ -193,7 +193,7 @@ def main():
     argument_spec.update(
         krbcanonicalname=dict(type='str', required=True, aliases=['name']),
         force=dict(type='bool', required=False),
-        skip_host_check=dict(type='bool', required=False),
+        skip_host_check=dict(type='bool', default=False, required=False),
         hosts=dict(type='list', required=False, elements='str'),
         state=dict(type='str', required=False, default='present',
                    choices=['present', 'absent']))

--- a/plugins/modules/identity/ipa/ipa_service.py
+++ b/plugins/modules/identity/ipa/ipa_service.py
@@ -32,6 +32,11 @@ options:
     - Force principal name even if host is not in DNS.
     required: false
     type: bool
+  skip_host_check:
+    description:
+    - Force service to be created even when host object does not exist to manage it
+    required: false
+    type: bool
   state:
     description: State to ensure.
     required: false
@@ -111,17 +116,19 @@ class ServiceIPAClient(IPAClient):
         return self._post_json(method='service_remove_host', name=name, item={'host': item})
 
 
-def get_service_dict(force=None, krbcanonicalname=None):
+def get_service_dict(force=None, krbcanonicalname=None, skip_host_check=None):
     data = {}
     if force is not None:
         data['force'] = force
     if krbcanonicalname is not None:
         data['krbcanonicalname'] = krbcanonicalname
+    if skip_host_check is not None:
+        data['skip_host_check'] = skip_host_check
     return data
 
 
 def get_service_diff(client, ipa_host, module_service):
-    non_updateable_keys = ['force', 'krbcanonicalname']
+    non_updateable_keys = ['force', 'krbcanonicalname', 'skip_host_check']
     for key in non_updateable_keys:
         if key in module_service:
             del module_service[key]
@@ -135,7 +142,7 @@ def ensure(module, client):
     hosts = module.params['hosts']
 
     ipa_service = client.service_find(name=name)
-    module_service = get_service_dict(force=module.params['force'])
+    module_service = get_service_dict(force=module.params['force'], skip_host_check=module.params['skip_host_check'])
     changed = False
     if state in ['present', 'enabled', 'disabled']:
         if not ipa_service:
@@ -183,6 +190,7 @@ def main():
     argument_spec.update(
         krbcanonicalname=dict(type='str', required=True, aliases=['name']),
         force=dict(type='bool', required=False),
+        skip_host_check=dict(type='bool', required=False),
         hosts=dict(type='list', required=False, elements='str'),
         state=dict(type='str', required=False, default='present',
                    choices=['present', 'absent']))

--- a/plugins/modules/identity/ipa/ipa_service.py
+++ b/plugins/modules/identity/ipa/ipa_service.py
@@ -34,7 +34,8 @@ options:
     type: bool
   skip_host_check:
     description:
-    - Force service to be created even when host object does not exist to manage it
+    - Force service to be created even when host object does not exist to manage it.
+    - This is only used on creation, not for updating existing services.
     required: false
     type: bool
     default: false

--- a/plugins/modules/identity/ipa/ipa_service.py
+++ b/plugins/modules/identity/ipa/ipa_service.py
@@ -37,6 +37,8 @@ options:
     - Force service to be created even when host object does not exist to manage it
     required: false
     type: bool
+    default: false
+    version_added: 4.7.0
   state:
     description: State to ensure.
     required: false


### PR DESCRIPTION
##### SUMMARY
The ipa_service module missing `skip_host_check` option to force service to be created even when host object does not exist to manage it. This PR adds new boolen `skip_host_check` option, which will handle this screnario.
 
Fixes #4416

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_service

##### ADDITIONAL INFORMATION
n/a