### PR TITLE
Add optional SSL parameter in znode.py

### DIFF
--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -48,6 +48,11 @@ options:
             - Recursively delete node and all its children.
         type: bool
         default: 'no'
+    usessl:
+        description:
+            - Using ssl or not (true or false).
+        type: bool
+        default: 'no'
 requirements:
     - kazoo >= 2.1
     - python >= 2.6
@@ -121,7 +126,8 @@ def main():
             op=dict(choices=['get', 'wait', 'list']),
             state=dict(choices=['present', 'absent']),
             timeout=dict(default=300, type='int'),
-            recursive=dict(default=False, type='bool')
+            recursive=dict(default=False, type='bool'),
+            usessl=dict(default=False, type='bool')
         ),
         supports_check_mode=False
     )
@@ -175,7 +181,7 @@ def check_params(params):
 class KazooCommandProxy():
     def __init__(self, module):
         self.module = module
-        self.zk = KazooClient(module.params['hosts'])
+        self.zk = KazooClient(module.params['hosts'], use_ssl=module.params['usessl'])
 
     def absent(self):
         return self._absent(self.module.params['name'])

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -50,7 +50,7 @@ options:
         default: 'no'
     use_tls:
         description:
-            - Using ssl or not (true or false).
+            - Using TLS/SSL or not.
         type: bool
         default: 'no'
 requirements:

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -128,7 +128,7 @@ def main():
             state=dict(choices=['present', 'absent']),
             timeout=dict(default=300, type='int'),
             recursive=dict(default=False, type='bool'),
-            usessl=dict(default=False, type='bool'),
+            use_tls=dict(default=False, type='bool'),
         ),
         supports_check_mode=False
     )

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -128,7 +128,7 @@ def main():
             state=dict(choices=['present', 'absent']),
             timeout=dict(default=300, type='int'),
             recursive=dict(default=False, type='bool'),
-            usessl=dict(default=False, type='bool')
+            usessl=dict(default=False, type='bool'),
         ),
         supports_check_mode=False
     )

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -48,7 +48,7 @@ options:
             - Recursively delete node and all its children.
         type: bool
         default: 'no'
-    usessl:
+    use_tls:
         description:
             - Using ssl or not (true or false).
         type: bool

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -52,7 +52,8 @@ options:
         description:
             - Using TLS/SSL or not.
         type: bool
-        default: 'no'
+        default: false
+        version_added: 5.0.0
 requirements:
     - kazoo >= 2.1
     - python >= 2.6


### PR DESCRIPTION
##### SUMMARY
Added optional SSL parameter to make SSL communication with Zookeeper possible.
Defaults to "disabled".

Disclaimer: This worked in our preconfigured environment. Additional testing might be required.

##### COMPONENT NAME
Module "clustering" - znode.py

##### ADDITIONAL INFORMATION
These changes make communication with Zookeeper via SSL possible. If you have a Zookeeper configured with SSL enabled, you need an additional parameter for the client to use SSL.
This parameter is set to "no" by default, so it should not have any impact on non-SSL infrastructure.
