### PR TITLE
Bugfix: Remove redundant VMID parameters

### DIFF
--- a/changelogs/fragments/5672-proxmox.yml
+++ b/changelogs/fragments/5672-proxmox.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "proxmox_disk - fixed possible issues with redundant ``vmid`` parameter (https://github.com/ansible-collections/community.general/issues/5492, https://github.com/ansible-collections/community.general/pull/5672)."
+  - "proxmox_nic - fixed possible issues with redundant ``vmid`` parameter (https://github.com/ansible-collections/community.general/issues/5492, https://github.com/ansible-collections/community.general/pull/5672)."

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -699,7 +699,7 @@ def main():
                 module.exit_json(changed=False, vmid=vmid, msg='Disk %s already detached in VM %s' % (disk, vmid))
             if disk not in vm_config:
                 module.exit_json(changed=False, vmid=vmid, msg="Disk %s not present in VM %s config" % (disk, vmid))
-            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(vmid=vmid, idlist=disk, force=0)
+            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(idlist=disk, force=0)
             module.exit_json(changed=True, vmid=vmid, msg="Disk %s detached from VM %s" % (disk, vmid))
         except Exception as e:
             module.fail_json(msg="Failed to detach disk %s from VM %s with exception: %s" % (disk, vmid, str(e)))
@@ -734,7 +734,7 @@ def main():
         try:
             if disk not in vm_config:
                 module.exit_json(changed=False, vmid=vmid, msg="Disk %s is already absent in VM %s" % (disk, vmid))
-            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(vmid=vmid, idlist=disk, force=1)
+            proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).unlink.put(idlist=disk, force=1)
             module.exit_json(changed=True, vmid=vmid, msg="Disk %s removed from VM %s" % (disk, vmid))
         except Exception as e:
             module.fail_json(vmid=vmid, msg='Unable to remove disk %s from VM %s: %s' % (disk, vmid, str(e)))

--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -223,7 +223,7 @@ class ProxmoxNicAnsible(ProxmoxAnsible):
 
         if interface in vminfo:
             if not self.module.check_mode:
-                self.proxmox_api.nodes(vm['node']).qemu(vmid).config.set(vmid=vmid, delete=interface)
+                self.proxmox_api.nodes(vm['node']).qemu(vmid).config.set(delete=interface)
             return True
 
         return False


### PR DESCRIPTION
##### SUMMARY
Removed redundant VMID parameter from URI builder from all functions in `proxmox_disk` and `proxmox_nic` modules.

It fixes possible issues similar to #5492.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_disk
proxmox_nic

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Conversation about this fix [was here](https://github.com/ansible-collections/community.general/pull/5493#issuecomment-1312785424).
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Modified functions have been tested with:

- Controller: openSUSE Tumbleweed (python 3.10)
- Target: Proxmox 7.3-3
- Ansible:
  - core 2.14.1
  - community-general 6.1.0
- Proxmoxer: 2.0.0
- Requests: 2.28.1
<!--- Paste verbatim command output below, e.g. before and after your change -->
