### PR TITLE
Terraform init -upgrade flag

### DIFF
--- a/changelogs/fragments/4455-terraform-provider-upgrade.yml
+++ b/changelogs/fragments/4455-terraform-provider-upgrade.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - terraform - adds ``terraform_upgrade`` parameter which allows ``terraform init`` to satisfy new provider constraints in an existing Terraform project (https://github.com/ansible-collections/community.general/issues/4333).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -129,6 +129,7 @@ options:
       - Allows Terraform init to upgrade providers to versions specified in the project's version constraints.
     default: false
     type: bool
+    version_added: 3.8.0
   init_reconfigure:
     description:
       - Forces backend reconfiguration during init.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -129,7 +129,7 @@ options:
       - Allows Terraform init to upgrade providers to versions specified in the project's version constraints.
     default: false
     type: bool
-    version_added: 3.8.0
+    version_added: 4.8.0
   init_reconfigure:
     description:
       - Forces backend reconfiguration during init.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -124,12 +124,12 @@ options:
     type: list
     elements: path
     version_added: '0.2.0'
-  init_reconfigure:
+  provider_upgrade:
     description:
       - Allows Terraform init to upgrade providers to versions specified in the project's version constraints.
     default: false
     type: bool
-  provider_upgrade:
+  init_reconfigure:
     description:
       - Forces backend reconfiguration during init.
     default: false

--- a/tests/integration/targets/terraform/.gitignore
+++ b/tests/integration/targets/terraform/.gitignore
@@ -1,0 +1,4 @@
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+skip/windows

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -1,2 +1,6 @@
 shippable/posix/group1
 skip/windows
+skip/aix
+skip/osx
+skip/macos
+skip/freebsd

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -4,3 +4,4 @@ skip/aix
 skip/osx
 skip/macos
 skip/freebsd
+skip/python2

--- a/tests/integration/targets/terraform/meta/main.yml
+++ b/tests/integration/targets/terraform/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_pkg_mgr
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -1,19 +1,37 @@
 ---
 
-- name: Check if terraform is present in path
-  command: "command -v terraform"
-  register: terraform_binary_path
-  ignore_errors: true
+# Fallback in case existing_terraform_path var is missing. Saves us from checking for `not defined`
+# conditions in multiple tasks below.
 
-- name: Check Terraform version
-  command: terraform version
-  register: terraform_version_output
-  when: terraform_binary_path.rc == 0
-
-- name: Set terraform version
+- name: Check if existing_terraform_path var is missing
   set_fact:
-    terraform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*)(v[0-9]+\\.[0-9]+\\.[0-9]+)') }}"
-  when: terraform_version_output.changed
+      existing_terraform_path: "{{ existing_terraform_path | default('') }}"
+
+# This block checks and registers Terraform version of the binary found in path. It's 
+# skipped when user sets `existing_terraform_path`.
+
+- name: Check for existing Terraform in path
+  block:
+  - name: Check if terraform is present in path
+    command: "command -v terraform"
+    register: terraform_binary_path
+    ignore_errors: true
+
+  - name: Check Terraform version
+    command: terraform version
+    register: terraform_version_output
+    when: terraform_binary_path.rc == 0
+
+  - name: Set terraform version
+    set_fact:
+      terraform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*v)([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
+    when: terraform_version_output.changed
+
+  when: existing_terraform_path | length == 0
+
+# This block handles taks of installing the Terraform binary. This happens if user does not set
+# `existing_terraform_path` AND if there is no existing terraform in $PATH OR version does not
+# match `terraform_version`
 
 - name: Execute Terraform install tasks
   block:
@@ -25,7 +43,7 @@
 
   - name: Install Terraform
     debug:
-      msg: "Installing terraform {{ terraform_version }}, found {{ terraform_version_installed | default('v0.0.0') }}"
+      msg: "Installing terraform {{ terraform_version }}, found {{ terraform_version_installed | default('0.0.0') }}"
 
   - name: Install Terraform binary
     unarchive:
@@ -35,7 +53,15 @@
       remote_src: yes
       validate_certs: "{{ validate_certs }}"
 
-  when: terraform_version_installed is not defined or terraform_version_installed != terraform_version
+  when: >-
+    (terraform_version_installed is not defined or terraform_version_installed != terraform_version) and existing_terraform_path | length == 0
+
+# This sets `terraform_binary_path` to coalesced output of first non-empty string in this order:
+# user-defined path, path from the 'Check if terraform is present in path' task, and lastly, the fallback path.
+
+- name: Set path to terraform binary
+  set_fact:
+    terraform_binary_path: "{{ existing_terraform_path or terraform_binary_path.stdout or remote_tmp_dir ~ '/terraform' }}"
 
 - name: Create terraform project directory
   file:

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -1,14 +1,7 @@
 ---
 
-# Fallback in case existing_terraform_path var is missing. Saves us from checking for `not defined`
-# conditions in multiple tasks below.
 
-- name: Check if existing_terraform_path var is missing
-  set_fact:
-      existing_terraform_path: "{{ existing_terraform_path | default('') }}"
-
-# This block checks and registers Terraform version of the binary found in path. It's 
-# skipped when user sets `existing_terraform_path`.
+# This block checks and registers Terraform version of the binary found in path.
 
 - name: Check for existing Terraform in path
   block:
@@ -27,11 +20,8 @@
       terraform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*v)([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
     when: terraform_version_output.changed
 
-  when: existing_terraform_path | length == 0
-
-# This block handles taks of installing the Terraform binary. This happens if user does not set
-# `existing_terraform_path` AND if there is no existing terraform in $PATH OR version does not
-# match `terraform_version`
+# This block handles the tasks of installing the Terraform binary. This happens if there is no existing
+# terraform in $PATH OR version does not match `terraform_version`.
 
 - name: Execute Terraform install tasks
   block:
@@ -53,15 +43,14 @@
       remote_src: yes
       validate_certs: "{{ validate_certs }}"
 
-  when: >-
-    (terraform_version_installed is not defined or terraform_version_installed != terraform_version) and existing_terraform_path | length == 0
+  when: terraform_version_installed is not defined or terraform_version_installed != terraform_version
 
 # This sets `terraform_binary_path` to coalesced output of first non-empty string in this order:
-# user-defined path, path from the 'Check if terraform is present in path' task, and lastly, the fallback path.
+# path from the 'Check if terraform is present in path' task, and lastly, the fallback path.
 
 - name: Set path to terraform binary
   set_fact:
-    terraform_binary_path: "{{ existing_terraform_path or terraform_binary_path.stdout or remote_tmp_dir ~ '/terraform' }}"
+    terraform_binary_path: "{{ terraform_binary_path.stdout or remote_tmp_dir ~ '/terraform' }}"
 
 - name: Create terraform project directory
   file:

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -1,0 +1,53 @@
+- name: Check if terraform is present
+  command: "command -v terraform"
+  register: terraform_binary_path
+  ignore_errors: true
+
+- name: Check Terraform version
+  command: terraform version
+  register: terraform_version_output
+  when: terraform_binary_path.rc == 0
+
+- name: Set terraform version
+  set_fact:
+    terrform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*)(v[0-9]+\\.[0-9]+\\.[0-9]+)') }}"
+  when: terraform_version_output.changed
+
+- name: Execute Terraform install tasks
+  block:
+
+  - name: Ensure unzip is present
+    ansible.builtin.package:
+      name: unzip
+      state: present
+
+  - name: Install Terraform
+    debug:
+      msg: "Installing terraform {{ terraform_version }}, found {{ terraform_version_installed | default('v0.0.0') }}"
+
+  - name: Install Terraform binary
+    unarchive:
+      src: "{{ terraform_url }}"
+      dest: "{{ remote_tmp_dir }}"
+      mode: 0755
+      remote_src: yes
+      validate_certs: "{{ validate_certs }}"
+
+  when: terraform_version_installed is not defined or terrform_version_installed != terraform_version
+
+- name: Create terraform project directory
+  file:
+    path: "{{terraform_project_dir}}/{{ item['name'] }}"
+    state: directory
+    mode: 0755
+  loop: "{{ terraform_provider_versions }}"
+  loop_control:
+    index_var: provider_index
+
+- name: Loop over provider upgrade test tasks
+  include_tasks: test_provider_upgrade.yml
+  vars:
+    tf_provider: "{{ terraform_provider_versions[provider_index] }}"
+  loop: "{{ terraform_provider_versions }}"
+  loop_control:
+    index_var: provider_index

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -1,4 +1,6 @@
-- name: Check if terraform is present
+---
+
+- name: Check if terraform is present in path
   command: "command -v terraform"
   register: terraform_binary_path
   ignore_errors: true
@@ -10,7 +12,7 @@
 
 - name: Set terraform version
   set_fact:
-    terrform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*)(v[0-9]+\\.[0-9]+\\.[0-9]+)') }}"
+    terraform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*)(v[0-9]+\\.[0-9]+\\.[0-9]+)') }}"
   when: terraform_version_output.changed
 
 - name: Execute Terraform install tasks
@@ -33,7 +35,7 @@
       remote_src: yes
       validate_certs: "{{ validate_certs }}"
 
-  when: terraform_version_installed is not defined or terrform_version_installed != terraform_version
+  when: terraform_version_installed is not defined or terraform_version_installed != terraform_version
 
 - name: Create terraform project directory
   file:

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -26,14 +26,14 @@
 - name: Execute Terraform install tasks
   block:
 
+  - name: Install Terraform
+    debug:
+      msg: "Installing terraform {{ terraform_version }}, found: {{ terraform_version_installed | default('no terraform binary found') }}."
+
   - name: Ensure unzip is present
     ansible.builtin.package:
       name: unzip
       state: present
-
-  - name: Install Terraform
-    debug:
-      msg: "Installing terraform {{ terraform_version }}, found {{ terraform_version_installed | default('0.0.0') }}"
 
   - name: Install Terraform binary
     unarchive:
@@ -54,7 +54,7 @@
 
 - name: Create terraform project directory
   file:
-    path: "{{terraform_project_dir}}/{{ item['name'] }}"
+    path: "{{ terraform_project_dir }}/{{ item['name'] }}"
     state: directory
     mode: 0755
   loop: "{{ terraform_provider_versions }}"

--- a/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
+++ b/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
@@ -13,7 +13,7 @@
 - name: Init Terraform configuration with pinned provider version
   community.general.terraform:
     project_path: "{{ terraform_provider_hcl.dest | dirname }}"
-    binary_path: "{{ remote_tmp_dir }}/terraform"
+    binary_path: "{{ terraform_binary_path }}"
     force_init: yes
     provider_upgrade: "{{ terraform_provider_upgrade }}"
     state: present

--- a/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
+++ b/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
@@ -20,4 +20,4 @@
   register: terraform_init_result
 
 - assert:
-    that: "{{ terraform_init_result.failed == false }}"
+    that: terraform_init_result is not failed

--- a/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
+++ b/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Output terraform provider test project
+  ansible.builtin.template:
+    src: templates/provider_test/main.tf.j2
+    dest: "{{ terraform_project_dir }}/{{ tf_provider['name'] }}/main.tf"
+    force: yes
+  register: terraform_provider_hcl
+
+# The purpose of this task is to init terraform multiple times with different provider module
+# versions, so that we can verify that provider upgrades during init work as intended.
+
+- name: Init Terraform configuration with pinned provider version
+  community.general.terraform:
+    project_path: "{{ terraform_provider_hcl.dest | dirname }}"
+    binary_path: "{{ remote_tmp_dir }}/terraform"
+    force_init: yes
+    provider_upgrade: "{{ terraform_provider_upgrade }}"
+    state: present
+  register: terraform_init_result
+
+- assert:
+    that: "{{ terraform_init_result.failed == false }}"

--- a/tests/integration/targets/terraform/templates/provider_test/main.tf.j2
+++ b/tests/integration/targets/terraform/templates/provider_test/main.tf.j2
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    {{ tf_provider['name'] }} = {
+      source  = "{{ tf_provider['source'] }}"
+      version = "{{ tf_provider['version'] }}"
+    }
+  }
+}

--- a/tests/integration/targets/terraform/vars/main.yml
+++ b/tests/integration/targets/terraform/vars/main.yml
@@ -1,5 +1,9 @@
 ---
 
+# If this is set, this playbook will not download Terraform or check its version. Instead, the binary specified
+# below will be used. Leave at empty string to perform the download of Terraform specified in `terraform_version`.
+existing_terraform_path: ""
+
 # Terraform version that will be downloaded
 terraform_version: 1.1.7
 

--- a/tests/integration/targets/terraform/vars/main.yml
+++ b/tests/integration/targets/terraform/vars/main.yml
@@ -3,8 +3,9 @@
 # Terraform version that will be downloaded
 terraform_version: 1.1.7
 
-# Architecture of the downloaded Terraform release (needs to match testing platform)
-terraform_arch: linux_amd64
+# Architecture of the downloaded Terraform release (needs to match target testing platform)
+
+terraform_arch: "{{ ansible_system | lower }}_{{terraform_arch_map[ansible_architecture] }}"
 
 # URL of where the Terraform binary will be downloaded from
 terraform_url: "https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_{{ terraform_arch }}.zip"
@@ -27,3 +28,10 @@ terraform_provider_versions:
   - name: "null" 
     source: "hashicorp/null"
     version: ">=3.0.0"
+
+# mapping between values returned from ansible_architecture and arch names used by golang builds of Terraform
+# see https://www.terraform.io/downloads
+
+terraform_arch_map:
+  x86_64: amd64
+  arm64: arm64

--- a/tests/integration/targets/terraform/vars/main.yml
+++ b/tests/integration/targets/terraform/vars/main.yml
@@ -10,7 +10,7 @@ terraform_arch: linux_amd64
 terraform_url: "https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_{{ terraform_arch }}.zip"
 
 # Controls whether the unarchive task will validate TLS certs of the Terraform binary host
-validate_certs: no
+validate_certs: yes
 
 # Directory where Terraform tests will be created
 terraform_project_dir: "{{ remote_tmp_dir }}/tf_provider_test"

--- a/tests/integration/targets/terraform/vars/main.yml
+++ b/tests/integration/targets/terraform/vars/main.yml
@@ -1,0 +1,29 @@
+---
+
+# Terraform version that will be downloaded
+terraform_version: 1.1.7
+
+# Architecture of the downloaded Terraform release (needs to match testing platform)
+terraform_arch: linux_amd64
+
+# URL of where the Terraform binary will be downloaded from
+terraform_url: "https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_{{ terraform_arch }}.zip"
+
+# Controls whether the unarchive task will validate TLS certs of the Terraform binary host
+validate_certs: no
+
+# Directory where Terraform tests will be created
+terraform_project_dir: "{{ remote_tmp_dir }}/tf_provider_test"
+
+# Controls whether terraform init will use the `-upgrade` flag
+terraform_provider_upgrade: yes
+
+# list of dicts containing Terraform providers that will be tested
+# The null provider is a good candidate, as it's small and has no external dependencies
+terraform_provider_versions: 
+  - name: "null" 
+    source: "hashicorp/null"
+    version: ">=2.0.0, < 3.0.0"
+  - name: "null" 
+    source: "hashicorp/null"
+    version: ">=3.0.0"

--- a/tests/integration/targets/terraform/vars/main.yml
+++ b/tests/integration/targets/terraform/vars/main.yml
@@ -1,9 +1,5 @@
 ---
 
-# If this is set, this playbook will not download Terraform or check its version. Instead, the binary specified
-# below will be used. Leave at empty string to perform the download of Terraform specified in `terraform_version`.
-existing_terraform_path: ""
-
 # Terraform version that will be downloaded
 terraform_version: 1.1.7
 


### PR DESCRIPTION
##### SUMMARY

This PR adds a new `provider_upgrade` option to the Terraform module. This is needed, so that `terraform init` can pull new provider versions when the version pinned within an existing Terraform project changes. 

This fixes #4333 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/cloud/misc/terraform.py

##### ADDITIONAL INFORMATION

I have included a basic integration test to test this behavior. Simply set `terraform_provider_upgrade: no` in the vars to see the previous failure behavior.

Changing provider constraints is a common usage scenario in Terraform. This prevents the user from having to completely blow away their terraform project directories every time the constraints are changed.
