### PR TITLE
Fix callback plugin types

### DIFF
--- a/changelogs/fragments/5761-callback-types.yml
+++ b/changelogs/fragments/5761-callback-types.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - "loganalytics callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."
+  - "logdna callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."
+  - "logstash callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."
+  - "splunk callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."
+  - "sumologic callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."
+  - "syslog_json callback plugin - adjust type of callback to ``notification``, it was incorrectly classified as ``aggregate`` before (https://github.com/ansible-collections/community.general/pull/5761)."

--- a/plugins/callback/loganalytics.py
+++ b/plugins/callback/loganalytics.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: loganalytics
-    type: aggregate
+    type: notification
     short_description: Posts task results to Azure Log Analytics
     author: "Cyrus Li (@zhcli) <cyrus1006@gmail.com>"
     description:
@@ -155,7 +155,7 @@ class AzureLogAnalyticsSource(object):
 
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'loganalytics'
     CALLBACK_NEEDS_WHITELIST = True
 

--- a/plugins/callback/logdna.py
+++ b/plugins/callback/logdna.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
     author: Unknown (!UNKNOWN)
     name: logdna
-    type: aggregate
+    type: notification
     short_description: Sends playbook logs to LogDNA
     description:
       - This callback will report logs from playbook actions, tasks, and events to LogDNA (https://app.logdna.com)
@@ -111,7 +111,7 @@ def isJSONable(obj):
 class CallbackModule(CallbackBase):
 
     CALLBACK_VERSION = 0.1
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'community.general.logdna'
     CALLBACK_NEEDS_WHITELIST = True
 

--- a/plugins/callback/logstash.py
+++ b/plugins/callback/logstash.py
@@ -113,7 +113,7 @@ from ansible.plugins.callback import CallbackBase
 class CallbackModule(CallbackBase):
 
     CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'community.general.logstash'
     CALLBACK_NEEDS_WHITELIST = True
 

--- a/plugins/callback/splunk.py
+++ b/plugins/callback/splunk.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: splunk
-    type: aggregate
+    type: notification
     short_description: Sends task result events to Splunk HTTP Event Collector
     author: "Stuart Hirst (!UNKNOWN) <support@convergingdata.com>"
     description:
@@ -165,7 +165,7 @@ class SplunkHTTPCollectorSource(object):
 
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'community.general.splunk'
     CALLBACK_NEEDS_WHITELIST = True
 

--- a/plugins/callback/sumologic.py
+++ b/plugins/callback/sumologic.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 name: sumologic
-type: aggregate
+type: notification
 short_description: Sends task result events to Sumologic
 author: "Ryan Currah (@ryancurrah)"
 description:
@@ -111,7 +111,7 @@ class SumologicHTTPCollectorSource(object):
 
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'community.general.sumologic'
     CALLBACK_NEEDS_WHITELIST = True
 

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -71,7 +71,7 @@ class CallbackModule(CallbackBase):
     """
 
     CALLBACK_VERSION = 2.0
-    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'community.general.syslog_json'
     CALLBACK_NEEDS_WHITELIST = True
 


### PR DESCRIPTION
##### SUMMARY
Some callback plugins were incorrectly classified as aggregate, even though they should be notification callbacks. (See https://docs.ansible.com/ansible/devel/plugins/callback.html#callback-plugins.)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
loganalytics
logdna
logstash
splunk
sumologic
syslog_json
