### PR TITLE
Bugfix - EnvironmentError with wrong indentation

### DIFF
--- a/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
+++ b/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Removed leftover ``EnvironmentError``. The ``else clause`` had a wrong indentation. The check is now handled in the ``split_pid_name``function. https://github.com/ansible-collections/community.general/pull/5202
+  - removed leftover ``EnvironmentError`` . The ``else clause`` had a wrong indentation. The check is now handled in the ``split_pid_name`` function. https://github.com/ansible-collections/community.general/pull/5202

--- a/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
+++ b/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - removed leftover ``EnvironmentError`` . The ``else clause`` had a wrong indentation. The check is now handled in the ``split_pid_name`` function. https://github.com/ansible-collections/community.general/pull/5202
+  - listen_ports_facts - removed leftover ``EnvironmentError`` . The ``else`` clause had a wrong indentation. The check is now handled in the ``split_pid_name`` function (https://github.com//pull/5202).

--- a/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
+++ b/changelogs/fragments/5202-bugfix-environmentError-wrong-indentation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Removed leftover ``EnvironmentError``. The ``else clause`` had a wrong indentation. The check is now handled in the ``split_pid_name``function. https://github.com/ansible-collections/community.general/pull/5202

--- a/plugins/modules/system/listen_ports_facts.py
+++ b/plugins/modules/system/listen_ports_facts.py
@@ -257,8 +257,6 @@ def netStatParse(raw):
             }
             if result not in results:
                 results.append(result)
-            else:
-                raise EnvironmentError('Could not get process information for the listening ports.')
     return results
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #4953 
As part of the above merge request a minor bug was introduced. 

- The indentation of an `else` statement was one too far.  
- The purpose of the `else` statement is now handled in the function: `split_pid_name`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
listen port facts

##### ADDITIONAL INFORMATION
The else statement:`EnvironmentError('Could not get process information for the listening ports.')` can be removed. The purpose was to check `if conns and pids` exists and else throw the error. 

See previous usage line in older version 173 / 194: https://github.com/ansible-collections/community.general/blob/6a7811f6963ad1f5f92342b786e70a809e1c9e08/plugins/modules/system/listen_ports_facts.py

This is now handled in the `split_pid_name` function. 