### PR TITLE
bugfix for xfs_quota not properly initializing project quotas

### DIFF
--- a/changelogs/fragments/5143-fix-xfs-project-quota-initialization.yaml
+++ b/changelogs/fragments/5143-fix-xfs-project-quota-initialization.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - xfs_quota - the call to "xfs_quota" to set up project quotas was missing the project name and hence failed (https://github.com/ansible-collections/community.general/issues/5143).
+  - xfs_quota - the call to ``xfs_quota`` to set up project quotas was missing the project name and hence failed (https://github.com/ansible-collections/community.general/issues/5143).

--- a/changelogs/fragments/5143-fix-xfs-project-quota-initialization.yaml
+++ b/changelogs/fragments/5143-fix-xfs-project-quota-initialization.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - xfs_quota - the call to "xfs_quota" to set up project quotas was missing the project name and hence failed (https://github.com/ansible-collections/community.general/issues/5143).

--- a/plugins/modules/system/xfs_quota.py
+++ b/plugins/modules/system/xfs_quota.py
@@ -294,7 +294,7 @@ def main():
                         break
 
         if not prj_set and not module.check_mode:
-            cmd = "project -s"
+            cmd = "project -s %s" % name
             rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
             if rc != 0:
                 result["cmd"] = cmd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`xfs_quota` is not properly initializing xfs project quota groups (https://github.com/ansible-collections/community.general/issues/5143), this PR proposes a fix.
Fixes #5143 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
xfs_quota

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This is an attempt to re-submit https://github.com/ansible-collections/community.general/pull/3350. Hopefully this time all tests succeed.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
