### PR TITLE
[opentelemetry][callback] fix warning when using the include_tasks

### DIFF
--- a/changelogs/fragments/4623-opentelemetry_bug_fix_include_tasks.yml
+++ b/changelogs/fragments/4623-opentelemetry_bug_fix_include_tasks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opentelemetry callback plugin - fix warning for the include_tasks (https://github.com/ansible-collections/community.general/pull/4623).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -197,7 +197,7 @@ class OpenTelemetrySource(object):
 
         task = tasks_data[task_uuid]
 
-        if self.ansible_version is None and result._task_fields['args'].get('_ansible_version'):
+        if self.ansible_version is None and hasattr(result, '_task_fields') and result._task_fields['args'].get('_ansible_version'):
             self.ansible_version = result._task_fields['args'].get('_ansible_version')
 
         task.add_host(HostData(host_uuid, host_name, status, result))

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # (C) 2021, Victor Martinez <VictorMartinezRubio@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -91,6 +92,21 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(host_data.uuid, 'include')
         self.assertEqual(host_data.name, 'include')
         self.assertEqual(host_data.status, 'ok')
+        self.assertEqual(self.opentelemetry.ansible_version, None)
+
+    def test_finish_task_include_with_ansible_version(self):
+        task_fields = {'args': { '_ansible_version' : '1.2.3'}}
+        result = TaskResult(host=None, task=self.mock_task, return_data={}, task_fields=task_fields)
+        tasks_data = OrderedDict()
+        tasks_data['myuuid'] = self.my_task
+
+        self.opentelemetry.finish_task(
+            tasks_data,
+            'ok',
+            result
+        )
+
+        self.assertEqual(self.opentelemetry.ansible_version, '1.2.3')
 
     def test_get_error_message(self):
         test_cases = (

--- a/tests/unit/plugins/callback/test_opentelemetry.py
+++ b/tests/unit/plugins/callback/test_opentelemetry.py
@@ -95,7 +95,7 @@ class TestOpentelemetry(unittest.TestCase):
         self.assertEqual(self.opentelemetry.ansible_version, None)
 
     def test_finish_task_include_with_ansible_version(self):
-        task_fields = {'args': { '_ansible_version' : '1.2.3'}}
+        task_fields = {'args': {'_ansible_version': '1.2.3'}}
         result = TaskResult(host=None, task=self.mock_task, return_data={}, task_fields=task_fields)
         tasks_data = OrderedDict()
         tasks_data['myuuid'] = self.my_task


### PR DESCRIPTION
##### SUMMARY

Fix the `include_tasks` when accessing the `_task_fields` object. Otherwise:

<img width="1776" alt="image" src="https://user-images.githubusercontent.com/2871786/166838149-f51c2cb1-5ee6-4a7a-8fdb-3ec84e77772d.png">

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`plugins/callback/opentelemetry.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- name: MyPlabook
  hosts: localhost
  connection: local

  tasks:

  - name: Call foo task
    include_tasks: foo.yml
```
Then

```bash
OTEL_EXPORTER_OTLP_ENDPOINT=0.0.0.0:4317 \
OTEL_EXPORTER_OTLP_INSECURE=true \
ansible-playbook -i hosts include_tasks.yml
```

produced:

```
PLAY [MyPlabook] *************************************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
[WARNING]: Platform darwin on host localhost is using the discovered Python interpreter at /usr/bin/python3, but future installation of another Python
interpreter could change the meaning of that path. See https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more
information.
ok: [localhost]

TASK [Call foo task] *********************************************************************************************************************************************
included: /Users/vmartinez/work/src/github.com/v1v/ansible-otel-plugin/foo.yml for localhost
[WARNING]: Failure using method (v2_playbook_on_include) in callback plugin (<ansible.plugins.callback.opentelemetry.CallbackModule object at 0x104ffb3d0>):
'IncludedFile' object has no attribute '_task_fields'
...
```
