### PR TITLE
Short descriptions (batch3) - massive fix on Capitalization and trailing period

### DIFF
--- a/plugins/modules/pulp_repo.py
+++ b/plugins/modules/pulp_repo.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
 ---
 module: pulp_repo
 author: "Joe Adams (@sysadmind)"
-short_description: Add or remove Pulp repos from a remote host.
+short_description: Add or remove Pulp repos from a remote host
 description:
   - Add or remove Pulp repos from a remote host.
   - Note, this is for Pulp 2 only.

--- a/plugins/modules/rax.py
+++ b/plugins/modules/rax.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax
-short_description: create / delete an instance in Rackspace Public Cloud
+short_description: Create / delete an instance in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud instance and optionally
        waits for it to be 'running'.

--- a/plugins/modules/rax_cdb.py
+++ b/plugins/modules/rax_cdb.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_cdb
-short_description: create/delete or resize a Rackspace Cloud Databases instance
+short_description: Create/delete or resize a Rackspace Cloud Databases instance
 description:
   - creates / deletes or resize a Rackspace Cloud Databases instance
     and optionally waits for it to be 'running'. The name option needs to be

--- a/plugins/modules/rax_cdb_database.py
+++ b/plugins/modules/rax_cdb_database.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: rax_cdb_database
-short_description: 'create / delete a database in the Cloud Databases'
+short_description: Create / delete a database in the Cloud Databases
 description:
   - create / delete a database in the Cloud Databases.
 options:

--- a/plugins/modules/rax_cdb_user.py
+++ b/plugins/modules/rax_cdb_user.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_cdb_user
-short_description: create / delete a Rackspace Cloud Database
+short_description: Create / delete a Rackspace Cloud Database
 description:
   - create / delete a database in the Cloud Databases.
 options:

--- a/plugins/modules/rax_clb.py
+++ b/plugins/modules/rax_clb.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_clb
-short_description: create / delete a load balancer in Rackspace Public Cloud
+short_description: Create / delete a load balancer in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud load balancer.
 options:

--- a/plugins/modules/rax_clb_nodes.py
+++ b/plugins/modules/rax_clb_nodes.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_clb_nodes
-short_description: add, modify and remove nodes from a Rackspace Cloud Load Balancer
+short_description: Add, modify and remove nodes from a Rackspace Cloud Load Balancer
 description:
   - Adds, modifies and removes nodes from a Rackspace Cloud Load Balancer
 options:

--- a/plugins/modules/rax_clb_ssl.py
+++ b/plugins/modules/rax_clb_ssl.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: rax_clb_ssl
-short_description: Manage SSL termination for a Rackspace Cloud Load Balancer.
+short_description: Manage SSL termination for a Rackspace Cloud Load Balancer
 description:
 - Set up, reconfigure, or remove SSL termination for an existing load balancer.
 options:

--- a/plugins/modules/rax_mon_alarm.py
+++ b/plugins/modules/rax_mon_alarm.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_mon_alarm
-short_description: Create or delete a Rackspace Cloud Monitoring alarm.
+short_description: Create or delete a Rackspace Cloud Monitoring alarm
 description:
 - Create or delete a Rackspace Cloud Monitoring alarm that associates an
   existing rax_mon_entity, rax_mon_check, and rax_mon_notification_plan with

--- a/plugins/modules/rax_mon_notification.py
+++ b/plugins/modules/rax_mon_notification.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_mon_notification
-short_description: Create or delete a Rackspace Cloud Monitoring notification.
+short_description: Create or delete a Rackspace Cloud Monitoring notification
 description:
 - Create or delete a Rackspace Cloud Monitoring notification that specifies a
   channel that can be used to communicate alarms, such as email, webhooks, or

--- a/plugins/modules/rax_network.py
+++ b/plugins/modules/rax_network.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_network
-short_description: create / delete an isolated network in Rackspace Public Cloud
+short_description: Create / delete an isolated network in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud isolated network.
 options:

--- a/plugins/modules/rax_queue.py
+++ b/plugins/modules/rax_queue.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rax_queue
-short_description: create / delete a queue in Rackspace Public Cloud
+short_description: Create / delete a queue in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud queue.
 options:

--- a/plugins/modules/rundeck_acl_policy.py
+++ b/plugins/modules/rundeck_acl_policy.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: rundeck_acl_policy
 
-short_description: Manage Rundeck ACL policies.
+short_description: Manage Rundeck ACL policies
 description:
     - Create, update and remove Rundeck ACL policies through HTTP API.
 author: "Loic Blot (@nerzhul)"

--- a/plugins/modules/rundeck_project.py
+++ b/plugins/modules/rundeck_project.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
 ---
 module: rundeck_project
 
-short_description: Manage Rundeck projects.
+short_description: Manage Rundeck projects
 description:
     - Create and remove Rundeck projects through HTTP API.
 author: "Loic Blot (@nerzhul)"

--- a/plugins/modules/say.py
+++ b/plugins/modules/say.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: say
-short_description: Makes a computer to speak.
+short_description: Makes a computer to speak
 description:
    - makes a computer speak! Amuse your friends, annoy your coworkers!
 notes:

--- a/plugins/modules/scaleway_image_info.py
+++ b/plugins/modules/scaleway_image_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_image_info
-short_description: Gather information about the Scaleway images available.
+short_description: Gather information about the Scaleway images available
 description:
   - Gather information about the Scaleway images available.
 author:

--- a/plugins/modules/scaleway_ip_info.py
+++ b/plugins/modules/scaleway_ip_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_ip_info
-short_description: Gather information about the Scaleway ips available.
+short_description: Gather information about the Scaleway ips available
 description:
   - Gather information about the Scaleway ips available.
 author:

--- a/plugins/modules/scaleway_organization_info.py
+++ b/plugins/modules/scaleway_organization_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_organization_info
-short_description: Gather information about the Scaleway organizations available.
+short_description: Gather information about the Scaleway organizations available
 description:
   - Gather information about the Scaleway organizations available.
 author:

--- a/plugins/modules/scaleway_security_group_info.py
+++ b/plugins/modules/scaleway_security_group_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_security_group_info
-short_description: Gather information about the Scaleway security groups available.
+short_description: Gather information about the Scaleway security groups available
 description:
   - Gather information about the Scaleway security groups available.
 author:

--- a/plugins/modules/scaleway_server_info.py
+++ b/plugins/modules/scaleway_server_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_server_info
-short_description: Gather information about the Scaleway servers available.
+short_description: Gather information about the Scaleway servers available
 description:
   - Gather information about the Scaleway servers available.
 author:

--- a/plugins/modules/scaleway_snapshot_info.py
+++ b/plugins/modules/scaleway_snapshot_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_snapshot_info
-short_description: Gather information about the Scaleway snapshots available.
+short_description: Gather information about the Scaleway snapshots available
 description:
   - Gather information about the Scaleway snapshot available.
 author:

--- a/plugins/modules/scaleway_volume_info.py
+++ b/plugins/modules/scaleway_volume_info.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: scaleway_volume_info
-short_description: Gather information about the Scaleway volumes available.
+short_description: Gather information about the Scaleway volumes available
 description:
   - Gather information about the Scaleway volumes available.
 author:

--- a/plugins/modules/sl_vm.py
+++ b/plugins/modules/sl_vm.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: sl_vm
-short_description: create or cancel a virtual instance in SoftLayer
+short_description: Create or cancel a virtual instance in SoftLayer
 description:
   - Creates or cancels SoftLayer instances.
   - When created, optionally waits for it to be 'running'.

--- a/plugins/modules/smartos_image_info.py
+++ b/plugins/modules/smartos_image_info.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: smartos_image_info
-short_description: Get SmartOS image details.
+short_description: Get SmartOS image details
 description:
     - Retrieve information about all installed images on SmartOS.
     - This module was called C(smartos_image_facts) before Ansible 2.9, returning C(ansible_facts).

--- a/plugins/modules/spectrum_device.py
+++ b/plugins/modules/spectrum_device.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: spectrum_device
-short_description: Creates/deletes devices in CA Spectrum.
+short_description: Creates/deletes devices in CA Spectrum
 description:
    - This module allows you to create and delete devices in CA Spectrum U(https://www.ca.com/us/products/ca-spectrum.html).
    - Tested on CA Spectrum 9.4.2, 10.1.1 and 10.2.1

--- a/plugins/modules/spectrum_model_attrs.py
+++ b/plugins/modules/spectrum_model_attrs.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: spectrum_model_attrs
-short_description: Enforce a model's attributes in CA Spectrum.
+short_description: Enforce a model's attributes in CA Spectrum
 description:
     - This module can be used to enforce a model's attributes in CA Spectrum.
 version_added: 2.5.0

--- a/plugins/modules/svc.py
+++ b/plugins/modules/svc.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 module: svc
 author:
 - Brian Coca (@bcoca)
-short_description:  Manage daemontools services
+short_description: Manage daemontools services
 description:
     - Controls daemontools services on remote hosts using the svc utility.
 options:

--- a/plugins/modules/swupd.py
+++ b/plugins/modules/swupd.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: swupd
-short_description: Manages updates and bundles in ClearLinux systems.
+short_description: Manages updates and bundles in ClearLinux systems
 description:
   - Manages updates and bundles with the swupd bundle manager, which is used by the
     Clear Linux Project for Intel Architecture.

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -16,7 +16,7 @@ author:
  - "Artem Feofanov (@tyouxa)"
  - "Nikolai Lomov (@lomserman)"
 
-short_description: Module for sending notifications via telegram
+short_description: Send notifications via telegram
 
 description:
     - Send notifications via telegram bot, to a verified group or user.

--- a/plugins/modules/telegram.py
+++ b/plugins/modules/telegram.py
@@ -16,7 +16,7 @@ author:
  - "Artem Feofanov (@tyouxa)"
  - "Nikolai Lomov (@lomserman)"
 
-short_description: module for sending notifications via telegram
+short_description: Module for sending notifications via telegram
 
 description:
     - Send notifications via telegram bot, to a verified group or user.

--- a/plugins/modules/twilio.py
+++ b/plugins/modules/twilio.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: twilio
-short_description: Sends a text message to a mobile phone through Twilio.
+short_description: Sends a text message to a mobile phone through Twilio
 description:
    - Sends a text message to a phone number through the Twilio messaging API.
 notes:

--- a/plugins/modules/utm_aaa_group.py
+++ b/plugins/modules/utm_aaa_group.py
@@ -15,7 +15,7 @@ module: utm_aaa_group
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: Create, update or destroy an aaa group object in Sophos UTM.
+short_description: Create, update or destroy an aaa group object in Sophos UTM
 
 description:
     - Create, update or destroy an aaa group object in Sophos UTM.

--- a/plugins/modules/utm_aaa_group_info.py
+++ b/plugins/modules/utm_aaa_group_info.py
@@ -17,7 +17,7 @@ module: utm_aaa_group_info
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: get info for reverse_proxy frontend entry in Sophos UTM
+short_description: Get info for reverse_proxy frontend entry in Sophos UTM
 
 description:
     - get info for a reverse_proxy frontend entry in SOPHOS UTM.

--- a/plugins/modules/utm_ca_host_key_cert.py
+++ b/plugins/modules/utm_ca_host_key_cert.py
@@ -16,7 +16,7 @@ module: utm_ca_host_key_cert
 author:
     - Stephan Schwarz (@stearz)
 
-short_description: create, update or destroy ca host_key_cert entry in Sophos UTM
+short_description: Create, update or destroy ca host_key_cert entry in Sophos UTM
 
 description:
     - Create, update or destroy a ca host_key_cert entry in SOPHOS UTM.

--- a/plugins/modules/utm_dns_host.py
+++ b/plugins/modules/utm_dns_host.py
@@ -15,7 +15,7 @@ module: utm_dns_host
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: create, update or destroy dns entry in Sophos UTM
+short_description: Create, update or destroy dns entry in Sophos UTM
 
 description:
     - Create, update or destroy a dns entry in SOPHOS UTM.

--- a/plugins/modules/utm_proxy_auth_profile.py
+++ b/plugins/modules/utm_proxy_auth_profile.py
@@ -16,7 +16,7 @@ module: utm_proxy_auth_profile
 author:
     - Stephan Schwarz (@stearz)
 
-short_description: create, update or destroy reverse_proxy auth_profile entry in Sophos UTM
+short_description: Create, update or destroy reverse_proxy auth_profile entry in Sophos UTM
 
 description:
     - Create, update or destroy a reverse_proxy auth_profile entry in SOPHOS UTM.

--- a/plugins/modules/utm_proxy_frontend.py
+++ b/plugins/modules/utm_proxy_frontend.py
@@ -16,7 +16,7 @@ module: utm_proxy_frontend
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: create, update or destroy reverse_proxy frontend entry in Sophos UTM
+short_description: Create, update or destroy reverse_proxy frontend entry in Sophos UTM
 
 description:
     - Create, update or destroy a reverse_proxy frontend entry in Sophos UTM.

--- a/plugins/modules/utm_proxy_frontend_info.py
+++ b/plugins/modules/utm_proxy_frontend_info.py
@@ -16,7 +16,7 @@ module: utm_proxy_frontend_info
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: create, update or destroy reverse_proxy frontend entry in Sophos UTM
+short_description: Create, update or destroy reverse_proxy frontend entry in Sophos UTM
 
 description:
     - Create, update or destroy a reverse_proxy frontend entry in SOPHOS UTM.

--- a/plugins/modules/utm_proxy_location.py
+++ b/plugins/modules/utm_proxy_location.py
@@ -16,7 +16,7 @@ module: utm_proxy_location
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: create, update or destroy reverse_proxy location entry in Sophos UTM
+short_description: Create, update or destroy reverse_proxy location entry in Sophos UTM
 
 description:
     - Create, update or destroy a reverse_proxy location entry in SOPHOS UTM.

--- a/plugins/modules/utm_proxy_location_info.py
+++ b/plugins/modules/utm_proxy_location_info.py
@@ -16,7 +16,7 @@ module: utm_proxy_location_info
 author:
     - Johannes Brunswicker (@MatrixCrawler)
 
-short_description: create, update or destroy reverse_proxy location entry in Sophos UTM
+short_description: Create, update or destroy reverse_proxy location entry in Sophos UTM
 
 description:
     - Create, update or destroy a reverse_proxy location entry in SOPHOS UTM.

--- a/plugins/modules/vertica_configuration.py
+++ b/plugins/modules/vertica_configuration.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vertica_configuration
-short_description: Updates Vertica configuration parameters.
+short_description: Updates Vertica configuration parameters
 description:
     - Updates Vertica configuration parameters.
 options:

--- a/plugins/modules/vertica_info.py
+++ b/plugins/modules/vertica_info.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vertica_info
-short_description: Gathers Vertica database facts.
+short_description: Gathers Vertica database facts
 description:
   - Gathers Vertica database information.
   - This module was called C(vertica_facts) before Ansible 2.9, returning C(ansible_facts).

--- a/plugins/modules/vertica_role.py
+++ b/plugins/modules/vertica_role.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vertica_role
-short_description: Adds or removes Vertica database roles and assigns roles to them.
+short_description: Adds or removes Vertica database roles and assigns roles to them
 description:
   - Adds or removes Vertica database role and, optionally, assign other roles.
 options:

--- a/plugins/modules/vertica_schema.py
+++ b/plugins/modules/vertica_schema.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vertica_schema
-short_description: Adds or removes Vertica database schema and roles.
+short_description: Adds or removes Vertica database schema and roles
 description:
   - Adds or removes Vertica database schema and, optionally, roles
     with schema access privileges.

--- a/plugins/modules/vertica_user.py
+++ b/plugins/modules/vertica_user.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vertica_user
-short_description: Adds or removes Vertica database users and assigns roles.
+short_description: Adds or removes Vertica database users and assigns roles
 description:
   - Adds or removes Vertica database user and, optionally, assigns roles.
   - A user will not be removed until all the dependencies have been dropped.

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: vmadm
-short_description: Manage SmartOS virtual machines and zones.
+short_description: Manage SmartOS virtual machines and zones
 description:
   - Manage SmartOS virtual machines through vmadm(1M).
 author: Jasper Lievisse Adriaanse (@jasperla)

--- a/plugins/modules/xenserver_facts.py
+++ b/plugins/modules/xenserver_facts.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: xenserver_facts
-short_description: get facts reported on xenserver
+short_description: Get facts reported on xenserver
 description:
   - Reads data out of XenAPI, can be used instead of multiple xe commands.
 author:

--- a/plugins/modules/zfs_facts.py
+++ b/plugins/modules/zfs_facts.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: zfs_facts
-short_description: Gather facts about ZFS datasets.
+short_description: Gather facts about ZFS datasets
 description:
   - Gather facts from ZFS dataset properties.
 author: Adam Števko (@xen0l)

--- a/plugins/modules/zpool_facts.py
+++ b/plugins/modules/zpool_facts.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: zpool_facts
-short_description: Gather facts about ZFS pools.
+short_description: Gather facts about ZFS pools
 description:
   - Gather facts from ZFS pool properties.
 author: Adam Števko (@xen0l)


### PR DESCRIPTION
##### SUMMARY
Massively updated the `short_description` field in modules' docs, capitalizing the first letter of the text and removing the period `.` from the end.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/pulp_repo.py
plugins/modules/rax.py
plugins/modules/rax_cdb.py
plugins/modules/rax_cdb_database.py
plugins/modules/rax_cdb_user.py
plugins/modules/rax_clb.py
plugins/modules/rax_clb_nodes.py
plugins/modules/rax_clb_ssl.py
plugins/modules/rax_mon_alarm.py
plugins/modules/rax_mon_notification.py
plugins/modules/rax_network.py
plugins/modules/rax_queue.py
plugins/modules/rundeck_acl_policy.py
plugins/modules/rundeck_project.py
plugins/modules/say.py
plugins/modules/scaleway_image_info.py
plugins/modules/scaleway_ip_info.py
plugins/modules/scaleway_organization_info.py
plugins/modules/scaleway_security_group_info.py
plugins/modules/scaleway_server_info.py
plugins/modules/scaleway_snapshot_info.py
plugins/modules/scaleway_volume_info.py
plugins/modules/sl_vm.py
plugins/modules/smartos_image_info.py
plugins/modules/spectrum_device.py
plugins/modules/spectrum_model_attrs.py
plugins/modules/svc.py
plugins/modules/swupd.py
plugins/modules/telegram.py
plugins/modules/twilio.py
plugins/modules/utm_aaa_group.py
plugins/modules/utm_aaa_group_info.py
plugins/modules/utm_ca_host_key_cert.py
plugins/modules/utm_dns_host.py
plugins/modules/utm_proxy_auth_profile.py
plugins/modules/utm_proxy_frontend.py
plugins/modules/utm_proxy_frontend_info.py
plugins/modules/utm_proxy_location.py
plugins/modules/utm_proxy_location_info.py
plugins/modules/vertica_configuration.py
plugins/modules/vertica_info.py
plugins/modules/vertica_role.py
plugins/modules/vertica_schema.py
plugins/modules/vertica_user.py
plugins/modules/vmadm.py
plugins/modules/xenserver_facts.py
plugins/modules/zfs_facts.py
plugins/modules/zpool_facts.py
