### PR TITLE
CI: try to run reuse workflow without explicitly allowing it for new contributors

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -8,7 +8,8 @@ name: Verify REUSE
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     branches: [main]
   # Run CI once per day (at 07:30 UTC)
   schedule:
@@ -21,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
##### SUMMARY
Right now we have to explicitly allow to run that workflow for new contributors. That's annoying and not really necessary.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
