### PR TITLE
Add ability to distinguish between different backends of the passwordstore lookup plugin

### DIFF
--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -288,8 +288,11 @@ class LookupModule(LookupBase):
 
     def check_pass(self):
         try:
+            pass_show = ["pass", "show", self.passname]
+            if self.backend == 'gopass':
+                pass_show = ["pass", "show", "--password", self.passname]
             self.passoutput = to_text(
-                check_output2(["pass", "show", self.passname], env=self.env),
+                check_output2(pass_show, env=self.env),
                 errors='surrogate_or_strict'
             ).splitlines()
             self.password = self.passoutput[0]


### PR DESCRIPTION
##### SUMMARY
The passwordstore lookup plugin was designed with pass as backend. gopass is a drop-in replacement which happens to have slightly different behaviour than pass. This change introduces a method `setup_backend` which populates `self.backend` with either the string `pass` (which is the default) or `gopass` if the string `gopass` is contained in the output of `pass --version`. Afterwards, the backends can be handled individually by the plugin.

Fixes #4766

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
passwordstore.py