### PR TITLE
nsupdate: fix zone lookup

### DIFF
--- a/changelogs/fragments/5818-nsupdate-fix-zone-lookup.yml
+++ b/changelogs/fragments/5818-nsupdate-fix-zone-lookup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - fix zone lookup. The SOA record for an existing zone is returned as an answer RR and not as an authority RR (https://github.com/ansible-collections/community.general/issues/5817, https://github.com/ansible-collections/community.general/pull/5818).


### PR DESCRIPTION
The SOA record for an existing zone is returned as an answer RR and not as an authority RR. It is returned as an authority for subdomains of a zone.

```
$ dig -t SOA example.com
;; ANSWER SECTION:
example.com.	3530	IN	SOA	ns.icann.org. noc.dns.icann.org. 2022091184 7200 3600 1209600 3600
```

```
$ dig -t SOA www.example.com
;; AUTHORITY SECTION:
example.com.	3600	IN	SOA	ns.icann.org. noc.dns.icann.org. 2022091184 7200 3600 1209600 3600
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issue  #5817
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nsupdate