### PR TITLE
Pacman: Add support for install reason

### DIFF
--- a/changelogs/fragments/4956-pacman-install-reason.yaml
+++ b/changelogs/fragments/4956-pacman-install-reason.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pacman - added parameters ``reason`` and ``reason_for`` to set/change the install reason of packages (https://github.com/ansible-collections/community.general/pull/4956).

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -453,9 +453,11 @@ class Pacman(object):
             "after": "\n".join(sorted(after)) + "\n" if after else "",
         }
 
+        changed_reason_pkgs = [p for p in pkgs_to_set_reason if p not in installed_pkgs]
+
         if self.m.check_mode:
-            self.add_exit_infos("Would have installed %d packages" % len(installed_pkgs))
-            self.exit_params["packages"] = sorted(installed_pkgs)
+            self.add_exit_infos("Would have installed %d packages" % (len(installed_pkgs) + len(changed_reason_pkgs)))
+            self.exit_params["packages"] = sorted(installed_pkgs + changed_reason_pkgs)
             return
 
         # actually do it
@@ -486,8 +488,8 @@ class Pacman(object):
                 self.fail("Failed to install package(s)", cmd=cmd, stdout=stdout, stderr=stderr)
             self.add_exit_infos(stdout=stdout, stderr=stderr)
 
-        self.exit_params["packages"] = installed_pkgs
-        self.add_exit_infos("Installed %d package(s)" % len(installed_pkgs))
+        self.exit_params["packages"] = installed_pkgs + changed_reason_pkgs
+        self.add_exit_infos("Installed %d package(s)" % (len(installed_pkgs) + len(changed_reason_pkgs)))
 
     def remove_packages(self, pkgs):
         # filter out pkgs that are already absent

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -107,7 +107,6 @@ options:
     reason:
         description:
             - The install reason to set for the packages
-        default:
         choices: [ dependency, explicit ]
         type: str
         version_added: 5.4.0

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -110,6 +110,7 @@ options:
         default:
         choices: [ dependency, explicit ]
         type: str
+        version_added: 5.4.0
 
     reason_for:
         description:
@@ -118,6 +119,7 @@ options:
         default: new
         choices: [ all, new ]
         type: str
+        version_added: 5.4.0
 
 notes:
   - When used with a C(loop:) each package will be processed individually,

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -359,7 +359,12 @@ class Pacman(object):
 
     def install_packages(self, pkgs):
         def _get_reason(name):
-            cmd = [self.pacman_path, "--query", "--info"] + [name]
+            cmd = [
+                self.pacman_path,
+                "--query",
+                "--info",
+                name
+            ]
             rc, stdout, stderr = self.m.run_command(cmd, check_rc=False)
             if rc != 0:
                 self.fail("Failed to get reason", cmd=cmd, stdout=stdout, stderr=stderr)
@@ -379,9 +384,9 @@ class Pacman(object):
             if p.name in self.inventory["installed_pkgs"]:
                 current_reasons[p.name] = _get_reason(p.name)
                 if self.m.params["reason_for"] == "all" and current_reasons[p.name] != self.m.params["reason"]:
-                    pkgs_to_set_reason.append(p.name)
+                    pkgs_to_set_reason.append(p.source)
             else:
-                pkgs_to_set_reason.append(p.name)
+                pkgs_to_set_reason.append(p.source)
             if p.source_is_URL:
                 # URL packages bypass the latest / upgradable_pkgs test
                 # They go through the dry-run to let pacman decide if they will be installed

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -380,6 +380,7 @@ class Pacman(object):
         pkgs_to_install_from_url = []
         installed_pkgs = []
         pkgs_to_set_reason = []
+        current_reasons = {}
         for p in pkgs:
             if p.name in self.inventory["installed_pkgs"]:
                 installed_pkgs.append(p.name)

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -106,15 +106,15 @@ options:
 
     reason:
         description:
-            - The install reason to set for the packages
+            - The install reason to set for the packages.
         choices: [ dependency, explicit ]
         type: str
         version_added: 5.4.0
 
     reason_for:
         description:
-            - Set the install reason for C(all) packages or only for C(new) packages
-            - In case of C(state=latest) already installed packages which will be updated to a newer version are not counted as C(new)
+            - Set the install reason for C(all) packages or only for C(new) packages.
+            - In case of C(state=latest) already installed packages which will be updated to a newer version are not counted as C(new).
         default: new
         choices: [ all, new ]
         type: str

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -488,7 +488,7 @@ class Pacman(object):
                 self.fail("Failed to install package(s)", cmd=cmd, stdout=stdout, stderr=stderr)
             self.add_exit_infos(stdout=stdout, stderr=stderr)
 
-        self.exit_params["packages"] = installed_pkgs + changed_reason_pkgs
+        self.exit_params["packages"] = sorted(installed_pkgs + changed_reason_pkgs)
         self.add_exit_infos("Installed %d package(s)" % (len(installed_pkgs) + len(changed_reason_pkgs)))
 
     def remove_packages(self, pkgs):

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -112,7 +112,7 @@ options:
         type: str
 
     reason_for:
-        descripton:
+        description:
             - Set the install reason for C(all) packages or only for C(new) packages
             - In case of C(state=latest) already installed packages which will be updated to a newer version are not counted as C(new)
         default: new

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -106,14 +106,15 @@ options:
 
     reason:
         description:
-            - The reason to set for the packages
+            - The install reason to set for the packages
         default: explicit
         choices: [ dependency, explicit ]
         type: str
 
     reason_for:
         descripton:
-            - Set the reason for all or only for new packages
+            - Set the install reason for C(all) packages or only for C(new) packages
+            - In case of C(state=latest) already installed packages which will be updated to a newer version are not counted as C(new)
         default: new
         choices: [ all, new ]
         type: str

--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -364,7 +364,11 @@ class Pacman(object):
         pkgs_to_install_from_url = []
         pkgs_to_set_reason = []
         for p in pkgs:
-            if self.m.params["reason"] and (not p.name in self.inventory["pkg_reasons"] or (self.m.params["reason_for"] == "all" and self.inventory["pkg_reasons"][p.name] != self.m.params["reason"])):
+            if self.m.params["reason"] and (
+                p.name not in self.inventory["pkg_reasons"]
+                or self.m.params["reason_for"] == "all"
+                and self.inventory["pkg_reasons"][p.name] != self.m.params["reason"]
+            ):
                 pkgs_to_set_reason.append(p.name)
             if p.source_is_URL:
                 # URL packages bypass the latest / upgradable_pkgs test
@@ -784,7 +788,7 @@ class Pacman(object):
             if not l:
                 continue
             pkg = l.split()[0]
-            installed_pkgs[pkg] = "explicit"
+            pkg_reasons[pkg] = "explicit"
         dummy, stdout, dummy = self.m.run_command([self.pacman_path, "--query", "--deps"], check_rc=True)
         # Format of a line: "pacman 6.0.1-2"
         for l in stdout.splitlines():
@@ -792,7 +796,7 @@ class Pacman(object):
             if not l:
                 continue
             pkg = l.split()[0]
-            installed_pkgs[pkg] = "dependency"
+            pkg_reasons[pkg] = "dependency"
 
         return dict(
             installed_pkgs=installed_pkgs,

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -12,3 +12,4 @@
     - include: 'remove_nosave.yml'
     - include: 'update_cache.yml'
     - include: 'locally_installed_package.yml'
+    - include: 'reason.yml'

--- a/tests/integration/targets/pacman/tasks/reason.yml
+++ b/tests/integration/targets/pacman/tasks/reason.yml
@@ -37,7 +37,7 @@
           - '{{url_pkg_url.stdout}}'
           - '{{file_pkg_path}}'
         reason: dependency
-        check_mode: True
+      check_mode: True
       register: install_1
 
     - name: Install packages from mixed sources as explicit

--- a/tests/integration/targets/pacman/tasks/reason.yml
+++ b/tests/integration/targets/pacman/tasks/reason.yml
@@ -36,8 +36,8 @@
           - '{{reg_pkg}}'
           - '{{url_pkg_url.stdout}}'
           - '{{file_pkg_path}}'
-      reason: dependency
-      check_mode: True
+        reason: dependency
+        check_mode: True
       register: install_1
 
     - name: Install packages from mixed sources as explicit
@@ -46,7 +46,7 @@
           - '{{reg_pkg}}'
           - '{{url_pkg_url.stdout}}'
           - '{{file_pkg_path}}'
-      reason: explicit
+        reason: explicit
       register: install_2
 
     - name: Install packages from mixed sources with new packages being installed as dependency - (idempotency)

--- a/tests/integration/targets/pacman/tasks/reason.yml
+++ b/tests/integration/targets/pacman/tasks/reason.yml
@@ -1,0 +1,97 @@
+---
+- vars:
+    reg_pkg: ed
+    url_pkg: lemon
+    file_pkg: hdparm
+    file_pkg_path: /tmp/pkg.zst
+    extra_pkg: core/sdparm
+    extra_pkg_outfmt: sdparm
+  block:
+    - name: Make sure that test packages are not installed
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg}}'
+          - '{{file_pkg}}'
+          - '{{extra_pkg}}'
+        state: absent
+
+    - name: Get URL for {{url_pkg}}
+      command:
+        cmd: pacman --sync --print-format "%l" {{url_pkg}}
+      register: url_pkg_url
+
+    - name: Get URL for {{file_pkg}}
+      command:
+        cmd: pacman --sync --print-format "%l" {{file_pkg}}
+      register: file_pkg_url
+    - name: Download {{file_pkg}} pkg
+      get_url:
+        url: '{{file_pkg_url.stdout}}'
+        dest: '{{file_pkg_path}}'
+
+    - name: Install packages from mixed sources as dependency (check mode)
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg_url.stdout}}'
+          - '{{file_pkg_path}}'
+      reason: dependency
+      check_mode: True
+      register: install_1
+
+    - name: Install packages from mixed sources as explicit
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg_url.stdout}}'
+          - '{{file_pkg_path}}'
+      reason: explicit
+      register: install_2
+
+    - name: Install packages from mixed sources with new packages being installed as dependency - (idempotency)
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg_url.stdout}}'
+          - '{{file_pkg_path}}'
+        reason: dependency
+      register: install_3
+
+    - name: Install new package with already installed packages from mixed sources as dependency
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg_url.stdout}}'
+          - '{{file_pkg_path}}'
+          - '{{extra_pkg}}'
+        reason: dependency
+      register: install_4
+
+    - name: Set install reason for all packages to dependency
+      pacman:
+        name:
+          - '{{reg_pkg}}'
+          - '{{url_pkg_url.stdout}}'
+          - '{{file_pkg_path}}'
+          - '{{extra_pkg}}'
+        reason: dependency
+        reason_for: all
+      register: install_5
+
+    - assert:
+        that:
+          - install_1 is changed
+          - install_1.msg == 'Would have installed 3 packages'
+          - install_1.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
+          - install_2 is changed
+          - install_2.msg == 'Installed 3 package(s)'
+          - install_2.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
+          - install_3 is not changed
+          - install_3.msg == 'package(s) already installed'
+          - install_4 is changed
+          - install_4.msg == 'Installed 1 package(s)'
+          - install_4.packages == [extra_pkg_outfmt]
+          - install_5 is changed
+          - install_5.msg == 'Installed 3 package(s)'
+          - install_5.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()

--- a/tests/unit/plugins/modules/packaging/os/test_pacman.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman.py
@@ -884,7 +884,7 @@ class TestPacman:
                     ],
                     "state": "present",
                 },
-                ["sudo", "somepackage", "otherpkg"],
+                ["otherpkg", "somepackage", "sudo"],
                 [
                     Package("sudo", "sudo"),
                     Package("grep", "grep"),

--- a/tests/unit/plugins/modules/packaging/os/test_pacman.py
+++ b/tests/unit/plugins/modules/packaging/os/test_pacman.py
@@ -100,6 +100,19 @@ valid_inventory = {
     "upgradable_pkgs": {
         "sqlite": VersionTuple(current="3.36.0-1", latest="3.37.0-1"),
     },
+    "pkg_reasons": {
+        "file": "explicit",
+        "filesystem": "explicit",
+        "findutils": "explicit",
+        "gawk": "explicit",
+        "gettext": "explicit",
+        "grep": "explicit",
+        "gzip": "explicit",
+        "pacman": "explicit",
+        "pacman-mirrorlist": "dependency",
+        "sed": "explicit",
+        "sqlite": "explicit",
+    },
 }
 
 empty_inventory = {
@@ -108,6 +121,7 @@ empty_inventory = {
     "installed_groups": {},
     "available_groups": {},
     "upgradable_pkgs": {},
+    "pkg_reasons": {},
 }
 
 
@@ -255,6 +269,27 @@ class TestPacman:
                         """,
                         "",
                     ),
+                    (  # pacman --query --explicit
+                        0,
+                        """file 5.41-1
+                        filesystem 2021.11.11-1
+                        findutils 4.8.0-1
+                        gawk 5.1.1-1
+                        gettext 0.21-1
+                        grep 3.7-1
+                        gzip 1.11-1
+                        pacman 6.0.1-2
+                        sed 4.8-1
+                        sqlite 3.36.0-1
+                        """,
+                        "",
+                    ),
+                    (  # pacman --query --deps
+                        0,
+                        """pacman-mirrorlist 20211114-1
+                        """,
+                        "",
+                    ),
                 ],
                 None,
             ),
@@ -272,6 +307,8 @@ class TestPacman:
                         "",
                         "warning: config file /etc/pacman.conf, line 34: directive 'TotalDownload' in section 'options' not recognized.",
                     ),
+                    (0, "", ""),
+                    (0, "", ""),
                 ],
                 None,
             ),
@@ -288,6 +325,8 @@ class TestPacman:
                         "partial\npkg\\nlist",
                         "some warning",
                     ),
+                    (0, "", ""),
+                    (0, "", ""),
                 ],
                 AnsibleFailJson,
             ),
@@ -375,6 +414,8 @@ class TestPacman:
                     (["pacman", "--query", "--groups"], {'check_rc': True}, 0, '', ''),
                     (["pacman", "--sync", "--groups", "--groups"], {'check_rc': True}, 0, '', ''),
                     (["pacman", "--query", "--upgrades"], {'check_rc': False}, 0, '', ''),
+                    (["pacman", "--query", "--explicit"], {'check_rc': True}, 0, 'foo 1.0.0-1', ''),
+                    (["pacman", "--query", "--deps"], {'check_rc': True}, 0, '', ''),
                 ],
                 False,
             ),


### PR DESCRIPTION
##### SUMMARY
Pacman allows setting the install reason of packages. This PR adds this feature to the pacman module.

By default, no reason is explicitly set and the default behaviour of pacman is left untouched.

`reason_for: all` sets the install reason for all packages and represents the behavior of pacman when `--asdeps` or `--asexplicit` are specified.

`reason_for: new; reason: dependency` is a combination which is, as far as I know, not possible with pacman but very useful, as this enables specifying all wanted optional dependencies of a package without setting the already explicitly installed ones to dependency.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pacman