### PR TITLE
Fix pipx_info tests

### DIFF
--- a/tests/integration/targets/pipx_info/tasks/main.yml
+++ b/tests/integration/targets/pipx_info/tasks/main.yml
@@ -56,7 +56,8 @@
       - info_all_deps.application|length == 1
       - info_all_deps.application[0].name == "tox"
       - "'version' in info_all_deps.application[0]"
-      - info_all_deps.application[0].dependencies == ["virtualenv"]
+      - info_all_deps.application[0].dependencies == ["chardet", "virtualenv"]
+        or info_all_deps.application[0].dependencies == ["virtualenv"]
       - "'injected' not in info_all.application[0]"
 
       - info_tox.application == info_all_deps.application


### PR DESCRIPTION
##### SUMMARY
They curently fail, probably since tox 4.0.2 has been released.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pipx_info tests
