### PR TITLE
netcup_dnsapi: Add timeout paramter

### DIFF
--- a/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
+++ b/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - netcup_dnsapi - add ``timeout`` parameter (https://github.com/ansible-collections/community.general/pull/5301)
+

--- a/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
+++ b/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - netcup_dnsapi - add ``timeout`` parameter (https://github.com/ansible-collections/community.general/pull/5301)
+  - netcup_dnsapi - add ``timeout`` parameter (https://github.com/ansible-collections/community.general/pull/5301).
 

--- a/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
+++ b/changelogs/fragments/5301-netcup_dnsapi-timeout.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - netcup_dnsapi - add ``timeout`` parameter (https://github.com/ansible-collections/community.general/pull/5301).
-

--- a/plugins/modules/net_tools/netcup_dns.py
+++ b/plugins/modules/net_tools/netcup_dns.py
@@ -72,6 +72,11 @@ options:
     default: present
     choices: [ 'present', 'absent' ]
     type: str
+  timeout:
+    description:
+      - HTTP(s) connection timeout
+    default: 5
+    type: int
 requirements:
   - "nc-dnsapi >= 0.1.3"
 author: "Nicolai Buchwitz (@nbuchwitz)"
@@ -129,6 +134,18 @@ EXAMPLES = '''
     type: "AAAA"
     value: "::1"
     solo: true
+
+- name: Increase the connection timeout to avoid problems with an unstable connection
+  community.general.netcup_dns:
+    api_key: "..."
+    api_password: "..."
+    customer_id: "..."
+    domain: "example.com"
+    name: "mail"
+    type: "A"
+    value: "127.0.0.1"
+    timeout: 30
+
 '''
 
 RETURN = '''
@@ -193,6 +210,7 @@ def main():
             priority=dict(required=False, type='int'),
             solo=dict(required=False, type='bool', default=False),
             state=dict(required=False, choices=['present', 'absent'], default='present'),
+            timeout=dict(required=False, type='int', default=5),
 
         ),
         supports_check_mode=True
@@ -211,6 +229,7 @@ def main():
     priority = module.params.get('priority')
     solo = module.params.get('solo')
     state = module.params.get('state')
+    timeout = module.params.get('timeout')
 
     if record_type == 'MX' and not priority:
         module.fail_json(msg="record type MX required the 'priority' argument")
@@ -218,7 +237,7 @@ def main():
     has_changed = False
     all_records = []
     try:
-        with nc_dnsapi.Client(customer_id, api_key, api_password) as api:
+        with nc_dnsapi.Client(customer_id, api_key, api_password, timeout) as api:
             all_records = api.dns_records(domain)
             record = DNSRecord(record, record_type, value, priority=priority)
 

--- a/plugins/modules/net_tools/netcup_dns.py
+++ b/plugins/modules/net_tools/netcup_dns.py
@@ -74,9 +74,10 @@ options:
     type: str
   timeout:
     description:
-      - HTTP(s) connection timeout
+      - HTTP(S) connection timeout in seconds.
     default: 5
     type: int
+    version_added: 5.7.0
 requirements:
   - "nc-dnsapi >= 0.1.3"
 author: "Nicolai Buchwitz (@nbuchwitz)"


### PR DESCRIPTION
##### SUMMARY
The `netcup_dnaspi` module relies on python package `nc_dnsapi` which supports specifying a connection timeout, defaulting to 5 (see https://github.com/nbuchwitz/nc_dnsapi/blob/master/nc_dnsapi/__init__.py#L186)
Being able to specify a value higher than the default is helpful when working on an unstable or high-latency internet connection (e.g. LTE)

This change adds a timeout parameter to the `netcup_dnsapi` module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
netcup_dnsapi

##### ADDITIONAL INFORMATION
none
