### PR TITLE
dig lookup: deprecate DLV record type

### DIFF
--- a/changelogs/fragments/4618-dig-dlv.yml
+++ b/changelogs/fragments/4618-dig-dlv.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "dig lookup plugin - the ``DLV`` record type has been decommissioned in 2017 and support for it will be removed from community.general 6.0.0 (https://github.com/ansible-collections/community.general/pull/4618)."

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -27,13 +27,15 @@ DOCUMENTATION = '''
         This needs to be passed-in as an additional parameter to the lookup
     options:
       _terms:
-        description: domain(s) to query
+        description: Domain(s) to query.
       qtype:
-        description: record type to query
+        description:
+            - Record type to query.
+            - C(DLV) is deprecated and will be removed in community.general 6.0.0.
         default: 'A'
         choices: [A, ALL, AAAA, CNAME, DNAME, DLV, DNSKEY, DS, HINFO, LOC, MX, NAPTR, NS, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, TLSA, TXT]
       flat:
-        description: If 0 each record is returned as a dictionary, otherwise a string
+        description: If 0 each record is returned as a dictionary, otherwise a string.
         default: 1
       retry_servfail:
         description: Retry a nameserver if it returns SERVFAIL.
@@ -163,6 +165,7 @@ RETURN = """
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_native
+from ansible.utils.display import Display
 import socket
 
 try:
@@ -176,6 +179,9 @@ try:
     HAVE_DNS = True
 except ImportError:
     HAVE_DNS = False
+
+
+display = Display()
 
 
 def make_rdata_dict(rdata):
@@ -325,6 +331,11 @@ class LookupModule(LookupBase):
         # print "--- domain = {0} qtype={1} rdclass={2}".format(domain, qtype, rdclass)
 
         ret = []
+
+        if qtype.upper() == 'DLV':
+            display.deprecated('The DLV record type has been decommissioned in 2017 and support for'
+                               ' it will be removed from community.general 6.0.0',
+                               version='6.0.0', removed_from_collection='community.general')
 
         if qtype.upper() == 'PTR':
             try:

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -335,7 +335,7 @@ class LookupModule(LookupBase):
         if qtype.upper() == 'DLV':
             display.deprecated('The DLV record type has been decommissioned in 2017 and support for'
                                ' it will be removed from community.general 6.0.0',
-                               version='6.0.0', removed_from_collection='community.general')
+                               version='6.0.0', collection_name='community.general')
 
         if qtype.upper() == 'PTR':
             try:


### PR DESCRIPTION
##### SUMMARY
To be merged for 5.0.0, so we can remove it (via #4613) in 6.0.0.

CC @jpmens

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dig lookup plugin
