### PR TITLE
[Scaleway] Fix mismatch default value function namespaces

### DIFF
--- a/plugins/modules/cloud/scaleway/scaleway_function_namespace.py
+++ b/plugins/modules/cloud/scaleway/scaleway_function_namespace.py
@@ -68,6 +68,7 @@ options:
       - Environment variables of the function namespace.
       - Injected in functions at runtime.
     type: dict
+    default: {}
 
   secret_environment_variables:
     description:
@@ -75,6 +76,7 @@ options:
       - Updating thoses values will not output a C(changed) state in Ansible.
       - Injected in functions at runtime.
     type: dict
+    default: {}
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY

Fix mismatch default value between documentation and argument_spec

Following #5415 and completing #5446

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`scaleway_function_namespace`

##### ADDITIONAL INFORMATION

CI Fails with the new ansible-core version (`2.15.0.dev0`) with the following error message : 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ERROR: plugins/modules/cloud/scaleway/scaleway_function_namespace.py:0:0: doc-default-does-not-match-spec: Argument 'environment_variables' in argument_spec defines default as ({}) but documentation defines default as (None) (0%)
ERROR: plugins/modules/cloud/scaleway/scaleway_function_namespace.py:0:0: doc-default-does-not-match-spec: Argument 'secret_environment_variables' in argument_spec defines default as ({}) but documentation defines default as (None) (0%)
```
