### PR TITLE
hponcfg: added missing types in documentation

### DIFF
--- a/plugins/modules/remote_management/hpilo/hponcfg.py
+++ b/plugins/modules/remote_management/hpilo/hponcfg.py
@@ -14,30 +14,33 @@ module: hponcfg
 author: Dag Wieers (@dagwieers)
 short_description: Configure HP iLO interface using hponcfg
 description:
-- This modules configures the HP iLO interface using hponcfg.
+ - This modules configures the HP iLO interface using hponcfg.
 options:
   path:
     description:
-    - The XML file as accepted by hponcfg.
+     - The XML file as accepted by hponcfg.
     required: true
     aliases: ['src']
+    type: path
   minfw:
     description:
-    - The minimum firmware level needed.
+     - The minimum firmware level needed.
     required: false
+    type: str
   executable:
     description:
-    - Path to the hponcfg executable (`hponcfg` which uses $PATH).
+     - Path to the hponcfg executable (`hponcfg` which uses $PATH).
     default: hponcfg
+    type: str
   verbose:
     description:
-    - Run hponcfg in verbose mode (-v).
+     - Run hponcfg in verbose mode (-v).
     default: no
     type: bool
 requirements:
-- hponcfg tool
+ - hponcfg tool
 notes:
-- You need a working hponcfg on the target system.
+ - You need a working hponcfg on the target system.
 '''
 
 EXAMPLES = r'''

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -25,7 +25,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -24,7 +24,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parame
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -19,7 +19,6 @@ plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/packaging/language/yarn.py use-argspec-type-path
 plugins/modules/packaging/os/redhat_subscription.py validate-modules:return-syntax-error
-plugins/modules/remote_management/hpilo/hponcfg.py validate-modules:parameter-type-not-in-doc
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/remote_management/manageiq/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions


### PR DESCRIPTION
##### SUMMARY
Added missing types to the documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/remote_management/hpilo/hponcfg.py