### PR TITLE
Expose unredirected_headers on maven_artifact

### DIFF
--- a/changelogs/fragments/4812-expose-unredirected-headers.yml
+++ b/changelogs/fragments/4812-expose-unredirected-headers.yml
@@ -1,3 +1,2 @@
 minor_changes:
-  - adds support for unredirected_headers to fetch_url function. This parameter is supported on ansible-core 2.12 and above. As we are ignoring such parameter for ansible-core version 2.11 and below, this does not present any breaking changes.
-  - the default value for unredirected_headers for ansible-core 2.12 and above is 'Authorizing' and 'Cookie' (https://github.com/ansible-collections/community.general/pull/4812)
+  - maven_artifact - add a new ``unredirected_headers`` option that can be used with ansible-core 2.12 and above. The default value is to not use ``Authorization`` and ``Cookie`` headers on redirects for security reasons. With ansible-core 2.11, all headers are still passed on for redirects (https://github.com/ansible-collections/community.general/pull/4812).

--- a/changelogs/fragments/4812-expose-unredirected-headers.yml
+++ b/changelogs/fragments/4812-expose-unredirected-headers.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - adds support for unredirected_headers to fetch_url function. This parameter is supported on ansible-core 2.12 and above. As we are ignoring such parameter for ansible-core version 2.11 and below, this does not present any breaking changes.
+  - the default value for unredirected_headers for ansible-core 2.12 and above is 'Authorizing' and 'Cookie' (https://github.com/ansible-collections/community.general/pull/4812)

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -155,8 +155,7 @@ options:
         elements: str
         version_added: 5.2.0
         description:
-            - A list of headers that should not be included in the redirection. This headers are sent to the fetch_url
-            C(fetch_url) function.
+            - A list of headers that should not be included in the redirection. This headers are sent to the fetch_url C(fetch_url) function.
             - On ansible-core version 2.12 or later, the default of this option is C([Authorization, Cookie]).
             - Useful if the redirection URL does not need to have sensitive headers in the request.
             - Requires ansible-core version 2.12 or later.

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -152,15 +152,14 @@ options:
         version_added: 3.2.0
     unredirected_headers:
         type: list
-        default: ['Authorization', 'Cookie']
         elements: str
         version_added: 5.2.0
         description:
-            A list of headers that should not be included in the redirection. This headers are sent to the fetch_url
+            - A list of headers that should not be included in the redirection. This headers are sent to the fetch_url
             C(fetch_url) function.
-            The default value will be applied only on ansible-core version 2.12 or later.
-            Useful if the redirection URL does not need to have sensitive headers in the request.
-            Requires ansible-core version 2.12 or later.
+            - On ansible-core version 2.12 or later, the default of this option is C([Authorization, Cookie]).
+            - Useful if the redirection URL does not need to have sensitive headers in the request.
+            - Requires ansible-core version 2.12 or later.
     directory_mode:
         type: str
         description:

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -154,8 +154,10 @@ options:
         type: list
         default: []
         elements: str
+        version_added: 5.2.0
         description:
-            A list of headers that should not be included in the redirection. This headers are sent to the fetch_url module.
+            A list of headers that should not be included in the redirection. This headers are sent to the fetch_url
+            ``fetch_url`` function.
             Useful if the redirection URL does not need to have sensitive headers in the request.
     directory_mode:
         type: str

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -153,6 +153,7 @@ options:
     unredirected_headers:
         type: list
         default: []
+        elements: str
         description:
             A list of headers that should not be included in the redirection. This headers are sent to the fetch_url module.
             Useful if the redirection URL does not need to have sensitive headers in the request.
@@ -515,7 +516,13 @@ class MavenDownloader:
         self.module.params['url_password'] = self.module.params.get('password', '')
         self.module.params['http_agent'] = self.user_agent
 
-        response, info = fetch_url(self.module, url_to_use, timeout=req_timeout, headers=self.headers, unredirected_headers=self.module.params.get('unredirected_headers', []))
+        response, info = fetch_url(
+            self.module,
+            url_to_use,
+            timeout=req_timeout,
+            headers=self.headers,
+            unredirected_headers=self.module.params.get('unredirected_headers', [])
+        )
         if info['status'] == 200:
             return response
         if force:

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -150,6 +150,12 @@ options:
         default: 'md5'
         choices: ['md5', 'sha1']
         version_added: 3.2.0
+    unredirected_headers:
+        type: list
+        default: []
+        description:
+            A list of headers that should not be included in the redirection. This headers are sent to the fetch_url module.
+            Useful if the redirection URL does not need to have sensitive headers in the request.
     directory_mode:
         type: str
         description:
@@ -509,7 +515,7 @@ class MavenDownloader:
         self.module.params['url_password'] = self.module.params.get('password', '')
         self.module.params['http_agent'] = self.user_agent
 
-        response, info = fetch_url(self.module, url_to_use, timeout=req_timeout, headers=self.headers)
+        response, info = fetch_url(self.module, url_to_use, timeout=req_timeout, headers=self.headers, unredirected_headers=self.module.params.get('unredirected_headers', []))
         if info['status'] == 200:
             return response
         if force:
@@ -614,6 +620,7 @@ def main():
             keep_name=dict(required=False, default=False, type='bool'),
             verify_checksum=dict(required=False, default='download', choices=['never', 'download', 'change', 'always']),
             checksum_alg=dict(required=False, default='md5', choices=['md5', 'sha1']),
+            unredirected_headers=dict(type='list', elements='str', required=False, default=[]),
             directory_mode=dict(type='str'),
         ),
         add_file_common_args=True,

--- a/plugins/modules/packaging/language/maven_artifact.py
+++ b/plugins/modules/packaging/language/maven_artifact.py
@@ -157,9 +157,10 @@ options:
         version_added: 5.2.0
         description:
             A list of headers that should not be included in the redirection. This headers are sent to the fetch_url
-            ``fetch_url`` function.
+            C(fetch_url) function.
+            The default value will be applied only on ansible-core version 2.12 or later.
             Useful if the redirection URL does not need to have sensitive headers in the request.
-            Requires Ansible version >=2.12
+            Requires ansible-core version 2.12 or later.
     directory_mode:
         type: str
         description:
@@ -636,7 +637,7 @@ def main():
             keep_name=dict(required=False, default=False, type='bool'),
             verify_checksum=dict(required=False, default='download', choices=['never', 'download', 'change', 'always']),
             checksum_alg=dict(required=False, default='md5', choices=['md5', 'sha1']),
-            unredirected_headers=dict(type='list', elements='str', required=False, default=['Authorization', 'Cookie']),
+            unredirected_headers=dict(type='list', elements='str', required=False),
             directory_mode=dict(type='str'),
         ),
         add_file_common_args=True,
@@ -644,7 +645,11 @@ def main():
     )
 
     if LooseVersion(ansible_version) < LooseVersion("2.12") and module.params['unredirected_headers']:
-        module.fail_json(msg="Unredirected Headers parameter provided, but Ansible version does not support it. Minimum version is 2.12")
+        module.fail_json(msg="Unredirected Headers parameter provided, but your ansible-core version does not support it. Minimum version is 2.12")
+
+    if LooseVersion(ansible_version) >= LooseVersion("2.12") and module.params['unredirected_headers'] is None:
+        # if the user did not supply unredirected params, we use the default, ONLY on ansible core 2.12 and above
+        module.params['unredirected_headers'] = ['Authorization', 'Cookie']
 
     if not HAS_LXML_ETREE:
         module.fail_json(msg=missing_required_lib('lxml'), exception=LXML_ETREE_IMP_ERR)


### PR DESCRIPTION
##### SUMMARY
Tries to fix #1171 

In some cases, when the initial request returns a redirect and we want to follow it to get the artifact, we might not want to include certain headers in the redirection request. Specially headers like
Authorization and Cookies.
Or perhaps the redirect server returns a 400 because it included some unexpected headers.
Fetch url already supports this feature, but it was being shadowed by maven_artifact. In here we just expose it, and give it a sensible default.

##### ISSUE TYPE
- New Feature

##### COMPONENT NAME
maven_artifact

##### ADDITIONAL INFORMATION
Mostly related to Code Artifact. To reproduce the error (before this PR), just trying to download an artifact from code artifact would trigger a 400. That was because after the initial request, AWS responds with a S3 url, which we follow but include some extra headers (like Authorization from the initial request), and AWS responds with 400.

If any more information is required, I'll be happy to supply it.
