### PR TITLE
Fixed `github_release` docs: only module-specific returned key is `tag`

### DIFF
--- a/plugins/modules/github_release.py
+++ b/plugins/modules/github_release.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
 
 RETURN = '''
 tag:
-    description: Version of the created/latest release
+    description: Version of the created/latest release.
     type: str
     returned: success
     sample: 1.1.0

--- a/plugins/modules/github_release.py
+++ b/plugins/modules/github_release.py
@@ -108,17 +108,8 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-create_release:
-    description:
-    - Version of the created release
-    - "For Ansible version 2.5 and later, if specified release version already exists, then State is unchanged"
-    - "For Ansible versions prior to 2.5, if specified release version already exists, then State is skipped"
-    type: str
-    returned: success
-    sample: 1.1.0
-
-latest_release:
-    description: Version of the latest release
+tag:
+    description: Version of the created/latest release
     type: str
     returned: success
     sample: 1.1.0


### PR DESCRIPTION
##### SUMMARY
As the title says, the docs were incorrect so I fixed it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`github_release`

##### ADDITIONAL INFORMATION
N/A