### PR TITLE
redhat_subscription: call 'remove' instead of 'unsubscribe'

### DIFF
--- a/changelogs/fragments/4809-redhat_subscription-unsubscribe.yaml
+++ b/changelogs/fragments/4809-redhat_subscription-unsubscribe.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - fix unsubscribing on RHEL 9 (https://github.com/ansible-collections/community.general/issues/4741).

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -468,7 +468,7 @@ class Rhsm(RegistrationBase):
             items = ["--all"]
 
         if items:
-            args = [SUBMAN_CMD, 'unsubscribe'] + items
+            args = [SUBMAN_CMD, 'remove'] + items
             rc, stderr, stdout = self.module.run_command(args, check_rc=True)
         return serials
 

--- a/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/packaging/os/test_redhat_subscription.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Author: Jiri Hnidek (jhnidek@redhat.com)
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -118,7 +119,7 @@ TEST_CASES = [
                     (0, 'system identity: b26df632-25ed-4452-8f89-0308bfd167cb', '')
                 ),
                 (
-                    ['/testbin/subscription-manager', 'unsubscribe', '--all'],
+                    ['/testbin/subscription-manager', 'remove', '--all'],
                     {'check_rc': True},
                     (0, '', '')
                 ),
@@ -755,7 +756,7 @@ Entitlement Type:    Physical
                 (
                     [
                         '/testbin/subscription-manager',
-                        'unsubscribe',
+                        'remove',
                         '--serial=7807912223970164816',
                     ],
                     {'check_rc': True},


### PR DESCRIPTION
##### SUMMARY
The `unsubscribe` command of `subscription-manager` was deprecated already in subscription-manager 1.11.3, shipped with RHEL 5.11. As it was removed in subscription-manager 1.29.x, unsubscribing from pools was thus broken.

The simple fix is to call the proper command, `remove`.

Fixes #4741.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ADDITIONAL INFORMATION
The issue #4741 has proper instructions on how to reproduce this. In short, when trying to unregister from attached pools, or unsubscribe in general.