### PR TITLE
Remove unsupported and unnecessary --no-emoji option

### DIFF
--- a/changelogs/fragments/4662-yarn-emoji.yml
+++ b/changelogs/fragments/4662-yarn-emoji.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - yarn - remove unsupported and unnecessary --no-emoji flag (https://github.com/ansible-collections/community.general/pull/4662).
+  - yarn - remove unsupported and unnecessary ``--no-emoji`` flag (https://github.com/ansible-collections/community.general/pull/4662).

--- a/changelogs/fragments/4662-yarn-emoji.yml
+++ b/changelogs/fragments/4662-yarn-emoji.yml
@@ -1,2 +1,2 @@
-bugfixes:
+breaking_changes:
   - yarn - remove unsupported and unnecessary ``--no-emoji`` flag (https://github.com/ansible-collections/community.general/pull/4662).

--- a/changelogs/fragments/4662-yarn-emoji.yml
+++ b/changelogs/fragments/4662-yarn-emoji.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yarn - remove unsupported and unnecessary --no-emoji flag (https://github.com/ansible-collections/community.general/pull/4662).

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -147,7 +147,7 @@ invocation:
             }
         }
 out:
-    description: Output generated from Yarn with emojis removed.
+    description: Output generated from Yarn.
     returned: always
     type: str
     sample: "yarn add v0.16.1[1/4] Resolving packages...[2/4] Fetching packages...[3/4] Linking dependencies...[4/4]
@@ -204,9 +204,6 @@ class Yarn(object):
             if self.registry:
                 cmd.append('--registry')
                 cmd.append(self.registry)
-
-            # always run Yarn without emojis when called via Ansible
-            cmd.append('--no-emoji')
 
             # If path is specified, cd into that path and run the command.
             cwd = None


### PR DESCRIPTION
##### SUMMARY

Yarn 2 and above no longer support the `--no-emoji` flag and have stricter checks on unrecognized command-line options, causing community.general.yarn's use of `--no-emoji` to throw errors on those versions.

Yarn 1.x doesn't properly support the `--no-emoji` flag, so community.general.yarn's use of `--no-emoji` has no effect there. Yarn 1.x attempts to only use emoji for interactive terminals of specific, known terminal types, so explicitly using `--no-emoji` should be unnecessary.

Fixes #4661, #4245

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yarn

##### ADDITIONAL INFORMATION

See discussion at #4245 and #4661.

* Yarn 1.x claims to support the `--no-emoji` flag; see https://github.com/yarnpkg/yarn/commit/10b82bb063c2e2feee669ddb9dfaf4126b74c7a7. However, this is apparently incorrect:
    * Later discussions at https://github.com/yarnpkg/yarn/issues/7439 indicated that `--no-emoji` doesn't work and that `--emoji=false` should be used instead. My local testing with Yarn 1.22.18 on my MacBook Pro confirms this.
    * Although Commander 2.x (the command-line parsing package used by Yarn) does have special handling for `--no-` flags (see [here](https://github.com/tj/commander.js/tree/v2.16.0#option-parsing)), the `--no-` options apparently still must be explicitly enabled (as in the `--no-sauce` example there). Yarn 1.x [doesn't do that](https://github.com/yarnpkg/yarn/blob/master/src/cli/index.js#L112).
    * Yarn 1.x [is in maintenance mode](https://github.com/yarnpkg/yarn#contributing-to-yarn), so none of this is likely to change.
* Yarn 2+ [does not support `--no-emoji`](https://yarnpkg.com/cli/install).