### PR TITLE
Fix:  Duplicate vmid in proxmox_disk module #5492

### DIFF
--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -725,7 +725,7 @@ def main():
             actual_size = disk_config['size']
             if size == actual_size:
                 module.exit_json(changed=False, vmid=vmid, msg="Disk %s is already %s size" % (disk, size))
-            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).resize.set(vmid=vmid, disk=disk, size=size)
+            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).resize.set(disk=disk, size=size)
             module.exit_json(changed=True, vmid=vmid, msg="Disk %s resized in VM %s" % (disk, vmid))
         except Exception as e:
             module.fail_json(msg="Failed to resize disk %s in VM %s with exception: %s" % (disk, vmid, str(e)))


### PR DESCRIPTION
https://github.com/ansible-collections/community.general/issues/5492

##### SUMMARY
Remove duplicated vmid reference in URI builder.

Fixes #5492

##### ISSUE TYPE
BUG: Resize disk blocking feature

