### PR TITLE
add option to force dig lookup to return empty list

### DIFF
--- a/changelogs/fragments/5439-dig-return-empty-result.yml
+++ b/changelogs/fragments/5439-dig-return-empty-result.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dig lookup plugin - add option to return empty result without empty strings, and return empty list instead of ``NXDOMAIN`` (https://github.com/ansible-collections/community.general/pull/5439, https://github.com/ansible-collections/community.general/issues/5428).


### PR DESCRIPTION
##### SUMMARY
This fix causes dig lookup to return an empty list instead of a list of empty strings, behaviour which was probably erroneously introduced years ago but which seems a bug.

Fixes https://github.com/ansible-collections/community.general/issues/5428

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dig

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Print retrieve NS] ************************************************************
ok: [localhost] => {
    "ns": []
}

TASK [nxdomain (real_empty==False)] *************************************************
ok: [localhost] => {
    "msg": [
        "NXDOMAIN"
    ]
}

TASK [nxdomain (real_empty==True)] **************************************************
ok: [localhost] => {
    "msg": []
}
```
