### PR TITLE
New Module: Keycloak User Rolemapping

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -587,6 +587,8 @@ files:
     maintainers: kris2kris
   $modules/identity/keycloak/keycloak_role.py:
     maintainers: laurpaum
+  $modules/identity/keycloak/keycloak_role_composites.py:
+    maintainers: bratwurzt
   $modules/identity/keycloak/keycloak_user_federation.py:
     maintainers: laurpaum
   $modules/identity/onepassword_info.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -575,6 +575,8 @@ files:
     maintainers: Gaetan2907
   $modules/identity/keycloak/keycloak_client_rolemapping.py:
     maintainers: Gaetan2907
+  $modules/identity/keycloak/keycloak_user_rolemapping.py:
+    maintainers: bratwurzt
   $modules/identity/keycloak/keycloak_group.py:
     maintainers: adamgoossens
   $modules/identity/keycloak/keycloak_identity_provider.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -587,8 +587,6 @@ files:
     maintainers: kris2kris
   $modules/identity/keycloak/keycloak_role.py:
     maintainers: laurpaum
-  $modules/identity/keycloak/keycloak_role_composites.py:
-    maintainers: bratwurzt
   $modules/identity/keycloak/keycloak_user_federation.py:
     maintainers: laurpaum
   $modules/identity/onepassword_info.py:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -608,6 +608,10 @@ plugin_routing:
       redirect: community.general.identity.keycloak.keycloak_role
     keycloak_user_federation:
       redirect: community.general.identity.keycloak.keycloak_user_federation
+    keyring:
+      redirect: community.general.system.keyring
+    keyring_info:
+      redirect: community.general.system.keyring_info
     keycloak_user_rolemapping:
       redirect: community.general.identity.keycloak.keycloak_user_rolemapping
     keyring:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -608,6 +608,8 @@ plugin_routing:
       redirect: community.general.identity.keycloak.keycloak_role
     keycloak_user_federation:
       redirect: community.general.identity.keycloak.keycloak_user_federation
+    keycloak_user_rolemapping:
+      redirect: community.general.identity.keycloak.keycloak_user_rolemapping
     keyring:
       redirect: community.general.system.keyring
     keyring_info:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -608,10 +608,6 @@ plugin_routing:
       redirect: community.general.identity.keycloak.keycloak_role
     keycloak_user_federation:
       redirect: community.general.identity.keycloak.keycloak_user_federation
-    keyring:
-      redirect: community.general.system.keyring
-    keyring_info:
-      redirect: community.general.system.keyring_info
     keycloak_user_rolemapping:
       redirect: community.general.identity.keycloak.keycloak_user_rolemapping
     keyring:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -806,8 +806,8 @@ class KeycloakAPI(object):
                 open_url(user_client_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                          validate_certs=self.validate_certs, timeout=self.connection_timeout)
             except Exception as e:
-                    self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
-                                              % (cid, uid, realm, json.dumps(role_rep), str(e)))
+                self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
+                                          % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
     def delete_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Delete the rolemapping of a client in a specified user on the Keycloak server.
@@ -824,8 +824,8 @@ class KeycloakAPI(object):
                 open_url(user_realm_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                          validate_certs=self.validate_certs, timeout=self.connection_timeout)
             except Exception as e:
-                    self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
-                                              % (json.dumps(role_rep), uid, realm, str(e)))
+                self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
+                                          % (json.dumps(role_rep), uid, realm, str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
             try:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -52,7 +52,14 @@ URL_CLIENT_ROLE_COMPOSITES = "{url}/admin/realms/{realm}/clients/{id}/roles/{nam
 
 URL_REALM_ROLES = "{url}/admin/realms/{realm}/roles"
 URL_REALM_ROLE = "{url}/admin/realms/{realm}/roles/{name}"
+URL_REALM_ROLEMAPPINGS = "{url}/admin/realms/{realm}/users/{id}/role-mappings/realm"
+URL_REALM_ROLEMAPPINGS_AVAILABLE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/realm/available"
+URL_REALM_ROLEMAPPINGS_COMPOSITE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/realm/composite"
 URL_REALM_ROLE_COMPOSITES = "{url}/admin/realms/{realm}/roles/{name}/composites"
+
+URL_ROLES_BY_ID = "{url}/admin/realms/{realm}/roles-by-id/{id}"
+URL_ROLES_BY_ID_COMPOSITES_CLIENTS = "{url}/admin/realms/{realm}/roles-by-id/{id}/composites/clients/{cid}"
+URL_ROLES_BY_ID_COMPOSITES = "{url}/admin/realms/{realm}/roles-by-id/{id}/composites"
 
 URL_CLIENTTEMPLATE = "{url}/admin/realms/{realm}/client-templates/{id}"
 URL_CLIENTTEMPLATES = "{url}/admin/realms/{realm}/client-templates"
@@ -64,15 +71,15 @@ URL_CLIENTSCOPE = "{url}/admin/realms/{realm}/client-scopes/{id}"
 URL_CLIENTSCOPE_PROTOCOLMAPPERS = "{url}/admin/realms/{realm}/client-scopes/{id}/protocol-mappers/models"
 URL_CLIENTSCOPE_PROTOCOLMAPPER = "{url}/admin/realms/{realm}/client-scopes/{id}/protocol-mappers/models/{mapper_id}"
 
-URL_CLIENT_ROLEMAPPINGS = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}"
-URL_CLIENT_ROLEMAPPINGS_AVAILABLE = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}/available"
-URL_CLIENT_ROLEMAPPINGS_COMPOSITE = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}/composite"
+URL_CLIENT_GROUP_ROLEMAPPINGS = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}"
+URL_CLIENT_GROUP_ROLEMAPPINGS_AVAILABLE = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}/available"
+URL_CLIENT_GROUP_ROLEMAPPINGS_COMPOSITE = "{url}/admin/realms/{realm}/groups/{id}/role-mappings/clients/{client}/composite"
 
 URL_USERS = "{url}/admin/realms/{realm}/users"
 URL_CLIENT_SERVICE_ACCOUNT_USER = "{url}/admin/realms/{realm}/clients/{id}/service-account-user"
-URL_USER_ROLEMAPPINGS = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}"
-URL_USER_ROLEMAPPINGS_AVAILABLE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}/available"
-URL_USER_ROLEMAPPINGS_COMPOSITE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}/composite"
+URL_CLIENT_USER_ROLEMAPPINGS = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}"
+URL_CLIENT_USER_ROLEMAPPINGS_AVAILABLE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}/available"
+URL_CLIENT_USER_ROLEMAPPINGS_COMPOSITE = "{url}/admin/realms/{realm}/users/{id}/role-mappings/clients/{client}/composite"
 
 URL_AUTHENTICATION_FLOWS = "{url}/admin/realms/{realm}/authentication/flows"
 URL_AUTHENTICATION_FLOW = "{url}/admin/realms/{realm}/authentication/flows/{id}"
@@ -475,10 +482,9 @@ class KeycloakAPI(object):
             self.module.fail_json(msg="Could not fetch rolemappings for client %s in realm %s: %s"
                                       % (cid, realm, str(e)))
 
-    def get_client_role_by_name(self, gid, cid, name, realm="master"):
+    def get_client_role_id_by_name(self, cid, name, realm="master"):
         """ Get the role ID of a client.
 
-        :param gid: ID of the group from which to obtain the rolemappings.
         :param cid: ID of the client from which to obtain the rolemappings.
         :param name: Name of the role.
         :param realm: Realm from which to obtain the rolemappings.
@@ -499,7 +505,7 @@ class KeycloakAPI(object):
         :param realm: client from this realm
         :return: dict of rolemapping representation or None if none matching exist
         """
-        rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
             rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
                                                          timeout=self.connection_timeout,
@@ -520,7 +526,7 @@ class KeycloakAPI(object):
         :param realm: Realm from which to obtain the rolemappings.
         :return: The rollemappings of specified group and client of the realm (default "master").
         """
-        available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        available_rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
             return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
                                                  timeout=self.connection_timeout,
@@ -537,14 +543,61 @@ class KeycloakAPI(object):
         :param realm: Realm from which to obtain the rolemappings.
         :return: The rollemappings of specified group and client of the realm (default "master").
         """
-        available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        composite_rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
                                                  timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
                                       % (cid, gid, realm, str(e)))
+
+    def get_role_by_id(self, rid, realm="master"):
+        """ Fetch a role by its id on the Keycloak server.
+
+        :param rid: ID of the role.
+        :param realm: Realm from which to obtain the rolemappings.
+        :return: The role.
+        """
+        client_roles_url = URL_ROLES_BY_ID.format(url=self.baseurl, realm=realm, id=rid)
+        try:
+            return json.loads(to_native(open_url(client_roles_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+                                                 validate_certs=self.validate_certs).read()))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch role for id %s in realm %s: %s"
+                                      % (rid, realm, str(e)))
+
+    def get_client_roles_by_id_composite_rolemappings(self, rid, cid, realm="master"):
+        """ Fetch a role by its id on the Keycloak server.
+
+        :param rid: ID of the composite role.
+        :param cid: ID of the client from which to obtain the rolemappings.
+        :param realm: Realm from which to obtain the rolemappings.
+        :return: The role.
+        """
+        client_roles_url = URL_ROLES_BY_ID_COMPOSITES_CLIENTS.format(url=self.baseurl, realm=realm, id=rid, cid=cid)
+        try:
+            return json.loads(to_native(open_url(client_roles_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+                                                 validate_certs=self.validate_certs).read()))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch role for id %s and cid %s in realm %s: %s"
+                                      % (rid, cid, realm, str(e)))
+
+    def add_client_roles_by_id_composite_rolemapping(self, rid, roles_rep, realm="master"):
+        """ Assign roles to composite role
+
+        :param rid: ID of the composite role.
+        :param roles_rep: Representation of the roles to assign.
+        :param realm: Realm from which to obtain the rolemappings.
+        :return: None.
+        """
+        available_rolemappings_url = URL_ROLES_BY_ID_COMPOSITES.format(url=self.baseurl, realm=realm, id=rid)
+        try:
+            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(roles_rep),
+                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
+        except Exception as e:
+            self.module.fail_json(msg="Could not assign roles to composite role %s and realm %s: %s"
+                                      % (rid, realm, str(e)))
 
     def add_group_rolemapping(self, gid, cid, role_rep, realm="master"):
         """ Fetch the composite role of a client in a specified goup on the Keycloak server.
@@ -555,7 +608,7 @@ class KeycloakAPI(object):
         :param realm: Realm from which to obtain the rolemappings.
         :return: None.
         """
-        available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        available_rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
             open_url(available_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
@@ -572,7 +625,7 @@ class KeycloakAPI(object):
         :param realm: Realm from which to obtain the rolemappings.
         :return: None.
         """
-        available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        available_rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
             open_url(available_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders,
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
@@ -590,7 +643,7 @@ class KeycloakAPI(object):
         :param realm: client from this realm
         :return: dict of rolemapping representation or None if none matching exist
         """
-        rolemappings_url = URL_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+        rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
             rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
                                                          validate_certs=self.validate_certs).read()))
@@ -598,7 +651,7 @@ class KeycloakAPI(object):
                 if rid == role['id']:
                     return role
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch rolemappings for client %s for user %s, realm %s: %s"
+            self.module.fail_json(msg="Could not fetch rolemappings for client %s and user %s, realm %s: %s"
                                       % (cid, uid, realm, str(e)))
         return None
 
@@ -608,14 +661,14 @@ class KeycloakAPI(object):
         :param uid: ID of the user from which to obtain the rolemappings.
         :param cid: ID of the client from which to obtain the rolemappings.
         :param realm: Realm from which to obtain the rolemappings.
-        :return: The rollemappings of specified group and client of the realm (default "master").
+        :return: The effective rollemappings of specified client and user of the realm (default "master").
         """
-        available_rolemappings_url = URL_USER_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+        available_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
             return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch available rolemappings for client %s for user %s, realm %s: %s"
+            self.module.fail_json(msg="Could not fetch effective rolemappings for client %s and user %s, realm %s: %s"
                                       % (cid, uid, realm, str(e)))
 
     def get_client_user_composite_rolemappings(self, uid, cid, realm="master"):
@@ -626,13 +679,63 @@ class KeycloakAPI(object):
         :param realm: Realm from which to obtain the rolemappings.
         :return: The rollemappings of specified group and client of the realm (default "master").
         """
-        available_rolemappings_url = URL_USER_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+        composite_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+        try:
+            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+                                                 validate_certs=self.validate_certs).read()))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch available rolemappings for user %s of realm %s: %s"
+                                      % (uid, realm, str(e)))
+
+    def get_realm_user_rolemapping_by_id(self, uid, rid, realm='master'):
+        """ Obtain role representation by id
+
+        :param uid: ID of the user from which to obtain the rolemappings.
+        :param rid: ID of the role.
+        :param realm: client from this realm
+        :return: dict of rolemapping representation or None if none matching exist
+        """
+        rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
+        try:
+            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+                                                         validate_certs=self.validate_certs).read()))
+            for role in rolemappings:
+                if rid == role['id']:
+                    return role
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch rolemappings for client %s and user %s, realm %s: %s"
+                                      % (cid, uid, realm, str(e)))
+        return None
+
+    def get_realm_user_available_rolemappings(self, uid, realm="master"):
+        """ Fetch the available role of a realm for a specified user on the Keycloak server.
+
+        :param uid: ID of the user from which to obtain the rolemappings.
+        :param realm: Realm from which to obtain the rolemappings.
+        :return: The rollemappings of specified group and client of the realm (default "master").
+        """
+        available_rolemappings_url = URL_REALM_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=uid)
         try:
             return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch available rolemappings for client %s for user %s, realm %s: %s"
-                                      % (cid, uid, realm, str(e)))
+            self.module.fail_json(msg="Could not fetch available rolemappings for user %s, realm %s: %s"
+                                      % (uid, realm, str(e)))
+
+    def get_realm_user_composite_rolemappings(self, uid, realm="master"):
+        """ Fetch the composite role of a realm for a specified user on the Keycloak server.
+
+        :param uid: ID of the user from which to obtain the rolemappings.
+        :param realm: Realm from which to obtain the rolemappings.
+        :return: The effective rollemappings of specified client and user of the realm (default "master").
+        """
+        composite_rolemappings_url = URL_REALM_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=uid)
+        try:
+            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+                                                 validate_certs=self.validate_certs).read()))
+        except Exception as e:
+            self.module.fail_json(msg="Could not fetch effective rolemappings for user %s, realm %s: %s"
+                                      % (uid, realm, str(e)))
 
     def get_user_by_username(self, username, realm="master"):
         """ Fetch a keycloak user within a realm based on its username.
@@ -676,38 +779,56 @@ class KeycloakAPI(object):
 
 
     def add_user_rolemapping(self, uid, cid, role_rep, realm="master"):
-        """ Fetch the composite role of a client in a specified user on the Keycloak server.
+        """ Assign a realm or client role to a specified user on the Keycloak server.
 
-        :param uid: ID of the user from which to obtain the rolemappings.
-        :param cid: ID of the client from which to obtain the rolemappings.
+        :param uid: ID of the user roles are assigned to.
+        :param cid: ID of the client from which to obtain the rolemappings. If empty, roles are from the realm
         :param role_rep: Representation of the role to assign.
         :param realm: Realm from which to obtain the rolemappings.
         :return: None.
         """
-        available_rolemappings_url = URL_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+        if cid is None:
+            user_realm_rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
+            try:
+                open_url(user_realm_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
+                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            except Exception as e:
+                self.module.fail_json(msg="Could not map roles to userId %s for realm %s and roles %s: %s"
+                                          % (uid, realm, json.dumps(role_rep), str(e)))
+        else:
+            user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
+                open_url(user_client_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch available rolemappings for client %s and userId %s, realm %s: %s"
-                                      % (cid, uid, realm, str(e)))
+                self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
+                                          % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
-    def delete_user_rolemapping(self, gid, cid, role_rep, realm="master"):
+    def delete_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Delete the rolemapping of a client in a specified user on the Keycloak server.
 
-        :param gid: ID of the user from which to obtain the rolemappings.
-        :param cid: ID of the client from which to obtain the rolemappings.
-        :param role_rep: Representation of the role to assign.
-        :param realm: Realm from which to obtain the rolemappings.
+        :param uid: ID of the user from which to remove the rolemappings.
+        :param cid: ID of the client from which to remove the rolemappings.
+        :param role_rep: Representation of the role to remove from rolemappings.
+        :param realm: Realm from which to remove the rolemappings.
         :return: None.
         """
-        available_rolemappings_url = URL_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
+        if cid is None:
+            user_realm_rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
         try:
-            open_url(available_rolemappings_url, method="DELETE", headers=self.restheaders,
+                open_url(user_realm_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
-            self.module.fail_json(msg="Could not delete available rolemappings for client %s and userId %s, realm %s: %s"
-                                      % (cid, gid, realm, str(e)))
+                self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
+                                          % (json.dumps(role_rep), uid, realm, str(e)))
+        else:
+            user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
+            try:
+                open_url(user_client_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
+                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            except Exception as e:
+                self.module.fail_json(msg="Could not remove roles %s for client %s from userId %s, realm %s: %s"
+                                          % (json.dumps(role_rep), cid, uid, realm, str(e)))
 
     def get_client_templates(self, realm='master'):
         """ Obtains client template representations for client templates in a realm

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -718,7 +718,7 @@ class KeycloakAPI(object):
             return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch available rolemappings for user %s, realm %s: %s"
+            self.module.fail_json(msg="Could not fetch available rolemappings for user %s of realm %s: %s"
                                       % (uid, realm, str(e)))
 
     def get_realm_user_composite_rolemappings(self, uid, realm="master"):
@@ -794,10 +794,10 @@ class KeycloakAPI(object):
                                           % (uid, realm, json.dumps(role_rep), str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
-            try:
+        try:
                 open_url(user_client_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
-                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
-            except Exception as e:
+                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
+        except Exception as e:
                 self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
                                           % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
@@ -816,8 +816,8 @@ class KeycloakAPI(object):
             open_url(user_realm_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
-            self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
-                                      % (json.dumps(role_rep), uid, realm, str(e)))
+                self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
+                                          % (json.dumps(role_rep), uid, realm, str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
             try:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -702,8 +702,8 @@ class KeycloakAPI(object):
                 if rid == role['id']:
                     return role
         except Exception as e:
-            self.module.fail_json(msg="Could not fetch rolemappings for client %s and user %s, realm %s: %s"
-                                      % (cid, uid, realm, str(e)))
+            self.module.fail_json(msg="Could not fetch rolemappings for user %s, realm %s: %s"
+                                      % (uid, realm, str(e)))
         return None
 
     def get_realm_user_available_rolemappings(self, uid, realm="master"):
@@ -799,7 +799,7 @@ class KeycloakAPI(object):
                          validate_certs=self.validate_certs, timeout=self.connection_timeout)
             except Exception as e:
                 self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
-                                              % (cid, uid, realm, json.dumps(role_rep), str(e)))
+                                          % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
     def delete_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Delete the rolemapping of a client in a specified user on the Keycloak server.
@@ -817,7 +817,7 @@ class KeycloakAPI(object):
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
-                                          % (json.dumps(role_rep), uid, realm, str(e)))
+                                      % (json.dumps(role_rep), uid, realm, str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
             try:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -561,7 +561,8 @@ class KeycloakAPI(object):
         """
         client_roles_url = URL_ROLES_BY_ID.format(url=self.baseurl, realm=realm, id=rid)
         try:
-            return json.loads(to_native(open_url(client_roles_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_roles_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch role for id %s in realm %s: %s"
@@ -577,7 +578,8 @@ class KeycloakAPI(object):
         """
         client_roles_url = URL_ROLES_BY_ID_COMPOSITES_CLIENTS.format(url=self.baseurl, realm=realm, id=rid, cid=cid)
         try:
-            return json.loads(to_native(open_url(client_roles_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_roles_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch role for id %s and cid %s in realm %s: %s"
@@ -593,7 +595,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_ROLES_BY_ID_COMPOSITES.format(url=self.baseurl, realm=realm, id=rid)
         try:
-            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(roles_rep),
+            open_url(available_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(roles_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not assign roles to composite role %s and realm %s: %s"
@@ -644,7 +646,8 @@ class KeycloakAPI(object):
         """
         rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
-            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                         timeout=self.connection_timeout,
                                                          validate_certs=self.validate_certs).read()))
             for role in rolemappings:
                 if rid == role['id']:
@@ -664,7 +667,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch effective rolemappings for client %s and user %s, realm %s: %s"
@@ -680,7 +684,8 @@ class KeycloakAPI(object):
         """
         composite_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=uid, client=cid)
         try:
-            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for user %s of realm %s: %s"
@@ -696,7 +701,8 @@ class KeycloakAPI(object):
         """
         rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
         try:
-            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                         timeout=self.connection_timeout,
                                                          validate_certs=self.validate_certs).read()))
             for role in rolemappings:
                 if rid == role['id']:
@@ -715,7 +721,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_REALM_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=uid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for user %s of realm %s: %s"
@@ -730,7 +737,8 @@ class KeycloakAPI(object):
         """
         composite_rolemappings_url = URL_REALM_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=uid)
         try:
-            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(composite_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch effective rolemappings for user %s, realm %s: %s"
@@ -787,19 +795,19 @@ class KeycloakAPI(object):
         if cid is None:
             user_realm_rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
             try:
-                open_url(user_realm_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
+                open_url(user_realm_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                          validate_certs=self.validate_certs, timeout=self.connection_timeout)
             except Exception as e:
                 self.module.fail_json(msg="Could not map roles to userId %s for realm %s and roles %s: %s"
                                           % (uid, realm, json.dumps(role_rep), str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
-        try:
-                open_url(user_client_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
-                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
-        except Exception as e:
-                self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
-                                          % (cid, uid, realm, json.dumps(role_rep), str(e)))
+            try:
+                open_url(user_client_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
+                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            except Exception as e:
+                    self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
+                                              % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
     def delete_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Delete the rolemapping of a client in a specified user on the Keycloak server.
@@ -812,16 +820,16 @@ class KeycloakAPI(object):
         """
         if cid is None:
             user_realm_rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
-        try:
-            open_url(user_realm_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
-                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
-        except Exception as e:
-                self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
-                                          % (json.dumps(role_rep), uid, realm, str(e)))
+            try:
+                open_url(user_realm_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
+                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            except Exception as e:
+                    self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
+                                              % (json.dumps(role_rep), uid, realm, str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
             try:
-                open_url(user_client_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
+                open_url(user_client_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                          validate_certs=self.validate_certs, timeout=self.connection_timeout)
             except Exception as e:
                 self.module.fail_json(msg="Could not remove roles %s for client %s from userId %s, realm %s: %s"
@@ -1206,7 +1214,6 @@ class KeycloakAPI(object):
             return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
                                                  timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
-
         except HTTPError as e:
             if e.code == 404:
                 return None

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -633,7 +633,6 @@ class KeycloakAPI(object):
             self.module.fail_json(msg="Could not delete available rolemappings for client %s in group %s, realm %s: %s"
                                       % (cid, gid, realm, str(e)))
 
-
     def get_client_user_rolemapping_by_id(self, uid, cid, rid, realm='master'):
         """ Obtain client representation by id
 
@@ -756,7 +755,6 @@ class KeycloakAPI(object):
             self.module.fail_json(msg='Could not obtain the user for realm %s and username %s: %s'
                                       % (realm, username, str(e)))
 
-
     def get_service_account_user_by_client_id(self, client_id, realm="master"):
         """ Fetch a keycloak service account user within a realm based on its client_id.
 
@@ -777,7 +775,6 @@ class KeycloakAPI(object):
             self.module.fail_json(msg='Could not obtain the service-account-user for realm %s and client_id %s: %s'
                                       % (realm, client_id, str(e)))
 
-
     def add_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Assign a realm or client role to a specified user on the Keycloak server.
 
@@ -797,12 +794,12 @@ class KeycloakAPI(object):
                                           % (uid, realm, json.dumps(role_rep), str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)
-        try:
+            try:
                 open_url(user_client_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
-                     validate_certs=self.validate_certs, timeout=self.connection_timeout)
-        except Exception as e:
+                         validate_certs=self.validate_certs, timeout=self.connection_timeout)
+            except Exception as e:
                 self.module.fail_json(msg="Could not map roles to userId %s for client %s, realm %s and roles %s: %s"
-                                          % (cid, uid, realm, json.dumps(role_rep), str(e)))
+                                              % (cid, uid, realm, json.dumps(role_rep), str(e)))
 
     def delete_user_rolemapping(self, uid, cid, role_rep, realm="master"):
         """ Delete the rolemapping of a client in a specified user on the Keycloak server.
@@ -816,10 +813,10 @@ class KeycloakAPI(object):
         if cid is None:
             user_realm_rolemappings_url = URL_REALM_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid)
         try:
-                open_url(user_realm_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
+            open_url(user_realm_rolemappings_url, method="DELETE", headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
-                self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
+            self.module.fail_json(msg="Could not remove roles %s from userId %s, realm %s: %s"
                                           % (json.dumps(role_rep), uid, realm, str(e)))
         else:
             user_client_rolemappings_url = URL_CLIENT_USER_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=uid, client=cid)

--- a/plugins/modules/identity/keycloak/keycloak_client_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_client_rolemapping.py
@@ -277,7 +277,7 @@ def main():
                 module.fail_json(msg='Either the `name` or `id` has to be specified on each role.')
             # Fetch missing role_id
             if role['id'] is None:
-                role_id = kc.get_client_role_by_name(gid, cid, role['name'], realm=realm)
+                role_id = kc.get_client_role_id_by_name(cid, role['name'], realm=realm)
                 if role_id is not None:
                     role['id'] = role_id
                 else:

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -54,7 +54,7 @@ options:
         type: str
         description:
             - Username of the user to be mapped.
-            - This parameter is required (can be replaced by uid for less API call).
+            - This parameter is not required (can be replaced by uid for less API call).
 
     uid:
         type: str
@@ -106,7 +106,7 @@ extends_documentation_fragment:
 
 
 author:
-    - @bratwurzt
+    - Dušan Marković (@bratwurzt)
 '''
 
 EXAMPLES = '''
@@ -179,7 +179,6 @@ EXAMPLES = '''
       - name: role_name2
         id: role_id2
   delegate_to: localhost
-
 '''
 
 RETURN = '''

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -8,14 +8,14 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: keycloak_client_rolemapping
+module: keycloak_user_rolemapping
 
-short_description: Allows administration of Keycloak client_rolemapping with the Keycloak API
+short_description: Allows administration of Keycloak user_rolemapping with the Keycloak API
 
-version_added: 3.5.0
+version_added: 5.1.2
 
 description:
-    - This module allows you to add, remove or modify Keycloak client_rolemapping with the Keycloak REST API.
+    - This module allows you to add, remove or modify Keycloak user_rolemapping with the Keycloak REST API.
       It requires access to the REST API via OpenID Connect; the user connecting and the client being
       used must have the requisite access rights. In a default Keycloak installation, admin-cli
       and an admin user would work, as would a separate client definition with the scope tailored
@@ -28,16 +28,16 @@ description:
       be returned that way by this module. You may pass single values for attributes when calling the module,
       and this will be translated into a list suitable for the API.
 
-    - When updating a client_rolemapping, where possible provide the role ID to the module. This removes a lookup
+    - When updating a user_rolemapping, where possible provide the role ID to the module. This removes a lookup
       to the API to translate the name into the role ID.
 
 
 options:
     state:
         description:
-            - State of the client_rolemapping.
-            - On C(present), the client_rolemapping will be created if it does not yet exist, or updated with the parameters you provide.
-            - On C(absent), the client_rolemapping will be removed if it exists.
+            - State of the user_rolemapping.
+            - On C(present), the user_rolemapping will be created if it does not yet exist, or updated with the parameters you provide.
+            - On C(absent), the user_rolemapping will be removed if it exists.
         default: 'present'
         type: str
         choices:
@@ -50,18 +50,25 @@ options:
             - They Keycloak realm under which this role_representation resides.
         default: 'master'
 
-    group_name:
+    username:
         type: str
         description:
-            - Name of the group to be mapped.
-            - This parameter is required (can be replaced by gid for less API call).
+            - Username of the user to be mapped.
+            - This parameter is required (can be replaced by uid for less API call).
 
-    gid:
+    uid:
         type: str
         description:
-            - Id of the group to be mapped.
+            - Id of the user to be mapped.
             - This parameter is not required for updating or deleting the rolemapping but
               providing it will reduce the number of API calls required.
+
+    service_account_user_client_id:
+        type: str
+        description:
+            - client_id of the service-account-user to be mapped.
+            - This parameter is not required for updating or deleting the rolemapping but
+              providing it will reduce the number of API calls required.    
 
     client_id:
         type: str
@@ -78,7 +85,7 @@ options:
 
     roles:
         description:
-            - Roles to be mapped to the group.
+            - Roles to be mapped to the user.
         type: list
         elements: dict
         suboptions:
@@ -99,12 +106,12 @@ extends_documentation_fragment:
 
 
 author:
-    - Gaëtan Daubresse (@Gaetan2907)
+    - Dušan Marković
 '''
 
 EXAMPLES = '''
-- name: Map a client role to a group, authentication with credentials
-  community.general.keycloak_client_rolemapping:
+- name: Map a client role to a user, authentication with credentials
+  community.general.keycloak_user_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -113,7 +120,7 @@ EXAMPLES = '''
     auth_password: PASSWORD
     state: present
     client_id: client1
-    group_name: group1
+    user_id: user1Id
     roles:
       - name: role_name1
         id: role_id1
@@ -121,15 +128,15 @@ EXAMPLES = '''
         id: role_id2
   delegate_to: localhost
 
-- name: Map a client role to a group, authentication with token
-  community.general.keycloak_client_rolemapping:
+- name: Map a client role to a user, authentication with token
+  community.general.keycloak_user_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
     token: TOKEN
     state: present
     client_id: client1
-    group_name: group1
+    username: user1
     roles:
       - name: role_name1
         id: role_id1
@@ -137,8 +144,8 @@ EXAMPLES = '''
         id: role_id2
   delegate_to: localhost
 
-- name: Unmap client role from a group
-  community.general.keycloak_client_rolemapping:
+- name: Unmap client role from a user
+  community.general.keycloak_user_rolemapping:
     realm: MyCustomRealm
     auth_client_id: admin-cli
     auth_keycloak_url: https://auth.example.com/auth
@@ -147,7 +154,7 @@ EXAMPLES = '''
     auth_password: PASSWORD
     state: absent
     client_id: client1
-    group_name: group1
+    username: user1
     roles:
       - name: role_name1
         id: role_id1
@@ -162,7 +169,7 @@ msg:
     description: Message as to what action was taken.
     returned: always
     type: str
-    sample: "Role role1 assigned to group group1."
+    sample: "Role role1 assigned to user user1."
 
 proposed:
     description: Representation of proposed client role mapping.
@@ -220,8 +227,9 @@ def main():
     meta_args = dict(
         state=dict(default='present', choices=['present', 'absent']),
         realm=dict(default='master'),
-        gid=dict(type='str'),
-        group_name=dict(type='str'),
+        uid=dict(type='str'),
+        username=dict(type='str'),
+        service_account_user_client_id=dict(type='str'),
         cid=dict(type='str'),
         client_id=dict(type='str'),
         roles=dict(type='list', elements='dict', options=roles_spec),
@@ -248,23 +256,31 @@ def main():
     state = module.params.get('state')
     cid = module.params.get('cid')
     client_id = module.params.get('client_id')
-    gid = module.params.get('gid')
-    group_name = module.params.get('group_name')
+    uid = module.params.get('uid')
+    username = module.params.get('username')
+    service_account_user_client_id = module.params.get('service_account_user_client_id')
     roles = module.params.get('roles')
 
     # Check the parameters
     if cid is None and client_id is None:
         module.fail_json(msg='Either the `client_id` or `cid` has to be specified.')
-    if gid is None and group_name is None:
-        module.fail_json(msg='Either the `group_name` or `gid` has to be specified.')
+    if uid is None and username is None and service_account_user_client_id is None:
+        module.fail_json(msg='Either the `username`, `uid` or `service_account_user_client_id` has to be specified.')
 
     # Get the potential missing parameters
-    if gid is None:
-        group_rep = kc.get_group_by_name(group_name, realm=realm)
-        if group_rep is not None:
-            gid = group_rep['id']
+    if uid is None and service_account_user_client_id is None:
+        user_rep = kc.get_user_by_username(username, realm=realm)
+        if user_rep is not None:
+            uid = user_rep['id']
         else:
-            module.fail_json(msg='Could not fetch group %s:' % group_name)
+            module.fail_json(msg='Could not fetch user for username %s:' % username)
+    else:
+        if uid is None and username is None:
+            user_rep = kc.get_service_account_user_by_client_id(service_account_user_client_id, realm=realm)
+            if user_rep is not None:
+                uid = user_rep['id']
+            else:
+                module.fail_json(msg='Could not fetch service-account-user for client_id %s:' % username)
     if cid is None:
         cid = kc.get_client_id(client_id, realm=realm)
         if cid is None:
@@ -277,20 +293,20 @@ def main():
                 module.fail_json(msg='Either the `name` or `id` has to be specified on each role.')
             # Fetch missing role_id
             if role['id'] is None:
-                role_id = kc.get_client_role_by_name(gid, cid, role['name'], realm=realm)
+                role_id = kc.get_client_role_by_name(uid, cid, role['name'], realm=realm)
                 if role_id is not None:
                     role['id'] = role_id
                 else:
                     module.fail_json(msg='Could not fetch role %s:' % (role['name']))
             # Fetch missing role_name
             else:
-                role['name'] = kc.get_client_group_rolemapping_by_id(gid, cid, role['id'], realm=realm)['name']
+                role['name'] = kc.get_client_user_rolemapping_by_id(uid, cid, role['id'], realm=realm)['name']
                 if role['name'] is None:
                     module.fail_json(msg='Could not fetch role %s' % (role['id']))
 
     # Get effective client-level role mappings
-    available_roles_before = kc.get_client_group_available_rolemappings(gid, cid, realm=realm)
-    assigned_roles_before = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
+    available_roles_before = kc.get_client_user_available_rolemappings(uid, cid, realm=realm)
+    assigned_roles_before = kc.get_client_user_composite_rolemappings(uid, cid, realm=realm)
 
     result['existing'] = assigned_roles_before
     result['proposed'] = roles
@@ -322,9 +338,9 @@ def main():
                 result['diff'] = dict(before=assigned_roles_before, after=update_roles)
             if module.check_mode:
                 module.exit_json(**result)
-            kc.add_group_rolemapping(gid, cid, update_roles, realm=realm)
-            result['msg'] = 'Roles %s assigned to group %s.' % (update_roles, group_name)
-            assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
+            kc.add_user_rolemapping(uid, cid, update_roles, realm=realm)
+            result['msg'] = 'Roles %s assigned to user for username %s.' % (update_roles, username)
+            assigned_roles_after = kc.get_client_user_composite_rolemappings(uid, cid, realm=realm)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
         else:
@@ -334,15 +350,15 @@ def main():
                 result['diff'] = dict(before=assigned_roles_before, after=update_roles)
             if module.check_mode:
                 module.exit_json(**result)
-            kc.delete_group_rolemapping(gid, cid, update_roles, realm=realm)
-            result['msg'] = 'Roles %s removed from group %s.' % (update_roles, group_name)
-            assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
+            kc.delete_user_rolemapping(uid, cid, update_roles, realm=realm)
+            result['msg'] = 'Roles %s removed from user for username %s.' % (update_roles, username)
+            assigned_roles_after = kc.get_client_user_composite_rolemappings(uid, cid, realm=realm)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
     # Do nothing
     else:
         result['changed'] = False
-        result['msg'] = 'Nothing to do, roles %s are correctly mapped with group %s.' % (roles, group_name)
+        result['msg'] = 'Nothing to do, roles %s are correctly mapped to user for username %s.' % (roles, username)
         module.exit_json(**result)
 
 

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# Copyright (c) 2022, Dušan Marković (@bratwurzt)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import absolute_import, division, print_function
@@ -13,7 +13,7 @@ module: keycloak_user_rolemapping
 
 short_description: Allows administration of Keycloak user_rolemapping with the Keycloak API
 
-version_added: 5.3.0
+version_added: 5.7.0
 
 description:
     - This module allows you to add, remove or modify Keycloak user_rolemapping with the Keycloak REST API.
@@ -60,14 +60,14 @@ options:
     uid:
         type: str
         description:
-            - Id of the user to be mapped.
+            - ID of the user to be mapped.
             - This parameter is not required for updating or deleting the rolemapping but
               providing it will reduce the number of API calls required.
 
     service_account_user_client_id:
         type: str
         description:
-            - client_id of the service-account-user to be mapped.
+            - Client ID of the service-account-user to be mapped.
             - This parameter is not required for updating or deleting the rolemapping but
               providing it will reduce the number of API calls required.
 
@@ -75,12 +75,13 @@ options:
         type: str
         description:
             - Name of the client to be mapped (different than I(cid)).
-            - This parameter is required (can be replaced by cid for less API call).
+            - This parameter is required if I(cid) is not provided (can be replaced by I(cid)
+              to reduce the number of API calls that must be made).
 
     cid:
         type: str
         description:
-            - Id of the client to be mapped.
+            - ID of the client to be mapped.
             - This parameter is not required for updating or deleting the rolemapping but
               providing it will reduce the number of API calls required.
 
@@ -93,7 +94,7 @@ options:
             name:
                 type: str
                 description:
-                    - Name of the role_representation.
+                    - Name of the role representation.
                     - This parameter is required only when creating or updating the role_representation.
             id:
                 type: str

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+# SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -172,7 +172,7 @@ EXAMPLES = '''
     auth_password: PASSWORD
     state: absent
     client_id: client1
-    username: user1
+    uid: 70e3ae72-96b6-11e6-9056-9737fd4d0764
     roles:
       - name: role_name1
         id: role_id1

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -12,7 +12,7 @@ module: keycloak_user_rolemapping
 
 short_description: Allows administration of Keycloak user_rolemapping with the Keycloak API
 
-version_added: 5.1.2
+version_added: 5.3.0
 
 description:
     - This module allows you to add, remove or modify Keycloak user_rolemapping with the Keycloak REST API.
@@ -106,7 +106,7 @@ extends_documentation_fragment:
 
 
 author:
-    - bratwurzt
+    - @bratwurzt
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -297,12 +297,12 @@ def main():
                 if role_id is not None:
                     role['id'] = role_id
                 else:
-                    module.fail_json(msg='Could not fetch role %s:' % (role['name']))
+                    module.fail_json(msg='Could not fetch role %s for client_id %s' % (role['name'], client_id))
             # Fetch missing role_name
             else:
                 role['name'] = kc.get_client_user_rolemapping_by_id(uid, cid, role['id'], realm=realm)['name']
                 if role['name'] is None:
-                    module.fail_json(msg='Could not fetch role %s' % (role['id']))
+                    module.fail_json(msg='Could not fetch role %s for client_id %s' % (role['id'], client_id))
 
     # Get effective client-level role mappings
     available_roles_before = kc.get_client_user_available_rolemappings(uid, cid, realm=realm)

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -50,10 +50,10 @@ options:
             - They Keycloak realm under which this role_representation resides.
         default: 'master'
 
-    username:
+    target_username:
         type: str
         description:
-            - Username of the user to be mapped.
+            - Username of the user roles are mapped to.
             - This parameter is not required (can be replaced by uid for less API call).
 
     uid:

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -256,7 +256,8 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password'], ['uid', 'target_username', 'service_account_user_client_id']]),
+                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password'],
+                                             ['uid', 'target_username', 'service_account_user_client_id']]),
                            required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
     result = dict(changed=False, msg='', diff={}, proposed={}, existing={}, end_state={})

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -68,7 +68,7 @@ options:
         description:
             - client_id of the service-account-user to be mapped.
             - This parameter is not required for updating or deleting the rolemapping but
-              providing it will reduce the number of API calls required.    
+              providing it will reduce the number of API calls required.
 
     client_id:
         type: str
@@ -321,8 +321,8 @@ def main():
             else:
                 if cid is None:
                     role['name'] = kc.get_realm_user_rolemapping_by_id(uid=uid, rid=role.get('id'), realm=realm)['name']
-            else:
-                role['name'] = kc.get_client_user_rolemapping_by_id(uid=uid, cid=cid, rid=role.get('id'), realm=realm)['name']
+                else:
+                    role['name'] = kc.get_client_user_rolemapping_by_id(uid=uid, cid=cid, rid=role.get('id'), realm=realm)['name']
                 if role.get('name') is None:
                     module.fail_json(msg='Could not fetch role %s for client_id %s or realm %s' % (role.get('id'), client_id, realm))
 
@@ -331,8 +331,8 @@ def main():
         available_roles_before = kc.get_realm_user_available_rolemappings(uid=uid, realm=realm)
         assigned_roles_before = kc.get_realm_user_composite_rolemappings(uid=uid, realm=realm)
     else:
-    available_roles_before = kc.get_client_user_available_rolemappings(uid=uid, cid=cid, realm=realm)
-    assigned_roles_before = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
+        available_roles_before = kc.get_client_user_available_rolemappings(uid=uid, cid=cid, realm=realm)
+        assigned_roles_before = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
 
     result['existing'] = assigned_roles_before
     result['proposed'] = roles
@@ -369,7 +369,7 @@ def main():
             if cid is None:
                 assigned_roles_after = kc.get_realm_user_composite_rolemappings(uid=uid, realm=realm)
             else:
-            assigned_roles_after = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
+                assigned_roles_after = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
         else:
@@ -384,7 +384,7 @@ def main():
             if cid is None:
                 assigned_roles_after = kc.get_realm_user_composite_rolemappings(uid=uid, realm=realm)
             else:
-            assigned_roles_after = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
+                assigned_roles_after = kc.get_client_user_composite_rolemappings(uid=uid, cid=cid, realm=realm)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
     # Do nothing

--- a/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
+++ b/plugins/modules/identity/keycloak/keycloak_user_rolemapping.py
@@ -128,6 +128,24 @@ EXAMPLES = '''
         id: role_id2
   delegate_to: localhost
 
+- name: Map a client role to a service account user for a client, authentication with credentials
+  community.general.keycloak_user_rolemapping:
+    realm: MyCustomRealm
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    state: present
+    client_id: client1
+    service_account_user_client_id: clientIdOfServiceAccount
+    roles:
+      - name: role_name1
+        id: role_id1
+      - name: role_name2
+        id: role_id2
+  delegate_to: localhost
+
 - name: Map a client role to a user, authentication with token
   community.general.keycloak_user_rolemapping:
     realm: MyCustomRealm

--- a/tests/integration/targets/keycloak_user_rolemapping/aliases
+++ b/tests/integration/targets/keycloak_user_rolemapping/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/keycloak_user_rolemapping/aliases
+++ b/tests/integration/targets/keycloak_user_rolemapping/aliases
@@ -1,4 +1,4 @@
-# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# Copyright (c) 2022, Dušan Marković (@bratwurzt)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 unsupported

--- a/tests/integration/targets/keycloak_user_rolemapping/aliases
+++ b/tests/integration/targets/keycloak_user_rolemapping/aliases
@@ -1,1 +1,4 @@
+# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 unsupported

--- a/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# Copyright (c) 2022, Dušan Marković (@bratwurzt)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+- name: Create realm
+  community.general.keycloak_realm:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    id: "{{ realm }}"
+    realm: "{{ realm }}"
+    state: present
+
+- name: Create client
+  community.general.keycloak_client:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id }}"
+    service_accounts_enabled: True
+    state: present
+  register: client
+
+- name: Create new realm role
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ role }}"
+    description: "{{ description_1 }}"
+    state: present
+
+- name: Map a realm role to client service account
+  vars:
+    - roles: [ {'name': '{{ role }}'} ]
+  community.general.keycloak_user_rolemapping:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    service_account_user_client_id: "{{ client_id }}"
+    roles: "{{ roles }}"
+    state: present
+  register: result
+
+- name: Assert realm role is assigned
+  assert:
+    that:
+      - result is changed
+      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count > 0
+
+- name: Unmap a realm role from client service account
+  vars:
+    - roles: [ {'name': '{{ role }}'} ]
+  community.general.keycloak_user_rolemapping:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    service_account_user_client_id: "{{ client_id }}"
+    roles: "{{ roles }}"
+    state: absent
+  register: result
+
+- name: Assert realm role is unassigned
+  assert:
+    that:
+      - result is changed
+      - (result.end_state | length) == (result.existing | length) - 1
+      - result.existing | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count > 0
+      - result.end_state | selectattr("clientRole", "eq", false) | selectattr("name", "eq", "{{role}}") | list | count == 0
+
+- name: Delete existing realm role
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ role }}"
+    state: absent
+
+- name: Create new client role
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id }}"
+    name: "{{ role }}"
+    description: "{{ description_1 }}"
+    state: present
+
+- name: Map a client role to client service account
+  vars:
+    - roles: [ {'name': '{{ role }}'} ]
+  community.general.keycloak_user_rolemapping:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id }}"
+    service_account_user_client_id: "{{ client_id }}"
+    roles: "{{ roles }}"
+    state: present
+  register: result
+
+- name: Assert client role is assigned
+  assert:
+    that:
+      - result is changed
+      - result.end_state | selectattr("clientRole", "eq", true) | selectattr("name", "eq", "{{role}}") | list | count > 0
+
+- name: Unmap a client role from client service account
+  vars:
+    - roles: [ {'name': '{{ role }}'} ]
+  community.general.keycloak_user_rolemapping:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    client_id: "{{ client_id }}"
+    service_account_user_client_id: "{{ client_id }}"
+    roles: "{{ roles }}"
+    state: absent
+  register: result
+
+- name: Assert client role is unassigned
+  assert:
+    that:
+      - result is changed
+      - result.end_state == []
+      - result.existing | selectattr("clientRole", "eq", true) | selectattr("name", "eq", "{{role}}") | list | count > 0

--- a/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/tasks/main.yml
@@ -1,4 +1,7 @@
----
+# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 - name: Create realm
   community.general.keycloak_realm:
     auth_keycloak_url: "{{ url }}"

--- a/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
@@ -1,0 +1,10 @@
+---
+url: http://localhost:8080/auth
+admin_realm: master
+admin_user: admin
+admin_password: password
+realm: myrealm
+client_id: myclient
+role: myrole
+description_1: desc 1
+description_2: desc 2

--- a/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# Copyright (c) 2022, Dušan Marković (@bratwurzt)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
+++ b/tests/integration/targets/keycloak_user_rolemapping/vars/main.yml
@@ -1,4 +1,8 @@
 ---
+# Copyright: (c) 2022, Dušan Marković (@bratwurzt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 url: http://localhost:8080/auth
 admin_realm: master
 admin_user: admin

--- a/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
+++ b/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
@@ -20,7 +20,7 @@ from ansible.module_utils.six import StringIO
 
 
 @contextmanager
-def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_role_by_name=None,
+def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_role_id_by_name=None,
                        get_client_group_rolemapping_by_id=None, get_client_group_available_rolemappings=None,
                        get_client_group_composite_rolemappings=None, add_group_rolemapping=None,
                        delete_group_rolemapping=None):
@@ -43,8 +43,8 @@ def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_ro
                       side_effect=get_group_by_name) as mock_get_group_by_name:
         with patch.object(obj, 'get_client_id',
                           side_effect=get_client_id) as mock_get_client_id:
-            with patch.object(obj, 'get_client_role_by_name',
-                              side_effect=get_client_role_by_name) as mock_get_client_role_by_name:
+            with patch.object(obj, 'get_client_role_id_by_name',
+                              side_effect=get_client_role_id_by_name) as mock_get_client_role_id_by_name:
                 with patch.object(obj, 'get_client_group_rolemapping_by_id',
                                   side_effect=get_client_group_rolemapping_by_id) as mock_get_client_group_rolemapping_by_id:
                     with patch.object(obj, 'get_client_group_available_rolemappings',
@@ -55,9 +55,9 @@ def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_ro
                                               side_effect=add_group_rolemapping) as mock_add_group_rolemapping:
                                 with patch.object(obj, 'delete_group_rolemapping',
                                                   side_effect=delete_group_rolemapping) as mock_delete_group_rolemapping:
-                                    yield mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping, \
-                                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings, \
-                                        mock_delete_group_rolemapping
+                                    yield mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping, \
+                                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, \
+                                          mock_get_client_group_composite_rolemappings, mock_delete_group_rolemapping
 
 
 def get_response(object_with_future_response, method, get_id_call_count):
@@ -143,7 +143,7 @@ class TestKeycloakRealm(ModuleTestCase):
             "subGroups": "[]"
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
-        return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
+        return_value_get_client_role_id_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
         return_value_get_client_group_available_rolemappings = [[
             {
                 "clientRole": "true",
@@ -188,10 +188,10 @@ class TestKeycloakRealm(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_by_name=return_value_get_client_role_by_name,
+                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
                                     get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
                                     get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
+                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
@@ -245,7 +245,7 @@ class TestKeycloakRealm(ModuleTestCase):
             "subGroups": "[]"
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
-        return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
+        return_value_get_client_role_id_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
         return_value_get_client_group_available_rolemappings = [[]]
         return_value_get_client_group_composite_rolemappings = [[
             {
@@ -272,10 +272,10 @@ class TestKeycloakRealm(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_by_name=return_value_get_client_role_by_name,
+                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
                                     get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
                                     get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
+                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
@@ -329,7 +329,7 @@ class TestKeycloakRealm(ModuleTestCase):
             "subGroups": "[]"
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
-        return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
+        return_value_get_client_role_id_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
         return_value_get_client_group_available_rolemappings = [[
             {
                 "clientRole": "true",
@@ -374,10 +374,10 @@ class TestKeycloakRealm(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_by_name=return_value_get_client_role_by_name,
+                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
                                     get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
                                     get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
+                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
@@ -431,7 +431,7 @@ class TestKeycloakRealm(ModuleTestCase):
             "subGroups": "[]"
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
-        return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
+        return_value_get_client_role_id_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
         return_value_get_client_group_available_rolemappings = [[]]
         return_value_get_client_group_composite_rolemappings = [
             [
@@ -461,10 +461,10 @@ class TestKeycloakRealm(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_by_name=return_value_get_client_role_by_name,
+                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
                                     get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
                                     get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
+                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
@@ -518,7 +518,7 @@ class TestKeycloakRealm(ModuleTestCase):
             "subGroups": "[]"
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
-        return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
+        return_value_get_client_role_id_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
         return_value_get_client_group_available_rolemappings = [
             [
                 {
@@ -547,10 +547,10 @@ class TestKeycloakRealm(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
-                                    get_client_role_by_name=return_value_get_client_role_by_name,
+                                    get_client_role_id_by_name=return_value_get_client_role_id_by_name,
                                     get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
                                     get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
-                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
+                    as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping,
                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:

--- a/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
+++ b/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
@@ -21,8 +21,8 @@ from ansible.module_utils.six import StringIO
 
 @contextmanager
 def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_role_by_name=None,
-                       get_client_rolemapping_by_id=None, get_client_available_rolemappings=None,
-                       get_client_composite_rolemappings=None, add_group_rolemapping=None,
+                       get_client_group_rolemapping_by_id=None, get_client_group_available_rolemappings=None,
+                       get_client_group_composite_rolemappings=None, add_group_rolemapping=None,
                        delete_group_rolemapping=None):
     """Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
 
@@ -45,18 +45,18 @@ def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_ro
                           side_effect=get_client_id) as mock_get_client_id:
             with patch.object(obj, 'get_client_role_by_name',
                               side_effect=get_client_role_by_name) as mock_get_client_role_by_name:
-                with patch.object(obj, 'get_client_rolemapping_by_id',
-                                  side_effect=get_client_rolemapping_by_id) as mock_get_client_rolemapping_by_id:
-                    with patch.object(obj, 'get_client_available_rolemappings',
-                                      side_effect=get_client_available_rolemappings) as mock_get_client_available_rolemappings:
-                        with patch.object(obj, 'get_client_composite_rolemappings',
-                                          side_effect=get_client_composite_rolemappings) as mock_get_client_composite_rolemappings:
+                with patch.object(obj, 'get_client_group_rolemapping_by_id',
+                                  side_effect=get_client_group_rolemapping_by_id) as mock_get_client_group_rolemapping_by_id:
+                    with patch.object(obj, 'get_client_group_available_rolemappings',
+                                      side_effect=get_client_group_available_rolemappings) as mock_get_client_group_available_rolemappings:
+                        with patch.object(obj, 'get_client_group_composite_rolemappings',
+                                          side_effect=get_client_group_composite_rolemappings) as mock_get_client_group_composite_rolemappings:
                             with patch.object(obj, 'add_group_rolemapping',
                                               side_effect=add_group_rolemapping) as mock_add_group_rolemapping:
                                 with patch.object(obj, 'delete_group_rolemapping',
                                                   side_effect=delete_group_rolemapping) as mock_delete_group_rolemapping:
                                     yield mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping, \
-                                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings, \
+                                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings, \
                                         mock_delete_group_rolemapping
 
 
@@ -144,7 +144,7 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
         return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
-        return_value_get_client_available_rolemappings = [[
+        return_value_get_client_group_available_rolemappings = [[
             {
                 "clientRole": "true",
                 "composite": "false",
@@ -160,7 +160,7 @@ class TestKeycloakRealm(ModuleTestCase):
                 "name": "test_role1"
             }
         ]]
-        return_value_get_client_composite_rolemappings = [
+        return_value_get_client_group_composite_rolemappings = [
             None,
             [
                 {
@@ -189,10 +189,10 @@ class TestKeycloakRealm(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
                                     get_client_role_by_name=return_value_get_client_role_by_name,
-                                    get_client_available_rolemappings=return_value_get_client_available_rolemappings,
-                                    get_client_composite_rolemappings=return_value_get_client_composite_rolemappings) \
+                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
                     as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
-                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings,
+                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
@@ -200,9 +200,9 @@ class TestKeycloakRealm(ModuleTestCase):
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
         self.assertEqual(mock_add_group_rolemapping.call_count, 1)
-        self.assertEqual(mock_get_client_rolemapping_by_id.call_count, 0)
-        self.assertEqual(mock_get_client_available_rolemappings.call_count, 1)
-        self.assertEqual(mock_get_client_composite_rolemappings.call_count, 2)
+        self.assertEqual(mock_get_client_group_rolemapping_by_id.call_count, 0)
+        self.assertEqual(mock_get_client_group_available_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_composite_rolemappings.call_count, 2)
         self.assertEqual(mock_delete_group_rolemapping.call_count, 0)
 
         # Verify that the module's changed status matches what is expected
@@ -246,8 +246,8 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
         return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
-        return_value_get_client_available_rolemappings = [[]]
-        return_value_get_client_composite_rolemappings = [[
+        return_value_get_client_group_available_rolemappings = [[]]
+        return_value_get_client_group_composite_rolemappings = [[
             {
                 "clientRole": "true",
                 "composite": "false",
@@ -273,10 +273,10 @@ class TestKeycloakRealm(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
                                     get_client_role_by_name=return_value_get_client_role_by_name,
-                                    get_client_available_rolemappings=return_value_get_client_available_rolemappings,
-                                    get_client_composite_rolemappings=return_value_get_client_composite_rolemappings) \
+                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
                     as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
-                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings,
+                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
@@ -284,9 +284,9 @@ class TestKeycloakRealm(ModuleTestCase):
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
         self.assertEqual(mock_add_group_rolemapping.call_count, 0)
-        self.assertEqual(mock_get_client_rolemapping_by_id.call_count, 0)
-        self.assertEqual(mock_get_client_available_rolemappings.call_count, 1)
-        self.assertEqual(mock_get_client_composite_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_rolemapping_by_id.call_count, 0)
+        self.assertEqual(mock_get_client_group_available_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_composite_rolemappings.call_count, 1)
         self.assertEqual(mock_delete_group_rolemapping.call_count, 0)
 
         # Verify that the module's changed status matches what is expected
@@ -330,7 +330,7 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
         return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
-        return_value_get_client_available_rolemappings = [[
+        return_value_get_client_group_available_rolemappings = [[
             {
                 "clientRole": "true",
                 "composite": "false",
@@ -346,7 +346,7 @@ class TestKeycloakRealm(ModuleTestCase):
                 "name": "test_role1"
             }
         ]]
-        return_value_get_client_composite_rolemappings = [
+        return_value_get_client_group_composite_rolemappings = [
             None,
             [
                 {
@@ -375,10 +375,10 @@ class TestKeycloakRealm(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
                                     get_client_role_by_name=return_value_get_client_role_by_name,
-                                    get_client_available_rolemappings=return_value_get_client_available_rolemappings,
-                                    get_client_composite_rolemappings=return_value_get_client_composite_rolemappings) \
+                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
                     as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
-                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings,
+                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
@@ -386,9 +386,9 @@ class TestKeycloakRealm(ModuleTestCase):
         self.assertEqual(mock_get_group_by_name.call_count, 0)
         self.assertEqual(mock_get_client_id.call_count, 0)
         self.assertEqual(mock_add_group_rolemapping.call_count, 1)
-        self.assertEqual(mock_get_client_rolemapping_by_id.call_count, 0)
-        self.assertEqual(mock_get_client_available_rolemappings.call_count, 1)
-        self.assertEqual(mock_get_client_composite_rolemappings.call_count, 2)
+        self.assertEqual(mock_get_client_group_rolemapping_by_id.call_count, 0)
+        self.assertEqual(mock_get_client_group_available_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_composite_rolemappings.call_count, 2)
         self.assertEqual(mock_delete_group_rolemapping.call_count, 0)
 
         # Verify that the module's changed status matches what is expected
@@ -432,8 +432,8 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
         return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
-        return_value_get_client_available_rolemappings = [[]]
-        return_value_get_client_composite_rolemappings = [
+        return_value_get_client_group_available_rolemappings = [[]]
+        return_value_get_client_group_composite_rolemappings = [
             [
                 {
                     "clientRole": "true",
@@ -462,10 +462,10 @@ class TestKeycloakRealm(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
                                     get_client_role_by_name=return_value_get_client_role_by_name,
-                                    get_client_available_rolemappings=return_value_get_client_available_rolemappings,
-                                    get_client_composite_rolemappings=return_value_get_client_composite_rolemappings) \
+                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
                     as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
-                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings,
+                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
@@ -473,9 +473,9 @@ class TestKeycloakRealm(ModuleTestCase):
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
         self.assertEqual(mock_add_group_rolemapping.call_count, 0)
-        self.assertEqual(mock_get_client_rolemapping_by_id.call_count, 0)
-        self.assertEqual(mock_get_client_available_rolemappings.call_count, 1)
-        self.assertEqual(mock_get_client_composite_rolemappings.call_count, 2)
+        self.assertEqual(mock_get_client_group_rolemapping_by_id.call_count, 0)
+        self.assertEqual(mock_get_client_group_available_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_composite_rolemappings.call_count, 2)
         self.assertEqual(mock_delete_group_rolemapping.call_count, 1)
 
         # Verify that the module's changed status matches what is expected
@@ -519,7 +519,7 @@ class TestKeycloakRealm(ModuleTestCase):
         }]
         return_value_get_client_id = "c0f8490c-b224-4737-a567-20223e4c1727"
         return_value_get_client_role_by_name = "e91af074-cfd5-40ee-8ef5-ae0ae1ce69fe"
-        return_value_get_client_available_rolemappings = [
+        return_value_get_client_group_available_rolemappings = [
             [
                 {
                     "clientRole": "true",
@@ -537,7 +537,7 @@ class TestKeycloakRealm(ModuleTestCase):
                 }
             ]
         ]
-        return_value_get_client_composite_rolemappings = [[]]
+        return_value_get_client_group_composite_rolemappings = [[]]
 
         changed = False
 
@@ -548,10 +548,10 @@ class TestKeycloakRealm(ModuleTestCase):
         with mock_good_connection():
             with patch_keycloak_api(get_group_by_name=return_value_get_group_by_name, get_client_id=return_value_get_client_id,
                                     get_client_role_by_name=return_value_get_client_role_by_name,
-                                    get_client_available_rolemappings=return_value_get_client_available_rolemappings,
-                                    get_client_composite_rolemappings=return_value_get_client_composite_rolemappings) \
+                                    get_client_group_available_rolemappings=return_value_get_client_group_available_rolemappings,
+                                    get_client_group_composite_rolemappings=return_value_get_client_group_composite_rolemappings) \
                     as (mock_get_group_by_name, mock_get_client_id, mock_get_client_role_by_name, mock_add_group_rolemapping,
-                        mock_get_client_rolemapping_by_id, mock_get_client_available_rolemappings, mock_get_client_composite_rolemappings,
+                        mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, mock_get_client_group_composite_rolemappings,
                         mock_delete_group_rolemapping):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
@@ -559,9 +559,9 @@ class TestKeycloakRealm(ModuleTestCase):
         self.assertEqual(mock_get_group_by_name.call_count, 1)
         self.assertEqual(mock_get_client_id.call_count, 1)
         self.assertEqual(mock_add_group_rolemapping.call_count, 0)
-        self.assertEqual(mock_get_client_rolemapping_by_id.call_count, 0)
-        self.assertEqual(mock_get_client_available_rolemappings.call_count, 1)
-        self.assertEqual(mock_get_client_composite_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_rolemapping_by_id.call_count, 0)
+        self.assertEqual(mock_get_client_group_available_rolemappings.call_count, 1)
+        self.assertEqual(mock_get_client_group_composite_rolemappings.call_count, 1)
         self.assertEqual(mock_delete_group_rolemapping.call_count, 0)
 
         # Verify that the module's changed status matches what is expected

--- a/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
+++ b/tests/unit/plugins/modules/identity/keycloak/test_keycloak_client_rolemapping.py
@@ -57,7 +57,7 @@ def patch_keycloak_api(get_group_by_name=None, get_client_id=None, get_client_ro
                                                   side_effect=delete_group_rolemapping) as mock_delete_group_rolemapping:
                                     yield mock_get_group_by_name, mock_get_client_id, mock_get_client_role_id_by_name, mock_add_group_rolemapping, \
                                         mock_get_client_group_rolemapping_by_id, mock_get_client_group_available_rolemappings, \
-                                          mock_get_client_group_composite_rolemappings, mock_delete_group_rolemapping
+                                        mock_get_client_group_composite_rolemappings, mock_delete_group_rolemapping
 
 
 def get_response(object_with_future_response, method, get_id_call_count):


### PR DESCRIPTION
##### SUMMARY
Add `keycloak_user_rolemapping` module to provide management of direct assignment of client/realm roles to users. Also provides user role mapping for service-account users.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
`keycloak_user_rolemapping`

##### ADDITIONAL INFORMATION
Example:
```
- name: Map a client role to a user, authentication with credentials
  community.general.keycloak_user_rolemapping:
    realm: MyCustomRealm
    auth_client_id: admin-cli
    auth_keycloak_url: https://auth.example.com/auth
    auth_realm: master
    auth_username: USERNAME
    auth_password: PASSWORD
    state: present
    client_id: client1
    user_id: user1Id
    roles:
      - name: role_name1
        id: role_id1
      - name: role_name2
        id: role_id2
  delegate_to: localhost

- name: Map a client role to a service account user for a client, authentication with credentials
  community.general.keycloak_user_rolemapping:
    realm: MyCustomRealm
    auth_client_id: admin-cli
    auth_keycloak_url: https://auth.example.com/auth
    auth_realm: master
    auth_username: USERNAME
    auth_password: PASSWORD
    state: present
    client_id: client1
    service_account_user_client_id: clientIdOfServiceAccount
    roles:
      - name: role_name1
        id: role_id1
      - name: role_name2
        id: role_id2
  delegate_to: localhost
```
