### PR TITLE
django_manage: deprecate venv creation when missing

### DIFF
--- a/changelogs/fragments/5404-django-manage-venv-deprecation.yml
+++ b/changelogs/fragments/5404-django-manage-venv-deprecation.yml
@@ -1,5 +1,5 @@
 deprecated_features:
   - >-
-    django_manage - The behavior of "creating the virtual environment when missing"
+    django_manage - the behavior of "creating the virtual environment when missing"
     is being deprecated and will be removed in community.general version 9.0.0
     (https://github.com/ansible-collections/community.general/pull/5405).

--- a/changelogs/fragments/5404-django-manage-venv-deprecation.yml
+++ b/changelogs/fragments/5404-django-manage-venv-deprecation.yml
@@ -1,0 +1,5 @@
+deprecated_features:
+  - >-
+    django_manage - The behavior of "creating the virtual environment when missing"
+    is being deprecated and will be removed in community.general version 9.0.0
+    (https://github.com/ansible-collections/community.general/pull/5405).

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -115,6 +115,8 @@ options:
         When a I(virtualenv) is set but the virtual environment does not exist, the current behavior is
         to create a new virtual environment. That behavior is deprecated and if that case happens it will
         generate a deprecation warning. Set this flag to C(true) to suppress the deprecation warning.
+      - Please note that you will receive no further warning about this being removed until the module
+        will start failing in such cases from community.general 9.0.0 on.
     type: bool
 
 notes:

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -192,14 +192,12 @@ def _ensure_virtualenv(module):
     if venv_param is None:
         return
 
-    ack_venv_deprecation = module.params['ack_venv_creation_deprecation']
-
     vbin = os.path.join(venv_param, 'bin')
     activate = os.path.join(vbin, 'activate')
 
     if not os.path.exists(activate):
         # In version 9.0.0, if the venv is not found, it should fail_json() here.
-        if not ack_venv_deprecation:
+        if not module.params['ack_venv_creation_deprecation']:
             module.deprecate(
                 'The behavior of "creating the virtual environment when missing" is being '
                 'deprecated and will be removed in community.general version 9.0.0. '

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -109,6 +109,14 @@ options:
     type: str
     required: false
     aliases: [test_runner]
+  ack_venv_creation_deprecation:
+    description:
+      - >-
+        When a I(virtualenv) is set but the virtual environment does not exist, the current behavior is
+        to create a new virtual environment. That behavior is deprecated and if that case happens it will
+        generate a deprecation warning. Set this flag to C(true) to suppress the deprecation warning.
+    type: bool
+
 notes:
   - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the I(virtualenv) parameter
     is specified. This requirement is deprecated and will be removed in community.general version 9.0.0.
@@ -193,7 +201,9 @@ def _ensure_virtualenv(module):
                 'The behavior of "creating the virtual environment when missing" is being '
                 'deprecated and will be removed in community.general version 9.0.0. '
                 'Set the module parameter `ack_venv_creation_deprecation: true` to '
-                'prevent this message from showing up in every run.'
+                'prevent this message from showing up when creating a virtualenv.',
+                version='9.0.0',
+                collection_name='community.general',
             )
 
         virtualenv = module.get_bin_path('virtualenv', True)

--- a/plugins/modules/web_infrastructure/django_manage.py
+++ b/plugins/modules/web_infrastructure/django_manage.py
@@ -118,6 +118,7 @@ options:
       - Please note that you will receive no further warning about this being removed until the module
         will start failing in such cases from community.general 9.0.0 on.
     type: bool
+    version_added: 5.8.0
 
 notes:
   - C(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the I(virtualenv) parameter


### PR DESCRIPTION
##### SUMMARY
As pointed out in https://github.com/ansible-collections/community.general/issues/5374#issuecomment-1287536369
creating the virtualenv from within `django_manage` is not only a bad design decision but it simply does not work as it is.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
django_manage
