### PR TITLE
terraform: bugfix: init command when default workspace doesn't exists

### DIFF
--- a/changelogs/fragments/5735-terraform-init-fix-when-default-workspace-doesnt-exists.yaml
+++ b/changelogs/fragments/5735-terraform-init-fix-when-default-workspace-doesnt-exists.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - terraform - fix ``current`` workspace never getting appended to the ``all`` key in the ``workspace_ctf`` object. (https://github.com/ansible-collections/community.general/pull/5735)
+  - terraform - fix ``terraform init`` failure when there are multiple workspaces on the remote backend and when ``default`` workspace is missing by setting ``TF_WORKSPACE`` environmental variable to the value of ``workspace`` when used. (https://github.com/ansible-collections/community.general/pull/5735)

--- a/changelogs/fragments/5735-terraform-init-fix-when-default-workspace-doesnt-exists.yaml
+++ b/changelogs/fragments/5735-terraform-init-fix-when-default-workspace-doesnt-exists.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - terraform - fix ``current`` workspace never getting appended to the ``all`` key in the ``workspace_ctf`` object. (https://github.com/ansible-collections/community.general/pull/5735)
-  - terraform - fix ``terraform init`` failure when there are multiple workspaces on the remote backend and when ``default`` workspace is missing by setting ``TF_WORKSPACE`` environmental variable to the value of ``workspace`` when used. (https://github.com/ansible-collections/community.general/pull/5735)
+  - terraform - fix ``current`` workspace never getting appended to the ``all`` key in the ``workspace_ctf`` object (https://github.com/ansible-collections/community.general/pull/5735).
+  - terraform - fix ``terraform init`` failure when there are multiple workspaces on the remote backend and when ``default`` workspace is missing by setting ``TF_WORKSPACE`` environmental variable to the value of ``workspace`` when used (https://github.com/ansible-collections/community.general/pull/5735).

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -48,7 +48,9 @@ options:
     version_added: 3.0.0
   workspace:
     description:
-      - The terraform workspace to work with.
+      - The terraform workspace to work with. This sets the 'TF_WORKSPACE' environmental variable
+        that is used to override workspace selection. For more information about workspaces
+        have a look at U(https://developer.hashicorp.com/terraform/language/state/workspaces).
     type: str
     default: default
   purge_workspace:

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -310,7 +310,7 @@ def _state_args(state_file):
     return []
 
 
-def init_plugins(bin_path, project_path, backend_config, backend_config_files, init_reconfigure, provider_upgrade, plugin_paths):
+def init_plugins(bin_path, project_path, backend_config, backend_config_files, init_reconfigure, provider_upgrade, plugin_paths, workspace):
     command = [bin_path, 'init', '-input=false', '-no-color']
     if backend_config:
         for key, val in backend_config.items():
@@ -328,7 +328,7 @@ def init_plugins(bin_path, project_path, backend_config, backend_config_files, i
     if plugin_paths:
         for plugin_path in plugin_paths:
             command.extend(['-plugin-dir', plugin_path])
-    rc, out, err = module.run_command(command, check_rc=True, cwd=project_path)
+    rc, out, err = module.run_command(command, check_rc=True, cwd=project_path, environ_update={"TF_WORKSPACE": workspace})
 
 
 def get_workspace_context(bin_path, project_path):
@@ -343,6 +343,7 @@ def get_workspace_context(bin_path, project_path):
             continue
         elif stripped_item.startswith('* '):
             workspace_ctx["current"] = stripped_item.replace('* ', '')
+            workspace_ctx["all"].append(stripped_item.replace('* ', ''))
         else:
             workspace_ctx["all"].append(stripped_item)
     return workspace_ctx
@@ -485,7 +486,7 @@ def main():
 
     if force_init:
         if overwrite_init or not os.path.isfile(os.path.join(project_path, ".terraform", "terraform.tfstate")):
-            init_plugins(command[0], project_path, backend_config, backend_config_files, init_reconfigure, provider_upgrade, plugin_paths)
+            init_plugins(command[0], project_path, backend_config, backend_config_files, init_reconfigure, provider_upgrade, plugin_paths, workspace)
 
     workspace_ctx = get_workspace_context(command[0], project_path)
     if workspace_ctx["current"] != workspace:

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -48,7 +48,7 @@ options:
     version_added: 3.0.0
   workspace:
     description:
-      - The terraform workspace to work with. This sets the 'TF_WORKSPACE' environmental variable
+      - The terraform workspace to work with. This sets the C(TF_WORKSPACE) environmental variable
         that is used to override workspace selection. For more information about workspaces
         have a look at U(https://developer.hashicorp.com/terraform/language/state/workspaces).
     type: str


### PR DESCRIPTION
##### SUMMARY
If the terraform config stores its state on a remote backend, it's possible that there are multiple workspaces to choose from. At the same time, remote backends (e.g. Terraform Cloud) are not required to store a `default` workspace, but one can name and create workspaces as s:he wishes. This is where the Ansible Terraform module has a problem.

**Line 331**: The `terraform init` is called but expects the `default` workspace to exist. Consequently, it should ask you which of the available workspaces you want to choose (which happens if you do `terraform init` from the CLI) - but that obviously doesn't happen in the Ansible (non-interactive) workflow since the `-input=false` flag is appended to the `terraform init` command. 
To "avoid" being prompted to choose the workspace and a consequent error, one can choose the Terraform workspace by setting the `TF_WORKSPACE` environmental variable. Since the Ansible Terraform module already has a `workspace` variable I just used it to set the `TF_WORKSPACE`. 
Additionally, my opinion is that we should avoid setting the `TF_WORKSPACE` environmental variable directly in the ansible playbook since it causes confusion about what has precedence in comparison to the `workspace` variable.

**Line 346**: `"current"` workspace gets NEVER appended to the ¨"all"¨ in the `workspace_ctx` which then causes issues on **line 493**.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/modules/terraform.py`
