### PR TITLE
add support to create L2TP and PPTP VPN connection

### DIFF
--- a/changelogs/fragments/4746-add-vpn-support-nmcli.yaml
+++ b/changelogs/fragments/4746-add-vpn-support-nmcli.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - adds ``vpn`` type and parameter for supporting VPN with service type L2TP and PPTP (https://github.com/ansible-collections/community.general/pull/4746).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1356,7 +1356,7 @@ EXAMPLES = r'''
             password-flags: 2
             user: brittany
             ipsec-enabled: true
-            ipsec-psk: "{{ psk }}"
+            ipsec-psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
         autoconnect: false
         state: present
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1341,7 +1341,9 @@ EXAMPLES = r'''
     autoconnect: true
     state: present
 
-- name: Create a VPN L2TP connection for ansible_user to connect on vpn.example.com authenticating with user 'brittany' and pre-shared key as 'Brittany123'
+- name: >-
+    Create a VPN L2TP connection for ansible_user to connect on vpn.example.com
+    authenticating with user 'brittany' and pre-shared key as 'Brittany123'
   community.general.nmcli:
     type: vpn
     conn_name: my-vpn-connection

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -908,7 +908,7 @@ options:
     vpn:
         description:
             - Configuration of a VPN connection (PPTP and L2TP).
-            - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome) 
+            - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome)
                 if host has UI - are installed on the host.
         type: dict
         version_added: 5.1.0
@@ -923,7 +923,7 @@ options:
                 required: true
                 choices: [ pptp, l2tp ]
             gateway:
-                description: The gateway to connection. It can be an IP address (for example C(192.0.2.1)) 
+                description: The gateway to connection. It can be an IP address (for example C(192.0.2.1))
                     or a FQDN address (for example C(vpn.example.com)).
                 type: str
                 required: true

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -55,7 +55,8 @@ options:
             - Type C(generic) is added in Ansible 2.5.
             - Type C(infiniband) is added in community.general 2.0.0.
             - Type C(gsm) is added in community.general 3.7.0.
-            - Type C(wireguard) is added in community.general 4.3.0
+            - Type C(wireguard) is added in community.general 4.3.0.
+            - Type C(vpn) is added in community.general 5.1.0.
         type: str
         choices: [ bond, bond-slave, bridge, bridge-slave, dummy, ethernet, generic, gre, infiniband, ipip, sit, team, team-slave, vlan, vxlan, wifi, gsm,
             wireguard, vpn ]

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -2098,6 +2098,9 @@ class Nmcli(object):
                     current_value = current_value.strip('"')
                 if key == self.mtu_setting and self.mtu is None:
                     self.mtu = 0
+                if key == 'vpn.data':
+                    current_value = list(map(str.strip, current_value.split(',')))
+                    value = list(map(str.strip, value.split(',')))
             else:
                 # parameter does not exist
                 current_value = None

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -939,7 +939,7 @@ options:
                 choices: [ 0, 1, 2 , 4 ]
                 default: 0
             user:
-                description: Username provided by VPN administrator
+                description: Username provided by VPN administrator.
                 type: str
                 required: true
             ipsec-enabled:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1931,7 +1931,7 @@ class Nmcli(object):
 
         # VPN doesn't need an interface but if sended it must be a valid interface.
         if self.type == 'vpn' and self.ifname is None:
-            options.__delitem__('connection.interface-name')
+            del options['connection.interface-name']
 
         options.update(self.connection_options())
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -955,7 +955,7 @@ options:
                 description:
                     - The pre-shared key in base64 encoding.
                     - >
-                      You can encode using this Ansible jinja2 expression: C("0s{{ '[YOUR PRE-SHARED KEY]' | b64encode }}").
+                      You can encode using this Ansible jinja2 expression: C("0s{{ '[YOUR PRE-SHARED KEY]' | ansible.builtin.b64encode }}").
                     - This is only used when I(ipsec-enabled=true).
                 type: str
 '''

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -954,7 +954,7 @@ options:
                 description:
                     - The pre-shared key in base64 encoding.
                     - >
-                      You can encode using this Ansible jinja2 expression: C("0s{{ ('[YOUR PRE-SHARED KEY]' | b64encode) }}").
+                      You can encode using this Ansible jinja2 expression: C("0s{{ '[YOUR PRE-SHARED KEY]' | b64encode }}").
                     - This is only used when I(ipsec-enabled=true).
                 type: str
 '''

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -931,10 +931,10 @@ options:
                 description:
                     - NMSettingSecretFlags indicating how to handle the I(password) property.
                     - 'Following choices are allowed:
-                      C(0) B(NONE): The system is responsible for providing and storing this secret (default),
+                      C(0) B(NONE): The system is responsible for providing and storing this secret (default);
                       C(1) B(AGENT_OWNED): A user secret agent is responsible for providing and storing this secret; when it is required agents will be
-                           asked to retrieve it
-                      C(2) B(NOT_SAVED): This secret should not be saved, but should be requested from the user each time it is needed
+                           asked to retrieve it;
+                      C(2) B(NOT_SAVED): This secret should not be saved, but should be requested from the user each time it is needed;
                       C(4) B(NOT_REQUIRED): In situations where it cannot be automatically determined that the secret is required
                            (some VPNs and PPP providers do not require all secrets) this flag indicates that the specific secret is not required.'
                 type: int

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -2126,6 +2126,10 @@ class Nmcli(object):
             'connection.interface-name': self.ifname,
         }
 
+        # VPN doesn't need an interface but if sended it must be a valid interface.
+        if self.type == 'vpn' and self.ifname is None:
+            del options['connection.interface-name']
+
         if not self.type:
             current_con_type = self.show_connection().get('connection.type')
             if current_con_type:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -913,7 +913,7 @@ options:
         version_added: 5.1.0
         suboptions:
             permissions:
-                description: User that will have persmission to use the connection
+                description: User that will have permission to use the connection.
                 type: str
                 required: true
             service-type:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -908,7 +908,7 @@ options:
     vpn:
         description:
             - The configuration to a VPN connection (PPTP and L2TP).
-            - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome) if host has UI - are installed on the host
+            - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome) if host has UI - are installed on the host.
         type: dict
         version_added: 5.1.0
         suboptions:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -907,7 +907,7 @@ options:
                 choices: [ 0, 1, 2 ]
     vpn:
         description:
-            - The configuration to a VPN connection (PPTP and L2TP).
+            - Configuration of a VPN connection (PPTP and L2TP).
             - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome) if host has UI - are installed on the host.
         type: dict
         version_added: 5.1.0

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -954,8 +954,7 @@ options:
                 description:
                     - The pre-shared key in base64 encoding.
                     - >
-                      You can encode using this linux command: C(echo "0s"$(base64 <<<'[YOUR PRE-SHARED KEY]' | rev | cut -c5- | rev))
-                      or just using this Ansible jinja2 expression: C("0s{{ ('[YOUR PRE-SHARED KEY]' | b64encode) }}").
+                      You can encode using this Ansible jinja2 expression: C("0s{{ ('[YOUR PRE-SHARED KEY]' | b64encode) }}").
                     - This is only used when I(ipsec-enabled=true).
                 type: str
 '''

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -910,6 +910,7 @@ options:
             - The configuration to a VPN connection (PPTP and L2TP).
             - In order to use L2TP you need to be sure that C(network-manager-l2tp) - and C(network-manager-l2tp-gnome) if host has UI - are installed on the host
         type: dict
+        version_added: 5.1.0
         suboptions:
             permissions:
                 description: User that will have persmission to use the connection

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -951,7 +951,7 @@ options:
                 description:
                     - The Pre-shared key encoded.
                     - You can encode using this linux command: C(echo "0s"$(base64 <<<'[YOUR PRE-SHARED KEY]' | rev | cut -c5- | rev))
-                    - This is only used when C(ipsec-enabled = yes)
+                    - This is only used when I(ipsec-enabled=true).
                 type: str
 '''
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1343,7 +1343,7 @@ EXAMPLES = r'''
 - name: Create a VPN L2TP connection for ansible_user to connect on vpn.example.com authenticating with user 'brittany' and pre-shared key as 'Brittany123'
   block:
     - ansible.builtin.set_fact:
-        psk: "0s{{ ('Brittany123' | ansible.builtin.b64encode) }}"
+        psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
 
     - name: Create the connection
       community.general.nmcli:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1344,7 +1344,7 @@ EXAMPLES = r'''
 - name: Create a VPN L2TP connection for ansible_user to connect on vpn.example.com authenticating with user 'brittany' and pre-shared key as 'Brittany123'
   block:
     - ansible.builtin.set_fact:
-      psk: "0s{{ ('Brittany123' | b64encode) }}"
+        psk: "0s{{ ('Brittany123' | ansible.builtin.b64encode) }}"
 
     - name: Create the connection
       community.general.nmcli:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -922,7 +922,7 @@ options:
                 required: true
                 choices: [ pptp, l2tp ]
             gateway:
-                description: The gateway to connection. It can be an IP (for example C(192.0.2.1)) or a FQDN address (for example C(vpn.example.com))
+                description: The gateway to connection. It can be an IP address (for example C(192.0.2.1)) or a FQDN address (for example C(vpn.example.com)).
                 type: str
                 required: true
             password-flags:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1342,24 +1342,19 @@ EXAMPLES = r'''
     state: present
 
 - name: Create a VPN L2TP connection for ansible_user to connect on vpn.example.com authenticating with user 'brittany' and pre-shared key as 'Brittany123'
-  block:
-    - ansible.builtin.set_fact:
-        psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
-
-    - name: Create the connection
-      community.general.nmcli:
-        type: vpn
-        conn_name: my-vpn-connection
-        vpn:
-            permissions: "{{ ansible_user }}"
-            service-type: l2tp
-            gateway: vpn.example.com
-            password-flags: 2
-            user: brittany
-            ipsec-enabled: true
-            ipsec-psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
-        autoconnect: false
-        state: present
+  community.general.nmcli:
+    type: vpn
+    conn_name: my-vpn-connection
+    vpn:
+        permissions: "{{ ansible_user }}"
+        service-type: l2tp
+        gateway: vpn.example.com
+        password-flags: 2
+        user: brittany
+        ipsec-enabled: true
+        ipsec-psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
+    autoconnect: false
+    state: present
 
 '''
 

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -945,7 +945,7 @@ options:
             ipsec-enabled:
                 description:
                     - Enable or disable IPSec tunnel to L2TP host.
-                    - This option is need when C(service-type) is C(l2tp)
+                    - This option is need when C(service-type) is C(l2tp).
                 type: bool
                 choices: [ yes, no ]
             ipsec-psk:

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1243,8 +1243,9 @@ ipv4.method:                            auto
 ipv6.method:                            auto
 vpn-type:                               pptp
 vpn.service-type:                       org.freedesktop.NetworkManager.pptp
-vpn.data:                               gateway=vpn.example.com, password-flags=2, user=brittany
+vpn.data:                               password-flags=2, gateway=vpn.example.com, user=brittany
 """
+
 
 def mocker_set(mocker,
                connection_exists=False,
@@ -1620,6 +1621,7 @@ def mocked_vpn_l2tp_connection_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_VPN_L2TP_SHOW_OUTPUT, ""))
+
 
 @pytest.fixture
 def mocked_vpn_pptp_connection_unchanged(mocker):
@@ -3538,6 +3540,7 @@ def test_wireguard_mod(mocked_generic_connection_modify, capfd):
     assert not results.get('failed')
     assert results['changed']
 
+
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_L2TP, indirect=['patch_ansible_module'])
 def test_vpn_l2tp_connection_unchanged(mocked_vpn_l2tp_connection_unchanged, capfd):
     """
@@ -3545,24 +3548,26 @@ def test_vpn_l2tp_connection_unchanged(mocked_vpn_l2tp_connection_unchanged, cap
     """
     with pytest.raises(SystemExit):
         nmcli.main()
-    
+
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
 
+
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_PPTP, indirect=['patch_ansible_module'])
 def test_vpn_pptp_connection_unchanged(mocked_vpn_pptp_connection_unchanged, capfd):
     """
-    Test : L2TP VPN connection unchanged
+    Test : PPTP VPN connection unchanged
     """
     with pytest.raises(SystemExit):
         nmcli.main()
-    
+
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
     assert not results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_L2TP, indirect=['patch_ansible_module'])
 def test_create_vpn_l2tp(mocked_generic_connection_create, capfd):
@@ -3589,15 +3594,20 @@ def test_create_vpn_l2tp(mocked_generic_connection_create, capfd):
 
     for param in ['connection.autoconnect', 'no',
                   'connection.permissions', 'brittany',
-                  'vpn.data', 'gateway=vpn.example.com, password-flags=2, user=brittany, ipsec-enabled=true, ipsec-psk=QnJpdHRhbnkxMjM=',
-                  'vpn-type', 'l2tp',
+                  'vpn.data', 'vpn-type', 'l2tp',
                   ]:
         assert param in add_args_text
+
+    vpn_data_index = add_args_text.index('vpn.data') + 1
+    args_vpn_data = add_args_text[vpn_data_index]
+    for vpn_data in ['gateway=vpn.example.com', 'password-flags=2', 'user=brittany', 'ipsec-enabled=true', 'ipsec-psk=QnJpdHRhbnkxMjM=']:
+        assert vpn_data in args_vpn_data
 
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_PPTP, indirect=['patch_ansible_module'])
 def test_create_vpn_pptp(mocked_generic_connection_create, capfd):
@@ -3624,10 +3634,14 @@ def test_create_vpn_pptp(mocked_generic_connection_create, capfd):
 
     for param in ['connection.autoconnect', 'no',
                   'connection.permissions', 'brittany',
-                  'vpn.data', 'gateway=vpn.example.com, password-flags=2, user=brittany',
-                  'vpn-type', 'pptp',
+                  'vpn.data', 'vpn-type', 'pptp',
                   ]:
         assert param in add_args_text
+
+    vpn_data_index = add_args_text.index('vpn.data') + 1
+    args_vpn_data = add_args_text[vpn_data_index]
+    for vpn_data in ['password-flags=2', 'gateway=vpn.example.com', 'user=brittany']:
+        assert vpn_data in args_vpn_data
 
     out, err = capfd.readouterr()
     results = json.loads(out)

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -98,6 +98,12 @@ TESTCASE_CONNECTION = [
         'state': 'absent',
         '_ansible_check_mode': True,
     },
+    {
+        'type': 'vpn',
+        'conn_name': 'non_existent_nw_device',
+        'state': 'absent',
+        '_ansible_check_mode': True,
+    },
 ]
 
 TESTCASE_GENERIC = [
@@ -1177,6 +1183,68 @@ wireguard.ip4-auto-default-route:       -1 (default)
 wireguard.ip6-auto-default-route:       -1 (default)
 """
 
+TESTCASE_VPN_L2TP = [
+    {
+        'type': 'vpn',
+        'conn_name': 'vpn_l2tp',
+        'vpn': {
+            'permissions': 'brittany',
+            'service-type': 'l2tp',
+            'gateway': 'vpn.example.com',
+            'password-flags': '2',
+            'user': 'brittany',
+            'ipsec-enabled': 'true',
+            'ipsec-psk': 'QnJpdHRhbnkxMjM=',
+        },
+        'autoconnect': 'false',
+        'state': 'present',
+        '_ansible_check_mode': False,
+    },
+]
+
+TESTCASE_VPN_L2TP_SHOW_OUTPUT = """\
+connection.id:                          vpn_l2tp
+connection.type:                        vpn
+connection.autoconnect:                 no
+connection.permissions:                 brittany
+ipv4.method:                            auto
+ipv6.method:                            auto
+vpn-type:                               l2tp
+vpn.service-type:                       org.freedesktop.NetworkManager.l2tp
+vpn.data:                               gateway=vpn.example.com, password-flags=2, user=brittany, ipsec-enabled=true, ipsec-psk=QnJpdHRhbnkxMjM=
+vpn.secrets:                            ipsec-psk = QnJpdHRhbnkxMjM=
+vpn.persistent:                         no
+vpn.timeout:                            0
+"""
+
+TESTCASE_VPN_PPTP = [
+    {
+        'type': 'vpn',
+        'conn_name': 'vpn_pptp',
+        'vpn': {
+            'permissions': 'brittany',
+            'service-type': 'pptp',
+            'gateway': 'vpn.example.com',
+            'password-flags': '2',
+            'user': 'brittany',
+        },
+        'autoconnect': 'false',
+        'state': 'present',
+        '_ansible_check_mode': False,
+    },
+]
+
+TESTCASE_VPN_PPTP_SHOW_OUTPUT = """\
+connection.id:                          vpn_pptp
+connection.type:                        vpn
+connection.autoconnect:                 no
+connection.permissions:                 brittany
+ipv4.method:                            auto
+ipv6.method:                            auto
+vpn-type:                               pptp
+vpn.service-type:                       org.freedesktop.NetworkManager.pptp
+vpn.data:                               gateway=vpn.example.com, password-flags=2, user=brittany
+"""
 
 def mocker_set(mocker,
                connection_exists=False,
@@ -1545,6 +1613,19 @@ def mocked_wireguard_connection_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_WIREGUARD_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
+def mocked_vpn_l2tp_connection_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_VPN_L2TP_SHOW_OUTPUT, ""))
+
+@pytest.fixture
+def mocked_vpn_pptp_connection_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_VPN_PPTP_SHOW_OUTPUT, ""))
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BOND, indirect=['patch_ansible_module'])
@@ -3451,6 +3532,102 @@ def test_wireguard_mod(mocked_generic_connection_modify, capfd):
     args_text = list(map(to_text, args[0]))
     for param in ['wireguard.listen-port', '51820']:
         assert param in args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_L2TP, indirect=['patch_ansible_module'])
+def test_vpn_l2tp_connection_unchanged(mocked_vpn_l2tp_connection_unchanged, capfd):
+    """
+    Test : L2TP VPN connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+    
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_PPTP, indirect=['patch_ansible_module'])
+def test_vpn_pptp_connection_unchanged(mocked_vpn_pptp_connection_unchanged, capfd):
+    """
+    Test : L2TP VPN connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+    
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_L2TP, indirect=['patch_ansible_module'])
+def test_create_vpn_l2tp(mocked_generic_connection_create, capfd):
+    """
+    Test : Create L2TP VPN connection
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[0]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'add'
+    assert add_args[0][3] == 'type'
+    assert add_args[0][4] == 'vpn'
+    assert add_args[0][5] == 'con-name'
+    assert add_args[0][6] == 'vpn_l2tp'
+
+    add_args_text = list(map(to_text, add_args[0]))
+
+    for param in ['connection.autoconnect', 'no',
+                  'connection.permissions', 'brittany',
+                  'vpn.data', 'gateway=vpn.example.com, password-flags=2, user=brittany, ipsec-enabled=true, ipsec-psk=QnJpdHRhbnkxMjM=',
+                  'vpn-type', 'l2tp',
+                  ]:
+        assert param in add_args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_VPN_PPTP, indirect=['patch_ansible_module'])
+def test_create_vpn_pptp(mocked_generic_connection_create, capfd):
+    """
+    Test : Create PPTP VPN connection
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[0]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'add'
+    assert add_args[0][3] == 'type'
+    assert add_args[0][4] == 'vpn'
+    assert add_args[0][5] == 'con-name'
+    assert add_args[0][6] == 'vpn_pptp'
+
+    add_args_text = list(map(to_text, add_args[0]))
+
+    for param in ['connection.autoconnect', 'no',
+                  'connection.permissions', 'brittany',
+                  'vpn.data', 'gateway=vpn.example.com, password-flags=2, user=brittany',
+                  'vpn-type', 'pptp',
+                  ]:
+        assert param in add_args_text
 
     out, err = capfd.readouterr()
     results = json.loads(out)


### PR DESCRIPTION
##### SUMMARY
Add support to `nmcli` module to manage L2TP and PPTP VPN connections.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/net_tools/nmcli.py

##### ADDITIONAL INFORMATION
It manages VPN connections of service types `L2TP` and `PPTP` on the host

