### PR TITLE
Proxmox Inventory: Fix for #4431

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -268,7 +268,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             try:
                 return iface['address']
             except Exception:
-                return None
+                pass
+
+        return None
 
     def _get_agent_network_interfaces(self, node, vmid, vmtype):
         result = []


### PR DESCRIPTION
##### SUMMARY
This commit fixes issue #4431, where the Proxmox inventory plugin would
randomly fail to acquire the node's IP address.

**Edit:** This is now a near complete re-write of `_get_node_ip()`, which resolves the Proxmox connection URL provided to the plugin, and attempts to match it against one of the PVE node's interfaces. If this process fails, no IP is returned.

This seems more logical to me, as the IP address is used to define the `ansible_host` var, which should be the same IP used to establish the connection, rather than an arbitrary and unpredictable IP.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION
See #4431