### PR TITLE
feat: Add crc32 filter

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -120,6 +120,8 @@ files:
     labels: xenserver
   $filters/counter.py:
     maintainers: keilr
+  $filters/crc32.py:
+    maintainers: jouir
   $filters/dict.py:
     maintainers: felixfontein
   $filters/dict_kv.py:

--- a/plugins/filter/crc32.py
+++ b/plugins/filter/crc32.py
@@ -6,8 +6,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleFilterError
-from ansible.module_utils.six import string_types
 from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.common.collections import is_string
 
 try:
     from zlib import crc32
@@ -46,7 +46,7 @@ RETURN = '''
 
 
 def crc32s(value):
-    if not isinstance(value, string_types):
+    if not is_string(value):
         raise AnsibleFilterError('Invalid value type (%s) for crc32 (%r)' %
                                  (type(value), value))
 

--- a/plugins/filter/crc32.py
+++ b/plugins/filter/crc32.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022, Julien Riou <julien@riou.xyz>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+from ansible.module_utils.six import string_types
+from ansible.module_utils.common.text.converters import to_bytes
+
+try:
+    from zlib import crc32
+    HAS_ZLIB = True
+except ImportError:
+    HAS_ZLIB = False
+
+
+DOCUMENTATION = '''
+  name: crc32
+  short_description: Generate a CRC32 checksum
+  version_added: 5.4.0
+  description:
+    - Checksum a string using CRC32 algorithm and return its hexadecimal representation.
+  options:
+    _input:
+      description:
+        - The string to checksum.
+      type: string
+      required: true
+  author:
+    - Julien Riou
+'''
+
+EXAMPLES = '''
+  - name: Checksum a test string
+    ansible.builtin.debug:
+      msg: "{{ 'test' | community.general.crc32 }}"
+'''
+
+RETURN = '''
+  _value:
+    description: CRC32 checksum.
+    type: string
+'''
+
+
+def crc32s(value):
+    if not isinstance(value, string_types):
+        raise AnsibleFilterError('Invalid value type (%s) for crc32 (%r)' %
+                                 (type(value), value))
+
+    if not HAS_ZLIB:
+        raise AnsibleFilterError('Failed to import zlib module')
+
+    data = to_bytes(value, errors='surrogate_or_strict')
+    return "{0:x}".format(crc32(data) & 0xffffffff)
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            'crc32': crc32s,
+        }

--- a/plugins/filter/crc32.py
+++ b/plugins/filter/crc32.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2022, Julien Riou <julien@riou.xyz>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/tests/unit/plugins/filter/test_crc32.py
+++ b/tests/unit/plugins/filter/test_crc32.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2022, Julien Riou <julien@riou.xyz>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/tests/unit/plugins/filter/test_crc32.py
+++ b/tests/unit/plugins/filter/test_crc32.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022, Julien Riou <julien@riou.xyz>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible.errors import AnsibleError
+from ansible_collections.community.general.plugins.filter.crc32 import crc32s
+
+
+class TestFilterCrc32(unittest.TestCase):
+
+    def test_checksum(self):
+        self.assertEqual(crc32s('test'), 'd87f7e0c')


### PR DESCRIPTION
##### SUMMARY
In order to create a [subscription](https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_subscription_module.html) on PostgreSQL, we have to provide a `slot_name` (by default, it's the same name as the ones in `publications`).

This name:
* can contain only lower case alphanumeric characters and the underscore sign
* is silently truncated to **63 chars**

Object names on PostgreSQL, including publications, can contain invalid characters for a replication slot name.

To solve this issue, [pglogical](https://github.com/2ndQuadrant/pglogical):
* [replaces all invalid chars with underscores](https://github.com/2ndQuadrant/pglogical/blob/REL2_4_1/pglogical_functions.c#L2386-L2394)
* [creates short hashes when size of a name is bigger than a threshold (16 chars)](https://github.com/2ndQuadrant/pglogical/blob/REL2_4_1/pglogical_functions.c#L2380-L2382)

In Ansible, what hashes algorithms do we have?
* md5: **32 chars**
* sha1: **40 chars**
* checksum: **40 chars** (alias of sha1)
* password_hash: contains invalid chars
* hash: choices between sha1 (default) and md5

There is no hash algorithm producing less than 16 chars like pglogical does. An alternative option is to truncate the result to the desired number of chars. But having a native algorithm is better, right?

This commit includes the CRC32 algorithm to Ansible to produce **8 chars** checksums.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
filters

##### ADDITIONAL INFORMATION
Playbook:
```yaml
---
- hosts: localhost
  tasks:
    - debug:
        msg: "{{ 'test' | community.general.crc32 }}"
```

Output:
```
ok: [localhost] => {
    "msg": "d87f7e0c"
}
```