### PR TITLE
Fix timezone test

### DIFF
--- a/tests/integration/targets/timezone/tasks/test.yml
+++ b/tests/integration/targets/timezone/tasks/test.yml
@@ -287,7 +287,7 @@
 
 - name:
   set_fact:
-    hwclock_supported: '{{ hwclock_test is successful or timedatectl_test is successful }}'
+    hwclock_supported: '{{ hwclock_test is successful or (timedatectl_test is successful and "RTC time: n/a" not in timedatectl_test.stdout) }}'
 ##
 ## test set hwclock, idempotency and checkmode
 ##


### PR DESCRIPTION
##### SUMMARY
It currently fails nightly CI on CentOS 8 Stream. `timedatectl` can be run, but prints `RTC time: n/a`, and then trying to set RTC time fails.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
