### PR TITLE
Fix keyring_info when using keyring library

### DIFF
--- a/changelogs/fragments/4964-fix-keyring-info.yml
+++ b/changelogs/fragments/4964-fix-keyring-info.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "keyring - fix the result from the keyring library never getting returned (https://github.com/ansible-collections/community.general/pull/4964)."
+  - "keyring_info - fix the result from the keyring library never getting returned (https://github.com/ansible-collections/community.general/pull/4964)."

--- a/changelogs/fragments/4964-fix-keyring-info.yml
+++ b/changelogs/fragments/4964-fix-keyring-info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "keyring - fix the result from the keyring library never getting returned (https://github.com/ansible-collections/community.general/pull/4964)."

--- a/plugins/modules/system/keyring_info.py
+++ b/plugins/modules/system/keyring_info.py
@@ -122,7 +122,9 @@ def run_module():
         pass
     except AttributeError:
         pass
-    passphrase = _alternate_retrieval_method(module)
+    
+    if passphrase is None:
+        passphrase = _alternate_retrieval_method(module)
 
     if passphrase is not None:
         result["msg"] = "Successfully retrieved password for %s@%s" % (

--- a/plugins/modules/system/keyring_info.py
+++ b/plugins/modules/system/keyring_info.py
@@ -122,7 +122,7 @@ def run_module():
         pass
     except AttributeError:
         pass
-    
+
     if passphrase is None:
         passphrase = _alternate_retrieval_method(module)
 


### PR DESCRIPTION
##### SUMMARY

The docs say this module works with the `keyring` library, but actually this line was clobbering any passphrase retrieved from that library, making it useless on any system without the alternate method (gnome-keyring).

After this change, it'll only use the alternate method if the first one didn't work, so the return value from the first one will actually get passed through.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

keyring_info

##### ADDITIONAL INFORMATION

Reproduction:

```yml
# tested on macOS

- name: Save a password to the keychain
  community.general.keyring:
    service: example-service
    username: example-user
    password: example-password
    keyring_password: ""

- name: Read it back from the keychain
  community.general.keyring_info:
    service: example-service
    username: example-user
    keyring_password: ""
  register: example_result

- debug:
    msg: "{{ example_result }}"
```

before the change

```
ok: [localhost] => 
    msg:
        changed: false
        failed: false
        msg: Password for example-service@example-user does not exist.
```

after the change

```
ok: [localhost] => 
    msg:
        changed: false
        failed: false
        msg: Successfully retrieved password for example-service@example-user
        passphrase: example-password