### PR TITLE
Ensure managed sudoers config files have 0440 permissions

### DIFF
--- a/changelogs/fragments/4814-sudoers-file-permissions.yml
+++ b/changelogs/fragments/4814-sudoers-file-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sudoers - ensure sudoers config files are created with the permissions requested by sudoers (https://github.com/ansible-collections/community.general/pull/4814)

--- a/changelogs/fragments/4814-sudoers-file-permissions.yml
+++ b/changelogs/fragments/4814-sudoers-file-permissions.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - sudoers - ensure sudoers config files are created with the permissions requested by sudoers (https://github.com/ansible-collections/community.general/pull/4814)
+  - sudoers - ensure sudoers config files are created with the permissions requested by sudoers (0440) (https://github.com/ansible-collections/community.general/pull/4814).

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -118,8 +118,6 @@ class Sudoers(object):
     FILE_MODE = 0o440
 
     def __init__(self, module):
-        self.module = module
-
         self.check_mode = module.check_mode
         self.name = module.params['name']
         self.user = module.params['user']

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -151,8 +151,8 @@ class Sudoers(object):
         with open(self.file, 'r') as f:
             content_matches = f.read() == self.content()
 
-        current_mode = oct(os.stat(self.file).st_mode & 0o777)
-        mode_matches = current_mode == oct(self.FILE_MODE)
+        current_mode = os.stat(self.file).st_mode & 0o777
+        mode_matches = current_mode == self.FILE_MODE
 
         return content_matches and mode_matches
 

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -115,7 +115,11 @@ from ansible.module_utils.common.text.converters import to_native
 
 class Sudoers(object):
 
+    FILE_MODE = 0o440
+
     def __init__(self, module):
+        self.module = module
+
         self.check_mode = module.check_mode
         self.name = module.params['name']
         self.user = module.params['user']
@@ -134,6 +138,8 @@ class Sudoers(object):
         with open(self.file, 'w') as f:
             f.write(self.content())
 
+        os.chmod(self.file, self.FILE_MODE)
+
     def delete(self):
         if self.check_mode:
             return
@@ -145,7 +151,12 @@ class Sudoers(object):
 
     def matches(self):
         with open(self.file, 'r') as f:
-            return f.read() == self.content()
+            content_matches = f.read() == self.content()
+
+        current_mode = oct(os.stat(self.file).st_mode & 0o777)
+        mode_matches = current_mode == oct(self.FILE_MODE)
+
+        return content_matches and mode_matches
 
     def content(self):
         if self.user:

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -29,6 +29,11 @@
     commands: /usr/local/bin/command
   register: rule_1
 
+- name: Stat my-sudo-rule-1 file
+  ansible.builtin.stat:
+    path: "{{ sudoers_path }}/my-sudo-rule-1"
+  register: rule_1_stat
+
 - name: Grab contents of my-sudo-rule-1
   ansible.builtin.slurp:
     src: "{{ sudoers_path }}/my-sudo-rule-1"
@@ -131,6 +136,13 @@
 
 
 # Run assertions
+
+- name: Check rule 1 file stat
+  ansible.builtin.assert:
+    that:
+      - rule_1_stat.stat.exists
+      - rule_1_stat.stat.isreg
+      - rule_1_stat.stat.mode == '0440'
 
 - name: Check changed status
   ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY
Related to #4794, this change allows files created by the sudoers module to be created with the correct permissions to pass validation by visudo.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Sudoers module

##### ADDITIONAL INFORMATION
Ensures that files touched by the sudoers module have 0440 permissions as required by visudo to pass validation.
Files that already exist with other permissions (or created by the sudoers module before this update) will be updated to the correct file permissions.
