### PR TITLE
New module: Proxmox disk management

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -374,6 +374,8 @@ files:
   $modules/cloud/misc/proxmox_template.py:
     maintainers: UnderGreen
     ignore: skvidal
+  $modules/cloud/misc/proxmox_disk.py:
+    maintainers: castorsky
   $modules/cloud/misc/rhevm.py:
     maintainers: $team_virt TimothyVandenbrande
     labels: rhevm virt

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1211,6 +1211,8 @@ plugin_routing:
       redirect: community.general.cloud.profitbricks.profitbricks_volume_attachments
     proxmox:
       redirect: community.general.cloud.misc.proxmox
+    proxmox_disk:
+      redirect: community.general.cloud.misc.proxmox_disk
     proxmox_domain_info:
       redirect: community.general.cloud.misc.proxmox_domain_info
     proxmox_group_info:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -286,7 +286,7 @@ options:
     choices: ['enospc', 'ignore', 'report', 'stop']
   wwn:
     description:
-      - The drive's worldwide name, encoded as 16 bytes hex string, prefixed by 0x.
+      - The drive's worldwide name, encoded as 16 bytes hex string, prefixed by C(0x).
     type: str
 extends_documentation_fragment:
   - community.general.proxmox.documentation

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -621,7 +621,7 @@ def main():
     disk_regex = compile(r'^([a-z]+)([0-9]+)$')
     disk_bus = sub(disk_regex, r'\1', disk)
     disk_number = int(sub(disk_regex, r'\2', disk))
-    if disk_bus not in proxmox.supported_ranges.keys():
+    if disk_bus not in proxmox.supported_ranges:
         proxmox.module.fail_json(msg='Unsupported disk bus: %s' % disk_bus)
     elif disk_number not in proxmox.supported_ranges[disk_bus]:
         bus_range = proxmox.supported_ranges[disk_bus]

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -498,10 +498,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
         params['target-disk'] = self.module.params['target_disk']
         params['target-vmid'] = self.module.params['target_vmid']
         params['format'] = self.module.params['format']
-        try:
-            params['delete'] = int(self.module.params['delete_moved'])
-        except TypeError:
-            params['delete'] = 0
+        params['delete'] = 1 if self.module.params.get('delete_moved', False) else 0
         # Remove not defined args
         params = dict((k, v) for k, v in params.items() if v is not None)
 

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -58,7 +58,7 @@ options:
         because shrinking disks is not supported by the PVE API and has to be done manually.
       - To entirely remove the disk from backing storage use I(state=absent).
     type: str
-    choices: ['present', 'updated', 'resized', 'detached', 'moved', 'absent']
+    choices: ['present', 'resized', 'detached', 'moved', 'absent']
     default: present
   create:
     description:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -621,11 +621,7 @@ def main():
 
     name = module.params['name']
     state = module.params['state']
-    vmid = module.params['vmid']
-
-    # If vmid is not defined then retrieve its value from the vm name,
-    if not vmid:
-        vmid = proxmox.get_vmid(name)
+    vmid = module.params['vmid'] or proxmox.get_vmid(name)
 
     # Ensure VM id exists and retrieve its config
     vm = None

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 ---
 module: proxmox_disk
 short_description: Management of a disk of a Qemu(KVM) VM in a Proxmox VE cluster.
-version_added: 5.5.0
+version_added: 5.6.0
 description:
   - Allows you to perform some supported operations on a disk in Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
 author: "Castor Sky (@castorsky) <csky57@gmail.com>"

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -227,7 +227,7 @@ options:
       - Maximum total r/w speed in megabytes per second.
       - Can be fractional but use with caution - fractionals less than 1 are not supported officially.
       - You can specify either total limit or per operation (mutually exclusive with I(mbps_rd) and I(mbps_wr)).
-   type: float
+    type: float
   mbps_max:
     description:
       - Maximum unthrottled total r/w pool in megabytes per second.
@@ -245,7 +245,7 @@ options:
     description:
       - Maximum write speed in megabytes per second.
       - You can specify either write or total limit (mutually exclusive with I(mbps)).
-   type: float
+    type: float
   mbps_wr_max:
     description:
       - Maximum unthrottled write pool in megabytes per second.

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -494,8 +494,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
         disk_config = disk_conf_str_to_dict(vm_config[disk])
         config_str = disk_config["volume"]
         params = self.sanitize_params()
-        for k, v in params.items():
-            config_str += ',%s=%s' % (k, v)
+        config_str = ','.join('%s=%s' % (k, v) for k, v in params.items())
 
         disk_config = {self.module.params["disk"]: config_str}
         self.proxmox_api.nodes(vm['node']).qemu(vmid).config.set(**disk_config)

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -56,11 +56,13 @@ options:
     type: str
   size:
     description:
-      - For I(state=present) I(size) is desired volume size in GB to allocate (specify I(size) without suffix).
+      - Desired volume size in GB to allocate when I(state=present) (specify I(size) without suffix).
       - >
-        For I(state=grown) C(size) is the new size of volume. With the C(+) sign
+        New (or additional) size of volume when I(state=grown). With the C(+) sign
         the value is added to the actual size of the volume
         and without it, the value is taken as an absolute one.
+      - >
+        I(size) has strict format 
     type: str
   bwlimit:
     description:
@@ -128,11 +130,11 @@ options:
     type: int
   detect_zeroes:
     description:
-      - Controls whether to detect and try to optimize writes of zeroes.
+      - Control whether to detect and try to optimize writes of zeroes.
     type: bool
   discard:
     description:
-      - Controls whether to pass discard/trim requests to the underlying storage.
+      - Control whether to pass discard/trim requests to the underlying storage.
     type: str
     choices: ['ignore', 'on']
   format:
@@ -258,7 +260,7 @@ options:
     type: bool
   snapshot:
     description:
-      - Controls qemu's snapshot mode feature.
+      - Control qemu's snapshot mode feature.
       - If activated, changes made to the disk are temporary and will be discarded when the VM is shutdown.
     type: bool
   ssd:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 ---
 module: proxmox_disk
 short_description: Management of a disk of a Qemu(KVM) VM in a Proxmox VE cluster.
-version_added: 5.4.0
+version_added: 5.5.0
 description:
   - Allows you to perform some supported operations on a disk in Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
 author: "Castor Sky (@castorsky) <csky57@gmail.com>"

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -20,7 +20,7 @@ options:
   name:
     description:
       - The (unique) name of the VM.
-      - Required only one of C(name) or C(vmid).
+      - Required only one of I(name) or I(vmid).
     type: str
   vmid:
     description:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -38,7 +38,7 @@ options:
         for VirtIO: 0-15;
         for Unused: 0-255.
     type: str
-    required: True
+    required: true
   state:
     description:
       - Indicates desired state of the disk.
@@ -53,9 +53,9 @@ options:
   force_replace:
     description:
       - Force replace existing attached disk with the new one leaving old disk unused.
-      - When disk exists and I(force_replace=False) creation will be silently skipped.
+      - When disk exists and I(force_replace=false) creation will be silently skipped.
     type: bool
-    default: False
+    default: false
   storage:
     description:
       - The drive's backing storage.
@@ -299,7 +299,7 @@ EXAMPLES = '''
     api_token_secret: some-token-data
     name: vm-name
     disk: scsi3
-    backup: True
+    backup: true
     cache: none
     storage: local-zfs
     size: 5
@@ -316,7 +316,7 @@ EXAMPLES = '''
     format: qcow2
     storage: local
     size: 16
-    force_replace: True
+    force_replace: true
     state: present
 
 - name: Update existing disk
@@ -327,8 +327,8 @@ EXAMPLES = '''
     api_token_secret: some-token-data
     vmid: 101
     disk: ide0
-    backup: False
-    ro: True
+    backup: false
+    ro: true
     aio: native
     state: updated
 

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -113,7 +113,7 @@ options:
   bps_rd_max_length:
     description:
       - Maximum length of read I/O bursts in seconds.
-    type: int['none', 'writethrough', 'writeback', 'unsafe', 'directsync']
+    type: int
   bps_wr:
     description:
       - Maximum write speed in bytes per second.

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -413,7 +413,7 @@ vmid:
   type: int
   sample: 101
 msg:
-  description: A short message
+  description: A short message on what the module did.
   returned: always
   type: str
   sample: "Disk scsi3 created in VM 101"

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -499,6 +499,8 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
             disk_config = disk_conf_str_to_dict(vm_config[disk])
             config_str = disk_config["volume"]
             attributes = self.get_create_attributes()
+            # 'import_from' fails on disk updates
+            attributes.pop('import_from', None)
 
             for k, v in attributes.items():
                 config_str += ',%s=%s' % (k, v)

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -482,7 +482,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
 
         config_str = "%s:%s" % (self.module.params["storage"], self.module.params["size"])
         if import_string:
-            config_str += 'import-from=%s' % import_string
+            config_str += ',import-from=%s' % import_string
 
         for k, v in params.items():
             config_str += ',%s=%s' % (k, v)

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -199,7 +199,7 @@ options:
   mpbs:
     description:
       - Maximum r/w speed in megabytes per second.
-    type:
+    type: int
   mpbs_max:
     description:
       - Maximum unthrottled r/w pool in megabytes per second.

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -19,12 +19,13 @@ author: "Castor Sky (@castorsky) <csky57@gmail.com>"
 options:
   name:
     description:
-      - The (unique) name of the VM.
-      - Required only one of I(name) or I(vmid).
+      - The unique name of the VM.
+      - You can specify either I(name) or I(vmid) or both of them.
     type: str
   vmid:
     description:
       - The unique ID of the VM.
+      - You can specify either I(vmid) or I(name) or both of them.
     type: int
   disk:
     description:
@@ -419,12 +420,9 @@ def disk_conf_str_to_dict(config_string):
         volume_name=volume_name
     )
 
-    for i in config:
-        kv = i.split('=')
-        try:
-            config_current[kv[0]] = kv[1]
-        except IndexError:
-            config_current[kv[0]] = ''
+    for option in config:
+        k, v = option.split('=')
+        config_current[k] = v
 
     return config_current
 
@@ -513,7 +511,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
             status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
             if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
                 return True
-            if timeout == 0:
+            if timeout <= 0:
                 self.module.fail_json(
                     msg='Reached timeout while waiting for moving VM disk. Last line in task before timeout: %s' %
                         self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -615,7 +615,7 @@ def main():
             ('mbps', 'mbps_wr'),
             ('iops', 'iops_rd'),
             ('iops', 'iops_wr'),
-            ('import_from', 'size')
+            ('import_from', 'size'),
         ]
     )
 

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -177,7 +177,7 @@ options:
       - Volume string format
       - C(<STORAGE>:<VMID>/<FULL_NAME>) or C(<ABSOLUTE_PATH>/<FULL_NAME>)
       - Attention! Only root can use absolute paths.
-      - This parameter is mutually exclusive with I(size). 
+      - This parameter is mutually exclusive with I(size).
     type: str
   iops:
     description:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -55,7 +55,7 @@ options:
     type: str
   size:
     description:
-      - For I(state=present) C(size) is desired volume size in GB to allocate.
+      - For I(state=present) I(size) is desired volume size in GB to allocate.
       - >
         For I(state=grown) C(size) is the new size of volume. With the C(+) sign
         the value is added to the actual size of the volume

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -128,7 +128,7 @@ options:
     type: int
   cache:
     description:
-      - The drive's cache mode
+      - The drive's cache mode.
     type: str
     choices: ['none', 'writethrough', 'writeback', 'unsafe', 'directsync']
   cyls:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -398,7 +398,7 @@ msg:
   sample: "Disk scsi3 created in VM 101"
 '''
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec,
                                                                                 ProxmoxAnsible)
 from re import compile, match, sub

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -522,16 +522,16 @@ def main():
     module_args = proxmox_auth_argument_spec()
     disk_args = dict(
         # Proxmox native parameters
-        aio=dict(choices=['native', 'threads', 'io_uring']),
+        aio=dict(type='str', choices=['native', 'threads', 'io_uring']),
         backup=dict(type='bool'),
         bps_max_length=dict(type='int'),
         bps_rd_max_length=dict(type='int'),
         bps_wr_max_length=dict(type='int'),
-        cache=dict(choices=['none', 'writethrough', 'writeback', 'unsafe', 'directsync']),
+        cache=dict(type='str', choices=['none', 'writethrough', 'writeback', 'unsafe', 'directsync']),
         cyls=dict(type='int'),
         detect_zeroes=dict(type='bool'),
-        discard=dict(choices=['ignore', 'on']),
-        format=dict(choices=['raw', 'cow', 'qcow', 'qed', 'qcow2', 'vmdk', 'cloop']),
+        discard=dict(type='str', choices=['ignore', 'on']),
+        format=dict(type='str', choices=['raw', 'cow', 'qcow', 'qed', 'qcow2', 'vmdk', 'cloop']),
         heads=dict(type='int'),
         import_from=dict(type='str'),
         iops=dict(type='int'),
@@ -550,10 +550,10 @@ def main():
         mbps_rd_max=dict(type='float'),
         mbps_wr=dict(type='float'),
         mbps_wr_max=dict(type='float'),
-        media=dict(choices=['cdrom', 'disk']),
+        media=dict(type='str', choices=['cdrom', 'disk']),
         queues=dict(type='int'),
         replicate=dict(type='bool'),
-        rerror=dict(choices=['ignore', 'report', 'stop']),
+        rerror=dict(type='str', choices=['ignore', 'report', 'stop']),
         ro=dict(type='bool'),
         scsiblock=dict(type='bool'),
         secs=dict(type='int'),
@@ -561,8 +561,8 @@ def main():
         shared=dict(type='bool'),
         snapshot=dict(type='bool'),
         ssd=dict(type='bool'),
-        trans=dict(choices=['auto', 'lba', 'none']),
-        werror=dict(choices=['enospc', 'ignore', 'report', 'stop']),
+        trans=dict(type='str', choices=['auto', 'lba', 'none']),
+        werror=dict(type='str', choices=['enospc', 'ignore', 'report', 'stop']),
         wwn=dict(type='str'),
 
         # Disk moving relates parameters
@@ -579,7 +579,8 @@ def main():
         disk=dict(type='str', required=True),
         storage=dict(type='str'),
         size=dict(type='str'),
-        state=dict(choices=['present', 'updated', 'grown', 'detached', 'moved', 'absent'], default='present'),
+        state=dict(type='str', choices=['present', 'updated', 'grown', 'detached', 'moved', 'absent'],
+                   default='present'),
         force_replace=dict(type='bool', default=False),
     )
 

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -1,0 +1,698 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2022, Castor Sky (@castorsky) <csky57@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: proxmox_disk
+short_description: Management of a disk of a Qemu(KVM) VM in a Proxmox VE cluster.
+version_added: 5.4.0
+description:
+  - Allows you to perform some supported operations on a disk in Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
+author: "Castor Sky (@castorsky) <csky57@gmail.com>"
+options:
+  name:
+    description:
+      - The (unique) name of the VM.
+      - Required only one of C(name) or C(vmid).
+    type: str
+  vmid:
+    description:
+      - The (unique) ID of the VM.
+    type: int
+  disk:
+    description:
+      - The disk key (C(unused[n]), C(ide[n]), C(sata[n]), C(scsi[n]) or C(virtio[n])) you want to operate on.
+    type: str
+    required: True
+  state:
+    description:
+      - Indicate desired state of the disk. C(absent) can be used only with C(remove) action
+    type: string
+    choices: ['present', 'absent']
+    default: present
+  action:
+    description:
+      - Action to perform on the disk.
+    type: str
+    choices: ['create', 'update', 'grow', 'detach', 'move', 'remove']
+  force_replace:
+    description:
+      - Force replace existing attached disk with the new one leaving old disk unused
+    type: bool
+    default: False
+  storage:
+    description:
+      - The drive’s backing storage.
+      - Used primarily in C(create) and C(move) actions.
+    type: str
+  size:
+    description:
+      - For create action C(size) is desired volume size in GB to allocate.
+      - For grow action C(size) is the new size of volume. With the C(+) sign the value is added to the actual size of the volume and without it, the value is taken as an absolute one.
+    type: str
+  bwlimit:
+    description:
+      - Override I/O bandwidth limit (in KB/s).
+      - Used only in C(move) action
+    type: int
+  delete_moved:
+    description:
+      - Delete the original disk after successful copy.
+      - By default the original disk is kept as unused disk.
+      - Used only in C(move) action
+    type: bool
+  target_disk:
+    description:
+      - The config key the disk will be moved to on the target VM (for example, C(ide0) or C(scsi1)).
+      - Default is the source disk key.
+      - Used only in C(move) action
+    type: str
+  target_storage:
+    description:
+      - Target storage.
+      - Used only in C(move) action
+    type: str
+  target_vmid:
+    description:
+      - The (unique) ID of the VM.
+      - Used only in C(move) action
+    type: int
+  timeout:
+    description:
+      - Timeout for move action
+      - Used only in C(move) action
+    type: int
+    default: 600
+  aio:
+    description:
+      - AIO type to use.
+    type: str
+    choices: ['native', 'threads', 'io_uring']
+  backup:
+    description:
+      - Whether the drive should be included when making backups.
+    type: bool
+  bps:
+    description:
+      - Maximum r/w speed in bytes per second.
+    type: int
+  bps_max_length:
+    description:
+      - Maximum length of I/O bursts in seconds.
+    type: int
+  bps_rd:
+    description:
+      - Maximum read speed in bytes per second.
+    type: int
+  bps_rd_max_length:
+    description:
+      - Maximum length of read I/O bursts in seconds.
+    type: int['none', 'writethrough', 'writeback', 'unsafe', 'directsync']
+  bps_wr:
+    description:
+      - Maximum write speed in bytes per second.
+    type: int
+  bps_wr_max_length:
+    description:
+      - Maximum length of write I/O bursts in seconds.
+    type: int
+  cache:
+    description:
+      - The drive’s cache mode
+    type: str
+    choices: ['none', 'writethrough', 'writeback', 'unsafe', 'directsync']
+  cyls:
+    description:
+      - Force the drive’s physical geometry to have a specific cylinder count.
+    type: int
+  detect_zeroes:
+    description:
+      - Controls whether to detect and try to optimize writes of zeroes.
+    type: bool
+  discard:
+    description:
+      - Controls whether to pass discard/trim requests to the underlying storage.
+    type: str
+    choices: ['ignore', 'on']
+  format:
+    description:
+      - The drive’s backing file’s data format.
+    type: str
+    choices: ['raw', 'cow', 'qcow', 'qed', 'qcow2', 'vmdk', 'cloop']
+  heads:
+    description:
+      - Force the drive’s physical geometry to have a specific head count.
+    type: int
+  import-from:
+    description:
+      - Import volume from this existing one. To use this parameter you have to specify C(size=0) in C(create) action
+      - Volume string format
+      - C(<STORAGE>:<VMID>/<FULL_NAME>) or C(<ABSOLUTE_PATH>/<FULL_NAME>)
+      - Attention! Only root can use absolute paths.
+    type: str
+  iops:
+    description:
+      - Maximum r/w I/O in operations per second.
+    type: int
+  iops_max:
+    description:
+      - Maximum unthrottled r/w I/O pool in operations per second.
+    type: int
+  iops_max_length:
+    description:
+      - Maximum length of I/O bursts in seconds.
+    type: int
+  iops_rd:
+    description:
+      - Maximum read I/O in operations per second.
+    type: int
+  iops_rd_max:
+    description:
+      - Maximum unthrottled read I/O pool in operations per second.
+    type: int
+  iops_rd_max_length:
+    description:
+      - Maximum length of read I/O bursts in seconds.
+    type: int
+  iops_wr:
+    description:
+      - Maximum write I/O in operations per second.
+    type: int
+  iops_wr_max:
+    description:
+      - Maximum unthrottled write I/O pool in operations per second.
+    type: int
+  iops_wr_max_length:
+    description:
+      - Maximum length of write I/O bursts in seconds.
+    type: int
+  iothread:
+    description:
+      - Whether to use iothreads for this drive (only for SCSI and VirtIO)
+    type: bool
+  mpbs:
+    description:
+      - Maximum r/w speed in megabytes per second.
+    type:
+  mpbs_max:
+    description:
+      - Maximum unthrottled r/w pool in megabytes per second.
+    type: int
+  mpbs_rd:
+    description:
+      - Maximum read speed in megabytes per second.
+    type: int
+  mpbs_rd_max:
+    description:
+      - Maximum unthrottled read pool in megabytes per second.
+    type: int
+  mpbs_wr:
+    description:
+      - Maximum write speed in megabytes per second.
+    type: int
+  mpbs_wr_max:
+    description:
+      - Maximum unthrottled write pool in megabytes per second.
+    type: int
+  media:
+    description:
+      - The drive’s media type.
+    type: str
+    choices: ['cdrom', 'disk']
+  queues:
+    description:
+      - Number of queues (SCSI only).
+    type: int
+  replicate:
+    description:
+      - Whether the drive should considered for replication jobs.
+    type: bool
+  rerror:
+    description:
+      - Read error action.
+    type: str
+    choices: ['ignore', 'report', 'stop']
+  ro:
+    description:
+      - Whether the drive is read-only.
+    type: bool
+  scsiblock:
+    description:
+      - Whether to use scsi-block for full passthrough of host block device
+      - Can lead to I/O errors in combination with low memory or high memory fragmentation on host
+    type: bool
+  secs:
+    description:
+      - Force the drive’s physical geometry to have a specific sector count.
+    type: int
+  serial:
+    description:
+      - The drive’s reported serial number, url-encoded, up to 20 bytes long.
+    type: str
+  shared:
+    description:
+      - Mark this locally-managed volume as available on all nodes.
+      - This option does not share the volume automatically, it assumes it is shared already!
+    type: bool
+  snapshot:
+    description:
+      - Controls qemu’s snapshot mode feature.
+      - If activated, changes made to the disk are temporary and will be discarded when the VM is shutdown.
+    type: bool
+  ssd:
+    description:
+      - Whether to expose this drive as an SSD, rather than a rotational hard disk.
+    type: bool
+  trans:
+    description:
+      - Force disk geometry bios translation mode.
+    type: str
+    choices: ['auto', 'lba', 'none']
+  werror:
+    description:
+      - Write error action.
+    type: str
+    choices: ['enospc', 'ignore', 'report', 'stop']
+  wwn:
+    description:
+      - The drive’s worldwide name, encoded as 16 bytes hex string, prefixed by 0x.
+    type: str
+extends_documentation_fragment:
+  - community.general.proxmox.documentation
+'''
+
+EXAMPLES = '''
+- name: Create new disk in VM (do not rewrite in case it exists already)
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    name: vm-name
+    disk: scsi3
+    action: create
+    state: present
+    backup: True
+    cache: none
+    storage: local-zfs
+    size: 5
+
+- name: Create new disk in VM (force rewrite in case it exists already)
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    vmid: 101
+    disk: scsi3
+    action: create
+    state: present
+    format: qcow2
+    storage: local
+    size: 16
+    force_replace: True
+
+- name: Update existing disk
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    vmid: 101
+    disk: ide0
+    action: update
+    backup: False
+    ro: True
+    aio: native
+    state: present
+
+- name: Grow existing disk
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    vmid: 101
+    disk: sata4
+    size: +5GB
+
+- name: Detach disk (leave it unused)
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    name: vm-name
+    disk: virtio0
+    action: detach
+    state: present
+
+- name: Move disk to another storage
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_password: secret
+    vmid: 101
+    disk: scsi7
+    target_storage: local
+    format: qcow2
+    action: move
+    state: present
+
+- name: Move disk from one VM to another
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    vmid: 101
+    disk: scsi7
+    target_vmid: 201
+    action: move
+    state: present
+
+- name: Move disk from one VM to another
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_token_id: token1
+    api_token_secret: some-token-data
+    name: vm-name
+    disk: scsi7
+
+- name: Remove disk permanently
+  community.general.proxmox_disk:
+    api_host: node1
+    api_user: root@pam
+    api_password: secret
+    vmid: 101
+    disk: scsi4
+    action: remove
+    state: absent
+'''
+
+RETURN = '''
+vmid:
+  description: The VM vmid.
+  returned: success
+  type: int
+  sample: 101
+msg:
+  description: A short message
+  returned: always
+  type: str
+  sample: "Disk scsi3 created in VM 101"
+'''
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec,
+                                                                                ProxmoxAnsible)
+from re import compile, match, sub
+from time import sleep
+
+
+def disk_conf_str_to_dict(config_string):
+    config = config_string.split(',')
+    storage_volume = config.pop(0).split(':')
+    config.sort()
+    storage_name = storage_volume[0]
+    volume_name = storage_volume[1]
+    config_current = dict(
+        volume='%s:%s' % (storage_name, volume_name),
+        storage_name=storage_name,
+        volume_name=volume_name
+    )
+
+    for i in config:
+        kv = i.split('=')
+        try:
+            config_current[kv[0]] = kv[1]
+        except IndexError:
+            config_current[kv[0]] = ''
+
+    return config_current
+
+
+class ProxmoxDiskAnsible(ProxmoxAnsible):
+    create_update_fields = [
+        'aio', 'backup', 'bps', 'bps_max_length', 'bps_rd', 'bps_rd_max_length', 'bps_wr', 'bps_wr_max_length',
+        'cache', 'cyls', 'detect_zeroes', 'discard', 'format', 'heads', 'import-from', 'iops', 'iops_max',
+        'iops_max_length', 'iops_rd', 'iops_rd_max', 'iops_rd_max_length', 'iops_wr', 'iops_wr_max',
+        'iops_wr_max_length', 'iothread', 'mpbs', 'mpbs_max', 'mpbs_rd', 'mpbs_rd_max', 'mpbs_wr', 'mpbs_wr_max',
+        'media', 'queues', 'replicate', 'rerror', 'ro', 'scsiblock', 'secs', 'serial', 'shared', 'snapshot',
+        'ssd', 'trans', 'werror', 'wwn'
+    ]
+    supported_ranges = dict(
+        ide=range(0, 4),
+        scsi=range(0, 31),
+        sata=range(0, 6),
+        virtio=range(0, 16),
+        unused=range(0, 256)
+    )
+
+    def sanitize_params(self):
+        # Sanitize parameters dictionary:
+        # - Remove not defined args
+        # - Ensure True and False converted to int.
+        # - Remove unnecessary parameters
+        params = dict((k, v) for k, v in self.module.params.items() if v is not None and k in self.create_update_fields)
+        params.update(dict((k, int(v)) for k, v in params.items() if isinstance(v, bool)))
+        return params
+
+    def create_disk(self, disk, vmid, vm, vm_config):
+        # Would not replace existing disk without 'force' flag
+        force_replace = self.module.params['force_replace']
+        if not force_replace and disk in vm_config:
+            self.module.fail_json(vmid=vmid, msg='Unable to replace existing disk %s without the *force* flag' % disk)
+
+        params = self.sanitize_params()
+        if params.get("import-from") and self.module.params["size"] != "0":
+            self.module.fail_json(vmid=vmid, msg='Only size=0 is acceptable with <import-from> parameter.')
+
+        config_str = "%s:%s" % (self.module.params["storage"], self.module.params["size"])
+
+        for k, v in params.items():
+            config_str += f',{k}={v}'
+
+        disk_config = {self.module.params["disk"]: config_str}
+        self.proxmox_api.nodes(vm['node']).qemu(vmid).config.set(**disk_config)
+
+    def update_disk(self, disk, vmid, vm, vm_config):
+        disk_config = disk_conf_str_to_dict(vm_config[disk])
+        config_str = disk_config["volume"]
+        params = self.sanitize_params()
+        for k, v in params.items():
+            config_str += f',{k}={v}'
+
+        disk_config = {self.module.params["disk"]: config_str}
+        self.proxmox_api.nodes(vm['node']).qemu(vmid).config.set(**disk_config)
+
+    def move_disk(self, disk, vmid, vm, vm_config):
+        params = dict()
+        params['disk'] = disk
+        params['vmid'] = vmid
+        params['bwlimit'] = self.module.params['bwlimit']
+        params['storage'] = self.module.params['target_storage']
+        params['target-disk'] = self.module.params['target_disk']
+        params['target-vmid'] = self.module.params['target_vmid']
+        params['format'] = self.module.params['format']
+        try:
+            params['delete'] = int(self.module.params['delete_moved'])
+        except TypeError:
+            params['delete'] = 0
+        # Remove not defined args
+        params = dict((k, v) for k, v in params.items() if v is not None)
+
+        taskid = self.proxmox_api.nodes(vm['node']).qemu(vmid).move_disk.post(**params)
+        timeout = self.module.params['timeout']
+        while timeout:
+            status_data = self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
+            if status_data['status'] == 'stopped' and status_data['exitstatus'] == 'OK':
+                return True
+            if timeout == 0:
+                self.module.fail_json(
+                    msg='Reached timeout while waiting for moving VM disk. Last line in task before timeout: %s' %
+                        self.proxmox_api.nodes(vm['node']).tasks(taskid).log.get()[:1])
+
+            sleep(1)
+            timeout -= 1
+        return False
+
+
+def main():
+    module_args = proxmox_auth_argument_spec()
+    disk_args = dict(
+        # Proxmox native parameters
+        aio=dict(choices=['native', 'threads', 'io_uring']),
+        backup=dict(type='bool'),
+        bps=dict(type='int'),
+        bps_max_length=dict(type='int'),
+        bps_rd=dict(type='int'),
+        bps_rd_max_length=dict(type='int'),
+        bps_wr=dict(type='int'),
+        bps_wr_max_length=dict(type='int'),
+        cache=dict(choices=['none', 'writethrough', 'writeback', 'unsafe', 'directsync']),
+        cyls=dict(type='int'),
+        detect_zeroes=dict(type='bool'),
+        discard=dict(choices=['ignore', 'on']),
+        format=dict(choices=['raw', 'cow', 'qcow', 'qed', 'qcow2', 'vmdk', 'cloop']),
+        heads=dict(type='int'),
+        iops=dict(type='int'),
+        iops_max=dict(type='int'),
+        iops_max_length=dict(type='int'),
+        iops_rd=dict(type='int'),
+        iops_rd_max=dict(type='int'),
+        iops_rd_max_length=dict(type='int'),
+        iops_wr=dict(type='int'),
+        iops_wr_max=dict(type='int'),
+        iops_wr_max_length=dict(type='int'),
+        iothread=dict(type='bool'),
+        mpbs=dict(type='int'),
+        mpbs_max=dict(type='int'),
+        mpbs_rd=dict(type='int'),
+        mpbs_rd_max=dict(type='int'),
+        mpbs_wr=dict(type='int'),
+        mpbs_wr_max=dict(type='int'),
+        media=dict(choices=['cdrom', 'disk']),
+        queues=dict(type='int'),
+        replicate=dict(type='bool'),
+        rerror=dict(choices=['ignore', 'report', 'stop']),
+        ro=dict(type='bool'),
+        scsiblock=dict(type='bool'),
+        secs=dict(type='int'),
+        serial=dict(typr='str'),
+        shared=dict(type='bool'),
+        snapshot=dict(type='bool'),
+        ssd=dict(type='bool'),
+        trans=dict(choices=['auto', 'lba', 'none']),
+        werror=dict(choices=['enospc', 'ignore', 'report', 'stop']),
+        wwn=dict(type='str'),
+
+        # Disk moving relates parameters
+        bwlimit=dict(type='int'),
+        target_storage=dict(type='str'),
+        target_disk=dict(type='str'),
+        target_vmid=dict(type='int'),
+        delete_moved=dict(type='bool'),
+        timeout=dict(type='int', default='600'),
+
+        # Module related parameters
+        name=dict(typr='str'),
+        vmid=dict(type='int'),
+        disk=dict(type='str', required=True),
+        storage=dict(type='str'),
+        size=dict(type='str'),
+        state=dict(choices=['present', 'absent'], default='present'),
+        force_replace=dict(type='bool', default=False),
+        action=dict(choices=['create', 'update', 'grow', 'detach', 'move', 'remove'], required=True)
+    )
+    # This is sole dashed parameter so add it separately
+    disk_args.update({'import-from': dict(type='str')})
+
+    module_args.update(disk_args)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_together=[('api_token_id', 'api_token_secret')],
+        required_one_of=[('name', 'vmid'), ('api_password', 'api_token_id')],
+        required_if=[
+            ('action', 'create', ('storage', 'size')),
+            ('action', 'grow', 'size')
+        ],
+        supports_check_mode=False,
+        mutually_exclusive=[('target_vmid', 'target_storage')]
+    )
+
+    proxmox = ProxmoxDiskAnsible(module)
+
+    disk = module.params['disk']
+    # Verify disk name has appropriate name
+    disk_regex = compile(r'^([a-z]+)([0-9]+)$')
+    disk_bus = sub(disk_regex, r'\1', disk)
+    disk_number = int(sub(disk_regex, r'\2', disk))
+    if disk_bus not in proxmox.supported_ranges.keys():
+        proxmox.module.fail_json(msg='Unsupported disk bus: %s' % disk_bus)
+    elif disk_number not in proxmox.supported_ranges[disk_bus]:
+        bus_range = proxmox.supported_ranges[disk_bus]
+        proxmox.module.fail_json(msg='Disk %s number not in range %s..%s ' % (disk, bus_range[0], bus_range[-1]))
+
+    name = module.params['name']
+    state = module.params['state']
+    vmid = module.params['vmid']
+    action = module.params['action']
+
+    # If vmid is not defined then retrieve its value from the vm name,
+    if not vmid:
+        vmid = proxmox.get_vmid(name)
+
+    # Ensure VM id exists and retrieve its config
+    vm = None
+    vm_config = None
+    try:
+        vm = proxmox.get_vm(vmid)
+        vm_config = proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).config.get()
+    except Exception as e:
+        proxmox.module.fail_json(msg='Getting information for VM %s failed with exception: %s' % (vmid, str(e)))
+
+    if state == 'present' and action == 'create':
+        try:
+            proxmox.create_disk(disk, vmid, vm, vm_config)
+            module.exit_json(changed=True, vmid=vmid, msg="Disk %s created in VM %s" % (disk, vmid))
+        except Exception as e:
+            module.fail_json(vmid=vmid, msg='Unable to create disk %s in VM %s: %s' % (disk, vmid, str(e)))
+
+    # Do not try to perform actions on missing disk
+    if disk not in vm_config and action in ['remove', 'update', 'grow', 'detach', 'move']:
+        module.fail_json(vmid=vmid, msg='Unable to %s missing disk %s in VM %s' % (action, disk, vmid))
+
+    elif state == 'absent' and action == 'remove':
+        try:
+            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(vmid=vmid, idlist=disk, force=1)
+            module.exit_json(changed=True, vmid=vmid, msg="Disk %s removed in VM %s" % (disk, vmid))
+        except Exception as e:
+            module.fail_json(vmid=vmid, msg='Unable to remove disk %s from VM %s: %s' % (disk, vmid, str(e)))
+
+    elif state == 'present' and action in ['update', 'grow', 'detach', 'move']:
+        try:
+            if action == 'update':
+                proxmox.update_disk(disk, vmid, vm, vm_config)
+                module.exit_json(changed=True, vmid=vmid, msg="Disk %s updated in VM %s" % (disk, vmid))
+
+            elif action == 'detach':
+                if disk_bus == 'unused':
+                    module.fail_json(changed=False, vmid=vmid,
+                                     msg='Unable to detach detached disk %s in VM %s' % (disk, vmid))
+                proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(vmid=vmid, idlist=disk, force=0)
+                module.exit_json(changed=True, vmid=vmid, msg="Disk %s detached from VM %s" % (disk, vmid))
+
+            elif action == 'move':
+                proxmox.move_disk(disk, vmid, vm, vm_config)
+                disk_config = disk_conf_str_to_dict(vm_config[disk])
+                module.exit_json(
+                    changed=True,
+                    vmid=vmid,
+                    msg="Disk %s moved from VM %s storage %s" % (disk, vmid, disk_config["storage_name"]))
+
+            elif action == 'grow':
+                size = module.params['size']
+                if not match(r'^\+?\d+(\.\d+)?[KMGT]?$', size):
+                    module.exit_json(vmid=vmid, msg="Unrecognized size pattern for disk %s: %s" % (disk, size))
+                proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).resize.set(vmid=vmid, disk=disk, size=size)
+                module.exit_json(changed=True, vmid=vmid, msg="Disk %s resized in VM %s" % (disk, vmid))
+
+        except Exception as e:
+            module.fail_json(msg="Action %s in VM %s failed with exception: %s" % (action, vmid, str(e)))
+
+    else:
+        module.fail_json(vmid=vmid,
+                         msg='Unsupported combination of parameters state=%s and action=%s' % (state, action))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -24,7 +24,7 @@ options:
     type: str
   vmid:
     description:
-      - The (unique) ID of the VM.
+      - The unique ID of the VM.
     type: int
   disk:
     description:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -30,6 +30,13 @@ options:
   disk:
     description:
       - The disk key (C(unused[n]), C(ide[n]), C(sata[n]), C(scsi[n]) or C(virtio[n])) you want to operate on.
+      - Disk buses (IDE, SATA and so on) have fixed ranges of C(n) that accepted by Proxmox API.
+      - >
+        For IDE: 0-3;
+        for SCSI: 0-30;
+        for SATA: 0-5;
+        for VirtIO: 0-15;
+        for Unused: 0-255.
     type: str
     required: True
   state:

--- a/plugins/modules/cloud/misc/proxmox_disk.py
+++ b/plugins/modules/cloud/misc/proxmox_disk.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 ---
 module: proxmox_disk
 short_description: Management of a disk of a Qemu(KVM) VM in a Proxmox VE cluster.
-version_added: 5.6.0
+version_added: 5.7.0
 description:
   - Allows you to perform some supported operations on a disk in Qemu(KVM) Virtual Machines in a Proxmox VE cluster.
 author: "Castor Sky (@castorsky) <csky57@gmail.com>"

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -354,9 +354,9 @@
       that:
       - results is not changed
       - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} already exists in VM {{ vmid }}."
+      - results.msg == "Disk {{ disk }} is up to date in VM {{ vmid }}"
 
-  - name: Add new disk replacing existing disk (detach latter)
+  - name: Add new disk replacing existing disk (detach old and leave unused)
     proxmox_disk:
       api_host: "{{ api_host }}"
       api_user: "{{ user }}@{{ domain }}"
@@ -366,8 +366,8 @@
       vmid: "{{ vmid }}"
       disk: "{{ disk }}"
       storage: "{{ storage }}"
-      size: 1
-      force_replace: True
+      size: 2
+      create: forced
       state: present
     register: results
 
@@ -392,7 +392,7 @@
       backup: False
       ro: True
       aio: native
-      state: updated
+      state: present
     register: results
 
   - assert:
@@ -414,7 +414,7 @@
       vmid: "{{ vmid }}"
       disk: "{{ disk }}"
       size: +1G
-      state: grown
+      state: resized
     register: results
 
   - assert:

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -389,7 +389,7 @@
       api_token_secret: "{{ api_token_secret | default(omit) }}"
       vmid: "{{ vmid }}"
       disk: "{{ disk }}"
-      backup: False
+      backup: false
       ro: true
       aio: native
       state: present

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -390,7 +390,7 @@
       vmid: "{{ vmid }}"
       disk: "{{ disk }}"
       backup: False
-      ro: True
+      ro: true
       aio: native
       state: present
     register: results

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -313,6 +313,202 @@
         - results.vmid == {{ vmid }}
         - results.msg == "Nic net5 deleted on VM with vmid {{ vmid }}"
 
+- name: Create new disk in VM
+  tags: ['create_disk']
+  block:
+  - name: Add new disk (without force) to VM
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      storage: "{{ storage }}"
+      size: 1
+      state: present
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
+
+  - name: Try add disk again with same options (expect no-op)
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      storage: "{{ storage }}"
+      size: 1
+      state: present
+    register: results
+
+  - assert:
+      that:
+      - results is not changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} already exists in VM {{ vmid }}."
+
+  - name: Add new disk replacing existing disk (detach latter)
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      storage: "{{ storage }}"
+      size: 1
+      force_replace: True
+      state: present
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
+
+- name: Update existing disk in VM
+  tags: ['update_disk']
+  block:
+  - name: Update disk configuration
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      backup: False
+      ro: True
+      aio: native
+      state: updated
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} updated in VM {{ vmid }}"
+
+- name: Grow existing disk in VM
+  tags: ['grow_disk']
+  block:
+  - name: Increase disk size
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      size: +1G
+      state: grown
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} resized in VM {{ vmid }}"
+
+- name: Detach disk and leave it unused
+  tags: ['detach_disk']
+  block:
+  - name: Detach disk
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      state: detached
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} detached from VM {{ vmid }}"
+
+- name: Move disk to another storage or another VM
+  tags: ['move_disk']
+  block:
+  - name: Move disk to another storage inside same VM
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      target_storage: "{{ target_storage }}"
+      format: "{{ target_format }}"
+      state: moved
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
+
+  - name: Move disk to another VM (same storage)
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ vmid }}"
+      disk: "{{ disk }}"
+      target_vmid: "{{ target_vm }}"
+      target_disk: "{{ target_disk }}"
+      state: moved
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ vmid }}
+      - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
+
+
+- name: Remove disk permanently
+  tags: ['remove_disk']
+  block:
+  - name: Remove disk
+    proxmox_disk:
+      api_host: "{{ api_host }}"
+      api_user: "{{ user }}@{{ domain }}"
+      api_password: "{{ api_password | default(omit) }}"
+      api_token_id: "{{ api_token_id | default(omit) }}"
+      api_token_secret: "{{ api_token_secret | default(omit) }}"
+      vmid: "{{ target_vm }}"
+      disk: "{{ target_disk }}"
+      state: absent
+    register: results
+
+  - assert:
+      that:
+      - results is changed
+      - results.vmid == {{ target_vm }}
+      - results.msg == "Disk {{ target_disk }} removed from VM {{ target_vm }}"
+
 - name: VM stop
   tags: [ 'stop' ]
   block:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `proxmox_disk` module to provide management of virtual volumes in QEMU(KVM) virtual machines
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- proxmox_disk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This module provides ability to manage disks in Proxmox VMs in such ways:
- create disk (fresh new or import from existing image);
- update disk (change some parameters, for example: iops limit, backup status);
- move disk (between storages in one VM or to another VM);
- grow size (shrinking not supported);
- detach disk (leave it `unused`);
- remove disk (permanently).
<!--- Paste verbatim command output below, e.g. before and after your change -->

