### PR TITLE
Remove currently unneeded generic tests from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -487,10 +487,11 @@ stages:
       - Docker_2_13
       - Docker_2_14
       - Docker_community_devel
-      - Generic_devel
-      - Generic_2_11
-      - Generic_2_12
-      - Generic_2_13
-      - Generic_2_14
+# Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+#      - Generic_devel
+#      - Generic_2_11
+#      - Generic_2_12
+#      - Generic_2_13
+#      - Generic_2_14
     jobs:
       - template: templates/coverage.yml

--- a/tests/integration/targets/one_host/aliases
+++ b/tests/integration/targets/one_host/aliases
@@ -4,4 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME
+disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!

--- a/tests/integration/targets/one_template/aliases
+++ b/tests/integration/targets/one_template/aliases
@@ -4,4 +4,4 @@
 
 azp/generic/1
 cloud/opennebula
-disabled  # FIXME
+disabled  # FIXME  - when this is fixed, also re-enable the generic tests in CI!


### PR DESCRIPTION
##### SUMMARY
They are needed for two integration test targets, both of them currently disabled. So avoid wasting CI cycles on these.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
