### PR TITLE
consul: deprecate params incompatible with state=absent

### DIFF
--- a/changelogs/fragments/5772-consul-deprecate-params-when-absent.yml
+++ b/changelogs/fragments/5772-consul-deprecate-params-when-absent.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - consul - deprecate using parameters unused for state=absent (https://github.com/ansible-collections/community.general/pull/5772).

--- a/changelogs/fragments/5772-consul-deprecate-params-when-absent.yml
+++ b/changelogs/fragments/5772-consul-deprecate-params-when-absent.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - consul - deprecate using parameters unused for state=absent (https://github.com/ansible-collections/community.general/pull/5772).
+  - consul - deprecate using parameters unused for ``state=absent`` (https://github.com/ansible-collections/community.general/pull/5772).

--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -609,7 +609,7 @@ def main():
             collection_name="community.general",
         )
         # When reaching c.g 8.0.0:
-        # - Replace the deprecation with a fail_json(), remove the "ack_params_state_absent" condition on the "if"
+        # - Replace the deprecation with a fail_json(), remove the "ack_params_state_absent" condition from the "if"
         # - Add mutually_exclusive for ('script', 'ttl', 'tcp', 'http'), then remove that validation from parse_check()
         # - Add required_by {'script': 'interval', 'http': 'interval', 'tcp': 'interval', then remove checks for 'interval' in ConsulCheck.__init__()
         # - Deprecate the parameter ack_params_state_absent

--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -611,7 +611,7 @@ def main():
         # When reaching c.g 8.0.0:
         # - Replace the deprecation with a fail_json(), remove the "ack_params_state_absent" condition from the "if"
         # - Add mutually_exclusive for ('script', 'ttl', 'tcp', 'http'), then remove that validation from parse_check()
-        # - Add required_by {'script': 'interval', 'http': 'interval', 'tcp': 'interval', then remove checks for 'interval' in ConsulCheck.__init__()
+        # - Add required_by {'script': 'interval', 'http': 'interval', 'tcp': 'interval'}, then remove checks for 'interval' in ConsulCheck.__init__()
         # - Deprecate the parameter ack_params_state_absent
 
     try:

--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -149,6 +149,10 @@ options:
         type: str
         description:
           - The token key identifying an ACL rule set. May be required to register services.
+    ack_params_state_absent:
+        type: bool
+        description:
+          - Disable deprecation warning when using parameters incompatible with I(state=absent).
 '''
 
 EXAMPLES = '''
@@ -584,7 +588,8 @@ def main():
             http=dict(type='str'),
             timeout=dict(type='str'),
             tags=dict(type='list', elements='str'),
-            token=dict(no_log=True)
+            token=dict(no_log=True),
+            ack_params_state_absent=dict(type='bool'),
         ),
         required_if=[
             ('state', 'present', ['service_name']),
@@ -592,14 +597,27 @@ def main():
         ],
         supports_check_mode=False,
     )
+    p = module.params
 
     test_dependencies(module)
+    if p['state'] == 'absent' and any(p[x] for x in ['script', 'ttl', 'tcp', 'http', 'interval']) and not p['ack_params_state_absent']:
+        module.deprecate(
+            "The use of parameters 'script', 'ttl', 'tcp', 'http', 'interval' along with 'state=absent' is deprecated. "
+            "In community.general 8.0.0 their use will become an error. "
+            "To suppress this deprecation notice, set parameter ack_params_state_absent=true.",
+            version="8.0.0",
+            collection_name="community.general",
+        )
+        # When reaching c.g 8.0.0:
+        # - Replace the deprecation with a fail_json(), remove the "ack_params_state_absent" condition on the "if"
+        # - Add mutually_exclusive for ('script', 'ttl', 'tcp', 'http'), then remove that validation from parse_check()
+        # - Add required_by {'script': 'interval', 'http': 'interval', 'tcp': 'interval', then remove checks for 'interval' in ConsulCheck.__init__()
+        # - Deprecate the parameter ack_params_state_absent
 
     try:
         register_with_consul(module)
     except ConnectionError as e:
-        module.fail_json(msg='Could not connect to consul agent at %s:%s, error was %s' % (
-            module.params['host'], module.params['port'], str(e)))
+        module.fail_json(msg='Could not connect to consul agent at %s:%s, error was %s' % (p['host'], p['port'], str(e)))
     except Exception as e:
         module.fail_json(msg=str(e))
 

--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -616,6 +616,8 @@ def main():
 
     try:
         register_with_consul(module)
+    except SystemExit:
+        raise
     except ConnectionError as e:
         module.fail_json(msg='Could not connect to consul agent at %s:%s, error was %s' % (p['host'], p['port'], str(e)))
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Deprecate using parameters unused for state=absent.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/consul.py