### PR TITLE
cmd_runner: deprecate fmt as the name for the format class

### DIFF
--- a/changelogs/fragments/4777-cmd-runner-deprecate-fmt.yaml
+++ b/changelogs/fragments/4777-cmd-runner-deprecate-fmt.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - cmd_runner module utils - deprecated ``fmt`` in favour of ``cmd_runner_fmt`` as the parameter format object (https://github.com/ansible-collections/community.general/pull/4777).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -297,7 +297,7 @@ class _CmdRunnerContext(object):
 cmd_runner_fmt = _Format()
 
 #
-# The fmt form will be deprecated in community.general 7.0.0
+# The fmt form is deprecated and will be removed in community.general 7.0.0
 # Please use:
 #   cmd_runner_fmt
 # Or, to retain the same effect, use:

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -294,4 +294,12 @@ class _CmdRunnerContext(object):
         return False
 
 
-fmt = _Format()
+cmd_runner_fmt = _Format()
+
+#
+# The fmt form will be deprecated in community.general 7.0.0
+# Please use:
+#   cmd_runner_fmt
+# Or, to retain the same effect, use:
+#   from ansible_collections.community.general.plugins.module_utils.cmd_runner import cmd_runner_fmt as fmt
+fmt = cmd_runner_fmt

--- a/plugins/module_utils/gconftool2.py
+++ b/plugins/module_utils/gconftool2.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, fmt
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt as fmt
 
 
 def gconftool2_runner(module, **kwargs):

--- a/tests/integration/targets/cmd_runner/library/cmd_echo.py
+++ b/tests/integration/targets/cmd_runner/library/cmd_echo.py
@@ -14,7 +14,7 @@ EXAMPLES = ""
 RETURN = ""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, fmt
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt as fmt
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Deprecate `fmt` in favour of `cmd_runner_fmt` as the name of the object to be imported for formatting parameters.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/cmd_runner.py
plugins/module_utils/gconftool2.py
