### PR TITLE
pacman: Fix removing locally installed packages

### DIFF
--- a/changelogs/fragments/4464-pacman-fix-local-remove.yaml
+++ b/changelogs/fragments/4464-pacman-fix-local-remove.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacman - fixed bug where absent state did not work for locally installed packages (https://github.com/ansible-collections/community.general/pull/4464).

--- a/changelogs/fragments/4464-pacman-fix-local-remove.yaml
+++ b/changelogs/fragments/4464-pacman-fix-local-remove.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pacman - fixed bug where absent state did not work for locally installed packages (https://github.com/ansible-collections/community.general/pull/4464).
+  - pacman - fixed bug where ``absent`` state did not work for locally installed packages (https://github.com/ansible-collections/community.general/pull/4464).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -627,7 +627,7 @@ class Pacman(object):
                     rc, stdout, stderr = self.m.run_command(cmd, check_rc=False)
                     if rc != 0:
                         if self.target_state == "absent":
-                            continue # Don't bark for unavailable packages when trying to remove them
+                            continue  # Don't bark for unavailable packages when trying to remove them
                         else:
                             self.fail(
                                 msg="Failed to list package %s" % (pkg),

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -610,8 +610,9 @@ class Pacman(object):
                 # Expand group members
                 for group_member in self.inventory["available_groups"][pkg]:
                     pkg_list.append(Package(name=group_member, source=group_member))
-            elif pkg in self.inventory["available_pkgs"]:
-                # just a regular pkg
+            elif pkg in self.inventory["available_pkgs"] or pkg in self.inventory["installed_pkgs"]:
+                # Just a regular pkg, either available in the repositories,
+                # or locally installed, which we need to know for absent state
                 pkg_list.append(Package(name=pkg, source=pkg))
             else:
                 # Last resort, call out to pacman to extract the info,
@@ -626,7 +627,7 @@ class Pacman(object):
                     rc, stdout, stderr = self.m.run_command(cmd, check_rc=False)
                     if rc != 0:
                         if self.target_state == "absent":
-                            continue  # Don't bark for unavailable packages when trying to remove them
+                            continue # Don't bark for unavailable packages when trying to remove them
                         else:
                             self.fail(
                                 msg="Failed to list package %s" % (pkg),

--- a/tests/integration/targets/pacman/aliases
+++ b/tests/integration/targets/pacman/aliases
@@ -5,3 +5,4 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/rhel
+needs/root

--- a/tests/integration/targets/pacman/tasks/locally_installed_package.yml
+++ b/tests/integration/targets/pacman/tasks/locally_installed_package.yml
@@ -1,0 +1,81 @@
+---
+- vars:
+    package_name: ansible-test-foo
+    username: ansible-regular-user
+  block:
+    - name: Install fakeroot
+      pacman:
+        state: present
+        name:
+          - fakeroot
+
+    - name: Create user
+      user:
+        name: '{{ username }}'
+        home: '/home/{{ username }}'
+        create_home: true
+
+    - name: Create directory
+      file:
+        path: '/home/{{ username }}/{{ package_name }}'
+        state: directory
+        owner: '{{ username }}'
+
+    - name: Create PKGBUILD
+      copy:
+        dest: '/home/{{ username }}/{{ package_name }}/PKGBUILD'
+        content: |
+          pkgname=('{{ package_name }}')
+          pkgver=1.0.0
+          pkgrel=1
+          pkgdesc="Test removing a local package not in the repositories"
+          arch=('any')
+          license=('GPL v3+')
+        owner: '{{ username }}'
+
+    - name: Build package
+      command:
+        cmd: su {{ username }} -c "makepkg -srf"
+        chdir: '/home/{{ username }}/{{ package_name }}'
+
+    - name: Install package
+      pacman:
+        state: present
+        name:
+          - '/home/{{ username }}/{{ package_name }}/{{ package_name }}-1.0.0-1-any.pkg.tar.zst'
+
+    - name: Remove package (check mode)
+      pacman:
+        state: absent
+        name:
+          - '{{ package_name }}'
+      check_mode: true
+      register: remove_1
+
+    - name: Remove package
+      pacman:
+        state: absent
+        name:
+          - '{{ package_name }}'
+      register: remove_2
+
+    - name: Remove package (idempotent)
+      pacman:
+        state: absent
+        name:
+          - '{{ package_name }}'
+      register: remove_3
+
+    - name: Check conditions
+      assert:
+        that:
+          - remove_1 is changed
+          - remove_2 is changed
+          - remove_3 is not changed
+
+  always:
+    - name: Remove directory
+      file:
+        path: '{{ remote_tmp_dir }}/{{ package_name }}'
+        state: absent
+      become: true

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -11,3 +11,4 @@
     - include: 'package_urls.yml'
     - include: 'remove_nosave.yml'
     - include: 'update_cache.yml'
+    - include: 'locally_installed_package.yml'


### PR DESCRIPTION
##### SUMMARY
Without this, using `absent` state for a locally installed package (for example from AUR, or from a package that was dropped from repositories) would return that package is already removed, despite remaining installed

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pacman