### PR TITLE
[stable-4] Skip Ansible 2.9 coverage reporting with new AZP container

### DIFF
--- a/.azure-pipelines/scripts/aggregate-coverage.sh
+++ b/.azure-pipelines/scripts/aggregate-coverage.sh
@@ -9,6 +9,10 @@ PATH="${PWD}/bin:${PATH}"
 
 mkdir "${agent_temp_directory}/coverage/"
 
+if [[ "$(ansible --version)" =~ \ 2\.9\. ]]; then
+    exit
+fi
+
 options=(--venv --venv-system-site-packages --color -v)
 
 ansible-test coverage combine --group-by command --export "${agent_temp_directory}/coverage/" "${options[@]}"

--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -5,6 +5,10 @@ set -o pipefail -eu
 
 PATH="${PWD}/bin:${PATH}"
 
+if [[ "$(ansible --version)" =~ \ 2\.9\. ]]; then
+    exit
+fi
+
 if ! ansible-test --help >/dev/null 2>&1; then
     # Install the devel version of ansible-test for generating code coverage reports.
     # This is only used by Ansible Collections, which are typically tested against multiple Ansible versions (in separate jobs).


### PR DESCRIPTION
##### SUMMARY
Fixes code coverage for stable-4 runs (that still use Ansible 2.9).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
