### PR TITLE
manageiq_tags: deprecate list state

### DIFF
--- a/changelogs/fragments/5727-manageiq-tags-deprecate-list-state.yaml
+++ b/changelogs/fragments/5727-manageiq-tags-deprecate-list-state.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - manageiq_tags - deprecate ``state=list`` in favour of using ``community.general.manageiq_tags_info`` (https://github.com/ansible-collections/community.general/pull/5727).

--- a/plugins/modules/manageiq_tags.py
+++ b/plugins/modules/manageiq_tags.py
@@ -27,7 +27,10 @@ options:
     description:
       - C(absent) - tags should not exist.
       - C(present) - tags should exist.
-      - C(list) - list current tags.
+      - >
+        C(list) - list current tags.
+        This state is deprecated and will be removed 8.0.0.
+        Please use the module M(community.general.manageiq_tags_info) instead.
     choices: ['absent', 'present', 'list']
     default: 'present'
   tags:
@@ -103,17 +106,6 @@ EXAMPLES = '''
       username: 'admin'
       password: 'smartvm'
       validate_certs: false
-
-- name: List current tags for a provider in ManageIQ.
-  community.general.manageiq_tags:
-    state: list
-    resource_name: 'EngLab'
-    resource_type: 'provider'
-    manageiq_connection:
-      url: 'http://127.0.0.1:3000'
-      username: 'admin'
-      password: 'smartvm'
-      validate_certs: false
 '''
 
 RETURN = '''
@@ -154,6 +146,13 @@ def main():
     resource_type_key = module.params['resource_type']
     resource_name = module.params['resource_name']
     state = module.params['state']
+
+    if state == "list":
+        module.deprecate(
+            'The value "list" for "state" is deprecated. Please use community.general.manageiq_tags_info instead.',
+            version='8.0.0',
+            collection_name='community.general'
+        )
 
     # get the action and resource type
     action = actions[state]

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -15,7 +15,7 @@ plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-s
 plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
-plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice
+plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice      # state=list - removed in 8.0.0
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/puppet.py validate-modules:parameter-invalid                          # invalid alias - removed in 7.0.0

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -10,7 +10,7 @@ plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-s
 plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
-plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice
+plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice      # state=list - removed in 8.0.0
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/puppet.py validate-modules:parameter-invalid                          # invalid alias - removed in 7.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -10,7 +10,7 @@ plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-s
 plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
-plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice
+plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice      # state=list - removed in 8.0.0
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/puppet.py validate-modules:parameter-invalid                          # invalid alias - removed in 7.0.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -11,7 +11,7 @@ plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-s
 plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
-plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice
+plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice      # state=list - removed in 8.0.0
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/puppet.py validate-modules:parameter-invalid                          # invalid alias - removed in 7.0.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -11,7 +11,7 @@ plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-s
 plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
 plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
-plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice
+plugins/modules/manageiq_tags.py validate-modules:parameter-state-invalid-choice      # state=list - removed in 8.0.0
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/puppet.py validate-modules:parameter-invalid                          # invalid alias - removed in 7.0.0


### PR DESCRIPTION
##### SUMMARY
Deprecate state "list" in favour of using manageiq_tags_info.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/manageiq_tags.py
