### PR TITLE
Improve CI coverage

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -221,6 +221,7 @@ stages:
           groups:
             - 1
             - 2
+            - 3
   - stage: Remote_2_11
     displayName: Remote 2.11
     dependsOn: []
@@ -238,6 +239,7 @@ stages:
           groups:
             - 1
             - 2
+            - 3
 
 ### Docker
   - stage: Docker_devel
@@ -317,6 +319,7 @@ stages:
             - name: Alpine 3
               test: alpine3
           groups:
+            - 1
             - 2
             - 3
 


### PR DESCRIPTION
##### SUMMARY
~~Contains #4548, needs to be rebased once that is merged.~~

Right now, some CI groups are skipped for some Ansible / remote / docker combinations to save CI cycles. Since #4548 reduces the number of CI runs, let's undo this so that every CI group is covered by the same targets.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
