### PR TITLE
Fix a logical flaw when deleting a build in the jenkins_build module

### DIFF
--- a/changelogs/fragments/5514-fix-logical-flaw-when-deleting-jenkins-build.yml
+++ b/changelogs/fragments/5514-fix-logical-flaw-when-deleting-jenkins-build.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - jenkins_build - fix the logical flaw when deleting a Jenkins build (https://github.com/ansible-collections/community.general/pull/5514).

--- a/plugins/modules/jenkins_build.py
+++ b/plugins/modules/jenkins_build.py
@@ -183,7 +183,10 @@ class JenkinsBuild:
         try:
             response = self.server.get_build_info(self.name, self.build_number)
             return response
-
+        except jenkins.JenkinsException as e:
+            response = {}
+            response["result"] = "ABSENT"
+            return response
         except Exception as e:
             self.module.fail_json(msg='Unable to fetch build information, %s' % to_native(e),
                                   exception=traceback.format_exc())
@@ -229,6 +232,9 @@ class JenkinsBuild:
             self.get_result()
         else:
             if self.state == "stopped" and build_status['result'] == "ABORTED":
+                result['changed'] = True
+                result['build_info'] = build_status
+            elif self.state == "absent" and build_status['result'] == "ABSENT":
                 result['changed'] = True
                 result['build_info'] = build_status
             elif build_status['result'] == "SUCCESS":

--- a/plugins/modules/jenkins_build.py
+++ b/plugins/modules/jenkins_build.py
@@ -237,7 +237,7 @@ class JenkinsBuild:
             elif self.state == "absent" and build_status['result'] == "ABSENT":
                 result['changed'] = True
                 result['build_info'] = build_status
-            elif build_status['result'] == "SUCCESS":
+            elif self.state != "absent" and build_status['result'] == "SUCCESS":
                 result['changed'] = True
                 result['build_info'] = build_status
             else:

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -12,9 +12,6 @@ from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules import jenkins_build
 
 import json
-import pytest
-
-jenkins = pytest.importorskip('jenkins')
 
 
 def set_module_args(args):
@@ -45,6 +42,12 @@ def fail_json(*args, **kwargs):
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
 
+class jenkins:
+    class JenkinsException(Exception):
+        pass
+
+    class NotFoundException(JenkinsException):
+        pass
 
 class JenkinsMock():
 

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -194,7 +194,7 @@ class TestJenkinsBuild(unittest.TestCase):
     def test_module_delete_build(self, build_status, jenkins_connection, test_deps):
         test_deps.return_value = None
         jenkins_connection.return_value = JenkinsMock()
-        build_status.return_value = JenkinsBuildMock()
+        build_status.return_value = JenkinsBuildMock().get_build_status()
 
         with self.assertRaises(AnsibleExitJson):
             set_module_args({

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -54,7 +54,8 @@ class jenkins:
 class JenkinsBuildMock():
     def get_build_status(self):
         try:
-            response = JenkinsMock.get_build_info('host-delete', 1234)
+            instance = JenkinsMock()
+            response = JenkinsMock.get_build_info(instance, 'host-delete', 1234)
             return response
         except jenkins.JenkinsException as e:
             response = {}

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -54,7 +54,7 @@ class jenkins:
 class JenkinsBuildMock():
     def get_build_status(self):
         try:
-            response = self.server.get_build_info(self.name, self.build_number)
+            response = JenkinsMock.get_build_info(self.name, self.build_number)
             return response
         except jenkins.JenkinsException as e:
             response = {}

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -42,12 +42,14 @@ def fail_json(*args, **kwargs):
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
 
+
 class jenkins:
     class JenkinsException(Exception):
         pass
 
     class NotFoundException(JenkinsException):
         pass
+
 
 class JenkinsMock():
 
@@ -63,6 +65,17 @@ class JenkinsMock():
             "building": True,
             "result": "SUCCESS"
         }
+
+    def get_build_status(self):
+        try:
+            response = self.get_build_info(self.name, self.build_number)
+            return response
+        except jenkins.JenkinsException as e:
+            response = {}
+            response["result"] = "ABSENT"
+            return response
+        except Exception as e:
+            fail_json(msg='Unable to fetch build information')
 
     def build_job(self, *args):
         return None
@@ -86,6 +99,17 @@ class JenkinsMockIdempotent():
             "building": False,
             "result": "ABORTED"
         }
+
+    def get_build_status(self):
+        try:
+            response = self.get_build_info(self.name, self.build_number)
+            return response
+        except jenkins.JenkinsException as e:
+            response = {}
+            response["result"] = "ABSENT"
+            return response
+        except Exception as e:
+            fail_json(msg='Unable to fetch build information')
 
     def build_job(self, *args):
         return None

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -54,7 +54,9 @@ class jenkins:
 class JenkinsBuildMock():
     def get_build_status(self):
         try:
-            response = JenkinsMock.get_build_info(self.name, self.build_number)
+            job_name = self.name
+            build_num = self.build_number
+            response = JenkinsMock.get_build_info(job_name, build_num)
             return response
         except jenkins.JenkinsException as e:
             response = {}

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -12,7 +12,9 @@ from ansible.module_utils.common.text.converters import to_bytes
 from ansible_collections.community.general.plugins.modules import jenkins_build
 
 import json
-import jenkins
+import pytest
+
+jenkins = pytest.importorskip('jenkins')
 
 
 def set_module_args(args):

--- a/tests/unit/plugins/modules/test_jenkins_build.py
+++ b/tests/unit/plugins/modules/test_jenkins_build.py
@@ -54,9 +54,7 @@ class jenkins:
 class JenkinsBuildMock():
     def get_build_status(self):
         try:
-            job_name = self.name
-            build_num = self.build_number
-            response = JenkinsMock.get_build_info(job_name, build_num)
+            response = JenkinsMock.get_build_info('host-delete', 1234)
             return response
         except jenkins.JenkinsException as e:
             response = {}

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -44,3 +44,6 @@ elastic-apm ; python_version >= '3.6'
 
 # requirements for scaleway modules
 passlib[argon2]
+
+# requirements for jenkins modules
+python-jenkins >= 0.4.12

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -44,6 +44,3 @@ elastic-apm ; python_version >= '3.6'
 
 # requirements for scaleway modules
 passlib[argon2]
-
-# requirements for jenkins modules
-python-jenkins >= 0.4.12


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
At present, after deleting a Jenkins build, the code tries to get the build status of the Jenkins build then judge the success/failure of the deletion. When the Jenkins build is successfully deleted, supposedly Jenkins will throw a jenkins.JenkinsException when fetching the build status, but currently the get_build_status() function will catch the exception then directly return a failure json which is a logical flaw.

Considering that deleting an already non-existent build can throw exceptions in the absent_build() function, I plan to adjust the judging logic in the get_build_status() and the get_result() function to fix this logical flaw in identifying the result of deleting an existing Jenkins build.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jenkins_build
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
