### PR TITLE
Bugfix: proxmox_disk - read time out on import

### DIFF
--- a/changelogs/fragments/5803-proxmox-read-timeout.yml
+++ b/changelogs/fragments/5803-proxmox-read-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_disk - fixed issue with read timeout on import action (https://github.com/ansible-collections/community.general/pull/5803).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use asynchronous `post()` API call for _create_ actions instead of synchronous `get()`.
Fixes #5753 .
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_disk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There is no user friendly method to control `requests` _timeout_ parameter from Ansible Playbook, so synchronous `get()` API call returns "read timeout" after default amount of time (it is 5 seconds now and it was enough for my servers to copy 300MB between storages).
Now the `proxmox_disk` module uses asyncronous calls and waits for tasks to finish (or reach timeout which can be controlled by the user).
Documentation has also been updated.
<!--- Paste verbatim command output below, e.g. before and after your change -->
