### PR TITLE
Gem: Support force flag when uninstalling

### DIFF
--- a/changelogs/fragments/5822-gem-uninstall-force.yml
+++ b/changelogs/fragments/5822-gem-uninstall-force.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gem - fix force parameter not being passed to gem command when uninstalling (https://github.com/ansible-collections/community.general/pull/5822).

--- a/plugins/modules/gem.py
+++ b/plugins/modules/gem.py
@@ -105,7 +105,7 @@ options:
     required: false
   force:
     description:
-      - Force gem to install, bypassing dependency checks.
+      - Force gem to un/install, bypassing dependency checks.
     required: false
     default: false
     type: bool
@@ -235,6 +235,8 @@ def uninstall(module):
     else:
         cmd.append('--all')
     cmd.append('--executable')
+    if module.params['force']:
+        cmd.append('--force')
     cmd.append(module.params['name'])
     module.run_command(cmd, environ_update=environ, check_rc=True)
 

--- a/plugins/modules/gem.py
+++ b/plugins/modules/gem.py
@@ -105,7 +105,7 @@ options:
     required: false
   force:
     description:
-      - Force gem to un/install, bypassing dependency checks.
+      - Force gem to (un-)install, bypassing dependency checks.
     required: false
     default: false
     type: bool


### PR DESCRIPTION
##### SUMMARY
Allow to use the `--force` flag when uninstalling gems. This is useful because when there are dependencies the gem binary will interactively ask for user confirmation and Ansible will hang forever.

Fixes #5821

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gem

##### ADDITIONAL INFORMATION
As can be seen on the picture below, `gem uninstall` implements the `--force` flag.

![imagen](https://user-images.githubusercontent.com/17771395/212134659-0e735f1d-a7fb-408b-9e5e-aa0c15838043.png) 
