### PR TITLE
Redfish: Added IndicatorLED commands to the Systems category

### DIFF
--- a/changelogs/fragments/4084-add-redfish-system-indicator-led.yml
+++ b/changelogs/fragments/4084-add-redfish-system-indicator-led.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redfish_command - add ``IndicatorLedOn``, ``IndicatorLedOff``, and ``IndicatorLedBlink`` commands to the Systems category for controling system LEDs (https://github.com/ansible-collections/community.general/issues/4084).
+

--- a/changelogs/fragments/4084-add-redfish-system-indicator-led.yml
+++ b/changelogs/fragments/4084-add-redfish-system-indicator-led.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - redfish_command - add ``IndicatorLedOn``, ``IndicatorLedOff``, and ``IndicatorLedBlink`` commands to the Systems category for controling system LEDs (https://github.com/ansible-collections/community.general/issues/4084).
-

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -738,9 +738,11 @@ class RedfishUtils(object):
     def manage_chassis_indicator_led(self, command):
         return self.manage_indicator_led(command, self.chassis_uri)
 
-    def manage_indicator_led(self, command, resource_uri):
+    def manage_indicator_led(self, command, resource_uri=None):
         result = {}
         key = 'IndicatorLED'
+        if resource_uri is None:
+            resource_uri = self.chassis_uri
 
         payloads = {'IndicatorLedOn': 'Lit', 'IndicatorLedOff': 'Off', "IndicatorLedBlink": 'Blinking'}
 

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -732,14 +732,20 @@ class RedfishUtils(object):
     def get_multi_volume_inventory(self):
         return self.aggregate_systems(self.get_volume_inventory)
 
-    def manage_indicator_led(self, command):
+    def manage_system_indicator_led(self, command):
+        return self.manage_power(command, self.systems_uri)
+
+    def manage_chassis_indicator_led(self, command):
+        return self.manage_power(command, self.chassis_uri)
+
+    def manage_indicator_led(self, command, resource_uri):
         result = {}
         key = 'IndicatorLED'
 
         payloads = {'IndicatorLedOn': 'Lit', 'IndicatorLedOff': 'Off', "IndicatorLedBlink": 'Blinking'}
 
         result = {}
-        response = self.get_request(self.root_uri + self.chassis_uri)
+        response = self.get_request(self.root_uri + resource_uri)
         if response['ret'] is False:
             return response
         result['ret'] = True
@@ -749,7 +755,7 @@ class RedfishUtils(object):
 
         if command in payloads.keys():
             payload = {'IndicatorLED': payloads[command]}
-            response = self.patch_request(self.root_uri + self.chassis_uri, payload)
+            response = self.patch_request(self.root_uri + resource_uri, payload)
             if response['ret'] is False:
                 return response
         else:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -733,10 +733,10 @@ class RedfishUtils(object):
         return self.aggregate_systems(self.get_volume_inventory)
 
     def manage_system_indicator_led(self, command):
-        return self.manage_power(command, self.systems_uri)
+        return self.manage_indicator_led(command, self.systems_uri)
 
     def manage_chassis_indicator_led(self, command):
-        return self.manage_power(command, self.chassis_uri)
+        return self.manage_indicator_led(command, self.chassis_uri)
 
     def manage_indicator_led(self, command, resource_uri):
         result = {}

--- a/plugins/modules/remote_management/redfish/redfish_command.py
+++ b/plugins/modules/remote_management/redfish/redfish_command.py
@@ -318,6 +318,14 @@ EXAMPLES = '''
       category: Systems
       command: DisableBootOverride
 
+  - name: Set system indicator LED to blink using security token for auth
+    community.general.redfish_command:
+      category: Systems
+      command: IndicatorLedBlink
+      resource_id: 437XR1138R2
+      baseuri: "{{ baseuri }}"
+      auth_token: "{{ result.session.token }}"
+
   - name: Add user
     community.general.redfish_command:
       category: Accounts
@@ -583,7 +591,8 @@ from ansible.module_utils.common.text.converters import to_native
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerForceRestart", "PowerGracefulRestart",
-                "PowerGracefulShutdown", "PowerReboot", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride"],
+                "PowerGracefulShutdown", "PowerReboot", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
+                "IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Chassis": ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",
                  "UpdateUserRole", "UpdateUserPassword", "UpdateUserName",
@@ -754,6 +763,8 @@ def main():
             elif command == "DisableBootOverride":
                 boot_opts['override_enabled'] = 'Disabled'
                 result = rf_utils.set_boot_override(boot_opts)
+            elif command.startswith('IndicatorLed'):
+                result = rf_utils.manage_system_indicator_led(command)
 
     elif category == "Chassis":
         result = rf_utils._find_chassis_resource()
@@ -769,7 +780,7 @@ def main():
         else:
             for command in command_list:
                 if command in led_commands:
-                    result = rf_utils.manage_indicator_led(command)
+                    result = rf_utils.manage_chassis_indicator_led(command)
 
     elif category == "Sessions":
         # execute only if we find SessionService resources


### PR DESCRIPTION
##### SUMMARY
Adds support for IndicatorLED commands in the Systems category. Introduces `IndicatorLedOn`, `IndicatorLedOff`, and `IndicatorLedBlink` to be consistent with functionality in the chassis view.

Fix #4084

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
New command example with results. Largely leveraged existing IndicatorLED code for the chassis.

```
  tasks:
  - name: Turn system LED on
    redfish_command:
      category: Systems
      command: IndicatorLedOn
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

```
PLAY [Set Indicator LED] ************************************************************************************************

TASK [Turn system LED on] ***********************************************************************************************
changed: [localhost]

TASK [debug] ************************************************************************************************************
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "failed": false,
        "msg": "Action was successful",
        "session": {}
    }
}

PLAY RECAP **************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
