### PR TITLE
xfconf and xfconf_info: use do_raise

### DIFF
--- a/changelogs/fragments/4975-xfconf-use-do-raise.yaml
+++ b/changelogs/fragments/4975-xfconf-use-do-raise.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - xfconf - use ``do_raise()`` instead of defining custom exception class (https://github.com/ansible-collections/community.general/pull/4975).
+  - xfconf_info - use ``do_raise()`` instead of defining custom exception class (https://github.com/ansible-collections/community.general/pull/4975).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -149,10 +149,6 @@ from ansible_collections.community.general.plugins.module_utils.module_helper im
 from ansible_collections.community.general.plugins.module_utils.xfconf import xfconf_runner
 
 
-class XFConfException(Exception):
-    pass
-
-
 class XFConfProperty(StateModuleHelper):
     change_params = 'value',
     diff_params = 'value',
@@ -198,7 +194,7 @@ class XFConfProperty(StateModuleHelper):
         if err.rstrip() == self.does_not:
             return None
         if rc or len(err):
-            raise XFConfException('xfconf-query failed with error (rc={0}): {1}'.format(rc, err))
+            self.do_raise('xfconf-query failed with error (rc={0}): {1}'.format(rc, err))
 
         result = out.rstrip()
         if "Value is an array with" in result:
@@ -231,7 +227,7 @@ class XFConfProperty(StateModuleHelper):
             value_type = value_type * values_len
         elif types_len != values_len:
             # or complain if lists' lengths are different
-            raise XFConfException('Number of elements in "value" and "value_type" must be the same')
+            self.do_raise('Number of elements in "value" and "value_type" must be the same')
 
         # calculates if it is an array
         self.vars.is_array = \

--- a/plugins/modules/system/xfconf_info.py
+++ b/plugins/modules/system/xfconf_info.py
@@ -120,10 +120,6 @@ from ansible_collections.community.general.plugins.module_utils.module_helper im
 from ansible_collections.community.general.plugins.module_utils.xfconf import xfconf_runner
 
 
-class XFConfException(Exception):
-    pass
-
-
 class XFConfInfo(ModuleHelper):
     module = dict(
         argument_spec=dict(

--- a/plugins/modules/system/xfconf_info.py
+++ b/plugins/modules/system/xfconf_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 module: xfconf_info
 author:
-    - "Alexei Znamensky (@russoz)"
+  - "Alexei Znamensky (@russoz)"
 short_description: Retrieve XFCE4 configurations
 version_added: 3.5.0
 description:
@@ -61,8 +61,8 @@ EXAMPLES = """
 RETURN = '''
   channels:
     description:
-        - List of available channels.
-        - Returned when the module receives no parameter at all.
+      - List of available channels.
+      - Returned when the module receives no parameter at all.
     returned: success
     type: list
     elements: str
@@ -73,47 +73,47 @@ RETURN = '''
     - xfwm4
   properties:
     description:
-        - List of available properties for a specific channel.
-        - Returned by passing only the I(channel) parameter to the module.
+      - List of available properties for a specific channel.
+      - Returned by passing only the I(channel) parameter to the module.
     returned: success
     type: list
     elements: str
     sample:
-        - /Gdk/WindowScalingFactor
-        - /Gtk/ButtonImages
-        - /Gtk/CursorThemeSize
-        - /Gtk/DecorationLayout
-        - /Gtk/FontName
-        - /Gtk/MenuImages
-        - /Gtk/MonospaceFontName
-        - /Net/DoubleClickTime
-        - /Net/IconThemeName
-        - /Net/ThemeName
-        - /Xft/Antialias
-        - /Xft/Hinting
-        - /Xft/HintStyle
-        - /Xft/RGBA
+      - /Gdk/WindowScalingFactor
+      - /Gtk/ButtonImages
+      - /Gtk/CursorThemeSize
+      - /Gtk/DecorationLayout
+      - /Gtk/FontName
+      - /Gtk/MenuImages
+      - /Gtk/MonospaceFontName
+      - /Net/DoubleClickTime
+      - /Net/IconThemeName
+      - /Net/ThemeName
+      - /Xft/Antialias
+      - /Xft/Hinting
+      - /Xft/HintStyle
+      - /Xft/RGBA
   is_array:
     description:
-    - Flag indicating whether the property is an array or not.
+      - Flag indicating whether the property is an array or not.
     returned: success
     type: bool
   value:
     description:
-    - The value of the property. Empty if the property is of array type.
+      - The value of the property. Empty if the property is of array type.
     returned: success
     type: str
     sample: Monospace 10
   value_array:
     description:
-    - The array value of the property. Empty if the property is not of array type.
+      - The array value of the property. Empty if the property is not of array type.
     returned: success
     type: list
     elements: str
     sample:
-    - Main
-    - Work
-    - Tmp
+      - Main
+      - Work
+      - Tmp
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import ModuleHelper
@@ -166,8 +166,10 @@ class XFConfInfo(ModuleHelper):
         elif self.vars.property is None:
             output = 'properties'
             proc = self._process_list_properties
+
         with self.runner.context('list_arg channel property', output_process=proc) as ctx:
             result = ctx.run(**self.vars)
+
         if not self.vars.list_arg and self.vars.is_array:
             output = "value_array"
         self.vars.set(output, result)


### PR DESCRIPTION
##### SUMMARY
Make both xfconf related modules use the `do_raise()` method of MH instead of defining custom exceptions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/xfconf.py
plugins/modules/system/xfconf_info.py
