### PR TITLE
nmap.py: add option sudo to let sudoers to fully use nmap plugin and …

### DIFF
--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -21,6 +21,10 @@ DOCUMENTATION = '''
             description: token that ensures this is a source file for the 'nmap' plugin.
             required: True
             choices: ['nmap', 'community.general.nmap']
+        sudo:
+            description: execute nmap with sudo
+            type: boolean
+            default: False
         address:
             description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
             required: True
@@ -135,8 +139,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not user_cache_setting or cache_needs_update:
             # setup command
             cmd = [self._nmap]
+
+            if self._options['sudo']:
+                cmd.insert(0, 'sudo')
+
             if not self._options['ports']:
-                cmd.append('-sP')
+                cmd.append('-sV')
+                cmd.append('-p 22')
+                cmd.append('--open')
+                cmd.append('-n')
 
             if self._options['ipv4'] and not self._options['ipv6']:
                 cmd.append('-4')


### PR DESCRIPTION
…modify nmap flags just to scan port 22, if port option is false

##### SUMMARY
If you use nmap plugin with an unprivileged user, its results are incomplete or confusing.
To avoid that, you have to launch a sudo ansible-playbook, so I have added a boolean sudo option that if set to Yes, it executes a "sudo nmap". 
Besides, I changed nmap flags just to scan for open ssh port, as inventory is mainly intended to list connectables target machines.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmap.py

##### ADDITIONAL INFORMATION


