### PR TITLE
Fix documentation for sudoers module

### DIFF
--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -23,6 +23,7 @@ options:
     description:
       - The commands allowed by the sudoers rule.
       - Multiple can be added by passing a list of commands.
+      - Use ALL for all commands
     type: list
     elements: str
   group:
@@ -80,7 +81,7 @@ EXAMPLES = '''
     state: present
     user: bob
     runas: alice
-    commands: ANY
+    commands: ALL
 
 - name: >-
     Allow the monitoring group to run sudo /usr/local/bin/gather-app-metrics

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -23,7 +23,7 @@ options:
     description:
       - The commands allowed by the sudoers rule.
       - Multiple can be added by passing a list of commands.
-      - Use ALL for all commands
+      - Use C(ALL) for all commands.
     type: list
     elements: str
   group:


### PR DESCRIPTION
##### SUMMARY
The sudoers module has a documentation bug where the examples show ANY as what should be used to allow running of any command.
The correct is ALL.
Fix the example and add ALL into the docs for commands:


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
sudoers.py

##### ADDITIONAL INFORMATION
Took sudoer module into use, and noted that using ANY does not actually work. Checking the man page for sudoers, it should be ALL.


