### PR TITLE
Allow choosen user ssh config file

### DIFF
--- a/changelogs/fragments/5305-remove_mutally-exclusive-clause-ssh-config-user-ssh-config-file.yaml
+++ b/changelogs/fragments/5305-remove_mutally-exclusive-clause-ssh-config-user-ssh-config-file.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - system/ssh_config - remove constraint between ``user`` and ``ssh_config_file`` parameters (https://github.com/ansible-collections/community.general/pull/5305).

--- a/plugins/modules/system/ssh_config.py
+++ b/plugins/modules/system/ssh_config.py
@@ -185,7 +185,7 @@ class SSHConfig():
         if self.user:
             if self.config_file is None:
                 self.config_file = os.path.join(os.path.expanduser('~%s' % self.user), '.ssh', 'config')
-            else
+            else:
                 self.config_file = os.path.join(os.path.expanduser('~%s' % self.user), '.ssh', 'config.d', self.config_file)
         elif self.config_file is None:
             self.config_file = '/etc/ssh/ssh_config'

--- a/plugins/modules/system/ssh_config.py
+++ b/plugins/modules/system/ssh_config.py
@@ -31,8 +31,7 @@ options:
     description:
       - Which user account this configuration file belongs to.
       - If none given and I(ssh_config_file) is not specified, C(/etc/ssh/ssh_config) is used.
-      - If a user is given, C(~/.ssh/config) is used.
-      - Mutually exclusive with I(ssh_config_file).
+      - If a user is given and I(ssh_config_file) is not specified, C(~/.ssh/config) is used.
     type: str
   group:
     description:
@@ -86,7 +85,7 @@ options:
     description:
       - SSH config file.
       - If I(user) and this option are not specified, C(/etc/ssh/ssh_config) is used.
-      - Mutually exclusive with I(user).
+      - If I(user) is specified and this option is not specified, C(~/.ssh/config) is used.
     type: path
 requirements:
 - StormSSH
@@ -184,7 +183,10 @@ class SSHConfig():
 
     def check_ssh_config_path(self):
         if self.user:
-            self.config_file = os.path.join(os.path.expanduser('~%s' % self.user), '.ssh', 'config')
+            if self.config_file is None:
+                self.config_file = os.path.join(os.path.expanduser('~%s' % self.user), '.ssh', 'config')
+            else
+                self.config_file = os.path.join(os.path.expanduser('~%s' % self.user), '.ssh', 'config.d', self.config_file)
         elif self.config_file is None:
             self.config_file = '/etc/ssh/ssh_config'
 
@@ -312,9 +314,6 @@ def main():
             user_known_hosts_file=dict(type='str', default=None),
         ),
         supports_check_mode=True,
-        mutually_exclusive=[
-            ['user', 'ssh_config_file'],
-        ],
     )
 
     if not HAS_STORM:


### PR DESCRIPTION
This is a work in progress WIP pull request.

OpenSSH 7.3 release, added a new directive, to include file in ssh_config:
" * ssh(1): Add an Include directive for ssh_config(5) files."
From the full release notes: https://www.openssh.com/txt/release-7.3

To be able to choose a different config file, the mutually exclusive constraint between user and ssh_config_file should be removed.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Removing the mutually exclusive constraint between user and ssh_config_file
allow to choose a different destination file for user ssh configuration.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/system/ssh_config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I've hard-coded a sub-directory: ```~/.ssh/config.d/``` as it's the one which seems make sense, and in
the spirit of the ssh configuration found on my Linux servers.

But it doesn't allow more structured sub-directories tree. (I don't have this need,
but maybe someone has).

And, hard-coding is always a bad idea, maybe this path should be made configurable?
What do you think?

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
