### PR TITLE
Replace antsibull-lint collection-docs with antsibull-docs lint-collection-docs

### DIFF
--- a/tests/sanity/extra/extra-docs.py
+++ b/tests/sanity/extra/extra-docs.py
@@ -14,7 +14,7 @@ def main():
     """Main entry point."""
     if not os.path.isdir(os.path.join('docs', 'docsite')):
         return
-    p = subprocess.run(['antsibull-lint', 'collection-docs', '.'], check=False)
+    p = subprocess.run(['antsibull-docs', 'lint-collection-docs', '.'], check=False)
     if p.returncode not in (0, 3):
         print('{0}:0:0: unexpected return code {1}'.format(sys.argv[0], p.returncode))
 


### PR DESCRIPTION
##### SUMMARY
Replace antsibull-lint collection-docs with antsibull-docs lint-collection-docs in CI, since antsibull-lint will be deprecated soon. See https://github.com/ansible-community/antsibull/issues/410.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
