### PR TITLE
bitwarden: Add field to search for all item attributes, instead of on…

### DIFF
--- a/changelogs/fragments/5297-bitwarden-add-search-field.yml
+++ b/changelogs/fragments/5297-bitwarden-add-search-field.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - bitwarden - add option ``search`` to search for other attributes.
+  - bitwarden - add option ``search`` to search for other attributes than name.

--- a/changelogs/fragments/5297-bitwarden-add-search-field.yml
+++ b/changelogs/fragments/5297-bitwarden-add-search-field.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bitwarden - add option ``search`` to search for other attributes.

--- a/changelogs/fragments/5297-bitwarden-add-search-field.yml
+++ b/changelogs/fragments/5297-bitwarden-add-search-field.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - bitwarden - add option ``search`` to search for other attributes than name.
+  - bitwarden lookup plugin - add option ``search`` to search for other attributes than name (https://github.com/ansible-collections/community.general/pull/5297).

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -22,6 +22,10 @@ DOCUMENTATION = """
         required: true
         type: list
         elements: str
+      search:
+        description: Search field, e.g. name or id
+        type: str
+        default: 'name'
       field:
         description: Field to fetch; leave unset to fetch whole response.
         type: str
@@ -32,6 +36,11 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: >-
       {{ lookup('community.general.bitwarden', 'a_test', field='password') }}
+
+- name: "Get 'password' from Bitwarden record with id 'bafba515-af11-47e6-abe3-af1200cd18b2'"
+  ansible.builtin.debug:
+    msg: >-
+      {{ lookup('community.general.bitwarden', 'bafba515-af11-47e6-abe3-af1200cd18b2', search='id', field='password') }}
 
 - name: "Get full Bitwarden record named 'a_test'"
   ansible.builtin.debug:
@@ -81,7 +90,7 @@ class Bitwarden(object):
             raise BitwardenException(err)
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 
-    def _get_matches(self, search_value, search_field="name"):
+    def _get_matches(self, search_value, search_field):
         """Return matching records whose search_field is equal to key.
         """
         out, err = self._run(['list', 'items', '--search', search_value])
@@ -97,7 +106,7 @@ class Bitwarden(object):
 
         If field is None, return the whole record for each match.
         """
-        matches = self._get_matches(search_value)
+        matches = self._get_matches(search_value, search_field)
 
         if field:
             return [match['login'][field] for match in matches]
@@ -110,10 +119,11 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         field = self.get_option('field')
+        search_field = self.get_option('search')
         if not _bitwarden.logged_in:
             raise AnsibleError("Not logged into Bitwarden. Run 'bw login'.")
 
-        return [_bitwarden.get_field(field, term) for term in terms]
+        return [_bitwarden.get_field(field, term, search_field) for term in terms]
 
 
 _bitwarden = Bitwarden()

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -25,7 +25,8 @@ DOCUMENTATION = """
       search:
         description: Field to retrieve, for example C(name) or C(id).
         type: str
-        default: 'name'
+        default: name
+        version_added: 5.7.0
       field:
         description: Field to fetch; leave unset to fetch whole response.
         type: str

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -23,7 +23,7 @@ DOCUMENTATION = """
         type: list
         elements: str
       search:
-        description: Search field, e.g. name or id
+        description: Field to retrieve, for example C(name) or C(id).
         type: str
         default: 'name'
       field:


### PR DESCRIPTION
##### SUMMARY
As of now, it is only possible to find bitwarden items via their name. 
Names however can occur multiple times on different items.
Finding them by alternative attributes like their unique id could resolve this problem 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
bitwarden

##### ADDITIONAL INFORMATION
