### PR TITLE
Change Proxmox `agent` argument to string.

### DIFF
--- a/changelogs/fragments/5107-proxmox-agent-argument.yaml
+++ b/changelogs/fragments/5107-proxmox-agent-argument.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - allow ``agent`` argument to be a string (https://github.com/ansible-collections/community.general/pull/5107).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -963,12 +963,9 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                 kwargs.update(kwargs[k])
                 del kwargs[k]
 
-        # Map bool to string, according to API documentation.
         try:
-            if boolean(kwargs['agent'], strict=True):
-                kwargs['agent'] = 'enabled=1'
-            else:
-                kwargs['agent'] = 'enabled=0'
+            # The API also allows booleans instead of e.g. `enabled=1` for backward-compatibility.
+            kwargs['agent'] = boolean(kwargs['agent'], strict=True)
         except TypeError:
             # Not something that Ansible would parse as a boolean.
             pass

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -25,7 +25,9 @@ options:
   agent:
     description:
       - Specify if the QEMU Guest Agent should be enabled/disabled.
-    type: bool
+      - Since community.general 5.5.0, this can also be a string instead of a boolean.
+        This allows to specify values such as C(enabled=1,fstrim_cloned_disks=1).
+    type: str
   args:
     description:
       - Pass arbitrary arguments to kvm.
@@ -809,6 +811,7 @@ from ansible_collections.community.general.plugins.module_utils.proxmox import (
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.parsing.convert_bool import boolean
 
 
 def parse_mac(netstr):
@@ -960,7 +963,17 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                 kwargs.update(kwargs[k])
                 del kwargs[k]
 
-        # Rename numa_enabled to numa. According the API documentation
+        # Map bool to string, according to API documentation.
+        try:
+            if boolean(kwargs['agent'], strict=True):
+                kwargs['agent'] = 'enabled=1'
+            else:
+                kwargs['agent'] = 'enabled=0'
+        except TypeError:
+            # Not something that Ansible would parse as a boolean.
+            pass
+
+        # Rename numa_enabled to numa, according the API documentation
         if 'numa_enabled' in kwargs:
             kwargs['numa'] = kwargs['numa_enabled']
             del kwargs['numa_enabled']
@@ -1040,7 +1053,7 @@ def main():
     module_args = proxmox_auth_argument_spec()
     kvm_args = dict(
         acpi=dict(type='bool'),
-        agent=dict(type='bool'),
+        agent=dict(type='str'),
         args=dict(type='str'),
         autostart=dict(type='bool'),
         balloon=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY

Allow specifying Proxmox `agent` argument as string.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_kvm`

##### ADDITIONAL INFORMATION

The `agent` argument can not only be `true` or `false` (or `0`/`1`) but also be a string, e.g. `enabled=1,fstrim_cloned_disks=1`.

Extracted from https://github.com/ansible-collections/community.general/pull/4027.