### PR TITLE
onepassword - Get first found config file

### DIFF
--- a/changelogs/fragments/4065-onepassword-config.yml
+++ b/changelogs/fragments/4065-onepassword-config.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - onepassword - Search all valid configuration locations and use the first found (https://github.com/ansible-collections/community.general/pull/4640)
+  - onepassword - search all valid configuration locations and use the first found (https://github.com/ansible-collections/community.general/pull/4640).

--- a/changelogs/fragments/4065-onepassword-config.yml
+++ b/changelogs/fragments/4065-onepassword-config.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - onepassword - Search all valid configuration locations and use the first found (https://github.com/ansible-collections/community.general/pull/4640)

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -105,15 +105,10 @@ from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 
+from ansible_collections.community.general.plugins.module_utils.onepassword import OnePasswordConfig
+
 
 class OnePass:
-
-    _config_file_paths = (
-        "~/.op/config",
-        "~/.config/op/config ",
-        "~/.config/.op/config ",
-    )
-
     def __init__(self, path='op'):
         self.cli_path = path
         self.logged_in = False
@@ -123,27 +118,12 @@ class OnePass:
         self.username = None
         self.secret_key = None
         self.master_password = None
-        self._config_file_path = ""
 
-        self._config_file_paths = [
-            "~/.op/config",
-            "~/.config/op/config"
-        ]
-
-    @property
-    def config_file_path(self):
-        if self._config_file_path:
-            return self._config_file_path
-
-        for path in self._config_file_paths:
-            realpath = os.path.expanduser(path)
-            if os.path.exists(realpath):
-                self._config_file_path = realpath
-                return self._config_file_path
+        self._config = OnePasswordConfig()
 
     def get_token(self):
         # If the config file exists, assume an initial signin has taken place and try basic sign in
-        if os.path.isfile(self.config_file_path):
+        if os.path.isfile(self._config.config_file_path):
 
             if not self.master_password:
                 raise AnsibleLookupError('Unable to sign in to 1Password. master_password is required.')

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -108,7 +108,7 @@ from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible_collections.community.general.plugins.module_utils.onepassword import OnePasswordConfig
 
 
-class OnePass:
+class OnePass(object):
     def __init__(self, path='op'):
         self.cli_path = path
         self.logged_in = False

--- a/plugins/module_utils/onepassword.py
+++ b/plugins/module_utils/onepassword.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 import os
 
 
-class OnePasswordConfig:
+class OnePasswordConfig(object):
     _config_file_paths = (
         "~/.op/config",
         "~/.config/op/config",

--- a/plugins/module_utils/onepassword.py
+++ b/plugins/module_utils/onepassword.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+
+class OnePasswordConfig:
+    _config_file_paths = (
+        "~/.op/config",
+        "~/.config/op/config",
+        "~/.config/.op/config",
+    )
+
+    def __init__(self):
+        self._config_file_path = ""
+
+    @property
+    def config_file_path(self):
+        if self._config_file_path:
+            return self._config_file_path
+
+        for path in self._config_file_paths:
+            realpath = os.path.expanduser(path)
+            if os.path.exists(realpath):
+                self._config_file_path = realpath
+                return self._config_file_path

--- a/plugins/modules/identity/onepassword_info.py
+++ b/plugins/modules/identity/onepassword_info.py
@@ -166,6 +166,8 @@ from subprocess import Popen, PIPE
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.community.general.plugins.module_utils.onepassword import OnePasswordConfig
+
 
 class AnsibleModuleError(Exception):
     def __init__(self, results):
@@ -175,17 +177,18 @@ class AnsibleModuleError(Exception):
         return self.results
 
 
-class OnePasswordInfo(object):
+class OnePasswordInfo:
 
     def __init__(self):
         self.cli_path = module.params.get('cli_path')
-        self.config_file_path = '~/.op/config'
         self.auto_login = module.params.get('auto_login')
         self.logged_in = False
         self.token = None
 
         terms = module.params.get('search_terms')
         self.terms = self.parse_search_terms(terms)
+
+        self._config = OnePasswordConfig()
 
     def _run(self, args, expected_rc=0, command_input=None, ignore_errors=False):
         if self.token:
@@ -299,7 +302,7 @@ class OnePasswordInfo(object):
 
     def get_token(self):
         # If the config file exists, assume an initial signin has taken place and try basic sign in
-        if os.path.isfile(self.config_file_path):
+        if os.path.isfile(self._config.config_file_path):
 
             if self.auto_login is not None:
 

--- a/plugins/modules/identity/onepassword_info.py
+++ b/plugins/modules/identity/onepassword_info.py
@@ -177,7 +177,7 @@ class AnsibleModuleError(Exception):
         return self.results
 
 
-class OnePasswordInfo:
+class OnePasswordInfo(object):
 
     def __init__(self):
         self.cli_path = module.params.get('cli_path')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #4065.

There are three [configuration file locations](https://developer.1password.com/docs/cli/about-biometric-unlock#remove-old-account-information). Use the first found valid config.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/lookup/onepassword.py`
`plugins/module_utils/onepassword.py`
`plugins/modules/identity/onepassword_info.py`

##### ADDITIONAL INFORMATION
This plugin is currently broken since the 1Password v2 CLI was released. More work is needed to address that issue, but this is a first step.