### PR TITLE
Parse lxc key from api data for lxc containers

### DIFF
--- a/changelogs/fragments/4555-proxmox-lxc-key.yml
+++ b/changelogs/fragments/4555-proxmox-lxc-key.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - proxmox inventory plugin - fix error when parsing container with LXC configs (https://github.com/ansible-collections/community.general/issues/4472, https://github.com/ansible-collections/community.general/pull/4472).
+minor_changes:
+  - proxmox inventory plugin - parse LXC configs returned by the proxmox API (https://github.com/ansible-collections/community.general/pull/4472).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2018 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = '''
@@ -169,6 +170,7 @@ from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.utils.display import Display
 from ansible.template import Templar
@@ -360,7 +362,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
                         properties[agent_iface_key] = agent_iface_value
 
-                if config not in plaintext_configs and not isinstance(value, int) and all("=" in v for v in value.split(",")):
+                if config == 'lxc':
+                    out_val = {}
+                    for k, v in value:
+                        if k.startswith('lxc.'):
+                            k = k[len('lxc.'):]
+                        out_val[k] = v
+                    value = out_val
+
+                if config not in plaintext_configs and isinstance(value, string_types) \
+                        and all("=" in v for v in value.split(",")):
                     # split off strings with commas to a dict
                     # skip over any keys that cannot be processed
                     try:


### PR DESCRIPTION
##### SUMMARY

When configuring containers in the `/etc/pve/lxc/` file, the API
adds a 'lxc' key that caused the plugin to crash as it tried to
split a list on ','.

This commit introduces logic to convert the list of lists in the
returned data to a dict as with the other keys.

```
'lxc': [['lxc.apparmor.profile', 'unconfined'],
	['lxc.cgroup.devices.allow', 'a']]
```

becomes

```
"proxmox_lxc": {
	"apparmor.profile": "unconfined",
	"cap.drop": "",
	"cgroup.devices.allow": "a"
}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox inventory plugin

##### ADDITIONAL INFORMATION
```bash
echo lxc.apparmor.profile: unconfined >> "/etc/pve/lxc/CONTAINERID.conf"
```

Caused the module to crash and return incomplete inventories.

Should also fix: #4472