### PR TITLE
redfish_command: VirtualMediaInsert does not work with HPE iLO4

### DIFF
--- a/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
+++ b/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
@@ -1,10 +1,10 @@
 bugfixes:
   - redfish_command - the iLO4 Redfish implementation only supports the ``image_url`` parameter in
     the underlying API calls to ``VirtualMediaInsert`` and ``VirtualMediaEject``. Any values set
-    (or the defaults) for ``write_protected`` or ``inserted`` will be ignored.
+    (or the defaults) for ``write_protected`` or ``inserted`` will be ignored
     (https://github.com/ansible-collections/community.general/pull/4596).
 minor_changes:
-  - redfish_* The contents of ``@Message.ExtendedInfo`` will be returned as a string in the event
+  - redfish_* modules - the contents of ``@Message.ExtendedInfo`` will be returned as a string in the event
     that ``@Message.ExtendedInfo.Messages`` does not exist. This is likely more useful than the
-    standard HTTP error.
+    standard HTTP error
     (https://github.com/ansible-collections/community.general/pull/4596).

--- a/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
+++ b/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - redfish_command The iLO4 Redfish implementation only supports the 'image_url' parameter in
+    the underlying API call to VirtualMediaInsert. Any values set (or the defaults) for
+    'write_protected' or 'inserted' will be ignored. Setting 'password', 'transfer_method',
+    'transfer_protocol_type', or 'username' will result in an error.

--- a/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
+++ b/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
@@ -1,7 +1,7 @@
 bugfixes:
   - redfish_command - the iLO4 Redfish implementation only supports the ``image_url`` parameter in
-    the underlying API call to ``VirtualMediaInsert``. Any values set (or the defaults) for
-    ``write_protected`` or ``inserted`` will be ignored.
+    the underlying API calls to ``VirtualMediaInsert`` and ``VirtualMediaEject``. Any values set
+    (or the defaults) for ``write_protected`` or ``inserted`` will be ignored.
     (https://github.com/ansible-collections/community.general/pull/4596).
 minor_changes:
   - redfish_* The contents of ``@Message.ExtendedInfo`` will be returned as a string in the event

--- a/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
+++ b/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
@@ -1,5 +1,6 @@
 bugfixes:
-  - redfish_command The iLO4 Redfish implementation only supports the 'image_url' parameter in
-    the underlying API call to VirtualMediaInsert. Any values set (or the defaults) for
-    'write_protected' or 'inserted' will be ignored. Setting 'password', 'transfer_method',
-    'transfer_protocol_type', or 'username' will result in an error.
+  - redfish_command - the iLO4 Redfish implementation only supports the ``image_url`` parameter in
+    the underlying API call to ``VirtualMediaInsert``. Any values set (or the defaults) for
+    ``write_protected`` or ``inserted`` will be ignored. Setting ``password``, ``transfer_method``,
+    ``transfer_protocol_type``, or ``username`` will result in an error
+    (https://github.com/ansible-collections/community.general/pull/4596).

--- a/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
+++ b/changelogs/fragments/4595-fix-VirtualMediaInsert-iLO4.yml
@@ -1,6 +1,10 @@
 bugfixes:
   - redfish_command - the iLO4 Redfish implementation only supports the ``image_url`` parameter in
     the underlying API call to ``VirtualMediaInsert``. Any values set (or the defaults) for
-    ``write_protected`` or ``inserted`` will be ignored. Setting ``password``, ``transfer_method``,
-    ``transfer_protocol_type``, or ``username`` will result in an error
+    ``write_protected`` or ``inserted`` will be ignored.
+    (https://github.com/ansible-collections/community.general/pull/4596).
+minor_changes:
+  - redfish_* The contents of ``@Message.ExtendedInfo`` will be returned as a string in the event
+    that ``@Message.ExtendedInfo.Messages`` does not exist. This is likely more useful than the
+    standard HTTP error.
     (https://github.com/ansible-collections/community.general/pull/4596).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2279,12 +2279,6 @@ class RedfishUtils(object):
             return {'ret': False, 'msg': "VirtualMedia resource not found"}
         if data["FirmwareVersion"].startswith("iLO 4"):
             image_only = True
-            for k, v in options.items():
-                if k in ['password', 'transfer_method', 'transfer_protocol_type', 'username']:
-                    if v is not None:
-                        return {'ret': False,
-                                'msg': "%s is not a valid option in virtual_media for iLO4 based systems"
-                                % k}
         virt_media_uri = data["VirtualMedia"]["@odata.id"]
         response = self.get_request(self.root_uri + virt_media_uri)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2236,7 +2236,7 @@ class RedfishUtils(object):
                 payload[param] = options.get(option)
         return payload
 
-    def virtual_media_insert_via_patch(self, options, param_map, uri, data, image_only):
+    def virtual_media_insert_via_patch(self, options, param_map, uri, data, image_only=False):
         # get AllowableValues
         ai = dict((k[:-24],
                    {'AllowableValues': v}) for k, v in data.items()

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2252,7 +2252,9 @@ class RedfishUtils(object):
             payload['Inserted'] = True
         # Some hardware (iLO 4) only supports the Image property on the PATCH operation
         if image_only:
-            payload = {'Image': payload['Image']}
+            # Delete WriteProtected and Inserted from the payload as they have defaults set
+            del payload['Inserted']
+            del payload['WriteProtected']
         # PATCH the resource
         response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -188,7 +188,12 @@ class RedfishUtils(object):
                 body = error.read().decode('utf-8')
                 data = json.loads(body)
                 ext_info = data['error']['@Message.ExtendedInfo']
-                msg = ext_info[0]['Message']
+                # if the ExtendedInfo contains a user friendly message send it
+                # otherwise try to send the entire contents of ExtendedInfo
+                try:
+                    msg = ext_info[0]['Message']
+                except:
+                    msg = str(data['error']['@Message.ExtendedInfo'])
             except Exception:
                 pass
         return msg

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2279,6 +2279,12 @@ class RedfishUtils(object):
             return {'ret': False, 'msg': "VirtualMedia resource not found"}
         if data["FirmwareVersion"].startswith("iLO 4"):
             image_only = True
+            for k, v in options.items():
+                if k in ['password', 'transfer_method', 'transfer_protocol_type', 'username']:
+                    if v is not None:
+                        return {'ret': False,
+                                'msg': "%s is not a valid option in virtual_media for iLO4 based systems"
+                                % k}
         virt_media_uri = data["VirtualMedia"]["@odata.id"]
         response = self.get_request(self.root_uri + virt_media_uri)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2250,11 +2250,13 @@ class RedfishUtils(object):
         payload = self._insert_virt_media_payload(options, param_map, data, ai)
         if 'Inserted' not in payload:
             payload['Inserted'] = True
-        # Some hardware (iLO 4) only supports the Image property on the PATCH operation
+
+        # Some hardware (such as iLO 4) only supports the Image property on the PATCH operation
+        # Inserted and WriteProtected are not writable
         if image_only:
-            # Delete WriteProtected and Inserted from the payload as they have defaults set
             del payload['Inserted']
             del payload['WriteProtected']
+
         # PATCH the resource
         response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
@@ -2284,8 +2286,12 @@ class RedfishUtils(object):
         data = response['data']
         if 'VirtualMedia' not in data:
             return {'ret': False, 'msg': "VirtualMedia resource not found"}
+
+        # Some hardware (such as iLO 4) only supports the Image property on the PATCH operation
+        # Inserted and WriteProtected are not writable
         if data["FirmwareVersion"].startswith("iLO 4"):
             image_only = True
+
         virt_media_uri = data["VirtualMedia"]["@odata.id"]
         response = self.get_request(self.root_uri + virt_media_uri)
         if response['ret'] is False:

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -192,7 +192,7 @@ class RedfishUtils(object):
                 # otherwise try to send the entire contents of ExtendedInfo
                 try:
                     msg = ext_info[0]['Message']
-                except:
+                except Exception:
                     msg = str(data['error']['@Message.ExtendedInfo'])
             except Exception:
                 pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This resolves #4595 on my systems that have an HPE iLO 4.

~~I obviously cannot test this on all of the hardware in the world that implements Redfish. Hopefully, servers that require the `Inserted` field for VirtualMediaInsert do not claim to implement a spec where that field is read-only.~~

I have reworked this so the code will only target systems that have an HPE iLO 4.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
