### PR TITLE
Fix returnall and directory avoidance for gopass

### DIFF
--- a/changelogs/fragments/5020-fix-returnall-and-directory-avoidance-for-gopass.yaml
+++ b/changelogs/fragments/5020-fix-returnall-and-directory-avoidance-for-gopass.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - passwordstore - fix returnall and directory avoidance for gopass (https://github.com/ansible-collections/community.general/pull/5020).

--- a/changelogs/fragments/5020-fix-returnall-and-directory-avoidance-for-gopass.yaml
+++ b/changelogs/fragments/5020-fix-returnall-and-directory-avoidance-for-gopass.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - passwordstore - fix returnall and directory avoidance for gopass (https://github.com/ansible-collections/community.general/pull/5020).
+  - passwordstore lookup plugin - fix ``returnall`` and directory avoidance for gopass (https://github.com/ansible-collections/community.general/pull/5020).

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -347,7 +347,7 @@ class LookupModule(LookupBase):
                         self.passdict[name.strip()] = value.strip()
             if (os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg"))
                 or not (self.backend == 'gopass' or self.is_real_pass())):
-                # Only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
+                # In pass and gopass, only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
                 return True
         except (subprocess.CalledProcessError) as e:
             # 'not in password store' is the expected error if a password wasn't found

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -331,7 +331,6 @@ class LookupModule(LookupBase):
         try:
             self.passoutput = to_text(
                 check_output2([self.pass_cmd, 'show'] +
-                              (['--password'] if self.backend == 'gopass' else []) +
                               [self.passname], env=self.env),
                 errors='surrogate_or_strict'
             ).splitlines()

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -345,10 +345,8 @@ class LookupModule(LookupBase):
                     if ':' in line:
                         name, value = line.split(':', 1)
                         self.passdict[name.strip()] = value.strip()
-            if (self.backend == 'gopass' or
-                    os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg"))
-                    or not self.is_real_pass()):
-                # When using real pass, only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
+            if (os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg"))):
+                # Only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
                 return True
         except (subprocess.CalledProcessError) as e:
             # 'not in password store' is the expected error if a password wasn't found

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -345,7 +345,7 @@ class LookupModule(LookupBase):
                     if ':' in line:
                         name, value = line.split(':', 1)
                         self.passdict[name.strip()] = value.strip()
-            if (os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg"))):
+            if os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg")):
                 # Only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
                 return True
         except (subprocess.CalledProcessError) as e:

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -345,7 +345,8 @@ class LookupModule(LookupBase):
                     if ':' in line:
                         name, value = line.split(':', 1)
                         self.passdict[name.strip()] = value.strip()
-            if os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg")):
+            if (os.path.isfile(os.path.join(self.paramvals['directory'], self.passname + ".gpg"))
+                or not (self.backend == 'gopass' or self.is_real_pass())):
                 # Only accept password as found if there is a .gpg file for it (might be a tree node otherwise)
                 return True
         except (subprocess.CalledProcessError) as e:

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -261,11 +261,11 @@ class LookupModule(LookupBase):
     def is_real_pass(self):
         if self.realpass is None:
             try:
-                self.passoutput = to_text(
+                passoutput = to_text(
                     check_output2([self.pass_cmd, "--version"], env=self.env),
                     errors='surrogate_or_strict'
                 )
-                self.realpass = 'pass: the standard unix password manager' in self.passoutput
+                self.realpass = 'pass: the standard unix password manager' in passoutput
             except (subprocess.CalledProcessError) as e:
                 raise AnsibleError(e)
 

--- a/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -318,9 +318,6 @@
         if [ "$1" = "--version" ]; then
           exit 2
         fi
-        if [ "$1" = "show" ] && [ "$2" != "--password" ]; then
-          exit 3
-        fi
         echo "gopass_ok"
       dest: "{{ gopasspath }}"
       mode: '0755'


### PR DESCRIPTION
##### SUMMARY
Gopass was always given the --password flag, despite there being no need for this. Therefore, it only ever returned the first line, breaking returnall.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
passwordstore

##### ADDITIONAL INFORMATION
Create a multi-line password in gopass
```
echo -e "Multi\\nline\\ntest" | gopass insert test
```

Run the following playbook:
```
---
- hosts: localhost
  tasks:
    - name: Print only first line
      ansible.builtin.debug:
        msg: "{{ lookup('community.general.passwordstore', 'test', backend='gopass') }}"
    - name: Print all lines
      ansible.builtin.debug:
        msg: "{{ lookup('community.general.passwordstore', 'test returnall=true', backend='gopass') }}"
```

Before patch:
```
❯ ansible-playbook playbook.yml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Print only first line] ***************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Multi"
}

TASK [Print all lines] *********************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Multi"
}

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

After patch:
```
❯ ansible-playbook playbook.yml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *****************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [Print only first line] *****************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Multi"
}

TASK [Print all lines] ***********************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Multi\nline\ntest"
}

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```