### PR TITLE
[TEMP] CI: Fix RHEL 8 issues by restricting bcrypt to < 4.0.0

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -55,6 +55,7 @@ redis < 4.0.0 ; python_version >= '2.7' and python_version < '3.6'
 redis ; python_version >= '3.6'
 pycdlib < 1.13.0 ; python_version < '3'  # 1.13.0 does not work with Python 2, while not declaring that
 python-daemon <= 2.3.0 ; python_version < '3'
+bcrypt < 4.0.0  # TEMP: restrict to < 4.0.0 since installing 4.0.0 fails on RHEL 8
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY
See https://dev.azure.com/ansible/community.general/_build/results?buildId=52124&view=logs&j=2af077cc-9967-5a59-41b3-7f2740d297c7&t=03acf6a6-34c4-5cf9-db61-19526b7fc7bb

```
Collecting stormssh
  Using cached https://files.pythonhosted.org/packages/0a/18/85d12be676ae0c1d98173b07cc289bbf9e0c67d6c7054b8df3e1003bf992/stormssh-0.7.0.tar.gz
Collecting paramiko (from stormssh)
  Using cached https://files.pythonhosted.org/packages/04/e5/39ec73dd4a8769d6759b8d6c60a1b2c9337f585407c2ae8bfb8ccb734278/paramiko-2.11.0-py2.py3-none-any.whl
Collecting termcolor (from stormssh)
  Using cached https://files.pythonhosted.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz
Collecting flask (from stormssh)
  Using cached https://files.pythonhosted.org/packages/cd/77/59df23681f4fd19b7cbbb5e92484d46ad587554f5d490f33ef907e456132/Flask-2.0.3-py3-none-any.whl
Requirement already satisfied: six in /usr/lib/python3.6/site-packages (from stormssh)
Collecting pynacl<1.5.0,>=1.4.0 (from -c /tmp/ansible.1ihk4dd9.test/constraints.txt (line 67))
  Downloading https://files.pythonhosted.org/packages/9d/57/2f5e6226a674b2bcb6db531e8b383079b678df5b10cdaa610d6cf20d77ba/PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl (961kB)
Collecting cryptography<3.4,>=3.3 (from -c /tmp/ansible.1ihk4dd9.test/constraints.txt (line 10))
  Downloading https://files.pythonhosted.org/packages/32/48/ec2a3e98d8b61d2c65e4c6905aad370049c4bd4a6b1b1d78f8983d38effe/cryptography-3.3.2-cp36-abi3-manylinux1_x86_64.whl (2.7MB)
Collecting bcrypt>=3.1.3 (from paramiko->stormssh)
  Using cached https://files.pythonhosted.org/packages/99/f2/b71b9b5b2400fffac7d42c560ac89f302c4d8e328337b2f05f0a4d9e590d/bcrypt-4.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    
            =============================DEBUG ASSISTANCE==========================
            If you are seeing an error here please try the following to
            successfully install cryptography:
    
            Upgrade to the latest pip and try again. This will fix errors for most
            users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
            =============================DEBUG ASSISTANCE==========================
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-9zjwcdng/bcrypt/setup.py", line 11, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
    
    ----------------------------------------

:stderr: WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Ignoring certifi: markers 'python_version < "3.5"' don't match your environment
Ignoring coverage: markers 'python_version > "3.7"' don't match your environment
Ignoring cryptography: markers 'python_version < "2.7"' don't match your environment
Ignoring cryptography: markers 'python_version < "3.6" and python_version >= "2.7"' don't match your environment
Ignoring deepdiff: markers 'python_version < "3"' don't match your environment
Ignoring jinja2: markers 'python_version < "2.7"' don't match your environment
Ignoring urllib3: markers 'python_version < "2.7"' don't match your environment
Ignoring sphinx: markers 'python_version < "2.7"' don't match your environment
Ignoring wheel: markers 'python_version < "2.7"' don't match your environment
Ignoring yamllint: markers 'python_version < "2.7"' don't match your environment
Ignoring paramiko: markers 'python_version < "2.7"' don't match your environment
Ignoring pytest: markers 'python_version < "2.7"' don't match your environment
Ignoring pytest: markers 'python_version == "2.7"' don't match your environment
Ignoring pytest-forked: markers 'python_version < "2.7"' don't match your environment
Ignoring requests: markers 'python_version < "2.7"' don't match your environment
Ignoring virtualenv: markers 'python_version < "2.7"' don't match your environment
Ignoring pathspec: markers 'python_version < "2.7"' don't match your environment
Ignoring pyopenssl: markers 'python_version < "2.7"' don't match your environment
Ignoring pyopenssl: markers 'python_version >= "2.7" and python_version < "3.6"' don't match your environment
Ignoring pyyaml: markers 'python_version < "2.7"' don't match your environment
Ignoring pycparser: markers 'python_version < "2.7"' don't match your environment
Ignoring xmltodict: markers 'python_version < "2.7"' don't match your environment
Ignoring lxml: markers 'python_version < "2.7"' don't match your environment
Ignoring pyvmomi: markers 'python_version < "2.7"' don't match your environment
Ignoring boto3: markers 'python_version < "2.7"' don't match your environment
Ignoring botocore: markers 'python_version < "2.7"' don't match your environment
Ignoring setuptools: markers 'python_version <= "2.7"' don't match your environment
Ignoring redis: markers 'python_version < "2.7"' don't match your environment
Ignoring redis: markers 'python_version >= "2.7" and python_version < "3.6"' don't match your environment
Ignoring pycdlib: markers 'python_version < "3"' don't match your environment
Ignoring python-daemon: markers 'python_version < "3"' don't match your environment
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-9zjwcdng/bcrypt/
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
constraints
ssh_config
