### PR TITLE
Pacman: Improve url integrity test

### DIFF
--- a/changelogs/fragments/4968-pacman-url-integrity-test.yaml
+++ b/changelogs/fragments/4968-pacman-url-integrity-test.yaml
@@ -1,4 +1,0 @@
-minor_changes:
-  - pacman - improved integrity tests for url packages (https://github.com/ansible-collections/community.general/pull/4968).
-bugfixes:
-  - pacman - fixed typo in integrity test

--- a/changelogs/fragments/4968-pacman-url-integrity-test.yaml
+++ b/changelogs/fragments/4968-pacman-url-integrity-test.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - pacman - improved integrity tests for url packages (https://github.com/ansible-collections/community.general/pull/4968).
+bug_fixes:
+  - pacman - fixed typo in integrity test

--- a/changelogs/fragments/4968-pacman-url-integrity-test.yaml
+++ b/changelogs/fragments/4968-pacman-url-integrity-test.yaml
@@ -1,4 +1,4 @@
 minor_changes:
   - pacman - improved integrity tests for url packages (https://github.com/ansible-collections/community.general/pull/4968).
-bug_fixes:
+bugfixes:
   - pacman - fixed typo in integrity test

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -1,6 +1,6 @@
 ---
 - vars:
-    port: 8000
+    port: 53280
     reg_pkg: ed
     url_pkg: lemon
     url_pkg_filename: url.pkg.zst

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -202,7 +202,7 @@
           - uninstall_1.msg == 'Would have removed 3 packages'
           - uninstall_1.packages | length() == 3  # pkgs have versions here
           - uninstall_1c is changed
-          - uninstall_1c.msg == 'Would have removed 3 packages'
+          - uninstall_1c.msg == 'Would have removed 1 packages'
           - uninstall_1c.packages | length() == 1  # pkgs have versions here
           - uninstall_2 is changed
           - uninstall_2.msg == 'Removed 3 package(s)'

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -38,7 +38,9 @@
         dest: '{{url_pkg_path}}/{{url_pkg_filename}}.sig'
     - name: Host {{url_pkg}}
       shell:
-        cmd: 'python -m http.server --directory {{url_pkg_path}} {{http_port}} >/dev/null 2>&1 &'
+        cmd: 'python -m http.server --directory {{url_pkg_path}} {{http_port}} >/dev/null 2>&1'
+      async: 90
+      poll: 0
     - name: Wait for http.server to come up online
       wait_for:
         host: 'localhost'

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -175,8 +175,8 @@
           - install_1.msg == 'Would have installed 3 packages'
           - install_1.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
           - install_1c is changed
-          - install_1c.msg == 'Would have installed 3 packages'
-          - install_1c.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
+          - install_1c.msg == 'Would have installed 1 packages'
+          - install_1c.packages|sort() == [url_pkg]
           - install_2 is changed
           - install_2.msg == 'Installed 3 package(s)'
           - install_2.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -2,6 +2,9 @@
 - vars:
     reg_pkg: ed
     url_pkg: lemon
+    url_pkg_filename: url.pkg.zst
+    url_pkg_path: '/tmp/{{url_pkg_filename}}'
+    url_pkg_url: 'http://127.0.0.1/{{url_pkg_filename}}'
     file_pkg: hdparm
     file_pkg_path: /tmp/pkg.zst
     extra_pkg: core/sdparm
@@ -19,7 +22,14 @@
     - name: Get URL for {{url_pkg}}
       command:
         cmd: pacman --sync --print-format "%l" {{url_pkg}}
-      register: url_pkg_url
+      register: url_pkg_stdout
+    - name: Download {{url_pkg}} pkg
+      get_url:
+        url: '{{url_pkg_stdout.stdout}}'
+        dest: '{{url_pkg_path}}'
+    - name: Host {{url_pkg}}
+      shell:
+        cmd: python -m http.server --directory /tmp/ 80 &
 
     - name: Get URL for {{file_pkg}}
       command:
@@ -34,7 +44,7 @@
       pacman:
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       check_mode: True
       register: install_1
@@ -43,7 +53,7 @@
       pacman:
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: install_2
 
@@ -51,7 +61,7 @@
       pacman:
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: install_3
 
@@ -67,7 +77,7 @@
       pacman:
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
           - '{{extra_pkg}}'
       register: install_5
@@ -77,7 +87,7 @@
         state: absent
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       check_mode: True
       register: uninstall_1
@@ -87,7 +97,7 @@
         state: absent
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: uninstall_2
 
@@ -96,7 +106,7 @@
         state: absent
         name:
           - '{{reg_pkg}}'
-          - '{{url_pkg_url.stdout}}'
+          - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: uninstall_3
 

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -4,8 +4,8 @@
     reg_pkg: ed
     url_pkg: lemon
     url_pkg_filename: url.pkg.zst
-    url_pkg_path: '/tmp/{{url_pkg_filename}}'
-    url_pkg_url: 'http://127.0.0.1:{{http_port}}/{{url_pkg_filename}}'
+    url_pkg_path: '/tmp/'
+    url_pkg_url: 'http://localhost:{{http_port}}/{{url_pkg_filename}}'
     file_pkg: hdparm
     file_pkg_path: /tmp/file.pkg.zst
     extra_pkg: core/sdparm
@@ -27,14 +27,19 @@
     - name: Download {{url_pkg}} pkg
       get_url:
         url: '{{url_pkg_stdout.stdout}}'
-        dest: '{{url_pkg_path}}'
+        dest: '{{url_pkg_path}}/{{url_pkg_filename}}'
     - name: Download {{url_pkg}} pkg sig
       get_url:
         url: '{{url_pkg_stdout.stdout}}.sig'
         dest: '{{url_pkg_path}}.sig'
     - name: Host {{url_pkg}}
       shell:
-        cmd: 'python -m http.server --directory /tmp/ {{http_port}} &'
+        cmd: 'python -m http.server --directory {{url_pkg_path}} {{http_port}} >/dev/null 2>&1 &'
+    - name: Wait for http.server to come up online
+      wait_for:
+        host: 'localhost'
+        port: '{{http_port}}'
+        state: started
 
     - name: Get URL for {{file_pkg}}
       command:

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -49,6 +49,17 @@
       check_mode: True
       register: install_1
 
+    - name: Install packages from url (check mode, cached)
+      pacman:
+        name:
+          - '{{url_pkg_url}}'
+      check_mode: True
+      register: install_1c
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
+
     - name: Install packages from mixed sources
       pacman:
         name:
@@ -68,6 +79,15 @@
           - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: install_3
+    - name: Install packages from url - (idempotency, cached)
+      pacman:
+        name:
+          - '{{url_pkg_url}}'
+      register: install_3c
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Install packages with their regular names (idempotency)
       pacman:
@@ -103,6 +123,17 @@
           - '{{file_pkg_path}}'
       check_mode: True
       register: uninstall_1
+    - name: Uninstall packages - url (check mode, cached)
+      pacman:
+        state: absent
+        name:
+          - '{{url_pkg_url}}'
+      check_mode: True
+      register: uninstall_1c
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Uninstall packages - mixed sources
       pacman:
@@ -126,16 +157,28 @@
           - '{{file_pkg_path}}'
       register: uninstall_3
 
+    - name: Uninstall package - url (idempotency, cached)
+      pacman:
+        state: absent
+        name:
+          - '{{url_pkg_url}}'
+      register: uninstall_3c
+
     - assert:
         that:
           - install_1 is changed
           - install_1.msg == 'Would have installed 3 packages'
           - install_1.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
+          - install_1c is changed
+          - install_1c.msg == 'Would have installed 3 packages'
+          - install_1c.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
           - install_2 is changed
           - install_2.msg == 'Installed 3 package(s)'
           - install_2.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
           - install_3 is not changed
           - install_3.msg == 'package(s) already installed'
+          - install_3c is not changed
+          - install_3c.msg == 'package(s) already installed'
           - install_4 is not changed
           - install_4.msg == 'package(s) already installed'
           - install_5 is changed
@@ -149,3 +192,5 @@
           - uninstall_2.packages | length() == 3
           - uninstall_3 is not changed
           - uninstall_3.msg == 'package(s) already absent'
+          - uninstall_3c is not changed
+          - uninstall_3c.msg == 'package(s) already absent'

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -1,10 +1,11 @@
 ---
 - vars:
+    port: 8000
     reg_pkg: ed
     url_pkg: lemon
     url_pkg_filename: url.pkg.zst
     url_pkg_path: '/tmp/{{url_pkg_filename}}'
-    url_pkg_url: 'http://127.0.0.1:8080/{{url_pkg_filename}}'
+    url_pkg_url: 'http://127.0.0.1:{{port}}/{{url_pkg_filename}}'
     file_pkg: hdparm
     file_pkg_path: /tmp/file.pkg.zst
     extra_pkg: core/sdparm
@@ -29,7 +30,7 @@
         dest: '{{url_pkg_path}}'
     - name: Host {{url_pkg}}
       shell:
-        cmd: python -m http.server --directory /tmp/ 8080 &
+        cmd: 'python -m http.server --directory /tmp/ {{port}} &'
 
     - name: Get URL for {{file_pkg}}
       command:

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -56,6 +56,10 @@
           - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: install_2
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Install packages from mixed sources - (idempotency)
       pacman:
@@ -72,6 +76,10 @@
           - '{{url_pkg}}'
           - '{{file_pkg}}'
       register: install_4
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Install new package with already installed packages from mixed sources
       pacman:
@@ -81,6 +89,10 @@
           - '{{file_pkg_path}}'
           - '{{extra_pkg}}'
       register: install_5
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Uninstall packages - mixed sources (check mode)
       pacman:
@@ -100,6 +112,10 @@
           - '{{url_pkg_url}}'
           - '{{file_pkg_path}}'
       register: uninstall_2
+    - name: Delete cached {{url_pkg}}
+      file:
+        path: '{{url_pkg_filename}}'
+        state: absent
 
     - name: Uninstall packages - mixed sources (idempotency)
       pacman:

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -1,11 +1,11 @@
 ---
 - vars:
-    port: 53280
+    http_port: 27617
     reg_pkg: ed
     url_pkg: lemon
     url_pkg_filename: url.pkg.zst
     url_pkg_path: '/tmp/{{url_pkg_filename}}'
-    url_pkg_url: 'http://127.0.0.1:{{port}}/{{url_pkg_filename}}'
+    url_pkg_url: 'http://127.0.0.1:{{http_port}}/{{url_pkg_filename}}'
     file_pkg: hdparm
     file_pkg_path: /tmp/file.pkg.zst
     extra_pkg: core/sdparm
@@ -30,7 +30,7 @@
         dest: '{{url_pkg_path}}'
     - name: Host {{url_pkg}}
       shell:
-        cmd: 'python -m http.server --directory /tmp/ {{port}} &'
+        cmd: 'python -m http.server --directory /tmp/ {{http_port}} &'
 
     - name: Get URL for {{file_pkg}}
       command:

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -201,6 +201,9 @@
           - uninstall_1 is changed
           - uninstall_1.msg == 'Would have removed 3 packages'
           - uninstall_1.packages | length() == 3  # pkgs have versions here
+          - uninstall_1c is changed
+          - uninstall_1c.msg == 'Would have removed 3 packages'
+          - uninstall_1c.packages | length() == 1  # pkgs have versions here
           - uninstall_2 is changed
           - uninstall_2.msg == 'Removed 3 package(s)'
           - uninstall_2.packages | length() == 3

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -28,6 +28,10 @@
       get_url:
         url: '{{url_pkg_stdout.stdout}}'
         dest: '{{url_pkg_path}}'
+    - name: Download {{url_pkg}} pkg sig
+      get_url:
+        url: '{{url_pkg_stdout.stdout}}.sig'
+        dest: '{{url_pkg_path}}.sig'
     - name: Host {{url_pkg}}
       shell:
         cmd: 'python -m http.server --directory /tmp/ {{http_port}} &'

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -19,6 +19,10 @@
           - '{{file_pkg}}'
           - '{{extra_pkg}}'
         state: absent
+    - name: Make sure that url package is not cached
+      file:
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
+        state: absent
 
     - name: Get URL for {{url_pkg}}
       command:
@@ -67,7 +71,7 @@
       register: install_1c
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Install packages from mixed sources
@@ -79,7 +83,7 @@
       register: install_2
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Install packages from mixed sources - (idempotency)
@@ -96,7 +100,7 @@
       register: install_3c
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Install packages with their regular names (idempotency)
@@ -108,7 +112,7 @@
       register: install_4
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Install new package with already installed packages from mixed sources
@@ -121,7 +125,7 @@
       register: install_5
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Uninstall packages - mixed sources (check mode)
@@ -142,7 +146,7 @@
       register: uninstall_1c
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Uninstall packages - mixed sources
@@ -155,7 +159,7 @@
       register: uninstall_2
     - name: Delete cached {{url_pkg}}
       file:
-        path: '{{url_pkg_filename}}'
+        path: '/var/cache/pacman/pkg/{{url_pkg_filename}}'
         state: absent
 
     - name: Uninstall packages - mixed sources (idempotency)

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -107,7 +107,7 @@
           - install_1.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
           - install_2 is changed
           - install_2.msg == 'Installed 3 package(s)'
-          - install_1.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
+          - install_2.packages|sort() == [reg_pkg, url_pkg, file_pkg]|sort()
           - install_3 is not changed
           - install_3.msg == 'package(s) already installed'
           - install_4 is not changed

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -31,7 +31,7 @@
     - name: Download {{url_pkg}} pkg sig
       get_url:
         url: '{{url_pkg_stdout.stdout}}.sig'
-        dest: '{{url_pkg_path}}.sig'
+        dest: '{{url_pkg_path}}/{{url_pkg_filename}}.sig'
     - name: Host {{url_pkg}}
       shell:
         cmd: 'python -m http.server --directory {{url_pkg_path}} {{http_port}} >/dev/null 2>&1 &'

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -6,7 +6,7 @@
     url_pkg_path: '/tmp/{{url_pkg_filename}}'
     url_pkg_url: 'http://127.0.0.1/{{url_pkg_filename}}'
     file_pkg: hdparm
-    file_pkg_path: /tmp/pkg.zst
+    file_pkg_path: /tmp/file.pkg.zst
     extra_pkg: core/sdparm
     extra_pkg_outfmt: sdparm
   block:

--- a/tests/integration/targets/pacman/tasks/package_urls.yml
+++ b/tests/integration/targets/pacman/tasks/package_urls.yml
@@ -4,7 +4,7 @@
     url_pkg: lemon
     url_pkg_filename: url.pkg.zst
     url_pkg_path: '/tmp/{{url_pkg_filename}}'
-    url_pkg_url: 'http://127.0.0.1/{{url_pkg_filename}}'
+    url_pkg_url: 'http://127.0.0.1:8080/{{url_pkg_filename}}'
     file_pkg: hdparm
     file_pkg_path: /tmp/file.pkg.zst
     extra_pkg: core/sdparm
@@ -29,7 +29,7 @@
         dest: '{{url_pkg_path}}'
     - name: Host {{url_pkg}}
       shell:
-        cmd: python -m http.server --directory /tmp/ 80 &
+        cmd: python -m http.server --directory /tmp/ 8080 &
 
     - name: Get URL for {{file_pkg}}
       command:


### PR DESCRIPTION
##### SUMMARY
This PR improves the integrity test for url packages.
It requests the url from pacman and hosts the package itself, which produces additional output. Furthermore this PR adds some tests for cases when the package url is already cached. In the other cases, the cached package must be deleted before the next test runs.

##### ISSUE TYPE
Bugfix Pull Request
Feature Pull Request

##### COMPONENT NAME
pacman