### PR TITLE
Bugfix: zypper issue with specified package versions

### DIFF
--- a/changelogs/fragments/4421-zypper_package_version_handling_fix
+++ b/changelogs/fragments/4421-zypper_package_version_handling_fix
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper - fixed bug that caused zypper to always report [ok] and do nothing on ``state: present`` when all packages in ``name: `` had a version specification (https://github.com/ansible-collections/community.general/issues/4371, https://github.com/ansible-collections/community.general/pull/4421).

--- a/changelogs/fragments/4421-zypper_package_version_handling_fix
+++ b/changelogs/fragments/4421-zypper_package_version_handling_fix
@@ -1,2 +1,0 @@
-bugfixes:
-  - zypper - fixed bug that caused zypper to always report [ok] and do nothing on ``state: present`` when all packages in ``name: `` had a version specification (https://github.com/ansible-collections/community.general/issues/4371, https://github.com/ansible-collections/community.general/pull/4421).

--- a/changelogs/fragments/4421-zypper_package_version_handling_fix.yml
+++ b/changelogs/fragments/4421-zypper_package_version_handling_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper - fixed bug that caused zypper to always report [ok] and do nothing on ``state=present`` when all packages in ``name`` had a version specification (https://github.com/ansible-collections/community.general/issues/4371, https://github.com/ansible-collections/community.general/pull/4421).

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -427,7 +427,9 @@ def package_present(m, name, want_latest):
         # if a version is given leave the package in to let zypper handle the version
         # resolution
         packageswithoutversion = [p for p in packages if not p.version]
-        prerun_state = get_installed_state(m, packageswithoutversion)
+        prerun_state = {}
+        if packageswithoutversion:
+            prerun_state = get_installed_state(m, packageswithoutversion)
         # generate lists of packages to install or remove
         packages = [p for p in packages if p.shouldinstall != (p.name in prerun_state)]
 


### PR DESCRIPTION
zypper.py was doing nothing on state=present, when ALL requestet/checked packages had a specific version stated. This was caused by get_installed_state() being called with an empty package list, which in this case returns information about all ALL installed packages. This lead to an exessive filter list prerun_state, essentially removing all packages that are installed in ANY version on the target system from the request list.

##### SUMMARY

I added an empty check to prevent get_installed_state() being called with an empty package list.

Fixes #https://github.com/ansible-collections/community.general/issues/4371

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zypper

##### ADDITIONAL INFORMATION

The following task ALWAYS reported [ok] if ANY version of _a-very-important-package_ was already installed on the target system.

```yaml (paste below)

    - name: Install a specific package version via zypper
      zypper:
        name:
          - "a-very-important-package=2.1"
        state: present
        oldpackage : yes

```
As soon as at least ONE other package WITHOUT a version specification was requestet, everything worked as expected.

```yaml (paste below)

    - name: Install a specific package version via zypper
      zypper:
        name:
          - "a-very-important-package=2.1"
          - "another-package"
        state: present
        oldpackage : yes

```
after my fix, that workaroud is not necessary and both of the above work as expected

