### PR TITLE
alternatives: Fix bug with priority default

### DIFF
--- a/changelogs/fragments/4810-alternatives-bug.yml
+++ b/changelogs/fragments/4810-alternatives-bug.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "alternatives - do not set the priority if the priority was not set by the user (https://github.com/ansible-collections/community.general/pull/4810, https://github.com/ansible-collections/community.general/issues/4803, https://github.com/ansible-collections/community.general/issues/4804)."
+  - "alternatives - do not set the priority if the priority was not set by the user (https://github.com/ansible-collections/community.general/pull/4810)."

--- a/changelogs/fragments/4810-alternatives-bug.yml
+++ b/changelogs/fragments/4810-alternatives-bug.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "alternatives - do not set the priority if the default value if the priority is not set (https://github.com/ansible-collections/community.general/pull/4810, https://github.com/ansible-collections/community.general/issues/4803, https://github.com/ansible-collections/community.general/issues/4804)."
+  - "alternatives - do not set the priority if the priority was not set by the user (https://github.com/ansible-collections/community.general/pull/4810, https://github.com/ansible-collections/community.general/issues/4803, https://github.com/ansible-collections/community.general/issues/4804)."

--- a/changelogs/fragments/4810-alternatives-bug.yml
+++ b/changelogs/fragments/4810-alternatives-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "alternatives - do not set the priority if the default value if the priority is not set (https://github.com/ansible-collections/community.general/pull/4810, https://github.com/ansible-collections/community.general/issues/4803, https://github.com/ansible-collections/community.general/issues/4804)."

--- a/plugins/modules/system/alternatives.py
+++ b/plugins/modules/system/alternatives.py
@@ -40,7 +40,7 @@ options:
     type: path
   priority:
     description:
-      - The priority of the alternative. If no priority is given for creation 50 is used as a fallback.
+      - The priority of the alternative. If no priority is given for creation C(50) is used as a fallback.
     type: int
   state:
     description:

--- a/plugins/modules/system/alternatives.py
+++ b/plugins/modules/system/alternatives.py
@@ -173,7 +173,7 @@ class AlternativesModule(object):
             priority_parameter = self.module.params['priority']
             if (
                 self.path not in self.current_alternatives or
-                (priority_parameter and self.current_alternatives[self.path].get('priority') != priority_parameter) or
+                (priority_parameter is not None and self.current_alternatives[self.path].get('priority') != priority_parameter) or
                 (subcommands_parameter is not None and (
                     not all(s in subcommands_parameter for s in self.current_alternatives[self.path].get('subcommands')) or
                     not all(s in self.current_alternatives[self.path].get('subcommands') for s in subcommands_parameter)
@@ -273,7 +273,9 @@ class AlternativesModule(object):
 
     @property
     def priority(self):
-        return self.module.params.get('priority') or self.current_alternatives.get(self.path, {}).get('priority') or 50
+        if self.module.params.get('priority') is not None:
+            return self.module.params.get('priority')
+        return self.current_alternatives.get(self.path, {}).get('priority', 50)
 
     @property
     def subcommands(self):

--- a/plugins/modules/system/alternatives.py
+++ b/plugins/modules/system/alternatives.py
@@ -40,9 +40,8 @@ options:
     type: path
   priority:
     description:
-      - The priority of the alternative.
+      - The priority of the alternative. If no priority is given for creation 50 is used as a fallback.
     type: int
-    default: 50
   state:
     description:
       - C(present) - install the alternative (if not already installed), but do
@@ -171,9 +170,10 @@ class AlternativesModule(object):
         if self.mode_present:
             # Check if we need to (re)install
             subcommands_parameter = self.module.params['subcommands']
+            priority_parameter = self.module.params['priority']
             if (
                 self.path not in self.current_alternatives or
-                self.current_alternatives[self.path].get('priority') != self.priority or
+                (priority_parameter and self.current_alternatives[self.path].get('priority') != priority_parameter) or
                 (subcommands_parameter is not None and (
                     not all(s in subcommands_parameter for s in self.current_alternatives[self.path].get('subcommands')) or
                     not all(s in self.current_alternatives[self.path].get('subcommands') for s in subcommands_parameter)
@@ -273,7 +273,7 @@ class AlternativesModule(object):
 
     @property
     def priority(self):
-        return self.module.params.get('priority')
+        return self.module.params.get('priority') or self.current_alternatives.get(self.path, {}).get('priority') or 50
 
     @property
     def subcommands(self):
@@ -373,7 +373,7 @@ def main():
             name=dict(type='str', required=True),
             path=dict(type='path', required=True),
             link=dict(type='path'),
-            priority=dict(type='int', default=50),
+            priority=dict(type='int'),
             state=dict(
                 type='str',
                 choices=AlternativeState.to_list(),

--- a/tests/integration/targets/alternatives/tasks/test.yml
+++ b/tests/integration/targets/alternatives/tasks/test.yml
@@ -48,4 +48,4 @@
   when: ansible_os_family == 'RedHat' and not with_alternatives and item == 1
 
 - name: check that alternative has been updated
-  command: "grep -Pzq '/bin/dummy{{ item }}\\n50' '{{ alternatives_dir }}/dummy'"
+  command: "grep -Pzq '/bin/dummy{{ item }}\\n' '{{ alternatives_dir }}/dummy'"

--- a/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -32,3 +32,15 @@
 
 - name: check that alternative priority has been updated
   command: "grep -Pzq '/bin/dummy{{ item }}\\n{{ 70 + item|int }}' '{{ alternatives_dir }}/dummy'"
+
+- name: no change without priority
+  alternatives:
+    name: dummy
+    path: '/usr/bin/dummy{{ item }}'
+    link: /usr/bin/dummy
+  register: alternative
+
+- name: check no change was triggerd without priority
+  assert:
+    that:
+      - 'alternative is not changed'

--- a/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/tests/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -40,7 +40,10 @@
     link: /usr/bin/dummy
   register: alternative
 
-- name: check no change was triggerd without priority
+- name: check no change was triggered without priority
   assert:
     that:
       - 'alternative is not changed'
+
+- name: check that alternative priority has not been changed
+  command: "grep -Pzq '/bin/dummy{{ item }}\\n{{ 70 + item|int }}' '{{ alternatives_dir }}/dummy'"


### PR DESCRIPTION
If neigther the priority nor the subcommands where specified the module decided to update the priority with the default value anyway. ~~This resulted in the bug #4803 and #4804 when the subcommands have not been specified.~~

##### SUMMARY
Do not set the priority if the default value if the priority is not set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
alternatives

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
