### PR TITLE
dnsmadeeasy: only get monitor if it is not null api response

### DIFF
--- a/changelogs/fragments/4459-only-get-monitor-if-it-is-not-null-api-response.yaml
+++ b/changelogs/fragments/4459-only-get-monitor-if-it-is-not-null-api-response.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnsmadeeasy dns delete should not break when api response does not contain monitor value(https://github.com/ansible-collections/community.general/issues/3620)

--- a/changelogs/fragments/4459-only-get-monitor-if-it-is-not-null-api-response.yaml
+++ b/changelogs/fragments/4459-only-get-monitor-if-it-is-not-null-api-response.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dnsmadeeasy dns delete should not break when api response does not contain monitor value(https://github.com/ansible-collections/community.general/issues/3620)
+  - dnsmadeeasy - fix failure on deleting DNS entries when API response does not contain monitor value (https://github.com/ansible-collections/community.general/issues/3620).

--- a/plugins/modules/net_tools/dnsmadeeasy.py
+++ b/plugins/modules/net_tools/dnsmadeeasy.py
@@ -623,7 +623,7 @@ def main():
     # Fetch existing monitor if the A record indicates it should exist and build the new monitor
     current_monitor = dict()
     new_monitor = dict()
-    if current_record and current_record['type'] == 'A':
+    if current_record and current_record['type'] == 'A' and current_record['monitor']:
         current_monitor = DME.getMonitor(current_record['id'])
 
     # Build the new monitor

--- a/plugins/modules/net_tools/dnsmadeeasy.py
+++ b/plugins/modules/net_tools/dnsmadeeasy.py
@@ -623,7 +623,7 @@ def main():
     # Fetch existing monitor if the A record indicates it should exist and build the new monitor
     current_monitor = dict()
     new_monitor = dict()
-    if current_record and current_record['type'] == 'A' and current_record['monitor']:
+    if current_record and current_record['type'] == 'A' and current_record.get('monitor'):
         current_monitor = DME.getMonitor(current_record['id'])
 
     # Build the new monitor


### PR DESCRIPTION
##### SUMMARY
dnsmadeeasy module, fails if "monitor" key is null in the api response, this change adds a check

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
net_tools/dnsmadeeasy

##### ADDITIONAL INFORMATION
it adds a check for "monitor" value in api response partially fixes #3620, delete should work, updates are not perfect