### PR TITLE
Fix GetChassisPower when multiple chassis are present

### DIFF
--- a/changelogs/fragments/4901-fix-redfish-chassispower.yml
+++ b/changelogs/fragments/4901-fix-redfish-chassispower.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_info - Fix to GetChassisPower to correctly report power information when multiple chassis exist, but not all chassis report power information (https://github.com/ansible-collections/community.general/issues/4901)

--- a/changelogs/fragments/4901-fix-redfish-chassispower.yml
+++ b/changelogs/fragments/4901-fix-redfish-chassispower.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_info - Fix to GetChassisPower to correctly report power information when multiple chassis exist, but not all chassis report power information (https://github.com/ansible-collections/community.general/issues/4901)
+  - redfish_info - fix to ``GetChassisPower`` to correctly report power information when multiple chassis exist, but not all chassis report power information (https://github.com/ansible-collections/community.general/issues/4901).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1888,14 +1888,13 @@ class RedfishUtils(object):
                         for property in properties:
                             if property in data:
                                 chassis_power_result[property] = data[property]
-                else:
-                    return {'ret': False, 'msg': 'Key PowerControl not found.'}
                 chassis_power_results.append(chassis_power_result)
-            else:
-                return {'ret': False, 'msg': 'Key Power not found.'}
 
-        result['entries'] = chassis_power_results
-        return result
+        if len(chassis_power_results) > 0:
+            result['entries'] = chassis_power_results
+            return result
+        else:
+            return {'ret': False, 'msg': 'Power information not found.'}
 
     def get_chassis_thermals(self):
         result = {}


### PR DESCRIPTION
When multiple chassis are present, and one or more of those chassis do _not_
report power information, the GetChassisPower command will fail. To address
that, only report a failure if _all_ of the Chassis objects lack power
power reporting functionality.

Fixes #4901

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
redfish_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Output from a system that has multiple chassis, but one chassis (the backplane) does _not_ report power information:
```
PLAY [all] **********************************************************************************************************************************************************************************

TASK [Gather initial BMC lan infomration] ***************************************************************************************************************************************************
ok: [s2r8node79]

TASK [Set BMC IP address as fact] ***********************************************************************************************************************************************************
ok: [s2r8node79]

TASK [Get Chassis Power] ********************************************************************************************************************************************************************
ok: [s2r8node79]

TASK [debug] ********************************************************************************************************************************************************************************
ok: [s2r8node79] => {
    "redfish_chassis_power": {
        "changed": false,
        "failed": false,
        "redfish_facts": {
            "chassis_power": {
                "entries": [
                    {
                        "Name": "System Power Control",
                        "PowerConsumedWatts": 382,
                        "PowerMetrics": {
                            "AverageConsumedWatts": 372,
                            "IntervalInMin": 5,
                            "MaxConsumedWatts": 385,
                            "MinConsumedWatts": 367
                        },
                        "RelatedItem": [
                            {
                                "@odata.id": "/redfish/v1/Systems/1/Processors/2"
                            },
                            {
                                "@odata.id": "/redfish/v1/Systems/1/Processors/1"
                            }
                        ],
                        "Status": {
                            "Health": "OK",
                            "State": "Enabled"
                        }
                    }
                ],
                "ret": true
            }
        }
    }
}

```
