### PR TITLE
Add project support for lxd_container and lxd_profile module

### DIFF
--- a/changelogs/fragments/4479-add-project-support-for-lxd_container-and-lxd_profile.yml
+++ b/changelogs/fragments/4479-add-project-support-for-lxd_container-and-lxd_profile.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - lxd_container - adds ``project`` option to allow selecting project for lxd instance (https://github.com/ansible-collections/community.general/pull/4479).
+  - lxd_profile - adds ``project`` option to allow selecting project for lxd profile (https://github.com/ansible-collections/community.general/pull/4479).

--- a/changelogs/fragments/4479-add-project-support-for-lxd_container-and-lxd_profile.yml
+++ b/changelogs/fragments/4479-add-project-support-for-lxd_container-and-lxd_profile.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - lxd_container - adds ``project`` option to allow selecting project for lxd instance (https://github.com/ansible-collections/community.general/pull/4479).
-  - lxd_profile - adds ``project`` option to allow selecting project for lxd profile (https://github.com/ansible-collections/community.general/pull/4479).
+  - lxd_container - adds ``project`` option to allow selecting project for LXD instance (https://github.com/ansible-collections/community.general/pull/4479).
+  - lxd_profile - adds ``project`` option to allow selecting project for LXD profile (https://github.com/ansible-collections/community.general/pull/4479).

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -27,6 +27,7 @@ options:
             See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
         required: false
         type: str
+        version_added: 4.8.0
     architecture:
         description:
           - 'The architecture for the instance (for example C(x86_64) or C(i686)).

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -21,6 +21,12 @@ options:
           - Name of an instance.
         type: str
         required: true
+    project:
+        description:
+         - 'Project of an instance.
+           See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
+         type: str
+         required: false
     architecture:
         description:
           - 'The architecture for the instance (for example C(x86_64) or C(i686)).
@@ -248,6 +254,25 @@ EXAMPLES = '''
         wait_for_ipv4_addresses: true
         timeout: 600
 
+# An example for creating container in project other than default
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Create a started container in project mytestproject
+      community.general.lxd_container:
+        name: mycontainer
+        project: mytestproject
+        ignore_volatile_options: true
+        state: started
+          protocol: simplestreams
+          type: image
+          mode: pull
+          server: https://images.linuxcontainers.org
+          alias: ubuntu/20.04/cloud
+        profiles: ["default"]
+        wait_for_ipv4_addresses: true
+        timeout: 600
+
 # An example for deleting a container
 - hosts: localhost
   connection: local
@@ -412,6 +437,7 @@ class LXDContainerManagement(object):
         """
         self.module = module
         self.name = self.module.params['name']
+        self.project = self.module.params['project']
         self._build_config()
 
         self.state = self.module.params['state']
@@ -468,16 +494,16 @@ class LXDContainerManagement(object):
                 self.config[attr] = param_val
 
     def _get_instance_json(self):
-        return self.client.do(
-            'GET', '{0}/{1}'.format(self.api_endpoint, self.name),
-            ok_error_codes=[404]
-        )
+        url = '{0}/{1}'.format(self.api_endpoint, self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        return self.client.do('GET', url, ok_error_codes=[404])
 
     def _get_instance_state_json(self):
-        return self.client.do(
-            'GET', '{0}/{1}/state'.format(self.api_endpoint, self.name),
-            ok_error_codes=[404]
-        )
+        url = '{0}/{1}/state'.format(self.api_endpoint, self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        return self.client.do('GET', url, ok_error_codes=[404])
 
     @staticmethod
     def _instance_json_to_module_state(resp_json):
@@ -486,18 +512,26 @@ class LXDContainerManagement(object):
         return ANSIBLE_LXD_STATES[resp_json['metadata']['status']]
 
     def _change_state(self, action, force_stop=False):
+        url = '{0}/{1}/state'.format(self.api_endpoint, self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
         body_json = {'action': action, 'timeout': self.timeout}
         if force_stop:
             body_json['force'] = True
-        return self.client.do('PUT', '{0}/{1}/state'.format(self.api_endpoint, self.name), body_json=body_json)
+        return self.client.do('PUT', url, body_json=body_json)
 
     def _create_instance(self):
+        url = self.api_endpoint
+        url_params = dict()
+        if self.target:
+            url_params['target'] = self.target
+        if self.project:
+            url_params['project'] = self.project
+        if url_params:
+            url = '{0}?{1}'.format(url, urlencode(url_params))
         config = self.config.copy()
         config['name'] = self.name
-        if self.target:
-            self.client.do('POST', '{0}?{1}'.format(self.api_endpoint, urlencode(dict(target=self.target))), config, wait_for_container=self.wait_for_container)
-        else:
-            self.client.do('POST', self.api_endpoint, config, wait_for_container=self.wait_for_container)
+        self.client.do('POST', url, config, wait_for_container=self.wait_for_container)
         self.actions.append('create')
 
     def _start_instance(self):
@@ -513,7 +547,10 @@ class LXDContainerManagement(object):
         self.actions.append('restart')
 
     def _delete_instance(self):
-        self.client.do('DELETE', '{0}/{1}'.format(self.api_endpoint, self.name))
+        url = '{0}/{1}'.format(self.api_endpoint, self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        self.client.do('DELETE', url)
         self.actions.append('delete')
 
     def _freeze_instance(self):
@@ -666,7 +703,10 @@ class LXDContainerManagement(object):
         if self._needs_to_change_instance_config('profiles'):
             body_json['profiles'] = self.config['profiles']
 
-        self.client.do('PUT', '{0}/{1}'.format(self.api_endpoint, self.name), body_json=body_json)
+        url = '{0}/{1}'.format(self.api_endpoint, self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        self.client.do('PUT', url, body_json=body_json)
         self.actions.append('apply_instance_configs')
 
     def run(self):
@@ -714,6 +754,9 @@ def main():
             name=dict(
                 type='str',
                 required=True
+            ),
+            project=dict(
+                type='str',
             ),
             architecture=dict(
                 type='str',

--- a/plugins/modules/cloud/lxd/lxd_container.py
+++ b/plugins/modules/cloud/lxd/lxd_container.py
@@ -23,10 +23,10 @@ options:
         required: true
     project:
         description:
-         - 'Project of an instance.
-           See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
-         type: str
-         required: false
+          - 'Project of an instance.
+            See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
+        required: false
+        type: str
     architecture:
         description:
           - 'The architecture for the instance (for example C(x86_64) or C(i686)).
@@ -264,6 +264,7 @@ EXAMPLES = '''
         project: mytestproject
         ignore_volatile_options: true
         state: started
+        source:
           protocol: simplestreams
           type: image
           mode: pull

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -27,6 +27,7 @@ options:
            See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
         type: str
         required: false
+        version_added: 4.8.0
     description:
         description:
           - Description of the profile.

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -21,6 +21,12 @@ options:
           - Name of a profile.
         required: true
         type: str
+    project:
+        description:
+         - 'Project of a profile.
+           See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
+        type: str
+        required: false
     description:
         description:
           - Description of the profile.
@@ -129,6 +135,18 @@ EXAMPLES = '''
             parent: br0
             type: nic
 
+# An example for creating a profile in project mytestproject
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Create a profile
+      community.general.lxd_profile:
+        name: testprofile
+        state: present
+        config: {}
+        description: test profile in project mytestproject
+        devices: {}
+
 # An example for creating a profile via http connection
 - hosts: localhost
   connection: local
@@ -208,6 +226,7 @@ actions:
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.lxd import LXDClient, LXDClientException
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 # ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
 ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
@@ -232,6 +251,7 @@ class LXDProfileManagement(object):
         """
         self.module = module
         self.name = self.module.params['name']
+        self.project = self.module.params['project']
         self._build_config()
         self.state = self.module.params['state']
         self.new_name = self.module.params.get('new_name', None)
@@ -272,10 +292,10 @@ class LXDProfileManagement(object):
                 self.config[attr] = param_val
 
     def _get_profile_json(self):
-        return self.client.do(
-            'GET', '/1.0/profiles/{0}'.format(self.name),
-            ok_error_codes=[404]
-        )
+        url = '/1.0/profiles/{0}'.format(self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        return self.client.do('GET', url, ok_error_codes=[404])
 
     @staticmethod
     def _profile_json_to_module_state(resp_json):
@@ -307,14 +327,20 @@ class LXDProfileManagement(object):
                         changed=False)
 
     def _create_profile(self):
+        url = '/1.0/profiles'
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
         config = self.config.copy()
         config['name'] = self.name
-        self.client.do('POST', '/1.0/profiles', config)
+        self.client.do('POST', url, config)
         self.actions.append('create')
 
     def _rename_profile(self):
+        url = '/1.0/profiles/{0}'.format(self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
         config = {'name': self.new_name}
-        self.client.do('POST', '/1.0/profiles/{0}'.format(self.name), config)
+        self.client.do('POST', url, config)
         self.actions.append('rename')
         self.name = self.new_name
 
@@ -421,11 +447,17 @@ class LXDProfileManagement(object):
             config = self._generate_new_config(config)
 
         # upload config to lxd
-        self.client.do('PUT', '/1.0/profiles/{0}'.format(self.name), config)
+        url = '/1.0/profiles/{0}'.format(self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        self.client.do('PUT', url, config)
         self.actions.append('apply_profile_configs')
 
     def _delete_profile(self):
-        self.client.do('DELETE', '/1.0/profiles/{0}'.format(self.name))
+        url = '/1.0/profiles/{0}'.format(self.name)
+        if self.project:
+            url = '{0}?{1}'.format(url, urlencode(dict(project=self.project)))
+        self.client.do('DELETE', url)
         self.actions.append('delete')
 
     def run(self):
@@ -468,6 +500,9 @@ def main():
             name=dict(
                 type='str',
                 required=True
+            ),
+            project=dict(
+                type='str',
             ),
             new_name=dict(
                 type='str',

--- a/plugins/modules/cloud/lxd/lxd_profile.py
+++ b/plugins/modules/cloud/lxd/lxd_profile.py
@@ -143,6 +143,7 @@ EXAMPLES = '''
     - name: Create a profile
       community.general.lxd_profile:
         name: testprofile
+        project: mytestproject
         state: present
         config: {}
         description: test profile in project mytestproject


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add [lxd project](https://linuxcontainers.org/lxd/docs/master/projects/) support to 'lxd_container' and 'lxd_profile' module

A new module parameter 'project' is added, if the parameter is set module will perform operations on the selected project.


This is related to:
* #4475 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* lxd_container
* lxd_profile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This change is backward compatible, if project parameter is not set,  query parameter will not be added.

Tested on Ubuntu 20.04 with LXD 4.24 including:
* instance without project
* instance with project
* profile without project
* profile with project 

