### PR TITLE
Consul session token

### DIFF
--- a/changelogs/fragments/5193-consul-session-token.yaml
+++ b/changelogs/fragments/5193-consul-session-token.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - consul_session - adds ``token`` parameter for session (https://github.com/ansible-collections/community.general/pull/5193).

--- a/plugins/modules/clustering/consul/consul_kv.py
+++ b/plugins/modules/clustering/consul/consul_kv.py
@@ -279,7 +279,7 @@ def remove_value(module):
                      data=existing)
 
 
-def get_consul_api(module, token=None):
+def get_consul_api(module):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),

--- a/plugins/modules/clustering/consul/consul_session.py
+++ b/plugins/modules/clustering/consul/consul_session.py
@@ -101,6 +101,12 @@ options:
           - Specifies the duration of a session in seconds (between 10 and 86400).
         type: int
         version_added: 5.4.0
+    token:
+        description:
+          - The token key identifying an ACL rule set that controls access to
+            the key value pair.
+        type: str
+        version_added: 5.6.0
 '''
 
 EXAMPLES = '''
@@ -241,7 +247,8 @@ def get_consul_api(module):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
-                         verify=module.params.get('validate_certs'))
+                         verify=module.params.get('validate_certs'),
+                         token=module.params.get('token'))
 
 
 def test_dependencies(module):
@@ -265,6 +272,7 @@ def main():
         node=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'info', 'list', 'node', 'present']),
         datacenter=dict(type='str'),
+        token=dict(type='str', no_log=True),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change allow to use a token when creating a session.
It also fixes the fact that session_id was taken as an argument of consul_kv but not applied when creating a new key/pair.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
consul_kv
consul_session

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```paste below
PLAY [Example] *************************************************
TASK [Create a session with a token] ******************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (community.general.consul_session) module: token. Supported parameters include: delay, id, node, scheme, datacenter, checks, validate_certs, behavior, name, port, host, ttl, state."}
NO MORE HOSTS LEFT *************************************************************
PLAY RECAP *********************************************************************localhost : ok=0    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0
```
After 
```
PLAY [Example] *************************************************
TASK [Create a session with a token] ******************************
changed: [localhost]
PLAY RECAP *********************************************************************localhost : ok=3    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```