### PR TITLE
Fix example in keycloak_realm documentation

### DIFF
--- a/plugins/modules/keycloak_realm.py
+++ b/plugins/modules/keycloak_realm.py
@@ -519,6 +519,7 @@ EXAMPLES = '''
     auth_username: USERNAME
     auth_password: PASSWORD
     id: realm
+    realm: realm
     state: present
 
 - name: Delete a Keycloak realm


### PR DESCRIPTION
##### SUMMARY

Add `realm` option in `keycloak_realm` minimal example. Without this option, Keycloak (v20.0.1 at least) fail with a 500 error : 

```
2022-12-01 09:37:13,198 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-77) Uncaught server error: java.lang.NullPointerException
	at org.keycloak.services.managers.RealmManager.determineDefaultRoleName(RealmManager.java:624)
	at org.keycloak.services.managers.RealmManager.importRealm(RealmManager.java:531)
	at org.keycloak.services.managers.RealmManager.importRealm(RealmManager.java:503)
	at org.keycloak.services.managers.RealmManagerProviderFactory.lambda$postInit$0(RealmManagerProviderFactory.java:51)
	at org.keycloak.services.DefaultKeycloakSessionFactory.publish(DefaultKeycloakSessionFactory.java:92)
	at org.keycloak.storage.ImportRealmFromRepresentation.fire(ImportRealmFromRepresentation.java:50)
	at org.keycloak.storage.datastore.LegacyExportImportManager.importRealm(LegacyExportImportManager.java:155)
	at org.keycloak.services.resources.admin.RealmsAdminResource.importRealm(RealmsAdminResource.java:133)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        [...]
```


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
keycloak_realm
