### PR TITLE
ldap_attrs: escape ldap search filter

### DIFF
--- a/changelogs/fragments/5435-escape-ldap-param.yml
+++ b/changelogs/fragments/5435-escape-ldap-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ldap_attrs - fix bug which caused a `Bad search filter` error. The error was occuring when the ldap attribute value contained special characters such as `(` or `*`

--- a/changelogs/fragments/5435-escape-ldap-param.yml
+++ b/changelogs/fragments/5435-escape-ldap-param.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ldap_attrs - fix bug which caused a `Bad search filter` error. The error was occuring when the ldap attribute value contained special characters such as `(` or `*`
+  - ldap_attrs - fix bug which caused a ``Bad search filter`` error. The error was occuring when the ldap attribute value contained special characters such as ``(`` or ``*`` (https://github.com/ansible-collections/community.general/issues/5434, https://github.com/ansible-collections/community.general/pull/5435).

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -265,7 +265,8 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            filterstr = "(%s=%s)" % (name, ldap.filter.escape_filter_chars(value.decode()))
+            escaped_value = ldap.filter.escape_filter_chars(value)
+            filterstr = "(%s=%s)" % (name, escaped_value.decode())
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = len(dns) == 1
         except ldap.NO_SUCH_OBJECT:

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -168,7 +168,7 @@ modlist:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.common.text.converters import to_native, to_bytes
+from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible_collections.community.general.plugins.module_utils.ldap import LdapGeneric, gen_specs
 
 import re
@@ -265,7 +265,7 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            escaped_value = ldap.filter.escape_filter_chars(value.decode('utf-8'))
+            escaped_value = ldap.filter.escape_filter_chars(to_text(value))
             filterstr = "(%s=%s)" % (name, escaped_value)
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = len(dns) == 1

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -176,6 +176,7 @@ import re
 LDAP_IMP_ERR = None
 try:
     import ldap
+    import ldap.filter
 
     HAS_LDAP = True
 except ImportError:
@@ -264,7 +265,7 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            filterstr = "(%s=%s)" % (name, value.decode())
+            filterstr = "(%s=%s)" % (name, ldap.filter.escape_filter_chars(value.decode()))
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = len(dns) == 1
         except ldap.NO_SUCH_OBJECT:

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -265,8 +265,8 @@ class LdapAttrs(LdapGeneric):
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
-            escaped_value = ldap.filter.escape_filter_chars(value)
-            filterstr = "(%s=%s)" % (name, escaped_value.decode())
+            escaped_value = ldap.filter.escape_filter_chars(value.decode('utf-8'))
+            filterstr = "(%s=%s)" % (name, escaped_value)
             dns = self.connection.search_s(self.dn, ldap.SCOPE_BASE, filterstr)
             is_present = len(dns) == 1
         except ldap.NO_SUCH_OBJECT:


### PR DESCRIPTION
##### SUMMARY
Escape ldap search parameter before passing it to `search_s`

Fixes #5434

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ldap_attrs
