### PR TITLE
Add discord integration tests

### DIFF
--- a/tests/integration/targets/discord/README.md
+++ b/tests/integration/targets/discord/README.md
@@ -1,0 +1,14 @@
+The integration tests can be executed locally:
+
+1. Create or use an existing discord server
+2. Open `Server Settings` and navigate to `Integrations` tab
+3. Click `Create Webhook` to create a new webhook
+4. Click `Copy Webhook URL` and extract the webhook_id + webhook_token
+
+    Example: https://discord.com/api/webhooks/`webhook_id`/`webhook_token`
+
+5. Replace the variables `webhook_id` and `webhook_token` in the var file
+6. Run the integration test
+````
+ansible-test integration -v --color yes discord --allow-unsupported
+````

--- a/tests/integration/targets/discord/README.md
+++ b/tests/integration/targets/discord/README.md
@@ -7,7 +7,7 @@ The integration tests can be executed locally:
 
     Example: https://discord.com/api/webhooks/`webhook_id`/`webhook_token`
 
-5. Replace the variables `webhook_id` and `webhook_token` in the var file
+5. Replace the variables `discord_id` and `discord_token` in the var file
 6. Run the integration test
 ````
 ansible-test integration -v --color yes discord --allow-unsupported

--- a/tests/integration/targets/discord/aliases
+++ b/tests/integration/targets/discord/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/discord/defaults/main.yml
+++ b/tests/integration/targets/discord/defaults/main.yml
@@ -1,0 +1,2 @@
+discord_id: 000
+discord_token: xxx

--- a/tests/integration/targets/discord/tasks/main.yml
+++ b/tests/integration/targets/discord/tasks/main.yml
@@ -1,0 +1,64 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+- name: Send basic message
+  community.general.discord:
+    webhook_id: "{{ discord_id }}"
+    webhook_token: "{{ discord_token }}"
+    content: "Messages from ansible-test"
+  register: result
+
+- name: Check result
+  assert:
+    that:
+      - result is changed
+      - result.http_code == 204
+
+- name: Send embeds
+  community.general.discord:
+    webhook_id: "{{ discord_id }}"
+    webhook_token: "{{ discord_token }}"
+    embeds:
+      - title: "Title of embed message 1"
+        description: "Description embed message 1"
+        footer:
+          text: "author ansible-test"
+        image:
+          url: "https://avatars.githubusercontent.com/u/44586252?s=200&v=4"
+      - title: "Title of embed message 2"
+        description: "Description embed message 2"
+        footer:
+          text: "author ansible-test"
+          icon_url: "https://avatars.githubusercontent.com/u/44586252?s=200&v=4"
+        fields:
+          - name: "Field 1"
+            value: 1
+          - name: "Field 2"
+            value: "Text"
+        timestamp: "{{ ansible_date_time.iso8601 }}"
+    username: Ansible Test
+    avatar_url: "https://avatars.githubusercontent.com/u/44586252?s=200&v=4"
+  register: result
+
+- name: Check result
+  assert:
+    that:
+      - result is changed
+      - result.http_code == 204
+
+- name: Use a wrong token
+  community.general.discord:
+    webhook_id: "{{ discord_id }}"
+    webhook_token: "wrong_token"
+    content: "Messages from ansible-test"
+  register: result
+  ignore_errors: true
+
+- name: Check result
+  assert:
+    that:
+      - result is not changed
+      - result.http_code == 401
+      - result.response.message == "Invalid Webhook Token"


### PR DESCRIPTION
##### SUMMARY
Add discord integration tests
To run the tests it is necessary to created a discord server and a webhook integration.  
These tests can be executed locally with an existing discord server. 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
discord

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-test integration -v --color yes discord --allow-unsupported
```
