### PR TITLE
Fix creation of srv entries #5167

### DIFF
--- a/plugins/modules/net_tools/cloudflare_dns.py
+++ b/plugins/modules/net_tools/cloudflare_dns.py
@@ -687,7 +687,7 @@ class CloudflareAPI(object):
                 "port": params['port'],
                 "weight": params['weight'],
                 "priority": params['priority'],
-                "name": params['record'][:-len('.' + params['zone'])],
+                "name": params['record'],
                 "proto": params['proto'],
                 "service": params['service']
             }


### PR DESCRIPTION
##### SUMMARY
Fixes #5167 

This PR removes the splicing of the record entry which resulted in malformed api calls. record must be the name of the subdomain or "@"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ADDITIONAL INFORMATION
See: https://github.com/ansible-collections/community.general/issues/5167#issuecomment-1227227916