### PR TITLE
ModuleHelper module utils: delegates unknown attributes to AnsibleModule

### DIFF
--- a/changelogs/fragments/4600-mh-delegate.yaml
+++ b/changelogs/fragments/4600-mh-delegate.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ModuleHelper module utils - ``ModuleHelperBase` now delegates unkwnon attributes to the underlying ``AnsibleModule`` instance (https://github.com/ansible-collections/community.general/pull/4600).
+  - ModuleHelper module utils - ``ModuleHelperBase` now delegates the attributes ``check_mode``, ``get_bin_path``, ``warn``, and ``deprecate`` to the underlying ``AnsibleModule`` instance (https://github.com/ansible-collections/community.general/pull/4600).

--- a/changelogs/fragments/4600-mh-delegate.yaml
+++ b/changelogs/fragments/4600-mh-delegate.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ModuleHelper module utils - ``ModuleHelperBase` now delegates unkwnon attributes to the underlying ``AnsibleModule`` instance (https://github.com/ansible-collections/community.general/pull/4600).

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -14,6 +14,9 @@ from ansible_collections.community.general.plugins.module_utils.mh.deco import m
 class ModuleHelperBase(object):
     module = None
     ModuleHelperException = _MHE
+    _delegated_to_module = (
+        'check_mode', 'get_bin_path', 'warn', 'deprecate',
+    )
 
     def __init__(self, module=None):
         self._changed = False
@@ -29,7 +32,9 @@ class ModuleHelperBase(object):
         return self.module._diff
 
     def __getattr__(self, attr):
-        return getattr(self.module, attr)
+        if attr in self._delegated_to_module:
+            return getattr(self.module, attr)
+        return getattr(object, attr)
 
     def __init_module__(self):
         pass

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -24,6 +24,13 @@ class ModuleHelperBase(object):
         if not isinstance(self.module, AnsibleModule):
             self.module = AnsibleModule(**self.module)
 
+    @property
+    def diff_mode(self):
+        return self.module._diff
+
+    def __getattr__(self, attr):
+        return getattr(self.module, attr)
+
     def __init_module__(self):
         pass
 

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -34,7 +34,7 @@ class ModuleHelperBase(object):
     def __getattr__(self, attr):
         if attr in self._delegated_to_module:
             return getattr(self.module, attr)
-        return getattr(object, attr)
+        raise AttributeError("ModuleHelperBase has no attribute '%s'" % (attr, ))
 
     def __init_module__(self):
         pass

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -44,7 +44,8 @@ class ModuleHelper(DeprecateAttrsMixin, VarsMixin, DependencyMixin, ModuleHelper
             version="6.0.0",
             collection_name="community.general",
             target=ModuleHelper,
-            module=self.module)
+            module=self.module,
+        )
 
     def update_output(self, **kwargs):
         self.update_vars(meta={"output": True}, **kwargs)
@@ -65,7 +66,7 @@ class ModuleHelper(DeprecateAttrsMixin, VarsMixin, DependencyMixin, ModuleHelper
             facts = self.vars.facts()
             if facts is not None:
                 result['ansible_facts'] = {self.facts_name: facts}
-        if self.module._diff:
+        if self.diff_mode:
             diff = result.get('diff', {})
             vars_diff = self.vars.diff() or {}
             result['diff'] = dict_merge(dict(diff), vars_diff)


### PR DESCRIPTION
##### SUMMARY
The `ModuleHelperBase` class now delegates unknown attributes to the `AnsibleModule` instance it contains.

The purpose of this change is to provide a way for module developers to avoid using `self.module` for every little thing. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py
plugins/module_utils/mh/module_helper.py
