### PR TITLE
Fixes #5691. Support gitlab forking_access_level, builds_access_level and container_registry_access_level fields

### DIFF
--- a/changelogs/fragments/5706-add-builds-forks-container-registry.yml
+++ b/changelogs/fragments/5706-add-builds-forks-container-registry.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gitlab_project - add ``builds`` option (https://github.com/ansible-collections/community.general/pull/5706).
+  - gitlab_project - add ``forks`` option (https://github.com/ansible-collections/community.general/pull/5706).
+  - gitlab_project - add ``container_registry`` option (https://github.com/ansible-collections/community.general/pull/5706).

--- a/changelogs/fragments/5706-add-builds-forks-container-registry.yml
+++ b/changelogs/fragments/5706-add-builds-forks-container-registry.yml
@@ -1,4 +1,2 @@
 minor_changes:
-  - gitlab_project - add ``builds`` option (https://github.com/ansible-collections/community.general/pull/5706).
-  - gitlab_project - add ``forks`` option (https://github.com/ansible-collections/community.general/pull/5706).
-  - gitlab_project - add ``container_registry`` option (https://github.com/ansible-collections/community.general/pull/5706).
+  - gitlab_project - add ``builds_access_level``, ``container_registry_access_level`` and ``forking_access_level`` options (https://github.com/ansible-collections/community.general/pull/5706).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -172,6 +172,30 @@ options:
       - This option is only used on creation, not for updates. This is also only used if I(initialize_with_readme=true).
     type: str
     version_added: "4.2.0"
+  builds:
+    description:
+      - C(private) means that repository CI/CD is allowed only to project members.
+      - C(disabled) means that repository CI/CD is disabled.
+      - C(enabled) means that repository CI/CD is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.2.0"
+  forks:
+    description:
+      - C(private) means that repository forks is allowed only to project members.
+      - C(disabled) means that repository forks are disabled.
+      - C(enabled) means that repository forks are enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.2.0"
+  container_registry:
+    description:
+      - C(private) means that container registry is allowed only to project members.
+      - C(disabled) means that container registry is disabled.
+      - C(enabled) means that container registry is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.2.0"
 '''
 
 EXAMPLES = r'''
@@ -287,6 +311,9 @@ class GitLabProject(object):
             'squash_option': options['squash_option'],
             'ci_config_path': options['ci_config_path'],
             'shared_runners_enabled': options['shared_runners_enabled'],
+            'builds_access_level': options['builds'],
+            'forking_access_level': options['forks'],
+            'container_registry_access_level': options['container_registry'],
         }
         # Because we have already call userExists in main()
         if self.project_object is None:
@@ -417,6 +444,9 @@ def main():
         ci_config_path=dict(type='str'),
         shared_runners_enabled=dict(type='bool'),
         avatar_path=dict(type='path'),
+        builds=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        forks=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        container_registry=dict(type='str', choices=['private', 'disabled', 'enabled']),
     ))
 
     module = AnsibleModule(
@@ -464,6 +494,9 @@ def main():
     shared_runners_enabled = module.params['shared_runners_enabled']
     avatar_path = module.params['avatar_path']
     default_branch = module.params['default_branch']
+    builds = module.params['builds']
+    forks = module.params['forks']
+    container_registry = module.params['container_registry']
 
     if default_branch and not initialize_with_readme:
         module.fail_json(msg="Param default_branch need param initialize_with_readme set to true")
@@ -533,6 +566,9 @@ def main():
             "ci_config_path": ci_config_path,
             "shared_runners_enabled": shared_runners_enabled,
             "avatar_path": avatar_path,
+            "builds": builds,
+            "forks": forks,
+            "container_registry": container_registry,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -172,7 +172,7 @@ options:
       - This option is only used on creation, not for updates. This is also only used if I(initialize_with_readme=true).
     type: str
     version_added: "4.2.0"
-  builds:
+  builds_access_level:
     description:
       - C(private) means that repository CI/CD is allowed only to project members.
       - C(disabled) means that repository CI/CD is disabled.
@@ -180,7 +180,7 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "6.2.0"
-  forks:
+  forking_access_level:
     description:
       - C(private) means that repository forks is allowed only to project members.
       - C(disabled) means that repository forks are disabled.
@@ -188,7 +188,7 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "6.2.0"
-  container_registry:
+  container_registry_access_level:
     description:
       - C(private) means that container registry is allowed only to project members.
       - C(disabled) means that container registry is disabled.
@@ -311,9 +311,9 @@ class GitLabProject(object):
             'squash_option': options['squash_option'],
             'ci_config_path': options['ci_config_path'],
             'shared_runners_enabled': options['shared_runners_enabled'],
-            'builds_access_level': options['builds'],
-            'forking_access_level': options['forks'],
-            'container_registry_access_level': options['container_registry'],
+            'builds_access_level': options['builds_access_level'],
+            'forking_access_level': options['forking_access_level'],
+            'container_registry_access_level': options['container_registry_access_level'],
         }
         # Because we have already call userExists in main()
         if self.project_object is None:
@@ -444,9 +444,9 @@ def main():
         ci_config_path=dict(type='str'),
         shared_runners_enabled=dict(type='bool'),
         avatar_path=dict(type='path'),
-        builds=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        forks=dict(type='str', choices=['private', 'disabled', 'enabled']),
-        container_registry=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        builds_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
     ))
 
     module = AnsibleModule(
@@ -494,9 +494,9 @@ def main():
     shared_runners_enabled = module.params['shared_runners_enabled']
     avatar_path = module.params['avatar_path']
     default_branch = module.params['default_branch']
-    builds = module.params['builds']
-    forks = module.params['forks']
-    container_registry = module.params['container_registry']
+    builds_access_level = module.params['builds_access_level']
+    forking_access_level = module.params['forking_access_level']
+    container_registry_access_level = module.params['container_registry_access_level']
 
     if default_branch and not initialize_with_readme:
         module.fail_json(msg="Param default_branch need param initialize_with_readme set to true")
@@ -566,9 +566,9 @@ def main():
             "ci_config_path": ci_config_path,
             "shared_runners_enabled": shared_runners_enabled,
             "avatar_path": avatar_path,
-            "builds": builds,
-            "forks": forks,
-            "container_registry": container_registry,
+            "builds_access_level": builds_access_level,
+            "forking_access_level": forking_access_level,
+            "container_registry_access_level": container_registry_access_level,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)


### PR DESCRIPTION
##### SUMMARY

Fixes #5691

Added support for `gitlab forking_access_level`, `builds_access_level` and `container_registry_access_level` fields (see [gitlab api rest](https://docs.gitlab.com/ee/api/projects.html#create-project) for detail of these fields).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_project

##### ADDITIONAL INFORMATION
Example of project creation using the new fields:

```yaml
- name: Setup gitlab project
  community.general.gitlab_project:
    api_url: https://gitlab.example.com/
    validate_certs: true
    api_username: dj-wasabi
    api_password: "MySecretPassword"
    name: my_project
    group: ansible
    builds: disabled
    container_registry: disabled
    forks: disabled
    state: present
  delegate_to: localhost
```