### PR TITLE
Restrict Python packages for nomad tests

### DIFF
--- a/tests/integration/targets/nomad/meta/main.yml
+++ b/tests/integration/targets/nomad/meta/main.yml
@@ -7,3 +7,4 @@ dependencies:
   - setup_pkg_mgr
   - setup_openssl
   - setup_remote_tmp_dir
+  - setup_remote_constraints

--- a/tests/integration/targets/nomad/tasks/main.yml
+++ b/tests/integration/targets/nomad/tasks/main.yml
@@ -20,6 +20,7 @@
   - name: Install requests<2.20 (CentOS/RHEL 6)
     pip:
       name: requests<2.20
+      extra_args: "-c {{ remote_constraints }}"
     register: result
     until: result is success
     when: ansible_distribution_file_variety|default() == 'RedHat' and ansible_distribution_major_version is version('6', '<=')
@@ -27,12 +28,14 @@
   - name: Install python-nomad
     pip:
       name: python-nomad
+      extra_args: "-c {{ remote_constraints }}"
     register: result
     until: result is success
 
   - name: Install jmespath
     pip:
       name: jmespath
+      extra_args: "-c {{ remote_constraints }}"
     register: result
     until: result is success
 


### PR DESCRIPTION
##### SUMMARY
Tests currently fail on CentOS 7.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
nomad integration tests
