### PR TITLE
multiple modules: removed unused imports

### DIFF
--- a/changelogs/fragments/5240-unused-imports.yaml
+++ b/changelogs/fragments/5240-unused-imports.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - ali_instance - minor refactor when checking for isntalled dependency (https://github.com/ansible-collections/community.general/pull/5240).
-  - ali_instance_info - minor refactor when checking for isntalled dependency (https://github.com/ansible-collections/community.general/pull/5240).
+  - ali_instance - minor refactor when checking for installed dependency (https://github.com/ansible-collections/community.general/pull/5240).
+  - ali_instance_info - minor refactor when checking for installed dependency (https://github.com/ansible-collections/community.general/pull/5240).

--- a/changelogs/fragments/5240-unused-imports.yaml
+++ b/changelogs/fragments/5240-unused-imports.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ali_instance - minor refactor when checking for isntalled dependency (https://github.com/ansible-collections/community.general/pull/5240).
+  - ali_instance_info - minor refactor when checking for isntalled dependency (https://github.com/ansible-collections/community.general/pull/5240).

--- a/plugins/module_utils/alicloud_ecs.py
+++ b/plugins/module_utils/alicloud_ecs.py
@@ -15,6 +15,7 @@ __metaclass__ = type
 
 import os
 import json
+import traceback
 from ansible.module_utils.basic import env_fallback
 
 try:
@@ -28,8 +29,11 @@ try:
     import footmark.dns
     import footmark.ram
     import footmark.market
+
+    FOOTMARK_IMP_ERR = None
     HAS_FOOTMARK = True
 except ImportError:
+    FOOTMARK_IMP_ERR = traceback.format_exc()
     HAS_FOOTMARK = False
 
 

--- a/plugins/modules/cloud/alicloud/ali_instance.py
+++ b/plugins/modules/cloud/alicloud/ali_instance.py
@@ -621,15 +621,6 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import ecs_argument_spec, ecs_connect
 
-HAS_FOOTMARK = False
-FOOTMARK_IMP_ERR = None
-try:
-    from footmark.exception import ECSResponseError
-    HAS_FOOTMARK = True
-except ImportError:
-    FOOTMARK_IMP_ERR = traceback.format_exc()
-    HAS_FOOTMARK = False
-
 
 def get_instances_info(connection, ids):
     result = []
@@ -806,9 +797,6 @@ def main():
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
-
-    if HAS_FOOTMARK is False:
-        module.fail_json(msg=missing_required_lib('footmark'), exception=FOOTMARK_IMP_ERR)
 
     ecs = ecs_connect(module)
     host_name = module.params['host_name']

--- a/plugins/modules/cloud/alicloud/ali_instance.py
+++ b/plugins/modules/cloud/alicloud/ali_instance.py
@@ -617,9 +617,10 @@ ids:
 
 import re
 import time
-import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import ecs_argument_spec, ecs_connect
+from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import (
+    ecs_argument_spec, ecs_connect, FOOTMARK_IMP_ERR, HAS_FOOTMARK
+)
 
 
 def get_instances_info(connection, ids):
@@ -797,6 +798,9 @@ def main():
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
+
+    if HAS_FOOTMARK is False:
+        module.fail_json(msg=missing_required_lib('footmark'), exception=FOOTMARK_IMP_ERR)
 
     ecs = ecs_connect(module)
     host_name = module.params['host_name']

--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -345,15 +345,6 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import ecs_argument_spec, ecs_connect
 
-HAS_FOOTMARK = False
-FOOTMARK_IMP_ERR = None
-try:
-    from footmark.exception import ECSResponseError
-    HAS_FOOTMARK = True
-except ImportError:
-    FOOTMARK_IMP_ERR = traceback.format_exc()
-    HAS_FOOTMARK = False
-
 
 def main():
     argument_spec = ecs_argument_spec()
@@ -367,9 +358,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    if HAS_FOOTMARK is False:
-        module.fail_json(msg=missing_required_lib('footmark'), exception=FOOTMARK_IMP_ERR)
 
     ecs = ecs_connect(module)
 

--- a/plugins/modules/cloud/alicloud/ali_instance_info.py
+++ b/plugins/modules/cloud/alicloud/ali_instance_info.py
@@ -341,9 +341,10 @@ ids:
     sample: [i-12345er, i-3245fs]
 '''
 
-import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import ecs_argument_spec, ecs_connect
+from ansible_collections.community.general.plugins.module_utils.alicloud_ecs import (
+    ecs_argument_spec, ecs_connect, FOOTMARK_IMP_ERR, HAS_FOOTMARK
+)
 
 
 def main():
@@ -358,6 +359,9 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+
+    if HAS_FOOTMARK is False:
+        module.fail_json(msg=missing_required_lib('footmark'), exception=FOOTMARK_IMP_ERR)
 
     ecs = ecs_connect(module)
 

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -390,11 +390,10 @@ EXAMPLES = r'''
 '''
 
 import time
-import traceback
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.proxmox import (

--- a/plugins/modules/cloud/misc/proxmox_domain_info.py
+++ b/plugins/modules/cloud/misc/proxmox_domain_info.py
@@ -75,7 +75,7 @@ proxmox_domains:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec, ProxmoxAnsible)
 

--- a/plugins/modules/cloud/misc/proxmox_group_info.py
+++ b/plugins/modules/cloud/misc/proxmox_group_info.py
@@ -72,7 +72,7 @@ proxmox_groups:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec, ProxmoxAnsible)
 

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -803,14 +803,12 @@ msg:
 
 import re
 import time
-import traceback
 from ansible.module_utils.six.moves.urllib.parse import quote
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import boolean
 
 

--- a/plugins/modules/cloud/misc/proxmox_nic.py
+++ b/plugins/modules/cloud/misc/proxmox_nic.py
@@ -137,7 +137,7 @@ msg:
   sample: "Nic net0 unchanged on VM with vmid 103"
 '''
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
 
 

--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -102,9 +102,9 @@ RETURN = r'''#'''
 import time
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible, HAS_PROXMOXER, PROXMOXER_IMP_ERR)
+from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
 
 
 class ProxmoxSnapAnsible(ProxmoxAnsible):

--- a/plugins/modules/cloud/misc/proxmox_storage_info.py
+++ b/plugins/modules/cloud/misc/proxmox_storage_info.py
@@ -110,7 +110,7 @@ proxmox_storages:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec, ProxmoxAnsible, proxmox_to_ansible_bool)
 

--- a/plugins/modules/cloud/misc/proxmox_tasks_info.py
+++ b/plugins/modules/cloud/misc/proxmox_tasks_info.py
@@ -115,7 +115,7 @@ msg:
     sample: 'Task: UPID:xyz:xyz does not exist on node: proxmoxnode'
 '''
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec, ProxmoxAnsible)
 

--- a/plugins/modules/cloud/misc/proxmox_template.py
+++ b/plugins/modules/cloud/misc/proxmox_template.py
@@ -117,7 +117,7 @@ EXAMPLES = '''
 import os
 import time
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
 
 

--- a/plugins/modules/cloud/misc/proxmox_user_info.py
+++ b/plugins/modules/cloud/misc/proxmox_user_info.py
@@ -155,7 +155,7 @@ proxmox_users:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec, ProxmoxAnsible, proxmox_to_ansible_bool)
 

--- a/plugins/modules/database/misc/redis.py
+++ b/plugins/modules/database/misc/redis.py
@@ -139,7 +139,7 @@ except ImportError:
 else:
     redis_found = True
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.formatters import human_to_bytes
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.redis import (

--- a/plugins/modules/monitoring/airbrake_deployment.py
+++ b/plugins/modules/monitoring/airbrake_deployment.py
@@ -95,7 +95,6 @@ EXAMPLES = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 
 # ===========================================

--- a/plugins/modules/monitoring/datadog/datadog_downtime.py
+++ b/plugins/modules/monitoring/datadog/datadog_downtime.py
@@ -151,7 +151,6 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 # Import Datadog
-from ansible.module_utils.common.text.converters import to_native
 
 DATADOG_IMP_ERR = None
 HAS_DATADOG = True

--- a/plugins/modules/remote_management/imc/imc_rest.py
+++ b/plugins/modules/remote_management/imc/imc_rest.py
@@ -264,7 +264,6 @@ output:
 import datetime
 import os
 import traceback
-from functools import partial
 
 LXML_ETREE_IMP_ERR = None
 try:

--- a/plugins/modules/remote_management/redfish/ilo_redfish_info.py
+++ b/plugins/modules/remote_management/redfish/ilo_redfish_info.py
@@ -106,7 +106,6 @@ CATEGORY_COMMANDS_DEFAULT = {
 }
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils.ilo_redfish_utils import iLORedfishUtils
 
 

--- a/plugins/modules/system/sap_task_list_execute.py
+++ b/plugins/modules/system/sap_task_list_execute.py
@@ -179,7 +179,6 @@ out:
 '''
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.json_utils import json
 import traceback
 try:
     from pyrfc import Connection

--- a/plugins/modules/web_infrastructure/rundeck_job_executions_info.py
+++ b/plugins/modules/web_infrastructure/rundeck_job_executions_info.py
@@ -131,7 +131,6 @@ executions:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible_collections.community.general.plugins.module_utils.rundeck import (
     api_argument_spec,

--- a/plugins/modules/web_infrastructure/rundeck_job_run.py
+++ b/plugins/modules/web_infrastructure/rundeck_job_run.py
@@ -174,12 +174,10 @@ execution_info:
 '''
 
 # Modules import
-import json
 from datetime import datetime, timedelta
 from time import sleep
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible_collections.community.general.plugins.module_utils.rundeck import (
     api_argument_spec,


### PR DESCRIPTION
##### SUMMARY
Removed many imports that are not used by their code.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/alicloud/ali_instance.py
plugins/modules/cloud/alicloud/ali_instance_info.py
plugins/modules/cloud/misc/proxmox.py
plugins/modules/cloud/misc/proxmox_domain_info.py
plugins/modules/cloud/misc/proxmox_group_info.py
plugins/modules/cloud/misc/proxmox_kvm.py
plugins/modules/cloud/misc/proxmox_nic.py
plugins/modules/cloud/misc/proxmox_snap.py
plugins/modules/cloud/misc/proxmox_storage_info.py
plugins/modules/cloud/misc/proxmox_tasks_info.py
plugins/modules/cloud/misc/proxmox_template.py
plugins/modules/cloud/misc/proxmox_user_info.py
plugins/modules/database/misc/redis.py
plugins/modules/monitoring/airbrake_deployment.py
plugins/modules/monitoring/datadog/datadog_downtime.py
plugins/modules/remote_management/imc/imc_rest.py
plugins/modules/remote_management/redfish/ilo_redfish_info.py
plugins/modules/system/sap_task_list_execute.py
plugins/modules/web_infrastructure/rundeck_job_executions_info.py
plugins/modules/web_infrastructure/rundeck_job_run.py
