### PR TITLE
nmcli: do not convert undefined lists to empty strings

### DIFF
--- a/changelogs/fragments/4813-fix-nmcli-convert-list.yaml
+++ b/changelogs/fragments/4813-fix-nmcli-convert-list.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fix error caused by adding undefined module arguments for list options (https://github.com/ansible-collections/community.general/issues/4373, https://github.com/ansible-collections/community.general/pull/4813).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1836,7 +1836,10 @@ class Nmcli(object):
 
     @staticmethod
     def list_to_string(lst):
-        return ",".join(lst or [""])
+        if lst is None:
+            return None
+        else:
+            return ",".join(lst)
 
     @staticmethod
     def settings_type(setting):


### PR DESCRIPTION
##### SUMMARY
Some parameters were changed to support lists e.g. ip4,ip6. These changes seem to cause the following error message if you only try to set specific parameters like zone or dns6.

> Error: Failed to modify connection 'ens192': ipv4.gateway: gateway cannot be set if there are no addresses configured\n

Fixes  #4373

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION

```
  - name: Add zone
    community.general.nmcli:
      type: ethernet
      conn_name: ens192
      zone: external
      state: present
```
> Error: Failed to modify connection 'ens192': ipv4.gateway: gateway cannot be set if there are no addresses configured\n

List parameters get converted to strings with the `list_to_string` function. If the parameter is `None`, it returns an empty string. As these options aren't None anymore, they get added as arguments to the `nmcli` command.

