### PR TITLE
linnode inventory, remove redundant

### DIFF
--- a/changelogs/fragments/5438-linode.yml
+++ b/changelogs/fragments/5438-linode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "linode inventory plugin - simplify option handling (https://github.com/ansible-collections/community.general/pull/5438)."

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -126,7 +126,6 @@ import os
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.six import string_types
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
-from ansible.template import Templar
 
 
 try:

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -147,7 +147,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         access_token = self.get_option('access_token')
         if self.templar.is_template(access_token):
-            access_token = self.templar.template(variable=access_token, disable_lookups=False)        
+            access_token = self.templar.template(variable=access_token, disable_lookups=False)
 
         if access_token is None:
             raise AnsibleError((

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -145,22 +145,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _build_client(self, loader):
         """Build the Linode client."""
 
-        t = Templar(loader=loader)
-
         access_token = self.get_option('access_token')
-        if t.is_template(access_token):
-            access_token = t.template(variable=access_token, disable_lookups=False)
-
-        if access_token is None:
-            try:
-                access_token = os.environ['LINODE_ACCESS_TOKEN']
-            except KeyError:
-                pass
+        if self.templar.is_template(access_token):
+            access_token = self.templar.template(variable=access_token, disable_lookups=False)        
 
         if access_token is None:
             raise AnsibleError((
                 'Could not retrieve Linode access token '
-                'from plugin configuration or environment'
+                'from plugin configuration sources'
             ))
 
         self.client = LinodeClient(access_token)

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -18,12 +18,15 @@ mandatory_py_version = pytest.mark.skipif(
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar
 from ansible_collections.community.general.plugins.inventory.linode import InventoryModule
 
 
 @pytest.fixture(scope="module")
 def inventory():
-    return InventoryModule()
+    plugin = InventoryModule()
+    plugin.templar = Templar(loader=DataLoader())
+    return plugin
 
 
 def test_missing_access_token_lookup(inventory):


### PR DESCRIPTION
templar is already in base class
env var is already consulted in via config resolution

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory/linnode