### PR TITLE
unixy Callback: Use Ansible's config manager

### DIFF
--- a/changelogs/fragments/5601-unixy-callback-use-config-manager.yml
+++ b/changelogs/fragments/5601-unixy-callback-use-config-manager.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - unixy callback plugin - fix plugin to work with ansible 2.14 by using Ansible's configuration manager for handling options (https://github.com/ansible-collections/community.general/issues/5600).
+  - unixy callback plugin - fix plugin to work with ansible-core 2.14 by using Ansible's configuration manager for handling options (https://github.com/ansible-collections/community.general/issues/5600).

--- a/changelogs/fragments/5601-unixy-callback-use-config-manager.yml
+++ b/changelogs/fragments/5601-unixy-callback-use-config-manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unixy callback plugin - fix plugin to work with ansible 2.14 by using Ansible's configuration manager for handling options (https://github.com/ansible-collections/community.general/issues/5600).

--- a/plugins/callback/unixy.py
+++ b/plugins/callback/unixy.py
@@ -63,7 +63,7 @@ class CallbackModule(CallbackModule_default):
 
     def _preprocess_result(self, result):
         self.delegated_vars = result._result.get('_ansible_delegated_vars', None)
-        self._handle_exception(result._result, use_stderr=self.display_failed_stderr)
+        self._handle_exception(result._result, use_stderr=self.get_option('display_failed_stderr'))
         self._handle_warnings(result._result)
 
     def _process_result_output(self, result, msg):
@@ -109,7 +109,7 @@ class CallbackModule(CallbackModule_default):
         self._display.display(msg)
 
     def v2_runner_on_skipped(self, result, ignore_errors=False):
-        if self.display_skipped_hosts:
+        if self.get_option('display_skipped_hosts'):
             self._preprocess_result(result)
             display_color = C.COLOR_SKIP
             msg = "skipped"
@@ -128,7 +128,7 @@ class CallbackModule(CallbackModule_default):
             msg += " | item: %s" % (item_value,)
 
         task_result = self._process_result_output(result, msg)
-        self._display.display("  " + task_result, display_color, stderr=self.display_failed_stderr)
+        self._display.display("  " + task_result, display_color, stderr=self.get_option('display_failed_stderr'))
 
     def v2_runner_on_ok(self, result, msg="ok", display_color=C.COLOR_OK):
         self._preprocess_result(result)
@@ -142,7 +142,7 @@ class CallbackModule(CallbackModule_default):
             display_color = C.COLOR_CHANGED
             task_result = self._process_result_output(result, msg)
             self._display.display("  " + task_result, display_color)
-        elif self.display_ok_hosts:
+        elif self.get('display_ok_hosts'):
             task_result = self._process_result_output(result, msg)
             self._display.display("  " + task_result, display_color)
 
@@ -162,7 +162,7 @@ class CallbackModule(CallbackModule_default):
         display_color = C.COLOR_UNREACHABLE
         task_result = self._process_result_output(result, msg)
 
-        self._display.display("  " + task_result, display_color, stderr=self.display_failed_stderr)
+        self._display.display("  " + task_result, display_color, stderr=self.get_option('display_failed_stderr'))
 
     def v2_on_file_diff(self, result):
         if result._task.loop and 'results' in result._result:
@@ -205,7 +205,7 @@ class CallbackModule(CallbackModule_default):
                 colorize(u'ignored', t['ignored'], None)),
                 log_only=True
             )
-        if stats.custom and self.show_custom_stats:
+        if stats.custom and self.get_option('show_custom_stats'):
             self._display.banner("CUSTOM STATS: ")
             # per host
             # TODO: come up with 'pretty format'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Start using Ansible's config manager in the unixy Callback plugin.

Fixes #5600

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`unixy`