### PR TITLE
hpilo_info: added missing types in documentation

### DIFF
--- a/plugins/modules/remote_management/hpilo/hpilo_info.py
+++ b/plugins/modules/remote_management/hpilo/hpilo_info.py
@@ -23,20 +23,24 @@ description:
 options:
   host:
     description:
-    - The HP iLO hostname/address that is linked to the physical system.
+        - The HP iLO hostname/address that is linked to the physical system.
+    type: str
     required: true
   login:
     description:
-    - The login name to authenticate to the HP iLO interface.
+      - The login name to authenticate to the HP iLO interface.
+    type: str
     default: Administrator
   password:
     description:
-    - The password to authenticate to the HP iLO interface.
+      - The password to authenticate to the HP iLO interface.
+    type: str
     default: admin
   ssl_version:
     description:
       - Change the ssl_version used.
     default: TLSv1
+    type: str
     choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
 requirements:
 - hpilo

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -25,7 +25,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -24,7 +24,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hpilo_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions


### PR DESCRIPTION
##### SUMMARY
Added missing types to documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/remote_management/hpilo/hpilo_info.py