### PR TITLE
nmcli: two fixes needed to make wifi.wake-on-wlan settings work properly

### DIFF
--- a/changelogs/fragments/5431-nmcli-wifi.yml
+++ b/changelogs/fragments/5431-nmcli-wifi.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - nmcli - fix failure to handle WIFI settings when connection type not specified (https://github.com/ansible-collections/community.general/pull/5431).
+  - nmcli - fix improper detection of changes to ``wifi.wake-on-wlan`` (https://github.com/ansible-collections/community.general/pull/5431).
+  - nmcli - fix change handling of values specified as an integer 0 (https://github.com/ansible-collections/community.general/pull/5431).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2164,6 +2164,8 @@ class Nmcli(object):
         if not self.type:
             current_con_type = self.show_connection().get('connection.type')
             if current_con_type:
+                if current_con_type == '802-11-wireless':
+                    current_con_type = 'wifi'
                 self.type = current_con_type
 
         options.update(self.connection_options(detect_change=True))

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2100,7 +2100,10 @@ class Nmcli(object):
         diff_after = dict()
 
         for key, value in options.items():
-            if not value:
+            # We can't just do `if not value` because then if there's a value
+            # of 0 specified as an integer it'll be interpreted as empty when
+            # it actually isn't.
+            if value != 0 and not value:
                 continue
 
             if key in conn_info:

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2105,6 +2105,10 @@ class Nmcli(object):
 
             if key in conn_info:
                 current_value = conn_info[key]
+                if key == '802-11-wireless.wake-on-wlan' and current_value is not None:
+                    match = re.match('0x([0-9A-Fa-f]+)', current_value)
+                    if match:
+                        current_value = str(int(match.group(1), 16))
                 if key in ('ipv4.routes', 'ipv6.routes') and current_value is not None:
                     current_value = self.get_route_params(current_value)
                 if key == self.mac_setting:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
There are two commits in this PR, both of which are necessary to make wifi.wake-on-wlan settings work properly with this module, and one of which is necessary to make any wifi.* setting work properly. See the descriptions of the fixes in the individual commits.
