### PR TITLE
[stable-4] gitlab_hook: use None for non-existent attr in gitlab API response

### DIFF
--- a/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
+++ b/changelogs/fragments/4668-gitlab_hook-use-None-for-non-existent-attr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_hook - avoid errors during idempotency check when an attribute does not exist (https://github.com/ansible-collections/community.general/pull/4668).

--- a/plugins/modules/source_control/gitlab/gitlab_hook.py
+++ b/plugins/modules/source_control/gitlab/gitlab_hook.py
@@ -257,7 +257,7 @@ class GitLabHook(object):
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(hook, arg_key) != arguments[arg_key]:
+                if getattr(hook, arg_key, None) != arguments[arg_key]:
                     setattr(hook, arg_key, arguments[arg_key])
                     changed = True
 


### PR DESCRIPTION
##### SUMMARY
Backport of #4668 to stable-4.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_hook
