### PR TITLE
[datadog_monitor] Remove '@' from API response

### DIFF
--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -337,7 +337,7 @@ def _update_monitor(module, monitor, options):
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
         msg = api.Monitor.update(**kwargs)
- 
+
         if 'message' in msg:
             msg['message'] = msg['message'].replace('@', '(@)')
 

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -228,6 +228,7 @@ def main():
             name=dict(required=True),
             query=dict(),
             notification_message=dict(no_log=True),
+            message=dict(no_log=True),
             silenced=dict(type='dict'),
             notify_no_data=dict(default=False, type='bool'),
             no_data_timeframe=dict(),

--- a/plugins/modules/monitoring/datadog/datadog_monitor.py
+++ b/plugins/modules/monitoring/datadog/datadog_monitor.py
@@ -228,7 +228,6 @@ def main():
             name=dict(required=True),
             query=dict(),
             notification_message=dict(no_log=True),
-            message=dict(no_log=True),
             silenced=dict(type='dict'),
             notify_no_data=dict(default=False, type='bool'),
             no_data_timeframe=dict(),
@@ -309,6 +308,10 @@ def _post_monitor(module, options):
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
         msg = api.Monitor.create(**kwargs)
+
+        if 'message' in msg:
+            msg['message'] = msg['message'].replace('@', '(@)')
+
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
         else:
@@ -334,6 +337,9 @@ def _update_monitor(module, monitor, options):
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
         msg = api.Monitor.update(**kwargs)
+ 
+        if 'message' in msg:
+            msg['message'] = msg['message'].replace('@', '(@)')
 
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))


### PR DESCRIPTION
##### SUMMARY
In #1338 we marked the the `notification_message` field as `no_log`. This is not always effective in removing the message string from the events generated when the task runs, though, since sometimes the server response contains a message string that isn't exactly equal to the input string specified in `notification_message`, so it doesn't get masked. This could happen, for example, if the input string has leading spaces, because the server trims the message string in the response. The server might also change double quotes to single quotes or do other transformations.  

This is the same problem we tried to fix in #1338 when the `notification_message` contains an `@<name>` to page team `<name>` and this also triggers a page when sending an event to Datadog from the [Datadog Ansible callback](https://github.com/DataDog/ansible-datadog-callback) after the task runs. For this reason, we want to modify the message so the `@<name>` isn't there even when not masked.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`datadog_monitor`

