### PR TITLE
Apk: add support for a custom world file

### DIFF
--- a/changelogs/fragments/4976-apk-add-support-for-a-custom-world-file.yaml
+++ b/changelogs/fragments/4976-apk-add-support-for-a-custom-world-file.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apk - add ``world`` parameter for supporting a custom world file (https://github.com/ansible-collections/community.general/pull/4976).


### PR DESCRIPTION
##### SUMMARY
This adds a new `world` parameter to the apk packaging module. This helps remove the hardcoded `/etc/apk/world` and therefore allows usage on more complex/non-standard linux systems with the `apk` package manager.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Apk custom world parameter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A