### PR TITLE
CI: Bump CentOS Stream 8 Python from 3.8 to 3.9

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -386,7 +386,7 @@ stages:
             - name: ArchLinux
               test: archlinux/3.10
             - name: CentOS Stream 8
-              test: centos-stream8/3.8
+              test: centos-stream8/3.9
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Bump CentOS Stream 8 Python from 3.8 to 3.9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
