### PR TITLE
Bug fix: Warns user if incorrect SDK version is installed

### DIFF
--- a/changelogs/fragments/4422-warn-user-if-incorrect-SDK-version-is-installed.yaml
+++ b/changelogs/fragments/4422-warn-user-if-incorrect-SDK-version-is-installed.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - dsv_lookup - Raise an Ansible error if the wrong `python-dsv-sdk` version is installed.
+  - dsv lookup plugin - raise an Ansible error if the wrong ``python-dsv-sdk`` version is installed (https://github.com/ansible-collections/community.general/pull/4422).

--- a/changelogs/fragments/4422-warn-user-if-incorrect-SDK-version-is-installed.yaml
+++ b/changelogs/fragments/4422-warn-user-if-incorrect-SDK-version-is-installed.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - dsv_lookup - Raise an Ansible error if the wrong `python-dsv-sdk` version is installed.

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -105,11 +105,15 @@ display = Display()
 class LookupModule(LookupBase):
     @staticmethod
     def Client(vault_parameters):
-        return SecretsVault(**vault_parameters)
+        try: 
+            vault = SecretsVault(**vault_parameters)
+            return vault
+        except:
+            raise AnsibleError("python-dsv-sdk==0.0.1 must be installed to use this plugin")
 
     def run(self, terms, variables, **kwargs):
         if sdk_is_missing:
-            raise AnsibleError("python-dsv-sdk must be installed to use this plugin")
+            raise AnsibleError("python-dsv-sdk==0.0.1 must be installed to use this plugin")
 
         self.set_options(var_options=variables, direct=kwargs)
 

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -105,10 +105,10 @@ display = Display()
 class LookupModule(LookupBase):
     @staticmethod
     def Client(vault_parameters):
-        try: 
+        try:
             vault = SecretsVault(**vault_parameters)
             return vault
-        except:
+        except AnsibleError:
             raise AnsibleError("python-dsv-sdk==0.0.1 must be installed to use this plugin")
 
     def run(self, terms, variables, **kwargs):

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -108,7 +108,7 @@ class LookupModule(LookupBase):
         try:
             vault = SecretsVault(**vault_parameters)
             return vault
-        except AnsibleError:
+        except TypeError:
             raise AnsibleError("python-dsv-sdk==0.0.1 must be installed to use this plugin")
 
     def run(self, terms, variables, **kwargs):


### PR DESCRIPTION
##### SUMMARY

This raises an error if the wrong `python-dsv-sdk` version is installed. This lookup plugin currently only supports v0.0.1 of the SDK. This is a temporary fix until full support with the latest SDK version can be developed.

(Re-submitted with clean git history)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dsv lookup plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the fix, the error presented to the user:
```
Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'community.general.dsv'. Error was a <class 'TypeError'>, original message: __init__() got an unexpected keyword argument 'tenant'"}
```
After:
```
Error was a <class 'ansible.errors.AnsibleError'>, original message: python-dsv-sdk==0.0.1 must be installed to use this plugin"}
```
