### PR TITLE
nmcli: Add xmit_hash_policy to bond options.

### DIFF
--- a/changelogs/fragments/5149-nmcli-bond-option.yml
+++ b/changelogs/fragments/5149-nmcli-bond-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli module - add bond option `xmit_hash_policy` to bond options (https://github.com/ansible-collections/community.general/issues/5148).

--- a/changelogs/fragments/5149-nmcli-bond-option.yml
+++ b/changelogs/fragments/5149-nmcli-bond-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli module - add bond option `xmit_hash_policy` to bond options (https://github.com/ansible-collections/community.general/issues/5148).
+  - nmcli - add bond option ``xmit_hash_policy`` to bond options (https://github.com/ansible-collections/community.general/issues/5148).

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -319,6 +319,10 @@ options:
         description:
             - This is only used with bond - updelay.
         type: int
+    xmit_hash_policy:
+        description:
+            - This is only used with bond - xmit_hash_policy type.
+        type: str
     arp_interval:
         description:
             - This is only used with bond - ARP interval.
@@ -1441,6 +1445,7 @@ class Nmcli(object):
         self.primary = module.params['primary']
         self.downdelay = module.params['downdelay']
         self.updelay = module.params['updelay']
+        self.xmit_hash_policy = module.params['xmit_hash_policy']
         self.arp_interval = module.params['arp_interval']
         self.arp_ip_target = module.params['arp_ip_target']
         self.slavepriority = module.params['slavepriority']
@@ -1581,6 +1586,7 @@ class Nmcli(object):
                 'mode': self.mode,
                 'primary': self.primary,
                 'updelay': self.updelay,
+                'xmit_hash_policy': self.xmit_hash_policy,
             })
         elif self.type == 'bond-slave':
             options.update({
@@ -2228,6 +2234,7 @@ def main():
             miimon=dict(type='int'),
             downdelay=dict(type='int'),
             updelay=dict(type='int'),
+            xmit_hash_policy=dict(type='str'),
             arp_interval=dict(type='int'),
             arp_ip_target=dict(type='str'),
             primary=dict(type='str'),

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -323,6 +323,7 @@ options:
         description:
             - This is only used with bond - xmit_hash_policy type.
         type: str
+        version_added: 5.6.0
     arp_interval:
         description:
             - This is only used with bond - ARP interval.


### PR DESCRIPTION
##### SUMMARY
Following my feature request: https://github.com/ansible-collections/community.general/issues/5148
 
With the nmcli you can specify the xmit_hash_policy type.
That isn't possible with the ansible module so far.


https://www.kernel.org/doc/Documentation/networking/bonding.txt

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module nmcli