### PR TITLE
java_certs : Not enough info on error

### DIFF
--- a/changelogs/fragments/5550-java_certs-not-enough-info-on-error.yml
+++ b/changelogs/fragments/5550-java_certs-not-enough-info-on-error.yml
@@ -1,2 +1,2 @@
 minor_changes:
-   - java_certs - add error output to json error structure.
+   - java_certs - add more detailed error output when extracting certificate from PKCS12 fails (https://github.com/ansible-collections/community.general/pull/5550).

--- a/changelogs/fragments/5550-java_certs-not-enough-info-on-error.yml
+++ b/changelogs/fragments/5550-java_certs-not-enough-info-on-error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+   - java_certs - add error output to json error structure.

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -281,7 +281,7 @@ def _export_public_cert_from_pkcs12(module, executable, pkcs_file, alias, passwo
     (export_rc, export_stdout, export_err) = module.run_command(export_cmd, data=password, check_rc=False)
 
     if export_rc != 0:
-        module.fail_json(msg="Internal module failure, cannot extract public certificate from pkcs12, message: %s" % export_stdout,
+        module.fail_json(msg="Internal module failure, cannot extract public certificate from PKCS12, message: %s" % export_stdout,
                          stderr=export_err,
                          rc=export_rc)
 

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -281,7 +281,8 @@ def _export_public_cert_from_pkcs12(module, executable, pkcs_file, alias, passwo
     (export_rc, export_stdout, export_err) = module.run_command(export_cmd, data=password, check_rc=False)
 
     if export_rc != 0:
-        module.fail_json(msg="Internal module failure, cannot extract public certificate from pkcs12, error: %s" % export_stdout,
+        module.fail_json(msg="Internal module failure, cannot extract public certificate from pkcs12, message: %s" % export_stdout,
+                         stderr=export_err,
                          rc=export_rc)
 
     with open(dest, 'w') as f:


### PR DESCRIPTION
##### SUMMARY
Just bumped into an issue when the message was `"Internal module failure, cannot extract public certificate from pkcs12, error: "` and found it not really helpfull.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
java_certs

##### ADDITIONAL INFORMATION
 Seems that the issue #2560 doesn't cover all cases, so to make debugging easier, I propose to add error output on json return instead of only expose standard output.
