### PR TITLE
proxmox module_utils: fix get_vm int parse handling

### DIFF
--- a/changelogs/fragments/4945-fix-get_vm-int-parse-handling.yaml
+++ b/changelogs/fragments/4945-fix-get_vm-int-parse-handling.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - proxmox - fix error handling for get vm by name when state absent (https://github.com/ansible-collections/community.general/pull/4945).
+  - proxmox_kvm - fix error handling for get vm by name when state absent (https://github.com/ansible-collections/community.general/pull/4945).

--- a/changelogs/fragments/4945-fix-get_vm-int-parse-handling.yaml
+++ b/changelogs/fragments/4945-fix-get_vm-int-parse-handling.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - proxmox - fix error handling for get vm by name when state absent (https://github.com/ansible-collections/community.general/pull/4945).
-  - proxmox_kvm - fix error handling for get vm by name when state absent (https://github.com/ansible-collections/community.general/pull/4945).
+  - proxmox - fix error handling when getting VM by name when ``state=absent`` (https://github.com/ansible-collections/community.general/pull/4945).
+  - proxmox_kvm - fix error handling when getting VM by name when ``state=absent`` (https://github.com/ansible-collections/community.general/pull/4945).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -127,7 +127,8 @@ class ProxmoxAnsible(object):
         return vms[0]
 
     def get_vm(self, vmid, ignore_missing=False):
-        vms = [vm for vm in self.proxmox_api.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
+        vmid = int(vmid) if vmid is not None else None
+        vms = [vm for vm in self.proxmox_api.cluster.resources.get(type='vm') if vmid and vm['vmid'] == vmid]
 
         if vms:
             return vms[0]

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -127,8 +127,7 @@ class ProxmoxAnsible(object):
         return vms[0]
 
     def get_vm(self, vmid, ignore_missing=False):
-        vmid = int(vmid) if vmid is not None else None
-        vms = [vm for vm in self.proxmox_api.cluster.resources.get(type='vm') if vmid and vm['vmid'] == vmid]
+        vms = [vm for vm in self.proxmox_api.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
 
         if vms:
             return vms[0]

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -743,6 +743,8 @@ def main():
             module.fail_json(msg="restarting of VM %s failed with exception: %s" % (vmid, e))
 
     elif state == 'absent':
+        if not vmid:
+            module.exit_json(changed=False, msg='VM with hostname = %s is already absent' % hostname)
         try:
             vm = proxmox.get_vm(vmid, ignore_missing=True)
             if not vm:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1370,6 +1370,8 @@ def main():
 
     elif state == 'absent':
         status = {}
+        if not vmid:
+            module.exit_json(changed=False, msg='VM with name = %s is already absent' % name)
         try:
             vm = proxmox.get_vm(vmid, ignore_missing=True)
             if not vm:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When target vm is not exist and get vm by only target vm name, proxmox module raise int parse error.

This PR fix only pattern of vmid is None.
I did't implement other pattern because I guess vmid is only int or None.

Closes #4944 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
none
```
