### PR TITLE
terraform: add option to generate a variables.tf from the supplied ansible vars

### DIFF
--- a/changelogs/fragments/5097-terraform-generate-tfvars.yaml
+++ b/changelogs/fragments/5097-terraform-generate-tfvars.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terraform - adds ``generate_variables`` parameter for automatically declaring the Terraform vars from Ansible (https://github.com/ansible-collections/community.general/pull/5097).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -471,10 +471,10 @@ def main():
             variables_args.extend(['-var-file', f])
 
     if declare_variables:
-       gen_variables_file = tempfile.NamedTemporaryFile(mode='w', dir=project_path, prefix="generated_variables_", suffix=".tf")
-       for k, v in variables.items():
-           gen_variables_file.write("variable \"" + k + "\" {}\n")
-           gen_variables_file.flush()
+        gen_variables_file = tempfile.NamedTemporaryFile(mode='w', dir=project_path, prefix="generated_variables_", suffix=".tf")
+        for k, v in variables.items():
+            gen_variables_file.write("variable \"" + k + "\" {}\n")
+            gen_variables_file.flush()
 
     preflight_validation(command[0], project_path, checked_version, variables_args)
 

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -30,12 +30,13 @@ options:
   declare_variables:
     description:
       - If true, generate a Terraform file that declares all variables supplied via this module's
-        'variables' parameter. Type, description, and default value are not specified.
+        I(variables) parameter. Type, description, and default value are not specified.
       - The file is generated before and automatically deleted after executing Terraform.
       - Terraform does not allow declaring variables twice, so you will need to remove all
         declarations of Ansible-sourced variables from your Terraform code before enabling this.
     default: false
     type: bool
+    version_added: 5.5.0
   project_path:
     description:
       - The path to the root of the Terraform directory with the

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -27,6 +27,15 @@ options:
       - The path of a terraform binary to use, relative to the 'service_path'
         unless you supply an absolute path.
     type: path
+  declare_variables:
+    description:
+      - If true, generate a Terraform file that declares all variables supplied via this module's
+        'variables' parameter. Type, description, and default value are not specified.
+      - The file is generated before and automatically deleted after executing Terraform.
+      - Terraform does not allow declaring variables twice, so you will need to remove all
+        declarations of Ansible-sourced variables from your Terraform code before enabling this.
+    default: false
+    type: bool
   project_path:
     description:
       - The path to the root of the Terraform directory with the

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -537,7 +537,7 @@ def main():
 
     # delete the generated variables.tf file after command returns
     if declare_variables:
-       gen_variables_file.close()
+        gen_variables_file.close()
 
     # Restore the Terraform workspace found when running the module
     if workspace_ctx["current"] != workspace:


### PR DESCRIPTION
##### SUMMARY
The Terraform module currently has a `variables:` parameter that iterates an Ansible dictionary and passes each variable as a command line argument to the terraform command. However, because Terraform requires all variables to be declared in a `variable "name" {}` block within one of the Terraform code files, the names of all variables must be repeated in the code files or in a separate `variables.tf`. Nothing other than the name of the variable is needed--specifying the type, description, or default value is optional. 

For use cases where the Terraform project is only ever run via Ansible, this creates a lot of repetition. This PR proposes a new feature where the module would automatically generate a `variables.tf` file containing the names of all keys in the `variables:` dictionary parameter. This new feature is disabled by default (this is also necessary because enabling it before deleting the existing declarations would cause an error) and enabled by the use of a new `declare_variables:` boolean.

Actually generating a file seems a bit clunky to me, but there doesn't seem to be any other way to do this as variables cannot be declared via command line arguments. Feel free to let me know if you can think of a better way to do this.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/terraform.py

##### ADDITIONAL INFORMATION
Please let me know if there is a cleaner way or an Ansible-specific API to handle the file creation and deletion, or if there are any tests or documentation I should add.
