### PR TITLE
mh base: add verbosity() property

### DIFF
--- a/changelogs/fragments/5035-mh-base-verbosity.yaml
+++ b/changelogs/fragments/5035-mh-base-verbosity.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ModuleHelper module utils - added property ``verbosity`` to base class (https://github.com/ansible-collections/community.general/pull/5035).

--- a/plugins/module_utils/mh/base.py
+++ b/plugins/module_utils/mh/base.py
@@ -31,6 +31,10 @@ class ModuleHelperBase(object):
     def diff_mode(self):
         return self.module._diff
 
+    @property
+    def verbosity(self):
+        return self.module._verbosity
+
     def do_raise(self, *args, **kwargs):
         raise _MHE(*args, **kwargs)
 


### PR DESCRIPTION
##### SUMMARY
Add a `verbosity` property to `ModuleHelper` base class, wrapping the `AnsibleModule._verbosity` one.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/mh/base.py
