### PR TITLE
Temporarily disable the yum_versionlock tests

### DIFF
--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -4,3 +4,4 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/rhel8.4  # TODO make sure that tests work on 8.4 as well!
+disabled  # TODO


### PR DESCRIPTION
##### SUMMARY
They have been failing on CentOS 8 Stream for some days now, see for example https://dev.azure.com/ansible/community.general/_build/results?buildId=48811&view=logs&j=48a38357-c733-5270-bc9f-8b347073680c&t=f738d932-52a6-55f4-0339-9d2c3f71394b&l=7479

It seems that for some reason some packages exist multiple times (like `curl`, see the package facts) and the module only locks one of them, so the other one can still be upgraded. Someone who knows more about yum will have to debug this and determine whether this is a bug in the tests, a bug in the module, or both.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
yum_versionlock
