### PR TITLE
Fix code in `rax_clb_nodes` that breaks in Python3

### DIFF
--- a/changelogs/fragments/4933-fix-rax-clb-nodes.yaml
+++ b/changelogs/fragments/4933-fix-rax-clb-nodes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rax_clb_nodes - fix code to be compatible with Python 3 (https://github.com/ansible-collections/community.general/pull/4933).

--- a/plugins/modules/cloud/rackspace/rax_clb_nodes.py
+++ b/plugins/modules/cloud/rackspace/rax_clb_nodes.py
@@ -252,7 +252,8 @@ def main():
                 'weight': weight,
             }
 
-            for name, value in mutable.items():
+            for name in list(mutable):
+                value = mutable[name]
                 if value is None or value == getattr(node, name):
                     mutable.pop(name)
 


### PR DESCRIPTION
##### SUMMARY
Fix syntax in `rax_clb_nodes` that breaks in Python3

  * Use syntax that works in both Python 2 and 3 when iterating through a
    dict that's going to be mutated during iteration
  * Fixes `dictionary changed size during iteration` error
  * Fixes #4932

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.general.rax_clb_nodes` defined here: https://github.com/ansible-collections/community.general/blob/main/plugins/modules/cloud/rackspace/rax_clb_nodes.py

##### ADDITIONAL INFORMATION
Prior to this change, you are unable to run the `rax_clb_nodes` task against hosts that only have Python 3 installed.  You would get this error:

```console
RuntimeError: dictionary changed size during iteration
```

Now it works as expected under hosts with Python 2 or Python 3.
