### PR TITLE
Fix keycloak realm parameters types

### DIFF
--- a/changelogs/fragments/4526-keycloak-realm-types.yaml
+++ b/changelogs/fragments/4526-keycloak-realm-types.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak - fix parameters `defaultDefaultClientScopes` and `defaultOptionalClientScopes` (https://github.com/ansible-collections/community.general/pull/4526).
+  - keycloak - fix parameters types for ``defaultDefaultClientScopes`` and ``defaultOptionalClientScopes`` from list of dictionaries to list of strings (https://github.com/ansible-collections/community.general/pull/4526).

--- a/changelogs/fragments/4526-keycloak-realm-types.yaml
+++ b/changelogs/fragments/4526-keycloak-realm-types.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak - fix parameters `defaultDefaultClientScopes` and `defaultOptionalClientScopes` (https://github.com/ansible-collections/community.general/pull/4526).

--- a/plugins/modules/identity/keycloak/keycloak_realm.py
+++ b/plugins/modules/identity/keycloak/keycloak_realm.py
@@ -156,7 +156,7 @@ options:
         aliases:
             - defaultDefaultClientScopes
         type: list
-        elements: dict
+        elements: str
     default_groups:
         description:
             - The realm default groups.
@@ -176,7 +176,7 @@ options:
         aliases:
             - defaultOptionalClientScopes
         type: list
-        elements: dict
+        elements: str
     default_roles:
         description:
             - The realm default roles.
@@ -621,10 +621,10 @@ def main():
         brute_force_protected=dict(type='bool', aliases=['bruteForceProtected']),
         client_authentication_flow=dict(type='str', aliases=['clientAuthenticationFlow']),
         client_scope_mappings=dict(type='dict', aliases=['clientScopeMappings']),
-        default_default_client_scopes=dict(type='list', elements='dict', aliases=['defaultDefaultClientScopes']),
+        default_default_client_scopes=dict(type='list', elements='str', aliases=['defaultDefaultClientScopes']),
         default_groups=dict(type='list', elements='dict', aliases=['defaultGroups']),
         default_locale=dict(type='str', aliases=['defaultLocale']),
-        default_optional_client_scopes=dict(type='list', elements='dict', aliases=['defaultOptionalClientScopes']),
+        default_optional_client_scopes=dict(type='list', elements='str', aliases=['defaultOptionalClientScopes']),
         default_roles=dict(type='list', elements='dict', aliases=['defaultRoles']),
         default_signature_algorithm=dict(type='str', aliases=['defaultSignatureAlgorithm']),
         direct_grant_flow=dict(type='str', aliases=['directGrantFlow']),


### PR DESCRIPTION
##### SUMMARY

Fix the type of parameters (`defaultDefaultClientScopes` and `defaultOptionalClientScopes`), according to https://www.keycloak.org/docs-api/17.0/rest-api/index.html#_realmrepresentation



##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

community.general.keycloak_realm

##### ADDITIONAL INFORMATION

Catch bug in Keycloak 15 and 17, with dictionary in defaultDefaultClientScopes/defaultOptionalClientScopes commands failed, because expected `<string> array`

<img width="841" alt="Снимок экрана 2022-04-19 в 11 42 00" src="https://user-images.githubusercontent.com/36310479/163970900-d673f8b4-8ee3-443f-9d35-f3037252806f.png">

