### PR TITLE
ModuleHelper: added a do_raise() method to MH base class

### DIFF
--- a/changelogs/fragments/4660-mh-added-do-raise.yaml
+++ b/changelogs/fragments/4660-mh-added-do-raise.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ModuleHelper module utils - ``ModuleHelperBase` now has a convenience method ``do_raise`` (https://github.com/ansible-collections/community.general/pull/4660).

--- a/changelogs/fragments/4660-mh-added-do-raise.yaml
+++ b/changelogs/fragments/4660-mh-added-do-raise.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ModuleHelper module utils - ``ModuleHelperBase` now has a convenience method ``do_raise`` (https://github.com/ansible-collections/community.general/pull/4660).
+  - ModuleHelper module utils - ``ModuleHelperBase`` now has a convenience method ``do_raise`` (https://github.com/ansible-collections/community.general/pull/4660).

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -31,6 +31,11 @@ class ModuleHelperBase(object):
     def diff_mode(self):
         return self.module._diff
 
+    def do_raise(self, *args, **kwargs):
+        exc_class = kwargs.get("exception_class", _MHE)
+        kwargs = dict((k, v) for k, v in kwargs.items() if k != 'exception_class')
+        raise exc_class(*args, **kwargs)
+
     def __getattr__(self, attr):
         if attr in self._delegated_to_module:
             return getattr(self.module, attr)

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -32,9 +32,7 @@ class ModuleHelperBase(object):
         return self.module._diff
 
     def do_raise(self, *args, **kwargs):
-        exc_class = _MHE
-        kwargs = dict((k, v) for k, v in kwargs.items() if k != 'exception_class')
-        raise exc_class(*args, **kwargs)
+        raise _MHE(*args, **kwargs)
 
     def __getattr__(self, attr):
         if attr in self._delegated_to_module:

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -32,7 +32,7 @@ class ModuleHelperBase(object):
         return self.module._diff
 
     def do_raise(self, *args, **kwargs):
-        exc_class = kwargs.get("exception_class", _MHE)
+        exc_class = _MHE
         kwargs = dict((k, v) for k, v in kwargs.items() if k != 'exception_class')
         raise exc_class(*args, **kwargs)
 

--- a/plugins/module_utils/mh/mixins/cmd.py
+++ b/plugins/module_utils/mh/mixins/cmd.py
@@ -128,8 +128,7 @@ class CmdMixin(object):
         for param in param_list:
             if isinstance(param, dict):
                 if len(param) != 1:
-                    raise self.ModuleHelperException("run_command parameter as a dict must "
-                                                     "contain only one key: {0}".format(param))
+                    self.do_raise("run_command parameter as a dict must contain only one key: {0}".format(param))
                 _param = list(param.keys())[0]
                 fmt = find_format(_param)
                 value = param[_param]
@@ -141,9 +140,9 @@ class CmdMixin(object):
                     fmt = find_format(param)
                     value = extra_params[param]
                 else:
-                    raise self.ModuleHelperException('Cannot determine value for parameter: {0}'.format(param))
+                    self.do_raise('Cannot determine value for parameter: {0}'.format(param))
             else:
-                raise self.ModuleHelperException("run_command parameter must be either a str or a dict: {0}".format(param))
+                self.do_raise("run_command parameter must be either a str or a dict: {0}".format(param))
             cmd_args = add_arg_formatted_param(cmd_args, fmt, value)
 
         return cmd_args


### PR DESCRIPTION
##### SUMMARY
Added a method `do_raise()` to MH base class, so that module developers won't have to import ModuleHelperException unless they want to subclass it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py