### PR TITLE
Update zypper.py

### DIFF
--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -511,9 +511,7 @@ def repo_refresh(m):
 
 
 def transactional_updates():
-    return os.path.exists('/var/lib/misc/transactional-update.state') or \
-           os.path.exists('/sbin/transactional-update') or \
-           os.path.exists('/bin/tukit')
+    return any(os.path.exists(p) for p in ['/var/lib/misc/transactional-update.state', '/sbin/transactional-update', '/bin/tukit'])
 
 # ===========================================
 # Main control flow

--- a/plugins/modules/packaging/os/zypper.py
+++ b/plugins/modules/packaging/os/zypper.py
@@ -511,7 +511,9 @@ def repo_refresh(m):
 
 
 def transactional_updates():
-    return os.path.exists('/var/lib/misc/transactional-update.state')
+    return os.path.exists('/var/lib/misc/transactional-update.state') or \
+           os.path.exists('/sbin/transactional-update') or \
+           os.path.exists('/bin/tukit')
 
 # ===========================================
 # Main control flow


### PR DESCRIPTION
add more checks for t-u

##### SUMMARY
Adds a few more files to check for to see if the target is using transactional updates. This is especially relevant for newly provisioned hosts that lack the file in /var/lib/misc. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper.py

##### ADDITIONAL INFORMATION
Provision a new MicroOS machine. Try to use the zypper module before any updates. It will fail. Add these checkes, and it will know to use t-u.