### PR TITLE
time_filter: allow 0 to return 0

### DIFF
--- a/plugins/filter/time.py
+++ b/plugins/filter/time.py
@@ -46,6 +46,11 @@ def multiply(factors):
 
 def to_time_unit(human_time, unit='ms', **kwargs):
     ''' Return a time unit from a human readable string '''
+
+    # No need to handle 0
+    if human_time is "0":
+        return 0
+
     unit_to_short_form = UNIT_TO_SHORT_FORM
     unit_factors = UNIT_FACTORS
 

--- a/tests/integration/targets/filter_time/tasks/main.yml
+++ b/tests/integration/targets/filter_time/tasks/main.yml
@@ -4,6 +4,13 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 
+- name: test zero is 0
+  assert:
+    that:
+      - "('0' | community.general.to_milliseconds) == 0"
+      - "('0' | community.general.to_seconds) == 0"
+      - "('0' | community.general.to_minutes) == 0"
+
 - name: test to_milliseconds filter
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY
time_filter should not fail for 0 even without a unit and return 0

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
time_filter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
