### PR TITLE
Fix #3320: lvreduce should be called without pvs

### DIFF
--- a/changelogs/fragments/3320-lvol-lvreduce.yaml
+++ b/changelogs/fragments/3320-lvol-lvreduce.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - Remove pvs from argument list of lvreduce. (https://github.com/ansible-collections/community.general/issues/3320).


### PR DESCRIPTION

##### SUMMARY
Fix #3320

lvreduce does not require pv as input, and will produce error like "Command does not accept argument /dev/sdb1" if pv given.
This fix omit pv for calls to lvreduce but retains pv for calls to lvextend

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol
