### PR TITLE
[pritunl] add mac_addresses parameter

### DIFF
--- a/changelogs/fragments/4535-pritunl-add-mac_addresses-parameter.yml
+++ b/changelogs/fragments/4535-pritunl-add-mac_addresses-parameter.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - pritunl_user - add ``mac_addresses`` parameter
+  - pritunl_user - add ``mac_addresses`` parameter (https://github.com/ansible-collections/community.general/pull/4535).

--- a/changelogs/fragments/4535-pritunl-add-mac_addresses-parameter.yml
+++ b/changelogs/fragments/4535-pritunl-add-mac_addresses-parameter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - pritunl_user - add ``mac_addresses`` parameter

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -82,20 +82,30 @@ options:
         default: null
         description:
             - Enable/Disable Gravatar usage for the user I(user_name).
+
+    user_mac_addresses:
+        type: list
+        elements: str
+        required: false
+        default: null
+        description:
+            - Allowed MAC Addresses for the user I(user_name).
 """
 
 EXAMPLES = """
 - name: Create the user Foo with email address foo@bar.com in MyOrg
   community.general.pritunl_user:
     state: present
-    name: MyOrg
+    organization: MyOrg
     user_name: Foo
     user_email: foo@bar.com
+    user_mac_addresses:
+      - "00:00:00:00:00:99"
 
 - name: Disable the user Foo but keep it in Pritunl
   community.general.pritunl_user:
     state: present
-    name: MyOrg
+    organization: MyOrg
     user_name: Foo
     user_email: foo@bar.com
     user_disabled: yes
@@ -103,7 +113,7 @@ EXAMPLES = """
 - name: Make sure the user Foo is not part of MyOrg anymore
   community.general.pritunl_user:
     state: absent
-    name: MyOrg
+    organization: MyOrg
     user_name: Foo
 """
 
@@ -153,7 +163,7 @@ from ansible_collections.community.general.plugins.module_utils.net_tools.pritun
     post_pritunl_user,
     pritunl_argument_spec,
 )
-
+record_ids=dict(type='list', elements='str'),
 
 def add_or_update_pritunl_user(module):
     result = {}
@@ -167,6 +177,7 @@ def add_or_update_pritunl_user(module):
         "groups": module.params.get("user_groups"),
         "disabled": module.params.get("user_disabled"),
         "gravatar": module.params.get("user_gravatar"),
+        "mac_addresses": module.params.get("user_mac_addresses"),
         "type": module.params.get("user_type"),
     }
 
@@ -323,6 +334,7 @@ def main():
             user_groups=dict(required=False, type="list", elements="str", default=None),
             user_disabled=dict(required=False, type="bool", default=None),
             user_gravatar=dict(required=False, type="bool", default=None),
+            user_mac_addresses=dict(required=False, type="list", elements="str", default=None),
         )
     ),
 

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -88,7 +88,7 @@ options:
         elements: str
         description:
             - Allowed MAC addresses for the user I(user_name).
-        version_added: 4.8.0
+        version_added: 5.0.0
 """
 
 EXAMPLES = """

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -216,7 +216,7 @@ def add_or_update_pritunl_user(module):
                 user_params[key] = users[0][key]
 
             # 'groups' is a list comparison
-            if key == "groups":
+            if key == "groups" or key == "mac_addresses":
                 if set(users[0][key]) != set(user_params[key]):
                     user_params_changed = True
 

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -164,6 +164,7 @@ from ansible_collections.community.general.plugins.module_utils.net_tools.pritun
     pritunl_argument_spec,
 )
 
+
 def add_or_update_pritunl_user(module):
     result = {}
 

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -86,8 +86,6 @@ options:
     user_mac_addresses:
         type: list
         elements: str
-        required: false
-        default: null
         description:
             - Allowed MAC Addresses for the user I(user_name).
 """

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -87,7 +87,8 @@ options:
         type: list
         elements: str
         description:
-            - Allowed MAC Addresses for the user I(user_name).
+            - Allowed MAC addresses for the user I(user_name).
+        version_added: 4.8.0
 """
 
 EXAMPLES = """

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -214,7 +214,7 @@ def add_or_update_pritunl_user(module):
             if user_params[key] is None:
                 user_params[key] = users[0][key]
 
-            # 'groups' is a list comparison
+            # 'groups' and 'mac_addresses' are list comparison
             if key == "groups" or key == "mac_addresses":
                 if set(users[0][key]) != set(user_params[key]):
                     user_params_changed = True

--- a/plugins/modules/net_tools/pritunl/pritunl_user.py
+++ b/plugins/modules/net_tools/pritunl/pritunl_user.py
@@ -163,7 +163,6 @@ from ansible_collections.community.general.plugins.module_utils.net_tools.pritun
     post_pritunl_user,
     pritunl_argument_spec,
 )
-record_ids=dict(type='list', elements='str'),
 
 def add_or_update_pritunl_user(module):
     result = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pritunl VPN supports to limit user by his MAC addresses, added this parameter to the module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pritunl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
