### PR TITLE
gitlab_group_members: fix group search for larger group count

### DIFF
--- a/changelogs/fragments/4460_group_search_for_larger_group_count.yml
+++ b/changelogs/fragments/4460_group_search_for_larger_group_count.yml
@@ -1,0 +1,1 @@
+bugfixes: add all=True in self._gitlab.groups.list for method get_group_id(self, gitlab_group) to search within larger group counts (https://github.com/ansible-collections/community.general/issues/4460).

--- a/changelogs/fragments/4460_group_search_for_larger_group_count.yml
+++ b/changelogs/fragments/4460_group_search_for_larger_group_count.yml
@@ -1,1 +1,2 @@
-bugfixes: add all=True in self._gitlab.groups.list for method get_group_id(self, gitlab_group) to search within larger group counts (https://github.com/ansible-collections/community.general/issues/4460).
+bugfixes:
+  - add all=True in self._gitlab.groups.list for method get_group_id(self, gitlab_group) to search within larger group counts (https://github.com/ansible-collections/community.general/issues/4460).

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -102,7 +102,7 @@ class GitLabGroup(object):
 
     # get group id if group exists
     def get_group_id(self, gitlab_group):
-        group_exists = self._gitlab.groups.list(search=gitlab_group)
+        group_exists = self._gitlab.groups.list(search=gitlab_group,all=True)
         if group_exists:
             return group_exists[0].id
 

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -102,7 +102,7 @@ class GitLabGroup(object):
 
     # get group id if group exists
     def get_group_id(self, gitlab_group):
-        group_exists = self._gitlab.groups.list(search=gitlab_group,all=True)
+        group_exists = self._gitlab.groups.list(search=gitlab_group, all=True)
         if group_exists:
             return group_exists[0].id
 


### PR DESCRIPTION
##### SUMMARY
Fixes #4460

add attribute all=True to search in all groups

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
community.general.gitlab_group_members

##### ADDITIONAL INFORMATION
We have a lot of groups which contains the name ob a parent group

test
  - test_group_1
  - test_group_2
  - ...

When we want to configure group "test", the group ist noch found. The search did not account the pagination

