### PR TITLE
Allow terraform module to specify complex variable structures

### DIFF
--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -450,14 +450,53 @@ def main():
         command.append('-parallelism=%d' % module.params.get('parallelism'))
 
     variables_args = []
-    for k, v in variables.items():
-        variables_args.extend([
-            '-var',
-            '{0}={1}'.format(k, v)
-        ])
+    def process_args (variables, top):
+      lowlevel_out = []
+      for k,v in variables.items():
+        if top:
+          if (isinstance(v, dict)):
+            variables_arg.extend([
+              "-var",
+              k + "={" + print_vars (v, False) + "}"
+            ])
+            print(variables_arg)
+          if (isinstance(v, list)):
+            l_out = []
+            for item in v:
+              l_out.append("{" + print_vars (item, False) + "}")                    
+            variables_arg.extend([
+              "-var",
+              k + "=[" + ",".join(l_out) + "]"
+            ])
+          if (isinstance(v, int) or isinstance(v, float)):
+            variables_arg.extend([
+              "-var",
+              '"{0}"={1}'.format(k, v)
+            ])
+          if (isinstance(v, str)):
+            variables_arg.extend([
+              "-var",
+              '"{0}"=\"{1}\"'.format(k, v)
+            ])
+        else:
+          if (isinstance(v, dict)):
+            lowlevel_out.append(k + "={" + print_vars (v, False) + "}")
+          if (isinstance(v, list)):
+            lowlevel_out.append(k + "=[" + print_vars (v, False) + "]")
+          if (isinstance(v, int) or isinstance(v, float)):
+            lowlevel_out.append('"{0}"={1}'.format(k, v))
+          if (isinstance(v, str)):
+            lowlevel_out.append('"{0}"=\"{1}\"'.format(k, v))
+      if top:
+        return (variables_arg)
+      else:
+        return ",".join(lowlevel_out)
+
+    process_args (variables, True)
+
     if variables_files:
-        for f in variables_files:
-            variables_args.extend(['-var-file', f])
+      for f in variables_files:
+          variables_args.extend(['-var-file', f])
 
     preflight_validation(command[0], project_path, checked_version, variables_args)
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -82,6 +82,13 @@ options:
     description:
       - A group of key-values to override template variables or those in
         variables files.
+      - Support complex variable structures to reflect terraform variable syntax:
+        - Terraform Objects are mapped to Ansible Dicts
+        - Terraform Lists are Ansible Lists
+        - Terraform Numbers can be Ansible Ints or Floats
+        - Terraform Bool can be Ansible Bools
+      - Note: passwords passed as variables will be visible in the log output. 
+        For production usecases consider 'no_log' set to 'true'
     type: dict
   targets:
     description:
@@ -187,6 +194,25 @@ EXAMPLES = """
     plugin_paths:
       - /path/to/plugins_dir_1
       - /path/to/plugins_dir_2
+
+- name: Complex variables example
+  community.general.terraform:
+    project_path: '{{ project_dir }}'
+    state: present
+    variables:
+      vm_name: "{{ inventory_hostname }}"
+      vm_vcpus: 2
+      vm_mem: 2048
+      vm_additional_disks:
+        - label: "Third Disk"
+          size: 40
+          thin_provisioned: true
+          unit_number: 2
+        - label: "Fourth Disk"
+          size: 22
+          thin_provisioned: true
+          unit_number: 3
+    force_init: true
 
 ### Example directory structure for plugin_paths example
 # $ tree /path/to/plugins_dir_1


### PR DESCRIPTION
##### SUMMARY
Added the capability to specify complex variables structures in the terraform module. With this change we can specify Terraform Object / Nested type variables via ansible:

For example, in TF:

```
variable "vm_additional_disks" {
  description = "Additional Disks"
  type = list(object({
    unit_number      = number
    size             = number
    label            = string
    thin_provisioned = bool
  }))
  default = []
}
```
Would translate to:
```
        vm_additional_disks:
          - label: "Third Disk"
            size: 40
            thin_provisioned: true
            unit_number: 2
          - label: "Fourth Disk"
            size: 22
            thin_provisioned: true
            unit_number: 3
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
complex variables for terraform module 

##### ADDITIONAL INFORMATION

Changed the `variable_args` to be constructed via a recursive function `process_args`. It's capable of handling nested lists, dictionaries, bools, string and numbers.
