### PR TITLE
Fix nsupdate when updating NS record

### DIFF
--- a/changelogs/fragments/5112-fix-nsupdate-ns-entry.yaml
+++ b/changelogs/fragments/5112-fix-nsupdate-ns-entry.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - compatibility with ns records (https://github.com/ansible-collections/community.general/pull/5112).

--- a/changelogs/fragments/5112-fix-nsupdate-ns-entry.yaml
+++ b/changelogs/fragments/5112-fix-nsupdate-ns-entry.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nsupdate - compatibility with ns records (https://github.com/ansible-collections/community.general/pull/5112).
+  - nsupdate - compatibility with NS records (https://github.com/ansible-collections/community.general/pull/5112).

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -427,7 +427,10 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
-        current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
+        if self.module.params['type'] == 'NS:
+            current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
+        else:
+            current_ttl = lookup.answer[0].ttl
         return current_ttl != self.module.params['ttl']
 
 

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -427,7 +427,7 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
-        current_ttl = lookup.authority[0].ttl if self.module.params['type'] == 'NS' else lookup.answer[0].ttl
+        current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
         return current_ttl != self.module.params['ttl']
 
 

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -427,7 +427,7 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
-        if self.module.params['type'] == 'NS:
+        if self.module.params['type'] == 'NS':
             current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
         else:
             current_ttl = lookup.answer[0].ttl

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -427,7 +427,7 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
-        current_ttl = lookup.answer[0].ttl
+        current_ttl = lookup.authority[0].ttl if self.module.params['type'] == 'NS' else lookup.answer[0].ttl
         return current_ttl != self.module.params['ttl']
 
 


### PR DESCRIPTION
##### SUMMARY
Fixed a bug where one cannot update an existing NS record.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nsupdate`

##### ADDITIONAL INFORMATION
In order to determine if any changes occurred, the `nsupdate` component queries the TTL of the resulting record. 

When querying `A`, `AAAA`, `SOA`, or `CNAME` records, one gets something like this in the ANSWER section:
```
;; ANSWER SECTION:
github.com.		60	IN	A	140.82.113.3
```
Here, we can see a TTL of 60 seconds.

However, an `NS` record and its TTL appears in the AUTHORITY section:
```
;; AUTHORITY SECTION:
github.com.		900	IN	NS	dns1.p08.nsone.net.
github.com.		900	IN	NS	dns2.p08.nsone.net.
github.com.		900	IN	NS	dns3.p08.nsone.net.
github.com.		900	IN	NS	dns4.p08.nsone.net.
```

The `nsupdate` component only searches for TTL in the ANSWER section. Thus, when updating `NS` records, the `nsupdate` component reads the wrong section for a TTL. When no ANSWER section records exist, the `nsupdate` component outright fails due to an index out of bounds error.

This bug fix reads the AUTHORITY section when an NS request is made.