### PR TITLE
nsupdate: issues/4657

### DIFF
--- a/changelogs/fragments/5377-nsupdate-ns-records-with-bind.yml
+++ b/changelogs/fragments/5377-nsupdate-ns-records-with-bind.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nsupdate - Fix silent failures when updating ``NS`` entries from Bind9 managed DNS zones (https://github.com/ansible-collections/community.general/issues/4657).
+  - nsupdate - fix silent failures when updating ``NS`` entries from Bind9 managed DNS zones (https://github.com/ansible-collections/community.general/issues/4657).

--- a/changelogs/fragments/5377-nsupdate-ns-records-with-bind.yml
+++ b/changelogs/fragments/5377-nsupdate-ns-records-with-bind.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Fix silent failures when updating ``NS`` entries from Bind9 managed DNS zones (https://github.com/ansible-collections/community.general/issues/4657).

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -341,11 +341,10 @@ class RecordManager(object):
         update = dns.update.Update(self.zone, keyring=self.keyring, keyalgorithm=self.algorithm)
 
         if self.module.params['type'].upper() == 'NS':
-            # When modifying a NS record, track records that are no longer required and only remove them
-            # after adding the new entries.
-            # Bind9 silently refuses to delete all the NS entries for a zone:
+            # When modifying a NS record, Bind9 silently refuses to delete all the NS entries for a zone:
             # 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
             # https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_18/lib/ns/update.c#L3304
+            # Let's perform dns inserts and updates first, deletes after.  
             query = dns.message.make_query(self.module.params['record'], self.module.params['type'])
             if self.keyring:
                 query.use_tsig(keyring=self.keyring, algorithm=self.algorithm)

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -359,8 +359,8 @@ class RecordManager(object):
             except (socket_error, dns.exception.Timeout) as e:
                 self.module.fail_json(msg='DNS server error: (%s): %s' % (e.__class__.__name__, to_native(e)))
 
-            entries_to_remove = [ n.to_text() for n in lookup.answer[0].items if n.to_text() not in self.value]
-        else:  
+            entries_to_remove = [ n.to_text() for n in lookup.answer[0].items if n.to_text() not in self.value ]
+        else: 
             update.delete(self.module.params['record'], self.module.params['type'])
             
         for entry in self.value:

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -339,7 +339,31 @@ class RecordManager(object):
 
     def modify_record(self):
         update = dns.update.Update(self.zone, keyring=self.keyring, keyalgorithm=self.algorithm)
-        update.delete(self.module.params['record'], self.module.params['type'])
+
+        if self.module.params['type'].upper() == 'NS':
+            # When modifying a NS record, track records that are no longer required and only remove them
+            # after adding the new entries.
+            # Bind9 silently refuses to delete all the NS entries for a zone:
+            # 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
+            # https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_18/lib/ns/update.c#L3304
+            query = dns.message.make_query(self.module.params['record'], self.module.params['type'])
+            if self.keyring:
+                query.use_tsig(keyring=self.keyring, algorithm=self.algorithm)
+
+            try:
+                if self.module.params['protocol'] == 'tcp':
+                    lookup = dns.query.tcp(query, self.module.params['server'], timeout=10, port=self.module.params['port'])
+                else:
+                    lookup = dns.query.udp(query, self.module.params['server'], timeout=10, port=self.module.params['port'])
+            except (dns.tsig.PeerBadKey, dns.tsig.PeerBadSignature) as e:
+                self.module.fail_json(msg='TSIG update error (%s): %s' % (e.__class__.__name__, to_native(e)))
+            except (socket_error, dns.exception.Timeout) as e:
+                self.module.fail_json(msg='DNS server error: (%s): %s' % (e.__class__.__name__, to_native(e)))
+
+            entries_to_remove = [ n.to_text() for n in lookup.answer[0].items if n.to_text() not in self.value]
+        else:  
+            update.delete(self.module.params['record'], self.module.params['type'])
+            
         for entry in self.value:
             try:
                 update.add(self.module.params['record'],
@@ -350,6 +374,11 @@ class RecordManager(object):
                 self.module.fail_json(msg='value needed when state=present')
             except dns.exception.SyntaxError:
                 self.module.fail_json(msg='Invalid/malformed value')
+
+        if self.module.params['type'].upper() == 'NS':
+            for entry in entries_to_remove:
+                update.delete(self.module.params['record'], self.module.params['type'], entry)
+
         response = self.__do_update(update)
 
         return dns.message.Message.rcode(response)

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -344,7 +344,7 @@ class RecordManager(object):
             # When modifying a NS record, Bind9 silently refuses to delete all the NS entries for a zone:
             # 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
             # https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_18/lib/ns/update.c#L3304
-            # Let's perform dns inserts and updates first, deletes after.  
+            # Let's perform dns inserts and updates first, deletes after.
             query = dns.message.make_query(self.module.params['record'], self.module.params['type'])
             if self.keyring:
                 query.use_tsig(keyring=self.keyring, algorithm=self.algorithm)
@@ -359,10 +359,10 @@ class RecordManager(object):
             except (socket_error, dns.exception.Timeout) as e:
                 self.module.fail_json(msg='DNS server error: (%s): %s' % (e.__class__.__name__, to_native(e)))
 
-            entries_to_remove = [ n.to_text() for n in lookup.answer[0].items if n.to_text() not in self.value ]
-        else: 
+            entries_to_remove = [n.to_text() for n in lookup.answer[0].items if n.to_text() not in self.value]
+        else:
             update.delete(self.module.params['record'], self.module.params['type'])
-            
+
         for entry in self.value:
             try:
                 update.add(self.module.params['record'],

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -342,7 +342,7 @@ class RecordManager(object):
 
         if self.module.params['type'].upper() == 'NS':
             # When modifying a NS record, Bind9 silently refuses to delete all the NS entries for a zone:
-            # > 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: 
+            # > 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible:
             # > updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
             # https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_18/lib/ns/update.c#L3304
             # Let's perform dns inserts and updates first, deletes after.

--- a/plugins/modules/net_tools/nsupdate.py
+++ b/plugins/modules/net_tools/nsupdate.py
@@ -342,7 +342,8 @@ class RecordManager(object):
 
         if self.module.params['type'].upper() == 'NS':
             # When modifying a NS record, Bind9 silently refuses to delete all the NS entries for a zone:
-            # 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
+            # > 09-May-2022 18:00:50.352 client @0x7fe7dd1f9568 192.168.1.3#45458/key rndc_ddns_ansible: 
+            # > updating zone 'lab/IN': attempt to delete all SOA or NS records ignored
             # https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_18/lib/ns/update.c#L3304
             # Let's perform dns inserts and updates first, deletes after.
             query = dns.message.make_query(self.module.params['record'], self.module.params['type'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #4657

The "modify_record" method of the nsupdate module uses a delete-first approach to DNS updates.  This prevents any updates to the NS records against Bind9 DNS servers.

This MR changes this behavior where updates to NS records will insert and update existing records, then perform the deletes. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
[plugins/modules/net_tools/nsupdate.py](https://github.com/ansible-collections/community.general/blob/main/plugins/modules/net_tools/nsupdate.py)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I have been using this patch in my infrastructure for 2 months without any side issues.
