### PR TITLE
nmap inventory plugin: Add sudo nmap

### DIFF
--- a/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
+++ b/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- nmap inventory plugin - add sudo option in plugin in order to execute the plugin with a non root user with sudo right on nmap executable (https://github.com/ansible-collections/community.general/pull/4506).
+- nmap inventory plugin - add ``sudo`` option in plugin in order to execute ``sudo nmap`` so that ``nmap`` runs with elevated privileges (https://github.com/ansible-collections/community.general/pull/4506).

--- a/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
+++ b/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  -  nmap.py - add sudo option in plugin in order to execute the plugin with a non root user with sudo right on nmap executable
-     (https://github.com/ansible-collections/community.general/pull/4506).
+- nmap.py - add sudo option in plugin in order to execute the plugin with a non root user 
+   with sudo right on nmap executable (https://github.com/ansible-collections/community.general/pull/4506).

--- a/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
+++ b/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
@@ -1,3 +1,2 @@
 minor_changes:
-- nmap.py - add sudo option in plugin in order to execute the plugin with a non root user 
-   with sudo right on nmap executable (https://github.com/ansible-collections/community.general/pull/4506).
+- nmap inventory plugin - add sudo option in plugin in order to execute the plugin with a non root user with sudo right on nmap executable (https://github.com/ansible-collections/community.general/pull/4506).

--- a/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
+++ b/changelogs/fragments/4506-sudo-in-nmap-inv-plugin.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  -  nmap.py - add sudo option in plugin in order to execute the plugin with a non root user with sudo right on nmap executable
+     (https://github.com/ansible-collections/community.general/pull/4506).

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -21,6 +21,10 @@ DOCUMENTATION = '''
             description: token that ensures this is a source file for the 'nmap' plugin.
             required: True
             choices: ['nmap', 'community.general.nmap']
+        sudo:
+            description: set to Yes to execute a "sudo nmap" plugin scan.
+            required: False
+            type: boolean
         address:
             description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
             required: True
@@ -47,6 +51,13 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 # inventory.config file in YAML format
 plugin: community.general.nmap
+strict: False
+address: 192.168.0.0/24
+
+
+# a sudo nmap scan to fully use nmap scan power.
+plugin: community.general.nmap
+sudo: yes
 strict: False
 address: 192.168.0.0/24
 '''
@@ -135,6 +146,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not user_cache_setting or cache_needs_update:
             # setup command
             cmd = [self._nmap]
+
+            if self._options['sudo']:
+                cmd.insert(0, 'sudo')
+
             if not self._options['ports']:
                 cmd.append('-sP')
 

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
         sudo:
             description: Set to C(true) to execute a C(sudo nmap) plugin scan.
             version_added: 4.8.0
+            default: false
             type: boolean
         address:
             description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -57,7 +57,7 @@ address: 192.168.0.0/24
 
 # a sudo nmap scan to fully use nmap scan power.
 plugin: community.general.nmap
-sudo: yes
+sudo: true
 strict: False
 address: 192.168.0.0/24
 '''

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -22,8 +22,8 @@ DOCUMENTATION = '''
             required: True
             choices: ['nmap', 'community.general.nmap']
         sudo:
-            description: set to Yes to execute a "sudo nmap" plugin scan.
-            required: False
+            description: Set to C(true) to execute a C(sudo nmap) plugin scan.
+            version_added: 4.8.0
             type: boolean
         address:
             description: Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.


### PR DESCRIPTION
##### SUMMARY
nmap executable works well when it is issued by a privileged user, because unprivileged users lacks of network raw socket rights.

As inventory plugin, to proper use it, you have to launch `ansible-inventory` from root or  `sudo ansible-inventory nmap_scan.yaml`, that in general is not a good idea.

So I have added a boolean sudo option that if set to Yes, it executes a "sudo nmap", so it will need an unprivileged user just with sudo power on nmap command 
i.e.
```
plugin: nmap
sudo: yes          # indicates that you are running it from an unprivileged user with sudo rights on nmap 
address: 192.168.0.0/24
exclude: 192.168.0.1, server2.example.com
ports: false
strict: false
```
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
general/plugins/inventory/nmap.py
