### PR TITLE
keycloak_user_federation: add explanation and example to vendor option

### DIFF
--- a/plugins/modules/identity/keycloak/keycloak_user_federation.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_federation.py
@@ -128,7 +128,8 @@ options:
 
             vendor:
                 description:
-                    - LDAP vendor (provider). Use short name. For instance, write rhds for "Red Hat Directory Server".
+                    - LDAP vendor (provider).
+                    - Use short name. For instance, write C(rhds) for "Red Hat Directory Server".
                 type: str
 
             usernameLDAPAttribute:

--- a/plugins/modules/identity/keycloak/keycloak_user_federation.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_federation.py
@@ -128,7 +128,7 @@ options:
 
             vendor:
                 description:
-                    - LDAP vendor (provider).
+                    - LDAP vendor (provider). Use short name. For instance, write rhds for "Red Hat Directory Server".
                 type: str
 
             usernameLDAPAttribute:


### PR DESCRIPTION
##### SUMMARY

Added an example to the vendor option. The description of the option is not verbose enough and can lead to problems.
More precisely, you need to enter the "short name" of the vendor and not the full name.
For instance, you need to enter rhds for "Red Hat Directory Server". If you enter "Red Hat Directory Server" in the option, the user federation will be created but the vendor will remain blank. 


##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

community.general.keycloak_user_federation module
vendor option


