### PR TITLE
snap: fix regex to support option values with whitespaces

### DIFF
--- a/changelogs/fragments/5475-snap-option-value-whitespace.yml
+++ b/changelogs/fragments/5475-snap-option-value-whitespace.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - snap - allow values in the ``options`` parameter to contain whitespaces (https://github.com/ansible-collections/community.general/pull/5475).

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -170,7 +170,7 @@ def _state_map(value):
 
 class Snap(CmdStateModuleHelper):
     __disable_re = re.compile(r'(?:\S+\s+){5}(?P<notes>\S+)')
-    __set_param_re = re.compile(r'(?P<snap_prefix>\S+:)?(?P<key>\S+)=(?P<value>\S+)')
+    __set_param_re = re.compile(r'(?P<snap_prefix>\S+:)?(?P<key>\S+)\s*=\s*(?P<value>.+)')
     module = dict(
         argument_spec={
             'name': dict(type='list', elements='str', required=True),
@@ -342,7 +342,7 @@ class Snap(CmdStateModuleHelper):
 
                 if selected_snap_name is None or (snap_name is not None and snap_name == selected_snap_name):
                     key = match.group("key")
-                    value = match.group("value")
+                    value = match.group("value").strip()
 
                     if key not in option_map or key in option_map and option_map[key] != value:
                         option_without_prefix = key + "=" + value

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -8,7 +8,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- block:
+- name: Has-snap block
+  when: has_snap
+  block:
     - name: Make sure package is not installed (hello-world)
       community.general.snap:
         name: hello-world
@@ -189,5 +191,3 @@
           - "'uhttpd:document-root-dir=/tmp' in install_with_option_changed.options_changed"
           - "'uhttpd:listening-port=8080' not in install_with_option_changed.options_changed"
           - remove is changed
-
-  when: has_snap


### PR DESCRIPTION
##### SUMMARY
Allow whitespaces in options' values.

Fixes #5466 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/snap.py