### PR TITLE
[pritunl] removed unnecessary data from auth string

### DIFF
--- a/changelogs/fragments/4530-fix-unauthorized-pritunl-request.yaml
+++ b/changelogs/fragments/4530-fix-unauthorized-pritunl-request.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - pritunl - fixed bug where pritunl plugin api add unneeded data in ``auth_string`` parameter (https://github.com/ansible-collections/community.general/issues/4527).

--- a/plugins/module_utils/net_tools/pritunl/api.py
+++ b/plugins/module_utils/net_tools/pritunl/api.py
@@ -337,7 +337,6 @@ def pritunl_auth_request(
 
     auth_string = "&".join(
         [api_token, auth_timestamp, auth_nonce, method.upper(), path]
-        + ([data] if data else [])
     )
 
     auth_signature = base64.b64encode(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
According to pritunl documentation we don't need "data" in auth_string, without data, requests work good.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #4527 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin: pritunl

