### PR TITLE
DOC: Document setting of NTP server in examples of ilo_redfish_config

### DIFF
--- a/plugins/modules/remote_management/redfish/ilo_redfish_config.py
+++ b/plugins/modules/remote_management/redfish/ilo_redfish_config.py
@@ -82,6 +82,17 @@ EXAMPLES = '''
       password: Testpass123
       attribute_name: TimeZone
       attribute_value: Chennai
+
+  - name: Set NTP Servers
+    community.general.ilo_redfish_config:
+      category: Manager
+      command: SetNTPServers
+      baseuri: 15.X.X.X
+      username: Admin
+      password: Testpass123
+      attribute_name: StaticNTPServers
+      attribute_value: X.X.X.X
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
Document example for setting static NTP server using `ilo_redfish_config`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ilo_redffish_config

##### ADDITIONAL INFORMATION
Tested on iLO 5 (HP Gen 10).
Command checked from iLO5 REST API reference:
  https://hewlettpackard.github.io/ilo-rest-api-docs/ilo5/#configuring-network-time-protocol-ntp
