### PR TITLE
Short descriptions (batch1) - massive fix on Capitalization and trailing period

### DIFF
--- a/plugins/modules/ali_instance.py
+++ b/plugins/modules/ali_instance.py
@@ -27,7 +27,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ali_instance
-short_description: Create, Start, Stop, Restart or Terminate an Instance in ECS. Add or Remove Instance to/from a Security Group.
+short_description: Create, Start, Stop, Restart or Terminate an Instance in ECS. Add or Remove Instance to/from a Security Group
 description:
     - Create, start, stop, restart, modify or terminate ecs instances.
     - Add or remove ecs instances to/from security group.

--- a/plugins/modules/ali_instance.py
+++ b/plugins/modules/ali_instance.py
@@ -27,7 +27,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ali_instance
-short_description: Create, Start, Stop, Restart or Terminate an Instance in ECS. Add or Remove Instance to/from a Security Group
+short_description: Create, Start, Stop, Restart or Terminate an Instance in ECS; Add or Remove Instance to/from a Security Group
 description:
     - Create, start, stop, restart, modify or terminate ecs instances.
     - Add or remove ecs instances to/from security group.

--- a/plugins/modules/ali_instance_info.py
+++ b/plugins/modules/ali_instance_info.py
@@ -27,7 +27,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ali_instance_info
-short_description: Gather information on instances of Alibaba Cloud ECS.
+short_description: Gather information on instances of Alibaba Cloud ECS
 description:
      - This module fetches data from the Open API in Alicloud.
        The module must be called from within the ECS instance itself.

--- a/plugins/modules/apache2_module.py
+++ b/plugins/modules/apache2_module.py
@@ -16,7 +16,7 @@ author:
     - Christian Berendt (@berendt)
     - Ralf Hertel (@n0trax)
     - Robin Roth (@robinro)
-short_description: Enables/disables a module of the Apache2 webserver.
+short_description: Enables/disables a module of the Apache2 webserver
 description:
    - Enables or disables a specified module of the Apache2 webserver.
 options:

--- a/plugins/modules/apt_rpm.py
+++ b/plugins/modules/apt_rpm.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: apt_rpm
-short_description: Apt_rpm package manager
+short_description: APT-RPM package manager
 description:
   - Manages packages with I(apt-rpm). Both low-level (I(rpm)) and high-level (I(apt-get)) package manager binaries required.
 options:

--- a/plugins/modules/apt_rpm.py
+++ b/plugins/modules/apt_rpm.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: apt_rpm
-short_description: apt_rpm package manager
+short_description: Apt_rpm package manager
 description:
   - Manages packages with I(apt-rpm). Both low-level (I(rpm)) and high-level (I(apt-get)) package manager binaries required.
 options:

--- a/plugins/modules/beadm.py
+++ b/plugins/modules/beadm.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: beadm
-short_description: Manage ZFS boot environments on FreeBSD/Solaris/illumos systems.
+short_description: Manage ZFS boot environments on FreeBSD/Solaris/illumos systems
 description:
     - Create, delete or activate ZFS boot environments.
     - Mount and unmount ZFS boot environments.

--- a/plugins/modules/circonus_annotation.py
+++ b/plugins/modules/circonus_annotation.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: circonus_annotation
-short_description: create an annotation in circonus
+short_description: Create an annotation in circonus
 description:
     - Create an annotation event with a given category, title and description. Optionally start, end or durations can be provided
 author: "Nick Harring (@NickatEpic)"

--- a/plugins/modules/clc_aa_policy.py
+++ b/plugins/modules/clc_aa_policy.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_aa_policy
-short_description: Create or Delete Anti Affinity Policies at CenturyLink Cloud.
+short_description: Create or Delete Anti Affinity Policies at CenturyLink Cloud
 description:
   - An Ansible module to Create or Delete Anti Affinity Policies at CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_alert_policy.py
+++ b/plugins/modules/clc_alert_policy.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_alert_policy
-short_description: Create or Delete Alert Policies at CenturyLink Cloud.
+short_description: Create or Delete Alert Policies at CenturyLink Cloud
 description:
   - An Ansible module to Create or Delete Alert Policies at CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_blueprint_package.py
+++ b/plugins/modules/clc_blueprint_package.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_blueprint_package
-short_description: deploys a blue print package on a set of servers in CenturyLink Cloud.
+short_description: Deploys a blue print package on a set of servers in CenturyLink Cloud
 description:
   - An Ansible module to deploy blue print package on a set of servers in CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_loadbalancer.py
+++ b/plugins/modules/clc_loadbalancer.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_loadbalancer
-short_description: Create, Delete shared loadbalancers in CenturyLink Cloud.
+short_description: Create, Delete shared loadbalancers in CenturyLink Cloud
 description:
   - An Ansible module to Create, Delete shared loadbalancers in CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_modify_server.py
+++ b/plugins/modules/clc_modify_server.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_modify_server
-short_description: modify servers in CenturyLink Cloud.
+short_description: Modify servers in CenturyLink Cloud
 description:
   - An Ansible module to modify servers in CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_publicip.py
+++ b/plugins/modules/clc_publicip.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_publicip
-short_description: Add and Delete public ips on servers in CenturyLink Cloud.
+short_description: Add and Delete public ips on servers in CenturyLink Cloud
 description:
   - An Ansible module to add or delete public ip addresses on an existing server or servers in CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_server.py
+++ b/plugins/modules/clc_server.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_server
-short_description: Create, Delete, Start and Stop servers in CenturyLink Cloud.
+short_description: Create, Delete, Start and Stop servers in CenturyLink Cloud
 description:
   - An Ansible module to Create, Delete, Start and Stop servers in CenturyLink Cloud.
 options:

--- a/plugins/modules/clc_server_snapshot.py
+++ b/plugins/modules/clc_server_snapshot.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: clc_server_snapshot
-short_description: Create, Delete and Restore server snapshots in CenturyLink Cloud.
+short_description: Create, Delete and Restore server snapshots in CenturyLink Cloud
 description:
   - An Ansible module to Create, Delete and Restore server snapshots in CenturyLink Cloud.
 options:

--- a/plugins/modules/cloud_init_data_facts.py
+++ b/plugins/modules/cloud_init_data_facts.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cloud_init_data_facts
-short_description: Retrieve facts of cloud-init.
+short_description: Retrieve facts of cloud-init
 description:
   - Gathers facts by reading the status.json and result.json of cloud-init.
 author: René Moser (@resmo)

--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: consul
-short_description: "Add, modify & delete services within a consul cluster."
+short_description: "Add, modify & delete services within a consul cluster"
 description:
  - Registers services and checks for an agent with a consul cluster.
    A service is some process running on the agent node that should be advertised by

--- a/plugins/modules/cpanm.py
+++ b/plugins/modules/cpanm.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cpanm
-short_description: Manages Perl library dependencies.
+short_description: Manages Perl library dependencies
 description:
   - Manage Perl library dependencies using cpanminus.
 options:

--- a/plugins/modules/deploy_helper.py
+++ b/plugins/modules/deploy_helper.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: deploy_helper
 author: "Ramon de la Fuente (@ramondelafuente)"
-short_description: Manages some of the steps common in deploying projects.
+short_description: Manages some of the steps common in deploying projects
 description:
   - The Deploy Helper manages some of the steps common in deploying software.
     It creates a folder structure, manages a symlink for the current release

--- a/plugins/modules/dimensiondata_vlan.py
+++ b/plugins/modules/dimensiondata_vlan.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: dimensiondata_vlan
-short_description: Manage a VLAN in a Cloud Control network domain.
+short_description: Manage a VLAN in a Cloud Control network domain
 extends_documentation_fragment:
 - community.general.dimensiondata
 - community.general.dimensiondata_wait

--- a/plugins/modules/dnsmadeeasy.py
+++ b/plugins/modules/dnsmadeeasy.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: dnsmadeeasy
-short_description: Interface with dnsmadeeasy.com (a DNS hosting service).
+short_description: Interface with dnsmadeeasy.com (a DNS hosting service)
 description:
    - >
      Manages DNS records via the v2 REST API of the DNS Made Easy service.  It handles records only; there is no manipulation of domains or

--- a/plugins/modules/github_deploy_key.py
+++ b/plugins/modules/github_deploy_key.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 ---
 module: github_deploy_key
 author: "Ali (@bincyber)"
-short_description: Manages deploy keys for GitHub repositories.
+short_description: Manages deploy keys for GitHub repositories
 description:
   - "Adds or removes deploy keys for GitHub repositories. Supports authentication using username and password,
   username and password and 2-factor authentication code (OTP), OAuth2 token, or personal access token. Admin

--- a/plugins/modules/github_issue.py
+++ b/plugins/modules/github_issue.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: github_issue
-short_description: View GitHub issue.
+short_description: View GitHub issue
 description:
     - View GitHub issue for a given repository and organization.
 options:

--- a/plugins/modules/github_key.py
+++ b/plugins/modules/github_key.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: github_key
-short_description: Manage GitHub access keys.
+short_description: Manage GitHub access keys
 description:
     - Creates, removes, or updates GitHub access keys.
 options:

--- a/plugins/modules/gitlab_deploy_key.py
+++ b/plugins/modules/gitlab_deploy_key.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: gitlab_deploy_key
-short_description: Manages GitLab project deploy keys.
+short_description: Manages GitLab project deploy keys
 description:
   - Adds, updates and removes project deploy keys
 author:

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: gitlab_hook
-short_description: Manages GitLab project hooks.
+short_description: Manages GitLab project hooks
 description:
   - Adds, updates and removes project hook
 author:

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: gitlab_runner
-short_description: Create, modify and delete GitLab Runners.
+short_description: Create, modify and delete GitLab Runners
 description:
   - Register, update and delete runners with the GitLab API.
   - All operations are performed using the GitLab API v4.

--- a/plugins/modules/gunicorn.py
+++ b/plugins/modules/gunicorn.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: gunicorn
-short_description: Run gunicorn with various settings.
+short_description: Run gunicorn with various settings
 description:
      - Starts gunicorn with the parameters specified. Common settings for gunicorn
        configuration are supported. For additional configuration use a config file

--- a/plugins/modules/hipchat.py
+++ b/plugins/modules/hipchat.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: hipchat
-short_description: Send a message to Hipchat.
+short_description: Send a message to Hipchat
 description:
    - Send a message to a Hipchat room, with options to control the formatting.
 options:

--- a/plugins/modules/homebrew_tap.py
+++ b/plugins/modules/homebrew_tap.py
@@ -19,7 +19,7 @@ module: homebrew_tap
 author:
     - "Indrajit Raychaudhuri (@indrajitr)"
     - "Daniel Jaouen (@danieljaouen)"
-short_description: Tap a Homebrew repository.
+short_description: Tap a Homebrew repository
 description:
     - Tap external Homebrew repositories.
 options:

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: htpasswd
-short_description: manage user files for basic authentication
+short_description: Manage user files for basic authentication
 description:
   - Add and remove username/password entries in a password file using htpasswd.
   - This is used by web servers such as Apache and Nginx for basic authentication.

--- a/plugins/modules/ibm_sa_host.py
+++ b/plugins/modules/ibm_sa_host.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ibm_sa_host
-short_description: Adds hosts to or removes them from IBM Spectrum Accelerate Family storage systems.
+short_description: Adds hosts to or removes them from IBM Spectrum Accelerate Family storage systems
 
 description:
     - "This module adds hosts to or removes them from IBM Spectrum Accelerate Family storage systems."

--- a/plugins/modules/ibm_sa_host_ports.py
+++ b/plugins/modules/ibm_sa_host_ports.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ibm_sa_host_ports
-short_description: Add host ports on IBM Spectrum Accelerate Family storage systems.
+short_description: Add host ports on IBM Spectrum Accelerate Family storage systems
 
 description:
     - "This module adds ports to or removes them from the hosts

--- a/plugins/modules/ibm_sa_pool.py
+++ b/plugins/modules/ibm_sa_pool.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ibm_sa_pool
-short_description: Handles pools on IBM Spectrum Accelerate Family storage systems.
+short_description: Handles pools on IBM Spectrum Accelerate Family storage systems
 
 description:
     - "This module creates or deletes pools to be used on IBM Spectrum Accelerate Family storage systems"

--- a/plugins/modules/ibm_sa_vol.py
+++ b/plugins/modules/ibm_sa_vol.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ibm_sa_vol
-short_description: Handle volumes on IBM Spectrum Accelerate Family storage systems.
+short_description: Handle volumes on IBM Spectrum Accelerate Family storage systems
 
 description:
     - "This module creates or deletes volumes to be used on IBM Spectrum Accelerate Family storage systems."

--- a/plugins/modules/ibm_sa_vol_map.py
+++ b/plugins/modules/ibm_sa_vol_map.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ibm_sa_vol_map
-short_description: Handles volume mapping on IBM Spectrum Accelerate Family storage systems.
+short_description: Handles volume mapping on IBM Spectrum Accelerate Family storage systems
 
 description:
     - "This module maps volumes to or unmaps them from the hosts on

--- a/plugins/modules/ipa_subca.py
+++ b/plugins/modules/ipa_subca.py
@@ -11,7 +11,7 @@ DOCUMENTATION = r'''
 ---
 module: ipa_subca
 author: Abhijeet Kasurde (@Akasurde)
-short_description: Manage FreeIPA Lightweight Sub Certificate Authorities.
+short_description: Manage FreeIPA Lightweight Sub Certificate Authorities
 description:
 - Add, modify, enable, disable and delete an IPA Lightweight Sub Certificate Authorities using IPA API.
 options:

--- a/plugins/modules/jira.py
+++ b/plugins/modules/jira.py
@@ -16,7 +16,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 module: jira
-short_description: create and modify issues in a JIRA instance
+short_description: Create and modify issues in a JIRA instance
 description:
   - Create and modify issues in a JIRA instance.
 

--- a/plugins/modules/ldap_entry.py
+++ b/plugins/modules/ldap_entry.py
@@ -14,7 +14,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ldap_entry
-short_description: Add or remove LDAP entries.
+short_description: Add or remove LDAP entries
 description:
   - Add or remove LDAP entries. This module only asserts the existence or
     non-existence of an LDAP entry, not its attributes. To assert the

--- a/plugins/modules/ldap_passwd.py
+++ b/plugins/modules/ldap_passwd.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ldap_passwd
-short_description: Set passwords in LDAP.
+short_description: Set passwords in LDAP
 description:
   - Set a password for an LDAP entry.  This module only asserts that
     a given password is valid for a given entry.  To assert the

--- a/plugins/modules/librato_annotation.py
+++ b/plugins/modules/librato_annotation.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: librato_annotation
-short_description: create an annotation in librato
+short_description: Create an annotation in librato
 description:
     - Create an annotation event on the given annotation stream :name. If the annotation stream does not exist, it will be created automatically
 author: "Seth Edwards (@Sedward)"

--- a/plugins/modules/linode_v4.py
+++ b/plugins/modules/linode_v4.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: linode_v4
-short_description: Manage instances on the Linode cloud.
+short_description: Manage instances on the Linode cloud
 description: Manage instances on the Linode cloud.
 requirements:
   - python >= 2.7

--- a/plugins/modules/listen_ports_facts.py
+++ b/plugins/modules/listen_ports_facts.py
@@ -18,7 +18,7 @@ description:
     - This module currently supports Linux only.
 requirements:
   - netstat or ss
-short_description: Gather facts on processes listening on TCP and UDP ports.
+short_description: Gather facts on processes listening on TCP and UDP ports
 notes:
   - |
     C(ss) returns all processes for each listen address and port.

--- a/plugins/modules/lldp.py
+++ b/plugins/modules/lldp.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 ---
 module: lldp
 requirements: [ lldpctl ]
-short_description: get details reported by lldp
+short_description: Get details reported by lldp
 description:
   - Reads data out of lldpctl
 options: {}

--- a/plugins/modules/logentries_msg.py
+++ b/plugins/modules/logentries_msg.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: logentries_msg
-short_description: Send a message to logentries.
+short_description: Send a message to logentries
 description:
    - Send a message to logentries
 requirements:

--- a/plugins/modules/manageiq_group.py
+++ b/plugins/modules/manageiq_group.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 
 module: manageiq_group
 
-short_description: Management of groups in ManageIQ.
+short_description: Management of groups in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 

--- a/plugins/modules/manageiq_policies.py
+++ b/plugins/modules/manageiq_policies.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 
 module: manageiq_policies
 
-short_description: Management of resource policy_profiles in ManageIQ.
+short_description: Management of resource policy_profiles in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 

--- a/plugins/modules/manageiq_provider.py
+++ b/plugins/modules/manageiq_provider.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: manageiq_provider
-short_description: Management of provider in ManageIQ.
+short_description: Management of provider in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 

--- a/plugins/modules/manageiq_tags.py
+++ b/plugins/modules/manageiq_tags.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 
 module: manageiq_tags
 
-short_description: Management of resource tags in ManageIQ.
+short_description: Management of resource tags in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 

--- a/plugins/modules/manageiq_tenant.py
+++ b/plugins/modules/manageiq_tenant.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 
 module: manageiq_tenant
 
-short_description: Management of tenants in ManageIQ.
+short_description: Management of tenants in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 

--- a/plugins/modules/manageiq_user.py
+++ b/plugins/modules/manageiq_user.py
@@ -12,7 +12,7 @@ DOCUMENTATION = '''
 
 module: manageiq_user
 
-short_description: Management of users in ManageIQ.
+short_description: Management of users in ManageIQ
 extends_documentation_fragment:
 - community.general.manageiq
 


### PR DESCRIPTION
##### SUMMARY
Massively updated the `short_description` field in modules' docs, capitalizing the first letter of the text and removing the period `.` from the end.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/ali_instance.py
plugins/modules/ali_instance_info.py
plugins/modules/apache2_module.py
plugins/modules/apt_rpm.py
plugins/modules/beadm.py
plugins/modules/circonus_annotation.py
plugins/modules/clc_aa_policy.py
plugins/modules/clc_alert_policy.py
plugins/modules/clc_blueprint_package.py
plugins/modules/clc_loadbalancer.py
plugins/modules/clc_modify_server.py
plugins/modules/clc_publicip.py
plugins/modules/clc_server.py
plugins/modules/clc_server_snapshot.py
plugins/modules/cloud_init_data_facts.py
plugins/modules/consul.py
plugins/modules/cpanm.py
plugins/modules/deploy_helper.py
plugins/modules/dimensiondata_vlan.py
plugins/modules/dnsmadeeasy.py
plugins/modules/github_deploy_key.py
plugins/modules/github_issue.py
plugins/modules/github_key.py
plugins/modules/gitlab_deploy_key.py
plugins/modules/gitlab_hook.py
plugins/modules/gitlab_runner.py
plugins/modules/gunicorn.py
plugins/modules/hipchat.py
plugins/modules/homebrew_tap.py
plugins/modules/htpasswd.py
plugins/modules/ibm_sa_host.py
plugins/modules/ibm_sa_host_ports.py
plugins/modules/ibm_sa_pool.py
plugins/modules/ibm_sa_vol.py
plugins/modules/ibm_sa_vol_map.py
plugins/modules/ipa_subca.py
plugins/modules/jira.py
plugins/modules/ldap_entry.py
plugins/modules/ldap_passwd.py
plugins/modules/librato_annotation.py
plugins/modules/linode_v4.py
plugins/modules/listen_ports_facts.py
plugins/modules/lldp.py
plugins/modules/logentries_msg.py
plugins/modules/manageiq_group.py
plugins/modules/manageiq_policies.py
plugins/modules/manageiq_provider.py
plugins/modules/manageiq_tags.py
plugins/modules/manageiq_tenant.py
plugins/modules/manageiq_user.py
