### PR TITLE
docs: align pacman examples with actual module path

### DIFF
--- a/plugins/modules/packaging/os/pacman.py
+++ b/plugins/modules/packaging/os/pacman.py
@@ -169,24 +169,24 @@ stderr:
 
 EXAMPLES = """
 - name: Install package foo from repo
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: foo
     state: present
 
 - name: Install package bar from file
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: ~/bar-1.0-1-any.pkg.tar.xz
     state: present
 
 - name: Install package foo from repo and bar from file
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name:
       - foo
       - ~/bar-1.0-1-any.pkg.tar.xz
     state: present
 
 - name: Install package from AUR using a Pacman compatible AUR helper
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: foo
     state: present
     executable: yay
@@ -195,30 +195,30 @@ EXAMPLES = """
 - name: Upgrade package foo
   # The 'changed' state of this call will indicate whether the cache was
   # updated *or* whether foo was installed/upgraded.
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: foo
     state: latest
     update_cache: true
 
 - name: Remove packages foo and bar
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name:
       - foo
       - bar
     state: absent
 
 - name: Recursively remove package baz
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: baz
     state: absent
     extra_args: --recursive
 
 - name: Run the equivalent of "pacman -Sy" as a separate step
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     update_cache: true
 
 - name: Run the equivalent of "pacman -Su" as a separate step
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     upgrade: true
 
 - name: Run the equivalent of "pacman -Syu" as a separate step
@@ -231,25 +231,25 @@ EXAMPLES = """
   #
   #   register: result
   #   changed_when: result.packages | length > 0
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     update_cache: true
     upgrade: true
 
 - name: Run the equivalent of "pacman -Rdd", force remove package baz
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: baz
     state: absent
     force: true
 
 - name: Install foo as dependency and leave reason untouched if already installed
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: foo
     state: present
     reason: dependency
     reason_for: new
 
 - name: Run the equivalent of "pacman -S --asexplicit", mark foo as explicit and install it if not present
-  community.general.pacman:
+  community.general.packaging.os.pacman:
     name: foo
     state: present
     reason: explicit


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I was trying to use the ansible community general examples provided here: https://docs.ansible.com/ansible/latest/collections/community/general/pacman_module.html#ansible-collections-community-general-pacman-module
Got errors that the name of the task or module was probably wrong. Then went into the source (this repo) and found out that the naming changed.

Adjusting the naming in my playbook fixed the issue.

This PR tries to align the doc-string and module path/naming.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Could not find an existing issue, searched for open issues containing "pacman".


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pacman component, align documentation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Create a sample task using this documentation

```
---
- hosts: all
  become: yes
  tasks:
  - name: Initial Setup
    community.general.pacman:
      name: neovim
      state: present
      update_cache: yes
```
