### PR TITLE
become: ksu followed by su

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -25,6 +25,8 @@ files:
     maintainers: $team_ansible_core
   $becomes/ksu.py:
     maintainers: $team_ansible_core
+  $becomes/ksusu.py:
+    maintainers: schallee
   $becomes/machinectl.py:
     maintainers: $team_ansible_core
   $becomes/pbrun.py:

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -113,7 +113,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_BECOME_FLAGS_SU
               - name: ANSIBLE_KSU_FLAGS_SU
         become_pass:
-            description: ksu password
+            description: C(ksu) password.
             required: False
             vars:
               - name: ansible_ksusu_pass

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
     name: ksusu
-    short_description: Kerberos substitute (ksu) user followed by substitute user (su).
+    short_description: Kerberos substitute (ksu) user followed by substitute user (su)
     description:
         - This become plugins allows your remote/login user to execute commands as another user by calling su through the ksu utility.
     author:

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -11,7 +11,7 @@ DOCUMENTATION = """
     description:
         - This become plugins allows your remote/login user to execute commands as another user by calling C(su) through the C(ksu) utility.
     author:
-    - Ed Schaller (@schallee)
+        - Ed Schaller (@schallee)
     version_added: 6.2.0
     options:
         become_user_ksu:

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
         - This become plugins allows your remote/login user to execute commands as another user by calling C(su) through the C(ksu) utility.
     author:
         - Ed Schaller (@schallee)
-    version_added: 6.2.0
+    version_added: 6.3.0
     options:
         become_user_ksu:
             description: User you use with C(ksu) to run C(su).

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -80,7 +80,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_BECOME_EXE_SU
               - name: ANSIBLE_KSUSU_EXE_SU
         become_flags_ksu:
-            description: Options to pass to ksu
+            description: Options to pass to C(ksu).
             default: '-Z -q'
             ini:
               - section: privilege_escalation

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -127,7 +127,7 @@ DOCUMENTATION = """
                 key: password
         prompt_l10n:
             description:
-                - List of localized strings to match for prompt detection
+                - List of localized strings to match for prompt detection.
                 - If empty we'll use the built in one
             default: []
             ini:

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2021, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+# Copyright (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
     name: ksusu
-    short_description: Kerberos substitute user
+    short_description: Kerberos substitute (ksu) user followed by substitute user (su).
     description:
         - This become plugins allows your remote/login user to execute commands as another user by calling su through the ksu utility.
     author:
     - Ed Schaller
-    version_added: 2.13.0
     options:
         become_user_ksu:
             description: User you use with ksu to run su
@@ -179,7 +178,5 @@ class BecomeModule(BecomeBase):
         flags_su = self.get_option('become_flags') or ''
         user_ksu = self.get_option('become_user_ksu') or 'root'
         user_su = self.get_option('become_user') or 'root'
-        prompt = ''
 
         return '%s %s %s -e %s -l %s %s %s ' % (exe_ksu, user_ksu, flags_ksu, exe_su, flags_su, user_su, self._build_success_command(cmd, shell))
-

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
     version_added: 6.2.0
     options:
         become_user_ksu:
-            description: User you use with ksu to run su
+            description: User you use with C(ksu) to run C(su).
             default: root
             ini:
               - section: privilege_escalation

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -51,7 +51,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_KSUSU_USER_SU
             required: False
         become_exe_ksu:
-            description: Ksu executable
+            description: C(ksu) executable.
             default: ksu
             ini:
               - section: privilege_escalation

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -9,7 +9,7 @@ DOCUMENTATION = """
     name: ksusu
     short_description: Kerberos substitute (ksu) user followed by substitute user (su)
     description:
-        - This become plugins allows your remote/login user to execute commands as another user by calling su through the ksu utility.
+        - This become plugins allows your remote/login user to execute commands as another user by calling C(su) through the C(ksu) utility.
     author:
     - Ed Schaller (@schallee)
     options:

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -12,6 +12,7 @@ DOCUMENTATION = """
         - This become plugins allows your remote/login user to execute commands as another user by calling C(su) through the C(ksu) utility.
     author:
     - Ed Schaller (@schallee)
+    version_added: 6.2.0
     options:
         become_user_ksu:
             description: User you use with ksu to run su

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -94,7 +94,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_BECOME_FLAGS_KSU
               - name: ANSIBLE_KSU_FLAGS_KSU
         become_flags:
-            description: Options to pass to su
+            description: Options to pass to C(su).
             default: ''
             ini:
               - section: privilege_escalation

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -129,7 +129,6 @@ DOCUMENTATION = """
             description:
                 - List of localized strings to match for prompt detection.
             default: ['Kerberos password for .*@.*:']
-            default: ['Kerberos password for .*@.*:']
             ini:
               - section: ksusu_become_plugin
                 key: localized_prompts

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -155,7 +155,7 @@ class BecomeModule(BecomeBase):
     def check_password_prompt(self, b_output):
         ''' checks if the expected password prompt exists in b_output '''
 
-        prompts = self.get_option('prompt_l10n') or ["Kerberos password for .*@.*:"]
+        prompts = self.get_option('prompt_l10n')
         b_prompt = b"|".join(to_bytes(p) for p in prompts)
 
         return bool(re.match(b_prompt, b_output))
@@ -171,12 +171,12 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe_ksu = self.get_option('become_exe_ksu') or 'ksu'
-        exe_su = self.get_option('become_exe_su') or '/bin/su'  # Must be absolute
-
-        flags_ksu = self.get_option('become_flags_ksu') or '-Z -q'
-        flags_su = self.get_option('become_flags') or ''
-        user_ksu = self.get_option('become_user_ksu') or 'root'
-        user_su = self.get_option('become_user') or 'root'
+	# defaults come from above via configuration manager
+        exe_ksu = self.get_option('become_exe_ksu')
+        exe_su = self.get_option('become_exe_su')
+        flags_ksu = self.get_option('become_flags_ksu')
+        flags_su = self.get_option('become_flags')
+        user_ksu = self.get_option('become_user_ksu')
+        user_su = self.get_option('become_user')
 
         return '%s %s %s -e %s -l %s %s %s ' % (exe_ksu, user_ksu, flags_ksu, exe_su, flags_su, user_su, self._build_success_command(cmd, shell))

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: ksusu
+    short_description: Kerberos substitute user
+    description:
+        - This become plugins allows your remote/login user to execute commands as another user by calling su through the ksu utility.
+    author:
+    - Ed Schaller
+    version_added: 2.13.0
+    options:
+        become_user_ksu:
+            description: User you use with ksu to run su
+            default: root
+            ini:
+              - section: privilege_escalation
+                key: become_user_ksu
+              - section: ksusu_become_plugin
+                key: user_ksu
+            vars:
+              - name: ansible_become_user_ksu
+              - name: ansible_ksusu_user_ksu
+            env:
+              - name: ANSIBLE_BECOME_USER_KSU
+              - name: ANSIBLE_KSUSU_USER_KSU
+            required: False
+        become_user:
+            description: User you 'become' to execute the task
+            default: root
+            ini:
+              - section: privilege_escalation
+                key: become_user
+              - section: privilege_escalation
+                key: become_user_su
+              - section: ksusu_become_plugin
+                key: user
+              - section: ksusu_become_plugin
+                key: user_su
+            vars:
+              - name: ansible_become_user
+              - name: ansible_become_user_su
+              - name: ansible_ksusu_user
+              - name: ansible_ksusu_user_su
+            env:
+              - name: ANSIBLE_BECOME_USER
+              - name: ANSIBLE_KSUSU_USER_SU
+            required: False
+        become_exe_ksu:
+            description: Ksu executable
+            default: ksu
+            ini:
+              - section: privilege_escalation
+                key: become_exe_ksu
+              - section: ksusu_become_plugin
+                key: executable_ksu
+            vars:
+              - name: ansible_become_exe_ksu
+              - name: ansible_ksusu_exe_ksu
+            env:
+              - name: ANSIBLE_BECOME_EXE_KSU
+              - name: ANSIBLE_KSU_EXE_KSU
+        become_exe_su:
+            description: Absolute path to the su executable
+            default: /bin/su
+            ini:
+              - section: privilege_escalation
+                key: become_exe_su
+              - section: ksusu_become_plugin
+                key: executable_su
+            vars:
+              - name: ansible_become_exe_su
+              - name: ansible_ksusu_exe_su
+            env:
+              - name: ANSIBLE_BECOME_EXE
+              - name: ANSIBLE_BECOME_EXE_SU
+              - name: ANSIBLE_KSUSU_EXE_SU
+        become_flags_ksu:
+            description: Options to pass to ksu
+            default: '-Z -q'
+            ini:
+              - section: privilege_escalation
+                key: become_flags_ksu
+              - section: ksusu_become_plugin
+                key: flags_ksu
+            vars:
+              - name: ansible_become_flags_ksu
+              - name: ansible_ksusu_flags_ksu
+            env:
+              - name: ANSIBLE_BECOME_FLAGS_KSU
+              - name: ANSIBLE_KSU_FLAGS_KSU
+        become_flags:
+            description: Options to pass to su
+            default: ''
+            ini:
+              - section: privilege_escalation
+                key: become_flags
+              - section: privilege_escalation
+                key: become_flags_su
+              - section: ksusu_become_plugin
+                key: flags_su
+            vars:
+              - name: ansible_become_flags
+              - name: ansible_become_flags_su
+              - name: ansible_ksusu_flags
+              - name: ansible_ksusu_flags_su
+            env:
+              - name: ANSIBLE_BECOME_FLAGS
+              - name: ANSIBLE_BECOME_FLAGS_SU
+              - name: ANSIBLE_KSU_FLAGS_SU
+        become_pass:
+            description: ksu password
+            required: False
+            vars:
+              - name: ansible_ksusu_pass
+              - name: ansible_become_pass
+              - name: ansible_become_password
+            env:
+              - name: ANSIBLE_BECOME_PASS
+              - name: ANSIBLE_KSUSU_PASS
+            ini:
+              - section: ksusu_become_plugin
+                key: password
+        prompt_l10n:
+            description:
+                - List of localized strings to match for prompt detection
+                - If empty we'll use the built in one
+            default: []
+            ini:
+              - section: ksusu_become_plugin
+                key: localized_prompts
+            vars:
+              - name: ansible_ksusu_prompt_l10n
+            env:
+              - name: ANSIBLE_KSUSU_PROMPT_L10N
+"""
+
+import re
+
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.plugins.become import BecomeBase
+
+
+class BecomeModule(BecomeBase):
+
+    name = 'community.general.ksusu'
+
+    # messages for detecting prompted password issues
+    fail = ('Password incorrect',)
+    missing = ('No password given',)
+
+    def check_password_prompt(self, b_output):
+        ''' checks if the expected password prompt exists in b_output '''
+
+        prompts = self.get_option('prompt_l10n') or ["Kerberos password for .*@.*:"]
+        b_prompt = b"|".join(to_bytes(p) for p in prompts)
+
+        return bool(re.match(b_prompt, b_output))
+
+    def build_become_command(self, cmd, shell):
+
+        super(BecomeModule, self).build_become_command(cmd, shell)
+
+        # Prompt handling for ``ksu`` is more complicated, this
+        # is used to satisfy the connection plugin
+        self.prompt = True
+
+        if not cmd:
+            return cmd
+
+        exe_ksu = self.get_option('become_exe_ksu')
+        exe_su = self.get_option('become_exe_su') or '/bin/su'  # Must be absolute
+
+        flags_ksu = self.get_option('become_flags_ksu') or '-Z -q'
+        flags_su = self.get_option('become_flags') or ''
+        user_ksu = self.get_option('become_user_ksu') or 'root'
+        user_su = self.get_option('become_user') or 'root'
+        prompt = ''
+
+        return '%s %s %s -e %s -l %s %s %s ' % (exe_ksu, user_ksu, flags_ksu, exe_su, flags_su, user_su, self._build_success_command(cmd, shell))
+

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -128,8 +128,7 @@ DOCUMENTATION = """
         prompt_l10n:
             description:
                 - List of localized strings to match for prompt detection.
-                - If empty we'll use the built in one
-            default: []
+            default: ['Kerberos password for .*@.*:']
             ini:
               - section: ksusu_become_plugin
                 key: localized_prompts
@@ -172,7 +171,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        exe_ksu = self.get_option('become_exe_ksu')
+        exe_ksu = self.get_option('become_exe_ksu') or 'ksu'
         exe_su = self.get_option('become_exe_su') or '/bin/su'  # Must be absolute
 
         flags_ksu = self.get_option('become_flags_ksu') or '-Z -q'

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -65,7 +65,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_BECOME_EXE_KSU
               - name: ANSIBLE_KSU_EXE_KSU
         become_exe_su:
-            description: Absolute path to the su executable
+            description: Absolute path to the C(su) executable.
             default: /bin/su
             ini:
               - section: privilege_escalation

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -129,6 +129,7 @@ DOCUMENTATION = """
             description:
                 - List of localized strings to match for prompt detection.
             default: ['Kerberos password for .*@.*:']
+            default: ['Kerberos password for .*@.*:']
             ini:
               - section: ksusu_become_plugin
                 key: localized_prompts
@@ -171,7 +172,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-	# defaults come from above via configuration manager
+        # defaults come from above via configuration manager
         exe_ksu = self.get_option('become_exe_ksu')
         exe_su = self.get_option('become_exe_su')
         flags_ksu = self.get_option('become_flags_ksu')

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -11,7 +11,7 @@ DOCUMENTATION = """
     description:
         - This become plugins allows your remote/login user to execute commands as another user by calling su through the ksu utility.
     author:
-    - Ed Schaller
+    - Ed Schaller (@schallee)
     options:
         become_user_ksu:
             description: User you use with ksu to run su

--- a/plugins/become/ksusu.py
+++ b/plugins/become/ksusu.py
@@ -30,7 +30,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_KSUSU_USER_KSU
             required: False
         become_user:
-            description: User you 'become' to execute the task
+            description: User you 'become' to execute the task.
             default: root
             ini:
               - section: privilege_escalation

--- a/tests/unit/plugins/become/test_ksusu.py
+++ b/tests/unit/plugins/become/test_ksusu.py
@@ -14,23 +14,25 @@ from ansible import context
 
 from .helper import call_become_plugin
 
+
 def _test_ksu_task(mocker, parser, task, shell='/bin/bash', cmd='/bin/foo'):
     context._init_global_context(parser.parse_args([]))
 
-    # Task arguments and defaults
+    # Task arguments and defaults:
     become_user_ksu = task.get('become_user_ksu', 'root')
     become_user = task.get('become_user', 'root')
     become_exe_ksu = task.get('become_exe_ksu', 'ksu')
     become_exe_su = task.get('become_exe_su', '/bin/su')
-    become_flags_ksu = task.get('become_flags_ksu', '-Z\\s+-q' )
+    become_flags_ksu = task.get('become_flags_ksu', '-Z\\s+-q')
     become_flags = task.get('become_flags', '')
     become_pass = task.get('become_pass', None)
     prompt_l10n = task.get('prompt_l10n', [])
 
-    task['become_method'] = 'community.general.ksusu' # force this
+    task['become_method'] = 'community.general.ksusu'  # Force the become method.
 
-    # We are appending here instead of formatting so the parts are easily understood
-    regex  = become_exe_ksu
+    # We are appending here instead of formatting so the parts are easily understood.
+    regex = ''
+    regex += become_exe_ksu
     regex += '\\s+' + become_user_ksu
     regex += '\\s+' + become_flags_ksu
     regex += '\\s+-e\\s+' + become_exe_su
@@ -55,6 +57,7 @@ def test_ksusu_defaults(mocker, parser, reset_cli_args):
 
     _test_ksu_task(mocker, parser, task)
 
+
 def test_ksusu_user_ksu(mocker, parser, reset_cli_args):
 
     task = {
@@ -62,6 +65,7 @@ def test_ksusu_user_ksu(mocker, parser, reset_cli_args):
     }
 
     _test_ksu_task(mocker, parser, task)
+
 
 def test_ksusu_user(mocker, parser, reset_cli_args):
 
@@ -71,6 +75,7 @@ def test_ksusu_user(mocker, parser, reset_cli_args):
 
     _test_ksu_task(mocker, parser, task)
 
+
 def test_ksusu_exe_ksu(mocker, parser, reset_cli_args):
 
     task = {
@@ -78,6 +83,7 @@ def test_ksusu_exe_ksu(mocker, parser, reset_cli_args):
     }
 
     _test_ksu_task(mocker, parser, task)
+
 
 def test_ksusu_exe_su(mocker, parser, reset_cli_args):
 
@@ -87,6 +93,7 @@ def test_ksusu_exe_su(mocker, parser, reset_cli_args):
 
     _test_ksu_task(mocker, parser, task)
 
+
 def test_ksusu_flags_ksu(mocker, parser, reset_cli_args):
 
     task = {
@@ -94,6 +101,7 @@ def test_ksusu_flags_ksu(mocker, parser, reset_cli_args):
     }
 
     _test_ksu_task(mocker, parser, task)
+
 
 def test_ksusu_flags(mocker, parser, reset_cli_args):
 

--- a/tests/unit/plugins/become/test_ksusu.py
+++ b/tests/unit/plugins/become/test_ksusu.py
@@ -23,7 +23,7 @@ def _test_ksu_task(mocker, parser, task, shell='/bin/bash', cmd='/bin/foo'):
     become_user = task.get('become_user', 'root')
     become_exe_ksu = task.get('become_exe_ksu', 'ksu')
     become_exe_su = task.get('become_exe_su', '/bin/su')
-    become_flags_ksu = task.get('become_flags_ksu', '-Z\\s+-q')
+    become_flags_ksu = task.get('become_flags_ksu', r'-Z\s+-q')
     become_flags = task.get('become_flags', '')
     become_pass = task.get('become_pass', None)
     prompt_l10n = task.get('prompt_l10n', [])

--- a/tests/unit/plugins/become/test_ksusu.py
+++ b/tests/unit/plugins/become/test_ksusu.py
@@ -31,16 +31,20 @@ def _test_ksu_task(mocker, parser, task, shell='/bin/bash', cmd='/bin/foo'):
     task['become_method'] = 'community.general.ksusu'  # Force the become method.
 
     # We are appending here instead of formatting so the parts are easily understood.
-    regex = ''
-    regex += become_exe_ksu
-    regex += '\\s+' + become_user_ksu
-    regex += '\\s+' + become_flags_ksu
-    regex += '\\s+-e\\s+' + become_exe_su
-    regex += '\\s+-l\\s+' + become_flags
-    regex += '\\s+' + become_user
-    regex += '\\s+' + shell
-    regex += "\\s+-c\\s+'echo\\s+BECOME-SUCCESS-.+?\\s*;\\s*" + cmd
-    regex += "\\s*'"
+    regex = (
+        r"{exe_ksu}\s+{user_ksu}\s+{flags_ksu}\s+"
+        r"-e\s+{exe_su}\s+-l\s+{flags}\s+{user}\s+{shell}"
+        r"\s+-c\s+'echo\s+BECOME-SUCCESS-.+?\s*;\s*{cmd}\s*".format(
+            exe_ksu=become_exe_ksu,
+            user_ksu=become_user_ksu,
+            flags_ksu=become_flags_ksu,
+            exe_su=become_exe_su,
+            flags=become_flags,
+            user=become_user,
+            shell=shell,
+            cmd=cmd,
+        )
+    )
     print('regex: %s' % regex)
 
     var_options = {}

--- a/tests/unit/plugins/become/test_ksusu.py
+++ b/tests/unit/plugins/become/test_ksusu.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright (c) 2020 Ansible Project
+#
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible import context
+
+from .helper import call_become_plugin
+
+def _test_ksu_task(mocker, parser, task, shell='/bin/bash', cmd='/bin/foo'):
+    context._init_global_context(parser.parse_args([]))
+
+    # Task arguments and defaults
+    become_user_ksu = task.get('become_user_ksu', 'root')
+    become_user = task.get('become_user', 'root')
+    become_exe_ksu = task.get('become_exe_ksu', 'ksu')
+    become_exe_su = task.get('become_exe_su', '/bin/su')
+    become_flags_ksu = task.get('become_flags_ksu', '-Z\\s+-q' )
+    become_flags = task.get('become_flags', '')
+    become_pass = task.get('become_pass', None)
+    prompt_l10n = task.get('prompt_l10n', [])
+
+    task['become_method'] = 'community.general.ksusu' # force this
+
+    # We are appending here instead of formatting so the parts are easily understood
+    regex  = become_exe_ksu
+    regex += '\\s+' + become_user_ksu
+    regex += '\\s+' + become_flags_ksu
+    regex += '\\s+-e\\s+' + become_exe_su
+    regex += '\\s+-l\\s+' + become_flags
+    regex += '\\s+' + become_user
+    regex += '\\s+' + shell
+    regex += "\\s+-c\\s+'echo\\s+BECOME-SUCCESS-.+?\\s*;\\s*" + cmd
+    regex += "\\s*'"
+    print('regex: %s' % regex)
+
+    var_options = {}
+    call_result = call_become_plugin(task, var_options, cmd=cmd, executable=shell)
+    print('cmd:   %s' % call_result)
+
+    assert (re.match(regex, call_result) is not None)
+
+
+def test_ksusu_defaults(mocker, parser, reset_cli_args):
+
+    task = {
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_user_ksu(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_user_ksu': 'test_user'
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_user(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_user': 'test_user'
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_exe_ksu(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_exe_ksu': 'test_ksu'
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_exe_su(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_exe_su': '/bin/test_su'
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_flags_ksu(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_flags_ksu': '-Z -q --test_flag'
+    }
+
+    _test_ksu_task(mocker, parser, task)
+
+def test_ksusu_flags(mocker, parser, reset_cli_args):
+
+    task = {
+        'become_flags': '--test_flag'
+    }
+
+    _test_ksu_task(mocker, parser, task)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

ksu is configured by the .k5login in the desired user's home directory. As such it is impractical to configure ksu to be able to become users other than root in the general case. The solution is to call ksu followed by running su similar to the existing sudosu.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.general.ksusu

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
