### PR TITLE
change list.copy() with list[:] for py2 compat in terraform module

### DIFF
--- a/changelogs/fragments/4621-terraform-py2-compat.yml
+++ b/changelogs/fragments/4621-terraform-py2-compat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - terraform - fix list init to support both PY2 and PY3 (https://github.com/ansible-collections/community.general/issues/4531).

--- a/changelogs/fragments/4621-terraform-py2-compat.yml
+++ b/changelogs/fragments/4621-terraform-py2-compat.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - terraform - fix list init to support both PY2 and PY3 (https://github.com/ansible-collections/community.general/issues/4531).
+  - terraform - fix list initialization to support both Python 2 and Python 3 (https://github.com/ansible-collections/community.general/issues/4531).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -332,7 +332,7 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
     if plan_path is None:
         f, plan_path = tempfile.mkstemp(suffix='.tfplan')
 
-    local_command = command.copy()
+    local_command = command[:]
 
     plan_command = [command[0], 'plan']
 


### PR DESCRIPTION
##### SUMMARY
Changes list.copy()  with list[:] for py2 compatibility.

Fixes #4531

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
See #4531 
