### PR TITLE
added password prompt support for machinectl

### DIFF
--- a/changelogs/fragments/4849-add-password-prompt-support-for-machinectl.yml
+++ b/changelogs/fragments/4849-add-password-prompt-support-for-machinectl.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - machinectl become method can now be used with a password from a none root user, if a polkit rule is present.

--- a/changelogs/fragments/4849-add-password-prompt-support-for-machinectl.yml
+++ b/changelogs/fragments/4849-add-password-prompt-support-for-machinectl.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - machinectl become method can now be used with a password from a none root user, if a polkit rule is present.
+  - machinectl become plugin - can now be used with a password from another user than root, if a polkit rule is present (https://github.com/ansible-collections/community.general/pull/4849).

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -71,7 +71,6 @@ DOCUMENTATION = '''
         alter the prompt behaviour to ask directly for the user credentials, if the user is allowed to perform the
         action (take a look at the examples section). If such a rule is not present the plugin only work if it is used
         in context with the root user, because then no further prompt will be shown by machinectl.
-)
 '''
 
 EXAMPLES = r'''

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -91,6 +91,9 @@ from ansible.plugins.become import BecomeBase
 from ansible.module_utils._text import to_bytes
 
 
+ansi_color_codes = re_compile(to_bytes(r'\x1B\[[0-9;]+m'))
+
+
 class BecomeModule(BecomeBase):
 
     name = 'community.general.machinectl'
@@ -101,9 +104,7 @@ class BecomeModule(BecomeBase):
 
     @staticmethod
     def remove_ansi_codes(line):
-        # taken from https://stackoverflow.com/a/38662876/9531111
-        ansi_escape = re_compile(to_bytes(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]'))
-        return ansi_escape.sub(b"", line)
+        return ansi_color_codes.sub(b"", line)
 
     def build_become_command(self, cmd, shell):
         super(BecomeModule, self).build_become_command(cmd, shell)

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -67,13 +67,16 @@ DOCUMENTATION = '''
               - section: machinectl_become_plugin
                 key: password
     notes:
-      - This plugin only works correctly with a polkit rule which will alter the behaviour of machinectl. This rule must
-        alter the prompt behaviour to ask directly for the user credentials, if the user is allowed to perform the
-        action (take a look at the examples section). If such a rule is not present the plugin only work if it is used
-        in context with the root user, because then no further prompt will be shown by machinectl.
+      - When not using this plugin with user C(root), it only works correctly with a polkit rule which will alter
+        the behaviour of machinectl. This rule must alter the prompt behaviour to ask directly for the user credentials,
+        if the user is allowed to perform the action (take a look at the examples section).
+        If such a rule is not present the plugin only work if it is used in context with the root user,
+        because then no further prompt will be shown by machinectl.
 '''
 
 EXAMPLES = r'''
+# A polkit rule needed to use the module with a non-root user.
+# See the Notes section for details.
 60-machinectl-fast-user-auth.rules: |
     polkit.addRule(function(action, subject) {
         if(action.id == "org.freedesktop.machine1.host-shell" && subject.isInGroup("wheel")) {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows the use of machinectl without being root by using the polkit auth dialog. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.general.machinectl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Example polkit rule in comments look strange, but I found no other example on how to include a multiline code snippet.

