### PR TITLE
Introduce dig lookup argument fail_on_error

### DIFF
--- a/changelogs/fragments/4973-introduce-dig-lookup-argument.yaml
+++ b/changelogs/fragments/4973-introduce-dig-lookup-argument.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dig lookup plugin - add option ``fail_on_error`` to allow stopping execution on lookup failures (https://github.com/ansible-collections/community.general/pull/4973).


### PR DESCRIPTION
with default False for backwards compatibility.

Allows fail-fast behavior on lookup failures instead of returning strings and continuing.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I would like the dig lookup to offer the option to fail on lookup errors. Right now it just returns empty strings or something like 'NXDOMAIN' as string which is ugly because you notice quite late that something is wrong with your infrastructure because a dig lookup in some config template produced an unexpected result although your playbook run was clean.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dig lookup plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
IMHO this should be the default, but for backwards compatibility I've disabled it.