### PR TITLE
Correctly handle exception when no VM name returned by proxmox

### DIFF
--- a/changelogs/fragments/4492-proxmox_kvm_fix_vm_without_name.yaml
+++ b/changelogs/fragments/4492-proxmox_kvm_fix_vm_without_name.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - fix a bug when getting a state of VM without name will fail (https://github.com/ansible-collections/community.general/pull/4508).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1397,7 +1397,7 @@ def main():
             module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
         vm = proxmox.get_vm(vmid)
         if not name:
-            name = vm['name']
+            name = vm.get('name', '(unnamed)')
         current = proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).status.current.get()['status']
         status['status'] = current
         if status:


### PR DESCRIPTION
##### SUMMARY
Handle a case when proxmox didn't return the VM name, which is generally wrong behavior on proxmox side, but can happen and we shouldn't fail.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm
##### ADDITIONAL INFORMATION
I was running a task:
```
    - name: Get VM state
      community.general.proxmox_kvm:
        api_host: '{{ proxmox_conf.api_host }}'
        api_user: '{{ proxmox_conf.api_user }}'
        api_token_id: '{{ proxmox_conf.api_token_id }}'
        api_token_secret: '{{ proxmox_conf.api_token_secret }}'
        proxmox_default_behavior: compatibility
        state: current
        vmid: '{{ item.vmid }}'
      register: vmstate
      with_items: '{{ clone.results }}'
      loop_control:
        pause: 1

```
and randomly (a frequency is 1/20, but maybe it depends on the API calls load on the backend proxmox) I get the failure like:

```
TASK [Get VM state] ************************************************************
221An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'name'
222failed: [localhost] (item={'changed': True, 'vmid': 59187, 'msg': 'VM 759936qjy4vwMoleculeAlma8OnProxmox with newid 59187 cloned from vm with vmid 124', 'invocation': {'module_args': {'api_host': '10.214.45.198:8006', 'api_user': '[MASKED]', 'api_token_id': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'api_token_secret': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'proxmox_default_behavior': 'compatibility', 'clone': 'Alma8-template', 'full': False, 'format': None, 'node': 'plcyf-pve02', 'newid': 59187, 'name': '759936qjy4vwMoleculeAlma8OnProxmox', 'vmid': 124, 'timeout': 600, 'state': 'present', 'update': False, 'validate_certs': False, 'acpi': True, 'agent': None, 'args': None, 'api_password': None, 'autostart': False, 'balloon': 0, 'bios': None, 'boot': 'cnd', 'bootdisk': None, 'cicustom': None, 'cipassword': None, 'citype': None, 'ciuser': None, 'cores': 1, 'cpu': 'kvm64', 'cpulimit': None, 'cpuunits': 1000, 'delete': None, 'description': None, 'digest': None, 'force': None, 'freeze': None, 'hostpci': None, 'hotplug': None, 'hugepages': None, 'ide': None, 'ipconfig': None, 'keyboard': None, 'kvm': True, 'localtime': None, 'lock': None, 'machine': None, 'memory': 512, 'migrate_downtime': None, 'migrate_speed': None, 'net': None, 'numa': None, 'numa_enabled': None, 'onboot': None, 'ostype': 'l26', 'parallel': None, 'pool': None, 'protection': None, 'reboot': None, 'revert': None, 'sata': None, 'scsi': None, 'scsihw': None, 'serial': None, 'shares': None, 'skiplock': None, 'smbios': None, 'snapname': None, 'sockets': 1, 'sshkeys': None, 'startdate': None, 'startup': None, 'storage': None, 'tablet': False, 'tags': None, 'target': None, 'tdf': None, 'template': False, 'vcpus': None, 'vga': 'std', 'virtio': None, 'watchdog': None}}, 'failed': False, 'item': {'groups': ['plcyf', 'all'], 'name': 'Alma8OnProxmox', 'template': 'Alma8-template', 'template_id': 124}, 'ansible_loop_var': 'item'}) => {"ansible_loop_var": "item", "changed": false, "item": {"ansible_loop_var": "item", "changed": true, "failed": false, "invocation": {"module_args": {"acpi": true, "agent": null, "api_host": "10.214.45.198:8006", "api_password": null, "api_token_id": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "api_token_secret": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "api_user": "[MASKED]", "args": null, "autostart": false, "balloon": 0, "bios": null, "boot": "cnd", "bootdisk": null, "cicustom": null, "cipassword": null, "citype": null, "ciuser": null, "clone": "Alma8-template", "cores": 1, "cpu": "kvm64", "cpulimit": null, "cpuunits": 1000, "delete": null, "description": null, "digest": null, "force": null, "format": null, "freeze": null, "full": false, "hostpci": null, "hotplug": null, "hugepages": null, "ide": null, "ipconfig": null, "keyboard": null, "kvm": true, "localtime": null, "lock": null, "machine": null, "memory": 512, "migrate_downtime": null, "migrate_speed": null, "name": "759936qjy4vwMoleculeAlma8OnProxmox", "net": null, "newid": 59187, "node": "plcyf-pve02", "numa": null, "numa_enabled": null, "onboot": null, "ostype": "l26", "parallel": null, "pool": null, "protection": null, "proxmox_default_behavior": "compatibility", "reboot": null, "revert": null, "sata": null, "scsi": null, "scsihw": null, "serial": null, "shares": null, "skiplock": null, "smbios": null, "snapname": null, "sockets": 1, "sshkeys": null, "startdate": null, "startup": null, "state": "present", "storage": null, "tablet": false, "tags": null, "target": null, "tdf": null, "template": false, "timeout": 600, "update": false, "validate_certs": false, "vcpus": null, "vga": "std", "virtio": null, "vmid": 124, "watchdog": null}}, "item": {"groups": ["plcyf", "all"], "name": "Alma8OnProxmox", "template": "Alma8-template", "template_id": 124}, "msg": "VM 759936qjy4vwMoleculeAlma8OnProxmox with newid 59187 cloned from vm with vmid 124", "vmid": 59187}, "module_stderr": "Traceback (most recent call last):\n  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 100, in <module>\n    _ansiballz_main()\n  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 41, in invoke_module\n    run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.general.proxmox_kvm_payload_6v5m9gur/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py\", line 1411, in <module>\n  File \"/tmp/ansible_community.general.proxmox_kvm_payload_6v5m9gur/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py\", line 1403, in main\nKeyError: 'name'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

The python error nicely formatted:
```
Traceback (most recent call last):
  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 100, in <module>
    _ansiballz_main()
  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 92, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/home/gitlab-runner/.ansible/tmp/ansible-tmp-1650018833.6964254-3818157-29224231583482/AnsiballZ_proxmox_kvm.py\", line 41, in invoke_module
    run_name='__main__', alter_sys=True)
  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_community.general.proxmox_kvm_payload_6v5m9gur/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py\", line 1411, in <module>
  File \"/tmp/ansible_community.general.proxmox_kvm_payload_6v5m9gur/ansible_community.general.proxmox_kvm_payload.zip/ansible_collections/community/general/plugins/modules/proxmox_kvm.py\", line 1403, in main
KeyError: 'name'

```