### PR TITLE
unixy Callback: Fix typo using ansibles config manager

### DIFF
--- a/changelogs/fragments/5744-unixy-callback-fix-config-manager-typo.yml
+++ b/changelogs/fragments/5744-unixy-callback-fix-config-manager-typo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unixy callback plugin - fix typo introduced when updating to use Ansible's configuration manager for handling options (https://github.com/ansible-collections/community.general/issues/5600).

--- a/plugins/callback/unixy.py
+++ b/plugins/callback/unixy.py
@@ -142,7 +142,7 @@ class CallbackModule(CallbackModule_default):
             display_color = C.COLOR_CHANGED
             task_result = self._process_result_output(result, msg)
             self._display.display("  " + task_result, display_color)
-        elif self.get('display_ok_hosts'):
+        elif self.get_option('display_ok_hosts'):
             task_result = self._process_result_output(result, msg)
             self._display.display("  " + task_result, display_color)
 


### PR DESCRIPTION
##### SUMMARY
Fixes typo introduced in 53da86c, thus

Fixes #5600 (again).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`unixy`

##### ADDITIONAL INFORMATION

In https://github.com/ansible-collections/community.general/pull/5601#discussion_r1058867612 it was realized that the patch contained a typo.  This gets corrected with this PR.

Does it require another changelog fragment, or is it sufficient to have [changelogs/fragments/5601-unixy-callback-use-config-manager.yml](https://github.com/ansible-collections/community.general/blob/main/changelogs/fragments/5601-unixy-callback-use-config-manager.yml) ?
