### PR TITLE
remove default icon_url that might override your setting icon_url

### DIFF
--- a/plugins/modules/notification/slack.py
+++ b/plugins/modules/notification/slack.py
@@ -419,7 +419,7 @@ def main():
             channel=dict(type='str'),
             thread_id=dict(type='str'),
             username=dict(type='str', default='Ansible'),
-            icon_url=dict(type='str', default='https://www.ansible.com/favicon.ico'),
+            icon_url=dict(type='str'),
             icon_emoji=dict(type='str'),
             link_names=dict(type='int', default=1, choices=[0, 1]),
             parse=dict(type='str', choices=['none', 'full']),


### PR DESCRIPTION
##### SUMMARY
I propose that we remove the default on `icon_url` param to avoid overriding the Slack app default settings.

If we want to re-use the same icon_url we configured in Slack panel, we have to use the Slack CDN URL.

By removing the default, it will then fallback on the Slack App default. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module: slack