### PR TITLE
OpenNebula/one_vm implement the one.vm.updateconf API call

### DIFF
--- a/changelogs/fragments/5812-implement-updateconf-api-call.yml
+++ b/changelogs/fragments/5812-implement-updateconf-api-call.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - one_vm - implement the ``one.vm.updateconf`` API call (https://github.com/ansible-collections/community.general/pull/5812).
+  - one_vm - add a new ``updateconf`` option which implements the ``one.vm.updateconf`` API call (https://github.com/ansible-collections/community.general/pull/5812).

--- a/changelogs/fragments/5812-implement-updateconf-api-call.yml
+++ b/changelogs/fragments/5812-implement-updateconf-api-call.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - one_vm - implement the ``one.vm.updateconf`` API call (https://github.com/ansible-collections/community.general/pull/5812).

--- a/plugins/module_utils/opennebula.py
+++ b/plugins/module_utils/opennebula.py
@@ -26,6 +26,52 @@ except ImportError:
     HAS_PYONE = False
 
 
+# A helper function to mitigate https://github.com/OpenNebula/one/issues/6064.
+# Used for template merging in the JSON-like template representation.
+def extend(to_extend, extend_by):
+    """Extends dictionary in-place (by merging), then returns it."""
+    def recurse(to_extend, extend_by):
+        for key, value in extend_by.items():
+            if key in to_extend:
+                if isinstance(to_extend[key], dict) and isinstance(value, dict):
+                    recurse(to_extend[key], value)
+                    continue
+            to_extend[key] = value
+    if extend_by:
+        recurse(to_extend, extend_by)
+    return to_extend
+
+
+# A helper function to mitigate https://github.com/OpenNebula/one/issues/6064.
+# It allows for easily handling lists like "NIC" or "DISK" in the JSON-like template representation.
+# There are either lists of dictionaries (length > 1) or just dictionaries.
+def flatten(to_flatten, extract=False):
+    """Flattens nested lists (with optional value extraction)."""
+    def recurse(to_flatten):
+        return sum(map(recurse, to_flatten), []) if isinstance(to_flatten, list) else [to_flatten]
+    value = recurse(to_flatten)
+    if extract and len(value) == 1:
+        return value[0]
+    return value
+
+
+# A helper function to mitigate https://github.com/OpenNebula/one/issues/6064.
+# It renders JSON-like template representation into OpenNebula's template syntax (string).
+def render(to_render):
+    """Converts dictionary to OpenNebula template."""
+    def recurse(to_render):
+        for key, value in sorted(to_render.items()):
+            if isinstance(value, dict):
+                yield '{}=[{}]'.format(key, ','.join(recurse(value)))
+                continue
+            if isinstance(value, list):
+                for item in value:
+                    yield '{}=[{}]'.format(key, ','.join(recurse(item)))
+                continue
+            yield '{}="{}"'.format(key, value)
+    return '\n'.join(recurse(to_render))
+
+
 class OpenNebulaModule:
     """
     Base class for all OpenNebula Ansible Modules.

--- a/plugins/module_utils/opennebula.py
+++ b/plugins/module_utils/opennebula.py
@@ -27,22 +27,6 @@ except ImportError:
 
 
 # A helper function to mitigate https://github.com/OpenNebula/one/issues/6064.
-# Used for template merging in the JSON-like template representation.
-def extend(to_extend, extend_by):
-    """Extends dictionary in-place (by merging), then returns it."""
-    def recurse(to_extend, extend_by):
-        for key, value in extend_by.items():
-            if key in to_extend:
-                if isinstance(to_extend[key], dict) and isinstance(value, dict):
-                    recurse(to_extend[key], value)
-                    continue
-            to_extend[key] = value
-    if extend_by:
-        recurse(to_extend, extend_by)
-    return to_extend
-
-
-# A helper function to mitigate https://github.com/OpenNebula/one/issues/6064.
 # It allows for easily handling lists like "NIC" or "DISK" in the JSON-like template representation.
 # There are either lists of dictionaries (length > 1) or just dictionaries.
 def flatten(to_flatten, extract=False):

--- a/plugins/module_utils/opennebula.py
+++ b/plugins/module_utils/opennebula.py
@@ -62,13 +62,13 @@ def render(to_render):
     def recurse(to_render):
         for key, value in sorted(to_render.items()):
             if isinstance(value, dict):
-                yield '{}=[{}]'.format(key, ','.join(recurse(value)))
+                yield '{0:}=[{1:}]'.format(key, ','.join(recurse(value)))
                 continue
             if isinstance(value, list):
                 for item in value:
-                    yield '{}=[{}]'.format(key, ','.join(recurse(item)))
+                    yield '{0:}=[{1:}]'.format(key, ','.join(recurse(item)))
                 continue
-            yield '{}="{}"'.format(key, value)
+            yield '{0:}="{1:}"'.format(key, value)
     return '\n'.join(recurse(to_render))
 
 

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -198,10 +198,11 @@ options:
     type: str
   updateconf:
     description:
-      - When C(instance_ids) is provided, updates running VMs with the C(updateconf) API call.
+      - When I(instance_ids) is provided, updates running VMs with the C(updateconf) API call.
       - When new VMs are being created, emulates the C(updateconf) API call via direct template merge.
       - Allows for complete modifications of the C(CONTEXT) attribute.
     type: dict
+    version_added: 6.3.0
 author:
     - "Milan Ilic (@ilicmilan)"
     - "Jan Meerkamp (@meerkampdvv)"
@@ -541,8 +542,9 @@ instances:
                         "USER_INPUTS": null
                     }
         updateconf:
-            description: A dictionary of key/values attributes that are set with the updateconf API call
+            description: A dictionary of key/values attributes that are set with the updateconf API call.
             type: dict
+            version_added: 6.3.0
             sample: {
                         "OS": { "ARCH": "x86_64" },
                         "CONTEXT": {
@@ -658,6 +660,7 @@ tagged_instances:
         updateconf:
             description: A dictionary of key/values attributes that are set with the updateconf API call
             type: dict
+            version_added: 6.3.0
             sample: {
                         "OS": { "ARCH": "x86_64" },
                         "CONTEXT": {
@@ -881,7 +884,7 @@ def get_vm_info(client, vm):
         'attributes': vm_attributes,
         'mode': permissions_str,
         'labels': vm_labels,
-        'updateconf': updateconf
+        'updateconf': updateconf,
     }
 
     return info

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -1683,7 +1683,7 @@ def main():
     if owner_id is not None or group_id is not None:
         changed = set_vm_ownership(module, one_client, vms, owner_id, group_id) or changed
 
-    if template_id is None and instance_ids is not None and updateconf is not None:
+    if template_id is None and updateconf is not None:
         changed = update_vms(module, one_client, vms, updateconf) or changed
 
     if wait and not module.check_mode and state != 'present':

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -1483,7 +1483,7 @@ def main():
         "count_labels": {"required": False, "type": "list", "elements": "str"},
         "disk_saveas": {"type": "dict"},
         "persistent": {"default": False, "type": "bool"},
-        "updateconf": {"required": False, "type": "dict"},
+        "updateconf": {"type": "dict"},
     }
 
     module = AnsibleModule(argument_spec=fields,

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -706,15 +706,17 @@ def check_updateconf(module, to_check):
 
 def parse_updateconf(vm_template):
     '''Extracts 'updateconf' attributes from a VM template.'''
-    updateconf = {
-        attr: {
-            subattr: value
-            for subattr, value in subattributes.items()
-            if not UPDATECONF_ATTRIBUTES[attr] or subattr in UPDATECONF_ATTRIBUTES[attr]
-        }
-        for attr, subattributes in vm_template.items()
-        if attr in UPDATECONF_ATTRIBUTES
-    }
+    updateconf = {}
+    for attr, subattributes in vm_template.items():
+        if attr not in UPDATECONF_ATTRIBUTES:
+            continue
+        tmp = {}
+        for subattr, value in subattributes.items():
+            if UPDATECONF_ATTRIBUTES[attr] and subattr not in UPDATECONF_ATTRIBUTES[attr]:
+                continue
+            tmp[subattr] = value
+        if tmp:
+            updateconf[attr] = tmp
     return updateconf
 
 

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -200,7 +200,7 @@ options:
     description:
       - When C(instance_ids) is provided, updates running VMs with the C(updateconf) API call.
       - When new VMs are being created, emulates the C(updateconf) API call via direct template merge.
-      - Allows for complete modifications of the C(CONTEXT) attribute (see https://docs.opennebula.io/6.6/integration_and_development/system_interfaces/api.html#one-vm-updateconf).
+      - Allows for complete modifications of the C(CONTEXT) attribute.
     type: dict
 author:
     - "Milan Ilic (@ilicmilan)"
@@ -692,12 +692,12 @@ def check_updateconf(module, to_check):
     '''Checks if attributes are compatible with one.vm.updateconf API call.'''
     for attr, subattributes in to_check.items():
         if attr not in UPDATECONF_ATTRIBUTES:
-            module.fail_json(msg="'{}' is not a valid VM attribute.".format(attr))
+            module.fail_json(msg="'{0:}' is not a valid VM attribute.".format(attr))
         if not UPDATECONF_ATTRIBUTES[attr]:
             continue
         for subattr in subattributes:
             if subattr not in UPDATECONF_ATTRIBUTES[attr]:
-                module.fail_json(msg="'{}' is not a valid VM subattribute of '{}'".format(subattr, attr))
+                module.fail_json(msg="'{0:}' is not a valid VM subattribute of '{1:}'".format(subattr, attr))
 
 
 def parse_updateconf(vm_template):
@@ -1107,8 +1107,10 @@ def get_all_vms_by_attributes(client, attributes_dict, labels_list):
     return vm_list
 
 
-def create_count_of_vms(
-        module, client, template_id, count, attributes_dict, labels_list, disk_size, network_attrs_list, wait, wait_timeout, vm_start_on_hold, vm_persistent, updateconf_dict):
+def create_count_of_vms(module, client,
+                        template_id, count,
+                        attributes_dict, labels_list, disk_size, network_attrs_list,
+                        wait, wait_timeout, vm_start_on_hold, vm_persistent, updateconf_dict):
     new_vms_list = []
 
     vm_name = ''
@@ -1137,7 +1139,9 @@ def create_count_of_vms(
             new_vm_name += next_index
         # Update NAME value in the attributes in case there is index
         attributes_dict['NAME'] = new_vm_name
-        new_vm_dict = create_vm(module, client, template_id, attributes_dict, labels_list, disk_size, network_attrs_list, vm_start_on_hold, vm_persistent, updateconf_dict)
+        new_vm_dict = create_vm(module, client,
+                                template_id, attributes_dict, labels_list, disk_size, network_attrs_list,
+                                vm_start_on_hold, vm_persistent, updateconf_dict)
         new_vm_id = new_vm_dict.get('vm_id')
         new_vm = get_vm_by_id(client, new_vm_id)
         new_vms_list.append(new_vm)
@@ -1155,9 +1159,10 @@ def create_count_of_vms(
     return True, new_vms_list, []
 
 
-def create_exact_count_of_vms(module, client, template_id, exact_count, attributes_dict, count_attributes_dict,
-                              labels_list, count_labels_list, disk_size, network_attrs_list, hard, wait, wait_timeout, vm_start_on_hold, vm_persistent, updateconf_dict):
-
+def create_exact_count_of_vms(module, client,
+                              template_id, exact_count, attributes_dict, count_attributes_dict,
+                              labels_list, count_labels_list, disk_size, network_attrs_list,
+                              hard, wait, wait_timeout, vm_start_on_hold, vm_persistent, updateconf_dict):
     vm_list = get_all_vms_by_attributes(client, count_attributes_dict, count_labels_list)
 
     vm_count_diff = exact_count - len(vm_list)

--- a/tests/unit/plugins/module_utils/test_opennebula.py
+++ b/tests/unit/plugins/module_utils/test_opennebula.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, Michal Opala <mopala@opennebula.io>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pytest
+import textwrap
+
+from ansible_collections.community.general.plugins.module_utils.opennebula import extend, flatten, render
+
+
+EXTEND_VALID = [
+    (
+        {"a": 1},
+        {"b": 2},
+        {"a": 1, "b": 2}
+    ),
+    (
+        {"a": 1, "b": 2},
+        {"b": 3},
+        {"a": 1, "b": 3}
+    ),
+    (
+        {"a": 1, "b": {"c": 2}},
+        {"b": {"c": 3}},
+        {"a": 1, "b": {"c": 3}}
+    ),
+    (
+        {"a": 1, "b": [2, 3]},
+        {"b": [4, 5]},
+        {"a": 1, "b": [4, 5]}
+    ),
+]
+
+FLATTEN_VALID = [
+    (
+        [[[1]], [2], 3],
+        False,
+        [1, 2, 3]
+    ),
+    (
+        [[[1]], [2], 3],
+        True,
+        [1, 2, 3]
+    ),
+    (
+        [[1]],
+        False,
+        [1]
+    ),
+    (
+        [[1]],
+        True,
+        1
+    ),
+    (
+        1,
+        False,
+        [1]
+    ),
+    (
+        1,
+        True,
+        1
+    ),
+]
+
+RENDER_VALID = [
+    (
+        {
+            "NIC": {"NAME": "NIC0", "NETWORK_ID": 0},
+            "CPU": 1,
+            "MEMORY": 1024,
+        },
+        textwrap.dedent('''
+            CPU="1"
+            MEMORY="1024"
+            NIC=[NAME="NIC0",NETWORK_ID="0"]
+        ''').strip()
+    ),
+    (
+        {
+            "NIC": [
+                {"NAME": "NIC0", "NETWORK_ID": 0},
+                {"NAME": "NIC1", "NETWORK_ID": 1},
+            ],
+            "CPU": 1,
+            "MEMORY": 1024,
+        },
+        textwrap.dedent('''
+            CPU="1"
+            MEMORY="1024"
+            NIC=[NAME="NIC0",NETWORK_ID="0"]
+            NIC=[NAME="NIC1",NETWORK_ID="1"]
+        ''').strip()
+    ),
+]
+
+
+@pytest.mark.parametrize('to_extend,extend_by,expected_result', EXTEND_VALID)
+def test_extend(to_extend, extend_by, expected_result):
+    result = extend(to_extend, extend_by)
+    assert result == expected_result, repr(result)
+
+
+@pytest.mark.parametrize('to_flatten,extract,expected_result', FLATTEN_VALID)
+def test_flatten(to_flatten, extract, expected_result):
+    result = flatten(to_flatten, extract)
+    assert result == expected_result, repr(result)
+
+
+@pytest.mark.parametrize('to_render,expected_result', RENDER_VALID)
+def test_render(to_render, expected_result):
+    result = render(to_render)
+    assert result == expected_result, repr(result)

--- a/tests/unit/plugins/module_utils/test_opennebula.py
+++ b/tests/unit/plugins/module_utils/test_opennebula.py
@@ -11,31 +11,8 @@ import textwrap
 
 import pytest
 
-from ansible_collections.community.general.plugins.module_utils.opennebula import extend, flatten, render
+from ansible_collections.community.general.plugins.module_utils.opennebula import flatten, render
 
-
-EXTEND_VALID = [
-    (
-        {"a": 1},
-        {"b": 2},
-        {"a": 1, "b": 2}
-    ),
-    (
-        {"a": 1, "b": 2},
-        {"b": 3},
-        {"a": 1, "b": 3}
-    ),
-    (
-        {"a": 1, "b": {"c": 2}},
-        {"b": {"c": 3}},
-        {"a": 1, "b": {"c": 3}}
-    ),
-    (
-        {"a": 1, "b": [2, 3]},
-        {"b": [4, 5]},
-        {"a": 1, "b": [4, 5]}
-    ),
-]
 
 FLATTEN_VALID = [
     (
@@ -100,12 +77,6 @@ RENDER_VALID = [
         ''').strip()
     ),
 ]
-
-
-@pytest.mark.parametrize('to_extend,extend_by,expected_result', EXTEND_VALID)
-def test_extend(to_extend, extend_by, expected_result):
-    result = extend(to_extend, extend_by)
-    assert result == expected_result, repr(result)
 
 
 @pytest.mark.parametrize('to_flatten,extract,expected_result', FLATTEN_VALID)

--- a/tests/unit/plugins/module_utils/test_opennebula.py
+++ b/tests/unit/plugins/module_utils/test_opennebula.py
@@ -7,8 +7,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import pytest
 import textwrap
+
+import pytest
 
 from ansible_collections.community.general.plugins.module_utils.opennebula import extend, flatten, render
 

--- a/tests/unit/plugins/modules/test_one_vm.py
+++ b/tests/unit/plugins/modules/test_one_vm.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, Michal Opala <mopala@opennebula.io>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+import pytest
+
+from ansible_collections.community.general.plugins.modules.one_vm import parse_updateconf
+
+
+PARSE_UPDATECONF_VALID = [
+    (
+        {
+            "CPU": 1,
+            "OS": {"ARCH": 2},
+        },
+        {
+            "OS": {"ARCH": 2},
+        }
+    ),
+    (
+        {
+            "OS": {"ARCH": 1, "ASD": 2},  # "ASD" is an invalid attribute, we ignore it
+        },
+        {
+            "OS": {"ARCH": 1},
+        }
+    ),
+    (
+        {
+            "OS": {"ASD": 1},  # "ASD" is an invalid attribute, we ignore it
+        },
+        {
+        }
+    ),
+    (
+        {
+            "MEMORY": 1,
+            "CONTEXT": {
+                "PASSWORD": 2,
+                "SSH_PUBLIC_KEY": 3,
+            },
+        },
+        {
+            "CONTEXT": {
+                "PASSWORD": 2,
+                "SSH_PUBLIC_KEY": 3,
+            },
+        }
+    ),
+]
+
+
+@pytest.mark.parametrize('vm_template,expected_result', PARSE_UPDATECONF_VALID)
+def test_parse_updateconf(vm_template, expected_result):
+    result = parse_updateconf(vm_template)
+    assert result == expected_result, repr(result)


### PR DESCRIPTION
##### SUMMARY
OpenNebula provides the [one.vm.updateconf](https://docs.opennebula.io/6.4/integration_and_development/system_interfaces/api.html#one-vm-updateconf) API call, that can be used to modify the [context of a VM](https://docs.opennebula.io/6.6/management_and_operations/references/template.html#context-section). For example `SSH_PUBLIC_KEY`, `PASSWORD` or even `START_SCRIPT` variables can be set. This PR implements exactly that, it allows for updating running VMs and setting the same parameters for freshly created ones. We believe this can prove useful for some users.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
one_vm module

##### ADDITIONAL INFORMATION
NA
