### PR TITLE
Fix Proxmox `node`, `name` condition.

### DIFF
--- a/changelogs/fragments/5108-proxmox-node-name-condition.yml
+++ b/changelogs/fragments/5108-proxmox-node-name-condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - fix wrong condition (https://github.com/ansible-collections/community.general/pull/5108).

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -1234,7 +1234,7 @@ def main():
                 module.exit_json(changed=False, vmid=vmid, msg="VM with vmid <%s> already exists" % vmid)
             elif proxmox.get_vmid(name, ignore_missing=True) and not (update or clone):
                 module.exit_json(changed=False, vmid=proxmox.get_vmid(name), msg="VM with name <%s> already exists" % name)
-            elif not (node, name):
+            elif (not node) or (not name):
                 module.fail_json(msg='node, name is mandatory for creating/updating vm')
             elif not proxmox.get_node(node):
                 module.fail_json(msg="node '%s' does not exist in cluster" % node)


### PR DESCRIPTION
##### SUMMARY

Fix condition which is always false.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_kvm`

##### ADDITIONAL INFORMATION

`not (node, name)` is always false, the correct check is if either `node` or `name` is unspecified.

Extracted from https://github.com/ansible-collections/community.general/pull/4027.