### PR TITLE
xfconf module utils: providing a cmd_runner object

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -307,6 +307,9 @@ files:
   $module_utils/xenserver.py:
     maintainers: bvitnik
     labels: xenserver
+  $module_utils/xfconf.py:
+    maintainers: russoz
+    labels: xfconf
   $modules/cloud/alicloud/:
     maintainers: xiaozhu36
   $modules/cloud/atomic/atomic_container.py:

--- a/changelogs/fragments/4776-xfconf-cmd-runner.yaml
+++ b/changelogs/fragments/4776-xfconf-cmd-runner.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - xfconf module utils - created new module util ``xfconf`` providing a ``cmd_runner`` specific for ``xfconf`` modules (https://github.com/ansible-collections/community.general/pull/4776).
+  - xfconf - changed implementation to use ``cmd_runner`` (https://github.com/ansible-collections/community.general/pull/4776).
+  - xfconf_info - changed implementation to use ``cmd_runner`` (https://github.com/ansible-collections/community.general/pull/4776).

--- a/plugins/module_utils/xfconf.py
+++ b/plugins/module_utils/xfconf.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# (c) 2022, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, fmt
+
+
+@fmt.unpack_args
+def _values_fmt(values, value_types):
+    result = []
+    for value, value_type in zip(values, value_types):
+        if value_type == 'bool':
+            value = boolean(value)
+        result.extend(['--type', '{0}'.format(value_type), '--set', '{0}'.format(value)])
+    return result
+
+
+def xfconf_runner(module, **kwargs):
+    runner = CmdRunner(
+        module,
+        command='xfconf-query',
+        arg_formats=dict(
+            channel=fmt.as_opt_val("--channel"),
+            property=fmt.as_opt_val("--property"),
+            force_array=fmt.as_bool("--force-array"),
+            reset=fmt.as_bool("--reset"),
+            create=fmt.as_bool("--create"),
+            list_arg=fmt.as_bool("--list"),
+            values_and_types=fmt.as_func(_values_fmt),
+        ),
+        **kwargs
+    )
+    return runner

--- a/plugins/module_utils/xfconf.py
+++ b/plugins/module_utils/xfconf.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, fmt
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt as fmt
 
 
 @fmt.unpack_args

--- a/plugins/modules/system/xfconf_info.py
+++ b/plugins/modules/system/xfconf_info.py
@@ -116,14 +116,15 @@ RETURN = '''
     - Tmp
 '''
 
-from ansible_collections.community.general.plugins.module_utils.module_helper import CmdModuleHelper, ArgFormat
+from ansible_collections.community.general.plugins.module_utils.module_helper import ModuleHelper
+from ansible_collections.community.general.plugins.module_utils.xfconf import xfconf_runner
 
 
 class XFConfException(Exception):
     pass
 
 
-class XFConfInfo(CmdModuleHelper):
+class XFConfInfo(ModuleHelper):
     module = dict(
         argument_spec=dict(
             channel=dict(type='str'),
@@ -135,16 +136,9 @@ class XFConfInfo(CmdModuleHelper):
         supports_check_mode=True,
     )
 
-    command = 'xfconf-query'
-    command_args_formats = dict(
-        channel=dict(fmt=['--channel', '{0}']),
-        property=dict(fmt=['--property', '{0}']),
-        _list_arg=dict(fmt="--list", style=ArgFormat.BOOLEAN),
-    )
-    check_rc = True
-
     def __init_module__(self):
-        self.vars.set("_list_arg", False, output=False)
+        self.runner = xfconf_runner(self.module, check_rc=True)
+        self.vars.set("list_arg", False, output=False)
         self.vars.set("is_array", False)
 
     def process_command_output(self, rc, out, err):
@@ -167,7 +161,7 @@ class XFConfInfo(CmdModuleHelper):
         return lines
 
     def __run__(self):
-        self.vars._list_arg = not (bool(self.vars.channel) and bool(self.vars.property))
+        self.vars.list_arg = not (bool(self.vars.channel) and bool(self.vars.property))
         output = 'value'
         proc = self.process_command_output
         if self.vars.channel is None:
@@ -176,15 +170,15 @@ class XFConfInfo(CmdModuleHelper):
         elif self.vars.property is None:
             output = 'properties'
             proc = self._process_list_properties
-        result = self.run_command(params=('_list_arg', 'channel', 'property'), process_output=proc)
-        if not self.vars._list_arg and self.vars.is_array:
+        with self.runner.context('list_arg channel property', output_process=proc) as ctx:
+            result = ctx.run(**self.vars)
+        if not self.vars.list_arg and self.vars.is_array:
             output = "value_array"
         self.vars.set(output, result)
 
 
 def main():
-    xfconf = XFConfInfo()
-    xfconf.run()
+    XFConfInfo.execute()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/system/xfconf_info.py
+++ b/plugins/modules/system/xfconf_info.py
@@ -74,7 +74,7 @@ RETURN = '''
   properties:
     description:
         - List of available properties for a specific channel.
-        - Returned by passed only the I(channel) parameter to the module.
+        - Returned by passing only the I(channel) parameter to the module.
     returned: success
     type: list
     elements: str


### PR DESCRIPTION
##### SUMMARY
Create a new `module_utils/xfconf.py`.
Changed `xfconf` and `xfconf_info` to use that runner instead of the features in `CmdStateModuleHelper`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/xfconf.py
plugins/modules/system/xfconf.py
plugins/modules/system/xfconf_info.py
