### PR TITLE
Fix lxd_container certificate validation issue #5616

### DIFF
--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -214,7 +214,6 @@ class LxdBase(object):
         raise ValueError(type)
 
 
-
 def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, project=None, timeout=None, verify=True):
     if not HAS_PYLXD:
         raise LXDClientException(_get_missing_pylxd_message(), PYLXD_IMPORT_ERROR)

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -107,7 +107,7 @@ class LXDClient(object):
                 self._raise_err_from_json(resp_json)
             return resp_json
         except socket.error as e:
-            raise LXDClientException('cannot connect to the LXD server', err=e)
+            raise LXDClientException('cannot connect to the LXD server', err=e) from e
 
     def _raise_err_from_json(self, resp_json):
         err_params = {}
@@ -202,7 +202,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
                 try:
                     client.authenticate(password)
                 except LXDAPIException as e:
-                    raise LXDClientException(str(e))
+                    raise LXDClientException(str(e)) from e
 
             return client
 
@@ -213,10 +213,10 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
     except ClientConnectionFailed as e:
         raise LXDClientException(
             "Failed to connect to '{endpoint}'   {msg}  !".format(endpoint=endpoint, msg=str(e))
-        )
+        ) from e
 # TODO: Does this actually happen???
 #   except TypeError as e:
 #       # Happens when the verification failed.
 #       raise LXDClientException(
 #           f("Failed to connect to '{endpoint}' looks like the SSL verification failed, error was: {e}"
-#       )
+#       ) from e

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -134,12 +134,14 @@ def default_cert_file():
     return os.path.expanduser('~/.config/lxc/client.crt')
 
 
+import traceback
 from ansible.module_utils.basic import missing_required_lib
 try:
     from pylxd import Client as PyLxdClient
     from pylxd.exceptions import LXDAPIException, ClientConnectionFailed
 except ImportError:
     HAS_PYLXD = False
+    PYLXD_IMPORT_ERROR = traceback.format_exc()
 else:
     HAS_PYLXD = True
 

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -144,6 +144,7 @@ except ImportError:
     PYLXD_IMPORT_ERROR = traceback.format_exc()
 else:
     HAS_PYLXD = True
+    PYLXD_IMPORT_ERROR = None
 
 
 def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, project=None, timeout=None, verify=True):

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -134,15 +134,11 @@ def default_cert_file():
     return os.path.expanduser('~/.config/lxc/client.crt')
 
 
-
-
-
-
-
 from pylxd import Client as PyLxdClient
 from pylxd.exceptions import LXDAPIException, ClientConnectionFailed
 
 import os
+
 
 def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, project=None, timeout=None, verify=True):
     try:
@@ -171,7 +167,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
             # Expand an initial '~/'-path component
             client_cert = os.path.expanduser(client_cert)
-            client_key  = os.path.expanduser(client_key)
+            client_key = os.path.expanduser(client_key)
 
             if not os.path.isfile(client_cert):
                 raise ValueError(
@@ -184,7 +180,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
             client = PyLxdClient(
                 endpoint=endpoint,
-                cert=( client_cert, client_key ),
+                cert=(client_cert, client_key),
                 verify=verify,
                 timeout=timeout,
                 project=project,

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -223,3 +223,39 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 #       raise LXDClientException(
 #           f("Failed to connect to '{endpoint}' looks like the SSL verification failed, error was: {e}"
 #       )
+
+
+# ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
+ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
+
+
+CLIENT_ARGUMENT_SPEC=dict(
+    url=dict(
+        type='str',
+        default=ANSIBLE_LXD_DEFAULT_URL,
+        aliases=['endpoint']
+    ),
+    client_key=dict(
+        type='path',
+        aliases=['key_file']
+    ),
+    client_cert=dict(
+        type='path',
+        aliases=['cert_file']
+    ),
+    trust_password=dict(
+        type='str',
+        no_log=True
+    ),
+    verify=dict(
+        type='bool',
+        default=True
+    ),
+    timeout=dict(
+        type='int',
+        default=30
+    ),
+    project=dict(
+        type='str',
+    ),
+)

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -134,13 +134,23 @@ def default_cert_file():
     return os.path.expanduser('~/.config/lxc/client.crt')
 
 
-from pylxd import Client as PyLxdClient
-from pylxd.exceptions import LXDAPIException, ClientConnectionFailed
-
-import os
+from ansible.module_utils.basic import missing_required_lib
+try:
+    from pylxd import Client as PyLxdClient
+    from pylxd.exceptions import LXDAPIException, ClientConnectionFailed
+except ImportError:
+    HAS_PYLXD = False
+else:
+    HAS_PYLXD = True
 
 
 def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, project=None, timeout=None, verify=True):
+
+    if not HAS_PYLXD:
+        raise LXDClientException(
+            missing_required_lib("pylxd", url='https://pylxd.readthedocs.io/'),
+        )
+
     try:
         # Connecting to the local unix socket
         if endpoint is None or endpoint == '/var/lib/lxd/unix.socket' or endpoint == 'unix:/var/lib/lxd/unix.socket':

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -150,9 +150,6 @@ else:
 # ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
 ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
-#
-CLIENT_ARGUMENT_SPEC=dict(
-)
 
 class LXDCommonManagement(object):
     def __init__(self, module):
@@ -230,13 +227,9 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
             client_key = os.path.expanduser(client_key)
 
             if not os.path.isfile(client_cert):
-                raise ValueError(
-                    "Invalid client_cert path: '{path}' does not exist or is not a file.".format(path=client_cert)
-                )
+                raise ValueError("Invalid client_cert path: '{path}' does not exist or is not a file.".format(path=client_cert))
             if not os.path.isfile(client_key):
-                raise ValueError(
-                    "Invalid client_key path: '{path}' does not exist or is not a file.".format(path=client_key)
-                )
+                raise ValueError("Invalid client_key path: '{path}' does not exist or is not a file.".format(path=client_key))
 
             client = PyLxdClient(
                 endpoint=endpoint,

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -181,11 +181,11 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
             if not os.path.isfile(client_cert):
                 raise ValueError(
-                    f"Invalid client_cert path: '{client_cert}' does not exist or is not a file."
+                    "Invalid client_cert path: '{}' does not exist or is not a file.".format(client_cert)
                 )
             if not os.path.isfile(client_key):
                 raise ValueError(
-                    f"Invalid client_key path: '{client_key}' does not exist or is not a file."
+                    "Invalid client_key path: '{}' does not exist or is not a file.".format(client_key)
                 )
 
             client = PyLxdClient(
@@ -212,7 +212,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
     except ClientConnectionFailed as e:
         raise LXDClientException(
-            f"Failed to connect to '{endpoint}'   " + str(e) + '  !'
+            "Failed to connect to '{}'   {}  !".format(endpoint, str(e))
         )
 # TODO: Does this actually happen???
 #   except TypeError as e:

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -107,7 +107,7 @@ class LXDClient(object):
                 self._raise_err_from_json(resp_json)
             return resp_json
         except socket.error as e:
-            raise LXDClientException('cannot connect to the LXD server', err=e) from e
+            raise LXDClientException('cannot connect to the LXD server', err=e)
 
     def _raise_err_from_json(self, resp_json):
         err_params = {}
@@ -202,7 +202,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
                 try:
                     client.authenticate(password)
                 except LXDAPIException as e:
-                    raise LXDClientException(str(e)) from e
+                    raise LXDClientException(str(e))
 
             return client
 
@@ -213,10 +213,10 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
     except ClientConnectionFailed as e:
         raise LXDClientException(
             "Failed to connect to '{endpoint}'   {msg}  !".format(endpoint=endpoint, msg=str(e))
-        ) from e
+        )
 # TODO: Does this actually happen???
 #   except TypeError as e:
 #       # Happens when the verification failed.
 #       raise LXDClientException(
 #           f("Failed to connect to '{endpoint}' looks like the SSL verification failed, error was: {e}"
-#       ) from e
+#       )

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -181,11 +181,11 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
             if not os.path.isfile(client_cert):
                 raise ValueError(
-                    "Invalid client_cert path: '{}' does not exist or is not a file.".format(client_cert)
+                    "Invalid client_cert path: '{path}' does not exist or is not a file.".format(path=client_cert)
                 )
             if not os.path.isfile(client_key):
                 raise ValueError(
-                    "Invalid client_key path: '{}' does not exist or is not a file.".format(client_key)
+                    "Invalid client_key path: '{path}' does not exist or is not a file.".format(path=client_key)
                 )
 
             client = PyLxdClient(
@@ -212,7 +212,7 @@ def pylxd_client(endpoint, client_cert=None, client_key=None, password=None, pro
 
     except ClientConnectionFailed as e:
         raise LXDClientException(
-            "Failed to connect to '{}'   {}  !".format(endpoint, str(e))
+            "Failed to connect to '{endpoint}'   {msg}  !".format(endpoint=endpoint, msg=str(e))
         )
 # TODO: Does this actually happen???
 #   except TypeError as e:

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -182,7 +182,7 @@ options:
         required: false
         type: bool
         default: true
-        version_added: [TODO]
+        version_added: 6.x.x
     trust_password:
         description:
           - The client trusted password.

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -804,7 +804,7 @@ def main():
             url=dict(
                 type='str',
                 default=ANSIBLE_LXD_DEFAULT_URL,
-                aliasses=['endpoint']
+                aliases=['endpoint']
             ),
             snap_url=dict(
                 type='str',

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -454,7 +454,7 @@ class LXDContainerManagement(object):
         self.wait_for_container = self.module.params['wait_for_container']
         self.ignore_volatile_options = self.module.params.get('ignore_volatile_options')
 
-        self.type = self.module.params['type']
+        self.instance_type = self.module.params['type']
 
         self.client_key = self.module.params.get('client_key')
         self.client_cert = self.module.params.get('client_cert')
@@ -499,7 +499,7 @@ class LXDContainerManagement(object):
         config = self.config.copy()
         config['name'] = self.name
 
-        match self.type:
+        match self.instance_type:
             case 'container':
                 self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
             case 'virtual-machine':
@@ -683,7 +683,7 @@ class LXDContainerManagement(object):
 
         try:
             try:
-                match self.type:
+                match self.instance_type:
                     case 'container':
                         self.instance = self.client.containers.get(self.name)
                     case 'virtual-machine':

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -151,6 +151,7 @@ options:
           - The unix domain socket path or the https URL for the LXD server.
         required: false
         default: unix:/var/lib/lxd/unix.socket
+        aliases: [ endpoint ]
         type: str
     snap_url:
         description:
@@ -172,6 +173,13 @@ options:
         required: false
         aliases: [ cert_file ]
         type: path
+    verify:
+        description:
+          - In the case where the certificate is self-signed (LXD's default), you may opt to disable the TLS fingerprint verification with verify=False. As this disables an important security feature, doing so is strongly discouraged. The client filesystem will be searched for potential certificate to use for TLS verification.
+        required: false
+        type: bool
+        default: true
+        version_added: [TODO]
     trust_password:
         description:
           - The client trusted password.

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -401,8 +401,10 @@ import os
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException
-from pylxd.exceptions import NotFound
+from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException, HAS_PYLXD
+
+if HAS_PYLXD:
+    from pylxd.exceptions import NotFound
 
 
 # LXD_ANSIBLE_STATES is a map of states that contain values of methods used

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -412,8 +412,9 @@ import os
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException, HAS_PYLXD, PYLXD_IMPORT_ERROR
-
+from ansible_collections.community.general.plugins.module_utils.lxd import HAS_PYLXD, PYLXD_IMPORT_ERROR
+from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException
+from ansible_collections.community.general.plugins.module_utils.lxd import CLIENT_ARGUMENT_SPEC, ANSIBLE_LXD_DEFAULT_URL
 if HAS_PYLXD:
     from pylxd.exceptions import NotFound
 
@@ -435,9 +436,6 @@ ANSIBLE_LXD_STATES = {
     'Stopped': 'stopped',
     'Frozen': 'frozen',
 }
-
-# ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
-ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
@@ -501,7 +499,7 @@ class LXDContainerManagement(object):
                 self.module.fail_json(msg=e.msg, exception=PYLXD_IMPORT_ERROR)
             else:
                 self.module.fail_json(msg=e.msg)
- 
+
         self.actions = []
 
     def _build_config(self):
@@ -743,13 +741,10 @@ def main():
     """Ansible Main module."""
 
     module = AnsibleModule(
-        argument_spec=dict(
+        argument_spec=CLIENT_ARGUMENT_SPEC | dict(
             name=dict(
                 type='str',
                 required=True
-            ),
-            project=dict(
-                type='str',
             ),
             architecture=dict(
                 type='str',
@@ -781,10 +776,6 @@ def main():
             target=dict(
                 type='str',
             ),
-            timeout=dict(
-                type='int',
-                default=30
-            ),
             type=dict(
                 type='str',
                 default='container',
@@ -802,28 +793,10 @@ def main():
                 type='bool',
                 default=False
             ),
-            url=dict(
-                type='str',
-                default=ANSIBLE_LXD_DEFAULT_URL,
-                aliases=['endpoint']
-            ),
             snap_url=dict(
                 type='str',
                 default='unix:/var/snap/lxd/common/lxd/unix.socket'
             ),
-            client_key=dict(
-                type='path',
-                aliases=['key_file']
-            ),
-            client_cert=dict(
-                type='path',
-                aliases=['cert_file']
-            ),
-            verify=dict(
-                type='bool',
-                default=True
-            ),
-            trust_password=dict(type='str', no_log=True)
         ),
         supports_check_mode=False,
     )

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -182,7 +182,7 @@ options:
         required: false
         type: bool
         default: true
-        version_added: 6.x.x
+        version_added: 6.3.0
     trust_password:
         description:
           - The client trusted password.

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -499,11 +499,10 @@ class LXDContainerManagement(object):
         config = self.config.copy()
         config['name'] = self.name
 
-        match self.instance_type:
-            case 'container':
-                self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
-            case 'virtual-machine':
-                self.instance = self.client.virtual_machines.create(config=config, wait=True, target=self.target)
+        if self.instance_type is 'container':
+            self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
+        elif self.instance_type is 'virtual-machine':
+            self.instance = self.client.virtual_machines.create(config=config, wait=True, target=self.target)
 
 # TODO: Re-add wait_for_container via stuff from Client.do() in pxd.py? Or just use/hijack the wait parameter above?
 
@@ -683,11 +682,10 @@ class LXDContainerManagement(object):
 
         try:
             try:
-                match self.instance_type:
-                    case 'container':
-                        self.instance = self.client.containers.get(self.name)
-                    case 'virtual-machine':
-                        self.instance = self.client.virtual_machines.get(self.name)
+                if self.instance_type is 'container':
+                    self.instance = self.client.containers.get(self.name)
+                elif self.instance_type is 'virtual-machine':
+                    self.instance = self.client.virtual_machines.get(self.name)
 
                 self.old_instance_json = self.client.api.instances[self.name].get().json()
 

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -402,7 +402,6 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException
-#from ansible.module_utils.lxd import pylxd_client, LXDClientException
 from pylxd.exceptions import NotFound
 
 
@@ -502,7 +501,7 @@ class LXDContainerManagement(object):
 
         match self.type:
             case 'container':
-               self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
+                self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
             case 'virtual-machine':
                 self.instance = self.client.virtual_machines.create(config=config, wait=True, target=self.target)
 
@@ -694,7 +693,7 @@ class LXDContainerManagement(object):
 
             except NotFound:
                 self.instance = None
-                self.old_instance_json = { 'metadata': {} }
+                self.old_instance_json = {'metadata': {}}
 
             self.old_state = ANSIBLE_LXD_STATES[self.instance.status] if self.instance else 'absent'
 
@@ -711,7 +710,7 @@ class LXDContainerManagement(object):
 # TODO: Is such logging needed at all when using the pylxd library
             if self.debug:
                 # Provide a dummy log event
-                result_json['logs'] = [ '(Currently no client logging after switch to pylxd)' ]
+                result_json['logs'] = ['(Currently no client logging after switch to pylxd)']
             if self.addresses is not None:
                 result_json['addresses'] = self.addresses
             self.module.exit_json(**result_json)
@@ -724,7 +723,7 @@ class LXDContainerManagement(object):
                 'actions': self.actions
             }
             if self.debug:
-               fail_params['logs'] = e.kwargs['logs']
+                fail_params['logs'] = e.kwargs['logs']
             self.module.fail_json(**fail_params)
 
 

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -412,7 +412,7 @@ import os
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException, HAS_PYLXD
+from ansible_collections.community.general.plugins.module_utils.lxd import pylxd_client, LXDClientException, HAS_PYLXD, PYLXD_IMPORT_ERROR
 
 if HAS_PYLXD:
     from pylxd.exceptions import NotFound
@@ -497,8 +497,11 @@ class LXDContainerManagement(object):
                 verify=self.verify,
             )
         except LXDClientException as e:
-            self.module.fail_json(msg=e.msg)
-
+            if not HAS_PYLXD:
+                self.module.fail_json(msg=e.msg, exception=PYLXD_IMPORT_ERROR)
+            else:
+                self.module.fail_json(msg=e.msg)
+ 
         self.actions = []
 
     def _build_config(self):

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -175,7 +175,10 @@ options:
         type: path
     verify:
         description:
-          - In the case where the certificate is self-signed (LXD's default), you may opt to disable the TLS fingerprint verification with verify=False. As this disables an important security feature, doing so is strongly discouraged. The client filesystem will be searched for potential certificate to use for TLS verification.
+          - In the case where the certificate is self-signed (LXD's default),
+            you may opt to disable the TLS fingerprint verification with verify=False.
+            As this disables an important security feature, doing so is strongly discouraged.
+            The client filesystem will be searched for potential certificate to use for TLS verification.
         required: false
         type: bool
         default: true

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -499,9 +499,9 @@ class LXDContainerManagement(object):
         config = self.config.copy()
         config['name'] = self.name
 
-        if self.instance_type is 'container':
+        if self.instance_type == 'container':
             self.instance = self.client.containers.create(config=config, wait=True, target=self.target)
-        elif self.instance_type is 'virtual-machine':
+        elif self.instance_type == 'virtual-machine':
             self.instance = self.client.virtual_machines.create(config=config, wait=True, target=self.target)
 
 # TODO: Re-add wait_for_container via stuff from Client.do() in pxd.py? Or just use/hijack the wait parameter above?
@@ -682,9 +682,9 @@ class LXDContainerManagement(object):
 
         try:
             try:
-                if self.instance_type is 'container':
+                if self.instance_type == 'container':
                     self.instance = self.client.containers.get(self.name)
-                elif self.instance_type is 'virtual-machine':
+                elif self.instance_type == 'virtual-machine':
                     self.instance = self.client.virtual_machines.get(self.name)
 
                 self.old_instance_json = self.client.api.instances[self.name].get().json()

--- a/plugins/modules/lxd_profile.py
+++ b/plugins/modules/lxd_profile.py
@@ -228,11 +228,8 @@ actions:
 
 import os
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.general.plugins.module_utils.lxd import LXDClient, LXDClientException
+from ansible_collections.community.general.plugins.module_utils.lxd import LXDClient, LXDClientException, ANSIBLE_LXD_DEFAULT_URL
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-
-# ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
-ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # PROFILE_STATES is a list for states supported
 PROFILES_STATES = [

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -44,3 +44,6 @@ elastic-apm ; python_version >= '3.6'
 
 # requirements for scaleway modules
 passlib[argon2]
+
+# requirements for lxd modules
+pylxd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes the certificate validation issue in **lxc_container** mentioned in #5616.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lxd_container

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The fix involves switching to pyLXD instead of the current module-provided client.

While pyLXD provides a much cleaner way to access and manipulate remote LXD servers, it also provides access to the low level api, which accepts og provides json data exactly as what the current implementation sends and receives. It is therefore possible to simply switch from the current usage of HTTPSConnection to pyLXD, which handles certificate validation. - Further rewrite to usage of the higher level api provided by pyLXD is of cause possible, however usage of the json api reduces the risks unintended changes. - Since pyLXD is maintained by linuxcontainers.org, which governs LXD itself. Hence this is a switch to an official client library, with the advantages this involves...


### **lxd_profile** and **lxd_project**

The lxd_profile and lxd_project modules have similar issues, but these are not fixed in this PR (at least not yet). However, the additions made in module_utils/lxd.py is placed there to also facilitate transitioning these modules to pylxd.

The current usage of self.client.do() could could be rewritten into something like this:

> old_config = self.lxd.api.profiles[self.name].get().json()['metadata']
> new_config=old_config
> new_config['description'] = 'Something'
> self.lxd.profiles.get(self.name).api.put(json=new_config)

> old_config = self.lxd.api.projects[self.name].get().json()['metadata']
> new_config=old_config
> new_config['description'] = 'Something'
> self.lxd.projects.get(self.name).api.put(json=new_config)

### **lxd_connection**

pyLXD also has the self.instance.execute() method, which if capable of executions on the remote server. However, the current implementations uses the lxc executable provided by LXD. The parameters of the module is therefore related to this binary to 'forward' the calls to already configures remote servers.