### PR TITLE
feat: add tags to proxmox containers

### DIFF
--- a/changelogs/fragments/5714-proxmox-lxc-tag-support.yml
+++ b/changelogs/fragments/5714-proxmox-lxc-tag-support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- proxmox - added new module parameter ``tags`` for use with PVE 7+ (https://github.com/ansible-collections/community.general/pull/5714).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -113,7 +113,7 @@ options:
       - Tags are only available in Proxmox 7+.
     type: list
     elements: str
-    version_added: TODO
+    version_added: 6.3.0
   timeout:
     description:
       - timeout for operations

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -439,7 +439,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
         # Fail on unsupported features
         for option, version in minimum_version.items():
-            if pve_major_version < version:
+            if pve_major_version < version and option in kwargs:
                 self.module.fail_json(changed=False, msg="Feature {option} is only supported in PVE {version}+, and you're using PVE {pve_major_version}".
                                       format(option=option, version=version, pve_major_version=pve_major_version))
 

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -113,7 +113,7 @@ options:
       - Tags are only available in Proxmox 7+.
     type: list
     elements: str
-    version_added: 6.3.0
+    version_added: 6.2.0
   timeout:
     description:
       - timeout for operations

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -435,11 +435,11 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         version = self.version()
         pve_major_version = 3 if version < LooseVersion('4.0') else version.version[0]
 
-        #The features work only on PVE 7
+        # The features work only on PVE 7
         if pve_major_version < 7:
-          for p in only_v7:
-            if p in kwargs:
-              del kwargs[p]
+            for p in only_v7:
+                if p in kwargs:
+                    del kwargs[p]
 
         if VZ_TYPE == 'lxc':
             kwargs['cpulimit'] = cpus


### PR DESCRIPTION
##### SUMMARY

Added tag support for proxmox containers in PVE 7, to achieve feature parity with VMs which support tags since PVE6. Fixes #5471 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox.py

##### ADDITIONAL INFORMATION

I've restricted the tags feature to PVE 7, because I'm not sure if the original bug preventing tags in containers - from [proxmox forum](https://forum.proxmox.com/threads/api-parse-errors-when-lxc-tags-are-null.85197/) - has been fixed, and if yes, in which proxmox 6 version it has been fixed.

I've used the code from `proxmox_kvm.py`, so the tag separator is still a `,`. It's not an issue because on PVE 7.0-7.2, `,` is the correct separator, and on pve 7.3, it's automatically changed (by proxmox) to a `;` (and proxmox inventory plugin support both separator, see #5602)
