### PR TITLE
Set firstrun to avoid use before definition

### DIFF
--- a/changelogs/fragments/4651-zypper-checkmode-fix.yaml
+++ b/changelogs/fragments/4651-zypper-checkmode-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zypper - fix undefined variable first run, when running in check_mode
+  - zypper - fix undefined variable when running in check mode (https://github.com/ansible-collections/community.general/pull/4667).

--- a/changelogs/fragments/4651-zypper-checkmode-fix.yaml
+++ b/changelogs/fragments/4651-zypper-checkmode-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper - fix undefined variable first run, when running in check_mode

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -323,6 +323,8 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
         if packages is None:
             firstrun = True
             packages = {}
+        else:
+            firstrun = False
         solvable_list = dom.getElementsByTagName('solvable')
         for solvable in solvable_list:
             name = solvable.getAttribute('name')


### PR DESCRIPTION
##### SUMMARY
At the moment if zypper updates itself the parse_zypper_xml function
calls itself with packages not None, but in check_mode zypper still
needs to update itself again -> rc = 103 and firstrun is undefined


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper
