### PR TITLE
Do not build docs for test-only, changelog-only, or meta-only changes

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -10,6 +10,11 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
+    paths-ignore:
+      - '.azure-pipelines/**'
+      - 'changelogs/**'
+      - 'meta/**'
+      - 'tests/**'
 
 jobs:
   build-docs:


### PR DESCRIPTION
##### SUMMARY
For example test-only PRs such as #5133 do not need a docs build. Since the docs build is pretty slow for community.general (5 minutes for each, i.e. 10 minutes in total), let's save some GHA time by skipping it for some paths!

CC @briantist 

##### ISSUE TYPE
- Test Pull Request
- Docs Pull Request

##### COMPONENT NAME
docs PR workflow
