### PR TITLE
lxc_container: minor refactor

### DIFF
--- a/changelogs/fragments/5358-lxc-container-refactor.yml
+++ b/changelogs/fragments/5358-lxc-container-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lxc_container - minor refactoring (https://github.com/ansible-collections/community.general/pull/5358).

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,7 +4,6 @@
 .azure-pipelines/scripts/publish-codecov.py compile-3.5!skip # Uses Python 3.6+ syntax
 .azure-pipelines/scripts/publish-codecov.py future-import-boilerplate
 .azure-pipelines/scripts/publish-codecov.py metaclass-boilerplate
-plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_project.py use-argspec-type-path # expanduser() applied to constants
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,5 +1,4 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_project.py use-argspec-type-path # expanduser() applied to constants
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,5 +1,4 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_project.py use-argspec-type-path # expanduser() applied to constants
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,6 +1,4 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/cloud/univention/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_project.py use-argspec-type-path # expanduser() applied to constants
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
@@ -15,6 +13,7 @@ plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:para
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements
+plugins/modules/cloud/univention/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,6 +1,4 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/cloud/univention/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
-plugins/modules/cloud/lxc/lxc_container.py use-argspec-type-path
 plugins/modules/cloud/lxc/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/cloud/lxd/lxd_project.py use-argspec-type-path # expanduser() applied to constants
 plugins/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
@@ -15,6 +13,7 @@ plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:para
 plugins/modules/cloud/spotinst/spotinst_aws_elastigroup.py validate-modules:undocumented-parameter
 plugins/modules/cloud/univention/udm_share.py validate-modules:parameter-list-no-elements
 plugins/modules/cloud/univention/udm_user.py validate-modules:parameter-list-no-elements
+plugins/modules/cloud/univention/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/clustering/consul/consul.py validate-modules:doc-missing-type
 plugins/modules/clustering/consul/consul.py validate-modules:undocumented-parameter
 plugins/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
Minor refactor: mostly pythonisms, but removing the call to `os.path.expanduser()` in line 1361 (pre-change) because:
* `source_dir` is passed as a parameter to the `_create_tar()` method
* `_create_tar()` is only called in one spot in the code, in line 1568 (post-change), inside the method `_container_create_tar()` as `self._create_tar(source_dir=work_dir)`
* the variable `work_dir` is defined in lines 1498-1502 (post-change) as:
  ```python
          # Create a temp dir
          temp_dir = tempfile.mkdtemp()

          # Set the name of the working dir, temp + container_name
          work_dir = os.path.join(temp_dir, self.container_name)
  ```

Therefore, `work_dir` will always be an absolute path, therefore `expanduser()` is redundant.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/cloud/lxc/lxc_container.py