### PR TITLE
Fix for agent enabled

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -424,7 +424,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         agent_iface_value = self._get_agent_network_interfaces(node, vmid, vmtype)
                         if agent_iface_value:
                             agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
-                            print ("%s: %s" % (agent_iface_key, agent_iface_value))
                             properties[agent_iface_key] = agent_iface_value
 
                 if config == 'lxc':

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -412,12 +412,20 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         properties[parsed_key] = [tag.strip() for tag in stripped_value.split(",")]
 
                 # The first field in the agent string tells you whether the agent is enabled
-                # the rest of the comma separated string is extra config for the agent
-                if config == 'agent' and int(value.split(',')[0]):
-                    agent_iface_value = self._get_agent_network_interfaces(node, vmid, vmtype)
-                    if agent_iface_value:
-                        agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
-                        properties[agent_iface_key] = agent_iface_value
+                # the rest of the comma separated string is extra config for the agent.
+                # In some (newer versions of proxmox) instances it can be 'enabled=1'.
+                if config == 'agent':
+                    agent_enabled=0
+                    if value.split(',')[0].isnumeric():
+                        agent_enabled=int(value.split(',')[0])
+                    if  value.split(',') == "enabled=1":
+                        agent_enabled=1
+                    if agent_enabled:
+                        agent_iface_value = self._get_agent_network_interfaces(node, vmid, vmtype)
+                        if agent_iface_value:
+                            agent_iface_key = self.to_safe('%s%s' % (key, "_interfaces"))
+                            print ("%s: %s" % (agent_iface_key, agent_iface_value))
+                            properties[agent_iface_key] = agent_iface_value
 
                 if config == 'lxc':
                     out_val = {}


### PR DESCRIPTION
##### SUMMARY
Some (newer?) instances of proxmox uses "enabled=1" instead of just "1" in the agent config line. This fix adds ´agent_enabled´, checks if the first field is int; if so, set it to value. If not check if string equals "enabled=1" to set it ´agent_enabled´ to 1. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.proxmox

##### ADDITIONAL INFORMATION
