### PR TITLE
nmcli: fix error when setting previously unset mac address

### DIFF
--- a/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
+++ b/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "nmcli - fix error when setting previously unset MAC address, gsm.apn or vpn.data: current values were being normalized without checking if they might be None"

--- a/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
+++ b/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "nmcli - fix error when setting previously unset MAC address, gsm.apn or vpn.data: current values were being normalized without checking if they might be None"
+  - "nmcli - fix error when setting previously unset MAC address, ``gsm.apn`` or ``vpn.data``: current values were being normalized without checking if they might be ``None`` (https://github.com/ansible-collections/community.general/pull/5291)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -2099,17 +2099,17 @@ class Nmcli(object):
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()
                     # ensure current_value is also converted to uppercase in case nmcli changes behaviour
-                    if (current_value):
+                    if current_value:
                         current_value = current_value.upper()
                 if key == 'gsm.apn':
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
-                    if (current_value):
+                    if current_value:
                         current_value = current_value.strip('"')
                 if key == self.mtu_setting and self.mtu is None:
                     self.mtu = 0
                 if key == 'vpn.data':
-                    if (current_value):
+                    if current_value:
                         current_value = sorted(re.sub(r'\s*=\s*', '=', part.strip(), count=1) for part in current_value.split(','))
                     value = sorted(part.strip() for part in value.split(','))
             else:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -2099,15 +2099,18 @@ class Nmcli(object):
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()
                     # ensure current_value is also converted to uppercase in case nmcli changes behaviour
-                    current_value = current_value.upper()
+                    if (current_value):
+                        current_value = current_value.upper()
                 if key == 'gsm.apn':
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
-                    current_value = current_value.strip('"')
+                    if (current_value):
+                        current_value = current_value.strip('"')
                 if key == self.mtu_setting and self.mtu is None:
                     self.mtu = 0
                 if key == 'vpn.data':
-                    current_value = sorted(re.sub(r'\s*=\s*', '=', part.strip(), count=1) for part in current_value.split(','))
+                    if (current_value):
+                        current_value = sorted(re.sub(r'\s*=\s*', '=', part.strip(), count=1) for part in current_value.split(','))
                     value = sorted(part.strip() for part in value.split(','))
             else:
                 # parameter does not exist


### PR DESCRIPTION
##### SUMMARY
This adds an `if` to avoid errors when setting a mac address in an existing connections that didn't have it and does the same thing for two other parameters.

Fixes #5290

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
N/A
