### PR TITLE
dependent lookup: prevent deprecation warning with ansible-core 2.14

### DIFF
--- a/changelogs/fragments/5543-dependent-template.yml
+++ b/changelogs/fragments/5543-dependent-template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dependent lookup plugin - avoid warning on deprecated parameter for ``Templar.template()`` (https://github.com/ansible-collections/community.general/pull/5543)."

--- a/plugins/lookup/dependent.py
+++ b/plugins/lookup/dependent.py
@@ -131,7 +131,9 @@ from ansible.template import Templar
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 
-_HAS_TEMPLATE_CACHE = LooseVersion(ansible_version) < LooseVersion('2.14.0')
+# Whether Templar has a cache, which can be controlled by Templar.template()'s cache option.
+# The cache was removed for ansible-core 2.14 (https://github.com/ansible/ansible/pull/78419)
+_TEMPLAR_HAS_TEMPLATE_CACHE = LooseVersion(ansible_version) < LooseVersion('2.14.0')
 
 
 class LookupModule(LookupBase):
@@ -143,7 +145,7 @@ class LookupModule(LookupBase):
         """
         templar.available_variables = variables or {}
         expression = "{0}{1}{2}".format("{{", expression, "}}")
-        if _HAS_TEMPLATE_CACHE:
+        if _TEMPLAR_HAS_TEMPLATE_CACHE:
             return templar.template(expression, cache=False)
         return templar.template(expression)
 

--- a/plugins/lookup/dependent.py
+++ b/plugins/lookup/dependent.py
@@ -125,7 +125,13 @@ from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six import string_types
 from ansible.plugins.lookup import LookupBase
+from ansible.release import __version__ as ansible_version
 from ansible.template import Templar
+
+from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
+
+
+_HAS_TEMPLATE_CACHE = LooseVersion(ansible_version) < LooseVersion('2.14.0')
 
 
 class LookupModule(LookupBase):
@@ -136,7 +142,10 @@ class LookupModule(LookupBase):
         ``variables`` are the variables to use.
         """
         templar.available_variables = variables or {}
-        return templar.template("{0}{1}{2}".format("{{", expression, "}}"), cache=False)
+        expression = "{0}{1}{2}".format("{{", expression, "}}")
+        if _HAS_TEMPLATE_CACHE:
+            return templar.template(expression, cache=False)
+        return templar.template(expression)
 
     def __process(self, result, terms, index, current, templar, variables):
         """Fills ``result`` list with evaluated items.


### PR DESCRIPTION
##### SUMMARY
```
[DEPRECATION WARNING]: The `cache` option to `Templar.template` is no longer functional, and will be removed in a future release. This feature will be removed in version 2.18. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dependent lookup
