### PR TITLE
Fix CI

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -7,7 +7,7 @@ coverage >= 4.2, < 5.0.0, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ 
 coverage >= 4.5.4, < 5.0.0 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 cryptography >= 3.0, < 3.4 ; python_version < '3.6' and python_version >= '2.7' # cryptography 3.4 drops support for python 2.7
-cryptography >= 3.3, < 3.4 ; python_version >= '2.7' # FIXME: the upper limit is needed for RHEL8.2, CentOS 8, Ubuntu 18.04, and OpenSuSE 15
+cryptography >= 3.3, < 3.4 ; python_version >= '2.7' and python_version < '3.9' # FIXME: the upper limit is needed for RHEL8.2, CentOS 8, Ubuntu 18.04, and OpenSuSE 15
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
@@ -56,12 +56,3 @@ redis ; python_version >= '3.6'
 pycdlib < 1.13.0 ; python_version < '3'  # 1.13.0 does not work with Python 2, while not declaring that
 python-daemon <= 2.3.0 ; python_version < '3'
 bcrypt < 4.0.0  # TEMP: restrict to < 4.0.0 since installing 4.0.0 fails on RHEL 8
-
-# freeze pylint and its requirements for consistent test results
-astroid == 2.2.5
-isort == 4.3.15
-lazy-object-proxy == 1.3.1
-mccabe == 0.6.1
-pylint == 2.3.1
-typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
-wrapt == 1.11.1


### PR DESCRIPTION
##### SUMMARY
Currently Alpine 3 nightly tests fail for ssh_config due to old cryptography being installed.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
