### PR TITLE
vdo: Use yaml.safe_load() instead of yaml.load()

### DIFF
--- a/changelogs/fragments/5632-vdo-Use-yaml-safe-load-instead-of-yaml-load.yml
+++ b/changelogs/fragments/5632-vdo-Use-yaml-safe-load-instead-of-yaml-load.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - The vdo module now uses yaml.safe_load() to parse command output instead of the deprecated yaml.load() which is potentially unsafe. Using yaml.load() without explicitely setting a Loader= is also an error in pyYAML 6.0.
+  - vdo - now uses ``yaml.safe_load()`` to parse command output instead of the deprecated ``yaml.load()`` which is potentially unsafe. Using ``yaml.load()`` without explicitely setting a ``Loader=`` is also an error in pyYAML 6.0 (https://github.com/ansible-collections/community.general/pull/5632).

--- a/changelogs/fragments/5632-vdo-Use-yaml-safe-load-instead-of-yaml-load.yml
+++ b/changelogs/fragments/5632-vdo-Use-yaml-safe-load-instead-of-yaml-load.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The vdo module now uses yaml.safe_load() to parse command output instead of the deprecated yaml.load() which is potentially unsafe. Using yaml.load() without explicitely setting a Loader= is also an error in pyYAML 6.0.

--- a/plugins/modules/vdo.py
+++ b/plugins/modules/vdo.py
@@ -332,7 +332,7 @@ def inventory_vdos(module, vdocmd):
     if rc != 0:
         module.fail_json(msg="Inventorying VDOs failed: %s" % vdostatusout, rc=rc, err=err)
 
-    vdostatusyaml = yaml.load(vdostatusout)
+    vdostatusyaml = yaml.safe_load(vdostatusout)
     if vdostatusyaml is None:
         return vdolist
 
@@ -548,7 +548,7 @@ def run_module():
     # Modify the current parameters of a VDO that exists.
     if desiredvdo in vdolist and state == 'present':
         rc, vdostatusoutput, err = module.run_command([vdocmd, "status"])
-        vdostatusyaml = yaml.load(vdostatusoutput)
+        vdostatusyaml = yaml.safe_load(vdostatusoutput)
 
         # An empty dictionary to contain dictionaries of VDO statistics
         processedvdos = {}


### PR DESCRIPTION
yaml.load() without specifying a Loader= is deprecated and unsafe.

For details, see
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #5631 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vdo
