### PR TITLE
nmcli: add transport_mode configuration for Infiniband devices

### DIFF
--- a/changelogs/fragments/5361-nmcli-add-infiniband-transport-mode.yaml
+++ b/changelogs/fragments/5361-nmcli-add-infiniband-transport-mode.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "nmcli - Add transport_mode configuration for Infiniband devices (https://github.com/ansible-collections/community.general/pull/5361)."
+  - "nmcli - add ``transport_mode`` configuration for Infiniband devices (https://github.com/ansible-collections/community.general/pull/5361)."

--- a/changelogs/fragments/5361-nmcli-add-infiniband-transport-mode.yaml
+++ b/changelogs/fragments/5361-nmcli-add-infiniband-transport-mode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "nmcli - Add transport_mode configuration for Infiniband devices (https://github.com/ansible-collections/community.general/pull/5361)."

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -72,8 +72,6 @@ options:
             - This option sets the connection type of Infiniband IPoIB devices.
         type: str
         choices: [ datagram, connected ]
-        default: datagram
-        version_added: 5.8.0
         version_added: 5.8.0
     master:
         description:
@@ -2299,7 +2297,7 @@ def main():
             gsm=dict(type='dict'),
             wireguard=dict(type='dict'),
             vpn=dict(type='dict'),
-            transport_mode=dict(type='str', default='datagram', choices=['datagram', 'connected']),
+            transport_mode=dict(type='str', choices=['datagram', 'connected']),
         ),
         mutually_exclusive=[['never_default4', 'gw4'],
                             ['routes4_extended', 'routes4'],

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -67,6 +67,12 @@ options:
         type: str
         choices: [ 802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast ]
         default: balance-rr
+    transport_mode: 
+        description:
+            - This option sets the connection type of Infiniband IPoIB devices. 
+        type: str
+        choices: [ datagram, connected ]
+        default: datagram
     master:
         description:
             - Master <master (ifname, or connection UUID or conn_name) of bridge, team, bond master connection profile.
@@ -1481,6 +1487,7 @@ class Nmcli(object):
         self.gsm = module.params['gsm']
         self.wireguard = module.params['wireguard']
         self.vpn = module.params['vpn']
+        self.transport_mode = module.params['transport_mode']
 
         if self.method4:
             self.ipv4_method = self.method4
@@ -1693,6 +1700,11 @@ class Nmcli(object):
                     options.update({
                         'vpn.data': vpn_data_values,
                     })
+        elif self.type == 'infiniband':
+            options.update({
+                'infiniband.transport-mode': self.transport_mode,
+            })
+
         # Convert settings values based on the situation.
         for setting, value in options.items():
             setting_type = self.settings_type(setting)
@@ -2285,6 +2297,7 @@ def main():
             gsm=dict(type='dict'),
             wireguard=dict(type='dict'),
             vpn=dict(type='dict'),
+            transport_mode=dict(type='str', default='datagram', choices=['datagram', 'connected']),
         ),
         mutually_exclusive=[['never_default4', 'gw4'],
                             ['routes4_extended', 'routes4'],

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -74,6 +74,7 @@ options:
         choices: [ datagram, connected ]
         default: datagram
         version_added: 5.8.0
+        version_added: 5.8.0
     master:
         description:
             - Master <master (ifname, or connection UUID or conn_name) of bridge, team, bond master connection profile.

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -67,9 +67,9 @@ options:
         type: str
         choices: [ 802.3ad, active-backup, balance-alb, balance-rr, balance-tlb, balance-xor, broadcast ]
         default: balance-rr
-    transport_mode: 
+    transport_mode:
         description:
-            - This option sets the connection type of Infiniband IPoIB devices. 
+            - This option sets the connection type of Infiniband IPoIB devices.
         type: str
         choices: [ datagram, connected ]
         default: datagram

--- a/plugins/modules/net_tools/nmcli.py
+++ b/plugins/modules/net_tools/nmcli.py
@@ -73,6 +73,7 @@ options:
         type: str
         choices: [ datagram, connected ]
         default: datagram
+        version_added: 5.8.0
     master:
         description:
             - Master <master (ifname, or connection UUID or conn_name) of bridge, team, bond master connection profile.

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -3810,4 +3810,3 @@ def test_infiniband_connection_static_transport_mode_connected(
 
     assert results.get('changed') is True
     assert not results.get('failed')
-

--- a/tests/unit/plugins/modules/net_tools/test_nmcli.py
+++ b/tests/unit/plugins/modules/net_tools/test_nmcli.py
@@ -105,6 +105,12 @@ TESTCASE_CONNECTION = [
         'state': 'absent',
         '_ansible_check_mode': True,
     },
+    {
+        'type': 'infiniband',
+        'conn_name': 'non_existent_nw_device',
+        'state': 'absent',
+        '_ansible_check_mode': True,
+    },
 ]
 
 TESTCASE_GENERIC = [
@@ -1271,6 +1277,53 @@ vpn.service-type:                       org.freedesktop.NetworkManager.pptp
 vpn.data:                               gateway=vpn.example.com, password-flags=2, user=brittany
 """
 
+TESTCASE_INFINIBAND_STATIC = [
+    {
+        'type': 'infiniband',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'infiniband_non_existant',
+        'ip4': '10.10.10.10/24',
+        'gw4': '10.10.10.1',
+        'state': 'present',
+        '_ansible_check_mode': False,
+    }
+]
+
+TESTCASE_INFINIBAND_STATIC_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.type:                        infiniband
+connection.interface-name:              infiniband_non_existant
+connection.autoconnect:                 yes
+ipv4.method:                            manual
+ipv4.addresses:                         10.10.10.10/24
+ipv4.gateway:                           10.10.10.1
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+infiniband.transport-mode               datagram
+"""
+
+TESTCASE_INFINIBAND_STATIC_MODIFY_TRANSPORT_MODE = [
+    {
+
+        'type': 'infiniband',
+        'conn_name': 'non_existent_nw_device',
+        'transport_mode': 'connected',
+        'state': 'present',
+        '_ansible_check_mode': False,
+    },
+]
+
+TESTCASE_INFINIBAND_STATIC_MODIFY_TRANSPORT_MODE_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              infiniband_non_existant
+infiniband.transport_mode:              connected
+"""
+
 
 def mocker_set(mocker,
                connection_exists=False,
@@ -1653,6 +1706,24 @@ def mocked_vpn_pptp_connection_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
                execute_return=(0, TESTCASE_VPN_PPTP_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
+def mocked_infiniband_connection_static_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_INFINIBAND_STATIC_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
+def mocked_infiniband_connection_static_transport_mode_connected_modify(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_INFINIBAND_STATIC_MODIFY_TRANSPORT_MODE_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_BOND, indirect=['patch_ansible_module'])
@@ -3696,3 +3767,47 @@ def test_create_vpn_pptp(mocked_generic_connection_create, capfd):
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_INFINIBAND_STATIC, indirect=['patch_ansible_module'])
+def test_infiniband_connection_static_unchanged(mocked_infiniband_connection_static_unchanged, capfd):
+    """
+    Test : Infiniband connection unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_INFINIBAND_STATIC_MODIFY_TRANSPORT_MODE, indirect=['patch_ansible_module'])
+def test_infiniband_connection_static_transport_mode_connected(
+        mocked_infiniband_connection_static_transport_mode_connected_modify, capfd):
+    """
+    Test : Modify Infiniband connection to use connected as transport_mode
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    add_args, add_kw = arg_list[1]
+
+    assert add_args[0][0] == '/usr/bin/nmcli'
+    assert add_args[0][1] == 'con'
+    assert add_args[0][2] == 'modify'
+    assert add_args[0][3] == 'non_existent_nw_device'
+
+    add_args_text = list(map(to_text, add_args[0]))
+
+    for param in ['infiniband.transport-mode', 'connected']:
+        assert param in add_args_text
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+
+    assert results.get('changed') is True
+    assert not results.get('failed')
+


### PR DESCRIPTION
##### SUMMARY
Adds transport_mode configuration for Infiniband based IPoIB devices, which is one of:
  - datagram (default)
  - connected
  
Fixes #5356

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli.py

##### ADDITIONAL INFORMATION
For Infiniband IPoIB devices like _ib0_ there are two different transport modes that can be chosen. 

- datagram 
- connected

```
# nmcli -t con show ib0 | grep infiniband.transport-mode
infiniband.transport-mode:datagram
# grep -H . /sys/class/net/ib0/{mtu,mode}
/sys/class/net/ib0/mtu:2044
/sys/class/net/ib0/mode:datagram

# nmcli -t con show ib0 | grep infiniband.transport-mode
infiniband.transport-mode:connected
# grep -H . /sys/class/net/ib0/{mtu,mode}
/sys/class/net/ib0/mtu:65520
/sys/class/net/ib0/mode:connected


```
