### PR TITLE
slack: add CP channel prefix

### DIFF
--- a/changelogs/fragments/5249-add-new-channel-prefix.yml
+++ b/changelogs/fragments/5249-add-new-channel-prefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - slack - fix message update for channels which starts with ``CP``. When ``message-id`` was passed it failed for channels wich starts with ``CP`` because of ``#`` simbol was added befor the ``channel_id``.(https://github.com/ansible-collections/community.general/pull/5249#issuecomment-1238520553).

--- a/changelogs/fragments/5249-add-new-channel-prefix.yml
+++ b/changelogs/fragments/5249-add-new-channel-prefix.yml
@@ -1,3 +1,2 @@
 bugfixes:
-  - slack - fix message update for channels which starts with ``CP``. When ``message-id`` was passed it failed for channels wich starts with ``CP`` because of ``#`` simbol was added befor the ``channel_id``.(https://github.com/ansible-collections/community.general/pull/5249#issuecomment-1238520553).
-  - slack - docs improved. It wasn't clear that when `message_id` is supplied `channel_id` couldn't be a channel name. It has to be literal Channel ID returned in payload from API in previous task.
+  - slack - fix message update for channels which start with ``CP``. When ``message-id`` was passed it failed for channels which started with ``CP`` because the ``#`` symbol was added before the ``channel_id`` (https://github.com/ansible-collections/community.general/pull/5249).

--- a/changelogs/fragments/5249-add-new-channel-prefix.yml
+++ b/changelogs/fragments/5249-add-new-channel-prefix.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - slack - fix message update for channels which starts with ``CP``. When ``message-id`` was passed it failed for channels wich starts with ``CP`` because of ``#`` simbol was added befor the ``channel_id``.(https://github.com/ansible-collections/community.general/pull/5249#issuecomment-1238520553).
+  - slack - docs improved. It wasn't clear that when `message_id` is supplied `channel_id` couldn't be a channel name. It has to be literal Channel ID returned in payload from API in previous task.

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -68,7 +68,8 @@ options:
     type: str
   message_id:
     description:
-      - Optional. Message ID to edit, instead of posting a new message. If supplyed `channel_id` must be in form of `C0xxxxxxx`. use `{{ slack_response.channel_id }}` to get `channel_id` from previous task run.
+      - Optional. Message ID to edit, instead of posting a new message. 
+        If supplyed `channel_id` must be in form of `C0xxxxxxx`. use `{{ slack_response.channel_id }}` to get `channel_id` from previous task run.
         Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -235,7 +235,9 @@ EXAMPLES = """
 - name: Edit message
   community.general.slack:
     token: thetoken/generatedby/slack
-    channel: "{{ slack_response.channel }}" #doesn't accept channel name. Must be `channel_id` stored in `slack_response` from the previous task.
+    # The 'channel' option does not accept the channel name. It must use the 'channel_id',
+    # which can be retrieved for example from 'slack_response' from the previous task.
+    channel: "{{ slack_response.channel }}"
     msg: Deployment complete!
     message_id: "{{ slack_response.ts }}"
 """

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -68,7 +68,7 @@ options:
     type: str
   message_id:
     description:
-      - Optional. Message ID to edit, instead of posting a new message. 
+      - Optional. Message ID to edit, instead of posting a new message.
       - If supplied I(channel_id) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel_id }}) to get I(channel_id) from previous task run.
       - Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -69,7 +69,7 @@ options:
   message_id:
     description:
       - Optional. Message ID to edit, instead of posting a new message. 
-        If supplyed `channel_id` must be in form of `C0xxxxxxx`. use `{{ slack_response.channel_id }}` to get `channel_id` from previous task run.
+      - If supplied I(channel_id) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel_id }}) to get I(channel_id) from previous task run.
         Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -68,7 +68,7 @@ options:
     type: str
   message_id:
     description:
-      - Optional. Message ID to edit, instead of posting a new message.
+      - Optional. Message ID to edit, instead of posting a new message. If supplyed `channel_id` must be in form of `C0xxxxxxx`. use `{{ slack_response.channel_id }}` to get `channel_id` from previous task run.
         Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0
@@ -234,7 +234,7 @@ EXAMPLES = """
 - name: Edit message
   community.general.slack:
     token: thetoken/generatedby/slack
-    channel: "{{ slack_response.channel }}"
+    channel: "{{ slack_response.channel }}" #doesn't accept channel name. Must be `channel_id` stored in `slack_response` from the previous task.
     msg: Deployment complete!
     message_id: "{{ slack_response.ts }}"
 """

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -70,7 +70,7 @@ options:
     description:
       - Optional. Message ID to edit, instead of posting a new message. 
       - If supplied I(channel_id) must be in form of C(C0xxxxxxx). use C({{ slack_response.channel_id }}) to get I(channel_id) from previous task run.
-        Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
+      - Corresponds to C(ts) in the Slack API (U(https://api.slack.com/messaging/modifying)).
     type: str
     version_added: 1.2.0
   username:

--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -294,7 +294,7 @@ def build_payload_for_slack(text, channel, thread_id, username, icon_url, icon_e
         # With a custom color we have to set the message as attachment, and explicitly turn markdown parsing on for it.
         payload = dict(attachments=[dict(text=escape_quotes(text), color=color, mrkdwn_in=["text"])])
     if channel is not None:
-        if channel.startswith(('#', '@', 'C0', 'GF', 'G0')):
+        if channel.startswith(('#', '@', 'C0', 'GF', 'G0', 'CP')):
             payload['channel'] = channel
         else:
             payload['channel'] = '#' + channel


### PR DESCRIPTION
##### SUMMARY
1. For channels wich ID starts with `CP` `#` symbol is being prepended
2. docs improved for cases when `message_id` is supplied
##### SUMMARY
1. `CP` string was added to the list which describes `channel_id` prefixed for which `#` symbol will be added in front of `channel_id`
2. Added notes regarding `channel_id` has to be literal Channel ID returned by previous task run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
slack
##### ADDITIONAL INFORMATION
1. When `build_payload_for_slack` is called there is an `if` which prepends `#` if `channel_id` starts with a certain symbols. I've stumbled upon a channel which ID starts with `CP` but current implementation doesn't have this string in the list so I got `#CPxxxxxx` added to payload.
2. It fails when `message_id` is supplied and `channel_id` is either "mychannel_name` or `#mychannel_name` it only works. When `channel_id` is in form of `C0xxxxxxx` which is returned by previous task run.
