### PR TITLE
Fix path detection for gopass

### DIFF
--- a/changelogs/fragments/4955-fix-path-detection-for-gopass.yaml
+++ b/changelogs/fragments/4955-fix-path-detection-for-gopass.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - passwordstore - fix password store path detection for gopass (https://github.com/ansible-collections/community.general/pull/4955).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -26,8 +26,8 @@ DOCUMENTATION = '''
           - 'The value is decided by checking the following in order:'
           - If set, this value is used.
           - If C(directory) is set, that value will be used.
-          - If the I(backend) is C(pass), C(~/.password-store) is used.
-          - If the I(backend) is C(gopass), the C(path) field in C(~/.config/gopass/config.yml) is used,
+          - If I(backend=pass), then C(~/.password-store) is used.
+          - If I(backend=gopass), then the C(path) field in C(~/.config/gopass/config.yml) is used,
             falling back to C(~/.local/share/gopass/stores/root) if not defined.
       directory:
         description: The directory of the password store.

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -26,9 +26,9 @@ DOCUMENTATION = '''
           - 'The value is decided by checking the following in order:'
           - If set, this value is used.
           - If C(directory) is set, that value will be used.
-          - If the backend is pass, '~/.password-store' is used.
-          - If the backend is gopass, the C(path) field in '~/.config/gopass/config.yml' is used,
-            falling back to '~/.local/share/gopass/stores/root' if not defined.
+          - If the I(backend) is C(pass), C(~/.password-store) is used.
+          - If the I(backend) is C(gopass), the C(path) field in C(~/.config/gopass/config.yml) is used,
+            falling back to C(~/.local/share/gopass/stores/root) if not defined.
       directory:
         description: The directory of the password store.
         env:

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -21,8 +21,14 @@ DOCUMENTATION = '''
         description: query key.
         required: True
       passwordstore:
-        description: location of the password store.
-        default: '~/.password-store'
+        description:
+          - Location of the password store.
+          - 'The value is decided by checking the following in order:'
+          - If set, this value is used.
+          - If C(directory) is set, that value will be used.
+          - If the backend is pass, '~/.password-store' is used.
+          - If the backend is gopass, the C(path) field in '~/.config/gopass/config.yml' is used,
+            falling back to '~/.local/share/gopass/stores/root' if not defined.
       directory:
         description: The directory of the password store.
         env:
@@ -428,11 +434,22 @@ class LookupModule(LookupBase):
             raise AnsibleError("{0} is not a correct value for locktimeout".format(timeout))
         unit_to_seconds = {"s": 1, "m": 60, "h": 3600}
         self.lock_timeout = int(timeout[:-1]) * unit_to_seconds[timeout[-1]]
+
+        directory = variables.get('passwordstore', os.environ.get('PASSWORD_STORE_DIR', None))
+
+        if directory is None:
+            if self.backend == 'gopass':
+                try:
+                    with open(os.path.expanduser('~/.config/gopass/config.yml')) as f:
+                        directory = yaml.safe_load(f)['path']
+                except (FileNotFoundError, KeyError, yaml.YAMLError):
+                    directory = os.path.expanduser('~/.local/share/gopass/stores/root')
+            else:
+                directory = os.path.expanduser('~/.password-store')
+
         self.paramvals = {
             'subkey': 'password',
-            'directory': variables.get('passwordstore', os.environ.get(
-                                       'PASSWORD_STORE_DIR',
-                                       os.path.expanduser('~/.password-store'))),
+            'directory': directory,
             'create': False,
             'returnall': False,
             'overwrite': False,


### PR DESCRIPTION
##### SUMMARY
As per https://github.com/gopasspw/gopass/blob/fc8c9a228618fa4a146a87c9027fa0434b0737fa/docs/features.md#initializing-a-password-store, gopass defaults to ~/.local/share/gopass/stores/root for its password store root location.

However, the user can also override this, and this will be stored in the gopass config file (https://github.com/gopasspw/gopass/blob/ed7451678c5e8138d5a8eaafa278d5065a9eb9fe/docs/config.md#configuration-options).

This patch ensures that the config setting in gopass is respected, falling back to the default gopass path. pass' behaviour remains unchanged.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
passwordstore

##### ADDITIONAL INFORMATION
I have to say I am unsure how to document this properly, especially given the weird way the `passwordstore` and `directory` settings on this module currently interact with each other (why are there 2 variables for what is essentially the same thing?)