### PR TITLE
[opentelemetry][callback] support opentelemetry-api 1.13

### DIFF
--- a/changelogs/fragments/5342-opentelemetry_bug_fix_opentelemetry-api-1.13.yml
+++ b/changelogs/fragments/5342-opentelemetry_bug_fix_opentelemetry-api-1.13.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opentelemetry callback plugin - support opentelemetry-api 1.13.0 that removed support for _time_ns (https://github.com/ansible-collections/community.general/pull/5342).

--- a/changelogs/fragments/5342-opentelemetry_bug_fix_opentelemetry-api-1.13.yml
+++ b/changelogs/fragments/5342-opentelemetry_bug_fix_opentelemetry-api-1.13.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - opentelemetry callback plugin - support opentelemetry-api 1.13.0 that removed support for _time_ns (https://github.com/ansible-collections/community.general/pull/5342).
+  - opentelemetry callback plugin - support opentelemetry-api 1.13.0 that removed support for ``_time_ns`` (https://github.com/ansible-collections/community.general/pull/5342).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -132,7 +132,7 @@ def time_ns():
         # Support versions older than 3.7 with opentelemetry-api > 1.12
         if OTEL_LIBRARY_TIME_NS_ERROR:
             return int(time.time() * 1e9)
-        return  _time_ns()
+        return _time_ns()
 
 
 class TaskData:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -121,6 +121,7 @@ try:
 
 except ImportError as imp_exc:
     OTEL_LIBRARY_IMPORT_ERROR = imp_exc
+    OTEL_LIBRARY_TIME_NS_ERROR = imp_exc
 else:
     OTEL_LIBRARY_IMPORT_ERROR = None
 

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -130,12 +130,9 @@ if sys.version_info >= (3, 7):
 elif not OTEL_LIBRARY_TIME_NS_ERROR:
     time_ns = _time_ns
 else:
-    # option 1
     def time_ns():
         # Support versions older than 3.7 with opentelemetry-api > 1.12
         return int(time.time() * 1e9)
-    # option 2 - not the recommended way to create a function, but it "reads" more similar to the previous cases
-    time_ns = lambda: int(time.time() * 1e9)
 
 
 class TaskData:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -125,6 +125,16 @@ else:
     OTEL_LIBRARY_IMPORT_ERROR = None
 
 
+def time_ns():
+    if sys.version_info >= (3, 7):
+        return time.time_ns()
+    else:
+        # Support versions older than 3.7 with opentelemetry-api > 1.12
+        if OTEL_LIBRARY_TIME_NS_ERROR:
+            return int(time.time() * 1e9)
+        return  _time_ns()
+
+
 class TaskData:
     """
     Data about an individual task.
@@ -136,14 +146,7 @@ class TaskData:
         self.path = path
         self.play = play
         self.host_data = OrderedDict()
-        if sys.version_info >= (3, 7):
-            self.start = time.time_ns()
-        else:
-            # Support versions older than 3.7 with opentelemetry-api > 1.12
-            if OTEL_LIBRARY_TIME_NS_ERROR:
-                self.start = int(time.time() * 1e9)
-            else:
-                self.start = _time_ns()
+        self.start = time_ns()
         self.action = action
         self.args = args
 
@@ -168,14 +171,7 @@ class HostData:
         self.name = name
         self.status = status
         self.result = result
-        if sys.version_info >= (3, 7):
-            self.finish = time.time_ns()
-        else:
-            # Support versions older than 3.7 with opentelemetry-api > 1.12
-            if OTEL_LIBRARY_TIME_NS_ERROR:
-                self.finish = int(time.time() * 1e9)
-            else:
-                self.finish = _time_ns()
+        self.finish = time_ns()
 
 
 class OpenTelemetrySource(object):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -125,14 +125,17 @@ else:
     OTEL_LIBRARY_IMPORT_ERROR = None
 
 
-def time_ns():
-    if sys.version_info >= (3, 7):
-        return time.time_ns()
-    else:
+if sys.version_info >= (3, 7):
+    time_ns = time.time_ns
+elif not OTEL_LIBRARY_TIME_NS_ERROR:
+    time_ns = _time_ns
+else:
+    # option 1
+    def time_ns():
         # Support versions older than 3.7 with opentelemetry-api > 1.12
-        if OTEL_LIBRARY_TIME_NS_ERROR:
-            return int(time.time() * 1e9)
-        return _time_ns()
+        return int(time.time() * 1e9)
+    # option 2 - not the recommended way to create a function, but it "reads" more similar to the previous cases
+    time_ns = lambda: int(time.time() * 1e9)
 
 
 class TaskData:


### PR DESCRIPTION
##### SUMMARY

`opentelemetry-api 1.13` [removed](https://github.com/open-telemetry/opentelemetry-python/commit/a6324d891365f61e3631dabd68f3321482f15c51) support for `_time_ns` , this change will allow to fallback to the previous implementation of [synthetically creating a time_ns](https://github.com/open-telemetry/opentelemetry-python/commit/a6324d891365f61e3631dabd68f3321482f15c51#diff-3fd7b941cb11a39b91324ef4f9784a23dc1436c67dbf696f4356a5ff9b95f793L29) when using <= `python 3.6` with `opentelemetry-api 1.13`, if that's even possible...

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`plugins/callback/opentelemetry.py`

##### ADDITIONAL INFORMATION

Closes https://github.com/ansible-collections/community.general/issues/5315