### PR TITLE
Updated tags delimiter

### DIFF
--- a/changelogs/fragments/5602-proxmox-tags.yml
+++ b/changelogs/fragments/5602-proxmox-tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox inventory plugin - handle tags delimited by semicolon instead of comma, which happens from Proxmox 7.3 on (https://github.com/ansible-collections/community.general/pull/5602)."

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -408,7 +408,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     stripped_value = value.strip()
                     if stripped_value:
                         parsed_key = key + "_parsed"
-                        properties[parsed_key] = [tag.strip() for tag in stripped_value.split(",")]
+                        properties[parsed_key] = [tag.strip() for tag in stripped_value.replace(',',';').split(";")]
 
                 # The first field in the agent string tells you whether the agent is enabled
                 # the rest of the comma separated string is extra config for the agent.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -408,7 +408,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     stripped_value = value.strip()
                     if stripped_value:
                         parsed_key = key + "_parsed"
-                        properties[parsed_key] = [tag.strip() for tag in stripped_value.replace(',',';').split(";")]
+                        properties[parsed_key] = [tag.strip() for tag in stripped_value.replace(',', ';').split(";")]
 
                 # The first field in the agent string tells you whether the agent is enabled
                 # the rest of the comma separated string is extra config for the agent.


### PR DESCRIPTION
Starting from Proxmox 7.3 tags are delimited by semicolon. For backward compatibility it needs to be splitted by both commas and semicolons.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replaced commas to semicolons in the tags string, then delimited by semicolons.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
