### PR TITLE
Fix #5313: redhat_subscription module is not idempotent when pool_ids are used

### DIFF
--- a/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
+++ b/changelogs/fragments/5313-fix-redhat_subscription-idempotency-pool_ids.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - make module idempotent when ``pool_ids`` are used (https://github.com/ansible-collections/community.general/issues/5313).


### PR DESCRIPTION
##### SUMMARY
This fix ensures the idempotency of the redhat_subscription module when pool_ids are used. The main problem was, that a 'None' quantity was not properly handled and that the quantity check compared a string with an integer.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redhat_subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
