### PR TITLE
xfconf: add command output to results

### DIFF
--- a/changelogs/fragments/5037-xfconf-add-cmd-output.yaml
+++ b/changelogs/fragments/5037-xfconf-add-cmd-output.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xfconf - add ``stdout``, ``stderr`` and ``cmd`` to the module results (https://github.com/ansible-collections/community.general/pull/5037).

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -148,6 +148,8 @@ RETURN = '''
       - A list with the resulting C(xfconf-query) command executed by the module.
     returned: success
     type: list
+    elements: str
+    version_added: 5.4.0
     sample:
       - /usr/bin/xfconf-query
       - --channel

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -143,6 +143,22 @@ RETURN = '''
     returned: success
     type: any
     sample: '"96" or ["red", "blue", "green"]'
+  cmd:
+    description:
+      - A list with the resulting C(xfconf-query) command executed by the module.
+    returned: success
+    type: list
+    sample:
+      - /usr/bin/xfconf-query
+      - --channel
+      - xfce4-panel
+      - --property
+      - /plugins/plugin-19/timezone
+      - --create
+      - --type
+      - string
+      - --set
+      - Pacific/Auckland
 '''
 
 from ansible_collections.community.general.plugins.module_utils.module_helper import StateModuleHelper

--- a/plugins/modules/system/xfconf.py
+++ b/plugins/modules/system/xfconf.py
@@ -211,6 +211,11 @@ class XFConfProperty(StateModuleHelper):
     def state_absent(self):
         with self.runner('channel property reset', check_mode_skip=True) as ctx:
             ctx.run(reset=True)
+            self.vars.stdout = ctx.results_out
+            self.vars.stderr = ctx.results_err
+            self.vars.cmd = ctx.cmd
+            if self.verbosity >= 4:
+                self.vars.run_info = ctx.run_info
         self.vars.value = None
 
     def state_present(self):
@@ -237,6 +242,11 @@ class XFConfProperty(StateModuleHelper):
 
         with self.runner('channel property create force_array values_and_types', check_mode_skip=True) as ctx:
             ctx.run(create=True, force_array=self.vars.is_array, values_and_types=(self.vars.value, value_type))
+            self.vars.stdout = ctx.results_out
+            self.vars.stderr = ctx.results_err
+            self.vars.cmd = ctx.cmd
+            if self.verbosity >= 4:
+                self.vars.run_info = ctx.run_info
 
         if not self.vars.is_array:
             self.vars.value = self.vars.value[0]

--- a/tests/unit/plugins/modules/system/test_xfconf.py
+++ b/tests/unit/plugins/modules/system/test_xfconf.py
@@ -268,7 +268,7 @@ def test_xfconf(mocker, capfd, patch_xfconf, testcase):
     # Mock function used for running commands first
     call_results = [item[2] for item in testcase['run_command.calls']]
     mock_run_command = mocker.patch(
-        'ansible_collections.community.general.plugins.module_utils.mh.module_helper.AnsibleModule.run_command',
+        'ansible.module_utils.basic.AnsibleModule.run_command',
         side_effect=call_results)
 
     # Try to run test case
@@ -295,6 +295,11 @@ def test_xfconf(mocker, capfd, patch_xfconf, testcase):
         print("call args list =\n%s" % call_args_list)
         print("expected args list =\n%s" % expected_call_args_list)
         assert call_args_list == expected_call_args_list
+
+        expected_cmd, dummy, expected_res = testcase['run_command.calls'][-1]
+        assert results['cmd'] == expected_cmd
+        assert results['stdout'] == expected_res[1]
+        assert results['stderr'] == expected_res[2]
 
     for conditional_test_result in ('msg', 'value', 'previous_value'):
         if conditional_test_result in testcase:


### PR DESCRIPTION
##### SUMMARY
Add `stdout`, `stderr` and `cmd` to the module output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/xfconf.py
