### PR TITLE
example fix: remove trailing whitespace after parameter

### DIFF
--- a/plugins/lookup/keyring.py
+++ b/plugins/lookup/keyring.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = """
-- name : output secrets to screen (BAD IDEA)
+- name: output secrets to screen (BAD IDEA)
   ansible.builtin.debug:
     msg: "Password: {{item}}"
   with_community.general.keyring:


### PR DESCRIPTION
##### SUMMARY
syntax error fix

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
keyring

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
