### PR TITLE
Clarify Error message when bitwarden vault not unlocked

### DIFF
--- a/changelogs/fragments/5811-clarify-bitwarden-error.yml
+++ b/changelogs/fragments/5811-clarify-bitwarden-error.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - bitwarden - Clarify what to do, if the bitwarden vault is not unlocked (https://github.com/ansible-collections/community.general/pull/5811)
+  - bitwarden lookup plugin - clarify what to do, if the bitwarden vault is not unlocked (https://github.com/ansible-collections/community.general/pull/5811).

--- a/changelogs/fragments/5811-clarify-bitwarden-error.yml
+++ b/changelogs/fragments/5811-clarify-bitwarden-error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - bitwarden - Clarify what to do, if the bitwarden vault is not unlocked (https://github.com/ansible-collections/community.general/pull/5811)

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -83,7 +83,7 @@ class Bitwarden(object):
         return self._cli_path
 
     @property
-    def logged_in(self):
+    def unlocked(self):
         out, err = self._run(['status'], stdin="")
         decoded = AnsibleJSONDecoder().raw_decode(out)[0]
         return decoded['status'] == 'unlocked'
@@ -135,7 +135,7 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         field = self.get_option('field')
         search_field = self.get_option('search')
-        if not _bitwarden.logged_in:
+        if not _bitwarden.unlocked:
             raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
 
         return [_bitwarden.get_field(field, term, search_field) for term in terms]

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -136,7 +136,7 @@ class LookupModule(LookupBase):
         field = self.get_option('field')
         search_field = self.get_option('search')
         if not _bitwarden.logged_in:
-            raise AnsibleError("Not logged into Bitwarden. Run 'bw login'.")
+            raise AnsibleError("Bitwarden Vault not unlocked. Run 'bw unlock'.")
 
         return [_bitwarden.get_field(field, term, search_field) for term in terms]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -136,7 +136,7 @@ class LookupModule(LookupBase):
         field = self.get_option('field')
         search_field = self.get_option('search')
         if not _bitwarden.logged_in:
-            raise AnsibleError("Bitwarden Vault not unlocked. Run 'bw unlock'.")
+            raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
 
         return [_bitwarden.get_field(field, term, search_field) for term in terms]
 

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -111,7 +111,7 @@ MOCK_RECORDS = [
 
 class MockBitwarden(Bitwarden):
 
-    logged_in = True
+    unlocked = True
 
     def _get_matches(self, search_value, search_field="name"):
         return list(filter(lambda record: record[search_field] == search_value, MOCK_RECORDS))
@@ -119,7 +119,7 @@ class MockBitwarden(Bitwarden):
 
 class LoggedOutMockBitwarden(MockBitwarden):
 
-    logged_in = False
+    unlocked = False
 
 
 class TestLookupModule(unittest.TestCase):
@@ -155,7 +155,7 @@ class TestLookupModule(unittest.TestCase):
                          self.lookup.run(['a_test'])[0])
 
     @patch('ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden', LoggedOutMockBitwarden())
-    def test_bitwarden_plugin_logged_out(self):
+    def test_bitwarden_plugin_unlocked(self):
         record = MOCK_RECORDS[0]
         record_name = record['name']
         with self.assertRaises(AnsibleError):


### PR DESCRIPTION

##### SUMMARY

The Error message of the Bitwarden lookup-plugin is not conclusive of what actually is the Error.
This PR adresses the issue, and tells the user to unlock the vault, instead of logging in. (Just logging in, still results in the error, because the vault is not unlocked)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
bitwarden lookup plugin

##### ADDITIONAL INFORMATION

You can be logged into the Bitwarden-CLI, but it will still be locked. This took me several hours to debug, since every time I ran 'bw login' it told me, that I am already logged in. If you run 'bw unlock' without being logged in, you are prompted to log in.  This clarifies the Error occurring and can drastically reduce debugging time, since you don't have to look into the source code to get an understanding of whats wrong.