### PR TITLE
Actually sort the fixtures

### DIFF
--- a/tests/unit/plugins/lookup/onepassword/test_onepassword.py
+++ b/tests/unit/plugins/lookup/onepassword/test_onepassword.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import operator
 import itertools
 import json
 import pytest
@@ -158,7 +159,7 @@ def test_op_get_field(mocker, op_fixture, output, expected, request):
     ("cli_class", "vault", "queries", "kwargs", "output", "expected"),
     (
         (_cli_class, item["vault_name"], item["queries"], item.get("kwargs", {}), item["output"], item["expected"])
-        for _cli_class in sorted(MOCK_ENTRIES)
+        for _cli_class in sorted(MOCK_ENTRIES, key=operator.attrgetter("__name__"))
         for item in MOCK_ENTRIES[_cli_class]
     )
 )

--- a/tests/unit/plugins/lookup/onepassword/test_onepassword.py
+++ b/tests/unit/plugins/lookup/onepassword/test_onepassword.py
@@ -158,7 +158,7 @@ def test_op_get_field(mocker, op_fixture, output, expected, request):
     ("cli_class", "vault", "queries", "kwargs", "output", "expected"),
     (
         (_cli_class, item["vault_name"], item["queries"], item.get("kwargs", {}), item["output"], item["expected"])
-        for _cli_class in MOCK_ENTRIES
+        for _cli_class in sorted(MOCK_ENTRIES)
         for item in MOCK_ENTRIES[_cli_class]
     )
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I removed my more complicated fix but failed to actually put the `sorted()` call back in.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`tests/unit/plugins/lookup/onepassword/test_onepassword.py`