### PR TITLE
Change CI group identifiers

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -392,56 +392,56 @@ stages:
             - 2
             - 3
 
-### Cloud
-  - stage: Cloud_devel
-    displayName: Cloud devel
+### Generic
+  - stage: Generic_devel
+    displayName: Generic devel
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/cloud/{0}/1
+          testFormat: devel/generic/{0}/1
           targets:
             - test: 2.7
             - test: '3.11'
-  - stage: Cloud_2_14
-    displayName: Cloud 2.14
+  - stage: Generic_2_14
+    displayName: Generic 2.14
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.14/cloud/{0}/1
+          testFormat: 2.14/generic/{0}/1
           targets:
             - test: '3.10'
-  - stage: Cloud_2_13
-    displayName: Cloud 2.13
+  - stage: Generic_2_13
+    displayName: Generic 2.13
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.13/cloud/{0}/1
+          testFormat: 2.13/generic/{0}/1
           targets:
             - test: 3.9
-  - stage: Cloud_2_12
-    displayName: Cloud 2.12
+  - stage: Generic_2_12
+    displayName: Generic 2.12
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.12/cloud/{0}/1
+          testFormat: 2.12/generic/{0}/1
           targets:
             - test: 3.8
-  - stage: Cloud_2_11
-    displayName: Cloud 2.11
+  - stage: Generic_2_11
+    displayName: Generic 2.11
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: 2.11/cloud/{0}/1
+          testFormat: 2.11/generic/{0}/1
           targets:
             - test: 2.7
             - test: 3.5
@@ -470,10 +470,10 @@ stages:
       - Docker_2_13
       - Docker_2_14
       - Docker_community_devel
-      - Cloud_devel
-      - Cloud_2_11
-      - Cloud_2_12
-      - Cloud_2_13
-      - Cloud_2_14
+      - Generic_devel
+      - Generic_2_11
+      - Generic_2_12
+      - Generic_2_13
+      - Generic_2_14
     jobs:
       - template: templates/coverage.yml

--- a/tests/integration/targets/alerta_customer/aliases
+++ b/tests/integration/targets/alerta_customer/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 disabled

--- a/tests/integration/targets/alternatives/aliases
+++ b/tests/integration/targets/alternatives/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 destructive
 needs/root
 skip/aix

--- a/tests/integration/targets/ansible_galaxy_install/aliases
+++ b/tests/integration/targets/ansible_galaxy_install/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/python2.6
 context/controller  # While this is not really true, this module mainly is run on the controller, *and* needs access to the ansible-galaxy CLI tool

--- a/tests/integration/targets/apache2_module/aliases
+++ b/tests/integration/targets/apache2_module/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/aix

--- a/tests/integration/targets/archive/aliases
+++ b/tests/integration/targets/archive/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 needs/root
-shippable/posix/group2
 destructive
 skip/aix
 skip/osx  # FIXME

--- a/tests/integration/targets/callback_diy/aliases
+++ b/tests/integration/targets/callback_diy/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 needs/target/callback

--- a/tests/integration/targets/callback_log_plays/aliases
+++ b/tests/integration/targets/callback_log_plays/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3

--- a/tests/integration/targets/callback_yaml/aliases
+++ b/tests/integration/targets/callback_yaml/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/target/callback

--- a/tests/integration/targets/cargo/aliases
+++ b/tests/integration/targets/cargo/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 destructive
-shippable/posix/group2
 skip/aix

--- a/tests/integration/targets/cloud_init_data_facts/aliases
+++ b/tests/integration/targets/cloud_init_data_facts/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/cmd_runner/aliases
+++ b/tests/integration/targets/cmd_runner/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/connection_chroot/aliases
+++ b/tests/integration/targets/connection_chroot/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 needs/root
-shippable/posix/group3
 skip/macos # Skipped due to limitation of macOS 10.15 SIP, please read https://github.com/ansible-collections/community.general/issues/1017#issuecomment-755088895

--- a/tests/integration/targets/consul/aliases
+++ b/tests/integration/targets/consul/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 destructive
 skip/aix
 skip/macos  # cannot simply create binaries in system locations on newer macOS versions

--- a/tests/integration/targets/copr/aliases
+++ b/tests/integration/targets/copr/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/root
 skip/macos
 skip/osx

--- a/tests/integration/targets/cpanm/aliases
+++ b/tests/integration/targets/cpanm/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 destructive
 skip/macos
 skip/osx

--- a/tests/integration/targets/cronvar/aliases
+++ b/tests/integration/targets/cronvar/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/deploy_helper/aliases
+++ b/tests/integration/targets/deploy_helper/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1

--- a/tests/integration/targets/django_manage/aliases
+++ b/tests/integration/targets/django_manage/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2
 skip/freebsd
 skip/macos

--- a/tests/integration/targets/dnf_versionlock/aliases
+++ b/tests/integration/targets/dnf_versionlock/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/dpkg_divert/aliases
+++ b/tests/integration/targets/dpkg_divert/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/etcd3/aliases
+++ b/tests/integration/targets/etcd3/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 skip/aix
 skip/osx

--- a/tests/integration/targets/filesize/aliases
+++ b/tests/integration/targets/filesize/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1

--- a/tests/integration/targets/filesystem/aliases
+++ b/tests/integration/targets/filesystem/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/filter_counter/aliases
+++ b/tests/integration/targets/filter_counter/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict/aliases
+++ b/tests/integration/targets/filter_dict/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict_kv/aliases
+++ b/tests/integration/targets/filter_dict_kv/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_from_csv/aliases
+++ b/tests/integration/targets/filter_from_csv/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_groupby_as_dict/aliases
+++ b/tests/integration/targets/filter_groupby_as_dict/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_hashids/aliases
+++ b/tests/integration/targets/filter_hashids/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/python2.7  # jc only supports python3.x

--- a/tests/integration/targets/filter_json_query/aliases
+++ b/tests/integration/targets/filter_json_query/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/aix

--- a/tests/integration/targets/filter_lists_mergeby/aliases
+++ b/tests/integration/targets/filter_lists_mergeby/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_path_join_shim/aliases
+++ b/tests/integration/targets/filter_path_join_shim/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_random_mac/aliases
+++ b/tests/integration/targets/filter_random_mac/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/aix

--- a/tests/integration/targets/filter_time/aliases
+++ b/tests/integration/targets/filter_time/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_unicode_normalize/aliases
+++ b/tests/integration/targets/filter_unicode_normalize/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_version_sort/aliases
+++ b/tests/integration/targets/filter_version_sort/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/flatpak/aliases
+++ b/tests/integration/targets/flatpak/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 destructive
 skip/aix
 skip/freebsd

--- a/tests/integration/targets/flatpak_remote/aliases
+++ b/tests/integration/targets/flatpak_remote/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 destructive
 skip/aix
 skip/freebsd

--- a/tests/integration/targets/gem/aliases
+++ b/tests/integration/targets/gem/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/git_config/aliases
+++ b/tests/integration/targets/git_config/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 skip/aix
 destructive

--- a/tests/integration/targets/github_issue/aliases
+++ b/tests/integration/targets/github_issue/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1

--- a/tests/integration/targets/gitlab_branch/aliases
+++ b/tests/integration/targets/gitlab_branch/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 disabled

--- a/tests/integration/targets/gitlab_deploy_key/aliases
+++ b/tests/integration/targets/gitlab_deploy_key/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_group/aliases
+++ b/tests/integration/targets/gitlab_group/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_hook/aliases
+++ b/tests/integration/targets/gitlab_hook/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_project/aliases
+++ b/tests/integration/targets/gitlab_project/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_runner/aliases
+++ b/tests/integration/targets/gitlab_runner/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/gitlab_user/aliases
+++ b/tests/integration/targets/gitlab_user/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 gitlab/ci
 disabled

--- a/tests/integration/targets/hg/aliases
+++ b/tests/integration/targets/hg/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python3
 skip/aix

--- a/tests/integration/targets/homebrew/aliases
+++ b/tests/integration/targets/homebrew/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/homebrew_cask/aliases
+++ b/tests/integration/targets/homebrew_cask/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/homectl/aliases
+++ b/tests/integration/targets/homectl/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/influxdb_user/aliases
+++ b/tests/integration/targets/influxdb_user/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 disabled
 skip/osx
 skip/macos

--- a/tests/integration/targets/ini_file/aliases
+++ b/tests/integration/targets/ini_file/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/interfaces_file/aliases
+++ b/tests/integration/targets/interfaces_file/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/ipify_facts/aliases
+++ b/tests/integration/targets/ipify_facts/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/iptables_state/aliases
+++ b/tests/integration/targets/iptables_state/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/docker             # kernel modules not loadable
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)

--- a/tests/integration/targets/iso_create/aliases
+++ b/tests/integration/targets/iso_create/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 skip/aix
 skip/python2.6

--- a/tests/integration/targets/iso_customize/aliases
+++ b/tests/integration/targets/iso_customize/aliases
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 skip/aix
 skip/freebsd
@@ -11,4 +11,3 @@ skip/alpine
 skip/python2.6
 skip/docker
 needs/root
-

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/target/setup_epel
 destructive
 skip/aix

--- a/tests/integration/targets/java_cert/aliases
+++ b/tests/integration/targets/java_cert/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/java_keystore/aliases
+++ b/tests/integration/targets/java_keystore/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/jboss/aliases
+++ b/tests/integration/targets/jboss/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/jira/aliases
+++ b/tests/integration/targets/jira/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 unsupported
-shippable/posix/group3

--- a/tests/integration/targets/kernel_blacklist/aliases
+++ b/tests/integration/targets/kernel_blacklist/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1

--- a/tests/integration/targets/launchd/aliases
+++ b/tests/integration/targets/launchd/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/ldap_search/aliases
+++ b/tests/integration/targets/ldap_search/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/listen_ports_facts/aliases
+++ b/tests/integration/targets/listen_ports_facts/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3
 destructive
 skip/aix
 skip/osx

--- a/tests/integration/targets/locale_gen/aliases
+++ b/tests/integration/targets/locale_gen/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
 needs/root
-shippable/posix/group3
 skip/aix

--- a/tests/integration/targets/lookup_cartesian/aliases
+++ b/tests/integration/targets/lookup_cartesian/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_collection_version/aliases
+++ b/tests/integration/targets/lookup_collection_version/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3

--- a/tests/integration/targets/lookup_dependent/aliases
+++ b/tests/integration/targets/lookup_dependent/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_dig/aliases
+++ b/tests/integration/targets/lookup_dig/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_etcd3/aliases
+++ b/tests/integration/targets/lookup_etcd3/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 needs/file/tests/utils/constraints.txt
 needs/target/setup_etcd3

--- a/tests/integration/targets/lookup_flattened/aliases
+++ b/tests/integration/targets/lookup_flattened/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_lmdb_kv/aliases
+++ b/tests/integration/targets/lookup_lmdb_kv/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 destructive
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_passwordstore/aliases
+++ b/tests/integration/targets/lookup_passwordstore/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 skip/aix
 skip/rhel

--- a/tests/integration/targets/lookup_random_pet/aliases
+++ b/tests/integration/targets/lookup_random_pet/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_random_string/aliases
+++ b/tests/integration/targets/lookup_random_string/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_random_words/aliases
+++ b/tests/integration/targets/lookup_random_words/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lvg/aliases
+++ b/tests/integration/targets/lvg/aliases
@@ -2,9 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
 needs/privileged
-shippable/posix/group1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/mail/aliases
+++ b/tests/integration/targets/mail/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1

--- a/tests/integration/targets/module_helper/aliases
+++ b/tests/integration/targets/module_helper/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/monit/aliases
+++ b/tests/integration/targets/monit/aliases
@@ -2,9 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 destructive
 needs/target/setup_epel
-shippable/posix/group2
 skip/osx
 skip/macos
 skip/freebsd

--- a/tests/integration/targets/mqtt/aliases
+++ b/tests/integration/targets/mqtt/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/nomad/aliases
+++ b/tests/integration/targets/nomad/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 nomad_job_info
 destructive
 skip/aix

--- a/tests/integration/targets/npm/aliases
+++ b/tests/integration/targets/npm/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 destructive
 skip/aix
 skip/freebsd

--- a/tests/integration/targets/odbc/aliases
+++ b/tests/integration/targets/odbc/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/osx
 skip/macos
 skip/rhel8.0

--- a/tests/integration/targets/one_host/aliases
+++ b/tests/integration/targets/one_host/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/generic/1
 cloud/opennebula
-shippable/cloud/group1
 disabled  # FIXME

--- a/tests/integration/targets/one_template/aliases
+++ b/tests/integration/targets/one_template/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/generic/1
 cloud/opennebula
-shippable/cloud/group1
 disabled  # FIXME

--- a/tests/integration/targets/osx_defaults/aliases
+++ b/tests/integration/targets/osx_defaults/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/rhel

--- a/tests/integration/targets/pacman/aliases
+++ b/tests/integration/targets/pacman/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/pam_limits/aliases
+++ b/tests/integration/targets/pam_limits/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/pamd/aliases
+++ b/tests/integration/targets/pamd/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/pids/aliases
+++ b/tests/integration/targets/pids/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3

--- a/tests/integration/targets/pipx/aliases
+++ b/tests/integration/targets/pipx/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 destructive
-shippable/posix/group2
 skip/python2
 skip/python3.5

--- a/tests/integration/targets/pipx_info/aliases
+++ b/tests/integration/targets/pipx_info/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/python2
 skip/python3.5

--- a/tests/integration/targets/pkgng/aliases
+++ b/tests/integration/targets/pkgng/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/root
 skip/docker
 skip/osx

--- a/tests/integration/targets/python_requirements_info/aliases
+++ b/tests/integration/targets/python_requirements_info/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/read_csv/aliases
+++ b/tests/integration/targets/read_csv/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/redis_info/aliases
+++ b/tests/integration/targets/redis_info/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/rundeck/aliases
+++ b/tests/integration/targets/rundeck/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/sefcontext/aliases
+++ b/tests/integration/targets/sefcontext/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 needs/root
-shippable/posix/group2
 skip/aix

--- a/tests/integration/targets/sensu_client/aliases
+++ b/tests/integration/targets/sensu_client/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/root

--- a/tests/integration/targets/sensu_handler/aliases
+++ b/tests/integration/targets/sensu_handler/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/root

--- a/tests/integration/targets/shutdown/aliases
+++ b/tests/integration/targets/shutdown/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1

--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/snap_alias/aliases
+++ b/tests/integration/targets/snap_alias/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/ssh_config/aliases
+++ b/tests/integration/targets/ssh_config/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 destructive
-shippable/posix/group2
 skip/python2.6  # stromssh only supports python3
 skip/python2.7  # stromssh only supports python3
 skip/freebsd # stromssh installation fails on freebsd

--- a/tests/integration/targets/sudoers/aliases
+++ b/tests/integration/targets/sudoers/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2

--- a/tests/integration/targets/supervisorctl/aliases
+++ b/tests/integration/targets/supervisorctl/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/2
 destructive
-shippable/posix/group2
 skip/python3
 skip/aix

--- a/tests/integration/targets/sysrc/aliases
+++ b/tests/integration/targets/sysrc/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 needs/root
 skip/docker
 skip/osx

--- a/tests/integration/targets/terraform/aliases
+++ b/tests/integration/targets/terraform/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/windows
 skip/aix
 skip/osx

--- a/tests/integration/targets/test_a_module/aliases
+++ b/tests/integration/targets/test_a_module/aliases
@@ -2,4 +2,4 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group3
+azp/posix/3

--- a/tests/integration/targets/timezone/aliases
+++ b/tests/integration/targets/timezone/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/ufw/aliases
+++ b/tests/integration/targets/ufw/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/wakeonlan/aliases
+++ b/tests/integration/targets/wakeonlan/aliases
@@ -2,5 +2,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix

--- a/tests/integration/targets/xattr/aliases
+++ b/tests/integration/targets/xattr/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group2
+azp/posix/2
 skip/aix
 skip/docker
 skip/freebsd

--- a/tests/integration/targets/xfs_quota/aliases
+++ b/tests/integration/targets/xfs_quota/aliases
@@ -2,9 +2,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 needs/privileged
 needs/root
-shippable/posix/group1
 skip/aix
 skip/osx
 skip/macos

--- a/tests/integration/targets/xml/aliases
+++ b/tests/integration/targets/xml/aliases
@@ -2,6 +2,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/3
 destructive
-shippable/posix/group3
 skip/aix

--- a/tests/integration/targets/yarn/aliases
+++ b/tests/integration/targets/yarn/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 destructive
 skip/aix
 skip/freebsd

--- a/tests/integration/targets/yum_versionlock/aliases
+++ b/tests/integration/targets/yum_versionlock/aliases
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-shippable/posix/group1
+azp/posix/1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/zypper/aliases
+++ b/tests/integration/targets/zypper/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/integration/targets/zypper_repository/aliases
+++ b/tests/integration/targets/zypper_repository/aliases
@@ -2,8 +2,8 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+azp/posix/1
 destructive
-shippable/posix/group1
 skip/aix
 skip/freebsd
 skip/osx

--- a/tests/sanity/extra/aliases.py
+++ b/tests/sanity/extra/aliases.py
@@ -20,13 +20,13 @@ def main():
     with open('.azure-pipelines/azure-pipelines.yml', 'rb') as f:
         azp = yaml.safe_load(f)
 
-    allowed_targets = set(['shippable/cloud/group1'])
+    allowed_targets = set(['azp/generic/1'])
     for stage in azp['stages']:
-        if stage['stage'].startswith(('Sanity', 'Unit', 'Cloud', 'Summary')):
+        if stage['stage'].startswith(('Sanity', 'Unit', 'Generic', 'Summary')):
             continue
         for job in stage['jobs']:
             for group in job['parameters']['groups']:
-                allowed_targets.add('shippable/posix/group{0}'.format(group))
+                allowed_targets.add('azp/posix/{0}'.format(group))
 
     for path in paths:
         targets = []

--- a/tests/utils/shippable/generic.sh
+++ b/tests/utils/shippable/generic.sh
@@ -8,11 +8,10 @@ set -o pipefail -eux
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-cloud="${args[0]}"
 python="${args[1]}"
 group="${args[2]}"
 
-target="shippable/${cloud}/group${group}/"
+target="azp/generic/${group}/"
 
 stage="${S:-prod}"
 

--- a/tests/utils/shippable/linux-community.sh
+++ b/tests/utils/shippable/linux-community.sh
@@ -12,9 +12,9 @@ image="${args[1]}"
 python="${args[2]}"
 
 if [ "${#args[@]}" -gt 3 ]; then
-    target="shippable/posix/group${args[3]}/"
+    target="azp/posix/${args[3]}/"
 else
-    target="shippable/posix/"
+    target="azp/posix/"
 fi
 
 # shellcheck disable=SC2086

--- a/tests/utils/shippable/linux.sh
+++ b/tests/utils/shippable/linux.sh
@@ -11,9 +11,9 @@ IFS='/:' read -ra args <<< "$1"
 image="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="shippable/posix/group${args[2]}/"
+    target="azp/posix/${args[2]}/"
 else
-    target="shippable/posix/"
+    target="azp/posix/"
 fi
 
 # shellcheck disable=SC2086

--- a/tests/utils/shippable/remote.sh
+++ b/tests/utils/shippable/remote.sh
@@ -12,9 +12,9 @@ platform="${args[0]}"
 version="${args[1]}"
 
 if [ "${#args[@]}" -gt 2 ]; then
-    target="shippable/posix/group${args[2]}/"
+    target="azp/posix/${args[2]}/"
 else
-    target="shippable/posix/"
+    target="azp/posix/"
 fi
 
 stage="${S:-prod}"


### PR DESCRIPTION
##### SUMMARY
Remove `shippable/` from CI group identifiers. Use `azp/posix/N` for the groups of posix containers/VMs, and `azp/generic/1` for the (single) group of system-independent environments (formerly 'cloud').

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
