### PR TITLE
portage: drop usage of gentoolkit, add knobs for --with-bdeps, --backtrack

### DIFF
--- a/changelogs/fragments/5349-drop-gentoolkit-more-knobs.yml
+++ b/changelogs/fragments/5349-drop-gentoolkit-more-knobs.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - portage - use Portage's python module instead of calling gentoolkit-provided program in shell (https://github.com/ansible-collections/community.general/pull/5349).
+  - portage - add knobs for Portage's ``--backtrack`` and ``--with-bdeps`` options (https://github.com/ansible-collections/community.general/pull/5349).

--- a/plugins/modules/packaging/os/portage.py
+++ b/plugins/modules/packaging/os/portage.py
@@ -42,6 +42,12 @@ options:
     type: bool
     default: false
 
+  backtrack:
+    description:
+      - Set backtrack value (C(--backtrack)).
+    type: int
+    version_added: 5.8.0
+
   deep:
     description:
       - Consider the entire dependency tree of packages (--deep)
@@ -351,6 +357,7 @@ def emerge_packages(module, packages):
     emerge_flags = {
         'jobs': '--jobs',
         'loadavg': '--load-average',
+        'backtrack': '--backtrack',
     }
 
     for flag, arg in emerge_flags.items():
@@ -490,6 +497,7 @@ def main():
                 choices=portage_present_states + portage_absent_states,
             ),
             update=dict(default=False, type='bool'),
+            backtrack=dict(default=None, type='int'),
             deep=dict(default=False, type='bool'),
             newuse=dict(default=False, type='bool'),
             changed_use=dict(default=False, type='bool'),

--- a/plugins/modules/packaging/os/portage.py
+++ b/plugins/modules/packaging/os/portage.py
@@ -166,6 +166,12 @@ options:
       - --load-average setting values
     type: float
 
+  withbdeps:
+    description:
+      - Specifies that build time dependencies should be installed.
+    type: bool
+    version_added: 5.8.0
+
   quietbuild:
     description:
       - Redirect all build output to logs alone, and do not display it
@@ -358,6 +364,7 @@ def emerge_packages(module, packages):
         'jobs': '--jobs',
         'loadavg': '--load-average',
         'backtrack': '--backtrack',
+        'withbdeps': '--with-bdeps',
     }
 
     for flag, arg in emerge_flags.items():
@@ -373,7 +380,10 @@ def emerge_packages(module, packages):
             continue
 
         """Add the --flag=value pair."""
-        args.extend((arg, to_native(flag_val)))
+        if isinstance(p[flag], bool):
+            args.extend((arg, to_native('y' if flag_val else 'n')))
+        else:
+            args.extend((arg, to_native(flag_val)))
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:
@@ -516,6 +526,7 @@ def main():
             keepgoing=dict(default=False, type='bool'),
             jobs=dict(default=None, type='int'),
             loadavg=dict(default=None, type='float'),
+            withbdeps=dict(default=None, type='bool'),
             quietbuild=dict(default=False, type='bool'),
             quietfail=dict(default=False, type='bool'),
         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This solves the issue brought up in https://github.com/ansible-collections/community.general/pull/3870. The Portage Ansible module depends on an external shell command, when it could simply use the Portage module on every system that uses Portage.

Additionally, this adds support for handling the `--with-bdeps` and `--backtrack` `emerge` command line options.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

Portage

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Similar to the other PR, this fixes the following kind of issue when running on a system that doesn't have the requisite external shell command:

```paste below
host | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3.9"
    },
    "changed": false,
    "msg": "Failed to find required executable \"equery\" in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin"
}
```
