### PR TITLE
Fix: Add user-agent header to allow request through WAF with bot protection

### DIFF
--- a/changelogs/fragments/5023-http-agent-param-keycloak.yml
+++ b/changelogs/fragments/5023-http-agent-param-keycloak.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module utils keycloak - add http_agent parameter and default its value `Ansible` (https://github.com/ansible-collections/community.general/issues/5023).
+  - keycloak_* modules - add ``http_agent`` parameter with default value ``Ansible`` (https://github.com/ansible-collections/community.general/issues/5023).

--- a/changelogs/fragments/5023-http-agent-param-keycloak.yml
+++ b/changelogs/fragments/5023-http-agent-param-keycloak.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module utils keycloak - add http_agent parameter and default its value `Ansible` (https://github.com/ansible-collections/community.general/issues/5023).

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -68,4 +68,9 @@ options:
         type: int
         default: 10
         version_added: 4.5.0
+    http_agent:
+        description:
+            - Configures the HTTP User-Agent Header
+        type: str
+        default: Ansible
 '''

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -70,7 +70,7 @@ options:
         version_added: 4.5.0
     http_agent:
         description:
-            - Configures the HTTP User-Agent Header
+            - Configures the HTTP User-Agent header.
         type: str
         default: Ansible
         version_added: 5.4.0

--- a/plugins/doc_fragments/keycloak.py
+++ b/plugins/doc_fragments/keycloak.py
@@ -73,4 +73,5 @@ options:
             - Configures the HTTP User-Agent Header
         type: str
         default: Ansible
+        version_added: 5.4.0
 '''

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -124,6 +124,7 @@ def get_token(module_params):
     """
     token = module_params.get('token')
     base_url = module_params.get('auth_keycloak_url')
+    http_agent = module_params.get('http_agent')
 
     if not base_url.lower().startswith(('http', 'https')):
         raise KeycloakError("auth_url '%s' should either start with 'http' or 'https'." % base_url)
@@ -138,7 +139,7 @@ def get_token(module_params):
         client_secret = module_params.get('auth_client_secret')
         connection_timeout = module_params.get('connection_timeout')
         auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
-        http_agent = module_params.get('http_agent')
+        
         temp_payload = {
             'grant_type': 'password',
             'client_id': client_id,

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -139,7 +139,6 @@ def get_token(module_params):
         client_secret = module_params.get('auth_client_secret')
         connection_timeout = module_params.get('connection_timeout')
         auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
-        
         temp_payload = {
             'grant_type': 'password',
             'client_id': client_id,
@@ -247,7 +246,8 @@ class KeycloakAPI(object):
         realm_info_url = URL_REALM_INFO.format(url=self.baseurl, realm=realm)
 
         try:
-            return json.loads(to_native(open_url(realm_info_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(realm_info_url, method='GET', http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -344,7 +344,8 @@ class KeycloakAPI(object):
             clientlist_url += '?clientId=%s' % filter
 
         try:
-            return json.loads(to_native(open_url(clientlist_url, http_agent=self.http_agent, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientlist_url, http_agent=self.http_agent, method='GET', headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of clients for realm %s: %s'
@@ -375,7 +376,8 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return json.loads(to_native(open_url(client_url, method='GET',  http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_url, method='GET', http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -460,7 +462,8 @@ class KeycloakAPI(object):
         """
         client_roles_url = URL_CLIENT_ROLES.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(client_roles_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_roles_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch rolemappings for client %s in realm %s: %s"
@@ -492,7 +495,8 @@ class KeycloakAPI(object):
         """
         rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                         timeout=self.connection_timeout,
                                                          validate_certs=self.validate_certs).read()))
             for role in rolemappings:
                 if rid == role['id']:
@@ -512,7 +516,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
@@ -528,7 +533,8 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
@@ -690,7 +696,8 @@ class KeycloakAPI(object):
         """
         clientscopes_url = URL_CLIENTSCOPES.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(clientscopes_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientscopes_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of clientscopes in realm %s: %s"
@@ -707,7 +714,8 @@ class KeycloakAPI(object):
         """
         clientscope_url = URL_CLIENTSCOPE.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(clientscope_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientscope_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -823,7 +831,8 @@ class KeycloakAPI(object):
         """
         protocolmappers_url = URL_CLIENTSCOPE_PROTOCOLMAPPERS.format(id=cid, url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(protocolmappers_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(protocolmappers_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of protocolmappers in realm %s: %s"
@@ -842,7 +851,8 @@ class KeycloakAPI(object):
         """
         protocolmapper_url = URL_CLIENTSCOPE_PROTOCOLMAPPER.format(url=self.baseurl, realm=realm, id=cid, mapper_id=pid)
         try:
-            return json.loads(to_native(open_url(protocolmapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(protocolmapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -922,7 +932,8 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of groups in realm %s: %s"
@@ -939,7 +950,8 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=gid)
         try:
-            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -1050,7 +1062,8 @@ class KeycloakAPI(object):
         """
         rolelist_url = URL_REALM_ROLES.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of roles for realm %s: %s'
@@ -1135,7 +1148,8 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         rolelist_url = URL_CLIENT_ROLES.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of roles for client %s in realm %s: %s'
@@ -1241,7 +1255,8 @@ class KeycloakAPI(object):
             authentication_flow = {}
             # Check if the authentication flow exists on the Keycloak serveraders
             authentications = json.load(open_url(URL_AUTHENTICATION_FLOWS.format(url=self.baseurl, realm=realm), method='GET',
-                                                 http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout, validate_certs=self.validate_certs))
+                                                 http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout, validate_certs=self.validate_certs))
             for authentication in authentications:
                 if authentication["alias"] == alias:
                     authentication_flow = authentication
@@ -1591,7 +1606,8 @@ class KeycloakAPI(object):
         """
         mappers_url = URL_IDENTITY_PROVIDER_MAPPERS.format(url=self.baseurl, realm=realm, alias=alias)
         try:
-            return json.loads(to_native(open_url(mappers_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(mappers_url, method='GET', http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of identity provider mappers for idp %s in realm %s: %s'
@@ -1609,7 +1625,8 @@ class KeycloakAPI(object):
         """
         mapper_url = URL_IDENTITY_PROVIDER_MAPPER.format(url=self.baseurl, realm=realm, alias=alias, id=mid)
         try:
-            return json.loads(to_native(open_url(mapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(mapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders,
+                                                 timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -104,6 +104,7 @@ def keycloak_argument_spec():
         validate_certs=dict(type='bool', default=True),
         connection_timeout=dict(type='int', default=10),
         token=dict(type='str', no_log=True),
+        http_agent=dict(type='str', default='Ansible'),
     )
 
 
@@ -137,6 +138,7 @@ def get_token(module_params):
         client_secret = module_params.get('auth_client_secret')
         connection_timeout = module_params.get('connection_timeout')
         auth_url = URL_TOKEN.format(url=base_url, realm=auth_realm)
+        http_agent = module_params.get('http_agent')
         temp_payload = {
             'grant_type': 'password',
             'client_id': client_id,
@@ -149,7 +151,7 @@ def get_token(module_params):
             (k, v) for k, v in temp_payload.items() if v is not None)
         try:
             r = json.loads(to_native(open_url(auth_url, method='POST',
-                                              validate_certs=validate_certs, timeout=connection_timeout,
+                                              validate_certs=validate_certs, http_agent=http_agent, timeout=connection_timeout,
                                               data=urlencode(payload)).read()))
         except ValueError as e:
             raise KeycloakError(
@@ -166,7 +168,8 @@ def get_token(module_params):
                 'Could not obtain access token from %s' % auth_url)
     return {
         'Authorization': 'Bearer ' + token,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': http_agent,
     }
 
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -169,8 +169,7 @@ def get_token(module_params):
                 'Could not obtain access token from %s' % auth_url)
     return {
         'Authorization': 'Bearer ' + token,
-        'Content-Type': 'application/json',
-        'User-Agent': http_agent,
+        'Content-Type': 'application/json'
     }
 
 
@@ -237,6 +236,7 @@ class KeycloakAPI(object):
         self.validate_certs = self.module.params.get('validate_certs')
         self.connection_timeout = self.module.params.get('connection_timeout')
         self.restheaders = connection_header
+        self.http_agent = self.module.params.get('http_agent')
 
     def get_realm_info_by_id(self, realm='master'):
         """ Obtain realm public info by id
@@ -247,7 +247,7 @@ class KeycloakAPI(object):
         realm_info_url = URL_REALM_INFO.format(url=self.baseurl, realm=realm)
 
         try:
-            return json.loads(to_native(open_url(realm_info_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(realm_info_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -272,7 +272,7 @@ class KeycloakAPI(object):
         realm_url = URL_REALM.format(url=self.baseurl, realm=realm)
 
         try:
-            return json.loads(to_native(open_url(realm_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(realm_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -297,7 +297,7 @@ class KeycloakAPI(object):
         realm_url = URL_REALM.format(url=self.baseurl, realm=realm)
 
         try:
-            return open_url(realm_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(realm_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(realmrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update realm %s: %s' % (realm, str(e)),
@@ -311,7 +311,7 @@ class KeycloakAPI(object):
         realm_url = URL_REALMS.format(url=self.baseurl)
 
         try:
-            return open_url(realm_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(realm_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(realmrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create realm %s: %s' % (realmrep['id'], str(e)),
@@ -326,7 +326,7 @@ class KeycloakAPI(object):
         realm_url = URL_REALM.format(url=self.baseurl, realm=realm)
 
         try:
-            return open_url(realm_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(realm_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not delete realm %s: %s' % (realm, str(e)),
@@ -344,7 +344,7 @@ class KeycloakAPI(object):
             clientlist_url += '?clientId=%s' % filter
 
         try:
-            return json.loads(to_native(open_url(clientlist_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientlist_url, http_agent=self.http_agent, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of clients for realm %s: %s'
@@ -375,7 +375,7 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return json.loads(to_native(open_url(client_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_url, method='GET',  http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -414,7 +414,7 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return open_url(client_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(client_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clientrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update client %s in realm %s: %s'
@@ -429,7 +429,7 @@ class KeycloakAPI(object):
         client_url = URL_CLIENTS.format(url=self.baseurl, realm=realm)
 
         try:
-            return open_url(client_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(client_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clientrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create client %s in realm %s: %s'
@@ -445,7 +445,7 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return open_url(client_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(client_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not delete client %s in realm %s: %s'
@@ -460,7 +460,7 @@ class KeycloakAPI(object):
         """
         client_roles_url = URL_CLIENT_ROLES.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(client_roles_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(client_roles_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch rolemappings for client %s in realm %s: %s"
@@ -492,7 +492,7 @@ class KeycloakAPI(object):
         """
         rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            rolemappings = json.loads(to_native(open_url(rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                          validate_certs=self.validate_certs).read()))
             for role in rolemappings:
                 if rid == role['id']:
@@ -512,7 +512,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_AVAILABLE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
@@ -528,7 +528,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS_COMPOSITE.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(available_rolemappings_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
@@ -545,7 +545,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="POST", headers=self.restheaders, data=json.dumps(role_rep),
+            open_url(available_rolemappings_url, method="POST", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not fetch available rolemappings for client %s in group %s, realm %s: %s"
@@ -562,7 +562,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="DELETE", headers=self.restheaders,
+            open_url(available_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders,
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not delete available rolemappings for client %s in group %s, realm %s: %s"
@@ -577,7 +577,7 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATES.format(url=self.baseurl, realm=realm)
 
         try:
-            return json.loads(to_native(open_url(url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of client templates for realm %s: %s'
@@ -596,7 +596,7 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATE.format(url=self.baseurl, id=id, realm=realm)
 
         try:
-            return json.loads(to_native(open_url(url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain client templates %s for realm %s: %s'
@@ -642,7 +642,7 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATE.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return open_url(url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clienttrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update client template %s in realm %s: %s'
@@ -657,7 +657,7 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATES.format(url=self.baseurl, realm=realm)
 
         try:
-            return open_url(url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clienttrep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create client template %s in realm %s: %s'
@@ -673,7 +673,7 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATE.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return open_url(url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not delete client template %s in realm %s: %s'
@@ -690,7 +690,7 @@ class KeycloakAPI(object):
         """
         clientscopes_url = URL_CLIENTSCOPES.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(clientscopes_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientscopes_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of clientscopes in realm %s: %s"
@@ -707,7 +707,7 @@ class KeycloakAPI(object):
         """
         clientscope_url = URL_CLIENTSCOPE.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(clientscope_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(clientscope_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -752,7 +752,7 @@ class KeycloakAPI(object):
         """
         clientscopes_url = URL_CLIENTSCOPES.format(url=self.baseurl, realm=realm)
         try:
-            return open_url(clientscopes_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(clientscopes_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clientscoperep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg="Could not create clientscope %s in realm %s: %s"
@@ -767,7 +767,7 @@ class KeycloakAPI(object):
         clientscope_url = URL_CLIENTSCOPE.format(url=self.baseurl, realm=realm, id=clientscoperep['id'])
 
         try:
-            return open_url(clientscope_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(clientscope_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(clientscoperep), validate_certs=self.validate_certs)
 
         except Exception as e:
@@ -805,7 +805,7 @@ class KeycloakAPI(object):
         # should have a good cid by here.
         clientscope_url = URL_CLIENTSCOPE.format(realm=realm, id=cid, url=self.baseurl)
         try:
-            return open_url(clientscope_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(clientscope_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
 
         except Exception as e:
@@ -823,7 +823,7 @@ class KeycloakAPI(object):
         """
         protocolmappers_url = URL_CLIENTSCOPE_PROTOCOLMAPPERS.format(id=cid, url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(protocolmappers_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(protocolmappers_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of protocolmappers in realm %s: %s"
@@ -842,7 +842,7 @@ class KeycloakAPI(object):
         """
         protocolmapper_url = URL_CLIENTSCOPE_PROTOCOLMAPPER.format(url=self.baseurl, realm=realm, id=cid, mapper_id=pid)
         try:
-            return json.loads(to_native(open_url(protocolmapper_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(protocolmapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -889,7 +889,7 @@ class KeycloakAPI(object):
         """
         protocolmappers_url = URL_CLIENTSCOPE_PROTOCOLMAPPERS.format(url=self.baseurl, id=cid, realm=realm)
         try:
-            return open_url(protocolmappers_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(protocolmappers_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(mapper_rep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg="Could not create protocolmapper %s in realm %s: %s"
@@ -905,7 +905,7 @@ class KeycloakAPI(object):
         protocolmapper_url = URL_CLIENTSCOPE_PROTOCOLMAPPER.format(url=self.baseurl, realm=realm, id=cid, mapper_id=mapper_rep['id'])
 
         try:
-            return open_url(protocolmapper_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(protocolmapper_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(mapper_rep), validate_certs=self.validate_certs)
 
         except Exception as e:
@@ -922,7 +922,7 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(groups_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of groups in realm %s: %s"
@@ -939,7 +939,7 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=gid)
         try:
-            return json.loads(to_native(open_url(groups_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(groups_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
@@ -985,7 +985,7 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
-            return open_url(groups_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(groups_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(grouprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg="Could not create group %s in realm %s: %s"
@@ -1000,7 +1000,7 @@ class KeycloakAPI(object):
         group_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=grouprep['id'])
 
         try:
-            return open_url(group_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(group_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(grouprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update group %s in realm %s: %s'
@@ -1037,7 +1037,7 @@ class KeycloakAPI(object):
         # should have a good groupid by here.
         group_url = URL_GROUP.format(realm=realm, groupid=groupid, url=self.baseurl)
         try:
-            return open_url(group_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(group_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg="Unable to delete group %s: %s" % (groupid, str(e)))
@@ -1050,7 +1050,7 @@ class KeycloakAPI(object):
         """
         rolelist_url = URL_REALM_ROLES.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(rolelist_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of roles for realm %s: %s'
@@ -1068,7 +1068,7 @@ class KeycloakAPI(object):
         """
         role_url = URL_REALM_ROLE.format(url=self.baseurl, realm=realm, name=quote(name))
         try:
-            return json.loads(to_native(open_url(role_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(role_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:
@@ -1088,7 +1088,7 @@ class KeycloakAPI(object):
         """
         roles_url = URL_REALM_ROLES.format(url=self.baseurl, realm=realm)
         try:
-            return open_url(roles_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(roles_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(rolerep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create role %s in realm %s: %s'
@@ -1102,7 +1102,7 @@ class KeycloakAPI(object):
         """
         role_url = URL_REALM_ROLE.format(url=self.baseurl, realm=realm, name=quote(rolerep['name']))
         try:
-            return open_url(role_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(role_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(rolerep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update role %s in realm %s: %s'
@@ -1116,7 +1116,7 @@ class KeycloakAPI(object):
         """
         role_url = URL_REALM_ROLE.format(url=self.baseurl, realm=realm, name=quote(name))
         try:
-            return open_url(role_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(role_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Unable to delete role %s in realm %s: %s'
@@ -1135,7 +1135,7 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         rolelist_url = URL_CLIENT_ROLES.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(rolelist_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(rolelist_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of roles for client %s in realm %s: %s'
@@ -1159,7 +1159,7 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         role_url = URL_CLIENT_ROLE.format(url=self.baseurl, realm=realm, id=cid, name=quote(name))
         try:
-            return json.loads(to_native(open_url(role_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(role_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:
@@ -1185,7 +1185,7 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         roles_url = URL_CLIENT_ROLES.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return open_url(roles_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(roles_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(rolerep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create role %s for client %s in realm %s: %s'
@@ -1205,7 +1205,7 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         role_url = URL_CLIENT_ROLE.format(url=self.baseurl, realm=realm, id=cid, name=quote(rolerep['name']))
         try:
-            return open_url(role_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(role_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(rolerep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update role %s for client %s in realm %s: %s'
@@ -1224,7 +1224,7 @@ class KeycloakAPI(object):
                                       % (clientid, realm))
         role_url = URL_CLIENT_ROLE.format(url=self.baseurl, realm=realm, id=cid, name=quote(name))
         try:
-            return open_url(role_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(role_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Unable to delete role %s for client %s in realm %s: %s'
@@ -1241,7 +1241,7 @@ class KeycloakAPI(object):
             authentication_flow = {}
             # Check if the authentication flow exists on the Keycloak serveraders
             authentications = json.load(open_url(URL_AUTHENTICATION_FLOWS.format(url=self.baseurl, realm=realm), method='GET',
-                                                 headers=self.restheaders, timeout=self.connection_timeout, validate_certs=self.validate_certs))
+                                                 http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout, validate_certs=self.validate_certs))
             for authentication in authentications:
                 if authentication["alias"] == alias:
                     authentication_flow = authentication
@@ -1260,7 +1260,7 @@ class KeycloakAPI(object):
         flow_url = URL_AUTHENTICATION_FLOW.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return open_url(flow_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(flow_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not delete authentication flow %s in realm %s: %s'
@@ -1283,7 +1283,7 @@ class KeycloakAPI(object):
                     realm=realm,
                     copyfrom=quote(config["copyFrom"])),
                 method='POST',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(new_name),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1292,7 +1292,7 @@ class KeycloakAPI(object):
                     URL_AUTHENTICATION_FLOWS.format(url=self.baseurl,
                                                     realm=realm),
                     method='GET',
-                    headers=self.restheaders,
+                    http_agent=self.http_agent, headers=self.restheaders,
                     timeout=self.connection_timeout,
                     validate_certs=self.validate_certs))
             for flow in flow_list:
@@ -1322,7 +1322,7 @@ class KeycloakAPI(object):
                     url=self.baseurl,
                     realm=realm),
                 method='POST',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(new_flow),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1332,7 +1332,7 @@ class KeycloakAPI(object):
                         url=self.baseurl,
                         realm=realm),
                     method='GET',
-                    headers=self.restheaders,
+                    http_agent=self.http_agent, headers=self.restheaders,
                     timeout=self.connection_timeout,
                     validate_certs=self.validate_certs))
             for flow in flow_list:
@@ -1357,7 +1357,7 @@ class KeycloakAPI(object):
                     realm=realm,
                     flowalias=quote(flowAlias)),
                 method='PUT',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(updatedExec),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1378,7 +1378,7 @@ class KeycloakAPI(object):
                     realm=realm,
                     id=executionId),
                 method='POST',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(authenticationConfig),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1403,7 +1403,7 @@ class KeycloakAPI(object):
                     realm=realm,
                     flowalias=quote(flowAlias)),
                 method='POST',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(newSubFlow),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1427,7 +1427,7 @@ class KeycloakAPI(object):
                     realm=realm,
                     flowalias=quote(flowAlias)),
                 method='POST',
-                headers=self.restheaders,
+                http_agent=self.http_agent, headers=self.restheaders,
                 data=json.dumps(newExec),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
@@ -1451,7 +1451,7 @@ class KeycloakAPI(object):
                             realm=realm,
                             id=executionId),
                         method='POST',
-                        headers=self.restheaders,
+                        http_agent=self.http_agent, headers=self.restheaders,
                         timeout=self.connection_timeout,
                         validate_certs=self.validate_certs)
             elif diff < 0:
@@ -1462,7 +1462,7 @@ class KeycloakAPI(object):
                             realm=realm,
                             id=executionId),
                         method='POST',
-                        headers=self.restheaders,
+                        http_agent=self.http_agent, headers=self.restheaders,
                         timeout=self.connection_timeout,
                         validate_certs=self.validate_certs)
         except Exception as e:
@@ -1484,7 +1484,7 @@ class KeycloakAPI(object):
                         realm=realm,
                         flowalias=quote(config["alias"])),
                     method='GET',
-                    headers=self.restheaders,
+                    http_agent=self.http_agent, headers=self.restheaders,
                     timeout=self.connection_timeout,
                     validate_certs=self.validate_certs))
             for execution in executions:
@@ -1497,7 +1497,7 @@ class KeycloakAPI(object):
                                 realm=realm,
                                 id=execConfigId),
                             method='GET',
-                            headers=self.restheaders,
+                            http_agent=self.http_agent, headers=self.restheaders,
                             timeout=self.connection_timeout,
                             validate_certs=self.validate_certs))
                     execution["authenticationConfig"] = execConfig
@@ -1513,7 +1513,7 @@ class KeycloakAPI(object):
         """
         idps_url = URL_IDENTITY_PROVIDERS.format(url=self.baseurl, realm=realm)
         try:
-            return json.loads(to_native(open_url(idps_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(idps_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of identity providers for realm %s: %s'
@@ -1530,7 +1530,7 @@ class KeycloakAPI(object):
         """
         idp_url = URL_IDENTITY_PROVIDER.format(url=self.baseurl, realm=realm, alias=alias)
         try:
-            return json.loads(to_native(open_url(idp_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(idp_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:
@@ -1550,7 +1550,7 @@ class KeycloakAPI(object):
         """
         idps_url = URL_IDENTITY_PROVIDERS.format(url=self.baseurl, realm=realm)
         try:
-            return open_url(idps_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(idps_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(idprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create identity provider %s in realm %s: %s'
@@ -1564,7 +1564,7 @@ class KeycloakAPI(object):
         """
         idp_url = URL_IDENTITY_PROVIDER.format(url=self.baseurl, realm=realm, alias=idprep['alias'])
         try:
-            return open_url(idp_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(idp_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(idprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update identity provider %s in realm %s: %s'
@@ -1577,7 +1577,7 @@ class KeycloakAPI(object):
         """
         idp_url = URL_IDENTITY_PROVIDER.format(url=self.baseurl, realm=realm, alias=alias)
         try:
-            return open_url(idp_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(idp_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Unable to delete identity provider %s in realm %s: %s'
@@ -1591,7 +1591,7 @@ class KeycloakAPI(object):
         """
         mappers_url = URL_IDENTITY_PROVIDER_MAPPERS.format(url=self.baseurl, realm=realm, alias=alias)
         try:
-            return json.loads(to_native(open_url(mappers_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(mappers_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of identity provider mappers for idp %s in realm %s: %s'
@@ -1609,7 +1609,7 @@ class KeycloakAPI(object):
         """
         mapper_url = URL_IDENTITY_PROVIDER_MAPPER.format(url=self.baseurl, realm=realm, alias=alias, id=mid)
         try:
-            return json.loads(to_native(open_url(mapper_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(mapper_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:
@@ -1630,7 +1630,7 @@ class KeycloakAPI(object):
         """
         mappers_url = URL_IDENTITY_PROVIDER_MAPPERS.format(url=self.baseurl, realm=realm, alias=alias)
         try:
-            return open_url(mappers_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(mappers_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(mapper), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not create identity provider mapper %s for idp %s in realm %s: %s'
@@ -1645,7 +1645,7 @@ class KeycloakAPI(object):
         """
         mapper_url = URL_IDENTITY_PROVIDER_MAPPER.format(url=self.baseurl, realm=realm, alias=alias, id=mapper['id'])
         try:
-            return open_url(mapper_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(mapper_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(mapper), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update mapper %s for identity provider %s in realm %s: %s'
@@ -1659,7 +1659,7 @@ class KeycloakAPI(object):
         """
         mapper_url = URL_IDENTITY_PROVIDER_MAPPER.format(url=self.baseurl, realm=realm, alias=alias, id=mid)
         try:
-            return open_url(mapper_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(mapper_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Unable to delete mapper %s for identity provider %s in realm %s: %s'
@@ -1676,7 +1676,7 @@ class KeycloakAPI(object):
             comps_url += '?%s' % filter
 
         try:
-            return json.loads(to_native(open_url(comps_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(comps_url, method='GET', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of components for realm %s: %s'
@@ -1693,7 +1693,7 @@ class KeycloakAPI(object):
         """
         comp_url = URL_COMPONENT.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return json.loads(to_native(open_url(comp_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(comp_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except HTTPError as e:
             if e.code == 404:
@@ -1713,13 +1713,13 @@ class KeycloakAPI(object):
         """
         comps_url = URL_COMPONENTS.format(url=self.baseurl, realm=realm)
         try:
-            resp = open_url(comps_url, method='POST', headers=self.restheaders, timeout=self.connection_timeout,
+            resp = open_url(comps_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(comprep), validate_certs=self.validate_certs)
             comp_url = resp.getheader('Location')
             if comp_url is None:
                 self.module.fail_json(msg='Could not create component in realm %s: %s'
                                           % (realm, 'unexpected response'))
-            return json.loads(to_native(open_url(comp_url, method="GET", headers=self.restheaders, timeout=self.connection_timeout,
+            return json.loads(to_native(open_url(comp_url, method="GET", http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                                  validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg='Could not create component in realm %s: %s'
@@ -1736,7 +1736,7 @@ class KeycloakAPI(object):
             self.module.fail_json(msg='Cannot update component without id')
         comp_url = URL_COMPONENT.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return open_url(comp_url, method='PUT', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(comp_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             data=json.dumps(comprep), validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Could not update component %s in realm %s: %s'
@@ -1749,7 +1749,7 @@ class KeycloakAPI(object):
         """
         comp_url = URL_COMPONENT.format(url=self.baseurl, realm=realm, id=cid)
         try:
-            return open_url(comp_url, method='DELETE', headers=self.restheaders, timeout=self.connection_timeout,
+            return open_url(comp_url, method='DELETE', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                             validate_certs=self.validate_certs)
         except Exception as e:
             self.module.fail_json(msg='Unable to delete component %s in realm %s: %s'


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When keycloak is running behind WAF or CDN, (.e.g Cloudflare with DNS Proxy) Requests with no User-Agent get status code 403 Forbidden.

Fixes #5023

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request 

##### COMPONENT NAME
module_utils/identity/keycloak

##### ADDITIONAL INFORMATION
When Keycloak is running behind a CDN/WAF, absence of use-agent gets considered as bot request and hence return 403 Forbidden

<!--- Paste verbatim command output below, e.g. before and after your change -->

**Before Change**
```bash
TASK [keycloakrealm : Create or update Keycloak realm (minimal example)] ****************************************************************************************************************
task path: /home/dishant/Projects/grist/keycloak-ansible/keycloakrealm/tasks/main.yml:34
redirecting (type: modules) community.general.keycloak_realm to community.general.identity.keycloak.keycloak_realm
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: dishant
<127.0.0.1> EXEC /bin/sh -c 'echo ~dishant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/dishant/.ansible/tmp `"&& mkdir "` echo /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545 `" && echo ansible-tmp-1659033296.2615469-369090-46313507833545="` echo /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545 `" ) && sleep 0'
redirecting (type: modules) community.general.keycloak_realm to community.general.identity.keycloak.keycloak_realm
Using module file /home/dishant/.ansible/collections/ansible_collections/community/general/plugins/modules/identity/keycloak/keycloak_realm.py
<127.0.0.1> PUT /home/dishant/.ansible/tmp/ansible-local-368771m5ibb0wr/tmp9emwij4y TO /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545/AnsiballZ_keycloak_realm.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545/ /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545/AnsiballZ_keycloak_realm.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545/AnsiballZ_keycloak_realm.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/dishant/.ansible/tmp/ansible-tmp-1659033296.2615469-369090-46313507833545/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
  File "/tmp/ansible_community.general.keycloak_realm_payload_mtp2yy2v/ansible_community.general.keycloak_realm_payload.zip/ansible_collections/community/general/plugins/modules/identity/keycloak/keycloak_realm.py", line 695, in main
  File "/tmp/ansible_community.general.keycloak_realm_payload_mtp2yy2v/ansible_community.general.keycloak_realm_payload.zip/ansible_collections/community/general/plugins/module_utils/identity/keycloak/keycloak.py", line 160, in get_token
    raise KeycloakError('Could not obtain access token from %s: %s'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "access_code_lifespan": null,
            "access_code_lifespan_login": null,
            "access_code_lifespan_user_action": null,
            "access_token_lifespan": null,
            "access_token_lifespan_for_implicit_flow": null,
            "account_theme": null,
            "action_token_generated_by_admin_lifespan": null,
            "action_token_generated_by_user_lifespan": null,
            "admin_events_details_enabled": null,
            "admin_events_enabled": null,
            "admin_theme": null,
            "attributes": null,
            "auth_client_id": "********-cli",
            "auth_client_secret": null,
            "auth_keycloak_url": "https://kc.korifi.run",
            "auth_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "auth_realm": "master",
            "auth_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "browser_flow": null,
            "browser_security_headers": null,
            "brute_force_protected": null,
            "client_authentication_flow": null,
            "client_scope_mappings": null,
            "connection_timeout": 10,
            "default_default_client_scopes": null,
            "default_groups": null,
            "default_locale": null,
            "default_optional_client_scopes": null,
            "default_roles": null,
            "default_signature_algorithm": null,
            "direct_grant_flow": null,
            "display_name": null,
            "display_name_html": null,
            "docker_authentication_flow": null,
            "duplicate_emails_allowed": null,
            "edit_username_allowed": null,
            "email_theme": null,
            "enabled": null,
            "enabled_event_types": null,
            "events_enabled": null,
            "events_expiration": null,
            "events_listeners": null,
            "failure_factor": null,
            "id": "demo",
            "internationalization_enabled": null,
            "login_theme": null,
            "login_with_email_allowed": null,
            "max_delta_time_seconds": null,
            "max_failure_wait_seconds": null,
            "minimum_quick_login_wait_seconds": null,
            "not_before": null,
            "offline_session_idle_timeout": null,
            "offline_session_max_lifespan": null,
            "offline_session_max_lifespan_enabled": null,
            "otp_policy_algorithm": null,
            "otp_policy_digits": null,
            "otp_policy_initial_counter": null,
            "otp_policy_look_ahead_window": null,
            "otp_policy_period": null,
            "otp_policy_type": null,
            "otp_supported_applications": null,
            "password_policy": null,
            "permanent_lockout": null,
            "quick_login_check_milli_seconds": null,
            "realm": "demo",
            "refresh_token_max_reuse": null,
            "registration_allowed": null,
            "registration_email_as_username": null,
            "registration_flow": null,
            "remember_me": null,
            "reset_credentials_flow": null,
            "reset_password_allowed": null,
            "revoke_refresh_token": null,
            "smtp_server": null,
            "ssl_required": null,
            "sso_session_idle_timeout": null,
            "sso_session_idle_timeout_remember_me": null,
            "sso_session_max_lifespan": null,
            "sso_session_max_lifespan_remember_me": null,
            "state": "present",
            "supported_locales": null,
            "token": null,
            "user_managed_access_allowed": null,
            "validate_certs": false,
            "verify_email": null,
            "wait_increment_seconds": null
        }
    },
    "msg": "Could not obtain access token from https://kc.korifi.run/realms/master/protocol/openid-connect/token: HTTP Error 403: Forbidden"
}
```

**After Change**
```bash
TASK [keycloakrealm : Create or update Keycloak realm (minimal example)] ****************************************************************************************************************
task path: /home/dishant/Projects/grist/keycloak-ansible/keycloakrealm/tasks/main.yml:34
redirecting (type: modules) community.general.keycloak_realm to community.general.identity.keycloak.keycloak_realm
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: dishant
<127.0.0.1> EXEC /bin/sh -c 'echo ~dishant && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/dishant/.ansible/tmp `"&& mkdir "` echo /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637 `" && echo ansible-tmp-1659033443.2723455-371110-261240589444637="` echo /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637 `" ) && sleep 0'
redirecting (type: modules) community.general.keycloak_realm to community.general.identity.keycloak.keycloak_realm
Using module file /home/dishant/.ansible/collections/ansible_collections/community/general/plugins/modules/identity/keycloak/keycloak_realm.py
<127.0.0.1> PUT /home/dishant/.ansible/tmp/ansible-local-370868g33w3t86/tmpz449juj8 TO /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637/AnsiballZ_keycloak_realm.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637/ /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637/AnsiballZ_keycloak_realm.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637/AnsiballZ_keycloak_realm.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/dishant/.ansible/tmp/ansible-tmp-1659033443.2723455-371110-261240589444637/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "diff": {},
    "end_state": {
        "accessCodeLifespan": 60,
        "accessCodeLifespanLogin": 1800,
        "accessCodeLifespanUserAction": 300,
        "accessTokenLifespan": 300,
        "accessTokenLifespanForImplicitFlow": 900,
        "actionTokenGeneratedByAdminLifespan": 43200,
        "actionTokenGeneratedByUserLifespan": 300,
        "adminEventsDetailsEnabled": false,
        "adminEventsEnabled": false,
        "attributes": {
            "cibaAuthRequestedUserHint": "login_hint",
            "cibaBackchannelTokenDeliveryMode": "poll",
            "cibaExpiresIn": "120",
            "cibaInterval": "5",
            "clientOfflineSessionIdleTimeout": "0",
            "clientOfflineSessionMaxLifespan": "0",
            "clientSessionIdleTimeout": "0",
            "clientSessionMaxLifespan": "0",
            "oauth2DeviceCodeLifespan": "600",
            "oauth2DevicePollingInterval": "5",
            "parRequestUriLifespan": "60"
        },
        "browserFlow": "browser",
        "browserSecurityHeaders": {
            "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
            "contentSecurityPolicyReportOnly": "",
            "strictTransportSecurity": "max-age=31536000; includeSubDomains",
            "xContentTypeOptions": "nosniff",
            "xFrameOptions": "SAMEORIGIN",
            "xRobotsTag": "none",
            "xXSSProtection": "1; mode=block"
        },
        "bruteForceProtected": false,
        "clientAuthenticationFlow": "clients",
        "clientOfflineSessionIdleTimeout": 0,
        "clientOfflineSessionMaxLifespan": 0,
        "clientPolicies": {
            "policies": []
        },
        "clientProfiles": {
            "profiles": []
        },
        "clientSessionIdleTimeout": 0,
        "clientSessionMaxLifespan": 0,
        "defaultRole": {
            "clientRole": false,
            "composite": true,
            "containerId": "demo",
            "description": "${role_default-roles}",
            "id": "8d4d2b6e-5281-4bee-9ec0-fbfcbc91d422",
            "name": "default-roles-demo"
        },
        "defaultSignatureAlgorithm": "RS256",
        "directGrantFlow": "direct grant",
        "dockerAuthenticationFlow": "docker auth",
        "duplicateEmailsAllowed": false,
        "editUsernameAllowed": false,
        "enabled": false,
        "enabledEventTypes": [],
        "eventsEnabled": false,
        "eventsListeners": [
            "jboss-logging"
        ],
        "failureFactor": 30,
        "id": "demo",
        "identityProviderMappers": [],
        "identityProviders": [],
        "internationalizationEnabled": false,
        "loginWithEmailAllowed": true,
        "maxDeltaTimeSeconds": 43200,
        "maxFailureWaitSeconds": 900,
        "minimumQuickLoginWaitSeconds": 60,
        "notBefore": 0,
        "oauth2DeviceCodeLifespan": 600,
        "oauth2DevicePollingInterval": 5,
        "offlineSessionIdleTimeout": 2592000,
        "offlineSessionMaxLifespan": 5184000,
        "offlineSessionMaxLifespanEnabled": false,
        "otpPolicyAlgorithm": "HmacSHA1",
        "otpPolicyDigits": 6,
        "otpPolicyInitialCounter": 0,
        "otpPolicyLookAheadWindow": 1,
        "otpPolicyPeriod": 30,
        "otpPolicyType": "totp",
        "otpSupportedApplications": [
            "FreeOTP",
            "Google Authenticator"
        ],
        "permanentLockout": false,
        "quickLoginCheckMilliSeconds": 1000,
        "realm": "demo",
        "refreshTokenMaxReuse": 0,
        "registrationAllowed": false,
        "registrationEmailAsUsername": false,
        "registrationFlow": "registration",
        "rememberMe": false,
        "requiredCredentials": [
            "password"
        ],
        "resetCredentialsFlow": "reset credentials",
        "resetPasswordAllowed": false,
        "revokeRefreshToken": false,
        "smtpServer": {},
        "sslRequired": "external",
        "ssoSessionIdleTimeout": 1800,
        "ssoSessionIdleTimeoutRememberMe": 0,
        "ssoSessionMaxLifespan": 36000,
        "ssoSessionMaxLifespanRememberMe": 0,
        "supportedLocales": [],
        "userManagedAccessAllowed": false,
        "verifyEmail": false,
        "waitIncrementSeconds": 60,
        "webAuthnPolicyAcceptableAaguids": [],
        "webAuthnPolicyAttestationConveyancePreference": "not specified",
        "webAuthnPolicyAuthenticatorAttachment": "not specified",
        "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
        "webAuthnPolicyCreateTimeout": 0,
        "webAuthnPolicyPasswordlessAcceptableAaguids": [],
        "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
        "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
        "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
        "webAuthnPolicyPasswordlessCreateTimeout": 0,
        "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
        "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
        "webAuthnPolicyPasswordlessRpId": "",
        "webAuthnPolicyPasswordlessSignatureAlgorithms": [
            "ES256"
        ],
        "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
        "webAuthnPolicyRequireResidentKey": "not specified",
        "webAuthnPolicyRpEntityName": "keycloak",
        "webAuthnPolicyRpId": "",
        "webAuthnPolicySignatureAlgorithms": [
            "ES256"
        ],
        "webAuthnPolicyUserVerificationRequirement": "not specified"
    },
    "existing": {
        "accessCodeLifespan": 60,
        "accessCodeLifespanLogin": 1800,
        "accessCodeLifespanUserAction": 300,
        "accessTokenLifespan": 300,
        "accessTokenLifespanForImplicitFlow": 900,
        "actionTokenGeneratedByAdminLifespan": 43200,
        "actionTokenGeneratedByUserLifespan": 300,
        "adminEventsDetailsEnabled": false,
        "adminEventsEnabled": false,
        "attributes": {
            "cibaAuthRequestedUserHint": "login_hint",
            "cibaBackchannelTokenDeliveryMode": "poll",
            "cibaExpiresIn": "120",
            "cibaInterval": "5",
            "clientOfflineSessionIdleTimeout": "0",
            "clientOfflineSessionMaxLifespan": "0",
            "clientSessionIdleTimeout": "0",
            "clientSessionMaxLifespan": "0",
            "oauth2DeviceCodeLifespan": "600",
            "oauth2DevicePollingInterval": "5",
            "parRequestUriLifespan": "60"
        },
        "browserFlow": "browser",
        "browserSecurityHeaders": {
            "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
            "contentSecurityPolicyReportOnly": "",
            "strictTransportSecurity": "max-age=31536000; includeSubDomains",
            "xContentTypeOptions": "nosniff",
            "xFrameOptions": "SAMEORIGIN",
            "xRobotsTag": "none",
            "xXSSProtection": "1; mode=block"
        },
        "bruteForceProtected": false,
        "clientAuthenticationFlow": "clients",
        "clientOfflineSessionIdleTimeout": 0,
        "clientOfflineSessionMaxLifespan": 0,
        "clientPolicies": {
            "policies": []
        },
        "clientProfiles": {
            "profiles": []
        },
        "clientSessionIdleTimeout": 0,
        "clientSessionMaxLifespan": 0,
        "defaultRole": {
            "clientRole": false,
            "composite": true,
            "containerId": "demo",
            "description": "${role_default-roles}",
            "id": "8d4d2b6e-5281-4bee-9ec0-fbfcbc91d422",
            "name": "default-roles-demo"
        },
        "defaultSignatureAlgorithm": "RS256",
        "directGrantFlow": "direct grant",
        "dockerAuthenticationFlow": "docker auth",
        "duplicateEmailsAllowed": false,
        "editUsernameAllowed": false,
        "enabled": false,
        "enabledEventTypes": [],
        "eventsEnabled": false,
        "eventsListeners": [
            "jboss-logging"
        ],
        "failureFactor": 30,
        "id": "demo",
        "identityProviderMappers": [],
        "identityProviders": [],
        "internationalizationEnabled": false,
        "loginWithEmailAllowed": true,
        "maxDeltaTimeSeconds": 43200,
        "maxFailureWaitSeconds": 900,
        "minimumQuickLoginWaitSeconds": 60,
        "notBefore": 0,
        "oauth2DeviceCodeLifespan": 600,
        "oauth2DevicePollingInterval": 5,
        "offlineSessionIdleTimeout": 2592000,
        "offlineSessionMaxLifespan": 5184000,
        "offlineSessionMaxLifespanEnabled": false,
        "otpPolicyAlgorithm": "HmacSHA1",
        "otpPolicyDigits": 6,
        "otpPolicyInitialCounter": 0,
        "otpPolicyLookAheadWindow": 1,
        "otpPolicyPeriod": 30,
        "otpPolicyType": "totp",
        "otpSupportedApplications": [
            "FreeOTP",
            "Google Authenticator"
        ],
        "permanentLockout": false,
        "quickLoginCheckMilliSeconds": 1000,
        "realm": "demo",
        "refreshTokenMaxReuse": 0,
        "registrationAllowed": false,
        "registrationEmailAsUsername": false,
        "registrationFlow": "registration",
        "rememberMe": false,
        "requiredCredentials": [
            "password"
        ],
        "resetCredentialsFlow": "reset credentials",
        "resetPasswordAllowed": false,
        "revokeRefreshToken": false,
        "smtpServer": {},
        "sslRequired": "external",
        "ssoSessionIdleTimeout": 1800,
        "ssoSessionIdleTimeoutRememberMe": 0,
        "ssoSessionMaxLifespan": 36000,
        "ssoSessionMaxLifespanRememberMe": 0,
        "supportedLocales": [],
        "userManagedAccessAllowed": false,
        "verifyEmail": false,
        "waitIncrementSeconds": 60,
        "webAuthnPolicyAcceptableAaguids": [],
        "webAuthnPolicyAttestationConveyancePreference": "not specified",
        "webAuthnPolicyAuthenticatorAttachment": "not specified",
        "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
        "webAuthnPolicyCreateTimeout": 0,
        "webAuthnPolicyPasswordlessAcceptableAaguids": [],
        "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
        "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
        "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
        "webAuthnPolicyPasswordlessCreateTimeout": 0,
        "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
        "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
        "webAuthnPolicyPasswordlessRpId": "",
        "webAuthnPolicyPasswordlessSignatureAlgorithms": [
            "ES256"
        ],
        "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
        "webAuthnPolicyRequireResidentKey": "not specified",
        "webAuthnPolicyRpEntityName": "keycloak",
        "webAuthnPolicyRpId": "",
        "webAuthnPolicySignatureAlgorithms": [
            "ES256"
        ],
        "webAuthnPolicyUserVerificationRequirement": "not specified"
    },
    "invocation": {
        "module_args": {
            "access_code_lifespan": null,
            "access_code_lifespan_login": null,
            "access_code_lifespan_user_action": null,
            "access_token_lifespan": null,
            "access_token_lifespan_for_implicit_flow": null,
            "account_theme": null,
            "action_token_generated_by_admin_lifespan": null,
            "action_token_generated_by_user_lifespan": null,
            "admin_events_details_enabled": null,
            "admin_events_enabled": null,
            "admin_theme": null,
            "attributes": null,
            "auth_client_id": "********-cli",
            "auth_client_secret": null,
            "auth_keycloak_url": "https://kc.korifi.run",
            "auth_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "auth_realm": "master",
            "auth_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "browser_flow": null,
            "browser_security_headers": null,
            "brute_force_protected": null,
            "client_authentication_flow": null,
            "client_scope_mappings": null,
            "connection_timeout": 10,
            "default_default_client_scopes": null,
            "default_groups": null,
            "default_locale": null,
            "default_optional_client_scopes": null,
            "default_roles": null,
            "default_signature_algorithm": null,
            "direct_grant_flow": null,
            "display_name": null,
            "display_name_html": null,
            "docker_authentication_flow": null,
            "duplicate_emails_allowed": null,
            "edit_username_allowed": null,
            "email_theme": null,
            "enabled": null,
            "enabled_event_types": null,
            "events_enabled": null,
            "events_expiration": null,
            "events_listeners": null,
            "failure_factor": null,
            "id": "demo",
            "internationalization_enabled": null,
            "login_theme": null,
            "login_with_email_allowed": null,
            "max_delta_time_seconds": null,
            "max_failure_wait_seconds": null,
            "minimum_quick_login_wait_seconds": null,
            "not_before": null,
            "offline_session_idle_timeout": null,
            "offline_session_max_lifespan": null,
            "offline_session_max_lifespan_enabled": null,
            "otp_policy_algorithm": null,
            "otp_policy_digits": null,
            "otp_policy_initial_counter": null,
            "otp_policy_look_ahead_window": null,
            "otp_policy_period": null,
            "otp_policy_type": null,
            "otp_supported_applications": null,
            "password_policy": null,
            "permanent_lockout": null,
            "quick_login_check_milli_seconds": null,
            "realm": "demo",
            "refresh_token_max_reuse": null,
            "registration_allowed": null,
            "registration_email_as_username": null,
            "registration_flow": null,
            "remember_me": null,
            "reset_credentials_flow": null,
            "reset_password_allowed": null,
            "revoke_refresh_token": null,
            "smtp_server": null,
            "ssl_required": null,
            "sso_session_idle_timeout": null,
            "sso_session_idle_timeout_remember_me": null,
            "sso_session_max_lifespan": null,
            "sso_session_max_lifespan_remember_me": null,
            "state": "present",
            "supported_locales": null,
            "token": null,
            "user_managed_access_allowed": null,
            "validate_certs": false,
            "verify_email": null,
            "wait_increment_seconds": null
        }
    },
    "msg": "Realm demo has been updated.",
    "proposed": {
        "id": "demo",
        "realm": "demo"
    }
}
```