### PR TITLE
gitlab_user: remove no longer true statement from documentation

### DIFF
--- a/plugins/modules/source_control/gitlab/gitlab_user.py
+++ b/plugins/modules/source_control/gitlab/gitlab_user.py
@@ -48,7 +48,6 @@ options:
     description:
       - The password of the user.
       - GitLab server enforces minimum password length to 8, set this value with 8 or more characters.
-      - Required only if C(state) is set to C(present).
     type: str
   reset_password:
     description:


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible-collections/community.general/issues/1892#issuecomment-1097818144

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
gitlab_user
