### PR TITLE
terraform: run `init` with no-color, too

### DIFF
--- a/changelogs/5147-terraform-init-no-color.yml
+++ b/changelogs/5147-terraform-init-no-color.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - terraform - run ``terraform init`` with ``-no-color`` not to mess up the stdout of the task.

--- a/changelogs/5147-terraform-init-no-color.yml
+++ b/changelogs/5147-terraform-init-no-color.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terraform - run ``terraform init`` with ``-no-color`` not to mess up the stdout of the task.

--- a/changelogs/fragments/5147-terraform-init-no-color.yml
+++ b/changelogs/fragments/5147-terraform-init-no-color.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terraform - run ``terraform init`` with ``-no-color`` not to mess up the stdout of the task (https://github.com/ansible-collections/community.general/pull/5147).

--- a/plugins/modules/cloud/misc/terraform.py
+++ b/plugins/modules/cloud/misc/terraform.py
@@ -273,7 +273,7 @@ def _state_args(state_file):
 
 
 def init_plugins(bin_path, project_path, backend_config, backend_config_files, init_reconfigure, provider_upgrade, plugin_paths):
-    command = [bin_path, 'init', '-input=false']
+    command = [bin_path, 'init', '-input=false', '-no-color']
     if backend_config:
         for key, val in backend_config.items():
             command.extend([


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
When running `terraform init` fails, it would output ansi color sequences, making the output hard to read.

Maybe setting TF_IN_AUTOMATION would also be beneficial: https://www.terraform.io/cli/config/environment-variables#tf_in_automation

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
