### PR TITLE
Slack: Add support for (some) groups

### DIFF
--- a/changelogs/fragments/5019-slack-support-more-groups.yml
+++ b/changelogs/fragments/5019-slack-support-more-groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - slack - fix incorrect channel prefix `#` caused by incomplete pattern detection by adding `G0` and `GF` as channel id patterns (https://github.com/ansible-collections/community.general/pull/5019)

--- a/changelogs/fragments/5019-slack-support-more-groups.yml
+++ b/changelogs/fragments/5019-slack-support-more-groups.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - slack - fix incorrect channel prefix `#` caused by incomplete pattern detection by adding `G0` and `GF` as channel id patterns (https://github.com/ansible-collections/community.general/pull/5019)
+  - slack - fix incorrect channel prefix ``#`` caused by incomplete pattern detection by adding ``G0`` and ``GF`` as channel ID patterns (https://github.com/ansible-collections/community.general/pull/5019).

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -293,7 +293,7 @@ def build_payload_for_slack(text, channel, thread_id, username, icon_url, icon_e
         # With a custom color we have to set the message as attachment, and explicitly turn markdown parsing on for it.
         payload = dict(attachments=[dict(text=escape_quotes(text), color=color, mrkdwn_in=["text"])])
     if channel is not None:
-        if channel.startswith(('#', '@', 'C0')):
+        if channel.startswith(('#', '@', 'C0', 'GF', 'G0')):
             payload['channel'] = channel
         else:
             payload['channel'] = '#' + channel


### PR DESCRIPTION
##### SUMMARY
Some of the older private channels in the workspace I'm working in have channel ID's starting with `G0` and `GF` and this resulted to false positive `channel_not_found` errors.
I've added these prefixes to the list to maintain as much backwards compatibility as possible.

Ideally the auto-prefix of the channel name with `#` is dropped entirely, given the Channel ID's have become more dominant in the Slack API over the past years.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Slack notification module

##### ADDITIONAL INFORMATION

This ansible task will trigger the "channel_not_found" error, because this module erroneously prefixes the channel id with `#`:

```ansible
- name: Send a message to slack
  community.general.slack:
    token: "{{ slack_token }}"
    channel: GF123456
    msg: my-message
```