### PR TITLE
redhat_subscription: improve wording wrt Satellite

### DIFF
--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -34,15 +34,15 @@ options:
         type: str
     username:
         description:
-            - access.redhat.com or Sat6 username
+            - access.redhat.com or Red Hat Satellite or Katello username
         type: str
     password:
         description:
-            - access.redhat.com or Sat6 password
+            - access.redhat.com or Red Hat Satellite or Katello password
         type: str
     server_hostname:
         description:
-            - Specify an alternative Red Hat Subscription Management or Sat6 server
+            - Specify an alternative Red Hat Subscription Management or Red Hat Satellite or Katello server
         type: str
     server_insecure:
         description:
@@ -50,12 +50,12 @@ options:
         type: str
     server_prefix:
         description:
-            - Specify the prefix when registering to the Red Hat Subscription Management or Sat6 server.
+            - Specify the prefix when registering to the Red Hat Subscription Management or Red Hat Satellite or Katello server.
         type: str
         version_added: 3.3.0
     server_port:
         description:
-            - Specify the port when registering to the Red Hat Subscription Management or Sat6 server.
+            - Specify the port when registering to the Red Hat Subscription Management or Red Hat Satellite or Katello server.
         type: str
         version_added: 3.3.0
     rhsm_baseurl:
@@ -98,7 +98,7 @@ options:
         type: str
     environment:
         description:
-            - Register with a specific environment in the destination org. Used with Red Hat Satellite 6.x or Katello
+            - Register with a specific environment in the destination org. Used with Red Hat Satellite or Katello
         type: str
     pool:
         description:
@@ -229,7 +229,7 @@ EXAMPLES = '''
     org_id: 222333444
     pool: '^Red Hat Enterprise Server$'
 
-- name: Register as user credentials into given environment (against Red Hat Satellite 6.x), and auto-subscribe.
+- name: Register as user credentials into given environment (against Red Hat Satellite or Katello), and auto-subscribe.
   community.general.redhat_subscription:
     state: present
     username: joe_user
@@ -397,7 +397,9 @@ class Rhsm(RegistrationBase):
                  rhsm_baseurl, server_insecure, server_hostname, server_proxy_hostname,
                  server_proxy_port, server_proxy_user, server_proxy_password, release):
         '''
-            Register the current system to the provided RHSM or Sat6 server
+            Register the current system to the provided RHSM or Red Hat Satellite
+            or Katello server
+
             Raises:
               * Exception - if error occurs while running command
         '''


### PR DESCRIPTION
##### SUMMARY

Do not mention an explicit version of Satellite for an environment to use; future versions of Satellite will support that, and older versions are long EOL.

Also mention Katello next to Red Hat Satellite.

Fixes #4152

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

redhat_subscription