### PR TITLE
clarify jc filter usage in the example

### DIFF
--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -100,19 +100,20 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
-        - name: install the prereqs of the jc filter (jc python package) on the local Ansible controller
-          delegate_to: localhost
-          ansible.builtin.pip:
-            name: jc
-            state: present
+       
         - name: run date command
           hosts: ubuntu
           tasks:
-          - shell: date
+          - name: install the prereqs of the jc filter (jc python package) on the local Ansible controller
+            delegate_to: localhost
+            ansible.builtin.pip:
+              name: jc
+              state: present
+          - ansible.builtin.shell: date
             register: result
-          - set_fact:
+          - ansible.builtin.set_fact:
               myvar: "{{ result.stdout | community.general.jc('date') }}"
-          - debug:
+          - ansible.builtin.debug:
               msg: "{{ myvar }}"
 
         produces:

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -42,7 +42,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-- name: Install the prereqs of the jc filter (jc python package) on the Ansible controller
+- name: Install the prereqs of the jc filter (jc Python package) on the Ansible controller
   delegate_to: localhost
   ansible.builtin.pip:
     name: jc

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -96,7 +96,7 @@ def jc(data, parser, quiet=True, raw=False):
     Example:
         # This step is optional in case you have the package already installed on your machine
         - name: add the jc prereqs to the running machine
-          delegate_to: 127.0.0.1
+          delegate_to: localhost
           pip:
             name: jc
             state: present

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
       type: boolean
       default: false
   requirements:
-    - jc installed as a Python library (https://pypi.org/project/jc/)
+    - jc installed as a Python library (U(https://pypi.org/project/jc/))
 '''
 
 EXAMPLES = '''

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -103,7 +103,7 @@ def jc(data, parser, quiet=True, raw=False):
         - name: run date command
           hosts: ubuntu
           tasks:
-          - name: install the prereqs of the jc filter (jc python package) on the Ansible controller
+          - name: install the prereqs of the jc filter (jc Python package) on the Ansible controller
             delegate_to: localhost
             ansible.builtin.pip:
               name: jc

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -94,7 +94,11 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
-
+        - name: add the jc prereqs to the running machine
+          delegate_to: 127.0.0.1
+          pip:
+            name: jc
+            state: present
         - name: run date command
           hosts: ubuntu
           tasks:

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -102,7 +102,7 @@ def jc(data, parser, quiet=True, raw=False):
     Example:
         - name: install the prereqs of the jc filter (jc python package) on the local Ansible controller
           delegate_to: localhost
-          pip:
+          ansible.builtin.pip:
             name: jc
             state: present
         - name: run date command

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
       type: boolean
       default: false
   requirements:
-    - jc (https://github.com/kellyjonbrazil/jc)
+    - jc (https://github.com/kellyjonbrazil/jc) installed on the local Ansible controller
 '''
 
 EXAMPLES = '''
@@ -134,7 +134,7 @@ def jc(data, parser, quiet=True, raw=False):
     """
 
     if not HAS_LIB:
-        raise AnsibleError('You need to install "jc" prior to running jc filter')
+        raise AnsibleError('You need to install "jc" on the local Ansible controller prior to running jc filter')
 
     try:
         jc_parser = importlib.import_module('jc.parsers.' + parser)

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
       type: boolean
       default: false
   requirements:
-    - jc installed as a Python library (U(https://pypi.org/project/jc/))
+    - jc installed as a Python library (https://pypi.org/project/jc/)
 '''
 
 EXAMPLES = '''

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -42,8 +42,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-# This step is optional in case you have the package already installed on your machine
-- name: Make sure the jc Python library is installed on the Ansible controller
+- name: Install the prereqs of the jc filter (jc python package) so the local Ansible controller
   delegate_to: localhost
   pip:
     name: jc
@@ -101,8 +100,7 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
-        # This step is optional in case you have the package already installed on your machine
-        - name: add the jc prereqs to the running machine
+        - name: install the prereqs of the jc filter (jc python package) so the local Ansible controller
           delegate_to: localhost
           pip:
             name: jc

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -44,7 +44,7 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 - name: Install the prereqs of the jc filter (jc python package) on the local Ansible controller
   delegate_to: localhost
-  pip:
+  ansible.builtin.pip:
     name: jc
     state: present
 

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -42,7 +42,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-- name: Install the prereqs of the jc filter (jc python package) on the local Ansible controller
+- name: Install the prereqs of the jc filter (jc python package) on the Ansible controller
   delegate_to: localhost
   ansible.builtin.pip:
     name: jc
@@ -103,7 +103,7 @@ def jc(data, parser, quiet=True, raw=False):
         - name: run date command
           hosts: ubuntu
           tasks:
-          - name: install the prereqs of the jc filter (jc python package) on the local Ansible controller
+          - name: install the prereqs of the jc filter (jc python package) on the Ansible controller
             delegate_to: localhost
             ansible.builtin.pip:
               name: jc
@@ -134,7 +134,7 @@ def jc(data, parser, quiet=True, raw=False):
     """
 
     if not HAS_LIB:
-        raise AnsibleError('You need to install "jc" on the local Ansible controller prior to running jc filter')
+        raise AnsibleError('You need to install "jc" on the Ansible controller prior to running jc filter')
 
     try:
         jc_parser = importlib.import_module('jc.parsers.' + parser)

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
       type: boolean
       default: false
   requirements:
-    - jc (https://github.com/kellyjonbrazil/jc) installed on the local Ansible controller
+    - jc installed as a Python library (U(https://pypi.org/project/jc/))
 '''
 
 EXAMPLES = '''

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -100,7 +100,6 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
-       
         - name: run date command
           hosts: ubuntu
           tasks:

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -43,7 +43,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 # This step is optional in case you have the package already installed on your machine
-- name: add the jc prereqs to the running machine
+- name: Make sure the jc Python library is installed on the Ansible controller
   delegate_to: localhost
   pip:
     name: jc

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -134,7 +134,7 @@ def jc(data, parser, quiet=True, raw=False):
     """
 
     if not HAS_LIB:
-        raise AnsibleError('You need to install "jc" on the Ansible controller prior to running jc filter')
+        raise AnsibleError('You need to install "jc" as a Python library on the Ansible controller prior to running jc filter')
 
     try:
         jc_parser = importlib.import_module('jc.parsers.' + parser)

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -42,7 +42,7 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-- name: Install the prereqs of the jc filter (jc python package) so the local Ansible controller
+- name: Install the prereqs of the jc filter (jc python package) on the local Ansible controller
   delegate_to: localhost
   pip:
     name: jc
@@ -100,7 +100,7 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
-        - name: install the prereqs of the jc filter (jc python package) so the local Ansible controller
+        - name: install the prereqs of the jc filter (jc python package) on the local Ansible controller
           delegate_to: localhost
           pip:
             name: jc

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -94,6 +94,7 @@ def jc(data, parser, quiet=True, raw=False):
         dictionary or list of dictionaries
 
     Example:
+        # This step is optional in case you have the package already installed on your machine
         - name: add the jc prereqs to the running machine
           delegate_to: 127.0.0.1
           pip:

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -42,6 +42,13 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
+# This step is optional in case you have the package already installed on your machine
+- name: add the jc prereqs to the running machine
+  delegate_to: localhost
+  pip:
+    name: jc
+    state: present
+
 - name: Run command
   ansible.builtin.command: uname -a
   register: result


### PR DESCRIPTION
##### SUMMARY
This PR adds a very small change to the jc filter to make it ever easier to use on your way to JC

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added a small change to the example, which shows how to quickly use the filter.

this is after I filed an issue regarding the jc filter not working (I added the package to the target machine and not the one that runs it.

Additionally I have `jc` installed on my machine so I was suprized I needed to use the jc python import.

related to #5390 

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
jc filter

##### ADDITIONAL INFORMATION
see the issue with the example and solution
