### PR TITLE
feat(ssh_config): host_key_algorithms option

### DIFF
--- a/changelogs/fragments/5605-ssh-config-add-host-key-algorithms.yaml
+++ b/changelogs/fragments/5605-ssh-config-add-host-key-algorithms.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - add `host_key_algorithms` option

--- a/changelogs/fragments/5605-ssh-config-add-host-key-algorithms.yaml
+++ b/changelogs/fragments/5605-ssh-config-add-host-key-algorithms.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config - add `host_key_algorithms` option
+  - ssh_config - add ``host_key_algorithms`` option (https://github.com/ansible-collections/community.general/pull/5605).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -88,6 +88,10 @@ options:
       - If I(user) and this option are not specified, C(/etc/ssh/ssh_config) is used.
       - Mutually exclusive with I(user).
     type: path
+  host_key_algorithms:
+    description:
+      - Sets the C(HostKeyAlgorithms) option.
+    type: str
 requirements:
 - StormSSH
 notes:
@@ -207,6 +211,7 @@ class SSHConfig():
             strict_host_key_checking=self.params.get('strict_host_key_checking'),
             user_known_hosts_file=self.params.get('user_known_hosts_file'),
             proxycommand=self.params.get('proxycommand'),
+            host_key_algorithms=self.params.get('host_key_algorithms'),
         )
 
         # Convert True / False to 'yes' / 'no' for usage in ssh_config
@@ -297,6 +302,7 @@ def main():
             group=dict(default=None, type='str'),
             host=dict(type='str', required=True),
             hostname=dict(type='str'),
+            host_key_algorithms=dict(type='str', no_log=False),
             identity_file=dict(type='path'),
             port=dict(type='str'),
             proxycommand=dict(type='str', default=None),

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -92,6 +92,7 @@ options:
     description:
       - Sets the C(HostKeyAlgorithms) option.
     type: str
+    version_added: 6.1.0
 requirements:
 - StormSSH
 notes:

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -15,6 +15,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add
   check_mode: yes
@@ -43,6 +44,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add
 
@@ -60,6 +62,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add_again
 
@@ -81,6 +84,7 @@
     that:
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
+      - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -88,6 +92,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: no
+    host_key_algorithms: "+ssh-ed25519"
     state: present
   register: options_update
 
@@ -107,6 +112,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: no
+    host_key_algorithms: "+ssh-ed25519"
     state: present
   register: options_update
 
@@ -129,6 +135,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -156,6 +163,11 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+
+- name: Debug
+  debug:
+    msg: "{{ slurp_ssh_config['content'] | b64decode }}"
 
 - name: Options - Delete a host
   community.general.ssh_config:
@@ -197,3 +209,4 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
+      - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`host_key_algorithms` option for ssh_config module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ssh_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example ad hoc execution:

```bash
ansible localhost --connection=local -a \
  "host=example.com ssh_config_file=/tmp/ssh_config remote_user=mariusz host_key_algorithms=+ssh-rsa" \
  -m community.general.ssh_config
```

Result (content of `/tmp/ssh_config`):

```
Host example.com
    user mariusz
    hostkeyalgorithms +ssh-rsa
```