### PR TITLE
htpasswd: improve documentation on crypt_scheme

### DIFF
--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -42,11 +42,11 @@ options:
       - Encryption scheme to be used.  As well as the four choices listed
         here, you can also use any other hash supported by passlib, such as
         C(portable_apache22) and C(host_apache24); or C(md5_crypt) and C(sha256_crypt),
-        which are linux passwd hashes.  Only some schemes in addition to
+        which are Linux passwd hashes.  Only some schemes in addition to
         the four choices below will be compatible with Apache or Nginx, and
         supported schemes depend on passlib version and its dependencies.
       - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter C(default_scheme).
-      - 'Some of the available choices might be: C(apr_md5_crypt), C(des_crypt), C(ldap_sha1), C(plaintext)'
+      - 'Some of the available choices might be: C(apr_md5_crypt), C(des_crypt), C(ldap_sha1), C(plaintext).'
   state:
     type: str
     required: false

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -41,8 +41,11 @@ options:
     description:
       - Encryption scheme to be used.  As well as the four choices listed
         here, you can also use any other hash supported by passlib, such as
-        md5_crypt and sha256_crypt, which are linux passwd hashes.  If you
-        do so the password file will not be compatible with Apache or Nginx
+        portable_apache22 and host_apache24; or md5_crypt and sha256_crypt,
+        which are linux passwd hashes.  Only some schemes in addition to
+        the four choices below will be compatible with Apache or Nginx and
+        supported schemes depend on passlib version and its dependencies
+      - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter default_scheme.
       - 'Some of the available choices might be: C(apr_md5_crypt), C(des_crypt), C(ldap_sha1), C(plaintext)'
   state:
     type: str

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -41,7 +41,7 @@ options:
     description:
       - Encryption scheme to be used.  As well as the four choices listed
         here, you can also use any other hash supported by passlib, such as
-        portable_apache22 and host_apache24; or md5_crypt and sha256_crypt,
+        C(portable_apache22) and C(host_apache24); or C(md5_crypt) and C(sha256_crypt),
         which are linux passwd hashes.  Only some schemes in addition to
         the four choices below will be compatible with Apache or Nginx and
         supported schemes depend on passlib version and its dependencies

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -43,8 +43,8 @@ options:
         here, you can also use any other hash supported by passlib, such as
         C(portable_apache22) and C(host_apache24); or C(md5_crypt) and C(sha256_crypt),
         which are linux passwd hashes.  Only some schemes in addition to
-        the four choices below will be compatible with Apache or Nginx and
-        supported schemes depend on passlib version and its dependencies
+        the four choices below will be compatible with Apache or Nginx, and
+        supported schemes depend on passlib version and its dependencies.
       - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter C(default_scheme).
       - 'Some of the available choices might be: C(apr_md5_crypt), C(des_crypt), C(ldap_sha1), C(plaintext)'
   state:

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -45,7 +45,7 @@ options:
         which are linux passwd hashes.  Only some schemes in addition to
         the four choices below will be compatible with Apache or Nginx and
         supported schemes depend on passlib version and its dependencies
-      - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter default_scheme.
+      - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter C(default_scheme).
       - 'Some of the available choices might be: C(apr_md5_crypt), C(des_crypt), C(ldap_sha1), C(plaintext)'
   state:
     type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Users who are not already familiar with passlib would need to do considerable research to get the `htpasswd` module to work with anything better than the default MD5 crypto scheme. The current module documentation makes it seem like there are only obsolete options such as MD5, DES that would be compatible with Apache.  
This is not the case and passlib also provides specific meta schemes for Apache htpasswd.

With MD5, DES being so obsolete, this change makes it much easier to change to more secure schemes:
- Document the existence of passlib Apache-specific meta schemes, I chose `portable_apache22` and `host_apache24` as examples.
- Mention that supported schemes vary per passlib version and installed dependencies.
- Add link to passlib RTD site that describes the various schemes for Apache, and very importantly also the requirements for using them such as passlib version and dependencies. Unfortunately the RTD site contains anchors only on function level and not on parameter level so the user needs to scroll down to parameter `default_scheme` for relevant details.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
htpasswd

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
