### PR TITLE
fix typo disable_looups in inventory/proxmox

### DIFF
--- a/changelogs/fragments/5640-fix-typo-proxmox-inventory.yml
+++ b/changelogs/fragments/5640-fix-typo-proxmox-inventory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "proxmox - fix lookup in inventory plugin (https://github.com/ansible-collections/community.general/pull/5640)"
+  - "proxmox inventory plugin - fix bug while templating when using templates for the ``url``, ``user``, ``password``, ``token_id``, or ``token_secret`` options (https://github.com/ansible-collections/community.general/pull/5640)."

--- a/changelogs/fragments/5640-fix-typo-proxmox-inventory.yml
+++ b/changelogs/fragments/5640-fix-typo-proxmox-inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox - fix lookup in inventory plugin (https://github.com/ansible-collections/community.general/pull/5640)"

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -615,7 +615,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for o in ('url', 'user', 'password', 'token_id', 'token_secret'):
             v = self.get_option(o)
             if self.templar.is_template(v):
-                v = self.templar.template(v, disable_looups=False)
+                v = self.templar.template(v, disable_lookups=False)
             setattr(self, 'proxmox_%s' % o, v)
 
         # some more cleanup and validation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolve issue with lookups in proxmox inventory config.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-inventory -i my.proxmox.yml --graph
[WARNING]:  * Failed to parse /home/ansible/infrastructure/my.proxmox.yml with auto plugin: template() got an unexpected keyword argument 'disable_looups'
[WARNING]:  * Failed to parse /home/ansible/infrastructure/my.proxmox.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory
[WARNING]:  * Failed to parse /home/ansible/infrastructure/my.proxmox.yml with ini plugin: Invalid host pattern '---' supplied, '---' is normally a sign this is a YAML file.
[WARNING]:  * Failed to parse /home/ansible/infrastructure/my.proxmox.yml with ansible_collections.community.general.plugins.inventory.proxmox plugin: template() got an unexpected keyword argument
'disable_looups'
[WARNING]: Unable to parse /home/ansible/infrastructure/my.proxmox.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
@all:
  |--@ungrouped:
```

Once typo is fixed, it correctly lists hosts.