### PR TITLE
machinectl: include the success command

### DIFF
--- a/changelogs/fragments/5287-machinectl-become-success.yml
+++ b/changelogs/fragments/5287-machinectl-become-success.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - machinectl become plugin - combine the success command when building the become command to be consistent with other become plugins (https://github.com/ansible-collections/community.general/pull/5287).

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -117,7 +117,7 @@ class BecomeModule(BecomeBase):
 
         flags = self.get_option('become_flags')
         user = self.get_option('become_user')
-        return '%s -q shell %s %s@ %s' % (become, flags, user, cmd)
+        return '%s -q shell %s %s@ %s' % (become, flags, user, self._build_success_command(cmd, shell))
 
     def check_success(self, b_output):
         b_output = self.remove_ansi_codes(b_output)


### PR DESCRIPTION
Combines the success command when building the become command. This is consistent with other become plugins.

##### SUMMARY

Was debugging an issue involving the combination of pipelining and running machinectl as sudo and came across this, though this is not the cause it seemed prudent to submit a PR for it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
machinectl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
