### PR TITLE
nmcli: honor IP options for VPNs

### DIFF
--- a/changelogs/fragments/5228-nmcli-ip-options.yaml
+++ b/changelogs/fragments/5228-nmcli-ip-options.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nmcli - honor IP options for VPNs (https://github.com/ansible-collections/community.general/pull/5228)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -1730,6 +1730,7 @@ class Nmcli(object):
             '802-11-wireless',
             'gsm',
             'wireguard',
+            'vpn',
         )
 
     @property

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -1208,6 +1208,8 @@ TESTCASE_VPN_L2TP = [
             'ipsec-enabled': 'true',
             'ipsec-psk': 'QnJpdHRhbnkxMjM=',
         },
+        'gw4_ignore_auto': True,
+        'routes4': ['192.168.200.0/24'],
         'autoconnect': 'false',
         'state': 'present',
         '_ansible_check_mode': False,
@@ -1220,7 +1222,14 @@ connection.type:                        vpn
 connection.autoconnect:                 no
 connection.permissions:                 brittany
 ipv4.method:                            auto
+ipv4.routes:                            { ip = 192.168.200.0/24 }
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                yes
 ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
 vpn.service-type:                       org.freedesktop.NetworkManager.l2tp
 vpn.data:                               gateway = vpn.example.com, ipsec-enabled = true, ipsec-psk = QnJpdHRhbnkxMjM=, password-flags = 2, user = brittany
 vpn.secrets:                            ipsec-psk = QnJpdHRhbnkxMjM=
@@ -1251,7 +1260,13 @@ connection.type:                        vpn
 connection.autoconnect:                 no
 connection.permissions:                 brittany
 ipv4.method:                            auto
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
 ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
 vpn.service-type:                       org.freedesktop.NetworkManager.pptp
 vpn.data:                               gateway=vpn.example.com, password-flags=2, user=brittany
 """


### PR DESCRIPTION
##### SUMMARY

This can be used for split tunneling - I extended a test as an example.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

nmcli

##### ADDITIONAL INFORMATION

Here is a complete example. `gw4_ignore_auto` is used as VPNs often come with a default route for `0.0.0.0/0`.

```YAML
- name: >-
    Create a VPN L2TP connection for ansible_user to connect on vpn.example.com
    authenticating with user 'brittany' and pre-shared key as 'Brittany123'. Split tunneling
    is configured and only traffic to 192.168.200.0/24 goes throught the VPN.
  community.general.nmcli:
    type: vpn
    conn_name: my-vpn-connection
    vpn:
        permissions: "{{ ansible_user }}"
        service-type: org.freedesktop.NetworkManager.l2tp
        gateway: vpn.example.com
        password-flags: 2
        user: brittany
        ipsec-enabled: true
        ipsec-psk: "0s{{ 'Brittany123' | ansible.builtin.b64encode }}"
        gw4_ignore_auto: true
        routes4: '192.168.200.0/24'
    autoconnect: false
    state: present
```

This example is based on an existing example. I'm not sure if it's a good idea to include such a complex usage in examples.

https://github.com/ansible-collections/community.general/blob/2a449eb16329b180555042473e751995b7d29c96/plugins/modules/net_tools/nmcli.py#L1344-L1359