### PR TITLE
redhat_subscription: add `server_proxy_scheme` parameter

### DIFF
--- a/changelogs/fragments/5662-redhat_subscription-server_proxy_scheme.yaml
+++ b/changelogs/fragments/5662-redhat_subscription-server_proxy_scheme.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redhat_subscription - add a ``server_proxy_scheme`` parameter to configure the scheme for the proxy server
+    (https://github.com/ansible-collections/community.general/pull/5662).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -70,6 +70,11 @@ options:
         description:
             - Specify an HTTP proxy hostname.
         type: str
+    server_proxy_scheme:
+        description:
+            - Specify an HTTP proxy scheme, for example C(http) or C(https).
+        type: str
+        version_added: 6.2.0
     server_proxy_port:
         description:
             - Specify an HTTP proxy port.
@@ -806,6 +811,7 @@ def main():
             'consumer_id': {},
             'force_register': {'default': False, 'type': 'bool'},
             'server_proxy_hostname': {},
+            'server_proxy_scheme': {},
             'server_proxy_port': {},
             'server_proxy_user': {},
             'server_proxy_password': {'no_log': True},

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -308,6 +308,7 @@ TEST_CASES = [
             'org_id': 'admin',
             'force_register': 'true',
             'server_proxy_hostname': 'proxy.company.com',
+            'server_proxy_scheme': 'https',
             'server_proxy_port': '12345',
             'server_proxy_user': 'proxy_user',
             'server_proxy_password': 'secret_proxy_password'
@@ -327,6 +328,7 @@ TEST_CASES = [
                         '--server.proxy_hostname=proxy.company.com',
                         '--server.proxy_password=secret_proxy_password',
                         '--server.proxy_port=12345',
+                        '--server.proxy_scheme=https',
                         '--server.proxy_user=proxy_user'
                     ],
                     {'check_rc': True},


### PR DESCRIPTION
##### SUMMARY

Add the `server_proxy_scheme` parameter to configure the scheme used for the proxy server. This completes the configuration parameters for the proxy server.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

This makes it possible to configure an https proxy server for `subscription-manager` using the `redhat_subscription` module, instead of doing it manually -- for example
```yaml
- redhat_subscription:
    server_proxy_hostname: my-proxy-server
    server_proxy_scheme: https
    server_proxy_port: proxy-port
    ...
```