### PR TITLE
Add puppet confdir option

### DIFF
--- a/changelogs/fragments/4740-puppet-feature.yaml
+++ b/changelogs/fragments/4740-puppet-feature.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- puppet - adds ``confdir`` parameter to configure a custom confir location (https://github.com/ansible-collections/community.general/pull/4740).

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -51,6 +51,10 @@ options:
     description:
       - Puppet environment to be used.
     type: str
+  confdir:
+    description:
+      - Path to the directory containing the puppet.conf file.
+    type: str
   logdest:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
@@ -179,6 +183,7 @@ def main():
             puppetmaster=dict(type='str'),
             modulepath=dict(type='str'),
             manifest=dict(type='str'),
+            confdir=dict(type='str'),
             noop=dict(type='bool'),
             logdest=dict(type='str', default='stdout', choices=['all', 'stdout', 'syslog']),
             # The following is not related to Ansible's diff; see https://github.com/ansible-collections/community.general/pull/3980#issuecomment-1005666154
@@ -255,6 +260,8 @@ def main():
             cmd += " --server %s" % shlex_quote(p['puppetmaster'])
         if p['show_diff']:
             cmd += " --show_diff"
+        if p['confdir']:
+            cmd += " --confdir '%s'" % p['confdir']
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
         if p['tags']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -261,7 +261,7 @@ def main():
         if p['show_diff']:
             cmd += " --show_diff"
         if p['confdir']:
-            cmd += " --confdir '%s'" % p['confdir']
+            cmd += " --confdir %s" % shlex_quote(p['confdir'])
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
         if p['tags']:

--- a/plugins/modules/system/puppet.py
+++ b/plugins/modules/system/puppet.py
@@ -55,6 +55,7 @@ options:
     description:
       - Path to the directory containing the puppet.conf file.
     type: str
+    version_added: 5.1.0
   logdest:
     description:
     - Where the puppet logs should go, if puppet apply is being used.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the confdir option to the puppet plugin to configure a custom confdir location.
See [puppet documentation](https://puppet.com/docs/puppet/7/dirs_confdir.html#confdir-location)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
system puppet