### PR TITLE
Fix command variable usage in CmdRunner

### DIFF
--- a/changelogs/fragments/4903-cmdrunner-bugfix.yaml
+++ b/changelogs/fragments/4903-cmdrunner-bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cmd_runner module utils - fix bug caused by using the ``command`` variable instead of ``self.command`` when looking for binary path (https://github.com/ansible-collections/community.general/pull/4903).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -191,7 +191,7 @@ class CmdRunner(object):
             environ_update = {}
         self.environ_update = environ_update
 
-        self.command[0] = module.get_bin_path(command[0], opt_dirs=path_prefix, required=True)
+        self.command[0] = module.get_bin_path(self.command[0], opt_dirs=path_prefix, required=True)
 
         for mod_param_name, spec in iteritems(module.argument_spec):
             if mod_param_name not in self.arg_formats:


### PR DESCRIPTION
##### SUMMARY
It exists a bug in CmdRunner where the wrong "command" variable is being used in order to get the binary path.

Before executing, it is ensured that the command is a list.

`self.command = _ensure_list(command)`

However, further in the code, `command[0]` is used instead of `self.command[0]`.

`self.command[0] = module.get_bin_path(command[0], opt_dirs=path_prefix, required=True)`

Because of this, if command is a string (p.e. xfconf-query), `get_bin_path` will look for "x" instead of "xfconf-query".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/cmd_runner.py

##### ADDITIONAL INFORMATION
Right now, this is affecting the following components:
- plugins/module_utils/xfconf.py
- plugins/module_utils/gconftool2.py