### PR TITLE
pipx module utils: removed unused import

### DIFF
--- a/plugins/module_utils/pipx.py
+++ b/plugins/module_utils/pipx.py
@@ -6,7 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt as fmt
 
 


### PR DESCRIPTION
##### SUMMARY
Removed unused import

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/pipx.py