### PR TITLE
[opentelemetry][callback] fix hardcoded value for ansible_task_message

### DIFF
--- a/changelogs/fragments/4624-opentelemetry_bug_fix_hardcoded_value.yml
+++ b/changelogs/fragments/4624-opentelemetry_bug_fix_hardcoded_value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opentelemetry callback plugin - fix task message attribute that is reported failed regardless of the task result (https://github.com/ansible-collections/community.general/pull/4624).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -258,8 +258,9 @@ class OpenTelemetrySource(object):
             else:
                 res = host_data.result._result
                 rc = res.get('rc', 0)
-                message = self.get_error_message(res)
-                enriched_error_message = self.enrich_error_message(res)
+                if host_data.status == 'failed':
+                    message = self.get_error_message(res)
+                    enriched_error_message = self.enrich_error_message(res)
 
             if host_data.status == 'failed':
                 status = Status(status_code=StatusCode.ERROR, description=message)


### PR DESCRIPTION
##### SUMMARY

Fix the value for the `ansible_task_message` attribute that was always set to `failed`

<img width="815" alt="image" src="https://user-images.githubusercontent.com/2871786/166839612-fa9c782e-b537-4b35-834c-0f268cd1c883.png">


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`plugins/callback/opentelemetry.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- name: Echo
  hosts: localhost
  connection: local

  tasks:
    - name: create the local src directory
      file:
        path: /tmp/local/src
        state: directory
```
Then

```bash
OTEL_EXPORTER_OTLP_ENDPOINT=0.0.0.0:4317 \
OTEL_EXPORTER_OTLP_INSECURE=true \
ansible-playbook -i hosts test.yml
```

produced:

```
PLAY [Echo] ******************************************************************************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************************************************
[WARNING]: Platform darwin on host localhost is using the discovered Python interpreter at /usr/bin/python3, but future installation of another Python
interpreter could change the meaning of that path. See https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more
information.
ok: [localhost]

TASK [create the local src directory] ****************************************************************************************************************************
ok: [localhost]

PLAY RECAP *******************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```

<img width="956" alt="image" src="https://user-images.githubusercontent.com/2871786/166839545-a36bfb79-f3b7-4f8f-8337-1922d3ef016d.png">

