### PR TITLE
Fixes #5313: redhat_subscription module is not idempotent when pool_ids are used

### DIFF
--- a/changelogs/fragments/5274-proxmox-snap-container-with-mountpoints.yml
+++ b/changelogs/fragments/5274-proxmox-snap-container-with-mountpoints.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - proxmox_snap - add ``unbind`` param to support snapshotting containers with configured mountpoints (https://github.com/ansible-collections/community.general/pull/5274).
+  - proxmox module utils, the proxmox* modules - add ``api_task_ok`` helper to standardize API task status checks across all proxmox modules (https://github.com/ansible-collections/community.general/pull/5274).

--- a/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
+++ b/changelogs/fragments/5291-fix-nmcli-error-when-setting-unset-mac-address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "nmcli - fix error when setting previously unset MAC address, ``gsm.apn`` or ``vpn.data``: current values were being normalized without checking if they might be ``None`` (https://github.com/ansible-collections/community.general/pull/5291)."

--- a/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
+++ b/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - fix redhat_subscription module is not idempotent when pool_ids are used (https://github.com/ansible-collections/community.general/issues/5313).

--- a/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
+++ b/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redhat_subscription - fix redhat_subscription module is not idempotent when pool_ids are used (https://github.com/ansible-collections/community.general/issues/5313).
+  - redhat_subscription - make module idempotent when ``pool_ids`` are used (https://github.com/ansible-collections/community.general/issues/5313).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -137,3 +137,7 @@ class ProxmoxAnsible(object):
                 return None
 
             self.module.fail_json(msg='VM with vmid %s does not exist in cluster' % vmid)
+
+    def api_task_ok(self, node, taskid):
+        status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
+        return status['status'] == 'stopped' and status['exitstatus'] == 'OK'

--- a/plugins/modules/cloud/misc/proxmox.py
+++ b/plugins/modules/cloud/misc/proxmox.py
@@ -482,8 +482,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)
 
         while timeout:
-            if (proxmox_node.tasks(taskid).status.get()['status'] == 'stopped' and
-                    proxmox_node.tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            if self.api_task_ok(node, taskid):
                 return True
             timeout -= 1
             if timeout == 0:
@@ -496,8 +495,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
     def start_instance(self, vm, vmid, timeout):
         taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.start.post()
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
@@ -513,8 +511,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         else:
             taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.shutdown.post()
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
@@ -527,8 +524,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
     def umount_instance(self, vm, vmid, timeout):
         taskid = getattr(self.proxmox_api.nodes(vm['node']), VZ_TYPE)(vmid).status.umount.post()
         while timeout:
-            if (self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['status'] == 'stopped' and
-                    self.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            if self.api_task_ok(vm['node'], taskid):
                 return True
             timeout -= 1
             if timeout == 0:
@@ -775,8 +771,7 @@ def main():
             taskid = getattr(proxmox.proxmox_api.nodes(vm['node']), VZ_TYPE).delete(vmid, **delete_params)
 
             while timeout:
-                task_status = proxmox.proxmox_api.nodes(vm['node']).tasks(taskid).status.get()
-                if (task_status['status'] == 'stopped' and task_status['exitstatus'] == 'OK'):
+                if proxmox.api_task_ok(vm['node'], taskid):
                     module.exit_json(changed=True, msg="VM %s removed" % vmid)
                 timeout -= 1
                 if timeout == 0:

--- a/plugins/modules/cloud/misc/proxmox_kvm.py
+++ b/plugins/modules/cloud/misc/proxmox_kvm.py
@@ -866,8 +866,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         timeout = self.module.params['timeout']
 
         while timeout:
-            task = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            if task['status'] == 'stopped' and task['exitstatus'] == 'OK':
+            if self.api_task_ok(node, taskid):
                 # Wait an extra second as the API can be a ahead of the hypervisor
                 time.sleep(1)
                 return True

--- a/plugins/modules/cloud/misc/proxmox_template.py
+++ b/plugins/modules/cloud/misc/proxmox_template.py
@@ -131,8 +131,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
         Check the task status and wait until the task is completed or the timeout is reached.
         """
         while timeout:
-            task_status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            if task_status['status'] == 'stopped' and task_status['exitstatus'] == 'OK':
+            if self.api_task_ok(node, taskid):
                 return True
             timeout = timeout - 1
             if timeout == 0:

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -2099,15 +2099,18 @@ class Nmcli(object):
                     # MAC addresses are case insensitive, nmcli always reports them in uppercase
                     value = value.upper()
                     # ensure current_value is also converted to uppercase in case nmcli changes behaviour
-                    current_value = current_value.upper()
+                    if current_value:
+                        current_value = current_value.upper()
                 if key == 'gsm.apn':
                     # Depending on version nmcli adds double-qoutes to gsm.apn
                     # Need to strip them in order to compare both
-                    current_value = current_value.strip('"')
+                    if current_value:
+                        current_value = current_value.strip('"')
                 if key == self.mtu_setting and self.mtu is None:
                     self.mtu = 0
                 if key == 'vpn.data':
-                    current_value = sorted(re.sub(r'\s*=\s*', '=', part.strip(), count=1) for part in current_value.split(','))
+                    if current_value:
+                        current_value = sorted(re.sub(r'\s*=\s*', '=', part.strip(), count=1) for part in current_value.split(','))
                     value = sorted(part.strip() for part in value.split(','))
             else:
                 # parameter does not exist

--- a/plugins/modules/packaging/os/redhat_subscription.py
+++ b/plugins/modules/packaging/os/redhat_subscription.py
@@ -593,15 +593,22 @@ class Rhsm(RegistrationBase):
         consumed_pools = RhsmPools(self.module, consumed=True)
 
         existing_pools = {}
+        serials_to_remove = []
         for p in consumed_pools:
-            existing_pools[p.get_pool_id()] = p.QuantityUsed
+            pool_id = p.get_pool_id()
+            quantity_used = p.get_quantity_used()
+            existing_pools[pool_id] = quantity_used
 
-        serials_to_remove = [p.Serial for p in consumed_pools if pool_ids.get(p.get_pool_id(), 0) != p.QuantityUsed]
+            quantity = pool_ids.get(pool_id, 0)
+            if quantity == 0 or quantity is not None and quantity != quantity_used:
+                serials_to_remove.append(p.Serial)
+
         serials = self.unsubscribe(serials=serials_to_remove)
 
         missing_pools = {}
         for pool_id, quantity in sorted(pool_ids.items()):
-            if existing_pools.get(pool_id, 0) != quantity:
+            quantity_used = existing_pools.get(pool_id, 0)
+            if quantity_used == 0 or quantity is not None and quantity_used != quantity:
                 missing_pools[pool_id] = quantity
 
         self.subscribe_by_pool_ids(missing_pools)
@@ -634,6 +641,9 @@ class RhsmPool(object):
 
     def get_pool_id(self):
         return getattr(self, 'PoolId', getattr(self, 'PoolID'))
+
+    def get_quantity_used(self):
+        return int(getattr(self, 'QuantityUsed'))
 
     def subscribe(self):
         args = "subscription-manager attach --pool %s" % self.get_pool_id()


### PR DESCRIPTION
This fix ensures the idempotency of the redhat_subscription module when pool_ids are used. The main problem was, that a 'None' quantity was not properly handled and that the quantity check compared a string with an integer.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redhat_subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
