### PR TITLE
passwordstore lookup: allow to pass options as lookup options

### DIFF
--- a/changelogs/fragments/5444-passwordstore-options.yml
+++ b/changelogs/fragments/5444-passwordstore-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "passwordstore lookup plugin - allow options to be passed lookup options instead of being part of the term strings (https://github.com/ansible-collections/community.general/pull/5444)."

--- a/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/password_tests.yml
@@ -5,7 +5,7 @@
 
   - name: Create a password ({{ backend }})
     set_fact:
-      newpass: "{{ lookup('community.general.passwordstore', 'test-pass length=8 create=yes', backend=backend) }}"
+      newpass: "{{ lookup('community.general.passwordstore', 'test-pass', length=8, create=true, backend=backend) }}"
 
   - name: Fetch password from an existing file ({{ backend }})
     set_fact:
@@ -18,7 +18,7 @@
 
   - name: Create a password with equal sign ({{ backend }})
     set_fact:
-      newpass: "{{ lookup('community.general.passwordstore', 'test-pass-equal userpass=SimpleSample= create=yes', backend=backend) }}"
+      newpass: "{{ lookup('community.general.passwordstore', 'test-pass-equal userpass=SimpleSample= create=true', backend=backend) }}"
 
   - name: Fetch a password with equal sign ({{ backend }})
     set_fact:
@@ -31,7 +31,7 @@
 
   - name: Create a password using missing=create ({{ backend }})
     set_fact:
-      newpass: "{{ lookup('community.general.passwordstore', 'test-missing-create missing=create length=8', backend=backend) }}"
+      newpass: "{{ lookup('community.general.passwordstore', 'test-missing-create', missing='create', length=8, backend=backend) }}"
 
   - name: Fetch password from an existing file ({{ backend }})
     set_fact:
@@ -44,7 +44,7 @@
 
   - name: Fetch password from existing file using missing=empty ({{ backend }})
     set_fact:
-      readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create missing=empty', backend=backend) }}"
+      readpass: "{{ lookup('community.general.passwordstore', 'test-missing-create', missing='empty', backend=backend) }}"
 
   - name: Verify password ({{ backend }})
     assert:
@@ -53,7 +53,7 @@
 
   - name: Fetch password from non-existing file using missing=empty ({{ backend }})
     set_fact:
-      readpass: "{{ query('community.general.passwordstore', 'test-missing-pass missing=empty', backend=backend) }}"
+      readpass: "{{ query('community.general.passwordstore', 'test-missing-pass', missing='empty', backend=backend) }}"
 
   - name: Verify password ({{ backend }})
     assert:
@@ -71,7 +71,7 @@
 
   - name: Fetch a password with YAML subkey ({{ backend }})
     set_fact:
-      readyamlpass: "{{ lookup('community.general.passwordstore', 'test-yaml-pass subkey=key', backend=backend) }}"
+      readyamlpass: "{{ lookup('community.general.passwordstore', 'test-yaml-pass', subkey='key', backend=backend) }}"
 
   - name: Read a yaml subkey ({{ backend }})
     assert:
@@ -96,7 +96,7 @@
 
   - name: Fetch all from multiline file ({{ backend }})
     set_fact:
-      readyamlpass: "{{ lookup('community.general.passwordstore', 'test-multiline-pass returnall=yes', backend=backend) }}"
+      readyamlpass: "{{ lookup('community.general.passwordstore', 'test-multiline-pass', returnall='yes', backend=backend) }}"
 
   - name: Multiline pass returnall returns everything in the file ({{ backend }})
     assert:
@@ -105,7 +105,7 @@
 
   - name: Create a password in a folder ({{ backend }})
     set_fact:
-      newpass: "{{ lookup('community.general.passwordstore', 'folder/test-pass length=8 create=yes', backend=backend) }}"
+      newpass: "{{ lookup('community.general.passwordstore', 'folder/test-pass', length=8, create=true, backend=backend) }}"
 
   - name: Fetch password from folder ({{ backend }})
     set_fact:

--- a/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -125,7 +125,9 @@
     that:
       - eval_error is failed
       - >-
-        "Passwordstore directory 'somenonexistentplace' does not exist" in eval_error.msg
+        "Passwordstore directory '" in eval_error.msg
+      - >-
+        "/somenonexistentplace' does not exist" in eval_error.msg
 
 - name: Test pass compatibility shim detection
   block:


### PR DESCRIPTION
##### SUMMARY
Something which should have been done a long time ago: allow to pass in options as lookup options instead of insisting that they have to be parsed from the terms.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
passwordstore lookup plugin
