### PR TITLE
dig: Fix evaluation of boolean parameters

### DIFF
--- a/changelogs/fragments/5129-dig-boolean-params-fix.yml
+++ b/changelogs/fragments/5129-dig-boolean-params-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dig lookup plugin - fix evaluation of falsy values for boolean parameters ``fail_on_error`` and ``retry_servfail``

--- a/changelogs/fragments/5129-dig-boolean-params-fix.yml
+++ b/changelogs/fragments/5129-dig-boolean-params-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dig lookup plugin - fix evaluation of falsy values for boolean parameters ``fail_on_error`` and ``retry_servfail``
+  - dig lookup plugin - fix evaluation of falsy values for boolean parameters ``fail_on_error`` and ``retry_servfail`` (https://github.com/ansible-collections/community.general/pull/5129).

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -172,6 +172,7 @@ RETURN = """
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.utils.display import Display
 import socket
 
@@ -321,9 +322,9 @@ class LookupModule(LookupBase):
                     except Exception as e:
                         raise AnsibleError("dns lookup illegal CLASS: %s" % to_native(e))
                 elif opt == 'retry_servfail':
-                    myres.retry_servfail = bool(arg)
+                    myres.retry_servfail = boolean(arg)
                 elif opt == 'fail_on_error':
-                    fail_on_error = bool(arg)
+                    fail_on_error = boolean(arg)
 
                 continue
 

--- a/tests/integration/targets/lookup_dig/aliases
+++ b/tests/integration/targets/lookup_dig/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+shippable/posix/group1
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_dig/meta/main.yml
+++ b/tests/integration/targets/lookup_dig/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_constraints

--- a/tests/integration/targets/lookup_dig/meta/main.yml
+++ b/tests/integration/targets/lookup_dig/meta/main.yml
@@ -1,2 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 dependencies:
   - setup_remote_constraints

--- a/tests/integration/targets/lookup_dig/tasks/main.yml
+++ b/tests/integration/targets/lookup_dig/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Install dnspython library
   pip:
     name: dnspython
-    state: present
+    extra_args: "-c {{ remote_constraints }}"
 
 - name: Test dig lookup with existing domain
   set_fact:

--- a/tests/integration/targets/lookup_dig/tasks/main.yml
+++ b/tests/integration/targets/lookup_dig/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install dnspython library
+  pip:
+    name: dnspython
+    state: present
+
+- name: Test dig lookup with existing domain
+  set_fact:
+    dig_existing: "{{ lookup('community.general.dig', 'github.com.') }}"
+
+- name: Test dig lookup with non-existing domain and fail_on_error=no
+  set_fact:
+    dig_nonexisting_fail_no: "{{ lookup('community.general.dig', 'non-existing.domain.', 'fail_on_error=no') }}"
+
+- name: Verify that NXDOMAIN was returned
+  assert:
+    that: dig_nonexisting_fail_no == 'NXDOMAIN'
+
+- name: Test dig lookup with non-existing domain and fail_on_error=yes
+  set_fact:
+    dig_nonexisting_fail_yes: "{{ lookup('community.general.dig', 'non-existing.domain.', 'fail_on_error=yes') }}"
+  ignore_errors: yes
+  register: dig_nonexisting_fail_yes_result
+
+- name: Verify that the task failed
+  assert:
+    that: dig_nonexisting_fail_yes_result is failed

--- a/tests/integration/targets/lookup_dig/tasks/main.yml
+++ b/tests/integration/targets/lookup_dig/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: Install dnspython library
   pip:
     name: dnspython
+    state: present
     extra_args: "-c {{ remote_constraints }}"
 
 - name: Test dig lookup with existing domain


### PR DESCRIPTION
##### SUMMARY
Fixes evaluation of falsy boolean parameters in dig lookup plugin.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.dig lookup plugin

##### ADDITIONAL INFORMATION
Plugin currently uses `bool()` function to convert string boolean values to boolean type. This function in not the right one for this task as is returns `True` for every non-empty string:
```
Python 3.9.7 (default, Sep 13 2021, 08:18:39) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> bool('False')
True
>>> bool('no')
True
```
There is function in ansible.module_utils for this which correctly handles string-to-boolean conversion.

I also added tests for dig lookup and this issue specifically.