### PR TITLE
Clearer error logging in passwordstore lookup

### DIFF
--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -268,7 +268,7 @@ class LookupModule(LookupBase):
                 )
                 self.realpass = 'pass: the standard unix password manager' in passoutput
             except (subprocess.CalledProcessError) as e:
-                raise AnsibleError(e)
+                raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
 
         return self.realpass
 
@@ -354,7 +354,7 @@ class LookupModule(LookupBase):
         except (subprocess.CalledProcessError) as e:
             # 'not in password store' is the expected error if a password wasn't found
             if 'not in the password store' not in e.output:
-                raise AnsibleError(e)
+                raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
 
         if self.paramvals['missing'] == 'error':
             raise AnsibleError('passwordstore: passname {0} not found and missing=error is set'.format(self.passname))
@@ -387,7 +387,7 @@ class LookupModule(LookupBase):
         try:
             check_output2([self.pass_cmd, 'insert', '-f', '-m', self.passname], input=msg, env=self.env)
         except (subprocess.CalledProcessError) as e:
-            raise AnsibleError(e)
+            raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
         return newpass
 
     def generate_password(self):
@@ -399,7 +399,7 @@ class LookupModule(LookupBase):
         try:
             check_output2([self.pass_cmd, 'insert', '-f', '-m', self.passname], input=msg, env=self.env)
         except (subprocess.CalledProcessError) as e:
-            raise AnsibleError(e)
+            raise AnsibleError('exit code {0} while running {1}. Error output: {2}'.format(e.returncode, e.cmd, e.output))
         return newpass
 
     def get_passresult(self):


### PR DESCRIPTION
(re-creation of ansible/ansible#47120)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There are many reasons why password store would return exit code 1. Just search for "exit 1" in https://git.zx2c4.com/password-store/tree/src/password-store.sh. This change creates clearer error messages, so one can see what is actually wrong.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #3759

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookup passwordstore

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```paste below
fatal: [testhost-01]: FAILED! => {
    "changed": false,
    "msg": "AnsibleError: An unhandled exception occurred while templating '{{ test_pass }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ lookup(\"passwordstore\", \"{{ test_passwordstore_path }}/test create={{ not ansible_check_mode }}\") }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: command ['pass', 'insert', '-f', '-m', u'testpath/test']. returned non-zero exit status 1"
}
```
after:
```
fatal: [testhost-01]: FAILED! => {
    "changed": false,
    "msg": "AnsibleError: An unhandled exception occurred while templating '{{ test_pass }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while templating '{{ lookup(\"passwordstore\", \"{{ test_passwordstore_path }}/test create={{ not ansible_check_mode }}\") }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: exit code 1 while running ['pass', 'insert', '-f', '-m', u'testpath/test']. Error output: Enter contents of testpath/test and press Ctrl+D when finished:\n\ngpg: ABCDEF0123456789: There is no assurance this key belongs to the named user\ngpg: [stdin]: encryption failed: Unusable public key\nPassword encryption aborted.\n"
}
```