### PR TITLE
onepassword_raw - Add missing parameter to doc string

### DIFF
--- a/changelogs/fragments/5506-onepassword_raw-missing-param.yml
+++ b/changelogs/fragments/5506-onepassword_raw-missing-param.yml
@@ -1,2 +1,2 @@
 bugfixes:
-   - onepassword_raw - add missing parameter to plugin documentation (https://github.com/ansible-collections/community.general/issues/5506)
+   - onepassword_raw - add missing parameter to plugin documentation (https://github.com/ansible-collections/community.general/issues/5506).

--- a/changelogs/fragments/5506-onepassword_raw-missing-param.yml
+++ b/changelogs/fragments/5506-onepassword_raw-missing-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+   - onepassword_raw - add missing parameter to plugin documentation (https://github.com/ansible-collections/community.general/issues/5506)

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -32,7 +32,7 @@ DOCUMENTATION = '''
       section:
         description: Item section containing the field to retrieve (case-insensitive). If absent will return first match from any section.
       domain:
-        description: Domain of 1Password. Default is U(1password.com).
+        description: Domain of 1Password.
         version_added: 3.2.0
         default: '1password.com'
         type: str

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -31,7 +31,7 @@ DOCUMENTATION = '''
       subdomain:
         description: The 1Password subdomain to authenticate against.
       domain:
-        description: Domain of 1Password. Default is U(1password.com).
+        description: Domain of 1Password.
         version_added: 6.0.0
         default: '1password.com'
         type: str

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -30,6 +30,11 @@ DOCUMENTATION = '''
         description: Item section containing the field to retrieve (case-insensitive). If absent will return first match from any section.
       subdomain:
         description: The 1Password subdomain to authenticate against.
+      domain:
+        description: Domain of 1Password. Default is U(1password.com).
+        version_added: 6.0.0
+        default: '1password.com'
+        type: str
       username:
         description: The username used to sign in.
       secret_key:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #5506 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/lookup/onepassword_raw.py`

##### ADDITIONAL INFORMATION
This might fail sanity tests since the version_added is 6.0.0 which is already release. Though I'm curious how this passed sanity tests originally...