### PR TITLE
homebrew: add Linux brew path to defaults

### DIFF
--- a/changelogs/fragments/5241-homebrew-add-linux-path.yaml
+++ b/changelogs/fragments/5241-homebrew-add-linux-path.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - homebrew - added Homebrew on Linux path to defaults (https://github.com/ansible-collections/community.general/pull/5241)
+  - homebrew, homebrew_tap - added Homebrew on Linux path to defaults (https://github.com/ansible-collections/community.general/pull/5241).

--- a/changelogs/fragments/5241-homebrew-add-linux-path.yaml
+++ b/changelogs/fragments/5241-homebrew-add-linux-path.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - homebrew - added Homebrew on Linux path to defaults (https://github.com/ansible-collections/community.general/pull/5241)

--- a/plugins/modules/packaging/os/homebrew.py
+++ b/plugins/modules/packaging/os/homebrew.py
@@ -39,7 +39,7 @@ options:
             - "A C(:) separated list of paths to search for C(brew) executable.
               Since a package (I(formula) in homebrew parlance) location is prefixed relative to the actual path of I(brew) command,
               providing an alternative I(brew) path enables managing different set of packages in an alternative location in the system."
-        default: '/usr/local/bin:/opt/homebrew/bin'
+        default: '/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin'
         type: path
     state:
         description:
@@ -876,7 +876,7 @@ def main():
                 elements='str',
             ),
             path=dict(
-                default="/usr/local/bin:/opt/homebrew/bin",
+                default="/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
                 required=False,
                 type='path',
             ),

--- a/plugins/modules/packaging/os/homebrew_tap.py
+++ b/plugins/modules/packaging/os/homebrew_tap.py
@@ -49,7 +49,7 @@ options:
     path:
         description:
             - "A ':' separated list of paths to search for C(brew) executable."
-        default: '/usr/local/bin:/opt/homebrew/bin'
+        default: '/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin'
         type: path
         version_added: '2.1.0'
 requirements: [ homebrew ]
@@ -219,7 +219,7 @@ def main():
             url=dict(default=None, required=False),
             state=dict(default='present', choices=['present', 'absent']),
             path=dict(
-                default="/usr/local/bin:/opt/homebrew/bin",
+                default="/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
                 required=False,
                 type='path',
             ),

--- a/plugins/modules/packaging/os/homebrew_tap.py
+++ b/plugins/modules/packaging/os/homebrew_tap.py
@@ -48,7 +48,7 @@ options:
         type: str
     path:
         description:
-            - "A ':' separated list of paths to search for C(brew) executable."
+            - "A C(:) separated list of paths to search for C(brew) executable."
         default: '/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin'
         type: path
         version_added: '2.1.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Homebrew on Linux is by default installed in `/home/linuxbrew/.linuxbrew/bin`, so let's search for brew there too.

https://docs.brew.sh/Homebrew-on-Linux#install

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
homebrew
