### PR TITLE
Keycloak client, Add always_display_in_console option

### DIFF
--- a/changelogs/fragments/4429-keycloak-client-add-always-display-in-console.yml
+++ b/changelogs/fragments/4429-keycloak-client-add-always-display-in-console.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - keycloak_client - add ``always_display_in_console`` parameter.(https://github.com/ansible-collections/community.general/issues/4390)

--- a/changelogs/fragments/4429-keycloak-client-add-always-display-in-console.yml
+++ b/changelogs/fragments/4429-keycloak-client-add-always-display-in-console.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - keycloak_client - add ``always_display_in_console`` parameter.(https://github.com/ansible-collections/community.general/issues/4390)
+  - keycloak_client - add ``always_display_in_console`` parameter (https://github.com/ansible-collections/community.general/issues/4390).

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -308,6 +308,7 @@ options:
         aliases:
             - alwaysDisplayInConsole
         type: bool
+        version_added: 4.7.0
 
     surrogate_auth_required:
         description:

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -620,7 +620,7 @@ EXAMPLES = '''
     use_template_config: False
     use_template_scope: false
     use_template_mappers: no
-    always_display_in_console: True
+    always_display_in_console: true
     registered_nodes:
       node01.example.com: 1507828202
     registration_access_token: eyJWT_TOKEN

--- a/plugins/modules/identity/keycloak/keycloak_client.py
+++ b/plugins/modules/identity/keycloak/keycloak_client.py
@@ -301,6 +301,14 @@ options:
             - useTemplateMappers
         type: bool
 
+    always_display_in_console:
+        description:
+            - Whether or not to display this client in account console, even if the
+              user does not have an active session.
+        aliases:
+            - alwaysDisplayInConsole
+        type: bool
+
     surrogate_auth_required:
         description:
             - Whether or not surrogate auth is required.
@@ -611,6 +619,7 @@ EXAMPLES = '''
     use_template_config: False
     use_template_scope: false
     use_template_mappers: no
+    always_display_in_console: True
     registered_nodes:
       node01.example.com: 1507828202
     registration_access_token: eyJWT_TOKEN
@@ -804,6 +813,7 @@ def main():
         use_template_config=dict(type='bool', aliases=['useTemplateConfig']),
         use_template_scope=dict(type='bool', aliases=['useTemplateScope']),
         use_template_mappers=dict(type='bool', aliases=['useTemplateMappers']),
+        always_display_in_console=dict(type='bool', aliases=['alwaysDisplayInConsole']),
         authentication_flow_binding_overrides=dict(type='dict', aliases=['authenticationFlowBindingOverrides']),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
         authorization_settings=dict(type='dict', aliases=['authorizationSettings']),


### PR DESCRIPTION
##### SUMMARY
The keycloak client module missing `always_display_in_console` which is keycloak client alias `alwaysDisplayInConsole`. It is simple boolean value. This PR adds new boolean value `always_display_in_console`.

Fixes: [#4390](https://github.com/ansible-collections/community.general/issues/4390)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
- keycloak_client

##### ADDITIONAL INFORMATION
n/a
