### PR TITLE
certifi dropped Python 2 support

### DIFF
--- a/tests/integration/targets/consul/meta/main.yml
+++ b/tests/integration/targets/consul/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - setup_pkg_mgr
   - setup_openssl
   - setup_remote_tmp_dir
+  - setup_remote_constraints

--- a/tests/integration/targets/consul/tasks/main.yml
+++ b/tests/integration/targets/consul/tasks/main.yml
@@ -12,12 +12,14 @@
   - name: Install requests<2.20 (CentOS/RHEL 6)
     pip:
       name: requests<2.20
+      extra_args: "-c {{ remote_constraints }}"
     register: result
     until: result is success
     when: ansible_distribution_file_variety|default() == 'RedHat' and ansible_distribution_major_version is version('6', '<=')
   - name: Install python-consul
     pip:
       name: python-consul
+      extra_args: "-c {{ remote_constraints }}"
     register: result
     until: result is success
   - name: Generate privatekey

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -1,3 +1,4 @@
+certifi < 2022.5.18 ; python_version < '3.5' # certifi 2022.5.18 requires Python 3.5 or later
 coverage >= 4.2, < 5.0.0, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6, coverage 5.0+ incompatible
 coverage >= 4.5.4, < 5.0.0 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6


### PR DESCRIPTION
##### SUMMARY
Add constraint so that systems with outdated pip2s don't try to install a bad version.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
