### PR TITLE
remove deprecated branch.protect() method in community.general.gitlab_branch

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_branch.py
+++ b/plugins/modules/source_control/gitlab/gitlab_branch.py
@@ -110,7 +110,6 @@ class GitlabBranch(object):
         return self.project.branches.create({'branch': branch, 'ref': ref_branch})
 
     def delete_branch(self, branch):
-        branch.unprotect()
         return branch.delete()
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`branch.protect()` method has been deprecated on upstream [python-gitlab/python-gitlab](https://github.com/python-gitlab/python-gitlab)

refer to the commit: https://github.com/python-gitlab/python-gitlab/commit/9656a16f9f34a1aeb8ea0015564bad68ffb39c26

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
[community.general.gitlab_branch](https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_branch_module.html)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
By using the latest python-gitlab, when delete branch, got error
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'ProjectBranch' object has no attribute 'unprotect'
```
