### PR TITLE
ldap_attrs: search_s based _is_value_present

### DIFF
--- a/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
+++ b/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ldap_attrs - Fixes issue 977 by ignoring the ``{x}`` prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).
+  - ldap_attrs - fixes issue 977 by ignoring the ``{x}`` prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).

--- a/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
+++ b/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Replacing compare_s with search_s fixes 977 because search is X-ORDERED agnostic
+  - ldap_attrs - Fixes issue 977 by ignoring the {x} prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).

--- a/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
+++ b/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ldap_attrs - fixes issue 977 by ignoring the ``{x}`` prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).
+  - ldap_attrs - fix ordering issue by ignoring the ``{x}`` prefix on attribute values (https://github.com/ansible-collections/community.general/issues/977, https://github.com/ansible-collections/community.general/pull/5385).

--- a/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
+++ b/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Replacing compare_s with search_s fixes 977 because search is X-ORDERED agnostic

--- a/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
+++ b/changelogs/fragments/5385-search_s-based-_is_value_present.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ldap_attrs - Fixes issue 977 by ignoring the {x} prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).
+  - ldap_attrs - Fixes issue 977 by ignoring the ``{x}`` prefix on attribute values (https://github.com/ansible-collections/community.general/pull/5385).

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -266,7 +266,7 @@ class LdapAttrs(LdapGeneric):
         try:
             filterstr = "(%s=%s)" % (name, value.decode())
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
-            is_present = bool(len(dns) == 1)
+            is_present = len(dns) == 1
         except (ldap.INVALID_DN_SYNTAX, ldap.NO_SUCH_OBJECT):
             is_present = False
 

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -169,7 +169,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native, to_bytes
-from ansible_collections.community.general.plugins.module_utils.ldap import ldap, LdapGeneric, gen_specs
+from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
 
 import re
 

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -166,11 +166,11 @@ modlist:
 '''
 
 import traceback
-import ldap
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native, to_bytes
-from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
+from ansible_collections.community.general.plugins.module_utils.ldap import ldap, LdapGeneric, gen_specs
+
 import re
 
 LDAP_IMP_ERR = None
@@ -264,7 +264,7 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            filterstr = f"({name}={value.decode()})"
+            filterstr = "(%s=%s)" % (name, value.decode())
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = bool(len(dns) == 1)
         except (ldap.INVALID_DN_SYNTAX, ldap.NO_SUCH_OBJECT):

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -166,6 +166,7 @@ modlist:
 '''
 
 import traceback
+import ldap
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native, to_bytes
@@ -263,9 +264,10 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            is_present = bool(
-                self.connection.compare_s(self.dn, name, value))
-        except ldap.NO_SUCH_ATTRIBUTE:
+            filterstr = f"({name}={value.decode()})"
+            dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
+            is_present = bool(len(dns) == 1)
+        except (ldap.INVALID_DN_SYNTAX, ldap.NO_SUCH_OBJECT):
             is_present = False
 
         return is_present

--- a/plugins/modules/net_tools/ldap/ldap_attrs.py
+++ b/plugins/modules/net_tools/ldap/ldap_attrs.py
@@ -267,7 +267,7 @@ class LdapAttrs(LdapGeneric):
             filterstr = "(%s=%s)" % (name, value.decode())
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = len(dns) == 1
-        except (ldap.INVALID_DN_SYNTAX, ldap.NO_SUCH_OBJECT):
+        except ldap.NO_SUCH_OBJECT:
             is_present = False
 
         return is_present


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.general/issues/977

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.ldap_attrs

##### ADDITIONAL INFORMATION
Instead of comparing the dn's attribute values using compare_s, I suggest using search_s plus filter, because search is X-ORDERED agnostic.