### PR TITLE
yarn: Fix state=latest not working with global=true

### DIFF
--- a/changelogs/fragments/5829-fix-yarn-global.yml
+++ b/changelogs/fragments/5829-fix-yarn-global.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - yarn - fix state=latest not working with global=true (https://github.com/ansible-collections/community.general/pull/5829).
+  - yarn - fix global=true to check for the configured global folder instead of assuming the default (https://github.com/ansible-collections/community.general/pull/5829)

--- a/changelogs/fragments/5829-fix-yarn-global.yml
+++ b/changelogs/fragments/5829-fix-yarn-global.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - yarn - fix state=latest not working with global=true (https://github.com/ansible-collections/community.general/pull/5829).
   - yarn - fix global=true to check for the configured global folder instead of assuming the default (https://github.com/ansible-collections/community.general/pull/5829)
+  - yarn - fix state=absent not working with global=true when the package does not include a binary (https://github.com/ansible-collections/community.general/pull/5829)

--- a/changelogs/fragments/5829-fix-yarn-global.yml
+++ b/changelogs/fragments/5829-fix-yarn-global.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - yarn - fix state=latest not working with global=true (https://github.com/ansible-collections/community.general/pull/5829).
-  - yarn - fix global=true to check for the configured global folder instead of assuming the default (https://github.com/ansible-collections/community.general/pull/5829)
-  - yarn - fix state=absent not working with global=true when the package does not include a binary (https://github.com/ansible-collections/community.general/pull/5829)
+  - yarn - fix ``state=latest`` not working with ``global=true`` (https://github.com/ansible-collections/community.general/pull/5829).
+  - yarn - fix ``global=true`` to check for the configured global folder instead of assuming the default (https://github.com/ansible-collections/community.general/pull/5829)
+  - yarn - fix ``state=absent`` not working with ``global=true`` when the package does not include a binary (https://github.com/ansible-collections/community.general/pull/5829)

--- a/changelogs/fragments/5829-fix-yarn-global.yml
+++ b/changelogs/fragments/5829-fix-yarn-global.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - yarn - fix ``state=latest`` not working with ``global=true`` (https://github.com/ansible-collections/community.general/pull/5829).
+  - yarn - fix ``state=latest`` not working with ``global=true`` (https://github.com/ansible-collections/community.general/issues/5712).
   - yarn - fix ``global=true`` to check for the configured global folder instead of assuming the default (https://github.com/ansible-collections/community.general/pull/5829)
   - yarn - fix ``state=absent`` not working with ``global=true`` when the package does not include a binary (https://github.com/ansible-collections/community.general/pull/5829)

--- a/changelogs/fragments/5829-fix-yarn-latest.yml
+++ b/changelogs/fragments/5829-fix-yarn-latest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yarn - fix state=latest not working with global=true https://github.com/ansible-collections/community.general/pull/5829).

--- a/changelogs/fragments/5829-fix-yarn-latest.yml
+++ b/changelogs/fragments/5829-fix-yarn-latest.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - yarn - fix state=latest not working with global=true https://github.com/ansible-collections/community.general/pull/5829).

--- a/plugins/modules/yarn.py
+++ b/plugins/modules/yarn.py
@@ -214,7 +214,7 @@ class Yarn(object):
 
             if self.globally and unsupported_with_global:
                 _rc, out, _err = self.module.run_command(self.executable + ['global', 'dir'], check_rc=check_rc)
-                path=out.strip()
+                path = out.strip()
 
             if path and not with_global_arg:
                 if not os.path.exists(path):

--- a/plugins/modules/yarn.py
+++ b/plugins/modules/yarn.py
@@ -206,9 +206,7 @@ class Yarn(object):
                 cmd.append(self.registry)
 
             # If path is specified, cd into that path and run the command.
-
             cwd = None
-
             if self.path and not with_global_arg:
                 if not os.path.exists(self.path):
                     # Module will make directory if not exists.

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -39,6 +39,7 @@
     package: 'iconv-lite'
   environment:
     PATH: "{{ node_bin_path }}:{{ansible_env.PATH}}"
+    YARN_IGNORE_ENGINES: true
   block:
 
     # Get the version of Yarn and register to a variable
@@ -136,31 +137,45 @@
         that:
           - yarn_uninstall_package is changed
 
-    - name: 'Global install package with explicit version (older version of package)'
+    - name: 'Global install binary with explicit version (older version of package)'
       yarn:
         global: true
         executable: '{{ yarn_bin_path }}/yarn'
-        name: left-pad
-        version: 1.1.0
+        name: prettier
+        version: 2.0.0
         state: present
       environment:
         PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
-      register: yarn_global_install_old_package
+      register: yarn_global_install_old_binary
 
     - assert:
         that:
-          - yarn_global_install_old_package is changed
+          - yarn_global_install_old_binary is changed
 
-    - name: 'Global upgrade old package'
+    - name: 'Global upgrade old binary'
       yarn:
         global: true
         executable: '{{ yarn_bin_path }}/yarn'
-        name: left-pad
+        name: prettier
         state: latest
       environment:
         PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
-      register: yarn_global_update_old_package
+      register: yarn_global_update_old_binary
 
     - assert:
         that:
-          - yarn_global_update_old_package is changed
+          - yarn_global_update_old_binary is changed
+
+    - name: 'Global remove a binary'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: prettier
+        state: absent
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_uninstall_binary
+
+    - assert:
+        that:
+          - yarn_global_uninstall_binary is changed

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -135,3 +135,47 @@
       assert:
         that:
           - yarn_uninstall_package is changed
+
+    - name: 'Global install package with explicit version (older version of package)'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        version: 1.1.0
+        state: present
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_install_old_package
+
+    - assert:
+        that:
+          - yarn_global_install_old_package is changed
+
+    - name: 'Global upgrade old package'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        state: latest
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_update_old_package
+
+    - assert:
+        that:
+          - yarn_global_update_old_package is changed
+
+    - name: 'Global remove a package'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        state: absent
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_uninstall_package
+
+    - name: 'Assert package removed'
+      assert:
+        that:
+          - yarn_global_uninstall_package is changed

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -179,3 +179,46 @@
     - assert:
         that:
           - yarn_global_uninstall_binary is changed
+
+    - name: 'Global install package with no binary with explicit version (older version of package)'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        version: 1.1.0
+        state: present
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_install_old_package
+
+    - assert:
+        that:
+          - yarn_global_install_old_package is changed
+
+    - name: 'Global upgrade old package with no binary'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        state: latest
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_update_old_package
+
+    - assert:
+        that:
+          - yarn_global_update_old_package is changed
+
+    - name: 'Global remove a package with no binary'
+      yarn:
+        global: true
+        executable: '{{ yarn_bin_path }}/yarn'
+        name: left-pad
+        state: absent
+      environment:
+        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_global_uninstall_package
+
+    - assert:
+        that:
+          - yarn_global_uninstall_package is changed

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -164,18 +164,3 @@
     - assert:
         that:
           - yarn_global_update_old_package is changed
-
-    - name: 'Global remove a package'
-      yarn:
-        global: true
-        executable: '{{ yarn_bin_path }}/yarn'
-        name: left-pad
-        state: absent
-      environment:
-        PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
-      register: yarn_global_uninstall_package
-
-    - name: 'Assert package removed'
-      assert:
-        that:
-          - yarn_global_uninstall_package is changed

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -24,6 +24,5 @@ plugins/modules/rax_files.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax.py use-argspec-type-path # fix needed
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/yarn.py use-argspec-type-path
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.6   # django generated code
 tests/integration/targets/django_manage/files/base_test/simple_project/p1/manage.py compile-2.7   # django generated code

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -19,4 +19,3 @@ plugins/modules/rax_files.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax.py use-argspec-type-path # fix needed
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/yarn.py use-argspec-type-path

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -19,4 +19,3 @@ plugins/modules/rax_files.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax.py use-argspec-type-path # fix needed
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/yarn.py use-argspec-type-path

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -21,4 +21,3 @@ plugins/modules/rax.py use-argspec-type-path # fix needed
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/yarn.py use-argspec-type-path

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -21,4 +21,3 @@ plugins/modules/rax.py use-argspec-type-path # fix needed
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error
-plugins/modules/yarn.py use-argspec-type-path


### PR DESCRIPTION
##### SUMMARY

Fixes #5712.

* Updates `_exec` to support running Yarn commands that wouldn't ordinarily be available with `yarn global` by setting the working directory to the path from `yarn global dir` instead.
* Updates `list_outdated` to use this new functionality when invoking `yarn outdated`.
* Updates `list_outdated` to check for actual errors in stderr output instead of failing on the presence of anything in stderr. This is b/c the Yarn global package.json has no license field, causing a warning to be logged to stderr when invoking `yarn outdated` in that directory.

Through testing, found a couple more related bugs to fix (see comments below):
* Replaces the hardcoded `DEFAULT_GLOBAL_INSTALLATION_PATH` with code to check the output of `yarn global dir`, as the default path may be different when the use is root, or when the user has set YARN_GLOBAL_FOLDER or the corresponding config flag.
* Updates `list` to function correctly for packages without binaries (regular libraries) when global=true by invoking `yarn list` without `global`, the same way I did for `yarn outdated` above.

And finally, added tests for all the above cases. Previously, there were no tests for `global=true` at all.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

yarn

##### ADDITIONAL INFORMATION

Before:

![image](https://user-images.githubusercontent.com/1320357/212242061-8185be66-5083-496a-b0e0-f97177f518ab.png)

After:

![image](https://user-images.githubusercontent.com/1320357/212242095-5f6f5135-16c7-4505-8466-f330e84fcfb5.png)
