### PR TITLE
Fix keycloak_client_rolemapping role removal and diff

### DIFF
--- a/changelogs/fragments/5619-keycloak-improvements.yml
+++ b/changelogs/fragments/5619-keycloak-improvements.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "keycloak_client_rolemapping - remove only listed mappings with ``state=absent`` (https://github.com/ansible-collections/community.general/pull/5619)."
+  - "keycloak_client_rolemapping - calculate ``proposed`` and ``after`` return values properly (https://github.com/ansible-collections/community.general/pull/5619)."

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -606,7 +606,7 @@ class KeycloakAPI(object):
         """
         available_rolemappings_url = URL_CLIENT_GROUP_ROLEMAPPINGS.format(url=self.baseurl, realm=realm, id=gid, client=cid)
         try:
-            open_url(available_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders,
+            open_url(available_rolemappings_url, method="DELETE", http_agent=self.http_agent, headers=self.restheaders, data=json.dumps(role_rep),
                      validate_certs=self.validate_certs, timeout=self.connection_timeout)
         except Exception as e:
             self.module.fail_json(msg="Could not delete available rolemappings for client %s in group %s, realm %s: %s"

--- a/plugins/modules/keycloak_client_rolemapping.py
+++ b/plugins/modules/keycloak_client_rolemapping.py
@@ -295,7 +295,7 @@ def main():
     assigned_roles_before = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
 
     result['existing'] = assigned_roles_before
-    result['proposed'] = assigned_roles_before.copy() if assigned_roles_before else []
+    result['proposed'] = list(assigned_roles_before) if assigned_roles_before else []
 
     update_roles = []
     for role_index, role in enumerate(roles, start=0):

--- a/plugins/modules/keycloak_client_rolemapping.py
+++ b/plugins/modules/keycloak_client_rolemapping.py
@@ -295,7 +295,7 @@ def main():
     assigned_roles_before = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
 
     result['existing'] = assigned_roles_before
-    result['proposed'] = roles
+    result['proposed'] = assigned_roles_before.copy() if assigned_roles_before else []
 
     update_roles = []
     for role_index, role in enumerate(roles, start=0):
@@ -307,6 +307,7 @@ def main():
                         'id': role['id'],
                         'name': role['name'],
                     })
+                    result['proposed'].append(available_role)
         # Fetch roles to remove if state absent
         else:
             for assigned_role in assigned_roles_before:
@@ -315,36 +316,38 @@ def main():
                         'id': role['id'],
                         'name': role['name'],
                     })
+                    if assigned_role in result['proposed']:  # Handle double removal
+                        result['proposed'].remove(assigned_role)
 
     if len(update_roles):
         if state == 'present':
             # Assign roles
             result['changed'] = True
+            if module._diff:
+                result['diff'] = dict(before=assigned_roles_before, after=result['proposed'])
             if module.check_mode:
                 module.exit_json(**result)
             kc.add_group_rolemapping(gid, cid, update_roles, realm=realm)
             result['msg'] = 'Roles %s assigned to group %s.' % (update_roles, group_name)
             assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
-            if module._diff:
-                result['diff'] = dict(before=assigned_roles_before, after=assigned_roles_after)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
         else:
             # Remove mapping of role
             result['changed'] = True
+            if module._diff:
+                result['diff'] = dict(before=assigned_roles_before, after=result['proposed'])
             if module.check_mode:
                 module.exit_json(**result)
             kc.delete_group_rolemapping(gid, cid, update_roles, realm=realm)
             result['msg'] = 'Roles %s removed from group %s.' % (update_roles, group_name)
             assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
-            if module._diff:
-                result['diff'] = dict(before=assigned_roles_before, after=assigned_roles_after)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
     # Do nothing
     else:
         result['changed'] = False
-        result['msg'] = 'Nothing to do, roles %s are correctly mapped with group %s.' % (roles, group_name)
+        result['msg'] = 'Nothing to do, roles %s are %s with group %s.' % (roles, 'mapped' if state == 'present' else 'not mapped', group_name)
         module.exit_json(**result)
 
 

--- a/plugins/modules/keycloak_client_rolemapping.py
+++ b/plugins/modules/keycloak_client_rolemapping.py
@@ -320,25 +320,25 @@ def main():
         if state == 'present':
             # Assign roles
             result['changed'] = True
-            if module._diff:
-                result['diff'] = dict(before=assigned_roles_before, after=update_roles)
             if module.check_mode:
                 module.exit_json(**result)
             kc.add_group_rolemapping(gid, cid, update_roles, realm=realm)
             result['msg'] = 'Roles %s assigned to group %s.' % (update_roles, group_name)
             assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
+            if module._diff:
+                result['diff'] = dict(before=assigned_roles_before, after=assigned_roles_after)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
         else:
             # Remove mapping of role
             result['changed'] = True
-            if module._diff:
-                result['diff'] = dict(before=assigned_roles_before, after=update_roles)
             if module.check_mode:
                 module.exit_json(**result)
             kc.delete_group_rolemapping(gid, cid, update_roles, realm=realm)
             result['msg'] = 'Roles %s removed from group %s.' % (update_roles, group_name)
             assigned_roles_after = kc.get_client_group_composite_rolemappings(gid, cid, realm=realm)
+            if module._diff:
+                result['diff'] = dict(before=assigned_roles_before, after=assigned_roles_after)
             result['end_state'] = assigned_roles_after
             module.exit_json(**result)
     # Do nothing


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- community.general.keycloak_client_rolemapping with `state: absent` removes all
roles. The intention is to only remove those listed. 

- The diff returned by the module has a `before` and `after` list. The latter contained the 
changed roles, instead of the roles after the change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.general.keycloak_client_rolemapping

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Fix these two issues.