### PR TITLE
chore: Update lxc_container to support py3

### DIFF
--- a/changelogs/fragments/5280-lxc_container-py3.yaml
+++ b/changelogs/fragments/5280-lxc_container-py3.yaml
@@ -1,5 +1,5 @@
 bugfixes:
   - lxc_container - the module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304).
 
-breaking_changes:
-  - The ``lxc_container`` module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304). 
+deprecated_feature:
+  - lxc_container - the module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304). 

--- a/changelogs/fragments/5280-lxc_container-py3.yaml
+++ b/changelogs/fragments/5280-lxc_container-py3.yaml
@@ -2,4 +2,4 @@ bugfixes:
   - The ``lxc_container``` module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304)
 
 breaking_changes:
-  - The ``lxc_container`` module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304)
+  - The ``lxc_container`` module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304). 

--- a/changelogs/fragments/5280-lxc_container-py3.yaml
+++ b/changelogs/fragments/5280-lxc_container-py3.yaml
@@ -1,5 +1,5 @@
 bugfixes:
-  - The ``lxc_container``` module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304)
+  - lxc_container - the module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304).
 
 breaking_changes:
   - The ``lxc_container`` module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304). 

--- a/changelogs/fragments/5280-lxc_container-py3.yaml
+++ b/changelogs/fragments/5280-lxc_container-py3.yaml
@@ -1,5 +1,5 @@
 bugfixes:
   - lxc_container - the module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304).
 
-deprecated_feature:
+deprecated_features:
   - lxc_container - the module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304). 

--- a/changelogs/fragments/5280-lxc_container-py3.yaml
+++ b/changelogs/fragments/5280-lxc_container-py3.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - The ``lxc_container``` module has been updated to support Python 3 (https://github.com/ansible-collections/community.general/pull/5304)
+
+breaking_changes:
+  - The ``lxc_container`` module will no longer make any effort to support Python 2 (https://github.com/ansible-collections/community.general/pull/5304)

--- a/plugins/modules/cloud/lxc/lxc_container.py
+++ b/plugins/modules/cloud/lxc/lxc_container.py
@@ -164,9 +164,9 @@ options:
         type: list
         elements: str
 requirements:
-  - 'lxc >= 1.0 # OS package'
-  - 'python >= 2.6 # OS Package'
-  - 'lxc-python2 >= 0.1 # PIP Package from https://github.com/lxc/python2-lxc'
+  - 'lxc >= 2.0 # OS package'
+  - 'python3 >= 3.5 # OS Package'
+  - 'python3-lxc # OS Package'
 notes:
   - Containers must have a unique name. If you attempt to create a container
     with a name that already exists in the users namespace the module will
@@ -184,10 +184,10 @@ notes:
     tarball of the running container. The "archive" option supports LVM backed
     containers and will create a snapshot of the running container when
     creating the archive.
-  - If your distro does not have a package for "python2-lxc", which is a
+  - If your distro does not have a package for C(python3-lxc), which is a
     requirement for this module, it can be installed from source at
-    "https://github.com/lxc/python2-lxc" or installed via pip using the package
-    name lxc-python2.
+    U(https://github.com/lxc/python3-lxc) or installed via pip using the
+    package name C(lxc).
 '''
 
 EXAMPLES = r"""
@@ -434,7 +434,6 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
-from ansible.module_utils.six.moves import xrange
 from ansible.module_utils.common.text.converters import to_text, to_bytes
 
 
@@ -559,7 +558,7 @@ popd
 def create_script(command):
     """Write out a script onto a target.
 
-    This method should be backward compatible with Python 2.4+ when executing
+    This method should be backward compatible with Python when executing
     from within the container.
 
     :param command: command to run, this can be a script and can use spacing
@@ -939,7 +938,7 @@ class LxcContainerManagement(object):
         """
 
         self.container = self.get_container_bind()
-        for dummy in xrange(timeout):
+        for dummy in range(timeout):
             if self._get_state() != 'running':
                 self.container.start()
                 self.state_change = True
@@ -992,7 +991,7 @@ class LxcContainerManagement(object):
         :type timeout: ``int``
         """
 
-        for dummy in xrange(timeout):
+        for dummy in range(timeout):
             if not self._container_exists(container_name=self.container_name, lxc_path=self.lxc_path):
                 break
 


### PR DESCRIPTION
##### SUMMARY
This change is mostly just a documentation change which will report the requirements correctly for python3-lxc. I've also removed the use of six which results in us changing `xrange` to `range`.

Fixes: https://github.com/ansible-collections/community.general/issues/5294

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc_container

Signed-off-by: Kevin Carter <kevin.carter@figment.io>