### PR TITLE
Clarification to use underscores instead of dashes in parser name

### DIFF
--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -26,6 +26,7 @@ DOCUMENTATION = '''
       description:
         - The correct parser for the input data.
         - For example C(ifconfig).
+        - Note: use underscores instead of dashes (if any) in the parser module name
         - See U(https://github.com/kellyjonbrazil/jc#parsers) for the latest list of parsers.
       type: string
       required: true

--- a/plugins/filter/jc.py
+++ b/plugins/filter/jc.py
@@ -26,7 +26,7 @@ DOCUMENTATION = '''
       description:
         - The correct parser for the input data.
         - For example C(ifconfig).
-        - Note: use underscores instead of dashes (if any) in the parser module name
+        - "Note: use underscores instead of dashes (if any) in the parser module name."
         - See U(https://github.com/kellyjonbrazil/jc#parsers) for the latest list of parsers.
       type: string
       required: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Clarify that parser names use underscores instead of dashes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This change is in response to an issue that was opened on the jc github repo:
https://github.com/kellyjonbrazil/jc/issues/317

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
