### PR TITLE
Fix plugin docs

### DIFF
--- a/plugins/callback/log_plays.py
+++ b/plugins/callback/log_plays.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
     type: notification
     short_description: write playbook output to log file
     description:
-      - This callback writes playbook output to a file per host in the `/var/log/ansible/hosts` directory
+      - This callback writes playbook output to a file per host in the C(/var/log/ansible/hosts) directory
     requirements:
      - Whitelist in configuration
      - A writeable /var/log/ansible/hosts directory by the user executing Ansible on the controller

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -14,9 +14,9 @@ DOCUMENTATION = '''
       - set as main display callback
     short_description: only print certain tasks
     description:
-      - This callback only prints tasks that have been tagged with `print_action` or that have failed.
+      - This callback only prints tasks that have been tagged with C(print_action) or that have failed.
         This allows operators to focus on the tasks that provide value only.
-      - Tasks that are not printed are placed with a '.'.
+      - Tasks that are not printed are placed with a C(.).
       - If you increase verbosity all tasks are printed.
     options:
       nocolor:

--- a/plugins/lookup/chef_databag.py
+++ b/plugins/lookup/chef_databag.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
          The lookup order mirrors the one from Chef, all folders in the base path are walked back looking for the following configuration
          file in order : .chef/knife.rb, ~/.chef/knife.rb, /etc/chef/client.rb"
     requirements:
-        - "pychef (python library https://pychef.readthedocs.io `pip install pychef`)"
+        - "pychef (L(Python library, https://pychef.readthedocs.io), C(pip install pychef))"
     options:
         name:
           description:


### PR DESCRIPTION
##### SUMMARY
Some plugins docs are using backticks for formatting.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
log_plays callback
selective callback
chef_databag lookup
