### PR TITLE
[Scaleway] Add module to manage container namespaces

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -462,9 +462,9 @@ files:
     maintainers: $team_scaleway
   $modules/scaleway_compute_private_network.py:
     maintainers: pastral
-  $modules/cloud/scaleway/scaleway_container_namespace.py:
+  $modules/scaleway_container_namespace.py:
      maintainers: Lunik
-  $modules/cloud/scaleway/scaleway_container_namespace_info.py:
+  $modules/scaleway_container_namespace_info.py:
      maintainers: Lunik
   $modules/scaleway_container_registry.py:
      maintainers: Lunik

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -462,6 +462,10 @@ files:
     maintainers: $team_scaleway
   $modules/scaleway_compute_private_network.py:
     maintainers: pastral
+  $modules/cloud/scaleway/scaleway_container_namespace.py:
+     maintainers: Lunik
+  $modules/cloud/scaleway/scaleway_container_namespace_info.py:
+     maintainers: Lunik
   $modules/scaleway_container_registry.py:
      maintainers: Lunik
   $modules/scaleway_container_registry_info.py:

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Scaleway Serverless container namespace management module
+#
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: scaleway_container_namespace
+short_description: Scaleway Container namespace management
+version_added: 6.0.0
+author: Guillaume MARTINEZ (@Lunik)
+description:
+  - This module manages container namespaces on Scaleway account.
+extends_documentation_fragment:
+  - community.general.scaleway
+  - community.general.scaleway_waitable_resource
+requirements:
+   - passlib[argon2] >= 1.7.4
+
+options:
+  state:
+    type: str
+    description:
+      - Indicate desired state of the container namespace.
+    default: present
+    choices:
+      - present
+      - absent
+
+  project_id:
+    type: str
+    description:
+      - Project identifier.
+    required: true
+
+  region:
+    type: str
+    description:
+      - Scaleway region to use (for example C(fr-par)).
+    required: true
+    choices:
+      - fr-par
+      - nl-ams
+      - pl-waw
+
+  name:
+    type: str
+    description:
+      - Name of the container namespace.
+    required: true
+
+  description:
+    description:
+      - Description of the container namespace.
+    type: str
+    default: ''
+
+  environment_variables:
+    description:
+      - Environment variables of the container namespace.
+      - Injected in containers at runtime.
+    type: dict
+
+  secret_environment_variables:
+    description:
+      - Secret environment variables of the container namespace.
+      - Updating thoses values will not output a C(changed) state in Ansible.
+      - Injected in containers at runtime.
+    type: dict
+'''
+
+EXAMPLES = '''
+- name: Create a container namespace
+  community.general.scaleway_container_namespace:
+    project_id: '{{ scw_project }}'
+    state: present
+    region: fr-par
+    name: my-awesome-container-namespace
+    environment_variables:
+      MY_VAR: my_value
+    secret_environment_variables:
+      MY_SECRET_VAR: my_secret_value
+  register: container_namespace_creation_task
+
+- name: Make sure container namespace is deleted
+  community.general.scaleway_container_namespace:
+    project_id: '{{ scw_project }}'
+    state: absent
+    region: fr-par
+    name: my-awesome-container-namespace
+'''
+
+RETURN = '''
+container_namespace:
+  description: The container namespace information.
+  returned: when I(state=present)
+  type: dict
+  sample:
+    description: ""
+    environment_variables:
+      MY_VAR: my_value
+    error_message: null
+    id: 531a1fd7-98d2-4a74-ad77-d398324304b8
+    name: my-awesome-container-namespace
+    organization_id: e04e3bdc-015c-4514-afde-9389e9be24b0
+    project_id: d44cea58-dcb7-4c95-bff1-1105acb60a98
+    region: fr-par
+    registry_endpoint: ""
+    registry_namespace_id: ""
+    secret_environment_variables:
+      - key: MY_SECRET_VAR
+        value: $argon2id$v=19$m=65536,t=1,p=2$tb6UwSPWx/rH5Vyxt9Ujfw$5ZlvaIjWwNDPxD9Rdght3NarJz4IETKjpvAU3mMSmFg
+    status: pending
+'''
+
+from ansible_collections.community.general.plugins.module_utils.scaleway import (
+    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
+    scaleway_waitable_resource_argument_spec, filter_sensitive_attributes,
+    resource_attributes_should_be_changed, SecretVariables
+)
+from ansible.module_utils.basic import AnsibleModule
+
+STABLE_STATES = (
+    "ready",
+    "absent"
+)
+
+MUTABLE_ATTRIBUTES = (
+    "description",
+    "environment_variables",
+    "secret_environment_variables"
+)
+
+
+def payload_from_wished_cn(wished_cn):
+    payload = {
+        "project_id": wished_cn["project_id"],
+        "name": wished_cn["name"],
+        "description": wished_cn["description"],
+        "environment_variables": wished_cn["environment_variables"],
+        "secret_environment_variables": SecretVariables.dict_to_list(wished_cn["secret_environment_variables"])
+    }
+
+    return payload
+
+
+def absent_strategy(api, wished_cn):
+    changed = False
+
+    cn_list = api.fetch_all_resources("namespaces")
+    cn_lookup = dict((fn["name"], fn)
+                     for fn in cn_list)
+
+    if wished_cn["name"] not in cn_lookup:
+        return changed, {}
+
+    target_cn = cn_lookup[wished_cn["name"]]
+    changed = True
+    if api.module.check_mode:
+        return changed, {"status": "Container namespace would be destroyed"}
+
+    api.wait_to_complete_state_transition(resource=target_cn, stable_states=STABLE_STATES, force_wait=True)
+    response = api.delete(path=api.api_path + "/%s" % target_cn["id"])
+    if not response.ok:
+        api.module.fail_json(msg='Error deleting container namespace [{0}: {1}]'.format(
+            response.status_code, response.json))
+
+    api.wait_to_complete_state_transition(resource=target_cn, stable_states=STABLE_STATES)
+    return changed, response.json
+
+
+def present_strategy(api, wished_cn):
+    changed = False
+
+    cn_list = api.fetch_all_resources("namespaces")
+    cn_lookup = dict((fn["name"], fn)
+                     for fn in cn_list)
+
+    payload_cn = payload_from_wished_cn(wished_cn)
+
+    if wished_cn["name"] not in cn_lookup:
+        changed = True
+        if api.module.check_mode:
+            return changed, {"status": "A container namespace would be created."}
+
+        # Create container namespace
+        api.warn(payload_cn)
+        creation_response = api.post(path=api.api_path,
+                                     data=payload_cn)
+
+        if not creation_response.ok:
+            msg = "Error during container namespace creation: %s: '%s' (%s)" % (creation_response.info['msg'],
+                                                                                creation_response.json['message'],
+                                                                                creation_response.json)
+            api.module.fail_json(msg=msg)
+
+        api.wait_to_complete_state_transition(resource=creation_response.json, stable_states=STABLE_STATES)
+        response = api.get(path=api.api_path + "/%s" % creation_response.json["id"])
+        return changed, response.json
+
+    target_cn = cn_lookup[wished_cn["name"]]
+    decoded_target_cn = deepcopy(target_cn)
+    decoded_target_cn["secret_environment_variables"] = SecretVariables.decode(decoded_target_cn["secret_environment_variables"],
+                                                                               payload_cn["secret_environment_variables"])
+    patch_payload = resource_attributes_should_be_changed(target=decoded_target_cn,
+                                                          wished=payload_cn,
+                                                          verifiable_mutable_attributes=MUTABLE_ATTRIBUTES,
+                                                          mutable_attributes=MUTABLE_ATTRIBUTES)
+
+    if not patch_payload:
+        return changed, target_cn
+
+    changed = True
+    if api.module.check_mode:
+        return changed, {"status": "Container namespace attributes would be changed."}
+
+    cn_patch_response = api.patch(path=api.api_path + "/%s" % target_cn["id"],
+                                  data=patch_payload)
+
+    if not cn_patch_response.ok:
+        api.module.fail_json(msg='Error during container namespace attributes update: [{0}: {1}]'.format(
+            cn_patch_response.status_code, cn_patch_response.json['message']))
+
+    api.wait_to_complete_state_transition(resource=target_cn, stable_states=STABLE_STATES)
+    response = api.get(path=api.api_path + "/%s" % target_cn["id"])
+    return changed, cn_patch_response.json
+
+
+state_strategy = {
+    "present": present_strategy,
+    "absent": absent_strategy
+}
+
+
+def core(module):
+    region = module.params["region"]
+    wished_container_namespace = {
+        "state": module.params["state"],
+        "project_id": module.params["project_id"],
+        "name": module.params["name"],
+        "description": module.params['description'],
+        "environment_variables": module.params['environment_variables'],
+        "secret_environment_variables": module.params['secret_environment_variables']
+    }
+
+    api = Scaleway(module=module)
+    api.api_path = "containers/v1beta1/regions/%s/namespaces" % region
+
+    changed, summary = state_strategy[wished_container_namespace["state"]](api=api, wished_cn=wished_container_namespace)
+
+    module.exit_json(changed=changed, container_namespace=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+
+
+def main():
+    argument_spec = scaleway_argument_spec()
+    argument_spec.update(scaleway_waitable_resource_argument_spec())
+    argument_spec.update(dict(
+        state=dict(type='str', default='present', choices=['absent', 'present']),
+        project_id=dict(type='str', required=True),
+        region=dict(type='str', required=True, choices=SCALEWAY_REGIONS),
+        name=dict(type='str', required=True),
+        description=dict(type='str', default=''),
+        environment_variables=dict(type='dict', default={}),
+        secret_environment_variables=dict(type='dict', default={}, no_log=True)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    core(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -68,6 +68,7 @@ options:
       - Environment variables of the container namespace.
       - Injected in containers at runtime.
     type: dict
+    default: {}
 
   secret_environment_variables:
     description:
@@ -75,6 +76,7 @@ options:
       - Updating thoses values will not output a C(changed) state in Ansible.
       - Injected in containers at runtime.
     type: dict
+    default: {}
 '''
 
 EXAMPLES = '''
@@ -121,9 +123,11 @@ container_namespace:
     status: pending
 '''
 
+from copy import deepcopy
+
 from ansible_collections.community.general.plugins.module_utils.scaleway import (
     SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
-    scaleway_waitable_resource_argument_spec, filter_sensitive_attributes,
+    scaleway_waitable_resource_argument_spec,
     resource_attributes_should_be_changed, SecretVariables
 )
 from ansible.module_utils.basic import AnsibleModule
@@ -256,7 +260,7 @@ def core(module):
 
     changed, summary = state_strategy[wished_container_namespace["state"]](api=api, wished_cn=wished_container_namespace)
 
-    module.exit_json(changed=changed, container_namespace=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+    module.exit_json(changed=changed, container_namespace=summary)
 
 
 def main():

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -245,6 +245,8 @@ state_strategy = {
 
 
 def core(module):
+    SecretVariables.ensure_scaleway_secret_package(module)
+
     region = module.params["region"]
     wished_container_namespace = {
         "state": module.params["state"],

--- a/plugins/modules/scaleway_container_namespace.py
+++ b/plugins/modules/scaleway_container_namespace.py
@@ -160,8 +160,8 @@ def absent_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((fn["name"], fn)
-                     for fn in cn_list)
+    cn_lookup = dict((cn["name"], cn)
+                     for cn in cn_list)
 
     if wished_cn["name"] not in cn_lookup:
         return changed, {}
@@ -185,8 +185,8 @@ def present_strategy(api, wished_cn):
     changed = False
 
     cn_list = api.fetch_all_resources("namespaces")
-    cn_lookup = dict((fn["name"], fn)
-                     for fn in cn_list)
+    cn_lookup = dict((cn["name"], cn)
+                     for cn in cn_list)
 
     payload_cn = payload_from_wished_cn(wished_cn)
 

--- a/plugins/modules/scaleway_container_namespace_info.py
+++ b/plugins/modules/scaleway_container_namespace_info.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Scaleway Serverless container namespace info module
+#
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: scaleway_container_namespace_info
+short_description: Retrieve information on Scaleway Container namespace
+version_added: 6.0.0
+author: Guillaume MARTINEZ (@Lunik)
+description:
+  - This module return information about a container namespace on Scaleway account.
+extends_documentation_fragment:
+  - community.general.scaleway
+
+
+options:
+  project_id:
+    type: str
+    description:
+      - Project identifier.
+    required: true
+
+  region:
+    type: str
+    description:
+      - Scaleway region to use (for example C(fr-par)).
+    required: true
+    choices:
+      - fr-par
+      - nl-ams
+      - pl-waw
+
+  name:
+    type: str
+    description:
+      - Name of the container namespace.
+    required: true
+'''
+
+EXAMPLES = '''
+- name: Get a container namespace info
+  community.general.scaleway_container_namespace_info:
+    project_id: '{{ scw_project }}'
+    region: fr-par
+    name: my-awesome-container-namespace
+  register: container_namespace_info_task
+'''
+
+RETURN = '''
+container_namespace:
+  description: The container namespace information.
+  returned: always
+  type: dict
+  sample:
+    description: ""
+    environment_variables:
+      MY_VAR: my_value
+    error_message: null
+    id: 531a1fd7-98d2-4a74-ad77-d398324304b8
+    name: my-awesome-container-namespace
+    organization_id: e04e3bdc-015c-4514-afde-9389e9be24b0
+    project_id: d44cea58-dcb7-4c95-bff1-1105acb60a98
+    region: fr-par
+    registry_endpoint: ""
+    registry_namespace_id: ""
+    secret_environment_variables: SENSITIVE_VALUE
+    status: pending
+'''
+
+from ansible_collections.community.general.plugins.module_utils.scaleway import (
+    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
+    filter_sensitive_attributes
+)
+from ansible.module_utils.basic import AnsibleModule
+
+SENSITIVE_ATTRIBUTES = (
+    "secret_environment_variables",
+)
+
+
+def info_strategy(api, wished_cn):
+    cn_list = api.fetch_all_resources("namespaces")
+    cn_lookup = dict((fn["name"], fn)
+                     for fn in cn_list)
+
+    if wished_cn["name"] not in cn_lookup:
+        msg = "Error during container namespace lookup: Unable to find container namespace named '%s' in project '%s'" % (wished_cn["name"],
+                                                                                                                          wished_cn["project_id"])
+
+        api.module.fail_json(msg=msg)
+
+    target_cn = cn_lookup[wished_cn["name"]]
+
+    response = api.get(path=api.api_path + "/%s" % target_cn["id"])
+    if not response.ok:
+        msg = "Error during container namespace lookup: %s: '%s' (%s)" % (response.info['msg'],
+                                                                          response.json['message'],
+                                                                          response.json)
+        api.module.fail_json(msg=msg)
+
+    return response.json
+
+
+def core(module):
+    region = module.params["region"]
+    wished_container_namespace = {
+        "project_id": module.params["project_id"],
+        "name": module.params["name"]
+    }
+
+    api = Scaleway(module=module)
+    api.api_path = "containers/v1beta1/regions/%s/namespaces" % region
+
+    summary = info_strategy(api=api, wished_cn=wished_container_namespace)
+
+    module.exit_json(changed=False, container_namespace=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+
+
+def main():
+    argument_spec = scaleway_argument_spec()
+    argument_spec.update(dict(
+        project_id=dict(type='str', required=True),
+        region=dict(type='str', required=True, choices=SCALEWAY_REGIONS),
+        name=dict(type='str', required=True)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    core(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/scaleway_container_namespace/aliases
+++ b/tests/integration/targets/scaleway_container_namespace/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cloud/scaleway
+unsupported

--- a/tests/integration/targets/scaleway_container_namespace/defaults/main.yml
+++ b/tests/integration/targets/scaleway_container_namespace/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+scaleway_region: fr-par
+name: cn-ansible-test
+description: Container namespace used for testing scaleway_container_namespace ansible module
+updated_description: Container namespace used for testing scaleway_container_namespace ansible module (Updated description)
+environment_variables:
+  MY_VAR: my_value
+secret_environment_variables:
+   MY_SECRET_VAR: my_secret_value
+updated_secret_environment_variables:
+  MY_SECRET_VAR: my_other_secret_value

--- a/tests/integration/targets/scaleway_container_namespace/tasks/main.yml
+++ b/tests/integration/targets/scaleway_container_namespace/tasks/main.yml
@@ -141,7 +141,7 @@
     name: '{{ name }}'
     region: '{{ scaleway_region }}'
     project_id: '{{ scw_project }}'
-    description: '{{ description }}'
+    description: '{{ updated_description }}'
     environment_variables: '{{ environment_variables }}'
     secret_environment_variables: '{{ updated_secret_environment_variables }}'
   register: cn_update_secret_check_task
@@ -161,7 +161,7 @@
     name: '{{ name }}'
     region: '{{ scaleway_region }}'
     project_id: '{{ scw_project }}'
-    description: '{{ description }}'
+    description: '{{ updated_description }}'
     environment_variables: '{{ environment_variables }}'
     secret_environment_variables: '{{ updated_secret_environment_variables }}'
   register: cn_update_secret_task
@@ -175,6 +175,7 @@
       - cn_update_secret_task is success
       - cn_update_secret_task is changed
       - cn_update_secret_task.container_namespace.status == "ready"
+      - "'hashed_value' in cn_update_secret_task.container_namespace.secret_environment_variables[0]"
 
 - name: Update container namespace secret variables (Confirmation)
   community.general.scaleway_container_namespace:
@@ -182,10 +183,10 @@
     name: '{{ name }}'
     region: '{{ scaleway_region }}'
     project_id: '{{ scw_project }}'
-    description: '{{ description }}'
+    description: '{{ updated_description }}'
     environment_variables: '{{ environment_variables }}'
     secret_environment_variables: '{{ updated_secret_environment_variables }}'
-  register: cn_update_secret_confirmation_task
+  register: cn_update_secret_congfirmation_task
 
 - ansible.builtin.debug:
     var: cn_update_secret_confirmation_task
@@ -196,6 +197,7 @@
       - cn_update_secret_confirmation_task is success
       - cn_update_secret_confirmation_task is not changed
       - cn_update_secret_confirmation_task.container_namespace.status == "ready"
+      - "'hashed_value' in cn_update_secret_confirmation_task.container_namespace.secret_environment_variables[0]"
 
 - name: Delete container namespace (Check)
   check_mode: yes

--- a/tests/integration/targets/scaleway_container_namespace/tasks/main.yml
+++ b/tests/integration/targets/scaleway_container_namespace/tasks/main.yml
@@ -1,0 +1,253 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create a container namespace (Check)
+  check_mode: yes
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_creation_check_task
+
+- ansible.builtin.debug:
+    var: cn_creation_check_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_creation_check_task is success
+      - cn_creation_check_task is changed
+
+- name: Create container_namespace
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_creation_task
+
+- ansible.builtin.debug:
+    var: cn_creation_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_creation_task is success
+      - cn_creation_task is changed
+      - cn_creation_task.container_namespace.status == "ready"
+
+- name: Create container namespace (Confirmation)
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_creation_confirmation_task
+
+- ansible.builtin.debug:
+    var: cn_creation_confirmation_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_creation_confirmation_task is success
+      - cn_creation_confirmation_task is not changed
+      - cn_creation_confirmation_task.container_namespace.status == "ready"
+
+- name: Update container namespace (Check)
+  check_mode: yes
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ updated_description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_update_check_task
+
+- ansible.builtin.debug:
+    var: cn_update_check_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_check_task is success
+      - cn_update_check_task is changed
+
+- name: Update container namespace
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ updated_description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_update_task
+
+- ansible.builtin.debug:
+    var: cn_update_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_task is success
+      - cn_update_task is changed
+      - cn_update_task.container_namespace.status == "ready"
+
+- name: Update container namespace (Confirmation)
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ updated_description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ secret_environment_variables }}'
+  register: cn_update_confirmation_task
+
+- ansible.builtin.debug:
+    var: cn_update_confirmation_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_confirmation_task is success
+      - cn_update_confirmation_task is not changed
+      - cn_update_confirmation_task.container_namespace.status == "ready"
+
+- name: Update container namespace secret variables (Check)
+  check_mode: yes
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ updated_secret_environment_variables }}'
+  register: cn_update_secret_check_task
+
+- ansible.builtin.debug:
+    var: cn_update_secret_check_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_secret_check_task is success
+      - cn_update_secret_check_task is changed
+
+- name: Update container namespace secret variables
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ updated_secret_environment_variables }}'
+  register: cn_update_secret_task
+
+- ansible.builtin.debug:
+    var: cn_update_secret_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_secret_task is success
+      - cn_update_secret_task is changed
+      - cn_update_secret_task.container_namespace.status == "ready"
+
+- name: Update container namespace secret variables (Confirmation)
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+    environment_variables: '{{ environment_variables }}'
+    secret_environment_variables: '{{ updated_secret_environment_variables }}'
+  register: cn_update_secret_confirmation_task
+
+- ansible.builtin.debug:
+    var: cn_update_secret_confirmation_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_update_secret_confirmation_task is success
+      - cn_update_secret_confirmation_task is not changed
+      - cn_update_secret_confirmation_task.container_namespace.status == "ready"
+
+- name: Delete container namespace (Check)
+  check_mode: yes
+  community.general.scaleway_container_namespace:
+    state: absent
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    description: '{{ description }}'
+    project_id: '{{ scw_project }}'
+  register: cn_deletion_check_task
+
+- ansible.builtin.debug:
+    var: cn_deletion_check_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_deletion_check_task is success
+      - cn_deletion_check_task is changed
+
+- name: Delete container namespace
+  community.general.scaleway_container_namespace:
+    state: absent
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    description: '{{ description }}'
+    project_id: '{{ scw_project }}'
+  register: cn_deletion_task
+
+- ansible.builtin.debug:
+    var: cn_deletion_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_deletion_task is success
+      - cn_deletion_task is changed
+
+- name: Delete container namespace (Confirmation)
+  community.general.scaleway_container_namespace:
+    state: absent
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    description: '{{ description }}'
+    project_id: '{{ scw_project }}'
+  register: cn_deletion_confirmation_task
+
+- ansible.builtin.debug:
+    var: cn_deletion_confirmation_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_deletion_confirmation_task is success
+      - cn_deletion_confirmation_task is not changed

--- a/tests/integration/targets/scaleway_container_namespace_info/aliases
+++ b/tests/integration/targets/scaleway_container_namespace_info/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cloud/scaleway
+unsupported

--- a/tests/integration/targets/scaleway_container_namespace_info/defaults/main.yml
+++ b/tests/integration/targets/scaleway_container_namespace_info/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+scaleway_region: fr-par
+name: cn-ansible-test
+description: Container namespace used for testing scaleway_container_namespace_info ansible module
+updated_description: Container namespace used for testing scaleway_container_namespace_info ansible module (Updated description)
+environment_variables:
+  MY_VAR: my_value
+secret_environment_variables:
+  MY_SECRET_VAR: my_secret_value

--- a/tests/integration/targets/scaleway_container_namespace_info/tasks/main.yml
+++ b/tests/integration/targets/scaleway_container_namespace_info/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) 2022, Guillaume MARTINEZ <lunik@tiwabbit.fr>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create container_namespace
+  community.general.scaleway_container_namespace:
+    state: present
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+    description: '{{ description }}'
+
+- name: Get container namespace info
+  community.general.scaleway_container_namespace_info:
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    project_id: '{{ scw_project }}'
+  register: cn_info_task
+
+- ansible.builtin.debug:
+    var: cn_info_task
+
+- name: Check module call result
+  ansible.builtin.assert:
+    that:
+      - cn_info_task is success
+      - cn_info_task is not changed
+
+- name: Delete container namespace
+  community.general.scaleway_container_namespace:
+    state: absent
+    name: '{{ name }}'
+    region: '{{ scaleway_region }}'
+    description: '{{ description }}'
+    project_id: '{{ scw_project }}'


### PR DESCRIPTION
##### SUMMARY

This PR add new modules to manage Scaleway container namespaces services (https://developers.scaleway.com/).

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

- `scaleway_container_namespace`
- `scaleway_container_namespace_info`

##### ADDITIONAL INFORMATION

This PR is a part of the original PR #5359 that was too large.

This PR require evolution on Scaleway config in ansible-test : https://github.com/ansible/ansible/pull/79141
