### PR TITLE
add persistent option for modprobe

### DIFF
--- a/changelogs/fragments/4028-modprobe-persistent-option.yml
+++ b/changelogs/fragments/4028-modprobe-persistent-option.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - modprobe - add persistent option (https://github.com/ansible-collections/community.general/issues/4028).
+  - modprobe - add ``persistent`` option (https://github.com/ansible-collections/community.general/issues/4028, https://github.com/ansible-collections/community.general/pull/542).

--- a/changelogs/fragments/4028-modprobe-persistent-option.yml
+++ b/changelogs/fragments/4028-modprobe-persistent-option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - modprobe - add persistent option (https://github.com/ansible-collections/community.general/issues/4028).

--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -63,6 +63,13 @@ EXAMPLES = '''
     name: dummy
     state: present
     params: 'numdummies=2'
+
+- name: Add the dummy module
+  community.general.modprobe:
+    name: dummy
+    state: present
+    params: 'numdummies=2'
+    persistent: present
 '''
 
 import os.path

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -12,7 +12,7 @@ from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.compat.mock import Mock
 from ansible_collections.community.general.tests.unit.compat.mock import mock_open
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.modules.modprobe import Modprobe
+from ansible_collections.community.general.plugins.modules.modprobe import Modprobe, build_module
 
 
 class TestLoadModule(ModuleTestCase):
@@ -42,15 +42,7 @@ class TestLoadModule(ModuleTestCase):
             state='present',
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
         self.module_loaded.side_effect = [True]
@@ -72,15 +64,7 @@ class TestLoadModule(ModuleTestCase):
             state='present',
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         module.warn = Mock()
 
@@ -121,15 +105,7 @@ class TestUnloadModule(ModuleTestCase):
             state='absent',
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
         self.module_loaded.side_effect = [False]
@@ -151,15 +127,7 @@ class TestUnloadModule(ModuleTestCase):
             state='absent',
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         module.fail_json = Mock()
 
@@ -207,15 +175,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -236,15 +196,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -265,15 +217,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -314,15 +258,7 @@ class TestPermanentParams(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -349,15 +285,7 @@ class TestPermanentParams(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -393,15 +321,7 @@ class TestCreateModuleFIle(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -436,15 +356,7 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -480,15 +392,7 @@ class TestDisableOldParams(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -511,15 +415,7 @@ class TestDisableOldParams(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -555,15 +451,7 @@ class TestDisableModulePermanent(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 
@@ -585,15 +473,7 @@ class TestDisableModulePermanent(ModuleTestCase):
             persistent='present'
         ))
 
-        module = AnsibleModule(
-            argument_spec=dict(
-                name=dict(type='str', required=True),
-                state=dict(type='str', default='present', choices=['absent', 'present']),
-                params=dict(type='str', default=''),
-                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
-            ),
-            supports_check_mode=True,
-        )
+        module = build_module()
 
         self.get_bin_path.side_effect = ['modprobe']
 

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -47,7 +47,7 @@ class TestLoadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -77,7 +77,7 @@ class TestLoadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -126,7 +126,7 @@ class TestUnloadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -156,7 +156,7 @@ class TestUnloadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -204,7 +204,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -212,7 +212,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -233,7 +233,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -241,7 +241,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -262,7 +262,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -270,7 +270,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -311,7 +311,7 @@ class TestPermanentParams(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -319,7 +319,7 @@ class TestPermanentParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -346,7 +346,7 @@ class TestPermanentParams(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -354,7 +354,7 @@ class TestPermanentParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -390,7 +390,7 @@ class TestCreateModuleFIle(ModuleTestCase):
         set_module_args(dict(
             name='dummy',
             state='present',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -398,7 +398,7 @@ class TestCreateModuleFIle(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -433,7 +433,7 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
             name='dummy',
             state='present',
             params='numdummies=4',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -441,7 +441,7 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -477,7 +477,7 @@ class TestDisableOldParams(ModuleTestCase):
             name='dummy',
             state='present',
             params='numdummies=4',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -485,7 +485,7 @@ class TestDisableOldParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -508,7 +508,7 @@ class TestDisableOldParams(ModuleTestCase):
             name='dummy',
             state='present',
             params='numdummies=4',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -516,7 +516,7 @@ class TestDisableOldParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -552,7 +552,7 @@ class TestDisableModulePermanent(ModuleTestCase):
             name='dummy',
             state='present',
             params='numdummies=4',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -560,7 +560,7 @@ class TestDisableModulePermanent(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )
@@ -582,7 +582,7 @@ class TestDisableModulePermanent(ModuleTestCase):
             name='dummy',
             state='present',
             params='numdummies=4',
-            persistent=True
+            persistent='present'
         ))
 
         module = AnsibleModule(
@@ -590,7 +590,7 @@ class TestDisableModulePermanent(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False),
+                persistent=dict(type='str', default='disabled', choices=['disabled', 'present', 'absent']),
             ),
             supports_check_mode=True,
         )

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import sys
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import ModuleTestCase, set_module_args
-from ansible_collections.community.general.tests.unit.compat.mock import call, patch
+from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.compat.mock import Mock
 from ansible_collections.community.general.tests.unit.compat.mock import mock_open
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -220,8 +220,8 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         self.get_bin_path.side_effect = ['modprobe']
 
         modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modules_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
                 modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
 
                 assert modprobe.module_is_loaded_persistently
@@ -249,8 +249,8 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         self.get_bin_path.side_effect = ['modprobe']
 
         modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data='')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modules_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
                 modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
 
                 assert not modprobe.module_is_loaded_persistently
@@ -278,7 +278,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
         self.get_bin_path.side_effect = ['modprobe']
 
         modprobe = Modprobe(module)
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modules_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
             modprobe.modules_files = []
 
             assert not modprobe.module_is_loaded_persistently
@@ -328,9 +328,9 @@ class TestPermanentParams(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open()) as mocked_file:
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
             mocked_file.side_effect = mock_files_content
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modprobe_files'):
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
                 modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
 
                 assert modprobe.permanent_params == set(['numdummies=4', 'dummy_parameter1=6', 'dummy_parameter2=5'])
@@ -363,9 +363,9 @@ class TestPermanentParams(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data='')) as mocked_file:
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='')) as mocked_file:
             mocked_file.side_effect = mock_files_content
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modprobe_files'):
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
                 modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
 
                 assert modprobe.permanent_params == set()
@@ -407,7 +407,7 @@ class TestCreateModuleFIle(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open()) as mocked_file:
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
             modprobe.create_module_file()
             mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf', 'w')
             mocked_file().write.assert_called_once_with('dummy\n')
@@ -450,7 +450,7 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open()) as mocked_file:
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open()) as mocked_file:
             modprobe.create_module_options_file()
             mocked_file.assert_called_once_with('/etc/modprobe.d/dummy.conf', 'w')
             mocked_file().write.assert_called_once_with('options dummy numdummies=4\n')
@@ -494,8 +494,8 @@ class TestDisableOldParams(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modprobe_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
                 modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
                 modprobe.disable_old_params()
                 mocked_file.assert_called_with('/etc/modprobe.d/dummy1.conf', 'w')
@@ -525,8 +525,8 @@ class TestDisableOldParams(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modprobe_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data=mock_data)) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modprobe_files'):
                 modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf']
                 modprobe.disable_old_params()
                 mocked_file.assert_called_once_with('/etc/modprobe.d/dummy1.conf')
@@ -569,8 +569,8 @@ class TestDisableModulePermanent(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modules_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='dummy')) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
                 modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
                 modprobe.disable_module_permanent()
                 mocked_file.assert_called_with('/etc/modules-load.d/dummy.conf', 'w')
@@ -599,8 +599,8 @@ class TestDisableModulePermanent(ModuleTestCase):
 
         modprobe = Modprobe(module)
 
-        with patch('ansible_collections.community.general.plugins.modules.system.modprobe.open', mock_open(read_data='notdummy')) as mocked_file:
-            with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modules_files'):
+        with patch('ansible_collections.community.general.plugins.modules.modprobe.open', mock_open(read_data='notdummy')) as mocked_file:
+            with patch('ansible_collections.community.general.plugins.modules.modprobe.Modprobe.modules_files'):
                 modprobe.modules_files = ['/etc/modules-load.d/dummy.conf']
                 modprobe.disable_module_permanent()
                 mocked_file.assert_called_once_with('/etc/modules-load.d/dummy.conf')

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import sys
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import ModuleTestCase, set_module_args
 from ansible_collections.community.general.tests.unit.compat.mock import call, patch
 from ansible_collections.community.general.tests.unit.compat.mock import Mock
@@ -46,7 +47,7 @@ class TestLoadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -76,7 +77,7 @@ class TestLoadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -125,7 +126,7 @@ class TestUnloadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -155,7 +156,7 @@ class TestUnloadModule(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -183,6 +184,9 @@ class TestUnloadModule(ModuleTestCase):
 
 class TestModuleIsLoadedPersistently(ModuleTestCase):
     def setUp(self):
+        if (sys.version_info[0] == 3 and sys.version_info[1] < 7) or (sys.version_info[0] == 2 and sys.version_info[1] < 7):
+            self.skipTest('open_mock doesnt support readline in earlier python versions')
+
         super(TestModuleIsLoadedPersistently, self).setUp()
 
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
@@ -208,7 +212,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -237,7 +241,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -266,7 +270,7 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -282,6 +286,8 @@ class TestModuleIsLoadedPersistently(ModuleTestCase):
 
 class TestPermanentParams(ModuleTestCase):
     def setUp(self):
+        if (sys.version_info[0] == 3 and sys.version_info[1] < 7) or (sys.version_info[0] == 2 and sys.version_info[1] < 7):
+            self.skipTest('open_mock doesnt support readline in earlier python versions')
         super(TestPermanentParams, self).setUp()
 
         self.mock_get_bin_path = patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
@@ -313,7 +319,7 @@ class TestPermanentParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -327,7 +333,7 @@ class TestPermanentParams(ModuleTestCase):
             with patch('ansible_collections.community.general.plugins.modules.system.modprobe.Modprobe.modprobe_files'):
                 modprobe.modprobe_files = ['/etc/modprobe.d/dummy1.conf', '/etc/modprobe.d/dummy2.conf']
 
-                assert modprobe.permanent_params == set(['dummy_parameter1=6', 'numdummies=4', 'dummy_parameter2=5'])
+                assert modprobe.permanent_params == set(['numdummies=4', 'dummy_parameter1=6', 'dummy_parameter2=5'])
 
     def test_module_permanent_params_empty(self):
 
@@ -348,7 +354,7 @@ class TestPermanentParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -392,7 +398,7 @@ class TestCreateModuleFIle(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -435,7 +441,7 @@ class TestCreateModuleOptionsFIle(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -479,7 +485,7 @@ class TestDisableOldParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -510,7 +516,7 @@ class TestDisableOldParams(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -554,7 +560,7 @@ class TestDisableModulePermanent(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )
@@ -584,7 +590,7 @@ class TestDisableModulePermanent(ModuleTestCase):
                 name=dict(type='str', required=True),
                 state=dict(type='str', default='present', choices=['absent', 'present']),
                 params=dict(type='str', default=''),
-                persistent=dict(type='bool', default=False)
+                persistent=dict(type='bool', default=False),
             ),
             supports_check_mode=True,
         )

--- a/tests/unit/plugins/modules/test_modprobe.py
+++ b/tests/unit/plugins/modules/test_modprobe.py
@@ -11,7 +11,6 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.compat.mock import Mock
 from ansible_collections.community.general.tests.unit.compat.mock import mock_open
-from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.modules.modprobe import Modprobe, build_module
 
 


### PR DESCRIPTION
##### SUMMARY
Add persistent option as was requested in #4028

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/system/modprobe.py

##### ADDITIONAL INFORMATION
If kernel module doesn't load after reboot(by PCI IDs, USB IDs, DMI IDs or similar triggers) you can use static files in /etc/modules-load.d to load this module. This is what I implemented. If you add option permanent and set it as true ansible will add module file which should enable module on startup. If you set permanent option as false then ansible will try to find line where you enabled this module previously and comment it out. Same works with kernel module options in /etc/modprobe.d directory.
Example:
```
 - name: Add the dummy module
    community.general.modprobe:
      name: dummy
      state: present
      params: 'numdummies=4'
      persistent: true
```
