### PR TITLE
opkg: extend docu about compatibilty with OpenWrt vs. Yocto based Linux distribitions

### DIFF
--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -15,9 +15,9 @@ DOCUMENTATION = '''
 ---
 module: opkg
 author: "Patrick Pelletier (@skinp)"
-short_description: Package manager for OpenWrt
+short_description: Package manager for OpenWrt and Openembedded/Yocto based Linux distributions
 description:
-    - Manages OpenWrt packages
+    - Manages ipk packages for OpenWrt and Openembedded/Yocto based Linux distributions
 options:
     name:
         description:

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -23,8 +23,9 @@ options:
         description:
             - Name of package(s) to install/remove.
             - C(NAME=VERSION) syntax is also supported to install a package
-              in a certain version. See the examples. This is supported since
-              community.general 6.2.0.
+              in a certain version. See the examples. This only works on Yocto based
+              Linux distributions (opkg>=0.3.2) and not for OpenWrt. This is
+              supported since community.general 6.2.0.
         aliases: [pkg]
         required: true
         type: list
@@ -67,7 +68,7 @@ EXAMPLES = '''
     name: foo
     state: present
 
-- name: Install foo in version 1.2
+- name: Install foo in version 1.2 (opkg>=0.3.2 on Yocto based Linux distributions)
   community.general.opkg:
     name: foo=1.2
     state: present


### PR DESCRIPTION
##### SUMMARY
The documentation did not yet state that this module also works for opkg on OpenEmbedded/Yocto based Linux distributions.
The review of PR #5718 showed that there are differences between OpenWrt and Yocto based Linux distributions, e.g. the `PACKAGE=VERSION` syntax is working for Yocto based Linux distributions but not for OpenWrt.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
- opkg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

- opkg from OpenWrt is maintained here: https://git.openwrt.org/project/opkg-lede.git
- opkg from Yocto is maintained here: https://git.yoctoproject.org/opkg/
    - The commit which added the `PACKAGE=VERSION` syntax is this one: [9da784d](https://git.yoctoproject.org/opkg/commit/?id=9da784d5508157cb327d53eb9abcf54e9926a5a5) -> part of release [0.3.2](https://git.yoctoproject.org/opkg/log/?h=v0.3.2)
    - The [opkg recipe](http://layers.openembedded.org/layerindex/recipe/252/) page shows which opkg version is contained in which Yocto release (table "Other branches" at the bottom of the page)
