### PR TITLE
Send string instead of boolean to proxmox api

### DIFF
--- a/changelogs/fragments/5198-proxmox.yml
+++ b/changelogs/fragments/5198-proxmox.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox_kvm - fix ``agent`` parameter when boolean value is specified (https://github.com/ansible-collections/community.general/pull/5198)."

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -966,7 +966,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         if 'agent' in kwargs:
             try:
                 # The API also allows booleans instead of e.g. `enabled=1` for backward-compatibility.
-                kwargs['agent'] = boolean(kwargs['agent'], strict=True)
+                kwargs['agent'] = '1' if boolean(kwargs['agent'], strict=True) else '0'
             except TypeError:
                 # Not something that Ansible would parse as a boolean.
                 pass

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -966,7 +966,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         if 'agent' in kwargs:
             try:
                 # The API also allows booleans instead of e.g. `enabled=1` for backward-compatibility.
-                kwargs['agent'] = '1' if boolean(kwargs['agent'], strict=True) else '0'
+                kwargs['agent'] = int(boolean(kwargs['agent'], strict=True))
             except TypeError:
                 # Not something that Ansible would parse as a boolean.
                 pass


### PR DESCRIPTION
##### SUMMARY
In [this commit](https://github.com/reitermarkus/community.general/commit/0be7b6e7b91bb2d7b6e16773cc9b93a655ca0dd6) the parameter sent to proxmox api has been changed from type bool to type string but instead of converting the boolean into a value that is readable by the proxmox api it just sends a string containing `'True'` or `'False'` to the pve api. According to [specification](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu) proxmox expects a `'1'` or a `'0'` as content of the `agent` parameter.

This bug resulted in failing vm creations:
```
fatal: [vm-template -> localhost]: FAILED! => {"changed": false, "msg": "creation of qemu VM test with vmid 171 failed with exception=400 Bad Request: Parameter verification failed. - {'agent': \"invalid format - format error\\nagent.enabled: type check ('boolean') failed - got 'True'\\n\"}", "vmid": "171"}
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`proxmox_kvm`