### PR TITLE
apache2_module: Accept the result of a2enmod when available

### DIFF
--- a/changelogs/fragments/4608-apache2-module-success-a2enmod.yml
+++ b/changelogs/fragments/4608-apache2-module-success-a2enmod.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apache2_module - return success if a2enmod detects that module was already installed (https://github.com/ansible-collections/community.general/pull/4608).

--- a/plugins/modules/web_infrastructure/apache2_module.py
+++ b/plugins/modules/web_infrastructure/apache2_module.py
@@ -196,6 +196,8 @@ def _set_state(module, state):
     a2mod_binary = {'present': 'a2enmod', 'absent': 'a2dismod'}[state]
     success_msg = "Module %s %s" % (name, state_string)
 
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+
     if _module_is_enabled(module) != want_enabled:
         if module.check_mode:
             module.exit_json(changed=True,
@@ -218,6 +220,8 @@ def _set_state(module, state):
             module.exit_json(changed=True,
                              result=success_msg,
                              warnings=module.warnings)
+        elif result == 0:
+            module.exit_json(changed=(' already ' not in stdout), result=success_msg)
         else:
             msg = (
                 'Failed to set module {name} to {state}:\n'

--- a/tests/integration/targets/apache2_module/tasks/actualtest.yml
+++ b/tests/integration/targets/apache2_module/tasks/actualtest.yml
@@ -101,7 +101,7 @@
 
   - name: use identifier to enable module, fix for https://github.com/ansible/ansible/issues/33669
     community.general.apache2_module:
-      name: dump_io
+      name: dumpio
       state: present
     ignore_errors: True
     register: enable_dumpio_wrong
@@ -132,7 +132,8 @@
       identifier: dumpio_module
       state: absent
 
-  - assert:
+  - name: ensure that identifier can be used to enable module
+    assert:
       that:
         - enable_dumpio_wrong is failed
         - enable_dumpio_correct_1 is changed


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-collections/community.general/issues/4592 with least changes for when a2enmod exists.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apache2_module

##### ADDITIONAL INFORMATION

The use case is the following: have the module run on a setup where the apache2 configuration is invalid because sites-enabled already contains missing apache2 modules.

Without ignore_configcheck, the module fails on configuration check.

With ignore_configcheck, the module fails by ignoring the output of a2enmod and only rechecking the configuration, which can still have other missing modules.

With the patch, in the second case, a second check is done on the output of a2enmod to decide what to return. If the module has been installed, result is success+changed. If the module was already installed, result is success+unchanged.

This patch is the minimalistic correction that does not alter previous methods nor does change the check_mode method.


