### PR TITLE
Allow for DN's to have {x} prefix on first RDN

### DIFF
--- a/changelogs/fragments/5450-allow-for-xordered-dns.yaml
+++ b/changelogs/fragments/5450-allow-for-xordered-dns.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap_attrs - allow for DN's to have ``{x}`` prefix on first RDN (https://github.com/ansible-collections/community.general/issues/977, https://github.com/ansible-collections/community.general/pull/5450).
+  - ldap_attrs - allow for DNs to have ``{x}`` prefix on first RDN (https://github.com/ansible-collections/community.general/issues/977, https://github.com/ansible-collections/community.general/pull/5450).

--- a/changelogs/fragments/5450-allow-for-xordered-dns.yaml
+++ b/changelogs/fragments/5450-allow-for-xordered-dns.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ldap_attrs - allow for DN's to have ``{x}`` prefix on first RDN (https://github.com/ansible-collections/community.general/issues/977, https://github.com/ansible-collections/community.general/pull/5450).

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -16,6 +16,7 @@ from ansible.module_utils.common.text.converters import to_native
 try:
     import ldap
     import ldap.dn
+    import ldap.filter
     import ldap.sasl
 
     HAS_LDAP = True
@@ -75,8 +76,10 @@ class LdapGeneric(object):
 
         if len(explode_dn) > 1:
             try:
+                escaped_value = ldap.filter.escape_filter_chars(explode_dn[0])
+                filterstr = "(%s)" % escaped_value
                 dns = self.connection.search_s(','.join(explode_dn[1:]),
-                                               ldap.SCOPE_ONELEVEL, "(%s)" % explode_dn[0])
+                                               ldap.SCOPE_ONELEVEL, filterstr)
                 if len(dns) == 1:
                     dn, dummy = dns[0]
             except Exception:

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -78,7 +78,7 @@ class LdapGeneric(object):
                 dns = self.connection.search_s(','.join(explode_dn[1:]),
                                                ldap.SCOPE_ONELEVEL, "(%s)" % explode_dn[0])
                 if len(dns) == 1:
-                    dn, _ = dns[0]
+                    dn, dummy = dns[0]
             except Exception:
                 pass
 

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -78,7 +78,7 @@ class LdapGeneric(object):
                 dns = self.connection.search_s(','.join(explode_dn[1:]),
                                                ldap.SCOPE_ONELEVEL, "(%s)" % explode_dn[0])
                 if len(dns) == 1:
-                    dn, attrs = dns[0]
+                    dn, _ = dns[0]
             except Exception:
                 pass
 


### PR DESCRIPTION
##### SUMMARY
Allow for DN's to have {x} prefix on first RDN.
This is an extension to https://github.com/ansible-collections/community.general/pull/5385

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ldap

##### ADDITIONAL INFORMATION
It turns out that in OpenLDAP's ``cn=config``, DN's can be ordered as well and configuring OpenLDAP through ansible therefor is quite cumbersome.

See the following example:

Suppose I want to enable slapd monitoring via ``cn=config``. I would need to add ``back_monitor`` to ``cn=module{0},cn=config`` which is now correctly handled by https://github.com/ansible-collections/community.general/pull/5385. However, I would also need to add a DN:
```
- name: Setup Monitor
  community.general.ldap_entry:
    dn: olcdatabase=monitor,cn=config
    objectClass: olcDatabaseConfig
    attributes:
      olcRootDN: "cn=admin,cn=Monitor"
      olcRootPW: "{{ '%s' | format(monitor_ldap_password) |  slapd_hash }}"
```
This entry, however will show up in ``cn=config`` as ``olcDatabase={2}monitor.ldif`` and subsequent runs will fail because a monitor database can only be added once here.
This problem can be solved by explicitly specifying the ``{2}`` prefix in the task, but I think it would be nice to let users add the bare DN and not have to think about the consequences of ordering.

The change tries to find the DN by searching ``ONELEVEL`` below the superior RDN for the first RDN. It goes at length to be backwards compatible by falling back to the original configured DN if anything unexpected happens. Only if searching results in one and only one result, the newly found DN is returned, possibly updating the bare version with the ordered prefix one.
