### PR TITLE
cmd_runner: add __call__ method to invoke context

### DIFF
--- a/changelogs/fragments/4791-cmd-runner-callable.yaml
+++ b/changelogs/fragments/4791-cmd-runner-callable.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cmd_runner module utils - add __call__ method to invoke context (https://github.com/ansible-collections/community.general/pull/4791).

--- a/changelogs/fragments/4791-cmd-runner-callable.yaml
+++ b/changelogs/fragments/4791-cmd-runner-callable.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cmd_runner module utils - add __call__ method to invoke context (https://github.com/ansible-collections/community.general/pull/4791).
+  - cmd_runner module utils - add ``__call__`` method to invoke context (https://github.com/ansible-collections/community.general/pull/4791).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -197,7 +197,7 @@ class CmdRunner(object):
             if mod_param_name not in self.arg_formats:
                 self.arg_formats[mod_param_name] = _Format.as_default_type(spec['type'], mod_param_name)
 
-    def context(self, args_order=None, output_process=None, ignore_value_none=True, check_mode_skip=False, check_mode_return=None, **kwargs):
+    def __call__(self, args_order=None, output_process=None, ignore_value_none=True, check_mode_skip=False, check_mode_return=None, **kwargs):
         if output_process is None:
             output_process = _process_as_is
         if args_order is None:
@@ -215,6 +215,9 @@ class CmdRunner(object):
 
     def has_arg_format(self, arg):
         return arg in self.arg_formats
+
+    # not decided whether to keep it or not, but if deprecating it will happen in a farther future.
+    context = __call__
 
 
 class _CmdRunnerContext(object):

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -209,11 +209,11 @@ class XFConfProperty(StateModuleHelper):
         return result
 
     def _get(self):
-        with self.runner.context('channel property', output_process=self.process_command_output) as ctx:
+        with self.runner('channel property', output_process=self.process_command_output) as ctx:
             return ctx.run()
 
     def state_absent(self):
-        with self.runner.context('channel property reset', check_mode_skip=True) as ctx:
+        with self.runner('channel property reset', check_mode_skip=True) as ctx:
             ctx.run(reset=True)
         self.vars.value = None
 
@@ -239,7 +239,7 @@ class XFConfProperty(StateModuleHelper):
             isinstance(self.vars.previous_value, list) or \
             values_len > 1
 
-        with self.runner.context('channel property create force_array values_and_types', check_mode_skip=True) as ctx:
+        with self.runner('channel property create force_array values_and_types', check_mode_skip=True) as ctx:
             ctx.run(create=True, force_array=self.vars.is_array, values_and_types=(self.vars.value, value_type))
 
         if not self.vars.is_array:


### PR DESCRIPTION
##### SUMMARY
Method `context()` renamed to `__call__()`, but retaining an alias from the old name to the new one, for compatibility.
That change will allow a more concise idiom when running the commands.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/cmd_runner.py