### PR TITLE
seport: add `local` argument

### DIFF
--- a/changelogs/fragments/5203-seport-add-local-argument.yaml
+++ b/changelogs/fragments/5203-seport-add-local-argument.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - seport - added new argument ``local`` (https://github.com/ansible-collections/community.general/pull/5203)


### PR DESCRIPTION
Using `local: true` users can enforce to work only with local policy
modifications. i.e.

    # Without `local`, no new modification is added when port already exists
    $ sudo ansible -m seport -a 'ports=22 state=present setype=ssh_port_t proto=tcp' localhost

    localhost | SUCCESS => {
        "changed": false,
        "ports": [
            "22"
        ],
        "proto": "tcp",
        "setype": "ssh_port_t",
        "state": "present"
    }

    $ sudo semanage port -l -C

    # With `local`, a port is always added/changed in local modification list
    $ sudo ansible -m seport -a 'ports=22 state=present setype=ssh_port_t proto=tcp local=true' localhost

    localhost | CHANGED => {
        "changed": true,
        "ports": [
            "22"
        ],
        "proto": "tcp",
        "setype": "ssh_port_t",
        "state": "present"
    }

    $ sudo semanage port -l -C
    SELinux Port Type              Proto    Port Number

    ssh_port_t                     tcp      22

    # With `local`, seport removes the port only from local modifications
    $ sudo ansible -m seport -a 'ports=22 state=absent setype=ssh_port_t proto=tcp local=true' localhost

    localhost | CHANGED => {
        "changed": true,
        "ports": [
            "22"
        ],
        "proto": "tcp",
        "setype": "ssh_port_t",
        "state": "absent"
    }

    $ sudo semanage port -l -C

    # Even though the port is still defined in system policy, the module
    # result is success as there's no port local modification
    $ sudo ansible -m seport -a 'ports=22 state=absent setype=ssh_port_t proto=tcp local=true' localhost

    localhost | SUCCESS => {
        "changed": false,
        "ports": [
            "22"
        ],
        "proto": "tcp",
        "setype": "ssh_port_t",
        "state": "absent"
    }

    # But it fails without `local` as it tries to remove port defined in
    # system policy
    $ sudo ansible -m seport -a 'ports=22 state=absent setype=ssh_port_t proto=tcp' localhost

    An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: Port tcp/22 is defined in policy, cannot be deleted
    localhost | FAILED! => {
        "changed": false,
        "msg": "ValueError: Port tcp/22 is defined in policy, cannot be deleted\n"
    }

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
