### PR TITLE
bugfixing keycloak user federation failing when updating default mapper simultaneously

### DIFF
--- a/changelogs/fragments/5750-bugfixing-keycloak-usrfed-fail-when-update-default-mapper-simultaneously.yml
+++ b/changelogs/fragments/5750-bugfixing-keycloak-usrfed-fail-when-update-default-mapper-simultaneously.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - >-
+    keycloak_user_federation - fixes federation creation issue. When a new
+    federation was created and at the same time a default / standard mapper
+    was also changed / updated the creation process failed as a bad None
+    set variable led to a bad malformed url request
+    (https://github.com/ansible-collections/community.general/pull/5750).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -923,6 +923,8 @@ def main():
         updated_mappers = desired_comp.pop('mappers', [])
         after_comp = kc.create_component(desired_comp, realm)
 
+        cid = after_comp['id']
+
         for mapper in updated_mappers:
             found = kc.get_components(urlencode(dict(parent=cid, name=mapper['name'])), realm)
             if len(found) > 1:

--- a/tests/integration/targets/keycloak_user_federation/tasks/main.yml
+++ b/tests/integration/targets/keycloak_user_federation/tasks/main.yml
@@ -162,6 +162,14 @@
       useKerberosForPasswordAuthentication: false
       debug: false
     mappers:
+      # overwrite / update pre existing default mapper
+      - name: "username"
+        providerId: "user-attribute-ldap-mapper"
+        config:
+          ldap.attribute: ldap_user
+          user.model.attribute: usr
+          read.only: true
+      # create new mapper
       - name: "full name"
         providerId: "full-name-ldap-mapper"
         providerType: "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
@@ -227,3 +235,83 @@
       - result is not changed
       - result.existing == {}
       - result.end_state == {}
+
+- name: Create new user federation together with mappers
+  community.general.keycloak_user_federation:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ federation }}"
+    state: present
+    provider_id: ldap
+    provider_type: org.keycloak.storage.UserStorageProvider
+    config:
+      enabled: true
+      priority: 0
+      fullSyncPeriod: -1
+      changedSyncPeriod: -1
+      cachePolicy: DEFAULT
+      batchSizeForSync: 1000
+      editMode: READ_ONLY
+      importEnabled: true
+      syncRegistrations: false
+      vendor: other
+      usernameLDAPAttribute: uid
+      rdnLDAPAttribute: uid
+      uuidLDAPAttribute: entryUUID
+      userObjectClasses: "inetOrgPerson, organizationalPerson"
+      connectionUrl: "ldaps://ldap.example.com:636"
+      usersDn: "ou=Users,dc=example,dc=com"
+      authType: simple
+      bindDn: cn=directory reader
+      bindCredential: secret
+      searchScope: 1
+      validatePasswordPolicy: false
+      trustEmail: false
+      useTruststoreSpi: "ldapsOnly"
+      connectionPooling: true
+      pagination: true
+      allowKerberosAuthentication: false
+      useKerberosForPasswordAuthentication: false
+      debug: false
+    mappers:
+      # overwrite / update pre existing default mapper
+      - name: "username"
+        providerId: "user-attribute-ldap-mapper"
+        config:
+          ldap.attribute: ldap_user
+          user.model.attribute: usr
+          read.only: true
+      # create new mapper
+      - name: "full name"
+        providerId: "full-name-ldap-mapper"
+        providerType: "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
+        config:
+          ldap.full.name.attribute: cn
+          read.only: true
+          write.only: false
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert user federation created
+  assert:
+    that:
+      - result is changed
+      - result.existing == {}
+      - result.end_state.name == "{{ federation }}"
+
+## no point in retesting this, just doing it to clean up introduced server changes
+- name: Delete absent user federation
+  community.general.keycloak_user_federation:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ federation }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current implementation of `keycloak_user_federation` module fails to create a new user federation when also simultaneously updating / changing a default / standard created mapper like `username`.
The cause of this as can be seen in the diffs is simply a variable set to `None` on default forgotten to be updated to proper id value.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
It seems there are currently no open issues matching this bug or at least I failed to find them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/keycloak_user_federation.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Tested with recent keycloak (api) version: `20.0.2`.
