### PR TITLE
hpilo_boot: added missing types in documentation

### DIFF
--- a/plugins/modules/remote_management/hpilo/hpilo_boot.py
+++ b/plugins/modules/remote_management/hpilo/hpilo_boot.py
@@ -20,37 +20,43 @@ description:
 options:
   host:
     description:
-    - The HP iLO hostname/address that is linked to the physical system.
+      - The HP iLO hostname/address that is linked to the physical system.
+    type: str
     required: true
   login:
     description:
-    - The login name to authenticate to the HP iLO interface.
+      - The login name to authenticate to the HP iLO interface.
     default: Administrator
+    type: str
   password:
     description:
-    - The password to authenticate to the HP iLO interface.
+      - The password to authenticate to the HP iLO interface.
     default: admin
+    type: str
   media:
     description:
-    - The boot media to boot the system from
+      - The boot media to boot the system from
     choices: [ "cdrom", "floppy", "rbsu", "hdd", "network", "normal", "usb" ]
+    type: str
   image:
     description:
-    - The URL of a cdrom, floppy or usb boot media image.
-      protocol://username:password@hostname:port/filename
-    - protocol is either 'http' or 'https'
-    - username:password is optional
-    - port is optional
+      - The URL of a cdrom, floppy or usb boot media image.
+        protocol://username:password@hostname:port/filename
+      - protocol is either 'http' or 'https'
+      - username:password is optional
+      - port is optional
+    type: str
   state:
     description:
-    - The state of the boot media.
-    - "no_boot: Do not boot from the device"
-    - "boot_once: Boot from the device once and then notthereafter"
-    - "boot_always: Boot from the device each time the server is rebooted"
-    - "connect: Connect the virtual media device and set to boot_always"
-    - "disconnect: Disconnects the virtual media device and set to no_boot"
-    - "poweroff: Power off the server"
+      - The state of the boot media.
+      - "no_boot: Do not boot from the device"
+      - "boot_once: Boot from the device once and then notthereafter"
+      - "boot_always: Boot from the device each time the server is rebooted"
+      - "connect: Connect the virtual media device and set to boot_always"
+      - "disconnect: Disconnects the virtual media device and set to no_boot"
+      - "poweroff: Power off the server"
     default: boot_once
+    type: str
     choices: [ "boot_always", "boot_once", "connect", "disconnect", "no_boot", "poweroff" ]
   force:
     description:
@@ -62,6 +68,7 @@ options:
     description:
       - Change the ssl_version used.
     default: TLSv1
+    type: str
     choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
 requirements:
 - python-hpilo

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -25,7 +25,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -24,7 +24,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_boot.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions


### PR DESCRIPTION
##### SUMMARY
Added missing types to documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/remote_management/hpilo/hpilo_boot.py
