### PR TITLE
Fix for vmadm get_vm_uuid out of range

### DIFF
--- a/changelogs/fragments/5628-fix-vmadm-off-by-one.yml
+++ b/changelogs/fragments/5628-fix-vmadm-off-by-one.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmadm - fix for vmadm get_vm_uuid out of range  (https://github.com/ansible-collections/community.general/pull/5628).
+  - vmadm - fix for index out of range error in ``get_vm_uuid`` (https://github.com/ansible-collections/community.general/pull/5628).

--- a/changelogs/fragments/5628-fix-vmadm-off-by-one.yml
+++ b/changelogs/fragments/5628-fix-vmadm-off-by-one.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmadm - fix for vmadm get_vm_uuid out of range  (https://github.com/ansible-collections/community.general/pull/5628).

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -438,7 +438,7 @@ def get_vm_prop(module, uuid, prop):
 def get_vm_uuid(module, alias):
     # Lookup the uuid that goes with the given alias.
     # Returns the uuid or '' if not found.
-    cmd = [module.vmadm, 'lookup', '-j', '-o', 'uuid', 'alias={1}'.format(alias)]
+    cmd = [module.vmadm, 'lookup', '-j', '-o', 'uuid', 'alias={0}'.format(alias)]
 
     (rc, stdout, stderr) = module.run_command(cmd)
 


### PR DESCRIPTION

##### SUMMARY
Method get_vm_uuid from vmadm  off-by-one error. 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmadm
##### ADDITIONAL INFORMATION
When running a playbook using the vmadm module results in:
```bash
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IndexError: Replacement index 1 out of range for positional args tuple
fatal: [192.168.1.111]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 192.168.1.111 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1669747224.152739-62818-126536782663630/AnsiballZ_vmadm.py\", line 107, in <module>\r\n    _ansiballz_main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1669747224.152739-62818-126536782663630/AnsiballZ_vmadm.py\", line 99, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1669747224.152739-62818-126536782663630/AnsiballZ_vmadm.py\", line 47, in invoke_module\r\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.vmadm', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.vmadm', _modlib_path=modlib_path),\r\n  File \"/opt/tools/lib/python3.10/runpy.py\", line 224, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/opt/tools/lib/python3.10/runpy.py\", line 96, in _run_module_code\r\n    _run_code(code, mod_globals, init_globals,\r\n  File \"/opt/tools/lib/python3.10/runpy.py\", line 86, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_community.general.vmadm_payload_jpca_c47/ansible_community.general.vmadm_payload.zip/ansible_collections/community/general/plugins/modules/vmadm.py\", line 785, in <module>\r\n  File \"/tmp/ansible_community.general.vmadm_payload_jpca_c47/ansible_community.general.vmadm_payload.zip/ansible_collections/community/general/plugins/modules/vmadm.py\", line 730, in main\r\n  File \"/tmp/ansible_community.general.vmadm_payload_jpca_c47/ansible_community.general.vmadm_payload.zip/ansible_collections/community/general/plugins/modules/vmadm.py\", line 441, in get_vm_uuid\r\nIndexError: Replacement index 1 out of range for positional args tuple\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

