### PR TITLE
keycloak_group: support keycloak subgroups

### DIFF
--- a/changelogs/fragments/5814-support-keycloak-subgroups.yml
+++ b/changelogs/fragments/5814-support-keycloak-subgroups.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_group - add new optional module parameter ``parents`` to properly handle keycloak subgroups (https://github.com/ansible-collections/community.general/pull/5814).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1362,7 +1362,8 @@ class KeycloakAPI(object):
             # current parent is given as name, it must be resolved
             # later, try next parent (recurse)
             childs_to_resolve.append(cp)
-            return self.get_subgroup_direct_parent(parents[1:],
+            return self.get_subgroup_direct_parent(
+                parents[1:],
                 realm=realm, childs_to_resolve=childs_to_resolve
             )
 
@@ -1393,10 +1394,10 @@ class KeycloakAPI(object):
 
             if not parent_id:
                 raise Exception(
-                    "Could not determine subgroup parent ID for given"\
-                    " parent chain {}. Assure that all parents exist"\
-                    " already and the list is complete and properly"\
-                    " ordered, starts with an ID or starts at the"\
+                    "Could not determine subgroup parent ID for given"
+                    " parent chain {0}. Assure that all parents exist"
+                    " already and the list is complete and properly"
+                    " ordered, starts with an ID or starts at the"
                     " toplvl".format(parents)
                 )
 

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1336,9 +1336,7 @@ class KeycloakAPI(object):
 
         return tmp
 
-    def get_subgroup_direct_parent(
-        self, parents, realm="master", children_to_resolve=None
-    ):
+    def get_subgroup_direct_parent(self, parents, realm="master", children_to_resolve=None):
         """ Get keycloak direct parent group API object for a given chain of parents.
 
         To succesfully work the API for subgroups we actually dont need

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1370,9 +1370,7 @@ class KeycloakAPI(object):
         if is_id:
             # current parent is given as ID, we can stop walking
             # upwards searching for an entry point
-            return self.get_subgroup_by_chain(
-                [cp] + list(reversed(children_to_resolve)), realm=realm
-            )
+            return self.get_subgroup_by_chain([cp] + list(reversed(children_to_resolve)), realm=realm)
         else:
             # current parent is given as name, it must be resolved
             # later, try next parent (recurse)

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1336,7 +1336,9 @@ class KeycloakAPI(object):
 
         return tmp
 
-    def get_subgroup_direct_parent(self, parents, realm="master", children_to_resolve=None):
+    def get_subgroup_direct_parent(
+        self, parents, realm="master", children_to_resolve=None
+    ):
         """ Get keycloak direct parent group API object for a given chain of parents.
 
         To succesfully work the API for subgroups we actually dont need

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1370,7 +1370,9 @@ class KeycloakAPI(object):
         if is_id:
             # current parent is given as ID, we can stop walking
             # upwards searching for an entry point
-            return self.get_subgroup_by_chain([cp] + list(reversed(children_to_resolve)), realm=realm)
+            return self.get_subgroup_by_chain(
+                [cp] + list(reversed(children_to_resolve)), realm=realm
+            )
         else:
             # current parent is given as name, it must be resolved
             # later, try next parent (recurse)

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1365,7 +1365,7 @@ class KeycloakAPI(object):
             return self.get_subgroup_by_chain(list(reversed(childs_to_resolve)), realm=realm)
 
         cp = parents[0]
-        _, is_id = self._get_normed_group_parent(cp)
+        unused, is_id = self._get_normed_group_parent(cp)
 
         if is_id:
             # current parent is given as ID, we can stop walking

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1398,7 +1398,7 @@ class KeycloakAPI(object):
                     " parent chain {0}. Assure that all parents exist"
                     " already and the list is complete and properly"
                     " ordered, starts with an ID or starts at the"
-                    " toplvl".format(parents)
+                    " top level".format(parents)
                 )
 
             parent_id = parent_id["id"]

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1336,7 +1336,7 @@ class KeycloakAPI(object):
 
         return tmp
 
-    def get_subgroup_direct_parent(self, parents, realm="master", childs_to_resolve=None):
+    def get_subgroup_direct_parent(self, parents, realm="master", children_to_resolve=None):
         """ Get keycloak direct parent group API object for a given chain of parents.
 
         To succesfully work the API for subgroups we actually dont need
@@ -1352,17 +1352,17 @@ class KeycloakAPI(object):
         :param parents: Topdown ordered list of subgroup parents
         :param realm: Realm in which the group resides; default 'master'
         """
-        if childs_to_resolve is None:
+        if children_to_resolve is None:
             # start recursion by reversing parents (in optimal cases
             # we dont need to walk the whole tree upwarts)
             parents = list(reversed(parents))
-            childs_to_resolve = []
+            children_to_resolve = []
 
         if not parents:
             # walk complete parents list to the top, all names, no id's,
             # try to resolve it assuming list is complete and 1st
             # element is a toplvl group
-            return self.get_subgroup_by_chain(list(reversed(childs_to_resolve)), realm=realm)
+            return self.get_subgroup_by_chain(list(reversed(children_to_resolve)), realm=realm)
 
         cp = parents[0]
         unused, is_id = self._get_normed_group_parent(cp)
@@ -1370,14 +1370,14 @@ class KeycloakAPI(object):
         if is_id:
             # current parent is given as ID, we can stop walking
             # upwards searching for an entry point
-            return self.get_subgroup_by_chain([cp] + list(reversed(childs_to_resolve)), realm=realm)
+            return self.get_subgroup_by_chain([cp] + list(reversed(children_to_resolve)), realm=realm)
         else:
             # current parent is given as name, it must be resolved
             # later, try next parent (recurse)
-            childs_to_resolve.append(cp)
+            children_to_resolve.append(cp)
             return self.get_subgroup_direct_parent(
                 parents[1:],
-                realm=realm, childs_to_resolve=childs_to_resolve
+                realm=realm, children_to_resolve=children_to_resolve
             )
 
     def create_group(self, grouprep, realm="master"):

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1284,6 +1284,16 @@ class KeycloakAPI(object):
             self.module.fail_json(msg="Could not fetch group %s in realm %s: %s"
                                       % (name, realm, str(e)))
 
+    def _get_normed_group_parent(self, parent):
+        """ Converts parent dict information into a more easy to use form.
+
+        :param parent: parent describing dict
+        """
+        if parent['id']:
+            return (parent['id'], True)
+
+        return (parent['name'], False)
+
     def get_subgroup_by_chain(self, name_chain, realm="master"):
         """ Access a subgroup API object by walking down a given name/id chain.
 
@@ -1297,8 +1307,10 @@ class KeycloakAPI(object):
         cp = name_chain[0]
 
         # for 1st parent in chain we must query the server
-        if cp.startswith("id:"):
-            tmp = self.get_group_by_groupid(cp[len("id:"):], realm=realm)
+        cp, is_id = self._get_normed_group_parent(cp)
+
+        if is_id:
+            tmp = self.get_group_by_groupid(cp, realm=realm)
         else:
             # given as name, assume toplvl group
             tmp = self.get_group_by_name(cp, realm=realm)
@@ -1308,14 +1320,14 @@ class KeycloakAPI(object):
 
         for p in name_chain[1:]:
             for sg in tmp['subGroups']:
-                equals = False
+                pv, is_id = self._get_normed_group_parent(p)
 
-                if p.startswith("id:"):
-                    equals = p[len("id:"):] == sg["id"]
+                if is_id:
+                    cmpkey = "id"
                 else:
-                    equals = p == sg["name"]
+                    cmpkey = "name"
 
-                if equals:
+                if pv == sg[cmpkey]:
                     tmp = sg
                     break
 
@@ -1353,8 +1365,9 @@ class KeycloakAPI(object):
             return self.get_subgroup_by_chain(list(reversed(childs_to_resolve)), realm=realm)
 
         cp = parents[0]
+        _, is_id = self._get_normed_group_parent(cp)
 
-        if cp.startswith("id:"):
+        if is_id:
             # current parent is given as ID, we can stop walking
             # upwards searching for an entry point
             return self.get_subgroup_by_chain([cp] + list(reversed(childs_to_resolve)), realm=realm)

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -22,7 +22,7 @@ description:
       to your needs and a user having the expected roles.
 
     - The names of module options are snake_cased versions of the camelCase ones found in the
-      Keycloak API and its documentation at U(https://www.keycloak.org/docs-api/8.0/rest-api/index.html).
+      Keycloak API and its documentation at U(https://www.keycloak.org/docs-api/20.0.2/rest-api/index.html).
 
     - Attributes are multi-valued in the Keycloak API. All attributes are lists of individual values and will
       be returned that way by this module. You may pass single values for attributes when calling the module,
@@ -69,6 +69,17 @@ options:
             - A dict of key/value pairs to set as custom attributes for the group.
             - Values may be single values (e.g. a string) or a list of strings.
 
+    parents:
+        version_added: TODO
+        type: list
+        description:
+            - List of parent groups for the group to handle sorted top to bottom.
+            - Set this to create a group as a subgroup of another group or groups (parents).
+            - Each element can describe a parent either by name or ID, both is
+              fine but using names needs some more internal API calls (to map
+              to ID's internally). On default given strings are interpreted as
+              names, to mark them as ID's prefix them with C(id:)
+
 notes:
     - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API
       are read-only for groups. This limitation will be removed in a later version of this module.
@@ -79,6 +90,7 @@ extends_documentation_fragment:
 
 author:
     - Adam Goossens (@adamgoossens)
+    - Mirko Wilhelmi (@morco)
 '''
 
 EXAMPLES = '''
@@ -92,6 +104,7 @@ EXAMPLES = '''
     auth_realm: master
     auth_username: USERNAME
     auth_password: PASSWORD
+  register: result_new_kcgrp
   delegate_to: localhost
 
 - name: Create a Keycloak group, authentication with token
@@ -156,6 +169,64 @@ EXAMPLES = '''
             - individual
             - list
             - items
+  delegate_to: localhost
+
+- name: Create a Keycloak subgroup of a base group (using parent name)
+  community.general.keycloak_group:
+    name: my-new-kc-group-sub
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    parents:
+      - my-new-kc-group
+  register: result_new_kcgrp_sub
+  delegate_to: localhost
+
+- name: Create a Keycloak subgroup of a base group (using parent id)
+  community.general.keycloak_group:
+    name: my-new-kc-group-sub2
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    parents:
+      - "id:{{ result_new_kcgrp.end_state.id }}"
+  delegate_to: localhost
+
+- name: Create a Keycloak subgroup of a subgroup (using parent names)
+  community.general.keycloak_group:
+    name: my-new-kc-group-sub-sub
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    parents:
+      - my-new-kc-group
+      - my-new-kc-group-sub
+  delegate_to: localhost
+
+- name: Create a Keycloak subgroup of a subgroup (using direct parent id)
+  community.general.keycloak_group:
+    name: my-new-kc-group-sub-sub
+    realm: MyCustomRealm
+    state: present
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://auth.example.com/auth
+    auth_realm: master
+    auth_username: USERNAME
+    auth_password: PASSWORD
+    parents:
+      - "id:{{  result_new_kcgrp_sub }}"
   delegate_to: localhost
 '''
 
@@ -235,6 +306,7 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         attributes=dict(type='dict'),
+        parents=dict(type='list', elements='str'),
     )
 
     argument_spec.update(meta_args)
@@ -245,7 +317,7 @@ def main():
                                              ['token', 'auth_realm', 'auth_username', 'auth_password']]),
                            required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
-    result = dict(changed=False, msg='', diff={}, group='')
+    result = dict(changed=False, msg='', diff={})
 
     # Obtain access token, initialize API
     try:
@@ -261,6 +333,8 @@ def main():
     name = module.params.get('name')
     attributes = module.params.get('attributes')
 
+    parents = module.params.get('parents')
+
     # attributes in Keycloak have their values returned as lists
     # via the API. attributes is a dict, so we'll transparently convert
     # the values to lists.
@@ -270,12 +344,12 @@ def main():
 
     # Filter and map the parameters names that apply to the group
     group_params = [x for x in module.params
-                    if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm'] and
+                    if x not in list(keycloak_argument_spec().keys()) + ['state', 'realm', 'parents'] and
                     module.params.get(x) is not None]
 
     # See if it already exists in Keycloak
     if gid is None:
-        before_group = kc.get_group_by_name(name, realm=realm)
+        before_group = kc.get_group_by_name(name, realm=realm, parents=parents)
     else:
         before_group = kc.get_group_by_groupid(gid, realm=realm)
 
@@ -318,9 +392,15 @@ def main():
         if module.check_mode:
             module.exit_json(**result)
 
-        # create it
-        kc.create_group(desired_group, realm=realm)
-        after_group = kc.get_group_by_name(name, realm)
+        # create it ...
+        if parents:
+            # ... as subgroup of another parent group
+            kc.create_subgroup(parents, desired_group, realm=realm)
+        else:
+            # ... as toplvl base group
+            kc.create_group(desired_group, realm=realm)
+
+        after_group = kc.get_group_by_name(name, realm, parents=parents)
 
         result['end_state'] = after_group
 

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -72,7 +72,7 @@ options:
             - Values may be single values (e.g. a string) or a list of strings.
 
     parents:
-        version_added: "6.3.0"
+        version_added: "6.4.0"
         type: list
         description:
             - List of parent groups for the group to handle sorted top to bottom.

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -323,7 +323,8 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         attributes=dict(type='dict'),
-        parents=dict(type='list', elements='dict',
+        parents=dict(
+            type='list', elements='dict',
             options=dict(
                 id=dict(type='str'),
                 name=dict(type='str')

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -345,7 +345,7 @@ def main():
                                              ['token', 'auth_realm', 'auth_username', 'auth_password']]),
                            required_together=([['auth_realm', 'auth_username', 'auth_password']]))
 
-    result = dict(changed=False, msg='', diff={})
+    result = dict(changed=False, msg='', diff={}, group='')
 
     # Obtain access token, initialize API
     try:

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -76,12 +76,6 @@ options:
         type: list
         description:
             - List of parent groups for the group to handle sorted top to bottom.
-            - >-
-              Set this to create a group as a subgroup of another group or groups (parents) or
-              when accessing an existing subgroup by name.
-            - >-
-              Not necessary to set when accessing an existing subgroup by its C(ID) because in
-              that case the group can be directly queried without necessarily knowing its parent(s).
         elements: dict
         suboptions:
           id:

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -37,7 +37,7 @@ options:
         description:
             - State of the group.
             - On C(present), the group will be created if it does not yet exist, or updated with the parameters you provide.
-            - On C(absent), the group will be removed if it exists.
+            - On C(absent), the group will be removed if it exists. Be aware that absenting a group with subgroups will automatically delete all its subgroups too.
         default: 'present'
         type: str
         choices:
@@ -78,7 +78,7 @@ options:
             - Each element can describe a parent either by name or ID, both is
               fine but using names needs some more internal API calls (to map
               to ID's internally). On default given strings are interpreted as
-              names, to mark them as ID's prefix them with C(id:)
+              names, to mark them as ID's prefix them with C(id:).
         elements: str
 
 notes:

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -75,13 +75,11 @@ options:
         description:
             - List of parent groups for the group to handle sorted top to bottom.
             - Set this to create a group as a subgroup of another group or groups (parents).
-        elements:
-            type: str
-            description:
-                - Each element can describe a parent either by name or ID, both is
-                  fine but using names needs some more internal API calls (to map
-                  to ID's internally). On default given strings are interpreted as
-                  names, to mark them as ID's prefix them with C(id:).
+            - Each element can describe a parent either by name or ID, both is
+              fine but using names needs some more internal API calls (to map
+              to ID's internally). On default given strings are interpreted as
+              names, to mark them as ID's prefix them with C(id:)
+        elements: str
 
 notes:
     - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -37,7 +37,9 @@ options:
         description:
             - State of the group.
             - On C(present), the group will be created if it does not yet exist, or updated with the parameters you provide.
-            - On C(absent), the group will be removed if it exists. Be aware that absenting a group with subgroups will automatically delete all its subgroups too.
+            - >-
+              On C(absent), the group will be removed if it exists. Be aware that absenting
+              a group with subgroups will automatically delete all its subgroups too.
         default: 'present'
         type: str
         choices:

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -76,27 +76,32 @@ options:
         type: list
         description:
             - List of parent groups for the group to handle sorted top to bottom.
-            - Set this to create a group as a subgroup of another group or groups (parents).
+            - >-
+              Set this to create a group as a subgroup of another group or groups (parents) or
+              when accessing an existing subgroup by name.
+            - >-
+              Not necessary to set when accessing an existing subgroup by its C(ID) because in
+              that case the group can be directly queried without necessarily knowing its parent(s).
         elements: dict
         suboptions:
           id:
             type: str
             description:
-              - Identify parent by ID
-              - Needs less API calls than using I(name)
-              - A deep parent chain can be started at any point when first given parent is given as ID
+              - Identify parent by ID.
+              - Needs less API calls than using I(name).
+              - A deep parent chain can be started at any point when first given parent is given as ID.
               - Note that in principle both ID and name can be specified at the same time
                 but current implementation only always use just one of them, with ID
-                being prefered
+                being preferred.
           name:
             type: str
             description:
-              - Identify parent by name
-              - Needs more internal API calls than using I(id) to map names to ID's under the hood
-              - When giving a parent chain with only names it must be complete up to the top
+              - Identify parent by name.
+              - Needs more internal API calls than using I(id) to map names to ID's under the hood.
+              - When giving a parent chain with only names it must be complete up to the top.
               - Note that in principle both ID and name can be specified at the same time
                 but current implementation only always use just one of them, with ID
-                being prefered
+                being preferred.
 
 notes:
     - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API
@@ -328,7 +333,7 @@ def main():
             options=dict(
                 id=dict(type='str'),
                 name=dict(type='str')
-            )
+            ),
         ),
     )
 

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -70,7 +70,7 @@ options:
             - Values may be single values (e.g. a string) or a list of strings.
 
     parents:
-        version_added: TODO
+        version_added: "6.3.0"
         type: list
         description:
             - List of parent groups for the group to handle sorted top to bottom.

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -76,6 +76,12 @@ options:
         type: list
         description:
             - List of parent groups for the group to handle sorted top to bottom.
+            - >-
+              Set this to create a group as a subgroup of another group or groups (parents) or
+              when accessing an existing subgroup by name.
+            - >-
+              Not necessary to set when accessing an existing subgroup by its C(ID) because in
+              that case the group can be directly queried without necessarily knowing its parent(s).
         elements: dict
         suboptions:
           id:

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -323,10 +323,12 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         attributes=dict(type='dict'),
-        parents=dict(type='list', elements='dict', options=dict(
-          id=dict(type='str'),
-          name=dict(type='str')
-        )),
+        parents=dict(type='list', elements='dict',
+            options=dict(
+                id=dict(type='str'),
+                name=dict(type='str')
+            )
+        ),
     )
 
     argument_spec.update(meta_args)

--- a/plugins/modules/keycloak_group.py
+++ b/plugins/modules/keycloak_group.py
@@ -75,10 +75,13 @@ options:
         description:
             - List of parent groups for the group to handle sorted top to bottom.
             - Set this to create a group as a subgroup of another group or groups (parents).
-            - Each element can describe a parent either by name or ID, both is
-              fine but using names needs some more internal API calls (to map
-              to ID's internally). On default given strings are interpreted as
-              names, to mark them as ID's prefix them with C(id:)
+        elements:
+            type: str
+            description:
+                - Each element can describe a parent either by name or ID, both is
+                  fine but using names needs some more internal API calls (to map
+                  to ID's internally). On default given strings are interpreted as
+                  names, to mark them as ID's prefix them with C(id:).
 
 notes:
     - Presently, the I(realmRoles), I(clientRoles) and I(access) attributes returned by the Keycloak API
@@ -90,7 +93,6 @@ extends_documentation_fragment:
 
 author:
     - Adam Goossens (@adamgoossens)
-    - Mirko Wilhelmi (@morco)
 '''
 
 EXAMPLES = '''

--- a/tests/integration/targets/keycloak_group/aliases
+++ b/tests/integration/targets/keycloak_group/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported

--- a/tests/integration/targets/keycloak_group/readme.adoc
+++ b/tests/integration/targets/keycloak_group/readme.adoc
@@ -1,3 +1,6 @@
+// Copyright (c) Ansible Project
+// GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 To be able to run these integration tests a keycloak server must be
 reachable under a specific url with a specific admin user and password.

--- a/tests/integration/targets/keycloak_group/readme.adoc
+++ b/tests/integration/targets/keycloak_group/readme.adoc
@@ -1,0 +1,24 @@
+
+To be able to run these integration tests a keycloak server must be
+reachable under a specific url with a specific admin user and password.
+The exact values expected for these parameters can be found in
+'vars/main.yml' file. A simple way to do this is to use the official
+keycloak docker images like this:
+
+----
+docker run --name mykeycloak -p 8080:8080 -e KC_HTTP_RELATIVE_PATH=<url-path> -e KEYCLOAK_ADMIN=<admin_user> -e KEYCLOAK_ADMIN_PASSWORD=<admin_password> quay.io/keycloak/keycloak:20.0.2 start-dev
+----
+
+Example with concrete values inserted:
+
+----
+docker run --name mykeycloak -p 8080:8080 -e KC_HTTP_RELATIVE_PATH=/auth -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:20.0.2 start-dev
+----
+
+This test suite can run against a fresh unconfigured server instance
+(no preconfiguration required) and cleans up after itself (undoes all
+its config changes) as long as it runs through completly. While its active
+it changes the server configuration in the following ways:
+
+  * creating, modifying and deleting some keycloak groups
+

--- a/tests/integration/targets/keycloak_group/tasks/main.yml
+++ b/tests/integration/targets/keycloak_group/tasks/main.yml
@@ -1,0 +1,593 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Create a keycloak group
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: test-group
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert group was created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "test-group"
+      - result.end_state.path == "/test-group"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Group creation rerun (test for idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: test-group
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state != {}
+      - result.end_state.name == "test-group"
+      - result.end_state.path == "/test-group"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Update the name of a keycloak group
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ result.end_state.id }}"
+    name: new-test-group
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group name was updated
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "new-test-group"
+      - result.end_state.path == "/new-test-group"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- set_fact:
+    remember_id: "{{ result.end_state.id }}"
+
+- name: Delete a keycloak group by id
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ remember_id }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group was deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Redo group deletion (check for idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ remember_id }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}
+
+- name: Create a keycloak group with some custom attributes
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: my-new_group
+    attributes:
+        attrib1: value1
+        attrib2: value2
+        attrib3:
+            - item1
+            - item2
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group was correctly created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "my-new_group"
+      - result.end_state.path == "/my-new_group"
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+      - result.end_state.attributes != {}
+      - result.end_state.attributes.attrib1 == ["value1"]
+      - result.end_state.attributes.attrib2 == ["value2"]
+      - result.end_state.attributes.attrib3 == ["item1", "item2"]
+
+- name: Delete a keycloak group based on name
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: my-new_group
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group was deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+## subgroup tests
+## we already testet this so no asserts for this
+- name: Create a new base group for subgroup testing (test setup)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: rootgrp
+  register: subgrp_basegrp_result
+
+- name: Debug
+  debug:
+    var: subgrp_basegrp_result
+
+- name: Create a subgroup using parent id
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subgrp1
+    parents:
+      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that subgroup was correctly created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "subgrp1"
+      - result.end_state.path == "/rootgrp/subgrp1"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Recreate a subgroup using parent id (test idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subgrp1
+    parents:
+      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state != {}
+      - result.end_state.name == "subgrp1"
+      - result.end_state.path == "/rootgrp/subgrp1"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Changing name of existing group
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ result.end_state.id }}"
+    name: new-subgrp1
+    parents:
+      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that subgroup name has changed correctly
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "new-subgrp1"
+      - result.end_state.path == "/rootgrp/new-subgrp1"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Create a subgroup using parent name
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subgrp2
+    parents:
+      - rootgrp
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that subgroup was correctly created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "subgrp2"
+      - result.end_state.path == "/rootgrp/subgrp2"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: Recreate a subgroup using parent name (test idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subgrp2
+    parents:
+      - rootgrp
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state != {}
+      - result.end_state.name == "subgrp2"
+      - result.end_state.path == "/rootgrp/subgrp2"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+## subgroup of subgroup tests
+- name: Create a subgroup of a subgroup using parent names (complete parent chain)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subsubgrp
+    parents:
+      - rootgrp
+      - subgrp2
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert subgroup of subgroup was created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "subsubgrp"
+      - result.end_state.path == "/rootgrp/subgrp2/subsubgrp"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: ReCreate a subgroup of a subgroup using parent names (test idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subsubgrp
+    parents:
+      - rootgrp
+      - subgrp2
+  register: result_subsubgrp
+
+- name: Debug
+  debug:
+    var: result_subsubgrp
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result_subsubgrp is not changed
+      - result_subsubgrp.end_state != {}
+      - result_subsubgrp.end_state.name == "subsubgrp"
+      - result_subsubgrp.end_state.path == "/rootgrp/subgrp2/subsubgrp"
+      - result_subsubgrp.end_state.attributes == {}
+      - result_subsubgrp.end_state.clientRoles == {}
+      - result_subsubgrp.end_state.realmRoles == []
+      - result_subsubgrp.end_state.subGroups == []
+
+- name: Create a subgroup of a subgroup using direct parent id (incomplete parent chain)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subsubsubgrp
+    parents:
+      - "id:{{ result_subsubgrp.end_state.id }}"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert subgroup of subgroup was created
+  assert:
+    that:
+      - result is changed
+      - result.end_state != {}
+      - result.end_state.name == "subsubsubgrp"
+      - result.end_state.path == "/rootgrp/subgrp2/subsubgrp/subsubsubgrp"
+      - result.end_state.attributes == {}
+      - result.end_state.clientRoles == {}
+      - result.end_state.realmRoles == []
+      - result.end_state.subGroups == []
+
+- name: ReCreate a subgroup of a subgroup using direct parent id (test idempotency)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: subsubsubgrp
+    parents:
+      - "id:{{ result_subsubgrp.end_state.id }}"
+  register: result_subsubsubgrp
+
+- name: Debug
+  debug:
+    var: result_subsubsubgrp
+
+- name: Assert that nothing changed
+  assert:
+    that:
+      - result_subsubsubgrp is not changed
+      - result_subsubsubgrp.end_state != {}
+      - result_subsubsubgrp.end_state.name == "subsubsubgrp"
+      - result_subsubsubgrp.end_state.path == "/rootgrp/subgrp2/subsubgrp/subsubsubgrp"
+      - result_subsubsubgrp.end_state.attributes == {}
+      - result_subsubsubgrp.end_state.clientRoles == {}
+      - result_subsubsubgrp.end_state.realmRoles == []
+      - result_subsubsubgrp.end_state.subGroups == []
+
+## subgroup deletion tests
+## note: in principle we already have tested group deletion in general
+##   enough already, but what makes it interesting here again is to
+##   see it works also properly for subgroups and groups with subgroups
+- name: Deleting a subgroup by id (no parents needed)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ result_subsubsubgrp.end_state.id  }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that subgroup was deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Redo subgroup deletion (idempotency test)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    id: "{{ result_subsubsubgrp.end_state.id  }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}
+
+- name: Deleting a subgroup by name
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: new-subgrp1
+    parents:
+      - rootgrp
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that subgroup was deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Redo deleting a subgroup by name (idempotency test)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: new-subgrp1
+    parents:
+      - rootgrp
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that nothing has changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}
+
+- name: Delete keycloak group which has subgroups
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: rootgrp
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group was deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Redo delete keycloak group which has subgroups (idempotency test)
+  community.general.keycloak_group:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: rootgrp
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert that group was deleted
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}

--- a/tests/integration/targets/keycloak_group/tasks/main.yml
+++ b/tests/integration/targets/keycloak_group/tasks/main.yml
@@ -179,7 +179,7 @@
     realm: "{{ realm }}"
     name: subgrp1
     parents:
-      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+      - id: "{{ subgrp_basegrp_result.end_state.id }}"
   register: result
 
 - name: Assert that subgroup was correctly created
@@ -203,7 +203,7 @@
     realm: "{{ realm }}"
     name: subgrp1
     parents:
-      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+      - id: "{{ subgrp_basegrp_result.end_state.id }}"
   register: result
 
 - name: Assert that nothing has changed
@@ -228,7 +228,7 @@
     id: "{{ result.end_state.id }}"
     name: new-subgrp1
     parents:
-      - "id:{{ subgrp_basegrp_result.end_state.id }}"
+      - id: "{{ subgrp_basegrp_result.end_state.id }}"
   register: result
 
 - name: Assert that subgroup name has changed correctly
@@ -252,7 +252,7 @@
     realm: "{{ realm }}"
     name: subgrp2
     parents:
-      - rootgrp
+      - name: rootgrp
   register: result
 
 - name: Assert that subgroup was correctly created
@@ -276,7 +276,7 @@
     realm: "{{ realm }}"
     name: subgrp2
     parents:
-      - rootgrp
+      - name: rootgrp
   register: result
 
 - name: Assert that nothing has changed
@@ -301,8 +301,8 @@
     realm: "{{ realm }}"
     name: subsubgrp
     parents:
-      - rootgrp
-      - subgrp2
+      - name: rootgrp
+      - name: subgrp2
   register: result
 
 - name: Assert subgroup of subgroup was created
@@ -326,8 +326,8 @@
     realm: "{{ realm }}"
     name: subsubgrp
     parents:
-      - rootgrp
-      - subgrp2
+      - name: rootgrp
+      - name: subgrp2
   register: result_subsubgrp
 
 - name: Assert that nothing has changed
@@ -351,7 +351,7 @@
     realm: "{{ realm }}"
     name: subsubsubgrp
     parents:
-      - "id:{{ result_subsubgrp.end_state.id }}"
+      - id: "{{ result_subsubgrp.end_state.id }}"
   register: result
 
 - name: Assert subgroup of subgroup was created
@@ -375,7 +375,7 @@
     realm: "{{ realm }}"
     name: subsubsubgrp
     parents:
-      - "id:{{ result_subsubgrp.end_state.id }}"
+      - id: "{{ result_subsubgrp.end_state.id }}"
   register: result_subsubsubgrp
 
 - name: Assert that nothing changed
@@ -437,7 +437,7 @@
     realm: "{{ realm }}"
     name: new-subgrp1
     parents:
-      - rootgrp
+      - name: rootgrp
     state: absent
   register: result
 
@@ -456,7 +456,7 @@
     realm: "{{ realm }}"
     name: new-subgrp1
     parents:
-      - rootgrp
+      - name: rootgrp
     state: absent
   register: result
 

--- a/tests/integration/targets/keycloak_group/tasks/main.yml
+++ b/tests/integration/targets/keycloak_group/tasks/main.yml
@@ -14,10 +14,6 @@
     state: present
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert group was created
   assert:
     that:
@@ -30,6 +26,9 @@
       - result.end_state.realmRoles == []
       - result.end_state.subGroups == []
 
+- set_fact:
+    test_group_id: "{{ result.end_state.id }}"
+
 - name: Group creation rerun (test for idempotency)
   community.general.keycloak_group:
     auth_keycloak_url: "{{ url }}"
@@ -40,10 +39,6 @@
     name: test-group
     state: present
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that nothing has changed
   assert:
@@ -64,14 +59,10 @@
     auth_username: "{{ admin_user }}"
     auth_password: "{{ admin_password }}"
     realm: "{{ realm }}"
-    id: "{{ result.end_state.id }}"
+    id: "{{ test_group_id }}"
     name: new-test-group
     state: present
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that group name was updated
   assert:
@@ -85,9 +76,6 @@
       - result.end_state.realmRoles == []
       - result.end_state.subGroups == []
 
-- set_fact:
-    remember_id: "{{ result.end_state.id }}"
-
 - name: Delete a keycloak group by id
   community.general.keycloak_group:
     auth_keycloak_url: "{{ url }}"
@@ -95,13 +83,9 @@
     auth_username: "{{ admin_user }}"
     auth_password: "{{ admin_password }}"
     realm: "{{ realm }}"
-    id: "{{ remember_id }}"
+    id: "{{ test_group_id }}"
     state: absent
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that group was deleted
   assert:
@@ -116,13 +100,9 @@
     auth_username: "{{ admin_user }}"
     auth_password: "{{ admin_password }}"
     realm: "{{ realm }}"
-    id: "{{ remember_id }}"
+    id: "{{ test_group_id }}"
     state: absent
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that nothing has changed
   assert:
@@ -145,10 +125,6 @@
             - item1
             - item2
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that group was correctly created
   assert:
@@ -176,10 +152,6 @@
     state: absent
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that group was deleted
   assert:
     that:
@@ -198,10 +170,6 @@
     name: rootgrp
   register: subgrp_basegrp_result
 
-- name: Debug
-  debug:
-    var: subgrp_basegrp_result
-
 - name: Create a subgroup using parent id
   community.general.keycloak_group:
     auth_keycloak_url: "{{ url }}"
@@ -213,10 +181,6 @@
     parents:
       - "id:{{ subgrp_basegrp_result.end_state.id }}"
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that subgroup was correctly created
   assert:
@@ -241,10 +205,6 @@
     parents:
       - "id:{{ subgrp_basegrp_result.end_state.id }}"
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that nothing has changed
   assert:
@@ -271,10 +231,6 @@
       - "id:{{ subgrp_basegrp_result.end_state.id }}"
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that subgroup name has changed correctly
   assert:
     that:
@@ -299,10 +255,6 @@
       - rootgrp
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that subgroup was correctly created
   assert:
     that:
@@ -326,10 +278,6 @@
     parents:
       - rootgrp
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that nothing has changed
   assert:
@@ -357,10 +305,6 @@
       - subgrp2
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert subgroup of subgroup was created
   assert:
     that:
@@ -386,10 +330,6 @@
       - subgrp2
   register: result_subsubgrp
 
-- name: Debug
-  debug:
-    var: result_subsubgrp
-
 - name: Assert that nothing has changed
   assert:
     that:
@@ -414,10 +354,6 @@
       - "id:{{ result_subsubgrp.end_state.id }}"
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert subgroup of subgroup was created
   assert:
     that:
@@ -441,10 +377,6 @@
     parents:
       - "id:{{ result_subsubgrp.end_state.id }}"
   register: result_subsubsubgrp
-
-- name: Debug
-  debug:
-    var: result_subsubsubgrp
 
 - name: Assert that nothing changed
   assert:
@@ -473,10 +405,6 @@
     state: absent
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that subgroup was deleted
   assert:
     that:
@@ -493,10 +421,6 @@
     id: "{{ result_subsubsubgrp.end_state.id  }}"
     state: absent
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that nothing changed
   assert:
@@ -517,10 +441,6 @@
     state: absent
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that subgroup was deleted
   assert:
     that:
@@ -540,10 +460,6 @@
     state: absent
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that nothing has changed
   assert:
     that:
@@ -561,10 +477,6 @@
     state: absent
   register: result
 
-- name: Debug
-  debug:
-    var: result
-
 - name: Assert that group was deleted
   assert:
     that:
@@ -581,10 +493,6 @@
     name: rootgrp
     state: absent
   register: result
-
-- name: Debug
-  debug:
-    var: result
 
 - name: Assert that group was deleted
   assert:

--- a/tests/integration/targets/keycloak_group/vars/main.yml
+++ b/tests/integration/targets/keycloak_group/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+url: http://localhost:8080/auth
+admin_realm: master
+admin_user: admin
+admin_password: password
+realm: master


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Keycloak allows arbitrary deep group nesting, creating groups as subgroups of other groups. The current version of the corresponding ansible module does not support this, only creating top level base groups. This feature request makes it possible for the module to handle subgroups in a optional non-breaking way by introducing a new optional module parameter `parents` to specify a list of parent groups (parent chain) to create / delete / manage subgroups.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/keycloak_group.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As this module seemingly had no integration tests yet I also added some test cases to check its already existing standard behaviour.

Tested with recent keycloak (api) version: `20.0.2`.
