### PR TITLE
remove mcodd as maintainer for newrelic_deployment and flowdock modules

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -618,7 +618,7 @@ files:
   $modules/monitoring/nagios.py:
     maintainers: tbielawa tgoetheyn
   $modules/monitoring/newrelic_deployment.py:
-    maintainers: mcodd
+    ignore: mcodd
   $modules/monitoring/pagerduty.py:
     maintainers: suprememoocow thaumos
     labels: pagerduty
@@ -710,7 +710,7 @@ files:
   $modules/notification/discord.py:
     maintainers: cwollinger
   $modules/notification/flowdock.py:
-    maintainers: mcodd
+    ignore: mcodd
   $modules/notification/grove.py:
     maintainers: zimbatm
   $modules/notification/hipchat.py:


### PR DESCRIPTION
##### SUMMARY
I have not maintained either of these modules for many years nor do I have access to newrelic or flowdock anymore.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- newrelic_deployment
- flowdock

##### ADDITIONAL INFORMATION
N/A
