### PR TITLE
opkg: fix issue that force=reinstall would not reinstall an existing package

### DIFF
--- a/changelogs/fragments/5705-opkg-fix-force-reinstall.yml
+++ b/changelogs/fragments/5705-opkg-fix-force-reinstall.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opkg - fix issue that ``force=reinstall`` would not reinstall an existing package (https://github.com/ansible-collections/community.general/pull/5705).

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -154,7 +154,7 @@ def install_packages(module, opkg_path, packages):
     install_c = 0
 
     for package in packages:
-        if query_package(module, opkg_path, package):
+        if query_package(module, opkg_path, package) and (force != '--force-reinstall'):
             continue
 
         rc, out, err = module.run_command("%s install %s %s" % (opkg_path, force, package))


### PR DESCRIPTION
##### SUMMARY
opkg: fix issue that force=reinstall would not reinstall an existing package

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- opkg

##### ADDITIONAL INFORMATION

Tested with opkg 0.4.2 on NI Linux Real-Time 8.8

Bug noticed while working on #5688 