### PR TITLE
multiple modules: removed unused imports

### DIFF
--- a/plugins/modules/cloud/misc/proxmox_snap.py
+++ b/plugins/modules/cloud/misc/proxmox_snap.py
@@ -100,7 +100,6 @@ EXAMPLES = r'''
 RETURN = r'''#'''
 
 import time
-import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native

--- a/plugins/modules/cloud/opennebula/one_service.py
+++ b/plugins/modules/cloud/opennebula/one_service.py
@@ -243,7 +243,6 @@ roles:
 '''
 
 import os
-import sys
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 

--- a/plugins/modules/cloud/ovh/ovh_monthly_billing.py
+++ b/plugins/modules/cloud/ovh/ovh_monthly_billing.py
@@ -73,8 +73,6 @@ EXAMPLES = '''
 RETURN = '''
 '''
 
-import os
-import sys
 import traceback
 
 try:

--- a/plugins/modules/cloud/xenserver/xenserver_guest_powerstate.py
+++ b/plugins/modules/cloud/xenserver/xenserver_guest_powerstate.py
@@ -171,8 +171,6 @@ instance:
     }
 '''
 
-import re
-
 HAS_XENAPI = False
 try:
     import XenAPI

--- a/plugins/modules/clustering/nomad/nomad_job_info.py
+++ b/plugins/modules/clustering/nomad/nomad_job_info.py
@@ -266,10 +266,6 @@ result:
 
 '''
 
-
-import os
-import json
-
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
 

--- a/plugins/modules/monitoring/icinga2_host.py
+++ b/plugins/modules/monitoring/icinga2_host.py
@@ -136,7 +136,6 @@ data:
 '''
 
 import json
-import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec

--- a/plugins/modules/net_tools/dnsimple_info.py
+++ b/plugins/modules/net_tools/dnsimple_info.py
@@ -229,7 +229,6 @@ dnsimple_record_info:
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib
-import json
 
 try:
     from requests import Request, Session

--- a/plugins/modules/net_tools/ipwcli_dns.py
+++ b/plugins/modules/net_tools/ipwcli_dns.py
@@ -158,7 +158,6 @@ record:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-import os
 
 
 class ResourceRecord(object):

--- a/plugins/modules/packaging/language/yarn.py
+++ b/plugins/modules/packaging/language/yarn.py
@@ -156,7 +156,6 @@ out:
 '''
 
 import os
-import re
 import json
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/packaging/os/apt_rpm.py
+++ b/plugins/modules/packaging/os/apt_rpm.py
@@ -71,10 +71,7 @@ EXAMPLES = '''
     update_cache: true
 '''
 
-import json
 import os
-import shlex
-import sys
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/packaging/os/portinstall.py
+++ b/plugins/modules/packaging/os/portinstall.py
@@ -58,9 +58,7 @@ EXAMPLES = '''
     state: absent
 '''
 
-import os
 import re
-import sys
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote

--- a/plugins/modules/packaging/os/urpmi.py
+++ b/plugins/modules/packaging/os/urpmi.py
@@ -81,10 +81,6 @@ EXAMPLES = '''
 '''
 
 
-import os
-import shlex
-import sys
-
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/remote_management/cobbler/cobbler_system.py
+++ b/plugins/modules/remote_management/cobbler/cobbler_system.py
@@ -145,7 +145,6 @@ system:
   type: dict
 '''
 
-import copy
 import datetime
 import ssl
 

--- a/plugins/modules/source_control/git_config.py
+++ b/plugins/modules/source_control/git_config.py
@@ -160,7 +160,6 @@ config_values:
     alias.diffc: "diff --cached"
     alias.remotev: "remote -v"
 '''
-import os
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/source_control/github/github_repo.py
+++ b/plugins/modules/source_control/github/github_repo.py
@@ -125,7 +125,6 @@ repo:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-import sys
 
 GITHUB_IMP_ERR = None
 try:

--- a/plugins/modules/system/alternatives.py
+++ b/plugins/modules/system/alternatives.py
@@ -128,7 +128,6 @@ EXAMPLES = r'''
 
 import os
 import re
-import subprocess
 
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/system/beadm.py
+++ b/plugins/modules/system/beadm.py
@@ -137,7 +137,6 @@ force:
 '''
 
 import os
-import re
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/plugins/modules/system/java_cert.py
+++ b/plugins/modules/system/java_cert.py
@@ -176,8 +176,6 @@ cmd:
 
 import os
 import tempfile
-import random
-import string
 import re
 
 

--- a/plugins/modules/web_infrastructure/jboss.py
+++ b/plugins/modules/web_infrastructure/jboss.py
@@ -73,7 +73,6 @@ EXAMPLES = r"""
 RETURN = r""" # """
 
 import os
-import shutil
 import time
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/web_infrastructure/jenkins_plugin.py
+++ b/plugins/modules/web_infrastructure/jenkins_plugin.py
@@ -296,7 +296,6 @@ from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils.common.text.converters import to_native
-import base64
 import hashlib
 import io
 import json

--- a/plugins/modules/web_infrastructure/rundeck_job_executions_info.py
+++ b/plugins/modules/web_infrastructure/rundeck_job_executions_info.py
@@ -127,9 +127,6 @@ executions:
     ]
 '''
 
-# Modules import
-import json
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible_collections.community.general.plugins.module_utils.rundeck import (


### PR DESCRIPTION
##### SUMMARY
Removed unused imports from multiple modules

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/misc/proxmox_snap.py
plugins/modules/cloud/opennebula/one_service.py
plugins/modules/cloud/ovh/ovh_monthly_billing.py
plugins/modules/cloud/xenserver/xenserver_guest_powerstate.py
plugins/modules/clustering/nomad/nomad_job_info.py
plugins/modules/monitoring/icinga2_host.py
plugins/modules/net_tools/dnsimple_info.py
plugins/modules/net_tools/ipwcli_dns.py
plugins/modules/packaging/language/yarn.py
plugins/modules/packaging/os/apt_rpm.py
plugins/modules/packaging/os/portinstall.py
plugins/modules/packaging/os/urpmi.py
plugins/modules/remote_management/cobbler/cobbler_system.py
plugins/modules/source_control/git_config.py
plugins/modules/source_control/github/github_repo.py
plugins/modules/system/alternatives.py
plugins/modules/system/beadm.py
plugins/modules/system/java_cert.py
plugins/modules/web_infrastructure/jboss.py
plugins/modules/web_infrastructure/jenkins_plugin.py
plugins/modules/web_infrastructure/rundeck_job_executions_info.py
