### PR TITLE
znode: add options for authentication

### DIFF
--- a/changelogs/fragments/5306-add-options-for-authentication.yml
+++ b/changelogs/fragments/5306-add-options-for-authentication.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - znode - possibility to use zookeeper ACL authentication (https://github.com/ansible-collections/community.general/pull/5306).
+  - znode - possibility to use ZooKeeper ACL authentication (https://github.com/ansible-collections/community.general/pull/5306).

--- a/changelogs/fragments/5306-add-options-for-authentication.yml
+++ b/changelogs/fragments/5306-add-options-for-authentication.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - znode - possibility to use zookeeper ACL authentication

--- a/changelogs/fragments/5306-add-options-for-authentication.yml
+++ b/changelogs/fragments/5306-add-options-for-authentication.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - znode - possibility to use zookeeper ACL authentication
+  - znode - possibility to use zookeeper ACL authentication (https://github.com/ansible-collections/community.general/pull/5306).

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -226,7 +226,7 @@ class KazooCommandProxy():
 
     def start(self):
         self.zk.start()
-        if (self.module.params['auth_credential']):
+        if self.module.params['auth_credential']:
             self.zk.add_auth(self.module.params['auth_scheme'], self.module.params['auth_credential'])
 
     def wait(self):

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -62,6 +62,7 @@ options:
             - 'The credential value. Depends on scheme (format "digest": user:password, "sasl": user:password).'
         type: str
         required: false
+        version_added: 5.7.0
 requirements:
     - kazoo >= 2.1
     - python >= 2.6

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -49,7 +49,7 @@ options:
             - Recursively delete node and all its children.
         type: bool
         default: false
-    scheme:
+    auth_scheme:
         description:
             - 'Authentication scheme.'
         choices: [ digest, sasl ]
@@ -57,9 +57,9 @@ options:
         default: "digest"
         required: false
         version_added: 5.7.0
-    credential:
+    auth_credential:
         description:
-            - 'The credential value. Depends on scheme (format for I(scheme=digest) is C(user:password), and the format for I(scheme=sasl) is C(user:password)).'
+            - 'The authentication credential value. Depends on auth_scheme (format for I(auth_scheme=digest) is C(user:password), and the format for I(auth_scheme=sasl) is C(user:password)).'
         type: str
         required: false
         version_added: 5.7.0
@@ -86,7 +86,7 @@ EXAMPLES = """
 - name: Getting the value and stat structure for a znode using digest authentication
   community.general.znode:
     hosts: 'localhost:2181'
-    credential: 'user1:s3cr3t'
+    auth_credential: 'user1:s3cr3t'
     name: /secretmypath
     op: get
 
@@ -144,8 +144,8 @@ def main():
             state=dict(choices=['present', 'absent']),
             timeout=dict(default=300, type='int'),
             recursive=dict(default=False, type='bool'),
-            scheme=dict(default='digest', choices=['digest', 'sasl']),
-            credential=dict(type='str', no_log=True),
+            auth_scheme=dict(default='digest', choices=['digest', 'sasl']),
+            auth_credential=dict(type='str', no_log=True),
         ),
         supports_check_mode=False
     )
@@ -224,8 +224,8 @@ class KazooCommandProxy():
 
     def start(self):
         self.zk.start()
-        if (self.module.params['credential']):
-            self.zk.add_auth(self.module.params['scheme'], self.module.params['credential'])
+        if (self.module.params['auth_credential']):
+            self.zk.add_auth(self.module.params['auth_scheme'], self.module.params['auth_credential'])
 
     def wait(self):
         return self._wait(self.module.params['name'], self.module.params['timeout'])

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -59,8 +59,9 @@ options:
         version_added: 5.7.0
     auth_credential:
         description:
-            - 'The authentication credential value. Depends on auth_scheme (format for I(auth_scheme=digest) is C(user:password),
-               and the format for I(auth_scheme=sasl) is C(user:password)).'
+            - 'The authentication credential value. Depends on I(auth_scheme).
+            - The format for I(auth_scheme=digest) is C(user:password),
+               and the format for I(auth_scheme=sasl) is C(user:password).'
         type: str
         required: false
         version_added: 5.7.0

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -56,6 +56,7 @@ options:
         type: str
         default: "digest"
         required: false
+        version_added: 5.7.0
     credential:
         description:
             - 'The credential value. Depends on scheme (format "digest": user:password, "sasl": user:password).'

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -59,7 +59,7 @@ options:
         version_added: 5.7.0
     credential:
         description:
-            - 'The credential value. Depends on scheme (format "digest": user:password, "sasl": user:password).'
+            - 'The credential value. Depends on scheme (format for I(scheme=digest) is C(user:password), and the format for I(scheme=sasl) is C(user:password)).'
         type: str
         required: false
         version_added: 5.7.0

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -59,9 +59,9 @@ options:
         version_added: 5.7.0
     auth_credential:
         description:
-            - 'The authentication credential value. Depends on I(auth_scheme).
+            - The authentication credential value. Depends on I(auth_scheme).
             - The format for I(auth_scheme=digest) is C(user:password),
-               and the format for I(auth_scheme=sasl) is C(user:password).'
+              and the format for I(auth_scheme=sasl) is C(user:password).
         type: str
         required: false
         version_added: 5.7.0

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -59,7 +59,8 @@ options:
         version_added: 5.7.0
     auth_credential:
         description:
-            - 'The authentication credential value. Depends on auth_scheme (format for I(auth_scheme=digest) is C(user:password), and the format for I(auth_scheme=sasl) is C(user:password)).'
+            - 'The authentication credential value. Depends on auth_scheme (format for I(auth_scheme=digest) is C(user:password),
+               and the format for I(auth_scheme=sasl) is C(user:password)).'
         type: str
         required: false
         version_added: 5.7.0

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -56,7 +56,7 @@ options:
         type: str
         default: "digest"
         required: false
-        version_added: 5.7.0
+        version_added: 5.8.0
     auth_credential:
         description:
             - The authentication credential value. Depends on I(auth_scheme).
@@ -64,7 +64,7 @@ options:
               and the format for I(auth_scheme=sasl) is C(user:password).
         type: str
         required: false
-        version_added: 5.7.0
+        version_added: 5.8.0
 requirements:
     - kazoo >= 2.1
     - python >= 2.6

--- a/plugins/modules/clustering/znode.py
+++ b/plugins/modules/clustering/znode.py
@@ -145,7 +145,7 @@ def main():
             timeout=dict(default=300, type='int'),
             recursive=dict(default=False, type='bool'),
             scheme=dict(default='digest', choices=['digest', 'sasl']),
-            credential=dict(type='str')
+            credential=dict(type='str', no_log=True),
         ),
         supports_check_mode=False
     )


### PR DESCRIPTION
##### SUMMARY

This adds the possibility to use zookeeper ACL authentication.
Kazoo supports "digest” and “sasl”.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
znode

##### ADDITIONAL INFORMATION
