### PR TITLE
gitlab_hook: use None for non-existent attr in gitlab API response

### DIFF
--- a/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
+++ b/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_hook - avoid errors during idempoency check when an attribute does not exist (https://github.com/ansible-collections/community.general/pull/4668).
+  - gitlab_hook - avoid errors during idempotency check when an attribute does not exist (https://github.com/ansible-collections/community.general/pull/4668).

--- a/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
+++ b/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_hook - use None for non-existent attribute, e.g. 'token'

--- a/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
+++ b/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_hook - use None for non-existent attribute, e.g. 'token'
+  - gitlab_hook - avoid errors during idempoency check when an attribute does not exist (https://github.com/ansible-collections/community.general/pull/4668).

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -257,7 +257,7 @@ class GitLabHook(object):
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(hook, arg_key) != arguments[arg_key]:
+                if getattr(hook, arg_key, '') != arguments[arg_key]:
                     setattr(hook, arg_key, arguments[arg_key])
                     changed = True
 

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -257,7 +257,7 @@ class GitLabHook(object):
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(hook, arg_key, '') != arguments[arg_key]:
+                if getattr(hook, arg_key, None) != arguments[arg_key]:
                     setattr(hook, arg_key, arguments[arg_key])
                     changed = True
 


### PR DESCRIPTION
##### SUMMARY
there is a problem when webhook token is defined with ansible, because gitlab API doesn`t return 'token' attribute

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_hook

##### ADDITIONAL INFORMATION

```
  - name: my/project crowdin webhook
    become: no
    local_action:
      module: community.general.gitlab_hook
      api_url: "{{ gitlab__api_url }}"
      api_token: "{{ vault.gitlab__api_token }}"
      state: present
      project: "my/project"
      hook_url: "https://crowdin.com/hooks/gitlab_server"
      push_events: yes
      hook_validate_certs: yes
      token: "{{ vault.gitlab__hook.crowdin_token }}"
```

error message
```
Traceback (most recent call last):
  File \"<stdin>\", line 102, in <module>
  File \"<stdin>\", line 94, in _ansiballz_main
  File \"<stdin>\", line 40, in invoke_module
  File \"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py\", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py\", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py\", line 87, in _run_code
    exec(code, run_globals)
  File \"/var/folders/l1/d5msh66s31ngsr9gdjc4kzx80000gn/T/ansible_community.general.gitlab_hook_payload_2yfbdmwa/ansible_community.general.gitlab_hook_payload.zip/ansible_collections/community/general/plugins/modules/source_control/gitlab/gitlab_hook.py\", line 390, in <module>
  File \"/var/folders/l1/d5msh66s31ngsr9gdjc4kzx80000gn/T/ansible_community.general.gitlab_hook_payload_2yfbdmwa/ansible_community.general.gitlab_hook_payload.zip/ansible_collections/community/general/plugins/modules/source_control/gitlab/gitlab_hook.py\", line 370, in main
  File \"/var/folders/l1/d5msh66s31ngsr9gdjc4kzx80000gn/T/ansible_community.general.gitlab_hook_payload_2yfbdmwa/ansible_community.general.gitlab_hook_payload.zip/ansible_collections/community/general/plugins/modules/source_control/gitlab/gitlab_hook.py\", line 212, in create_or_update_hook
  File \"/var/folders/l1/d5msh66s31ngsr9gdjc4kzx80000gn/T/ansible_community.general.gitlab_hook_payload_2yfbdmwa/ansible_community.general.gitlab_hook_payload.zip/ansible_collections/community/general/plugins/modules/source_control/gitlab/gitlab_hook.py\", line 260, in update_hook
  File \"/Users/k-petrov/Library/Python/3.8/lib/python/site-packages/gitlab/base.py\", line 142, in __getattr__
    raise AttributeError(message) from exc
AttributeError: ProjectHook object has no attribute token
```

gitlab API doesn`t return token (https://docs.gitlab.com/ee/api/projects.html#get-project-hook)

ipython:
```
In [51]: hook.attributes.keys()
Out[51]: dict_keys(['id', 'url', 'created_at', 'push_events', 'tag_push_events', 'merge_requests_events', 'repository_update_events', 'enable_ssl_verification', 'project_id', 'issues_events', 'confidential_issues_events', 'note_events', 'confidential_note_events', 'pipeline_events', 'wiki_page_events', 'deployment_events', 'job_events', 'releases_events', 'push_events_branch_filter'])
```