### PR TITLE
scaleway module utils: make function private that should be removed

### DIFF
--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -83,11 +83,9 @@ def parse_pagination_link(header):
         return parsed_relations
 
 
-def _filter_sensitive_attributes(container, attributes):
-    # WARNING: Will re removed once removing this no longer triggers a pylint bug.
-    for attr in attributes:
-        container[attr] = "SENSITIVE_VALUE"
-
+def filter_sensitive_attributes(container, attributes):
+    # WARNING: This function is effectively private, **do not use it**!
+    # It will be removed or renamed once changing its name no longer triggers a pylint bug.
     return container
 
 

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -83,7 +83,8 @@ def parse_pagination_link(header):
         return parsed_relations
 
 
-def filter_sensitive_attributes(container, attributes):
+def _filter_sensitive_attributes(container, attributes):
+    '''WARNING: Will re removed once removing this no longer triggers a pylint bug.'''
     for attr in attributes:
         container[attr] = "SENSITIVE_VALUE"
 

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -84,7 +84,7 @@ def parse_pagination_link(header):
 
 
 def _filter_sensitive_attributes(container, attributes):
-    '''WARNING: Will re removed once removing this no longer triggers a pylint bug.'''
+    # WARNING: Will re removed once removing this no longer triggers a pylint bug.
     for attr in attributes:
         container[attr] = "SENSITIVE_VALUE"
 

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -84,8 +84,10 @@ def parse_pagination_link(header):
 
 
 def filter_sensitive_attributes(container, attributes):
-    # WARNING: This function is effectively private, **do not use it**!
-    # It will be removed or renamed once changing its name no longer triggers a pylint bug.
+    '''
+    WARNING: This function is effectively private, **do not use it**!
+    It will be removed or renamed once changing its name no longer triggers a pylint bug.
+    '''
     for attr in attributes:
         container[attr] = "SENSITIVE_VALUE"
 

--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -86,6 +86,9 @@ def parse_pagination_link(header):
 def filter_sensitive_attributes(container, attributes):
     # WARNING: This function is effectively private, **do not use it**!
     # It will be removed or renamed once changing its name no longer triggers a pylint bug.
+    for attr in attributes:
+        container[attr] = "SENSITIVE_VALUE"
+
     return container
 
 


### PR DESCRIPTION
##### SUMMARY
Removing it in #5497 triggered a pylint bug. This tries to at least make it private.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
scaleway module utils
