### PR TITLE
Skip cloud_init_data_facts test on Ubuntu 22.04

### DIFF
--- a/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/tests/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -13,7 +13,7 @@
   # Will also have to skip on OpenSUSE when running on Python 2 on newer Leap versions
   # (!= 42 and >= 15) ascloud-init will install the Python 3 package, breaking our build on py2.
   when:
-  - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int == 14)
+  - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int in [14, 22])  # TODO: check Ubuntu 22.04
   - not (ansible_os_family == "Suse" and ansible_distribution_major_version|int != 42 and ansible_python.version.major != 3)
   - not (ansible_distribution == "CentOS" and ansible_distribution_major_version|int == 8)  # TODO: cannot start service
   - not (ansible_distribution == 'Archlinux')  # TODO: package seems to be broken, cannot be downloaded from mirrors?


### PR DESCRIPTION
##### SUMMARY
The test currently fails on Ubuntu 22.04:
```
00:54 fatal: [testhost]: FAILED! => {"cache_update_time": 1657180992, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'cloud-init=22.2-0ubuntu1~22.04.3' 'udev=249.11-0ubuntu3'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n udev : Depends: libudev1 (= 249.11-0ubuntu3) but 249.11-0ubuntu3.1 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " udev : Depends: libudev1 (= 249.11-0ubuntu3) but 249.11-0ubuntu3.1 is to be installed"]}
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
cloud_init_data_facts
