### PR TITLE
CI: Remove 'warn:' that's removed in ansible-core 2.14

### DIFF
--- a/tests/integration/targets/dnf_versionlock/tasks/lock_updates.yml
+++ b/tests/integration/targets/dnf_versionlock/tasks/lock_updates.yml
@@ -37,8 +37,6 @@
       command: >-
         dnf update -y
         --setopt=obsoletes=0 {{ _packages | join(' ') }}
-      args:
-        warn: false
       register: update_locked_packages
       changed_when: '"Nothing to do" not in update_locked_packages.stdout'
 

--- a/tests/integration/targets/monit/tasks/check_state.yml
+++ b/tests/integration/targets/monit/tasks/check_state.yml
@@ -1,7 +1,5 @@
 - name: "{{ reason }} ('up')"
   command: "curl -sf http://localhost:8082/hello"
-  args:
-    warn: false
   when: service_state == 'up'
   register: curl_result
   until: not curl_result.failed
@@ -10,8 +8,6 @@
 
 - name: "{{ reason }} ('down')"
   command: "curl -sf http://localhost:8082/hello"
-  args:
-    warn: false
   register: curl_result
   failed_when: curl_result == 0
   when: service_state == 'down'

--- a/tests/integration/targets/monit/tasks/main.yml
+++ b/tests/integration/targets/monit/tasks/main.yml
@@ -43,6 +43,18 @@
       src: httpd_echo.py
       dest: "{{ process_file }}"
 
+  - name: Install virtualenv
+    package:
+      name: virtualenv
+      state: present
+    when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8'
+
+  - name: Install virtualenv
+    package:
+      name: python-virtualenv
+      state: present
+    when: ansible_os_family == 'Archlinux'
+
   - name: install dependencies
     pip:
       name: "{{ item }}"

--- a/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
+++ b/tests/integration/targets/pkgng/tasks/create-outofdate-pkg.yml
@@ -21,7 +21,6 @@
       - '{{ pkgng_test_outofdate_pkg_tempdir.path }}'
       - '--manifest'
       - '{{ pkgng_test_outofdate_pkg_tempdir.path }}/MANIFEST'
-    warn: no
 
 # pkg switched from .txz to .pkg in version 1.17.0
 # Might as well look for all valid pkg extensions.

--- a/tests/integration/targets/setup_cron/tasks/main.yml
+++ b/tests/integration/targets/setup_cron/tasks/main.yml
@@ -32,8 +32,6 @@
       until: faketime_package_installed is success
     - name: Find libfaketime path
       shell: '{{ list_pkg_files }} {{ faketime_pkg }} | grep -F libfaketime.so.1'
-      args:
-        warn: false
       register: libfaketime_path
     - when: ansible_service_mgr == 'systemd'
       block:

--- a/tests/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/tests/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -165,8 +165,6 @@
 
   - name: Reinstall internationalization files
     shell: yum -y reinstall glibc-common || yum -y install glibc-common
-    args:
-      warn: false
     when: locale_present is failed
 
   - name: Generate locale (RedHat)


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible/ansible/pull/77411.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
