### PR TITLE
nmcli: use capital case "DNS" in documentation, improve examples

### DIFF
--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -157,8 +157,8 @@ options:
         version_added: 2.0.0
     dns4:
         description:
-            - A list of up to 3 dns servers.
-            - IPv4 format e.g. to add two IPv4 DNS server addresses, use C(192.0.2.53 198.51.100.53).
+            - A list of up to 3 DNS servers.
+            - IPv4 format e.g. to add two IPv4 DNS server addresses, use C(192.0.2.53) C(198.51.100.53).
         elements: str
         type: list
     dns4_search:
@@ -255,8 +255,8 @@ options:
         version_added: 4.4.0
     dns6:
         description:
-            - A list of up to 3 dns servers.
-            - IPv6 format e.g. to add two IPv6 DNS server addresses, use C(2001:4860:4860::8888 2001:4860:4860::8844).
+            - A list of up to 3 DNS servers.
+            - IPv6 format e.g. to add two IPv6 DNS server addresses, use C(2001:4860:4860::8888) C(2001:4860:4860::8844).
         elements: str
         type: list
     dns6_search:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -158,7 +158,7 @@ options:
     dns4:
         description:
             - A list of up to 3 DNS servers.
-            - IPv4 format e.g. to add two IPv4 DNS server addresses, use C(192.0.2.53) C(198.51.100.53).
+            - The entries must be IPv4 addresses, for example C(192.0.2.53).
         elements: str
         type: list
     dns4_search:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -256,7 +256,7 @@ options:
     dns6:
         description:
             - A list of up to 3 DNS servers.
-            - IPv6 format e.g. to add two IPv6 DNS server addresses, use C(2001:4860:4860::8888) C(2001:4860:4860::8844).
+            - The entries must be IPv6 addresses, for example C(2001:4860:4860::8888).
         elements: str
         type: list
     dns6_search:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In documentation sometimes DNS was written in (incorrect) lower
case "dns" and sometimes in (correct) capital case "DNS". Use the
right capital case spelling in all parameter descriptions.

Also the example for `dns4` and `dns6` parameters looked like a
space-separated string while the parameter expects a list of
strings. Try to improve the example by changing the single
space-separated string to two individual code-strings.
This could probably be further improved to make it more clear
that the two IP addresses for DNS parameter should be a list of
strings and not a single space-separated string.

Or perhaps the examples in description of parameters `dns4` and
`dns6` should be dropped completely to avoid confusion.
There is already an example task "Add two IPv4 DNS server
addresses" that shows how to use the DNS parameters.

The whole sentence "IPv4 format e.g. to add two IPv4 DNS server
addresses" is awkward and its existence makes no sense to me.
Looking for feedback on dropping it completely from `dns4` and
`dns6`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
