### PR TITLE
Reenable and enhance `copr` integration tests

### DIFF
--- a/tests/integration/targets/copr/aliases
+++ b/tests/integration/targets/copr/aliases
@@ -7,5 +7,3 @@ needs/root
 skip/macos
 skip/osx
 skip/freebsd
-
-disabled  # FIXME tests are currently failing

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -3,14 +3,21 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- when: ansible_distribution == 'Fedora'
+- when:
+    # Fedora or RHEL/CentOS >= 8
+    # This module requires the dnf module which is not available on RHEL 7.
+    - >
+      ansible_distribution == 'Fedora'
+      or (ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+          and ansible_distribution_major_version | int >= 8)
   block:
+  - debug: var=copr_chroot
   - name: enable copr project
     copr:
       host: copr.fedorainfracloud.org
       state: enabled
-      name: '@copr/integration_tests'
-      chroot: fedora-rawhide-x86_64
+      name: '{{ copr_fullname }}'
+      chroot: "{{ copr_chroot }}"
     register: result
 
   - name: assert that the copr project was enabled
@@ -24,8 +31,8 @@
     check_mode: yes
     copr:
       state: enabled
-      name: '@copr/integration_tests'
-      chroot: fedora-rawhide-x86_64
+      name: '{{ copr_fullname }}'
+      chroot: '{{ copr_chroot }}'
     register: result
 
   - name: assert that the copr project was enabled
@@ -34,10 +41,53 @@
         - result is not changed
         - result.msg == 'enabled'
 
+  - name: Ensure the repo is installed and enabled | slurp
+    register: result
+    ansible.builtin.slurp:
+      src: "{{ copr_repofile }}"
+
+  - name: Ensure the repo is installed and enabled
+    vars:
+      content: "{{ result.content | b64decode }}"
+      _baseurl: "{{ 'https://download.copr.fedorainfracloud.org/results/gotmax23/community.general.copr_integration_tests' | regex_escape }}"
+      baseurl: "{{ content | regex_search('baseurl=' ~ _baseurl) }}"
+    block:
+      - ansible.builtin.debug:
+          var: content
+      - ansible.builtin.debug:
+          var: baseurl
+      - name: Ensure the repo is installed and enabled
+        ansible.builtin.assert:
+          that:
+            - "'enabled=1' in content"
+            - baseurl | length > 0
+
+  - name: Install test package from Copr
+    when:
+      # Copr does not build new packages for EOL Fedoras.
+      - >
+        not (ansible_distribution == 'Fedora' and
+             ansible_distribution_major_version | int < 35)
+    block:
+      - name: install test package from the copr
+        ansible.builtin.package:
+          update_cache: true
+          name: copr-module-integration-dummy-package
+
+      - name: uninstall test package
+        register: result
+        ansible.builtin.package:
+          name: copr-module-integration-dummy-package
+          state: absent
+
+      - name: check uninstall test package
+        ansible.builtin.assert:
+          that: result.changed | bool
+
   - name: remove copr project
     copr:
       state: absent
-      name: '@copr/integration_tests'
+      name: '{{ copr_fullname }}'
     register: result
 
   - name: assert that the copr project was removed
@@ -46,11 +96,20 @@
         - 'result is changed'
         - result.msg == 'absent'
 
+  - name: Ensure the repo file was removed | stat
+    register: result
+    ansible.builtin.stat:
+      dest: "{{ copr_repofile }}"
+
+  - name: Ensure the repo file was removed
+    ansible.builtin.assert:
+      that: not result.stat.exists | bool
+
   - name: disable copr project
     copr:
       state: disabled
-      name: '@copr/integration_tests'
-      chroot: fedora-rawhide-x86_64
+      name: '{{ copr_fullname }}'
+      chroot: '{{ copr_chroot }}'
     register: result
 
   - name: assert that the copr project was disabled
@@ -59,10 +118,37 @@
         - 'result is changed'
         - result.msg == 'disabled'
 
+  - name: Ensure the repo is installed but disabled | slurp
+    register: result
+    ansible.builtin.slurp:
+      src: "{{ copr_repofile }}"
+
+  - name: Ensure the repo is installed but disabled
+    vars:
+      content: "{{ result.content | b64decode }}"
+      _baseurl: "{{ 'https://download.copr.fedorainfracloud.org/results/gotmax23/community.general.copr_integration_tests' | regex_escape }}"
+      baseurl: "{{ content | regex_search('baseurl=' ~ _baseurl) }}"
+    block:
+      - ansible.builtin.debug:
+          var: content
+      - ansible.builtin.debug:
+          var: baseurl
+      - name: Ensure the repo is installed but disabled
+        ansible.builtin.assert:
+          that:
+            - "'enabled=0' in content"
+            - baseurl | length > 0
+
   always:
     - name: clean up
+      ignore_errors: true
       copr:
         host: copr.fedorainfracloud.org
         state: absent
-        name: '@copr/integration_tests'
-        chroot: fedora-rawhide-x86_64
+        name: '{{ copr_fullname }}'
+        chroot: '{{ copr_chroot }}'
+
+    - name: cleanup test package
+      ansible.builtin.package:
+        name: copr-module-integration-dummy-package
+        state: absent

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -12,12 +12,18 @@
     ansible_python_interpreter: /usr/libexec/platform-python
 
 - when:
-    # Fedora or RHEL/CentOS >= 8
+    # Fedora or RHEL >= 8
     # This module requires the dnf module which is not available on RHEL 7.
     - >
       ansible_distribution == 'Fedora'
       or (ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
           and ansible_distribution_major_version | int >= 8)
+    # The copr module imports dnf which is only available for the system Python
+    # interpreter.
+    - >
+      not (ansible_distribution == 'CentOS' and
+           ansible_distribution_major_version | int == 8 and not
+           ansible_python_version.startswith('3.6'))
   block:
   - debug: var=copr_chroot
   - name: enable copr project

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -3,6 +3,14 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Fix improperly set ansible_python_interpreter on Stream 8
+  when:
+    - "ansible_distribution == 'CentOS'"
+    - "ansible_distribution_release == 'Stream'"
+    - "ansible_distribution_major_version == '8'"
+  ansible.builtin.set_fact:
+    ansible_python_interpreter: /usr/libexec/platform-python
+
 - when:
     # Fedora or RHEL/CentOS >= 8
     # This module requires the dnf module which is not available on RHEL 7.

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -3,14 +3,6 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Fix improperly set ansible_python_interpreter on Stream 8
-  when:
-    - "ansible_distribution == 'CentOS'"
-    - "ansible_distribution_release == 'Stream'"
-    - "ansible_distribution_major_version == '8'"
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: /usr/libexec/platform-python
-
 - when:
     # Fedora or RHEL >= 8
     # This module requires the dnf module which is not available on RHEL 7.

--- a/tests/integration/targets/copr/vars/main.yml
+++ b/tests/integration/targets/copr/vars/main.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Maxwell G <gotmax@e.email>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+copr_host: copr.fedorainfracloud.org
+copr_namespace: gotmax23
+copr_name: community.general.copr_integration_tests
+copr_fullname: '{{ copr_namespace }}/{{ copr_name }}'
+copr_repofile: '/etc/yum.repos.d/_copr:{{ copr_host }}:{{ copr_namespace }}:{{ copr_name }}.repo'
+
+# TODO: Fix chroot autodetection so this isn't necessary
+_copr_chroot_fedora: "fedora-rawhide-x86_64"
+_copr_chroot_rhelish: "epel-{{ ansible_distribution_major_version }}-x86_64"
+copr_chroot: "{{ _copr_chroot_fedora if ansible_distribution == 'Fedora' else _copr_chroot_rhelish }}"


### PR DESCRIPTION
##### SUMMARY 
- Switch to a new test Copr repository. @copr/integration_tests was removed which caused the tests to fail. I created a new one under my account that I'll ensure stays around.
- Add basic testing to ensure that repo files are created in the correct location and contain the correct baseurl and enabled status.
- Also run tests on Enterprise Linux.
- Test that packages from the Copr install.

Resolves: https://github.com/ansible-collections/community.general/issues/5595

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
copr
