### PR TITLE
Do not ignore tld option in DSV lookup plugin

### DIFF
--- a/changelogs/fragments/4911-dsv-honor-tld-option.yml
+++ b/changelogs/fragments/4911-dsv-honor-tld-option.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - dsv lookup plugin - do not ignore the `tld` parameter.

--- a/changelogs/fragments/4911-dsv-honor-tld-option.yml
+++ b/changelogs/fragments/4911-dsv-honor-tld-option.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - dsv lookup plugin - do not ignore the `tld` parameter.
+  - dsv lookup plugin - do not ignore the ``tld`` parameter (https://github.com/ansible-collections/community.general/pull/4911).

--- a/plugins/lookup/dsv.py
+++ b/plugins/lookup/dsv.py
@@ -122,6 +122,7 @@ class LookupModule(LookupBase):
                 "tenant": self.get_option("tenant"),
                 "client_id": self.get_option("client_id"),
                 "client_secret": self.get_option("client_secret"),
+                "tld": self.get_option("tld"),
                 "url_template": self.get_option("url_template"),
             }
         )


### PR DESCRIPTION
##### SUMMARY
Option defined to configure the top-level domain of the tenant was ignored.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lookup/dsv

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
