### PR TITLE
Disable opentelemetry installation for unit tests

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -29,10 +29,11 @@ dnsimple >= 2 ; python_version >= '3.6'
 dataclasses ; python_version == '3.6'
 
 # requirement for the opentelemetry callback plugin
-# WARNING: these libraries depend on grpcio, which takes 7 minutes (!) to build in CI on Python 3.10
-opentelemetry-api ; python_version >= '3.6' and python_version < '3.10'
-opentelemetry-exporter-otlp ; python_version >= '3.6' and python_version < '3.10'
-opentelemetry-sdk ; python_version >= '3.6' and python_version < '3.10'
+# WARNING: these libraries rely on Protobuf for Python, which regularly stops installing.
+#          That's why they are disabled for now.
+# opentelemetry-api ; python_version >= '3.6' and python_version < '3.10'
+# opentelemetry-exporter-otlp ; python_version >= '3.6' and python_version < '3.10'
+# opentelemetry-sdk ; python_version >= '3.6' and python_version < '3.10'
 
 # requirement for the elastic callback plugin
 elastic-apm ; python_version >= '3.6'


### PR DESCRIPTION
##### SUMMARY
Regularly CI (unit tests) is breaking because Protobuf for Python that's required by opentelemetry:
```
01:16 ______ ERROR collecting tests/unit/plugins/callback/test_opentelemetry.py ______
01:16 tests/unit/plugins/callback/test_opentelemetry.py:12: in <module>
01:16     from ansible_collections.community.general.plugins.callback.opentelemetry import OpenTelemetrySource, TaskData, CallbackModule
01:16 <frozen importlib._bootstrap>:991: in _find_and_load
01:16     ???
01:16 <frozen importlib._bootstrap>:975: in _find_and_load_unlocked
01:16     ???
01:16 <frozen importlib._bootstrap>:671: in _load_unlocked
01:16     ???
01:16 /root/ansible/lib/ansible/utils/collection_loader/_collection_finder.py:434: in exec_module
01:16     exec(code_obj, module.__dict__)
01:16 plugins/callback/opentelemetry.py:89: in <module>
01:16 E    1. Downgrade the protobuf package to 3.20.x or lower.
01:16 E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
01:16 E   
01:16 E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```
(Python 3.8 and 3.9)

See for example https://dev.azure.com/ansible/community.general/_build/results?buildId=45905&view=results

This is usually fixed after a couple of days, but this is really annoying me, so I'm going to disable these tests by removing the dependencies from tests/unit/requirements.txt.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
