### PR TITLE
Added conditional to only collect qmpstatus on qemu VMs

### DIFF
--- a/changelogs/fragments/4816-proxmox-fix-extended-status.yaml
+++ b/changelogs/fragments/4816-proxmox-fix-extended-status.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox inventory - fixed extended status detection for qemu (https://github.com/ansible-collections/community.general/pull/4816).

--- a/changelogs/fragments/4816-proxmox-fix-extended-status.yaml
+++ b/changelogs/fragments/4816-proxmox-fix-extended-status.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox inventory - fixed extended status detection for qemu (https://github.com/ansible-collections/community.general/pull/4816).
+  - proxmox inventory plugin - fixed extended status detection for qemu (https://github.com/ansible-collections/community.general/pull/4816).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -443,7 +443,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_vm_status(self, properties, node, vmid, vmtype, name):
         ret = self._get_json("%s/api2/json/nodes/%s/%s/%s/status/current" % (self.proxmox_url, node, vmtype, vmid))
         properties[self._fact('status')] = ret['status']
-        properties[self._fact('qmpstatus')] = ret['qmpstatus']
+        if vmtype == 'qemu':
+            properties[self._fact('qmpstatus')] = ret['qmpstatus']
 
     def _get_vm_snapshots(self, properties, node, vmid, vmtype, name):
         ret = self._get_json("%s/api2/json/nodes/%s/%s/%s/snapshot" % (self.proxmox_url, node, vmtype, vmid))

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_vm_status(self, properties, node, vmid, vmtype, name):
         ret = self._get_json("%s/api2/json/nodes/%s/%s/%s/status/current" % (self.proxmox_url, node, vmtype, vmid))
         properties[self._fact('status')] = ret['status']
-        if vmtype == 'qemu':
+        if want_facts and vmtype == 'qemu':
             properties[self._fact('qmpstatus')] = ret['qmpstatus']
 
     def _get_vm_snapshots(self, properties, node, vmid, vmtype, name):

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_vm_status(self, properties, node, vmid, vmtype, name):
         ret = self._get_json("%s/api2/json/nodes/%s/%s/%s/status/current" % (self.proxmox_url, node, vmtype, vmid))
         properties[self._fact('status')] = ret['status']
-        if want_facts and vmtype == 'qemu':
+        if self.get_option('want_facts') and vmtype == 'qemu':
             properties[self._fact('qmpstatus')] = ret['qmpstatus']
 
     def _get_vm_snapshots(self, properties, node, vmid, vmtype, name):

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -443,7 +443,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_vm_status(self, properties, node, vmid, vmtype, name):
         ret = self._get_json("%s/api2/json/nodes/%s/%s/%s/status/current" % (self.proxmox_url, node, vmtype, vmid))
         properties[self._fact('status')] = ret['status']
-        if self.get_option('want_facts') and vmtype == 'qemu':
+        if vmtype == 'qemu':
             properties[self._fact('qmpstatus')] = ret['qmpstatus']
 
     def _get_vm_snapshots(self, properties, node, vmid, vmtype, name):

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -713,6 +713,7 @@ def test_populate(inventory, mocker):
     group_paused = inventory.inventory.groups['proxmox_all_paused']
     assert group_paused.hosts == [host_qemu_multi_nic]
 
+
 def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # module settings
     inventory.proxmox_user = 'root@pam'

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -520,6 +520,99 @@ def get_json(url):
                 }
             ]
         }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/lxc/100/status/current":
+        # _get_vm_status (lxc)
+        return {
+            "swap": 0,
+            "name": "test-lxc",
+            "diskread": 0,
+            "vmid": 100,
+            "diskwrite": 0,
+            "pid": 9000,
+            "mem": 89980928,
+            "netin": 1950776396424,
+            "disk": 4998168576,
+            "cpu": 0.00163430613110039,
+            "type": "lxc",
+            "uptime": 6793736,
+            "maxmem": 1073741824,
+            "status": "running",
+            "cpus": "1",
+            "ha": {
+              "group": null,
+              "state": "started",
+              "managed": 1
+            },
+            "maxdisk": 3348329267200,
+            "netout": 1947793356037,
+            "maxswap": 1073741824
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/101/status/current":
+        # _get_vm_status (qemu)
+        return {
+            "status": "stopped",
+            "uptime": 0,
+            "maxmem": 5364514816,
+            "maxdisk": 34359738368,
+            "netout": 0,
+            "cpus": 2,
+            "ha": {
+                "managed": 0
+            },
+            "diskread": 0,
+            "vmid": 101,
+            "diskwrite": 0,
+            "name": "test-qemu",
+            "cpu": 0,
+            "disk": 0,
+            "netin": 0,
+            "mem": 0,
+            "qmpstatus": "stopped"
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/102/status/current":
+        # _get_vm_status (qemu)
+        return {
+            "status": "stopped",
+            "uptime": 0,
+            "maxmem": 5364514816,
+            "maxdisk": 34359738368,
+            "netout": 0,
+            "cpus": 2,
+            "ha": {
+                "managed": 0
+            },
+            "diskread": 0,
+            "vmid": 102,
+            "diskwrite": 0,
+            "name": "test-qemu-windows",
+            "cpu": 0,
+            "disk": 0,
+            "netin": 0,
+            "mem": 0,
+            "qmpstatus": "prelaunch"
+        }
+    elif url == "https://localhost:8006/api2/json/nodes/testnode/qemu/103/status/current":
+        # _get_vm_status (qemu)
+        return {
+            "status": "stopped",
+            "uptime": 0,
+            "maxmem": 5364514816,
+            "maxdisk": 34359738368,
+            "netout": 0,
+            "cpus": 2,
+            "ha": {
+                "managed": 0
+            },
+            "diskread": 0,
+            "vmid": 103,
+            "diskwrite": 0,
+            "name": "test-qemu-multi-nic",
+            "cpu": 0,
+            "disk": 0,
+            "netin": 0,
+            "mem": 0,
+            "qmpstatus": "paused"
+        }
 
 
 def get_vm_snapshots(node, properties, vmtype, vmid, name):
@@ -568,7 +661,7 @@ def test_populate(inventory, mocker):
     # bypass authentication and API fetch calls
     inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
     inventory._get_json = mocker.MagicMock(side_effect=get_json)
-    inventory._get_vm_status = mocker.MagicMock(side_effect=get_vm_status)
+    inventory._get_vm_status = mocker.MagicMock(side_effect=get_json)
     inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
     inventory._can_add_host = mocker.MagicMock(return_value=True)

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -705,6 +705,13 @@ def test_populate(inventory, mocker):
     for group in ['paused', 'prelaunch']:
         assert ('%sall_%s' % (inventory.group_prefix, group)) in inventory.inventory.groups
 
+    # check if qemu-windows is in the prelaunch group
+    group_prelaunch = inventory.inventory.groups['proxmox_all_prelaunch']
+    assert group_prelaunch.hosts == [host_qemu_windows]
+
+    # check if qemu-multi-nic is in the paused group
+    group_paused = inventory.inventory.groups['proxmox_all_paused']
+    assert group_paused.hosts == [host_qemu_multi_nic]
 
 def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # module settings

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -630,10 +630,6 @@ def get_vm_snapshots(node, properties, vmtype, vmid, name):
          }]
 
 
-def get_vm_status(properties, node, vmtype, vmid, name):
-    return True
-
-
 def get_option(opts):
     def fn(option):
         default = opts.get('default', False)
@@ -731,7 +727,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # bypass authentication and API fetch calls
     inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
     inventory._get_json = mocker.MagicMock(side_effect=get_json)
-    inventory._get_vm_status = mocker.MagicMock(side_effect=get_vm_status)
+    inventory._get_vm_status = mocker.MagicMock(side_effect=get_json)
     inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
     inventory._can_add_host = mocker.MagicMock(return_value=True)

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -657,7 +657,6 @@ def test_populate(inventory, mocker):
     # bypass authentication and API fetch calls
     inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
     inventory._get_json = mocker.MagicMock(side_effect=get_json)
-    inventory._get_vm_status = mocker.MagicMock(side_effect=get_json)
     inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
     inventory._can_add_host = mocker.MagicMock(return_value=True)
@@ -727,7 +726,6 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # bypass authentication and API fetch calls
     inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
     inventory._get_json = mocker.MagicMock(side_effect=get_json)
-    inventory._get_vm_status = mocker.MagicMock(side_effect=get_json)
     inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
     inventory._can_add_host = mocker.MagicMock(return_value=True)

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -539,9 +539,9 @@ def get_json(url):
             "status": "running",
             "cpus": "1",
             "ha": {
-              "group": null,
-              "state": "started",
-              "managed": 1
+                "group": 'null',
+                "state": "started",
+                "managed": 1
             },
             "maxdisk": 3348329267200,
             "netout": 1947793356037,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes an issue with LXC containers after #4723 was implemented. I completely missed this when reviewing it and the unit tests didn't cover it :-)

I'm not too sure however on how to update the unit tests in order to fix this (yet, but it's late, unless I come up with an idea earlier then someone else, I'll adjust the tests as well :-) )
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox inventory
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Running the module without this task results in the errors below:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[WARNING]:  * Failed to parse /opt/ansible/projects/element-networks/inventory/04_nc_proxmox.yml with
ansible_collections.community.general.plugins.inventory.proxmox plugin: 'qmpstatus'
  File "/usr/lib/python3/dist-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/opt/ansible/projects/element-networks/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 656, in parse
    self._populate()
  File "/opt/ansible/projects/element-networks/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 597, in _populate
    name = self._handle_item(node['node'], ittype, item)
  File "/opt/ansible/projects/element-networks/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 507, in _handle_item
    self._get_vm_status(properties, node, vmid, ittype, name)
  File "/opt/ansible/projects/element-networks/collections/ansible_collections/community/general/plugins/inventory/proxmox.py", line 446, in _get_vm_status
    properties[self._fact('qmpstatus')] = ret['qmpstatus']

```
