### PR TITLE
ansible_galaxy_install: added deprecation for ansible 2.9 and ansible-base 2.10

### DIFF
--- a/changelogs/fragments/4601-ansible-galaxy-install-deprecate-ansible29-and-210.yaml
+++ b/changelogs/fragments/4601-ansible-galaxy-install-deprecate-ansible29-and-210.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - ansible_galaxy_install - deprecated support for ``ansible`` 2.9 and ``ansible-base`` 2.10 (https://github.com/ansible-collections/community.general/pull/4601).

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -240,7 +240,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
         self.ansible_version = self._get_ansible_galaxy_version()
         if self.ansible_version < (2, 11) and not self.vars.ack_min_ansiblecore211:
             self.module.deprecate(
-                "Support for Ansible 2.9 and Ansible-base 2.10 is being deprecated. "
+                "Support for Ansible 2.9 and ansible-base 2.10 is being deprecated. "
                 "At the same time support for them is ended, also the ack_ansible29 option will be removed. "
                 "Upgrading is strongly recommended, or set 'ack_min_ansiblecore211' to supress this message.",
                 version="8.0.0",

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -238,7 +238,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
 
     def __init_module__(self):
         self.ansible_version = self._get_ansible_galaxy_version()
-        if self.ansible_version < (2, 11):
+        if self.ansible_version < (2, 11) and not self.vars.ack_min_ansiblecore211:
             self.module.deprecate(
                 "Support for Ansible 2.9 and Ansible-base 2.10 is being deprecated. "
                 "At the same time support for them is ended, also the ack_ansible29 option will be removed. "

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -79,7 +79,7 @@ options:
       - Acknowledge the module is deprecating support for Ansible 2.9 and ansible-base 2.10.
       - Support for those versions will be removed in community.general 8.0.0.
         At the same time, this option will be removed without any deprecation warning!
-      - This option is completely ignored if using a version of Ansible greater than C(2.9.x).
+      - This option is completely ignored if using a version of ansible-core/ansible-base/Ansible greater than C(2.11).
       - For the sake of conciseness, setting this parameter to C(true) implies I(ack_ansible29=true).
     type: bool
     default: false

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -301,7 +301,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
         self.vars.set("new_collections", {})
         self.vars.set("new_roles", {})
         self.vars.set("ansible29_change", False, change=True, output=False)
-        if not self.vars.ack_ansible29 and not self.vars.ack_min_ansiblecore211:
+        if not (self.vars.ack_ansible29 or self.vars.ack_min_ansiblecore211):
             self.module.warn("Ansible 2.9 or older: unable to retrieve lists of roles and collections already installed")
             if self.vars.requirements_file is not None and self.vars.type == 'both':
                 self.module.warn("Ansible 2.9 or older: will install only roles from requirement files")

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -76,7 +76,7 @@ options:
     default: false
   ack_min_ansiblecore211:
     description:
-      - Acknowledge the module is deprecating support for Ansible 2.9 and Ansible Core 2.10.
+      - Acknowledge the module is deprecating support for Ansible 2.9 and ansible-base 2.10.
       - Support for those versions will be removed in community.general 8.0.0.
         At the same time, this option will be removed without any deprecation warning!
       - This option is completely ignored if using a version of Ansible greater than C(2.9.x).

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -70,6 +70,8 @@ options:
     description:
       - Acknowledge using Ansible 2.9 with its limitations, and prevents the module from generating warnings about them.
       - This option is completely ignored if using a version of Ansible greater than C(2.9.x).
+      - Note that this option will be removed without any further deprecation warning once support
+        for Ansible 2.9 is removed from this module.
     type: bool
     default: false
   ack_min_ansiblecore211:

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -76,6 +76,7 @@ options:
     description:
       - Acknowledge the module is deprecating support for Ansible 2.9 and Ansible Core 2.10.
       - Support for those versions will be removed in community.general 8.0.0.
+        At the same time, this option will be removed without any deprecation warning!
       - This option is completely ignored if using a version of Ansible greater than C(2.9.x).
       - For the sake of conciseness, setting this parameter to C(true) implies I(ack_ansible29=true).
     type: bool

--- a/plugins/modules/packaging/language/ansible_galaxy_install.py
+++ b/plugins/modules/packaging/language/ansible_galaxy_install.py
@@ -241,6 +241,7 @@ class AnsibleGalaxyInstall(CmdModuleHelper):
         if self.ansible_version < (2, 11):
             self.module.deprecate(
                 "Support for Ansible 2.9 and Ansible-base 2.10 is being deprecated. "
+                "At the same time support for them is ended, also the ack_ansible29 option will be removed. "
                 "Upgrading is strongly recommended, or set 'ack_min_ansiblecore211' to supress this message.",
                 version="8.0.0",
                 collection_name="community.general",


### PR DESCRIPTION
##### SUMMARY
Adding deprecation for no-longer supported ansible versions. Particularly in this context, `ansible-galaxy` changed quite a bit between those versions and the most recent ones, adding some complexity to the module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/packaging/language/ansible_galaxy_install.py