### PR TITLE
Add Support to Bitwarden Lookup for Custom Fields

### DIFF
--- a/changelogs/fragments/5694-add-custom-fields-to-bitwarden.yml
+++ b/changelogs/fragments/5694-add-custom-fields-to-bitwarden.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - bitwarden - can now retrieve secrets from custom fields
+  - bitwarden lookup plugin - can now retrieve secrets from custom fields (https://github.com/ansible-collections/community.general/pull/5694).

--- a/changelogs/fragments/5694-add-custom-fields-to-bitwarden.yml
+++ b/changelogs/fragments/5694-add-custom-fields-to-bitwarden.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bitwarden - can now retrieve secrets from custom fields

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -114,7 +114,7 @@ class Bitwarden(object):
         """
         matches = self._get_matches(search_value, search_field)
 
-        if field in ['password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
+        if field in ['autofillOnPageLoad', 'password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
             return [match['login'][field] for match in matches]
         elif not field:
             return matches

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -47,6 +47,11 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: >-
       {{ lookup('community.general.bitwarden', 'a_test') }}
+
+- name: "Get custom field 'api_key' from Bitwarden record named 'a_test'"
+  ansible.builtin.debug:
+    msg: >-
+      {{ lookup('community.general.bitwarden', 'a_test', field='api_key') }}
 """
 
 RETURN = """
@@ -109,8 +114,17 @@ class Bitwarden(object):
         """
         matches = self._get_matches(search_value, search_field)
 
-        if field:
+        if field in ['password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
             return [match['login'][field] for match in matches]
+        else:
+            custom_field_matches = []
+            for match in matches:
+              for custom_field in match['fields']:
+                if custom_field['name'] == field:
+                  custom_field_matches.append(custom_field['value'])
+            if not len(custom_field_matches):
+              raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
+            return custom_field_matches
 
         return matches
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -116,6 +116,8 @@ class Bitwarden(object):
 
         if field in ['password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
             return [match['login'][field] for match in matches]
+        elif not field:
+          return matches
         else:
             custom_field_matches = []
             for match in matches:
@@ -125,8 +127,6 @@ class Bitwarden(object):
             if not len(custom_field_matches):
               raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
             return custom_field_matches
-
-        return matches
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -117,15 +117,15 @@ class Bitwarden(object):
         if field in ['password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
             return [match['login'][field] for match in matches]
         elif not field:
-          return matches
+            return matches
         else:
             custom_field_matches = []
             for match in matches:
-              for custom_field in match['fields']:
-                if custom_field['name'] == field:
-                  custom_field_matches.append(custom_field['value'])
+                for custom_field in match['fields']:
+                    if custom_field['name'] == field:
+                        custom_field_matches.append(custom_field['value'])
             if not len(custom_field_matches):
-              raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
+                raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
             return custom_field_matches
 
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -124,7 +124,7 @@ class Bitwarden(object):
                 for custom_field in match['fields']:
                     if custom_field['name'] == field:
                         custom_field_matches.append(custom_field['value'])
-            if not len(custom_field_matches):
+            if matches and not custom_field_matches:
                 raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
             return custom_field_matches
 


### PR DESCRIPTION
##### SUMMARY
Currently the Bitwarden lookup plugin only searches for fields in the login key (password, passwordRevisionDate, totp, urs, username). It is not uncommon to create custom fields in Bitwarden, for things such as api keys, which we should also be able to look up. I tried to make the lookup work seamlessly across custom or standard fields, so it does not add complexity for the user.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
bitwarden

##### ADDITIONAL INFORMATION
Example code :
```yaml
- debug:
    msg: |
      Full record: {{ lookup('community.general.bitwarden', 'MI6 Secrets') | first | to_nice_yaml }}
      Username: {{ lookup('community.general.bitwarden', 'MI6 Secrets', field="username") | first }}
      Password: {{ lookup('community.general.bitwarden', 'MI6 Secrets', field="password") | first }}
      Custom Field (pin_code): {{ lookup('community.general.bitwarden', 'MI6 Secrets', field="pin_code") | first }}
```

Example output:
```text
TASK [debug] **************************************************************************************************************************************************************************
changed: [localhost] => 
  msg: |-
    Full record: collectionIds: []
    favorite: false
    fields:
    -   name: pin_code
        type: 0
        value: '1234'
    folderId: null
    id: f22421bb-c99c-4bc1-afa9-c52ad43ead2c
    login:
        password: 007JawsSucks
        passwordRevisionDate: null
        totp: null
        uris:
        -   match: null
            uri: https://mi6.uk
        username: jamesbond
    name: MI6 Secrets
    notes: null
    object: item
    organizationId: null
    revisionDate: '2022-12-16T20:30:33.823Z'
    type: 1
  
    Username: jamesbond
    Password: 007JawsSucks
    Custom Field (pin_code): 1234
```
