### PR TITLE
redhat_subscription: don't discard vars with key

### DIFF
--- a/changelogs/fragments/5627-redhat_subscription-subscribe-parameters-2.yaml
+++ b/changelogs/fragments/5627-redhat_subscription-subscribe-parameters-2.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - redhat_subscription - do not ignore ``consumer_name`` and other variables if ``activationkey`` is specified
+    (https://github.com/ansible-collections/community.general/issues/3486, https://github.com/ansible-collections/community.general/pull/5627).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -411,23 +411,28 @@ class Rhsm(RegistrationBase):
         if org_id:
             args.extend(['--org', org_id])
 
+        if auto_attach:
+            args.append('--auto-attach')
+
+        if consumer_type:
+            args.extend(['--type', consumer_type])
+
+        if consumer_name:
+            args.extend(['--name', consumer_name])
+
+        if consumer_id:
+            args.extend(['--consumerid', consumer_id])
+
+        if environment:
+            args.extend(['--environment', environment])
+
         if activationkey:
             args.extend(['--activationkey', activationkey])
         else:
-            if auto_attach:
-                args.append('--auto-attach')
             if username:
                 args.extend(['--username', username])
             if password:
                 args.extend(['--password', password])
-            if consumer_type:
-                args.extend(['--type', consumer_type])
-            if consumer_name:
-                args.extend(['--name', consumer_name])
-            if consumer_id:
-                args.extend(['--consumerid', consumer_id])
-            if environment:
-                args.extend(['--environment', environment])
 
         if release:
             args.extend(['--release', release])


### PR DESCRIPTION
##### SUMMARY

From the man-pages of subscription-manager, none of the parameters used is tied to `activationkey` except the two that remain in its else-clause.

Per the documentation, none of these should be tied to `activationkey`, and as such, no correct usage of the module per its documentation should be affected in a negative way.

Fixes #3486.

Notes by Pino Toscano (@ptoscano):
In reality, there are some combinations of command line options to `register` that are not accepted -- for example, when using `--activationkey` you cannot specify `--consumerid`, `--environment`, and `--auto-attach`; that said, since these things may change depending on the version of subscription-manager, then simply passing all the arguments and let subscription-manager figure it out is better than having to reimplement the same logic locally in this Ansible module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

Note that `type` is not mentioned in the man-pages on 7.6 (at least), but is still present and available.