### PR TITLE
redhat_subscription: Add support for Red Hat API token

### DIFF
--- a/changelogs/fragments/5725-redhat_subscription-add-red-hat-api-token.yml
+++ b/changelogs/fragments/5725-redhat_subscription-add-red-hat-api-token.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redhat_subscription - adds ``token`` parameter for subscription-manager authentication using Red Hat API token (https://github.com/ansible-collections/community.general/pull/5725).

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -102,6 +102,37 @@ TEST_CASES = [
             'msg': "System successfully registered to 'satellite.company.com'."
         }
     ],
+    # Test simple registration using token
+    [
+        {
+            'state': 'present',
+            'server_hostname': 'satellite.company.com',
+            'token': 'fake_token',
+        },
+        {
+            'id': 'test_registeration_token',
+            'run_command.calls': [
+                (
+                    ['/testbin/subscription-manager', 'identity'],
+                    {'check_rc': False},
+                    (1, '', '')
+                ),
+                (
+                    ['/testbin/subscription-manager', 'config', '--server.hostname=satellite.company.com'],
+                    {'check_rc': True},
+                    (0, '', '')
+                ),
+                (
+                    ['/testbin/subscription-manager', 'register',
+                        '--token', 'fake_token'],
+                    {'check_rc': True, 'expand_user_and_vars': False},
+                    (0, '', '')
+                )
+            ],
+            'changed': True,
+            'msg': "System successfully registered to 'satellite.company.com'."
+        }
+    ],
     # Test unregistration, when system is unregistered
     [
         {


### PR DESCRIPTION
##### SUMMARY
Add support using Red Hat API token

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Updated redhat_subscription.py to allow using Red Hat API token.

##### ADDITIONAL INFORMATION
Added support for using Red Hat API token in addition to activationkey/org ID or username/password combination.
Following this to generate an access token from the offline token.
https://access.redhat.com/articles/3626371



