### PR TITLE
lxc_container: fix lxc argument when executing lxc command

### DIFF
--- a/changelogs/fragments/5659-fix-lxc_container-command.yml
+++ b/changelogs/fragments/5659-fix-lxc_container-command.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - lxc_container - fix the arguments of the lxc command which broke the creation and cloning of containers (https://github.com/ansible-collections/community.general/issues/5578).

--- a/plugins/modules/lxc_container.py
+++ b/plugins/modules/lxc_container.py
@@ -677,7 +677,7 @@ class LxcContainerManagement(object):
 
         false_values = BOOLEANS_FALSE.union([None, ''])
         result = dict(
-            (k, v)
+            (v, self.module.params[k])
             for k, v in variables.items()
             if self.module.params[k] not in false_values
         )


### PR DESCRIPTION
##### SUMMARY
lxc_container fails when executing the lxc command (e.g. when creating a new container) because PR #5358 broke the module argument parsing. The resulting argument dict contained only the module argument name and the argument flag but not the value. E.g.
```
- lxc_container:
    template: debian
```
would result in the lxc command:
* `lxc template --template` (current result)
* `lxc --template debian` (while this is the correct line)

Fixes: 6f88426cf1dc ("lxc_container: minor refactor (#5358)")
Fixes #5578

CC: @russoz

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc_container

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
To reproduce the issue create a container which doesn't exist before:

```
  - name: Create a started container
    community.general.lxc_container:
      name: some
      state: started
      template: template
      template_options: --dist debian --release bullseye --arch amd64
```
will execute
`/usr/bin/lxc-create --name some --quiet template --template backing_store --bdev -- --dist debian --release bullseye --arch amd64`

correct would be
`/usr/bin/lxc-create --name some --quiet --template template --bdev dir -- --dist debian --release bullseye --arch amd64`
