### PR TITLE
filesystem tests: increase xfs size to 300 MB

### DIFF
--- a/tests/integration/targets/filesystem/defaults/main.yml
+++ b/tests/integration/targets/filesystem/defaults/main.yml
@@ -19,7 +19,7 @@ tested_filesystems:
   ext4dev: {fssize: 10, grow: True}
   ext3: {fssize: 10, grow: True}
   ext2: {fssize: 10, grow: True}
-  xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
+  xfs: {fssize: 300, grow: False}  # grow requires a mounted filesystem
   btrfs: {fssize: 150, grow: False}  # grow requires a mounted filesystem
   reiserfs: {fssize: 33, grow: False}  # grow not implemented
   vfat: {fssize: 20, grow: True}


### PR DESCRIPTION
##### SUMMARY
This seems to be new minimal size. The xfs tests on Arch no longer pass with smaller sizes: https://dev.azure.com/ansible/community.general/_build/results?buildId=51678&view=logs&j=57f52a93-2f8f-5f4a-64e7-e08c30d14461&t=639a25f5-5b1b-5d56-c79d-060a9682ed36&l=9760

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
filesystem
