### PR TITLE
redhat_subscription: require credentials only when needed

### DIFF
--- a/changelogs/fragments/5664-redhat_subscription-credentials-when-needed.yaml
+++ b/changelogs/fragments/5664-redhat_subscription-credentials-when-needed.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - redhat_subscription - credentials (``username``, ``activationkey``, and so on) are required now
+    only if a system needs to be registered, or ``force_register`` is specified
+    (https://github.com/ansible-collections/community.general/pull/5664).


### PR DESCRIPTION
##### SUMMARY

The module currently has a static `required_if` statement for its parameters that forces any of `username` or `activationkey` in case `state=present`; while this is generally a good idea, it can be an extra requirements in some cases. In particular, if the system is already registered, there is no need for credentials -- some of the operations of the module, such as manipulating pools, can be done perfectly without credentials.

Hence:
- change the static `required_if` to require credentials only when forcing the registration
- check for credentials manually when a registration is needed, i.e. on an unregistered system; the fail message is the same as the one shown by `required_if`

Adapt the tests to this new situation:
- `test_without_required_parameters` now needs to mock an unregistered system
- add a new version of `test_without_required_parameters` to test an already registered system
- add a simple test case for only `state=present` usable on an already registered system
- remove the credentials from a test case for pool attachment that mocks an already registered system

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

This makes it possible to use credentials-less tasks on already registered systems, e.g.:
```yaml
- redhat_subscription:
```
or
```yaml
- redhat_subscription:
  pool_ids:
    - 0123456789abcdef0123456789abcdef
```
