### PR TITLE
Allow terraform module to specify complex variable structures

### DIFF
--- a/changelogs/fragments/4797-terraform-complex-variables.yml
+++ b/changelogs/fragments/4797-terraform-complex-variables.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module. 

--- a/changelogs/fragments/4797-terraform-complex-variables.yml
+++ b/changelogs/fragments/4797-terraform-complex-variables.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797).
+  - terraform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797).

--- a/changelogs/fragments/4797-terraform-complex-variables.yml
+++ b/changelogs/fragments/4797-terraform-complex-variables.yml
@@ -1,2 +1,3 @@
 minor_changes:
-  - terraform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797).
+  - terraform - adds capability to handle complex variable structures for ``variables`` parameter in the module.
+    This must be enabled with the new ``complex_vars`` parameter (https://github.com/ansible-collections/community.general/pull/4797).

--- a/changelogs/fragments/4797-terraform-complex-variables.yml
+++ b/changelogs/fragments/4797-terraform-complex-variables.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797). 
+  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797).

--- a/changelogs/fragments/4797-terraform-complex-variables.yml
+++ b/changelogs/fragments/4797-terraform-complex-variables.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module. 
+  - terrform - adds capability to handle complex variable structures for ``variables`` parameter in the module (https://github.com/ansible-collections/community.general/pull/4797). 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -93,7 +93,8 @@ options:
   complex_vars:
     description:
       - Enable/disable capability to handle complex variable structures for C(terraform).
-      - If C(true) the C(variables) would accept I(Booleans), I(Objects) and I(Lists) to be passed to C(terraform).
+      - If C(true) the I(variables) also accepts dictionaries, lists, and booleans to be passed to C(terraform).
+        Strings that are passed are correctly quoted.
       - When disabled, supports only simple variables (strings, integers, and floats), and passes them on unquoted.
     type: bool
     default: false

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -482,17 +482,17 @@ def main():
                     ret_out.append('{0}={{{1}}}'.format(k, process_complex_args(v)))
                 if isinstance(v, list):
                     ret_out.append("{0}=[{1}]".format(k, process_complex_args(v)))
-                if isinstance(v, (integer_types, float, str)):
+                if isinstance(v, (integer_types, float, str, bool)):
                     ret_out.append('{0}={1}'.format(k, json.dumps(v)))
         if isinstance(vars, list):
             l_out = []
             for item in vars:
                 if isinstance(item, dict):
                     l_out.append("{{{0}}}".format(process_complex_args(item)))
-                elif isinstance(item, (str, integer_types, float)):
+                elif isinstance(item, (str, integer_types, float, bool)):
                     l_out.append(json.dumps(item))
                 else:
-                    module.fail_json(msg="List can contain, dictionaries, strings, integer_types and float.")
+                    module.fail_json(msg="List can contain, dictionaries, strings, integer_types, boolean and float.")
             ret_out.append("[{0}]".format(",".join(l_out)))
         return ",".join(ret_out)
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -96,6 +96,7 @@ options:
       - When disabled, supports only simple variables I(Strings), I(Integers) and I(Floats).
     type: bool
     default: false
+    version_added: 5.7.0
   targets:
     description:
       - A list of specific resources to target in this plan/application. The

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -81,6 +81,7 @@ options:
   variables:
     description:
       - A group of key-values pairs to override template variables or those in variables files.
+        By default, only string, boolean, and number values are allowed, which are passed on unquoted.
       - Support complex variable structures (Lists, Dictionaries and Boolean) to reflect terraform variable syntax when C(complex_vars=true).
       - Ansible integers or floats are mapped to terraform numbers.
       - Ansible strings are mapped to terraform strings.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -82,10 +82,10 @@ options:
     description:
       - A group of key-values to override template variables or those in variables files.
       - Support complex variable structures to reflect terraform variable syntax.
-      - Terraform objects are mapped to Ansible dictionaries.
-      - Terraform Lists are Ansible Lists.
-      - Terraform Numbers can be Ansible Ints or Floats.
-      - Terraform Bool can be Ansible Bools.
+      - Ansible dictionaries are mapped to terraform objects.
+      - Ansible lists are mapped to terraform lists.
+      - Ansible integers or floats are mapped to terraform numbers.
+      - Ansible booleans are mapped to terraform booleans.
       - "B(Note) passwords passed as variables will be visible in the log output. Make sure to use C(no_log: true) in production!"
     type: dict
   targets:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -82,7 +82,7 @@ options:
     description:
       - A group of key-values to override template variables or those in variables files.
       - Support complex variable structures to reflect terraform variable syntax.
-      - Terraform Objects are mapped to Ansible Dicts.
+      - Terraform objects are mapped to Ansible dictionaries.
       - Terraform Lists are Ansible Lists.
       - Terraform Numbers can be Ansible Ints or Floats.
       - Terraform Bool can be Ansible Bools.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -67,7 +67,7 @@ options:
   state_file:
     description:
       - The path to an existing Terraform state file to use when building plan.
-        If this is not specified, the default `terraform.tfstate` will be used.
+        If this is not specified, the default C(terraform.tfstate) will be used.
       - This option is ignored when plan is specified.
     type: path
   variables_files:
@@ -108,7 +108,7 @@ options:
   force_init:
     description:
       - To avoid duplicating infra, if a state file can't be found this will
-        force a `terraform init`. Generally, this should be turned off unless
+        force a C(terraform init). Generally, this should be turned off unless
         you intend to provision an entirely new Terraform deployment.
     default: false
     type: bool
@@ -154,7 +154,7 @@ options:
     type: int
     version_added: '3.8.0'
 notes:
-   - To just run a `terraform plan`, use check mode.
+   - To just run a C(terraform plan), use check mode.
 requirements: [ "terraform" ]
 author: "Ryan Scott Brown (@ryansb)"
 '''
@@ -229,7 +229,7 @@ EXAMPLES = """
 RETURN = """
 outputs:
   type: complex
-  description: A dictionary of all the TF outputs by their assigned name. Use `.outputs.MyOutputName.value` to access the value.
+  description: A dictionary of all the TF outputs by their assigned name. Use C(.outputs.MyOutputName.value) to access the value.
   returned: on success
   sample: '{"bukkit_arn": {"sensitive": false, "type": "string", "value": "arn:aws:s3:::tf-test-bukkit"}'
   contains:
@@ -247,12 +247,12 @@ outputs:
       description: The value of the output as interpolated by Terraform
 stdout:
   type: str
-  description: Full `terraform` command stdout, in case you want to display it or examine the event log
+  description: Full C(terraform )command stdout, in case you want to display it or examine the event log
   returned: always
   sample: ''
 command:
   type: str
-  description: Full `terraform` command built by this module, in case you want to re-run the command outside the module or debug a problem.
+  description: Full C(erraform) command built by this module, in case you want to re-run the command outside the module or debug a problem.
   returned: always
   sample: terraform apply ...
 """

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -81,7 +81,7 @@ options:
   variables:
     description:
       - A group of key-values pairs to override template variables or those in variables files.
-        By default, only string, boolean, and number values are allowed, which are passed on unquoted.
+        By default, only string and number values are allowed, which are passed on unquoted.
       - Support complex variable structures (lists, dictionaries, numbers, and booleans) to reflect terraform variable syntax when I(complex_vars=true).
       - Ansible integers or floats are mapped to terraform numbers.
       - Ansible strings are mapped to terraform strings.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -88,7 +88,6 @@ options:
       - Terraform Bool can be Ansible Bools.
       - "B(Note) passwords passed as variables will be visible in the log output. Make sure to use C(no_log: true) in production!"
     type: dict
-    default: {}
   targets:
     description:
       - A list of specific resources to target in this plan/application. The

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -473,7 +473,7 @@ def main():
     if state == 'present' and module.params.get('parallelism') is not None:
         command.append('-parallelism=%d' % module.params.get('parallelism'))
 
-    def process_args(variables, top):
+    def process_args(variables, top=True):
         variables_args = []
         lowlevel_out = []
         for k, v in variables.items():

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -515,7 +515,7 @@ def main():
 
             else:
                 if (isinstance(v, dict)):
-                    lowlevel_out.append(k + '={' + process_args(v, False) + '}')
+                    lowlevel_out.append('%s={%s}' % (k, process_args(v, False)))
                 if (isinstance(v, list)):
                     lowlevel_out.append(k + '=[' + process_args(v, False) + ']')
                 if ((isinstance(v, int) or isinstance(v, float)) and not isinstance(v, bool)):

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -261,6 +261,7 @@ import os
 import json
 import tempfile
 from ansible.module_utils.six.moves import shlex_quote
+from ansible.module_utils.six import integer_types
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -491,7 +492,7 @@ def main():
                         "-var",
                         k + '=[' + ",".join(l_out) + ']'
                     ])
-                if ((isinstance(v, int) or isinstance(v, float)) and not isinstance(v, bool)):
+                if (isinstance(v, (integer_types, float)) and not isinstance(v, bool)):
                     variables_args.extend([
                         "-var",
                         '{0}={1}'.format(k, v)
@@ -518,15 +519,8 @@ def main():
                     lowlevel_out.append('%s={%s}' % (k, process_args(v, False)))
                 if (isinstance(v, list)):
                     lowlevel_out.append(k + '=[' + process_args(v, False) + ']')
-                if ((isinstance(v, int) or isinstance(v, float)) and not isinstance(v, bool)):
-                    lowlevel_out.append('{0}={1}'.format(k, v))
-                if (isinstance(v, str)):
-                    lowlevel_out.append('{0}="{1}"'.format(k, v))
-                if (isinstance(v, bool)):
-                    if v:
-                        lowlevel_out.append('{0}=true'.format(k))
-                    else:
-                        lowlevel_out.append('{0}=false'.format(k))
+                if isinstance(v, (integer_types, float, str)):
+                    lowlevel_out.append('{0}={1}'.format(k, json.dumps(v)))
         if top:
             return (variables_args)
         else:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -478,7 +478,7 @@ def main():
         lowlevel_out = []
         for k, v in variables.items():
             if top:
-                if (isinstance(v, dict)):
+                if isinstance(v, dict):
                     variables_args.extend([
                         "-var",
                         k + '={' + process_args(v, False) + '}'

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -247,12 +247,12 @@ outputs:
       description: The value of the output as interpolated by Terraform
 stdout:
   type: str
-  description: Full C(terraform )command stdout, in case you want to display it or examine the event log
+  description: Full C(terraform) command stdout, in case you want to display it or examine the event log
   returned: always
   sample: ''
 command:
   type: str
-  description: Full C(erraform) command built by this module, in case you want to re-run the command outside the module or debug a problem.
+  description: Full C(terraform) command built by this module, in case you want to re-run the command outside the module or debug a problem.
   returned: always
   sample: terraform apply ...
 """

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -91,7 +91,9 @@ options:
     type: dict
   complex_vars:
     description:
-      - Enable/disable capability to handle complex variable structures for C(terraform). If C(true) the C(variables) would accept I(Booleans), I(Objects) and I(Lists) to be passed to C(terraform). When disables supports only simple variables I(Strings) and I(Numbers).
+      - Enable/disable capability to handle complex variable structures for C(terraform).
+      - If C(true) the C(variables) would accept I(Booleans), I(Objects) and I(Lists) to be passed to C(terraform).
+      - When disabled, supports only simple variables I(Strings), I(Integers) and I(Floats).
     type: bool
     default: false
   targets:
@@ -424,7 +426,7 @@ def main():
             purge_workspace=dict(type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent', 'planned']),
             variables=dict(type='dict'),
-            complex_vars=dict(type=bool, default=False),
+            complex_vars=dict(type='bool', default=False),
             variables_files=dict(aliases=['variables_file'], type='list', elements='path'),
             plan_file=dict(type='path'),
             state_file=dict(type='path'),

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -488,10 +488,7 @@ def main():
                 return 'true'
             else:
                 return 'false'
-        elif isinstance(vars, (integer_types, float)):
-            return str(vars)
-        else:
-            return vars
+        return str(vars)
 
     def process_complex_args(vars):
         ret_out = []

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -86,7 +86,7 @@ options:
       - Ansible lists are mapped to terraform lists.
       - Ansible integers or floats are mapped to terraform numbers.
       - Ansible booleans are mapped to terraform booleans.
-      - "B(Note) passwords passed as variables will be visible in the log output. Make sure to use C(no_log: true) in production!"
+      - "B(Note) passwords passed as variables will be visible in the log output. Make sure to use I(no_log=true) in production!"
     type: dict
   targets:
     description:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -82,7 +82,7 @@ options:
     description:
       - A group of key-values pairs to override template variables or those in variables files.
         By default, only string, boolean, and number values are allowed, which are passed on unquoted.
-      - Support complex variable structures (Lists, Dictionaries and Boolean) to reflect terraform variable syntax when C(complex_vars=true).
+      - Support complex variable structures (lists, dictionaries, numbers, and booleans) to reflect terraform variable syntax when I(complex_vars=true).
       - Ansible integers or floats are mapped to terraform numbers.
       - Ansible strings are mapped to terraform strings.
       - Ansible dictionaries are mapped to terraform objects.

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -389,7 +389,7 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
             msg='Terraform plan could not be created\r\nSTDOUT: {out}\r\n\r\nSTDERR: {err}\r\nCOMMAND: {cmd} {args}'.format(
                 out=out,
                 err=err,
-                cmd=plan_command,
+                cmd=' '.join(plan_command),
                 args=' '.join([shlex_quote(arg) for arg in variables_args])
             )
         )
@@ -401,7 +401,7 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
         rc=rc,
         out=out,
         err=err,
-        cmd=plan_command,
+        cmd=' '.join(plan_command),
         args=' '.join([shlex_quote(arg) for arg in variables_args])
     ))
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -386,17 +386,24 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
     elif rc == 1:
         # failure to plan
         module.fail_json(
-            msg='Terraform plan could not be created\r\nSTDOUT: {0}\r\n\r\nSTDERR: {1}\r\nCOMMAND: {2}'.format(
-                out,
-                err,
-                ' '.join([shlex_quote(arg) for arg in variables_args])
+            msg='Terraform plan could not be created\r\nSTDOUT: {out}\r\n\r\nSTDERR: {err}\r\nCOMMAND: {cmd} {args}'.format(
+                out=out,
+                err=err,
+                cmd=plan_command,
+                args=' '.join([shlex_quote(arg) for arg in variables_args])
             )
         )
     elif rc == 2:
         # changes, but successful
         return plan_path, True, out, err, plan_command if state == 'planned' else command
 
-    module.fail_json(msg='Terraform plan failed with unexpected exit code {0}. \r\nSTDOUT: {1}\r\n\r\nSTDERR: {2}'.format(rc, out, err))
+    module.fail_json(msg='Terraform plan failed with unexpected exit code {rc}. \r\nSTDOUT: {out}\r\nSTDERR: {err}\r\nCOMMAND: {cmd} {args}'.format(
+        rc=rc,
+        out=out,
+        err=err,
+        cmd=plan_command,
+        args=' '.join([shlex_quote(arg) for arg in variables_args])
+    ))
 
 
 def main():
@@ -501,7 +508,7 @@ def main():
                 elif isinstance(v, (integer_types, float, str, bool)):
                     ret_out.append('{0}={1}'.format(k, format_args(v)))
                 else:
-                    # only to handle anything unforseen
+                    # only to handle anything unforeseen
                     module.fail_json(msg="Supported types are, dictionaries, lists, strings, integer_types, boolean and float.")
         if isinstance(vars, list):
             l_out = []
@@ -513,7 +520,7 @@ def main():
                 elif isinstance(item, (str, integer_types, float, bool)):
                     l_out.append(format_args(item))
                 else:
-                    # only to handle anything unforseen
+                    # only to handle anything unforeseen
                     module.fail_json(msg="Supported types are, dictionaries, lists, strings, integer_types, boolean and float.")
 
             ret_out.append("[{0}]".format(",".join(l_out)))

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -323,7 +323,7 @@ def get_workspace_context(bin_path, project_path):
     command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
-        module.warn("Failed to list Terraform workspaces:\r\n{0}".format(err))
+        module.warn("Failed to list Terraform workspaces:\n{0}".format(err))
     for item in out.split('\n'):
         stripped_item = item.strip()
         if not stripped_item:
@@ -386,7 +386,7 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
     elif rc == 1:
         # failure to plan
         module.fail_json(
-            msg='Terraform plan could not be created\r\nSTDOUT: {out}\r\n\r\nSTDERR: {err}\r\nCOMMAND: {cmd} {args}'.format(
+            msg='Terraform plan could not be created\nSTDOUT: {out}\nSTDERR: {err}\nCOMMAND: {cmd} {args}'.format(
                 out=out,
                 err=err,
                 cmd=' '.join(plan_command),
@@ -397,7 +397,7 @@ def build_plan(command, project_path, variables_args, state_file, targets, state
         # changes, but successful
         return plan_path, True, out, err, plan_command if state == 'planned' else command
 
-    module.fail_json(msg='Terraform plan failed with unexpected exit code {rc}. \r\nSTDOUT: {out}\r\nSTDERR: {err}\r\nCOMMAND: {cmd} {args}'.format(
+    module.fail_json(msg='Terraform plan failed with unexpected exit code {rc}.\nSTDOUT: {out}\nSTDERR: {err}\nCOMMAND: {cmd} {args}'.format(
         rc=rc,
         out=out,
         err=err,

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -94,7 +94,7 @@ options:
     description:
       - Enable/disable capability to handle complex variable structures for C(terraform).
       - If C(true) the C(variables) would accept I(Booleans), I(Objects) and I(Lists) to be passed to C(terraform).
-      - When disabled, supports only simple variables I(Strings), I(Integers) and I(Floats).
+      - When disabled, supports only simple variables (strings, integers, and floats), and passes them on unquoted.
     type: bool
     default: false
     version_added: 5.7.0

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -86,7 +86,7 @@ options:
       - Terraform Lists are Ansible Lists.
       - Terraform Numbers can be Ansible Ints or Floats.
       - Terraform Bool can be Ansible Bools.
-      - B(Note) passwords passed as variables will be visible in the log output. For production usecases consider C(no_log) set to C(true).
+      - "B(Note) passwords passed as variables will be visible in the log output. Make sure to use C(no_log: true) in production!"
     type: dict
     default: {}
   targets:

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -260,6 +260,7 @@ command:
 import os
 import json
 import tempfile
+import re
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils.six import integer_types
 
@@ -489,7 +490,7 @@ def main():
 
     def format_args(vars):
         if isinstance(vars, str):
-            return '"{string}"'.format(string=vars)
+            return '"{string}"'.format(string=re.sub('"', '\\"', vars))
         elif isinstance(vars, bool):
             if vars:
                 return 'true'

--- a/tests/integration/targets/terraform/files/complex_variables/main.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/main.tf
@@ -18,10 +18,18 @@ resource "null_resource" "mynullresource" {
     name = var.boolean ? var.dictionaries.name : var.list_of_objects[0].name
 
     # top level string
-    sample_string = var.string_type
+    sample_string_1 = var.string_type
 
     # nested lists
     num_from_matrix = var.list_of_lists[1][2]
   }
 
+}
+
+output "string_type" {
+  value = var.string_type
+}
+
+output "multiline_string" {
+  value = var.multiline_string
 }

--- a/tests/integration/targets/terraform/files/complex_variables/main.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/main.tf
@@ -1,0 +1,27 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+resource "null_resource" "mynullresource" {
+  triggers = {
+    # plain dictionaries
+    dict_name = var.dictionaries.name
+    dict_age  = var.dictionaries.age
+
+    # list of dicrs
+    join_dic_name = join(",", var.list_of_objects.*.name)
+
+    # list-of-strings
+    join_list = join(",", var.list_of_strings.*)
+
+    # testing boolean
+    name = var.boolean ? var.dictionaries.name : var.list_of_objects[0].name
+
+    # top level string
+    sample_string = var.string_type
+
+    # nested lists
+    num_from_matrix = var.list_of_lists[1][2]
+  }
+
+}

--- a/tests/integration/targets/terraform/files/complex_variables/variables.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/variables.tf
@@ -18,7 +18,7 @@ variable "list_of_strings" {
   type        = list(string)
   description = "list of strings"
   validation {
-    condition     = (var.list_of_strings[1] == "cli specials\"&$%@#*!(){}[]:\"\"")
+    condition     = (var.list_of_strings[1] == "cli specials\"&$%@#*!(){}[]:\"\" \\\\")
     error_message = "Strings do not match."
   }
 }
@@ -29,7 +29,7 @@ variable "list_of_objects" {
     age  = number
   }))
   validation {
-    condition     = (var.list_of_objects[1].name == "cli specials\"&$%@#*!(){}[]:\"\"")
+    condition     = (var.list_of_objects[1].name == "cli specials\"&$%@#*!(){}[]:\"\" \\\\")
     error_message = "Strings do not match."
   }
 }
@@ -43,7 +43,15 @@ variable "boolean" {
 variable "string_type" {
   type = string
   validation {
-    condition     = (var.string_type == "cli specials\"&$%@#*!(){}[]:\"\"")
+    condition     = (var.string_type == "cli specials\"&$%@#*!(){}[]:\"\" \\\\")
+    error_message = "Strings do not match."
+  }
+}
+
+variable "multiline_string" {
+  type = string
+  validation {
+    condition     = (var.multiline_string == "one\ntwo\n")
     error_message = "Strings do not match."
   }
 }

--- a/tests/integration/targets/terraform/files/complex_variables/variables.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/variables.tf
@@ -18,7 +18,7 @@ variable "list_of_strings" {
   type        = list(string)
   description = "list of strings"
   validation {
-    condition     = (var.list_of_strings[1] == "cli specials\"&$%@#*!(){}[]\"\"")
+    condition     = (var.list_of_strings[1] == "cli specials\"&$%@#*!(){}[]:\"\"")
     error_message = "Strings do not match."
   }
 }
@@ -29,7 +29,7 @@ variable "list_of_objects" {
     age  = number
   }))
   validation {
-    condition     = (var.list_of_objects[1].name == "cli specials\"&$%@#*!(){}[]\"\"")
+    condition     = (var.list_of_objects[1].name == "cli specials\"&$%@#*!(){}[]:\"\"")
     error_message = "Strings do not match."
   }
 }
@@ -43,7 +43,7 @@ variable "boolean" {
 variable "string_type" {
   type = string
   validation {
-    condition     = (var.string_type == "cli specials\"&$%@#*!(){}[]\"\"")
+    condition     = (var.string_type == "cli specials\"&$%@#*!(){}[]:\"\"")
     error_message = "Strings do not match."
   }
 }

--- a/tests/integration/targets/terraform/files/complex_variables/variables.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/variables.tf
@@ -17,6 +17,10 @@ variable "dictionaries" {
 variable "list_of_strings" {
   type        = list(string)
   description = "list of strings"
+  validation {
+    condition     = (var.list_of_strings[1] == "cli specials\"&$%@#*!(){}[]\"\"")
+    error_message = "Strings do not match."
+  }
 }
 
 variable "list_of_objects" {
@@ -24,7 +28,10 @@ variable "list_of_objects" {
     name = string
     age  = number
   }))
-
+  validation {
+    condition     = (var.list_of_objects[1].name == "cli specials\"&$%@#*!(){}[]\"\"")
+    error_message = "Strings do not match."
+  }
 }
 
 variable "boolean" {
@@ -36,10 +43,9 @@ variable "boolean" {
 variable "string_type" {
   type = string
   validation {
-    condition     = (var.string_type == "randomstring2\"&$%@")
+    condition     = (var.string_type == "cli specials\"&$%@#*!(){}[]\"\"")
     error_message = "Strings do not match."
   }
-  default = "randomstring2\"&$%@"
 }
 
 variable "list_of_lists" {

--- a/tests/integration/targets/terraform/files/complex_variables/variables.tf
+++ b/tests/integration/targets/terraform/files/complex_variables/variables.tf
@@ -1,0 +1,48 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+variable "dictionaries" {
+  type = object({
+    name = string
+    age  = number
+  })
+  description = "Same as ansible Dict"
+  default = {
+    age = 1
+    name = "value"
+  }
+}
+
+variable "list_of_strings" {
+  type        = list(string)
+  description = "list of strings"
+}
+
+variable "list_of_objects" {
+  type = list(object({
+    name = string
+    age  = number
+  }))
+
+}
+
+variable "boolean" {
+  type        = bool
+  description = "boolean"
+
+}
+
+variable "string_type" {
+  type = string
+  validation {
+    condition     = (var.string_type == "randomstring2\"&$%@")
+    error_message = "Strings do not match."
+  }
+  default = "randomstring2\"&$%@"
+}
+
+variable "list_of_lists" {
+  type = list(list(any))
+  default = [ [ 1 ], [1, 2, 3], [3] ]
+}

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -24,26 +24,30 @@
     project_path: "{{ terraform_project_dir }}/complex_vars"
     binary_path: "{{ terraform_binary_path }}"
     force_init: yes
+    complex_vars: true
     variables:
       dictionaries:
         name: "kosala"
         age: 99
       list_of_strings:
         - "kosala"
-        - 'cli specials"&$%@#*!(){}[]:""'
+        - 'cli specials"&$%@#*!(){}[]:"" \\'
         - "xxx"
         - "zzz"
       list_of_objects:
         - name: "kosala"
           age: 99
-        - name: 'cli specials"&$%@#*!(){}[]:""'
+        - name: 'cli specials"&$%@#*!(){}[]:"" \\'
           age: 0.1
         - name: "zzz"
           age: 9.789
         - name: "lll"
           age: 1000
       boolean: true
-      string_type: 'cli specials"&$%@#*!(){}[]:""'
+      string_type: 'cli specials"&$%@#*!(){}[]:"" \\'
+      multiline_string: |
+        one
+        two
       list_of_lists:
         - [ 1 ]
         - [ 11, 12, 13 ]

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -30,20 +30,20 @@
         age: 99
       list_of_strings:
         - "kosala"
-        - 'cli specials"&$%@#*!(){}[]""'
+        - 'cli specials"&$%@#*!(){}[]:""'
         - "xxx"
         - "zzz"
       list_of_objects:
         - name: "kosala"
           age: 99
-        - name: 'cli specials"&$%@#*!(){}[]""'
+        - name: 'cli specials"&$%@#*!(){}[]:""'
           age: 0.1
         - name: "zzz"
           age: 9.789
         - name: "lll"
           age: 1000
       boolean: true
-      string_type: 'cli specials"&$%@#*!(){}[]""'
+      string_type: 'cli specials"&$%@#*!(){}[]:""'
       list_of_lists:
         - [ 1 ]
         - [ 11, 12, 13 ]

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -26,24 +26,24 @@
     force_init: yes
     variables:
       dictionaries:
-        name: kosala
+        name: "kosala"
         age: 99
       list_of_strings:
-        - kosala
-        - yyy
-        - xxx
-        - zzz
+        - "kosala"
+        - 'cli specials"&$%@#*!(){}[]""'
+        - "xxx"
+        - "zzz"
       list_of_objects:
-        - name: kosala
+        - name: "kosala"
           age: 99
-        - name: yyy
+        - name: 'cli specials"&$%@#*!(){}[]""'
           age: 0.1
-        - name: zzz
+        - name: "zzz"
           age: 9.789
-        - name: lll
+        - name: "lll"
           age: 1000
       boolean: true
-      string_type: 'randomstring2"&$%@'
+      string_type: 'cli specials"&$%@#*!(){}[]""'
       list_of_lists:
         - [ 1 ]
         - [ 11, 12, 13 ]

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Create terraform project directory (complex variables)
-  file:
+  ansible.builtin.file:
     path: "{{ terraform_project_dir }}/complex_vars"
     state: directory
     mode: 0755

--- a/tests/integration/targets/terraform/tasks/complex_variables.yml
+++ b/tests/integration/targets/terraform/tasks/complex_variables.yml
@@ -1,0 +1,56 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create terraform project directory (complex variables)
+  file:
+    path: "{{ terraform_project_dir }}/complex_vars"
+    state: directory
+    mode: 0755
+
+- name: copy terraform files to work space
+  ansible.builtin.copy:
+    src: "complex_variables/{{ item }}"
+    dest: "{{ terraform_project_dir }}/complex_vars/{{ item }}"
+  with_items:
+    - main.tf
+    - variables.tf
+
+# This task would test the various complex variable structures of the with the
+# terraform null_resource
+- name: test complex variables
+  community.general.terraform:
+    project_path: "{{ terraform_project_dir }}/complex_vars"
+    binary_path: "{{ terraform_binary_path }}"
+    force_init: yes
+    variables:
+      dictionaries:
+        name: kosala
+        age: 99
+      list_of_strings:
+        - kosala
+        - yyy
+        - xxx
+        - zzz
+      list_of_objects:
+        - name: kosala
+          age: 99
+        - name: yyy
+          age: 0.1
+        - name: zzz
+          age: 9.789
+        - name: lll
+          age: 1000
+      boolean: true
+      string_type: 'randomstring2"&$%@'
+      list_of_lists:
+        - [ 1 ]
+        - [ 11, 12, 13 ]
+        - [ 2 ]
+        - [ 3 ]
+    state: present
+  register: terraform_init_result
+
+- assert:
+    that: terraform_init_result is not failed

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -9,17 +9,17 @@
 - name: Check for existing Terraform in path
   block:
   - name: Check if terraform is present in path
-    command: "command -v terraform"
+    ansible.builtin.command: "command -v terraform"
     register: terraform_binary_path
     ignore_errors: true
 
   - name: Check Terraform version
-    command: terraform version
+    ansible.builtin.command: terraform version
     register: terraform_version_output
     when: terraform_binary_path.rc == 0
 
   - name: Set terraform version
-    set_fact:
+    ansible.builtin.set_fact:
       terraform_version_installed: "{{ terraform_version_output.stdout | regex_search('(?!Terraform.*v)([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
     when: terraform_version_output.changed
 
@@ -30,7 +30,7 @@
   block:
 
   - name: Install Terraform
-    debug:
+    ansible.builtin.debug:
       msg: "Installing terraform {{ terraform_version }}, found: {{ terraform_version_installed | default('no terraform binary found') }}."
 
   - name: Ensure unzip is present
@@ -39,7 +39,7 @@
       state: present
 
   - name: Install Terraform binary
-    unarchive:
+    ansible.builtin.unarchive:
       src: "{{ terraform_url }}"
       dest: "{{ remote_tmp_dir }}"
       mode: 0755
@@ -52,11 +52,11 @@
 # path from the 'Check if terraform is present in path' task, and lastly, the fallback path.
 
 - name: Set path to terraform binary
-  set_fact:
+  ansible.builtin.set_fact:
     terraform_binary_path: "{{ terraform_binary_path.stdout or remote_tmp_dir ~ '/terraform' }}"
 
 - name: Loop over provider upgrade test tasks
-  include_tasks: test_provider_upgrade.yml
+  ansible.builtin.include_tasks: test_provider_upgrade.yml
   vars:
     tf_provider: "{{ terraform_provider_versions[provider_index] }}"
   loop: "{{ terraform_provider_versions }}"
@@ -64,4 +64,4 @@
     index_var: provider_index
 
 - name: Test Complex Varibles
-  include_tasks: complex_variables.yml
+  ansible.builtin.include_tasks: complex_variables.yml

--- a/tests/integration/targets/terraform/tasks/main.yml
+++ b/tests/integration/targets/terraform/tasks/main.yml
@@ -55,15 +55,6 @@
   set_fact:
     terraform_binary_path: "{{ terraform_binary_path.stdout or remote_tmp_dir ~ '/terraform' }}"
 
-- name: Create terraform project directory
-  file:
-    path: "{{ terraform_project_dir }}/{{ item['name'] }}"
-    state: directory
-    mode: 0755
-  loop: "{{ terraform_provider_versions }}"
-  loop_control:
-    index_var: provider_index
-
 - name: Loop over provider upgrade test tasks
   include_tasks: test_provider_upgrade.yml
   vars:
@@ -71,3 +62,6 @@
   loop: "{{ terraform_provider_versions }}"
   loop_control:
     index_var: provider_index
+
+- name: Test Complex Varibles
+  include_tasks: complex_variables.yml

--- a/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
+++ b/tests/integration/targets/terraform/tasks/test_provider_upgrade.yml
@@ -3,6 +3,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Create terraform project directory (provider upgrade)
+  file:
+    path: "{{ terraform_project_dir }}/{{ item['name'] }}"
+    state: directory
+    mode: 0755
+  loop: "{{ terraform_provider_versions }}"
+  loop_control:
+    index_var: provider_index
+
 - name: Output terraform provider test project
   ansible.builtin.template:
     src: templates/provider_test/main.tf.j2


### PR DESCRIPTION
* Terrform variable types are mapped to ansible veriable types

* Currently handles Dict, List, Str, Int, Bool types

* Updated the documentation accordingly

* Updated with an example.

##### SUMMARY

Added the capability to specify complex variables structures in the terraform module. With this change we can specify Terraform Object / Nested type variables via ansible:

For example, in TF:
```
variable "vm_additional_disks" {
  description = "Additional Disks"
  type = list(object({
    unit_number      = number
    size             = number
    label            = string
    thin_provisioned = bool
  }))
  default = []
}
```
Would translate to:
```
        vm_additional_disks:
          - label: "Third Disk"
            size: 40
            thin_provisioned: true
            unit_number: 2
          - label: "Fourth Disk"
            size: 22
            thin_provisioned: true
            unit_number: 3
```
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
Changed the variable_args to be constructed via a recursive function process_args. It's capable of handling nested lists, dictionaries, bools, string and numbers.

