### PR TITLE
CI: Disable repo URL test for OpenSuSE 15.4

### DIFF
--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -227,33 +227,33 @@
         - "get_repository_details_from_zypper.rc == 0"
         - "'/systemsmanagement:/Uyuni:/Stable/' in get_repository_details_from_zypper.stdout"
 
-- name: add same repository via url to .repo file again to verify idempotency
-  community.general.zypper_repository:
-    repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
-    state: present
-  register: added_again_by_repo_file
+  - name: add same repository via url to .repo file again to verify idempotency
+    community.general.zypper_repository:
+      repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
+      state: present
+    register: added_again_by_repo_file
 
-- name: verify nothing was changed adding a repo with the same .repo file
-  assert:
-    that:
-      - added_again_by_repo_file is not changed
+  - name: verify nothing was changed adding a repo with the same .repo file
+    assert:
+      that:
+        - added_again_by_repo_file is not changed
 
-- name: remove repository via url to .repo file
-  community.general.zypper_repository:
-    repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
-    state: absent
-  register: removed_by_repo_file
+  - name: remove repository via url to .repo file
+    community.general.zypper_repository:
+      repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
+      state: absent
+    register: removed_by_repo_file
 
-- name: get list of files in /etc/zypp/repos.d/
-  command: ls /etc/zypp/repos.d/
-  changed_when: false
-  register: etc_zypp_reposd
+  - name: get list of files in /etc/zypp/repos.d/
+    command: ls /etc/zypp/repos.d/
+    changed_when: false
+    register: etc_zypp_reposd
 
-- name: verify removal via .repo file was successful, including cleanup of local .repo file in /etc/zypp/repos.d/
-  assert:
-    that:
-      - "removed_by_repo_file"
-      - "'/systemsmanagement:/Uyuni:/Stable/' not in etc_zypp_reposd.stdout"
+  - name: verify removal via .repo file was successful, including cleanup of local .repo file in /etc/zypp/repos.d/
+    assert:
+      that:
+        - "removed_by_repo_file"
+        - "'/systemsmanagement:/Uyuni:/Stable/' not in etc_zypp_reposd.stdout"
 
 - name: Copy test .repo file
   copy:

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -207,22 +207,25 @@
     that:
       - remove_repo is changed
 
-- name: add new repository via url to .repo file
-  community.general.zypper_repository:
-    repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
-    state: present
-  register: added_by_repo_file
+# For now, the URL does not work for 15.4
+- when: ansible_distribution_version is version('15.4', '<')
+  block:
+  - name: add new repository via url to .repo file
+    community.general.zypper_repository:
+      repo: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_{{ ansible_distribution_version }}/systemsmanagement:Uyuni:Stable.repo
+      state: present
+    register: added_by_repo_file
 
-- name: get repository details from zypper
-  command: zypper lr systemsmanagement_Uyuni_Stable
-  register: get_repository_details_from_zypper
+  - name: get repository details from zypper
+    command: zypper lr systemsmanagement_Uyuni_Stable
+    register: get_repository_details_from_zypper
 
-- name: verify adding via .repo file was successful
-  assert:
-    that:
-      - "added_by_repo_file is changed"
-      - "get_repository_details_from_zypper.rc == 0"
-      - "'/systemsmanagement:/Uyuni:/Stable/' in get_repository_details_from_zypper.stdout"
+  - name: verify adding via .repo file was successful
+    assert:
+      that:
+        - "added_by_repo_file is changed"
+        - "get_repository_details_from_zypper.rc == 0"
+        - "'/systemsmanagement:/Uyuni:/Stable/' in get_repository_details_from_zypper.stdout"
 
 - name: add same repository via url to .repo file again to verify idempotency
   community.general.zypper_repository:


### PR DESCRIPTION
##### SUMMARY
Fixes currently broken CI.

ansible-core devel bumped OpenSuSE to 15.4, which isn't properly released yet.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zypper_repository integration tests
