### PR TITLE
Implement contructable support for opennebula inventory plugin: keyed…

### DIFF
--- a/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
+++ b/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
@@ -1,3 +1,3 @@
 ---
-bugfix:
+bugfixes:
   - opennebula inventory plugin - complete the implementation of ``constructable`` for opennebula inventory plugin allows keyed_groups, compose, groups.  (https://github.com/ansible-collections/community.general/issues/4497)

--- a/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
+++ b/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
@@ -1,0 +1,3 @@
+---
+bugfix:
+  - opennebula inventory plugin - complete the implementation of ``constructable`` for opennebula inventory plugin allows keyed_groups, compose, groups.  (https://github.com/ansible-collections/community.general/issues/4497)

--- a/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
+++ b/changelogs/fragments/4524-update-opennebula-inventory-plugin-to-match-documentation.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - opennebula inventory plugin - complete the implementation of ``constructable`` for opennebula inventory plugin allows keyed_groups, compose, groups.  (https://github.com/ansible-collections/community.general/issues/4497)
+  - opennebula inventory plugin - complete the implementation of ``constructable`` for opennebula inventory plugin. Now ``keyed_groups``, ``compose``, ``groups`` actually work (https://github.com/ansible-collections/community.general/issues/4497).

--- a/tests/unit/plugins/inventory/fixtures/opennebula_inventory.json
+++ b/tests/unit/plugins/inventory/fixtures/opennebula_inventory.json
@@ -1,0 +1,222 @@
+[
+    {
+        "DEPLOY_ID": "bcfec9d9-c0d0-4523-b5e7-62993947e94c",
+        "ETIME": 0,
+        "GID": 105,
+        "GNAME": "SW",
+        "HISTORY_RECORDS": {},
+        "ID": 451,
+        "LAST_POLL": 0,
+        "LCM_STATE": 3,
+        "MONITORING": {},
+        "NAME": "terraform_demo_00",
+        "RESCHED": 0,
+        "STATE": 3,
+        "STIME": 1649886492,
+        "TEMPLATE": {
+            "NIC": [
+                {
+                    "AR_ID": "0",
+                    "BRIDGE": "mgmt0",
+                    "BRIDGE_TYPE": "linux",
+                    "CLUSTER_ID": "0",
+                    "IP": "192.168.11.248",
+                    "MAC": "02:00:c0:a8:2b:bb",
+                    "MODEL": "virtio",
+                    "NAME": "NIC0",
+                    "NETWORK": "Infrastructure",
+                    "NETWORK_ID": "0",
+                    "NIC_ID": "0",
+                    "SECURITY_GROUPS": "0,101",
+                    "TARGET": "one-453-0",
+                    "VLAN_ID": "12",
+                    "VN_MAD": "802.1Q"
+                }
+            ],
+            "NIC_DEFAULT": {
+                "MODEL": "virtio"
+            },
+            "TEMPLATE_ID": "28",
+            "TM_MAD_SYSTEM": "shared",
+            "VCPU": "4",
+            "VMID": "453"
+        },
+        "USER_TEMPLATE": {
+            "GUEST_OS": "linux",
+            "INPUTS_ORDER": "",
+            "LABELS": "foo,bench",
+            "LOGO": "images/logos/linux.png",
+            "MEMORY_UNIT_COST": "MB",
+            "SCHED_REQUIREMENTS": "ARCH=\"x86_64\"",
+            "TGROUP": "bench_clients"
+        }
+    },
+    {
+        "DEPLOY_ID": "25895435-5e3a-4d50-a025-e03a7a463abd",
+        "ETIME": 0,
+        "GID": 105,
+        "GNAME": "SW",
+        "HISTORY_RECORDS": {},
+        "ID": 451,
+        "LAST_POLL": 0,
+        "LCM_STATE": 3,
+        "MONITORING": {},
+        "NAME": "terraform_demo_01",
+        "RESCHED": 0,
+        "STATE": 3,
+        "STIME": 1649886492,
+        "TEMPLATE": {
+            "NIC": [
+                {
+                    "AR_ID": "0",
+                    "BRIDGE": "mgmt0",
+                    "BRIDGE_TYPE": "linux",
+                    "CLUSTER_ID": "0",
+                    "IP": "192.168.11.241",
+                    "MAC": "02:00:c0:a8:4b:bb",
+                    "MODEL": "virtio",
+                    "NAME": "NIC0",
+                    "NETWORK": "Infrastructure",
+                    "NETWORK_ID": "0",
+                    "NIC_ID": "0",
+                    "SECURITY_GROUPS": "0,101",
+                    "TARGET": "one-451-0",
+                    "VLAN_ID": "12",
+                    "VN_MAD": "802.1Q"
+                }
+            ],
+            "NIC_DEFAULT": {
+                "MODEL": "virtio"
+            },
+            "TEMPLATE_ID": "28",
+            "TM_MAD_SYSTEM": "shared",
+            "VCPU": "4",
+            "VMID": "451"
+        },
+        "USER_TEMPLATE": {
+            "GUEST_OS": "linux",
+            "INPUTS_ORDER": "",
+            "LABELS": "foo,bench",
+            "LOGO": "images/logos/linux.png",
+            "MEMORY_UNIT_COST": "MB",
+            "SCHED_REQUIREMENTS": "ARCH=\"x86_64\"",
+            "TESTATTR": "testvar",
+            "TGROUP": "bench_clients"
+        }
+    },
+    {
+        "DEPLOY_ID": "2b00c379-3601-45ee-acf5-e7b3ff2b7bca",
+        "ETIME": 0,
+        "GID": 105,
+        "GNAME": "SW",
+        "HISTORY_RECORDS": {},
+        "ID": 451,
+        "LAST_POLL": 0,
+        "LCM_STATE": 3,
+        "MONITORING": {},
+        "NAME": "terraform_demo_srv_00",
+        "RESCHED": 0,
+        "STATE": 3,
+        "STIME": 1649886492,
+        "TEMPLATE": {
+            "NIC": [
+                {
+                    "AR_ID": "0",
+                    "BRIDGE": "mgmt0",
+                    "BRIDGE_TYPE": "linux",
+                    "CLUSTER_ID": "0",
+                    "IP": "192.168.11.247",
+                    "MAC": "02:00:c0:a8:0b:cc",
+                    "MODEL": "virtio",
+                    "NAME": "NIC0",
+                    "NETWORK": "Infrastructure",
+                    "NETWORK_ID": "0",
+                    "NIC_ID": "0",
+                    "SECURITY_GROUPS": "0,101",
+                    "TARGET": "one-452-0",
+                    "VLAN_ID": "12",
+                    "VN_MAD": "802.1Q"
+                }
+            ],
+            "NIC_DEFAULT": {
+                "MODEL": "virtio"
+            },
+            "TEMPLATE_ID": "28",
+            "TM_MAD_SYSTEM": "shared",
+            "VCPU": "4",
+            "VMID": "452"
+        },
+        "USER_TEMPLATE": {
+            "GUEST_OS": "linux",
+            "INPUTS_ORDER": "",
+            "LABELS": "serv,bench",
+            "LOGO": "images/logos/linux.png",
+            "MEMORY_UNIT_COST": "MB",
+            "SCHED_REQUIREMENTS": "ARCH=\"x86_64\"",
+            "TGROUP": "bench_server"
+        }
+    },
+    {
+        "DEPLOY_ID": "97037f55-dd2c-4549-8d24-561a6569e870",
+        "ETIME": 0,
+        "GID": 105,
+        "GNAME": "SW",
+        "HISTORY_RECORDS": {},
+        "ID": 311,
+        "LAST_POLL": 0,
+        "LCM_STATE": 3,
+        "MONITORING": {},
+        "NAME": "bs-windows",
+        "RESCHED": 0,
+        "STATE": 3,
+        "STIME": 1648076254,
+        "TEMPLATE": {
+            "NIC": [
+                {
+                    "AR_ID": "0",
+                    "BRIDGE": "mgmt0",
+                    "BRIDGE_TYPE": "linux",
+                    "CLUSTER_ID": "0",
+                    "IP": "192.168.11.209",
+                    "MAC": "02:00:c0:a8:0b:dd",
+                    "MODEL": "virtio",
+                    "NAME": "NIC0",
+                    "NETWORK": "Infrastructure",
+                    "NETWORK_ID": "0",
+                    "NETWORK_UNAME": "admin",
+                    "NIC_ID": "0",
+                    "SECURITY_GROUPS": "0,101",
+                    "TARGET": "one-311-0",
+                    "VLAN_ID": "12",
+                    "VN_MAD": "802.1Q"
+                },
+                [
+                    "TEMPLATE_ID",
+                    "23"
+                ],
+                [
+                    "TM_MAD_SYSTEM",
+                    "shared"
+                ],
+                [
+                    "VCPU",
+                    "4"
+                ],
+                [
+                    "VMID",
+                    "311"
+                ]
+            ]
+        },
+        "UID": 22,
+        "UNAME": "bsanders",
+        "USER_TEMPLATE": {
+            "GUEST_OS": "windows",
+            "INPUTS_ORDER": "",
+            "LABELS": "serv",
+            "HYPERVISOR": "kvm",
+            "SCHED_REQUIREMENTS": "ARCH=\"x86_64\"",
+            "SET_HOSTNAME": "windows"
+        }
+    }
+]

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 
 from collections import OrderedDict
 import json
-from unittest.mock import create_autospec
 
 import pytest
 
@@ -18,6 +17,7 @@ from ansible.inventory.data import InventoryData
 from ansible.parsing.dataloader import DataLoader
 from ansible.template import Templar
 from ansible_collections.community.general.plugins.inventory.opennebula import InventoryModule
+from ansible_collections.community.general.tests.unit.compat.mock import create_autospec
 
 
 @pytest.fixture

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -268,10 +268,10 @@ def test_populate_constructable_templating(inventory, mocker):
     # but options_constructable_test asks ansible to filter it out
     assert len(get_vm_pool_json().VM) == 4
     assert set([vm.NAME for vm in get_vm_pool_json().VM]) == set([
-            'terraform_demo_00',
-	    'terraform_demo_01',
-	    'terraform_demo_srv_00',
-	    'bs-windows',
+        'terraform_demo_00',
+        'terraform_demo_01',
+        'terraform_demo_srv_00',
+        'bs-windows',
     ])
     assert set(inventory.inventory.hosts) == set(['terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00'])
 
@@ -281,7 +281,6 @@ def test_populate_constructable_templating(inventory, mocker):
 
     assert 'benchmark_clients' in inventory.inventory.groups
     assert 'lin' in inventory.inventory.groups
-    from pprint import pprint; pprint(inventory.inventory.groups)
     assert inventory.inventory.groups['benchmark_clients'].hosts == [host_demo00, host_demo01]
     assert inventory.inventory.groups['lin'].hosts == [host_demo00, host_demo01, host_demosrv]
 

--- a/tests/unit/plugins/inventory/test_opennebula.py
+++ b/tests/unit/plugins/inventory/test_opennebula.py
@@ -10,10 +10,13 @@ __metaclass__ = type
 
 from collections import OrderedDict
 import json
+from unittest.mock import create_autospec
 
 import pytest
 
 from ansible.inventory.data import InventoryData
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar
 from ansible_collections.community.general.plugins.inventory.opennebula import InventoryModule
 
 
@@ -44,6 +47,7 @@ def get_vm_pool_json():
         data.VM.append(type('pyone.bindings.VMType90Sub', (object,), fake_server)())
 
     return data
+
 
 def get_vm_pool():
     data = type('pyone.bindings.VM_POOLSub', (object,), {'VM': []})()
@@ -206,6 +210,7 @@ def get_vm_pool():
 
     return data
 
+
 options_base_test = {
     'api_url': 'https://opennebula:2633/RPC2',
     'api_username': 'username',
@@ -214,7 +219,7 @@ options_base_test = {
     'hostname': 'v4_first_ip',
     'group_by_labels': True,
     'filter_by_label': None,
-    }
+}
 
 options_constructable_test = options_base_test.copy()
 options_constructable_test.update({
@@ -223,10 +228,11 @@ options_constructable_test.update({
     'groups': {
         'benchmark_clients': "TGROUP.endswith('clients')",
         'lin': 'is_linux == True'
-        },
+    },
     'keyed_groups': [{'key': 'TGROUP', 'prefix': 'tgroup'}],
 
-    })
+})
+
 
 # given a dictionary `opts_dict`, return a function that behaves like ansible's inventory get_options
 def mk_get_options(opts_dict):
@@ -242,58 +248,32 @@ def test_get_connection_info(inventory, mocker):
     assert (auth.username and auth.password)
 
 
-def test_populate_contructable(inventory, mocker):
-    # bypass API fetch call
-    inventory._get_vm_pool = mocker.MagicMock(side_effect=get_vm_pool_json)
-    inventory.get_option = mocker.MagicMock(side_effect=mk_get_options(options_constructable_test))
-    inventory._populate()
-
-    # note the vm_pool (and json data file) has four hosts,
-    # but options_constructable_test asks ansible to filter it out
-    assert len(get_vm_pool_json().VM) == 4
-    assert {vm.NAME for vm in get_vm_pool_json().VM} == {
-            'terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00', 'bs-windows'
-            }
-    assert set(inventory.inventory.hosts) == {'terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00'}
-
-    host_demo00 = inventory.inventory.get_host('terraform_demo_00')
-    host_demo01 = inventory.inventory.get_host('terraform_demo_01')
-    host_demosrv = inventory.inventory.get_host('terraform_demo_srv_00')
-
-#    assert 'benchmark_clients' in inventory.inventory.groups
-#    assert 'lin' in inventory.inventory.groups
-#    assert inventory.inventory.groups['benchmark_clients'] == [host_demo00, host_demo01]
-#    assert inventory.inventory.groups['lin'].hosts == [host_demo00, host_demo01, host_demosrv]
-
-    # test group by label:
-    assert 'bench' in inventory.inventory.groups
-    assert 'foo' in inventory.inventory.groups
-    assert inventory.inventory.groups['bench'].hosts == [host_demo00, host_demo01, host_demosrv]
-    assert inventory.inventory.groups['serv'].hosts == [host_demosrv]
-    assert inventory.inventory.groups['foo'].hosts == [host_demo00, host_demo01]
-
-    # test `compose` transforms GUEST_OS=Linux to is_linux == True
-    assert host_demo00.get_vars()['GUEST_OS'] == 'linux'
-#    assert host_demo00.get_vars()['is_linux'] == True
-
-    # test `keyed_groups`
-#    assert inventory.inventory.groups['tgroup_bench_clients'].hosts == [host_demo00, host_demo01]
-#    assert inventory.inventory.groups['tgroup_bench_server'].hosts == [host_demosrv]
-
-
 def test_populate_constructable_templating(inventory, mocker):
     # bypass API fetch call
     inventory._get_vm_pool = mocker.MagicMock(side_effect=get_vm_pool_json)
     inventory.get_option = mocker.MagicMock(side_effect=mk_get_options(options_constructable_test))
+
+    # the templating engine is needed for the constructable groups/vars
+    # so give that some fake data and instantiate it.
+    fake_config_filepath = '/fake/opennebula.yml'
+    fake_cache = {fake_config_filepath: options_constructable_test.copy()}
+    fake_cache[fake_config_filepath]['plugin'] = 'community.general.opennebula'
+    dataloader = create_autospec(DataLoader, instance=True)
+    dataloader._FILE_CACHE = fake_cache
+    inventory.templar = Templar(loader=dataloader)
+
     inventory._populate()
 
     # note the vm_pool (and json data file) has four hosts,
     # but options_constructable_test asks ansible to filter it out
     assert len(get_vm_pool_json().VM) == 4
-    assert {vm.NAME for vm in get_vm_pool_json().VM} == {
-            'terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00', 'bs-windows'
-            }
-    assert set(inventory.inventory.hosts) == {'terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00'}
+    assert set([vm.NAME for vm in get_vm_pool_json().VM]) == set([
+            'terraform_demo_00',
+	    'terraform_demo_01',
+	    'terraform_demo_srv_00',
+	    'bs-windows',
+    ])
+    assert set(inventory.inventory.hosts) == set(['terraform_demo_00', 'terraform_demo_01', 'terraform_demo_srv_00'])
 
     host_demo00 = inventory.inventory.get_host('terraform_demo_00')
     host_demo01 = inventory.inventory.get_host('terraform_demo_01')
@@ -301,7 +281,8 @@ def test_populate_constructable_templating(inventory, mocker):
 
     assert 'benchmark_clients' in inventory.inventory.groups
     assert 'lin' in inventory.inventory.groups
-    assert inventory.inventory.groups['benchmark_clients'] == [host_demo00, host_demo01]
+    from pprint import pprint; pprint(inventory.inventory.groups)
+    assert inventory.inventory.groups['benchmark_clients'].hosts == [host_demo00, host_demo01]
     assert inventory.inventory.groups['lin'].hosts == [host_demo00, host_demo01, host_demosrv]
 
     # test group by label:
@@ -313,7 +294,7 @@ def test_populate_constructable_templating(inventory, mocker):
 
     # test `compose` transforms GUEST_OS=Linux to is_linux == True
     assert host_demo00.get_vars()['GUEST_OS'] == 'linux'
-    assert host_demo00.get_vars()['is_linux'] == True
+    assert host_demo00.get_vars()['is_linux'] is True
 
     # test `keyed_groups`
     assert inventory.inventory.groups['tgroup_bench_clients'].hosts == [host_demo00, host_demo01]


### PR DESCRIPTION
…_groups, compose, groups

##### SUMMARY
#4497 noted that the opennebula inventory plugin inherits `Constructable`, and the doc string also includes the macro(?) for that, however the code does not implement the standard dynamic inventory features such as keyed_groups, etc.  This PR aims to implement that functionality.

I have included a new unit test, as well as new test-fixture data and re-worked some of the helper logic in the tests.  Hopefully @feldsam is ok with the changes.  I would be happy to refactor the pre-existing test and move the pre-existing sample data to the external file to make it match what I did.

Note, the PR is incomplete as not all of the testing logic passes, see below.

Fixes #4497 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
opennebula inventory plugin

##### ADDITIONAL INFORMATION

The code currently produces the output I would expect, however the unit test I added fails due to a traceback.  I looked briefly  into this, but wasn't quite sure why it was failing.  The two `test_` functions I added are identical except that one of them has commented out portions that are currently failing here:

```
[gw1] linux -- Python 3.8.0 /usr/bin/python3.8
inventory = <ansible_collections.community.general.plugins.inventory.opennebula.InventoryModule object at 0x7f1ceb5ce5b0>
mocker = <pytest_mock.plugin.MockerFixture object at 0x7f1ceb5ce6d0>

    def test_populate_constructable_templating(inventory, mocker):
        # bypass API fetch call
        inventory._get_vm_pool = mocker.MagicMock(side_effect=get_vm_pool_json)
        inventory.get_option = mocker.MagicMock(side_effect=mk_get_options(options_constructable_test))
>       inventory._populate()

tests/unit/plugins/inventory/test_opennebula.py:288: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
plugins/inventory/opennebula.py:239: in _populate
    self._add_host_to_composed_groups(self.get_option('groups'), server, hostname, strict=strict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.community.general.plugins.inventory.opennebula.InventoryModule object at 0x7f1ceb5ce5b0>
groups = {'benchmark_clients': "TGROUP.endswith('clients')", 'lin': 'is_linux == True'}
variables = {'GUEST_OS': 'linux', 'INPUTS_ORDER': '', 'LABELS': ['foo', 'bench'], 'LOGO': 'images/logos/linux.png', ...}
host = 'terraform_demo_00', strict = False, fetch_hostvars = True

    def _add_host_to_composed_groups(self, groups, variables, host, strict=False, fetch_hostvars=True):
        ''' helper to create complex groups for plugins based on jinja2 conditionals, hosts that meet the conditional are added to group'''
        # process each 'group entry'
        if groups and isinstance(groups, dict):
            if fetch_hostvars:
                variables = combine_vars(variables, self.inventory.get_host(host).get_vars())
>           self.templar.available_variables = variables
E           AttributeError: 'InventoryModule' object has no attribute 'templar'

/root/ansible/lib/ansible/plugins/inventory/__init__.py:369: AttributeError
```
