### PR TITLE
Add --equal equivalent to sefcontext

### DIFF
--- a/plugins/modules/system/sefcontext.py
+++ b/plugins/modules/system/sefcontext.py
@@ -29,7 +29,6 @@ options:
     - when set, ftype, seuser, selevel are ignored.
     type: str
     required: no
-    default: None
   ftype:
     description:
     - The file type that should have SELinux contexts applied.

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -100,3 +100,56 @@
     that:
     - sixth is not changed
     - sixth.setype == 'unlabeled_t'
+
+#
+# NB: file equivalancy exists, or doesn't
+#
+- name: Create SELinux equivalance of /var/lib/pgsql for /tmp/foo
+  sefcontext:
+    equiv: '/var/lib/pgsql'
+    path: '/tmp/foo'
+    setype: 'many_t'
+    reload: no
+  register: equiv1
+
+- assert:
+    that:
+      - equiv1 is changed
+
+- name: Create SELinux equivalance of /var/lib/pgsql /tmp/foo (again)
+  sefcontext:
+    equiv: '/var/lib/pgsql'
+    path: '/tmp/foo'
+    setype: 'many_t'
+    reload: no
+  register: equiv2
+
+- assert:
+    that:
+      - equiv2 is not changed
+
+- name: Delete SELinux equivalance of /var/lib/pgsql for /tmp/foo
+  sefcontext:
+    state: absent
+    equiv: '/var/lib/pgsql'
+    path: '/tmp/foo'
+    setype: 'many_t'
+    reload: no
+  register: equiv3
+
+- assert:
+    that:
+      - equiv3 is changed
+
+- name: Delete SELinux equivalance of /var/lib/pgsql for /tmp/foo (again)
+  sefcontext:
+    state: absent
+    equiv: '/var/lib/pgsql'
+    path: '/tmp/foo'
+    setype: 'many_t'
+    reload: no
+  register: equiv4
+
+- assert:
+    that:
+      - equiv4 is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add the ability to idempotently add and remove an fcontext
equivalence, mirroring the 'semanage fcontext --equal' operations.

This operation requires a bogus setype, or even a valid one for that
matter, as the value is unused, and I did not want to make the
conditional change to
AnsibleModule(... setype=dict(type='str', required=True), ...

New tests were added to
tests/integration/targets/sefcontext/tasks/sefcontext.yml.

During testing it was discovered that deletions using 'semanage
fcontext' do not work for an individual equivalence deletion, only
--deleteall, which blows out ALL local settings.  This makes this
module an improvement over the command line tools in this case.

This should address https://github.com/ansible-collections/community.general/issues/1193

Signed-off-by: Doug Maxey <dithotxgh@github.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.general.sefcontext
