### PR TITLE
[stable-4] Replace devel with stable-2.14 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -53,14 +53,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_14
+    displayName: Sanity 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.14/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -133,14 +133,14 @@ stages:
             - test: 3
             - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_14
+    displayName: Units 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.14/units/{0}/1
           targets:
             - test: 2.7
             - test: 3.5
@@ -211,13 +211,13 @@ stages:
             - test: 3.5
 
 ## Remote
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: Remote_2_14
+    displayName: Remote 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.14/{0}
           targets:
             - name: macOS 12.0
               test: macos/12.0
@@ -317,13 +317,13 @@ stages:
             - 2
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_14
+    displayName: Docker 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.14/linux/{0}
           targets:
             - name: CentOS 7
               test: centos7
@@ -422,13 +422,13 @@ stages:
             - 3
 
 ### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: Docker_community_2_14
+    displayName: Docker (community images) 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
+          testFormat: 2.14/linux-community/{0}
           targets:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
@@ -442,14 +442,14 @@ stages:
             - 3
 
 ### Cloud
-  - stage: Cloud_devel
-    displayName: Cloud devel
+  - stage: Cloud_2_14
+    displayName: Cloud 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/cloud/{0}/1
+          testFormat: 2.14/cloud/{0}/1
           targets:
             - test: 2.7
             - test: '3.10'
@@ -506,32 +506,32 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
+      - Sanity_2_14
       - Sanity_2_9
       - Sanity_2_10
       - Sanity_2_11
       - Sanity_2_12
       - Sanity_2_13
-      - Units_devel
+      - Units_2_14
       - Units_2_9
       - Units_2_10
       - Units_2_11
       - Units_2_12
       - Units_2_13
-      - Remote_devel
+      - Remote_2_14
       - Remote_2_9
       - Remote_2_10
       - Remote_2_11
       - Remote_2_12
       - Remote_2_13
-      - Docker_devel
+      - Docker_2_14
       - Docker_2_9
       - Docker_2_10
       - Docker_2_11
       - Docker_2_12
       - Docker_2_13
-      - Docker_community_devel
-      - Cloud_devel
+      - Docker_community_2_14
+      - Cloud_2_14
       - Cloud_2_9
       - Cloud_2_10
       - Cloud_2_11

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, and ansible-core 2.14 releases of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 ## External requirements
 


### PR DESCRIPTION
##### SUMMARY
Now that stable-2.14 has been branched, use that instead of devel.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
