### PR TITLE
[stable-3] Disable opentelemetry unit tests since requirements have conflicts way too often

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -28,11 +28,11 @@ datadog-api-client >= 1.0.0b3 ; python_version >= '3.6'
 dnsimple >= 2 ; python_version >= '3.6'
 dataclasses ; python_version == '3.6'
 
-# requirement for the opentelemetry callback plugin
-# WARNING: these libraries depend on grpcio, which takes 7 minutes (!) to build in CI on Python 3.10
-opentelemetry-api ; python_version >= '3.6' and python_version < '3.10'
-opentelemetry-exporter-otlp ; python_version >= '3.6' and python_version < '3.10'
-opentelemetry-sdk ; python_version >= '3.6' and python_version < '3.10'
+# These libraries tend to have conflicting dependencies that break CI quite often.
+# Disable them in stable-3 for now.
+# opentelemetry-api ; python_version >= '3.6' and python_version < '3.10'
+# opentelemetry-exporter-otlp ; python_version >= '3.6' and python_version < '3.10'
+# opentelemetry-sdk ; python_version >= '3.6' and python_version < '3.10'
 
 # requirement for the elastic callback plugin
 elastic-apm ; python_version >= '3.6'


### PR DESCRIPTION
##### SUMMARY
Example: https://dev.azure.com/ansible/community.general/_build/results?buildId=45004&view=logs&j=602cf013-5dea-52b3-7f57-27e24552d081&t=03289533-9b66-55f1-fce2-72fef36c372f&l=525

I've seen this multiple times during the last months, so at least let's disable this for stable-3 so at least the old branch's CI status which has tests run only once per week won't waffle because of this.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
