### PR TITLE
Fix CI due to pycdlib dropping Python 2 support

### DIFF
--- a/tests/integration/targets/iso_create/meta/main.yml
+++ b/tests/integration/targets/iso_create/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - setup_pkg_mgr
   - setup_remote_tmp_dir
+  - setup_remote_constraints

--- a/tests/integration/targets/iso_create/tasks/main.yml
+++ b/tests/integration/targets/iso_create/tasks/main.yml
@@ -10,6 +10,7 @@
   pip:
     name: pycdlib
     # state: latest
+    extra_args: "-c {{ remote_constraints }}"
   register: install_pycdlib
 - debug: var=install_pycdlib
 

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -49,6 +49,7 @@ cffi >= 1.14.2, != 1.14.3 # Yanked version which older versions of pip will stil
 redis == 2.10.6 ; python_version < '2.7'
 redis < 4.0.0 ; python_version >= '2.7' and python_version < '3.6'
 redis ; python_version >= '3.6'
+pycdlib < 1.13.0 ; python_version < '3'  # 1.13.0 does not work with Python 2, while not declaring that
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
See https://github.com/clalancette/pycdlib/issues/95.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
