### PR TITLE
cmd_runner: added flag check_mode_skip to context

### DIFF
--- a/changelogs/fragments/4736-cmd-runner-skip-if-check.yml
+++ b/changelogs/fragments/4736-cmd-runner-skip-if-check.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cmd_runner module util - added parameter ``skip_if_check_mode`` to ``CmdRunner.context()``, so that the command is not executed when ``check_mode=True`` (https://github.com/ansible-collections/community.general/pull/4736).
+  - cmd_runner module util - added parameters ``check_mode_skip`` and ``check_mode_return`` to ``CmdRunner.context()``, so that the command is not executed when ``check_mode=True`` (https://github.com/ansible-collections/community.general/pull/4736).

--- a/changelogs/fragments/4736-cmd-runner-skip-if-check.yml
+++ b/changelogs/fragments/4736-cmd-runner-skip-if-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cmd_runner module util - added parameter ``skip_if_check_mode`` to ``CmdRunner.context()``, so that the command is not executed when ``check_mode=True`` (https://github.com/ansible-collections/community.general/pull/4736).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -197,7 +197,7 @@ class CmdRunner(object):
             if mod_param_name not in self.arg_formats:
                 self.arg_formats[mod_param_name] = _Format.as_default_type(spec['type'], mod_param_name)
 
-    def context(self, args_order=None, output_process=None, ignore_value_none=True, **kwargs):
+    def context(self, args_order=None, output_process=None, ignore_value_none=True, skip_if_check_mode=False, **kwargs):
         if output_process is None:
             output_process = _process_as_is
         if args_order is None:
@@ -209,18 +209,20 @@ class CmdRunner(object):
         return _CmdRunnerContext(runner=self,
                                  args_order=args_order,
                                  output_process=output_process,
-                                 ignore_value_none=ignore_value_none, **kwargs)
+                                 ignore_value_none=ignore_value_none,
+                                 skip_if_check_mode=skip_if_check_mode, **kwargs)
 
     def has_arg_format(self, arg):
         return arg in self.arg_formats
 
 
 class _CmdRunnerContext(object):
-    def __init__(self, runner, args_order, output_process, ignore_value_none, **kwargs):
+    def __init__(self, runner, args_order, output_process, ignore_value_none, skip_if_check_mode, **kwargs):
         self.runner = runner
         self.args_order = tuple(args_order)
         self.output_process = output_process
         self.ignore_value_none = ignore_value_none
+        self.skip_if_check_mode = skip_if_check_mode
         self.run_command_args = dict(kwargs)
 
         self.environ_update = runner.environ_update
@@ -260,6 +262,8 @@ class _CmdRunnerContext(object):
             except Exception as e:
                 raise FormatError(arg_name, value, runner.arg_formats[arg_name], e)
 
+        if self.skip_if_check_mode and module.check_mode:
+            return
         results = module.run_command(self.cmd, **self.run_command_args)
         self.results_rc, self.results_out, self.results_err = results
         self.results_processed = self.output_process(*results)

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -197,7 +197,7 @@ class CmdRunner(object):
             if mod_param_name not in self.arg_formats:
                 self.arg_formats[mod_param_name] = _Format.as_default_type(spec['type'], mod_param_name)
 
-    def context(self, args_order=None, output_process=None, ignore_value_none=True, skip_if_check_mode=False, **kwargs):
+    def context(self, args_order=None, output_process=None, ignore_value_none=True, check_mode_skip=False, check_mode_return=None, **kwargs):
         if output_process is None:
             output_process = _process_as_is
         if args_order is None:
@@ -210,19 +210,21 @@ class CmdRunner(object):
                                  args_order=args_order,
                                  output_process=output_process,
                                  ignore_value_none=ignore_value_none,
-                                 skip_if_check_mode=skip_if_check_mode, **kwargs)
+                                 check_mode_skip=check_mode_skip,
+                                 check_mode_return=check_mode_return, **kwargs)
 
     def has_arg_format(self, arg):
         return arg in self.arg_formats
 
 
 class _CmdRunnerContext(object):
-    def __init__(self, runner, args_order, output_process, ignore_value_none, skip_if_check_mode, **kwargs):
+    def __init__(self, runner, args_order, output_process, ignore_value_none, check_mode_skip, check_mode_return, **kwargs):
         self.runner = runner
         self.args_order = tuple(args_order)
         self.output_process = output_process
         self.ignore_value_none = ignore_value_none
-        self.skip_if_check_mode = skip_if_check_mode
+        self.check_mode_skip = check_mode_skip
+        self.check_mode_return = check_mode_return
         self.run_command_args = dict(kwargs)
 
         self.environ_update = runner.environ_update
@@ -262,8 +264,8 @@ class _CmdRunnerContext(object):
             except Exception as e:
                 raise FormatError(arg_name, value, runner.arg_formats[arg_name], e)
 
-        if self.skip_if_check_mode and module.check_mode:
-            return
+        if self.check_mode_skip and module.check_mode:
+            return self.check_mode_return
         results = module.run_command(self.cmd, **self.run_command_args)
         self.results_rc, self.results_out, self.results_err = results
         self.results_processed = self.output_process(*results)

--- a/tests/integration/targets/cmd_runner/library/cmd_echo.py
+++ b/tests/integration/targets/cmd_runner/library/cmd_echo.py
@@ -6,36 +6,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import sys
 
-DOCUMENTATION = '''
-module: cmd_echo
-author: "Alexei Znamensky (@russoz)"
-short_description: Simple module for testing
-description:
-  - Simple module test description.
-options:
-  command:
-    description: aaa
-    type: list
-    elements: str
-    required: true
-  arg_formats:
-    description: bbb
-    type: dict
-    required: true
-  arg_order:
-    description: ccc
-    type: raw
-    required: true
-  arg_values:
-    description: ddd
-    type: list
-    required: true
-  aa:
-    description: eee
-    type: raw
-'''
+DOCUMENTATION = ""
 
 EXAMPLES = ""
 
@@ -51,10 +23,14 @@ def main():
             arg_formats=dict(type="dict", default={}),
             arg_order=dict(type="raw", required=True),
             arg_values=dict(type="dict", default={}),
+            skip_if_check=dict(type="bool", default=False),
             aa=dict(type="raw"),
         ),
+        supports_check_mode=True,
     )
     p = module.params
+
+    info = None
 
     arg_formats = {}
     for arg, fmt_spec in p['arg_formats'].items():
@@ -65,11 +41,11 @@ def main():
 
     runner = CmdRunner(module, ['echo', '--'], arg_formats=arg_formats)
 
-    info = None
-    with runner.context(p['arg_order']) as ctx:
+    with runner.context(p['arg_order'], skip_if_check_mode=p['skip_if_check']) as ctx:
         result = ctx.run(**p['arg_values'])
         info = ctx.run_info
-    rc, out, err = result
+    check = "check"
+    rc, out, err = result if result is not None else (None, None, None)
 
     module.exit_json(rc=rc, out=out, err=err, info=info)
 

--- a/tests/integration/targets/cmd_runner/library/cmd_echo.py
+++ b/tests/integration/targets/cmd_runner/library/cmd_echo.py
@@ -23,7 +23,7 @@ def main():
             arg_formats=dict(type="dict", default={}),
             arg_order=dict(type="raw", required=True),
             arg_values=dict(type="dict", default={}),
-            skip_if_check=dict(type="bool", default=False),
+            check_mode_skip=dict(type="bool", default=False),
             aa=dict(type="raw"),
         ),
         supports_check_mode=True,
@@ -41,7 +41,7 @@ def main():
 
     runner = CmdRunner(module, ['echo', '--'], arg_formats=arg_formats)
 
-    with runner.context(p['arg_order'], skip_if_check_mode=p['skip_if_check']) as ctx:
+    with runner.context(p['arg_order'], check_mode_skip=p['check_mode_skip']) as ctx:
         result = ctx.run(**p['arg_values'])
         info = ctx.run_info
     check = "check"

--- a/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
+++ b/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
@@ -4,8 +4,10 @@
     arg_formats: "{{ item.arg_formats|default(omit) }}"
     arg_order: "{{ item.arg_order }}"
     arg_values: "{{ item.arg_values|default(omit) }}"
+    skip_if_check: "{{ item.skip_if_check|default(omit) }}"
     aa: "{{ item.aa|default(omit) }}"
   register: test_result
+  check_mode: "{{ item.check_mode|default(omit) }}"
   ignore_errors: "{{ item.expect_error|default(omit) }}"
 
 - name: check results [{{ item.name }}]

--- a/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
+++ b/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
@@ -4,7 +4,7 @@
     arg_formats: "{{ item.arg_formats|default(omit) }}"
     arg_order: "{{ item.arg_order }}"
     arg_values: "{{ item.arg_values|default(omit) }}"
-    skip_if_check: "{{ item.skip_if_check|default(omit) }}"
+    check_mode_skip: "{{ item.check_mode_skip|default(omit) }}"
     aa: "{{ item.aa|default(omit) }}"
   register: test_result
   check_mode: "{{ item.check_mode|default(omit) }}"

--- a/tests/integration/targets/cmd_runner/vars/main.yml
+++ b/tests/integration/targets/cmd_runner/vars/main.yml
@@ -101,7 +101,7 @@ cmd_echo_tests:
       - test_result.out == "-- --answer=11 --bb-here\n"
       - test_result.err == ""
 
-  - name: set aa and bb value with check_mode and skip_if_check on
+  - name: set aa and bb value with check_mode and check_mode_skip on
     arg_formats:
       aa:
         func: as_opt_eq_val
@@ -112,7 +112,7 @@ cmd_echo_tests:
     arg_order: 'aa bb'
     arg_values:
       bb: true
-    skip_if_check: true
+    check_mode_skip: true
     aa: 11
     check_mode: true
     expect_error: true  # because if result contains rc != 0, ansible assumes error

--- a/tests/integration/targets/cmd_runner/vars/main.yml
+++ b/tests/integration/targets/cmd_runner/vars/main.yml
@@ -82,3 +82,41 @@ cmd_echo_tests:
       - >-
         "MissingArgumentValue: Cannot find value for parameter bb"
         in test_result.module_stderr
+
+  - name: set aa and bb value with check_mode on
+    arg_formats:
+      aa:
+        func: as_opt_eq_val
+        args: [--answer]
+      bb:
+        func: as_bool
+        args: [--bb-here]
+    arg_order: 'aa bb'
+    arg_values:
+      bb: true
+    aa: 11
+    check_mode: true
+    assertions:
+      - test_result.rc == 0
+      - test_result.out == "-- --answer=11 --bb-here\n"
+      - test_result.err == ""
+
+  - name: set aa and bb value with check_mode and skip_if_check on
+    arg_formats:
+      aa:
+        func: as_opt_eq_val
+        args: [--answer]
+      bb:
+        func: as_bool
+        args: [--bb-here]
+    arg_order: 'aa bb'
+    arg_values:
+      bb: true
+    skip_if_check: true
+    aa: 11
+    check_mode: true
+    expect_error: true  # because if result contains rc != 0, ansible assumes error
+    assertions:
+      - test_result.rc == None
+      - test_result.out == None
+      - test_result.err == None


### PR DESCRIPTION
##### SUMMARY
Added parameters `check_mode_skip` and `check_mode_return` to `CmdRunner.context()`, so that the command is not executed when `check_mode=True`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/cmd_runner.py
