### PR TITLE
snap: use MH execute() static method

### DIFF
--- a/changelogs/fragments/5773-snap-mh-execute.yml
+++ b/changelogs/fragments/5773-snap-mh-execute.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - snap - minor refactor when executing module (https://github.com/ansible-collections/community.general/pull/5773).

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -399,8 +399,7 @@ class Snap(CmdStateModuleHelper):
 
 
 def main():
-    snap = Snap()
-    snap.run()
+    Snap.execute()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Use `ModuleHelper.execute()` method to run module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/snap.py