### PR TITLE
pipx: add required_if fo upgrade and reinstall

### DIFF
--- a/changelogs/fragments/5100-pipx-req-if.yaml
+++ b/changelogs/fragments/5100-pipx-req-if.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pipx - module fails faster when ``name`` is missing for states ``upgrade`` and ``reinstall`` (https://github.com/ansible-collections/community.general/pull/5100).

--- a/plugins/modules/packaging/language/pipx.py
+++ b/plugins/modules/packaging/language/pipx.py
@@ -164,7 +164,8 @@ class PipX(StateModuleHelper):
             ('state', 'install', ['name']),
             ('state', 'absent', ['name']),
             ('state', 'uninstall', ['name']),
-            # missing upgrade and reinstall requiring 'name'
+            ('state', 'upgrade', ['name']),
+            ('state', 'reinstall', ['name']),
             ('state', 'inject', ['name', 'inject_packages']),
         ],
         supports_check_mode=True,

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -24,7 +24,6 @@
   community.general.pipx:
     name: tox
   register: install_tox_again
-  ignore_errors: yes
 
 - name: install application tox again force
   community.general.pipx:
@@ -61,11 +60,23 @@
     state: reinstall
   register: reinstall_tox_324
 
+- name: reinstall without name
+  community.general.pipx:
+    state: reinstall
+  register: reinstall_noname
+  ignore_errors: yes
+
 - name: upgrade tox 3.24.0
   community.general.pipx:
     name: tox
     state: upgrade
   register: upgrade_tox_324
+
+- name: upgrade without name
+  community.general.pipx:
+    state: upgrade
+  register: upgrade_noname
+  ignore_errors: yes
 
 - name: downgrade tox 3.24.0
   community.general.pipx:
@@ -94,6 +105,8 @@
         - downgrade_tox_324.application.tox.version == '3.24.0'
         - uninstall_tox_324 is changed
         - "'tox' not in uninstall_tox_324.application"
+        - upgrade_noname is failed
+        - reinstall_noname is failed
 
 ##############################################################################
 - name: ensure application ansible-lint is uninstalled


### PR DESCRIPTION
##### SUMMARY
Add `required_if` clause for states `upgrade` and `reinstall`, requiring parameter `name`. That mimics the behaviour of the underlying `pipx`, effectively making the module fail faster in that situation.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pipx
