### PR TITLE
[Scaleway] Remove unused sensitive values filtering

### DIFF
--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -83,13 +83,6 @@ def parse_pagination_link(header):
         return parsed_relations
 
 
-def filter_sensitive_attributes(container, attributes):
-    for attr in attributes:
-        container[attr] = "SENSITIVE_VALUE"
-
-    return container
-
-
 class SecretVariables(object):
     @staticmethod
     def ensure_scaleway_secret_package(module):

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -83,6 +83,13 @@ def parse_pagination_link(header):
         return parsed_relations
 
 
+def filter_sensitive_attributes(container, attributes):
+    for attr in attributes:
+        container[attr] = "SENSITIVE_VALUE"
+
+    return container
+
+
 class SecretVariables(object):
     @staticmethod
     def ensure_scaleway_secret_package(module):

--- a/plugins/modules/scaleway_container_namespace_info.py
+++ b/plugins/modules/scaleway_container_namespace_info.py
@@ -73,19 +73,16 @@ container_namespace:
     region: fr-par
     registry_endpoint: ""
     registry_namespace_id: ""
-    secret_environment_variables: SENSITIVE_VALUE
+    secret_environment_variables:
+      - key: MY_SECRET_VAR
+        value: $argon2id$v=19$m=65536,t=1,p=2$tb6UwSPWx/rH5Vyxt9Ujfw$5ZlvaIjWwNDPxD9Rdght3NarJz4IETKjpvAU3mMSmFg
     status: pending
 '''
 
 from ansible_collections.community.general.plugins.module_utils.scaleway import (
-    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
-    filter_sensitive_attributes
+    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway
 )
 from ansible.module_utils.basic import AnsibleModule
-
-SENSITIVE_ATTRIBUTES = (
-    "secret_environment_variables",
-)
 
 
 def info_strategy(api, wished_cn):
@@ -123,7 +120,7 @@ def core(module):
 
     summary = info_strategy(api=api, wished_cn=wished_container_namespace)
 
-    module.exit_json(changed=False, container_namespace=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+    module.exit_json(changed=False, container_namespace=summary)
 
 
 def main():

--- a/plugins/modules/scaleway_container_registry_info.py
+++ b/plugins/modules/scaleway_container_registry_info.py
@@ -79,14 +79,9 @@ container_registry:
 '''
 
 from ansible_collections.community.general.plugins.module_utils.scaleway import (
-    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
-    filter_sensitive_attributes
+    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway
 )
 from ansible.module_utils.basic import AnsibleModule
-
-SENSITIVE_ATTRIBUTES = (
-    "secret_environment_variables",
-)
 
 
 def info_strategy(api, wished_cn):
@@ -124,7 +119,7 @@ def core(module):
 
     summary = info_strategy(api=api, wished_cn=wished_container_namespace)
 
-    module.exit_json(changed=False, container_registry=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+    module.exit_json(changed=False, container_registry=summary)
 
 
 def main():

--- a/plugins/modules/scaleway_function_info.py
+++ b/plugins/modules/scaleway_function_info.py
@@ -80,20 +80,17 @@ function:
     region: fr-par
     runtime: python310
     runtime_message: ""
-    secret_environment_variables: SENSITIVE_VALUE
+    secret_environment_variables:
+      - key: MY_SECRET_VAR
+        value: $argon2id$v=19$m=65536,t=1,p=2$tb6UwSPWx/rH5Vyxt9Ujfw$5ZlvaIjWwNDPxD9Rdght3NarJz4IETKjpvAU3mMSmFg
     status: created
     timeout: 300s
 '''
 
 from ansible_collections.community.general.plugins.module_utils.scaleway import (
-    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway,
-    filter_sensitive_attributes
+    SCALEWAY_ENDPOINT, SCALEWAY_REGIONS, scaleway_argument_spec, Scaleway
 )
 from ansible.module_utils.basic import AnsibleModule
-
-SENSITIVE_ATTRIBUTES = (
-    "secret_environment_variables",
-)
 
 
 def info_strategy(api, wished_fn):
@@ -131,7 +128,7 @@ def core(module):
 
     summary = info_strategy(api=api, wished_fn=wished_function)
 
-    module.exit_json(changed=False, function=filter_sensitive_attributes(summary, SENSITIVE_ATTRIBUTES))
+    module.exit_json(changed=False, function=summary)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

This PR remove the call to `filter_sensitive_attributes` in Scaleway modules.
Also remove the `filter_sensitive_attributes` from module utils.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- `scaleway_container_namespace_info`
- `scaleway_container_registry_info`
- `scaleway_function_info`

##### ADDITIONAL INFORMATION

Since the returned values are hashed, we don't need to filter them from before return the to the user.
Also, the not `_info` modules already returns the hashed value.

Should I make a Changelog fragment for this PR ?