### PR TITLE
gitlab: Use `all=True` in most `list()` calls

### DIFF
--- a/changelogs/fragments/4491-specify_all_in_list_calls.yaml
+++ b/changelogs/fragments/4491-specify_all_in_list_calls.yaml
@@ -1,0 +1,23 @@
+bugfixes:
+  - >
+    gitlab_group_members - handle more than 20 groups when finding a group
+    (https://github.com/ansible-collections/community.general/pull/4491,
+    https://github.com/ansible-collections/community.general/issues/4460,
+    https://github.com/ansible-collections/community.general/issues/3729).
+  - >
+    gitlab_group - improve searching for projects inside group on deletion
+    (https://github.com/ansible-collections/community.general/pull/4491).
+  - >
+    gitlab_hook - handle more than 20 hooks when finding a hook
+    (https://github.com/ansible-collections/community.general/pull/4491).
+  - >
+    gitlab_project - handle more than 20 namespaces when finding a namespace
+    (https://github.com/ansible-collections/community.general/pull/4491).
+  - >
+    gitlab_project_members - handle more than 20 projects and users when
+    finding a project resp. user
+    (https://github.com/ansible-collections/community.general/pull/4491).
+  - >
+    gitlab_user - handle more than 20 users and SSH keys when finding a user
+    resp. SSH key
+    (https://github.com/ansible-collections/community.general/pull/4491).

--- a/plugins/modules/source_control/gitlab/gitlab_group.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group.py
@@ -279,7 +279,7 @@ class GitLabGroup(object):
     def delete_group(self):
         group = self.group_object
 
-        if len(group.projects.list()) >= 1:
+        if len(group.projects.list(all=False)) >= 1:
             self._module.fail_json(
                 msg="There are still projects in this group. These needs to be moved or deleted before this group can be removed.")
         else:

--- a/plugins/modules/source_control/gitlab/gitlab_group_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_group_members.py
@@ -172,13 +172,13 @@ class GitLabGroup(object):
 
     # get user id if the user exists
     def get_user_id(self, gitlab_user):
-        user_exists = self._gitlab.users.list(username=gitlab_user)
+        user_exists = self._gitlab.users.list(username=gitlab_user, all=True)
         if user_exists:
             return user_exists[0].id
 
     # get group id if group exists
     def get_group_id(self, gitlab_group):
-        groups = self._gitlab.groups.list(search=gitlab_group)
+        groups = self._gitlab.groups.list(search=gitlab_group, all=True)
         for group in groups:
             if group.full_path == gitlab_group:
                 return group.id

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -268,7 +268,7 @@ class GitLabHook(object):
     @param hook_url Url to call on event
     '''
     def find_hook(self, project, hook_url):
-        hooks = project.hooks.list()
+        hooks = project.hooks.list(all=True)
         for hook in hooks:
             if (hook.url == hook_url):
                 return hook

--- a/plugins/modules/source_control/gitlab/gitlab_project.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project.py
@@ -494,9 +494,9 @@ def main():
         namespace_id = group.id
     else:
         if username:
-            namespace = gitlab_instance.namespaces.list(search=username)[0]
+            namespace = gitlab_instance.namespaces.list(search=username, all=False)[0]
         else:
-            namespace = gitlab_instance.namespaces.list(search=gitlab_instance.user.username)[0]
+            namespace = gitlab_instance.namespaces.list(search=gitlab_instance.user.username, all=False)[0]
         namespace_id = namespace.id
 
     if not namespace_id:

--- a/plugins/modules/source_control/gitlab/gitlab_project_members.py
+++ b/plugins/modules/source_control/gitlab/gitlab_project_members.py
@@ -178,12 +178,12 @@ class GitLabProjectMembers(object):
             project_exists = self._gitlab.projects.get(project_name)
             return project_exists.id
         except gitlab.exceptions.GitlabGetError as e:
-            project_exists = self._gitlab.projects.list(search=project_name)
+            project_exists = self._gitlab.projects.list(search=project_name, all=False)
             if project_exists:
                 return project_exists[0].id
 
     def get_user_id(self, gitlab_user):
-        user_exists = self._gitlab.users.list(username=gitlab_user)
+        user_exists = self._gitlab.users.list(username=gitlab_user, all=False)
         if user_exists:
             return user_exists[0].id
 

--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -349,7 +349,7 @@ class GitLabUser(object):
     @param sshkey_name Name of the ssh key
     '''
     def ssh_key_exists(self, user, sshkey_name):
-        keyList = map(lambda k: k.title, user.keys.list())
+        keyList = map(lambda k: k.title, user.keys.list(all=True))
 
         return sshkey_name in keyList
 
@@ -519,7 +519,7 @@ class GitLabUser(object):
     @param username Username of the user
     '''
     def find_user(self, username):
-        users = self._gitlab.users.list(search=username)
+        users = self._gitlab.users.list(search=username, all=True)
         for user in users:
             if (user.username == username):
                 return user


### PR DESCRIPTION
#### SUMMARY

Use `all=True` in most `list()` calls

##### ISSUE TYPE

  * Bugfix Pull Request

##### ADDITIONAL INFORMATION
If `all=True` is not set then by default only 20 records will be
returned when calling `list()`. Use `all=True` so that all records
will be returned.

For the `list()` use where do not desire to retrieve all entries then
use`all=False` to show explicityly that we don't want to get all of
the entries.

Fixes #3729, fixes #4460