### PR TITLE
consul: add support for session TTL

### DIFF
--- a/changelogs/fragments/4996-consul-session-ttl.yml
+++ b/changelogs/fragments/4996-consul-session-ttl.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - consul - adds ``ttl`` parameter for session  (https://github.com/ansible-collections/community.general/pull/4996).

--- a/plugins/modules/clustering/consul/consul_session.py
+++ b/plugins/modules/clustering/consul/consul_session.py
@@ -95,6 +95,11 @@ options:
         choices: [ delete, release ]
         type: str
         default: release
+    ttl:
+        description:
+          - Specifies the duration of a session in seconds (between 10 and 86400).
+        type: int
+        version_added: 5.4.0
 '''
 
 EXAMPLES = '''
@@ -121,6 +126,11 @@ EXAMPLES = '''
 - name: Retrieve active sessions
   community.general.consul_session:
     state: list
+
+- name: Register session with a ttl
+  community.general.consul_session:
+    name: session-with-ttl
+    ttl: 600  # sec
 '''
 
 try:
@@ -185,6 +195,7 @@ def update_session(module):
     datacenter = module.params.get('datacenter')
     node = module.params.get('node')
     behavior = module.params.get('behavior')
+    ttl = module.params.get('ttl')
 
     consul_client = get_consul_api(module)
 
@@ -192,6 +203,7 @@ def update_session(module):
         session = consul_client.session.create(
             name=name,
             behavior=behavior,
+            ttl=ttl,
             node=node,
             lock_delay=delay,
             dc=datacenter,
@@ -201,6 +213,7 @@ def update_session(module):
                          session_id=session,
                          name=name,
                          behavior=behavior,
+                         ttl=ttl,
                          delay=delay,
                          checks=checks,
                          node=node)
@@ -241,6 +254,7 @@ def main():
         checks=dict(type='list', elements='str'),
         delay=dict(type='int', default='15'),
         behavior=dict(type='str', default='release', choices=['release', 'delete']),
+        ttl=dict(type='int'),
         host=dict(type='str', default='localhost'),
         port=dict(type='int', default=8500),
         scheme=dict(type='str', default='http'),

--- a/tests/integration/targets/consul/tasks/consul_session.yml
+++ b/tests/integration/targets/consul/tasks/consul_session.yml
@@ -158,3 +158,15 @@
     that:
       - search_deleted is skipped  # each iteration is skipped
       - search_deleted is not changed  # and then unchanged
+
+- name: ensure session can be created with a ttl
+  consul_session:
+    state: present
+    name: session-with-ttl
+    ttl: 180  # sec
+  register: result
+
+- assert:
+    that:
+      - result is changed
+      - result['ttl'] == 180


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This pull request add the possibility to set a TTL when creating a session.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
consul_session

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Consul  API: https://www.consul.io/api-docs/session#ttl
- Python consul lib already support this parameter: https://python-consul.readthedocs.io/en/latest/#consul-session

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without the PR it is not possible to set a TTL on a session.
Here is a test playbook
```yaml
- name: test module
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Register basic session with consul
      community.general.consul_session:
        name: session-with-ttl
        # ttl: 180  # sec
    - name: Retrieve active sessions
      community.general.consul_session:
        state: list
```
The output of the run is the following where we can see the `TTL` key is an empty string where we cannot pass anything.
```
❯ ansible-playbook test.yaml

PLAY [test module] *************************************************************************************************************************************************************************************************************************************************************

TASK [Register basic session with consul] **************************************************************************************************************************************************************************************************************************************
changed: [localhost] => {
    "behavior": "release",
    "changed": true,
    "checks": null,
    "delay": 15,
    "invocation": { <-- we cannot invoke the module with ttl key
        "module_args": {
            "behavior": "release",
            "checks": null,
            "datacenter": null,
            "delay": 15,
            "host": "localhost",
            "id": null,
            "name": "session-with-ttl",
            "node": null,
            "port": 8500,
            "scheme": "http",
            "state": "present",
            "validate_certs": true
        }
    },
    "name": "session-with-ttl",
    "node": null,
    "session_id": "2a0919ce-3026-2a34-db91-ffa20e907aa7"
}

TASK [Retrieve active sessions] ************************************************************************************************************************************************************************************************************************************************
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "behavior": "release",
            "checks": null,
            "datacenter": null,
            "delay": 15,
            "host": "localhost",
            "id": null,
            "name": null,
            "node": null,
            "port": 8500,
            "scheme": "http",
            "state": "list",
            "validate_certs": true
        }
    },
    "sessions": [
        {
            "Behavior": "release",
            "CreateIndex": 29,
            "ID": "2a0919ce-3026-2a34-db91-ffa20e907aa7",
            "LockDelay": 15000000000,
            "ModifyIndex": 29,
            "Name": "session-with-ttl",
            "Node": "server-1",
            "NodeChecks": [
                "serfHealth"
            ],
            "ServiceChecks": null,
            "TTL": ""
        },
        {
            "Behavior": "release",
            "CreateIndex": 9,
            "ID": "93d59352-8a33-1743-7f16-b7353a615ca7",
            "LockDelay": 15000000000,
            "ModifyIndex": 9,
            "Name": "session-with-ttl",
            "Node": "server-1",
            "NodeChecks": [
                "serfHealth"
            ],
            "ServiceChecks": null,
            "TTL": ""
        },
        {
            "Behavior": "release",
            "CreateIndex": 22,
            "ID": "ea87c387-edb6-2eb6-10fd-d01eca97fe17",
            "LockDelay": 15000000000,
            "ModifyIndex": 22,
            "Name": "session-with-ttl",
            "Node": "server-1",
            "NodeChecks": [
                "serfHealth"
            ],
            "ServiceChecks": null,
            "TTL": "" <-- TTL is empty as expected
        }
    ]
}
PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

With the `ttl` key in the playbook above uncommented we have the following behavior where we can see the `TTL` key is not an empty string and have the value `180s`.
```
❯ ansible-playbook test.yaml

PLAY [test module] *************************************************************************************************************************************************************************************************************************************************************

TASK [Register basic session with consul] **************************************************************************************************************************************************************************************************************************************
changed: [localhost] => {
    "behavior": "release",
    "changed": true,
    "checks": null,
    "delay": 15,
    "invocation": {
        "module_args": {
            "behavior": "release",
            "checks": null,
            "datacenter": null,
            "delay": 15,
            "host": "localhost",
            "id": null,
            "name": "session-with-ttl",
            "node": null,
            "port": 8500,
            "scheme": "http",
            "state": "present",
            "ttl": 180, <-- we can invoke the module with ttl
            "validate_certs": true
        }
    },
    "name": "session-with-ttl",
    "node": null,
    "session_id": "f9cf72ce-a1f4-a38b-0385-3ce8515d3a0a",
    "ttl": 180
}

TASK [Retrieve active sessions] ************************************************************************************************************************************************************************************************************************************************
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "behavior": "release",
            "checks": null,
            "datacenter": null,
            "delay": 15,
            "host": "localhost",
            "id": null,
            "name": null,
            "node": null,
            "port": 8500,
            "scheme": "http",
            "state": "list",
            "ttl": null,
            "validate_certs": true
        }
    },
    "sessions": [
        {
            "Behavior": "release",
            "CreateIndex": 9,
            "ID": "93d59352-8a33-1743-7f16-b7353a615ca7",
            "LockDelay": 15000000000,
            "ModifyIndex": 9,
            "Name": "session-with-ttl",
            "Node": "server-1",
            "NodeChecks": [
                "serfHealth"
            ],
            "ServiceChecks": null,
            "TTL": ""
        },
        {
            "Behavior": "release",
            "CreateIndex": 14,
            "ID": "f9cf72ce-a1f4-a38b-0385-3ce8515d3a0a",
            "LockDelay": 15000000000,
            "ModifyIndex": 14,
            "Name": "session-with-ttl",
            "Node": "server-1",
            "NodeChecks": [
                "serfHealth"
            ],
            "ServiceChecks": null,
            "TTL": "180s" <-- the ttl is correctly applied and visible via consul api
        }
    ]
}

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```