### PR TITLE
redhat_subscription: drop unneeded args to `Rhsm.register()`

### DIFF
--- a/changelogs/fragments/5583-redhat_subscription-subscribe-parameters.yaml
+++ b/changelogs/fragments/5583-redhat_subscription-subscribe-parameters.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - redhat_subscription - do not pass arguments to ``subscription-manager register`` for things already configured; now a specified ``rhsm_baseurl`` is properly set for subscription-manager
+    (https://github.com/ansible-collections/community.general/pull/5583).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -394,8 +394,7 @@ class Rhsm(RegistrationBase):
 
     def register(self, username, password, auto_attach, activationkey, org_id,
                  consumer_type, consumer_name, consumer_id, force_register, environment,
-                 rhsm_baseurl, server_insecure, server_hostname, server_proxy_hostname,
-                 server_proxy_port, server_proxy_user, server_proxy_password, release):
+                 release):
         '''
             Register the current system to the provided RHSM or Red Hat Satellite
             or Katello server
@@ -409,26 +408,8 @@ class Rhsm(RegistrationBase):
         if force_register:
             args.extend(['--force'])
 
-        if rhsm_baseurl:
-            args.extend(['--baseurl', rhsm_baseurl])
-
-        if server_insecure:
-            args.extend(['--insecure'])
-
-        if server_hostname:
-            args.extend(['--serverurl', server_hostname])
-
         if org_id:
             args.extend(['--org', org_id])
-
-        if server_proxy_hostname and server_proxy_port:
-            args.extend(['--proxy', server_proxy_hostname + ':' + server_proxy_port])
-
-        if server_proxy_user:
-            args.extend(['--proxyuser', server_proxy_user])
-
-        if server_proxy_password:
-            args.extend(['--proxypassword', server_proxy_password])
 
         if activationkey:
             args.extend(['--activationkey', activationkey])
@@ -924,8 +905,7 @@ def main():
                 rhsm.configure(**module.params)
                 rhsm.register(username, password, auto_attach, activationkey, org_id,
                               consumer_type, consumer_name, consumer_id, force_register,
-                              environment, rhsm_baseurl, server_insecure, server_hostname,
-                              server_proxy_hostname, server_proxy_port, server_proxy_user, server_proxy_password, release)
+                              environment, release)
                 if syspurpose and 'sync' in syspurpose and syspurpose['sync'] is True:
                     rhsm.sync_syspurpose()
                 if pool_ids:

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -92,7 +92,6 @@ TEST_CASES = [
                 ),
                 (
                     ['/testbin/subscription-manager', 'register',
-                        '--serverurl', 'satellite.company.com',
                         '--username', 'admin',
                         '--password', 'admin'],
                     {'check_rc': True, 'expand_user_and_vars': False},
@@ -180,7 +179,6 @@ TEST_CASES = [
                     [
                         '/testbin/subscription-manager',
                         'register',
-                        '--serverurl', 'satellite.company.com',
                         '--org', 'admin',
                         '--activationkey', 'some-activation-key'
                     ],
@@ -340,9 +338,6 @@ TEST_CASES = [
                         'register',
                         '--force',
                         '--org', 'admin',
-                        '--proxy', 'proxy.company.com:12345',
-                        '--proxyuser', 'proxy_user',
-                        '--proxypassword', 'secret_proxy_password',
                         '--username', 'admin',
                         '--password', 'admin'
                     ],


### PR DESCRIPTION
##### SUMMARY

Stop passing all the `rhsm_`, and `server_` module arguments to `Rhsm.register()`, and thus as arguments for `subscription-manager register`:
- right before calling `Rhsm.register()`, `Rhsm.configure()` is called to configure subscription-manager with all the `rhsm_`, and `server_` arguments; hence, they are already configured
- the passed argument to `--serverurl` is partially wrong: `Rhsm.register()` passes only the hostname, whereas the other bits (port and prefix) are supported too; this "works" because port and prefix were already configured previously, and the lax parsing that subscription-manager does allows for missing bits
- the parsing done by subscription-manager for `--baseurl` strips out the URL scheme and always uses https: this means that specifying `rhsm_baseurl: http://server` as module parameter will be taken as `https://server` by subscription-manager; since `rhsm_baseurl` is already configured by `Rhsm.configure()`, this issue is gone

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

There should be no behaviour change for the module; the only change is when a http URL for `rhsm_baseurl` is specified, now it is really used as it is.