### PR TITLE
changed the default proxmox container unprivileged flag

### DIFF
--- a/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
+++ b/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - proxmox module - Deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0. (https://github.com/ansible-collections/community.general/pull/5224)

--- a/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
+++ b/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - proxmox module - Deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0. (https://github.com/ansible-collections/community.general/pull/5224)
+  - proxmox module - Deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0. (https://github.com//pull/5224).

--- a/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
+++ b/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - proxmox - deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0 (https://github.com/pull/5224).
+  - proxmox - deprecated the current ``unprivileged`` default value, will be changed to ``true`` in community.general 7.0.0 (https://github.com/pull/5224).

--- a/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
+++ b/changelogs/fragments/5224-proxmox-unprivileged-default.yaml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - proxmox module - Deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0. (https://github.com//pull/5224).
+  - proxmox - deprecated the current ``unprivileged`` default value, will be changed to ``true`` in 7.0.0 (https://github.com/pull/5224).

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -613,9 +613,7 @@ def main():
     if module.params['unprivileged'] is None:
         module.params['unprivileged'] = False
         module.deprecate(
-            'The default value `false` for the parameter "unprivileged" is deprecated and it will be replaced by `true`'
-                False, True
-            ),
+            'The default value `false` for the parameter "unprivileged" is deprecated and it will be replaced by `true`',
             version='7.0.0',
             collection_name='community.general'
         )

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -142,7 +142,7 @@ options:
     description:
       - Indicate if the container should be unprivileged.
       - >
-        The default value for this param is C(false) but that is being deprecated
+        The default value for this parameter is C(false) but that is being deprecated
         and it will be replaced with C(true) in community.general 7.0.0.
     type: bool
   description:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -613,7 +613,7 @@ def main():
     if module.params['unprivileged'] is None:
         module.params['unprivileged'] = False
         module.deprecate(
-            'The default value {0} for the parameter "unprivileged" is being deprecated and it will be replaced by {1}'.format(
+            'The default value `false` for the parameter "unprivileged" is deprecated and it will be replaced by `true`'
                 False, True
             ),
             version='7.0.0',

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -142,7 +142,7 @@ options:
     description:
       - Indicate if the container should be unprivileged.
       - >
-        The default value for this parameter is C(false) but that is being deprecated
+        The default value for this parameter is C(false) but that is deprecated
         and it will be replaced with C(true) in community.general 7.0.0.
     type: bool
   description:
@@ -613,7 +613,7 @@ def main():
     if module.params['unprivileged'] is None:
         module.params['unprivileged'] = False
         module.deprecate(
-            'The default value `false` for the parameter "unprivileged" is deprecated and it will be replaced by `true`',
+            'The default value `false` for the parameter "unprivileged" is deprecated and it will be replaced with `true`',
             version='7.0.0',
             collection_name='community.general'
         )

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -140,9 +140,10 @@ options:
     type: str
   unprivileged:
     description:
-      - Indicate if the container should be unprivileged
+      - Indicate if the container should be unprivileged.
+      - The default value for this param is C(no) but that is being deprecated.
+      - It will be replaced with C(yes) in community.general 7.0.0
     type: bool
-    default: True
   description:
     description:
       - Specify the description for the container. Only used on the configuration web interface.
@@ -566,7 +567,7 @@ def main():
         purge=dict(type='bool', default=False),
         state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
         pubkey=dict(type='str'),
-        unprivileged=dict(type='bool', default=True),
+        unprivileged=dict(type='bool'),
         description=dict(type='str'),
         hookscript=dict(type='str'),
         proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults']),
@@ -607,6 +608,16 @@ def main():
         template_store = module.params['ostemplate'].split(":")[0]
     timeout = module.params['timeout']
     clone = module.params['clone']
+
+    if module.params['unprivileged'] is None:
+        module.params['unprivileged'] = False
+        module.deprecate(
+            'The default value {0} is being deprecated and it will be replaced by {1}'.format(
+                False, True
+            ),
+            version='7.0.0',
+            collection_name='community.general'
+        )
 
     if module.params['proxmox_default_behavior'] == 'compatibility':
         old_default_values = dict(

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -141,8 +141,9 @@ options:
   unprivileged:
     description:
       - Indicate if the container should be unprivileged.
-      - The default value for this param is C(false) but that is being deprecated.
-      - It will be replaced with C(true) in community.general 7.0.0
+      - >
+        The default value for this param is C(false) but that is being deprecated
+        and it will be replaced with C(true) in community.general 7.0.0.
     type: bool
   description:
     description:

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -142,7 +142,7 @@ options:
     description:
       - Indicate if the container should be unprivileged
     type: bool
-    default: false
+    default: True
   description:
     description:
       - Specify the description for the container. Only used on the configuration web interface.
@@ -566,7 +566,7 @@ def main():
         purge=dict(type='bool', default=False),
         state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
         pubkey=dict(type='str'),
-        unprivileged=dict(type='bool', default=False),
+        unprivileged=dict(type='bool', default=True),
         description=dict(type='str'),
         hookscript=dict(type='str'),
         proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults']),

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -612,7 +612,7 @@ def main():
     if module.params['unprivileged'] is None:
         module.params['unprivileged'] = False
         module.deprecate(
-            'The default value {0} is being deprecated and it will be replaced by {1}'.format(
+            'The default value {0} for the parameter "unprivileged" is being deprecated and it will be replaced by {1}'.format(
                 False, True
             ),
             version='7.0.0',

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -141,8 +141,8 @@ options:
   unprivileged:
     description:
       - Indicate if the container should be unprivileged.
-      - The default value for this param is C(no) but that is being deprecated.
-      - It will be replaced with C(yes) in community.general 7.0.0
+      - The default value for this param is C(false) but that is being deprecated.
+      - It will be replaced with C(true) in community.general 7.0.0
     type: bool
   description:
     description:


### PR DESCRIPTION
##### SUMMARY
Currently the default for the `unprivileged` attribute is set to false, which means all containers are created by default with root mapped to the host root - not very safe to say the least.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`proxmox` module
