### PR TITLE
vmadm: deprecating unused parameter debug

### DIFF
--- a/changelogs/fragments/4580-vmadm-deprecate-param-debug.yaml
+++ b/changelogs/fragments/4580-vmadm-deprecate-param-debug.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - vmadm - deprecated module parameter ``debug`` that was not used anywhere (https://github.com/ansible-collections/community.general/pull/4580).

--- a/plugins/modules/cloud/smartos/vmadm.py
+++ b/plugins/modules/cloud/smartos/vmadm.py
@@ -661,7 +661,7 @@ def main():
             'zfs_root_compression', 'zpool'
         ],
         'bool': [
-            'archive_on_delete', 'autoboot', 'debug', 'delegate_dataset',
+            'archive_on_delete', 'autoboot', 'delegate_dataset',
             'docker', 'firewall_enabled', 'force', 'indestructible_delegated',
             'indestructible_zoneroot', 'maintain_resolvers', 'nowait'
         ],
@@ -704,6 +704,7 @@ def main():
         nics=dict(type='list', elements='dict'),
         resolvers=dict(type='list', elements='str'),
         filesystems=dict(type='list', elements='dict'),
+        debug=dict(type='bool', removed_in_version='6.0.0', removed_from_collection='community.general'),
     )
 
     # Add our 'simple' options to options dict.

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -15,7 +15,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -14,7 +14,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -9,7 +9,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -9,7 +9,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -9,7 +9,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -13,7 +13,6 @@ plugins/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 plugins/modules/cloud/rackspace/rax_scaling_group.py use-argspec-type-path  # fix needed, expanduser() applied to dict values
 plugins/modules/cloud/scaleway/scaleway_organization_info.py validate-modules:return-syntax-error
 plugins/modules/cloud/smartos/vmadm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/cloud/smartos/vmadm.py validate-modules:undocumented-parameter
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:parameter-type-not-in-doc
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
Parameter `debug` seems to be not used anywhere. Deprecating.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/cloud/smartos/vmadm.py
