### PR TITLE
sudoers: fix handling of state: absent (#4852)

### DIFF
--- a/changelogs/fragments/4852-sudoers-state-absent.yml
+++ b/changelogs/fragments/4852-sudoers-state-absent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "sudoers - fix incorrect handling of ``state: absent`` (https://github.com/ansible-collections/community.general/issues/4852)"

--- a/changelogs/fragments/4852-sudoers-state-absent.yml
+++ b/changelogs/fragments/4852-sudoers-state-absent.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "sudoers - fix incorrect handling of ``state: absent`` (https://github.com/ansible-collections/community.general/issues/4852)"
+  - "sudoers - fix incorrect handling of ``state: absent`` (https://github.com/ansible-collections/community.general/issues/4852)."

--- a/plugins/modules/system/sudoers.py
+++ b/plugins/modules/system/sudoers.py
@@ -168,9 +168,12 @@ class Sudoers(object):
         return "{owner} ALL={runas}{nopasswd} {commands}\n".format(owner=owner, runas=runas_str, nopasswd=nopasswd_str, commands=commands_str)
 
     def run(self):
-        if self.state == 'absent' and self.exists():
-            self.delete()
-            return True
+        if self.state == 'absent':
+            if self.exists():
+                self.delete()
+                return True
+            else:
+                return False
 
         if self.exists() and self.matches():
             return False

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -135,6 +135,18 @@
   register: revoke_rule_1_stat
 
 
+- name: Revoke non-existing rule
+  community.general.sudoers:
+    name: non-existing-rule
+    state: absent
+  register: revoke_non_existing_rule
+
+- name: Stat non-existing rule
+  ansible.builtin.stat:
+    path: "{{ sudoers_path }}/non-existing-rule"
+  register: revoke_non_existing_rule_stat
+
+
 # Run assertions
 
 - name: Check rule 1 file stat
@@ -151,6 +163,7 @@
       - rule_1_again is not changed
       - rule_5 is changed
       - revoke_rule_1 is changed
+      - revoke_non_existing_rule is not changed
 
 - name: Check contents
   ansible.builtin.assert:
@@ -166,3 +179,4 @@
   ansible.builtin.assert:
     that:
       - not revoke_rule_1_stat.stat.exists
+      - non revoke_non_existing_rule_stat.stat.exists

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -179,4 +179,4 @@
   ansible.builtin.assert:
     that:
       - not revoke_rule_1_stat.stat.exists
-      - non revoke_non_existing_rule_stat.stat.exists
+      - not revoke_non_existing_rule_stat.stat.exists


### PR DESCRIPTION
##### SUMMARY
This PR decouples the check for `state == absent` from the file existence check, so that `run` does not "fall through" into code paths intended for `state == present`.

fixes #4852

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sudoers

##### ADDITIONAL INFORMATION
Refer to #4852. Please ask if anything is unclear.