### PR TITLE
CI: remove FreeBSD 12.0 and 12.2, re-enable pkgng tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -280,8 +280,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
+            #- name: FreeBSD 12.2
+            #  test: freebsd/12.2
           groups:
             - 1
             - 2
@@ -312,8 +312,8 @@ stages:
               test: rhel/8.2
             - name: RHEL 7.8
               test: rhel/7.8
-            - name: FreeBSD 12.0
-              test: freebsd/12.0
+            #- name: FreeBSD 12.0
+            #  test: freebsd/12.0
           groups:
             - 1
             - 2

--- a/tests/integration/targets/pkgng/aliases
+++ b/tests/integration/targets/pkgng/aliases
@@ -3,4 +3,3 @@ needs/root
 skip/docker
 skip/osx
 skip/rhel
-disabled  # FIXME


### PR DESCRIPTION
##### SUMMARY
Looks like FreeBSD 12.2 and 12.0 packages were removed from most mirrors, which causes tests to fail. Let's drop them from testing (at least temporarily, maybe even permanently).

Fixes #4492.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
