### PR TITLE
[stable-4] Fix CI

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -36,4 +36,5 @@ dataclasses ; python_version == '3.6'
 # opentelemetry-sdk ; python_version >= '3.6' and python_version < '3.10'
 
 # requirement for the elastic callback plugin
-elastic-apm ; python_version >= '3.6'
+elastic-apm < 6.13.0 ; python_version == '3.6'
+elastic-apm ; python_version >= '3.7'


### PR DESCRIPTION
##### SUMMARY
Nightly currently fails (ansible-base 2.10 Python 3.6 unit tests):
https://dev.azure.com/ansible/community.general/_build/results?buildId=58662&view=logs&j=e78eaf5f-f379-5300-4702-e3e77c80bf61&t=ec1d214a-386a-5c51-8b46-9fd9c5bdbf67&l=457
```
00:54 ERROR: elastic-apm 6.13.0 has requirement wrapt>=1.14.1, but you'll have wrapt 1.11.1 which is incompatible.
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
