### PR TITLE
fix invalid fail_json call

### DIFF
--- a/changelogs/fragments/4733-redis-fail.yml
+++ b/changelogs/fragments/4733-redis-fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "redis* modules - fix call to ``module.fail_json`` when failing because of missing Python libraries (https://github.com/ansible-collections/community.general/pull/4733)."

--- a/plugins/module_utils/redis.py
+++ b/plugins/module_utils/redis.py
@@ -37,7 +37,7 @@ def fail_imports(module, needs_certifi=True):
         errors.append(missing_required_lib('certifi'))
         traceback.append(CERTIFI_IMPORT_ERROR)
     if errors:
-        module.fail_json(errors=errors, traceback='\n'.join(traceback))
+        module.fail_json(msg='\n'.join(errors), traceback='\n'.join(traceback))
 
 
 def redis_auth_argument_spec(tls_default=True):


### PR DESCRIPTION
Currently causes this error:
```
TypeError: AnsibleModule.fail_json() missing 1 required positional argument: 'msg'
gitlab | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3.10"
    },
    "changed": false,
    "module_stderr": "Shared connection to 10.0.3.100 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1653579059.8318024-147674-84188943153768/AnsiballZ_redis.py\", line 107, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1653579059.8318024-147674-84188943153768/AnsiballZ_redis.py\", line 99, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1653579059.8318024-147674-84188943153768/AnsiballZ_redis.py\", line 47, in invoke_module\r\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.redis', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.redis', _modlib_path=modlib_path),\r\n  File \"/usr/lib/python3.10/runpy.py\", line 209, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\r\n    _run_code(code, mod_globals, init_globals,\r\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_community.general.redis_payload_di15cy0s/ansible_community.general.redis_payload.zip/ansible_collections/community/general/plugins/modules/redis.py\", line 328, in <module>\r\n  File \"/tmp/ansible_community.general.redis_payload_di15cy0s/ansible_community.general.redis_payload.zip/ansible_collections/community/general/plugins/modules/redis.py\", line 195, in main\r\n  File \"/tmp/ansible_community.general.redis_payload_di15cy0s/ansible_community.general.redis_payload.zip/ansible_collections/community/general/plugins/module_utils/redis.py\", line 40, in fail_imports\r\nTypeError: AnsibleModule.fail_json() missing 1 required positional argument: 'msg'\r\n",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

#
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/redis