### PR TITLE
python-daemon 2.3.1 requires Python 3+

### DIFF
--- a/tests/integration/targets/monit/meta/main.yml
+++ b/tests/integration/targets/monit/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - setup_pkg_mgr
+  - setup_remote_constraints

--- a/tests/integration/targets/monit/tasks/main.yml
+++ b/tests/integration/targets/monit/tasks/main.yml
@@ -62,6 +62,7 @@
     pip:
       name: "{{ item }}"
       virtualenv: "{{ process_venv }}"
+      extra_args: "-c {{ remote_constraints }}"
     loop:
       - setuptools==44
       - python-daemon

--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -50,6 +50,7 @@ redis == 2.10.6 ; python_version < '2.7'
 redis < 4.0.0 ; python_version >= '2.7' and python_version < '3.6'
 redis ; python_version >= '3.6'
 pycdlib < 1.13.0 ; python_version < '3'  # 1.13.0 does not work with Python 2, while not declaring that
+python-daemon <= 2.3.0 ; python_version < '3'
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
Fix nightly CI errors.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
monit
