### PR TITLE
sefcontext: add support for path substitutions

### DIFF
--- a/changelogs/fragments/5830-sefcontext-path-subs.yml
+++ b/changelogs/fragments/5830-sefcontext-path-subs.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - sefcontext - add support for path substitutions (https://github.com/ansible-collections/community.general/issues/1193)
+  - sefcontext - add support for path substitutions (https://github.com/ansible-collections/community.general/issues/1193).

--- a/changelogs/fragments/5830-sefcontext-path-subs.yml
+++ b/changelogs/fragments/5830-sefcontext-path-subs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sefcontext - add support for path substitutions (https://github.com/ansible-collections/community.general/issues/1193)

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -237,9 +237,9 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, equal, do_re
                     changed = True
 
                     if module._diff:
-                            prepared_diff += '# Change to semanage file context path substitutions\n'
-                            prepared_diff += '-%s = %s\n' % (orig_equal, target)
-                            prepared_diff += '+%s = %s\n' % (equal, target)
+                        prepared_diff += '# Change to semanage file context path substitutions\n'
+                        prepared_diff += '-%s = %s\n' % (orig_equal, target)
+                        prepared_diff += '+%s = %s\n' % (equal, target)
             else:
                 # Add missing path substitution entry
                 if not module.check_mode:
@@ -289,8 +289,8 @@ def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore='
             changed = True
 
             if module._diff:
-                 prepared_diff += '# Deletion to semanage file context path substitutions\n'
-                 prepared_diff += '-%s = %s\n' % (orig_equal, target)
+                prepared_diff += '# Deletion to semanage file context path substitutions\n'
+                prepared_diff += '-%s = %s\n' % (orig_equal, target)
 
     except Exception as e:
         module.fail_json(msg="%s: %s\n" % (e.__class__.__name__, to_native(e)))

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -270,7 +270,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, equal, do_re
     module.exit_json(changed=changed, seuser=seuser, serange=serange, **result)
 
 
-def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore=''):
+def semanage_fcontext_delete(module, result, target, ftype, equal, do_reload, sestore=''):
     ''' Delete SELinux file context mapping definition from the policy. '''
 
     changed = False
@@ -292,7 +292,7 @@ def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore='
             if module._diff:
                 prepared_diff += '# Deletion to semanage file context mappings\n'
                 prepared_diff += '-%s      %s      %s:%s:%s:%s\n' % (target, ftype, exists[0], exists[1], exists[2], exists[3])
-        if equal_exists:
+        if (equal_exists and (equal is not None and equal_exists == equal)) or (equal_exists and equal is None):
             # Remove existing path substitution entry
             orig_equal = equal_exists
 

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -53,7 +53,7 @@ options:
   equal:
     description:
     - Path to use for substituting the I(target). The context labeling for the I(target) subtree is made equivalent to this path.
-    version_added: 5.9.0
+    version_added: 6.3.0
     type: str
   seuser:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -106,6 +106,17 @@ EXAMPLES = r'''
     setype: httpd_git_rw_content_t
     state: present
 
+- name: Substitute file contexts for path /srv/containers with /var/lib/containers
+  community.general.sefcontext:
+    target: /srv/containers
+    equal: /var/lib/containers
+    state: present
+
+- name: Delete any file context mappings for path /srv/git
+  community.general.sefcontext:
+    target: /srv/git
+    state: absent
+
 - name: Apply new SELinux file context to filesystem
   ansible.builtin.command: restorecon -irv /srv/git_repos
 '''

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -56,10 +56,12 @@ options:
   seuser:
     description:
     - SELinux user for the specified I(target).
+    - Defaults to C(system_u) for new file contexts and to existing value when modifying file contexts.
     type: str
   selevel:
     description:
     - SELinux range for the specified I(target).
+    - Defaults to C(s0) for new file contexts and to existing value when modifying file contexts.
     type: str
     aliases: [ serange ]
   state:
@@ -111,6 +113,12 @@ EXAMPLES = r'''
     target: /srv/containers
     equal: /var/lib/containers
     state: present
+
+- name: Delete file context path substitution for /srv/containers
+  community.general.sefcontext:
+    target: /srv/containers
+    equal: /var/lib/containers
+    state: absent
 
 - name: Delete any file context mappings for path /srv/git
   community.general.sefcontext:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -50,7 +50,7 @@ options:
     type: str
   equal:
     description:
-    - Path to use for substituting the target. The context labeling for the I(target) subtree is made equivalent to this path.
+    - Path to use for substituting the I(target). The context labeling for the I(target) subtree is made equivalent to this path.
     type: str
   seuser:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -24,7 +24,7 @@ attributes:
   diff_mode:
     support: full
   platform:
-    platforms: rhel
+    platforms: linux
 options:
   target:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -57,6 +57,7 @@ options:
     - This is also referred to as SELinux file context equivalence and it implements the C(equal) functionality of the SELinux management tools.
     version_added: 6.4.0
     type: str
+    aliases: [ equal ]
   seuser:
     description:
     - SELinux user for the specified I(target).

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -107,7 +107,7 @@ EXAMPLES = r'''
 - name: Allow apache to modify files in /srv/git_repos
   community.general.sefcontext:
     target: '/srv/git_repos(/.*)?'
-    setype: httpd_git_rw_content_t
+    setype: httpd_sys_rw_content_t
     state: present
 
 - name: Substitute file contexts for path /srv/containers with /var/lib/containers

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -17,6 +17,7 @@ description:
   - Similar to the C(semanage fcontext) command.
 extends_documentation_fragment:
   - community.general.attributes
+  - community.general.attributes.platform
 attributes:
   check_mode:
     support: full

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -333,7 +333,7 @@ def main():
             target=dict(type='str', required=True, aliases=['path']),
             ftype=dict(type='str', default='a', choices=list(option_to_file_type_str.keys())),
             setype=dict(type='str'),
-            substitute=dict(type='str'),
+            substitute=dict(type='str', aliases=['equal']),
             seuser=dict(type='str'),
             selevel=dict(type='str', aliases=['serange']),
             state=dict(type='str', default='present', choices=['absent', 'present']),

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -243,7 +243,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, equal, do_re
                 # Modify existing path substitution entry
                 orig_equal = exists
 
-                if target != orig_equal:
+                if equal != orig_equal:
                     if not module.check_mode:
                         sefcontext.modify_equal(target, equal)
                     changed = True

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -54,6 +54,7 @@ options:
   substitute:
     description:
     - Path to use to substitute file context(s) for the specified I(target). The context labeling for the I(target) subtree is made equivalent to this path.
+    - This is also referred to as SELinux file context equivalence and it implements the C(equal) functionality of the SELinux management tools.
     version_added: 6.4.0
     type: str
   seuser:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -87,7 +87,7 @@ options:
 notes:
 - The changes are persistent across reboots.
 - I(setype) and I(equal) are mutually exclusive.
-- If I(state) is C(present) then one of I(setype) or I(equal) is mandatory.
+- If I(state=present) then one of I(setype) or I(equal) is mandatory.
 - The M(community.general.sefcontext) module does not modify existing files to the new
   SELinux context(s), so it is advisable to first create the SELinux
   file contexts before creating files, or run C(restorecon) manually

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -101,11 +101,11 @@ author:
 - Dag Wieers (@dagwieers)
 attributes:
     check_mode:
-      support: full
+        support: full
     diff_mode:
-      support: full
+        support: full
     platform:
-      platforms: rhel
+        platforms: rhel
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -301,7 +301,6 @@ def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore='
     module.exit_json(changed=changed, **result)
 
 
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -54,7 +54,7 @@ options:
   substitute:
     description:
     - Path to use to substitute file context(s) for the specified I(target). The context labeling for the I(target) subtree is made equivalent to this path.
-    version_added: 6.3.0
+    version_added: 6.4.0
     type: str
   seuser:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -255,7 +255,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, substitute, 
 
                 if substitute != orig_substitute:
                     if not module.check_mode:
-                        sefcontext.modify_substitute(target, substitute)
+                        sefcontext.modify_equal(target, substitute)
                     changed = True
 
                     if module._diff:
@@ -265,7 +265,7 @@ def semanage_fcontext_modify(module, result, target, ftype, setype, substitute, 
             else:
                 # Add missing path substitution entry
                 if not module.check_mode:
-                    sefcontext.add_substitute(target, substitute)
+                    sefcontext.add_equal(target, substitute)
                 changed = True
                 if module._diff:
                     prepared_diff += '# Addition to semanage file context path substitutions\n'

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -99,6 +99,13 @@ requirements:
 - policycoreutils-python
 author:
 - Dag Wieers (@dagwieers)
+attributes:
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms: rhel
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -291,7 +291,7 @@ def semanage_fcontext_delete(module, result, target, ftype, setype, substitute, 
         sefcontext.set_reload(do_reload)
         exists = semanage_fcontext_exists(sefcontext, target, ftype)
         substitute_exists = semanage_fcontext_substitute_exists(sefcontext, target)
-        if exists and substitute is None and ((setype is not None and exists[2] == setype) or setype is None):
+        if exists and substitute is None:
             # Remove existing entry
             orig_seuser, orig_serole, orig_setype, orig_serange = exists
 

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -100,12 +100,12 @@ requirements:
 author:
 - Dag Wieers (@dagwieers)
 attributes:
-    check_mode:
-        support: full
-    diff_mode:
-        support: full
-    platform:
-        platforms: rhel
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  platform:
+    platforms: rhel
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -281,7 +281,7 @@ def semanage_fcontext_delete(module, result, target, ftype, equal, do_reload, se
         sefcontext.set_reload(do_reload)
         exists = semanage_fcontext_exists(sefcontext, target, ftype)
         equal_exists = semanage_fcontext_equal_exists(sefcontext, target)
-        if exists:
+        if exists and equal is None:
             # Remove existing entry
             orig_seuser, orig_serole, orig_setype, orig_serange = exists
 

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -51,7 +51,7 @@ options:
   equal:
     description:
     - Path to use for substituting the I(target). The context labeling for the I(target) subtree is made equivalent to this path.
-    version_added: 5.8.5
+    version_added: 5.9.0
     type: str
   seuser:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -51,6 +51,7 @@ options:
   equal:
     description:
     - Path to use for substituting the I(target). The context labeling for the I(target) subtree is made equivalent to this path.
+    version_added: 5.8.5
     type: str
   seuser:
     description:

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -28,6 +28,7 @@ options:
     - Target path (expression).
     type: str
     required: true
+    aliases: [ path ]
   ftype:
     description:
     - The file type that should have SELinux contexts applied.
@@ -45,22 +46,25 @@ options:
     default: a
   setype:
     description:
-    - SELinux type for the specified target.
+    - SELinux type for the specified I(target).
     type: str
-    required: true
-    aliases: [ equal ]
+  equal:
+    description:
+    - Path to use for substituting the target. The context labeling for the I(target) subtree is made equivalent to this path.
+    type: str
   seuser:
     description:
-    - SELinux user for the specified target.
+    - SELinux user for the specified I(target).
     type: str
   selevel:
     description:
-    - SELinux range for the specified target.
+    - SELinux range for the specified I(target).
     type: str
     aliases: [ serange ]
   state:
     description:
     - Whether the SELinux file context must be C(absent) or C(present).
+    - Specifying C(absent) deletes labeling mappings to both SELinux types and path substitutions.
     type: str
     choices: [ absent, present ]
     default: present
@@ -77,6 +81,8 @@ options:
     default: false
 notes:
 - The changes are persistent across reboots.
+- I(setype) and I(equal) are mutually exclusive.
+- If I(state) is C(present) then one of I(setype) or I(equal) is mandatory.
 - The M(community.general.sefcontext) module does not modify existing files to the new
   SELinux context(s), so it is advisable to first create the SELinux
   file contexts before creating files, or run C(restorecon) manually

--- a/plugins/modules/sefcontext.py
+++ b/plugins/modules/sefcontext.py
@@ -22,6 +22,8 @@ attributes:
     support: full
   diff_mode:
     support: full
+  platform:
+    platforms: rhel
 options:
   target:
     description:
@@ -99,13 +101,6 @@ requirements:
 - policycoreutils-python
 author:
 - Dag Wieers (@dagwieers)
-attributes:
-  check_mode:
-    support: full
-  diff_mode:
-    support: full
-  platform:
-    platforms: rhel
 '''
 
 EXAMPLES = r'''

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -230,4 +230,4 @@
 
 - assert:
     that:
-    - subst_ninth is not changed
+    - subst_tenth is not changed

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -109,7 +109,7 @@
 - name: Set SELinux file context path substitution of foo
   sefcontext:
     path: /tmp/foo
-    equal: /home
+    substitute: /home
     state: present
     reload: no
   register: subst_first
@@ -117,12 +117,12 @@
 - assert:
     that:
     - subst_first is changed
-    - subst_first.equal == '/home'
+    - subst_first.substitute == '/home'
 
 - name: Set SELinux file context path substitution of foo (again)
   sefcontext:
     path: /tmp/foo
-    equal: /home
+    substitute: /home
     state: present
     reload: no
   register: subst_second
@@ -130,12 +130,12 @@
 - assert:
     that:
     - subst_second is not changed
-    - subst_second.equal == '/home'
+    - subst_second.substitute == '/home'
 
 - name: Change SELinux file context path substitution of foo
   sefcontext:
     path: /tmp/foo
-    equal: /boot
+    substitute: /boot
     state: present
     reload: no
   register: subst_third
@@ -143,12 +143,12 @@
 - assert:
     that:
     - subst_third is changed
-    - subst_third.equal == '/boot'
+    - subst_third.substitute == '/boot'
 
 - name: Change SELinux file context path substitution of foo (again)
   sefcontext:
     path: /tmp/foo
-    equal: /boot
+    substitute: /boot
     state: present
     reload: no
   register: subst_fourth
@@ -156,12 +156,12 @@
 - assert:
     that:
     - subst_fourth is not changed
-    - subst_fourth.equal == '/boot'
+    - subst_fourth.substitute == '/boot'
 
 - name: Try to delete non-existing SELinux file context path substitution of foo
   sefcontext:
     path: /tmp/foo
-    equal: /dev
+    substitute: /dev
     state: absent
     reload: no
   register: subst_fifth
@@ -169,12 +169,12 @@
 - assert:
     that:
     - subst_fifth is not changed
-    - subst_fifth.equal == '/dev'
+    - subst_fifth.substitute == '/dev'
 
 - name: Delete SELinux file context path substitution of foo
   sefcontext:
     path: /tmp/foo
-    equal: /boot
+    substitute: /boot
     state: absent
     reload: no
   register: subst_sixth
@@ -182,12 +182,12 @@
 - assert:
     that:
     - subst_sixth is changed
-    - subst_sixth.equal == '/boot'
+    - subst_sixth.substitute == '/boot'
 
 - name: Delete SELinux file context path substitution of foo (again)
   sefcontext:
     path: /tmp/foo
-    equal: /boot
+    substitute: /boot
     state: absent
     reload: no
   register: subst_seventh
@@ -195,12 +195,12 @@
 - assert:
     that:
     - subst_seventh is not changed
-    - subst_seventh.equal == '/boot'
+    - subst_seventh.substitute == '/boot'
 
 - name: Set SELinux file context path substitution of foo
   sefcontext:
     path: /tmp/foo
-    equal: /home
+    substitute: /home
     state: present
     reload: no
   register: subst_eighth
@@ -208,7 +208,7 @@
 - assert:
     that:
     - subst_eighth is changed
-    - subst_eighth.equal == '/home'
+    - subst_eighth.substitute == '/home'
 
 - name: Delete SELinux file context path substitution of foo
   sefcontext:

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -100,3 +100,129 @@
     that:
     - sixth is not changed
     - sixth.setype == 'unlabeled_t'
+
+- name: Set SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    equal: /home
+    state: present
+    reload: no
+  register: subst_first
+
+- assert:
+    that:
+    - subst_first is changed
+    - subst_first.equal == '/home'
+
+- name: Set SELinux file context path substitution of foo (again)
+  sefcontext:
+    path: /tmp/foo
+    equal: /home
+    state: present
+    reload: no
+  register: subst_second
+
+- assert:
+    that:
+    - subst_second is not changed
+    - subst_second.equal == '/home'
+
+- name: Change SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    equal: /boot
+    state: present
+    reload: no
+  register: subst_third
+
+- assert:
+    that:
+    - subst_third is changed
+    - subst_third.equal == '/boot'
+
+- name: Change SELinux file context path substitution of foo (again)
+  sefcontext:
+    path: /tmp/foo
+    equal: /boot
+    state: present
+    reload: no
+  register: subst_fourth
+
+- assert:
+    that:
+    - subst_fourth is not changed
+    - subst_fourth.equal == '/boot'
+
+- name: Try to delete non-existing SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    equal: /dev
+    state: absent
+    reload: no
+  register: subst_fifth
+
+- assert:
+    that:
+    - subst_fifth is not changed
+    - subst_fifth.equal == '/dev'
+
+- name: Delete SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    equal: /boot
+    state: absent
+    reload: no
+  register: subst_sixth
+
+- assert:
+    that:
+    - subst_sixth is changed
+    - subst_sixth.equal == '/boot'
+
+- name: Delete SELinux file context path substitution of foo (again)
+  sefcontext:
+    path: /tmp/foo
+    equal: /boot
+    state: absent
+    reload: no
+  register: subst_seventh
+
+- assert:
+    that:
+    - subst_seventh is not changed
+    - subst_seventh.equal == '/boot'
+
+- name: Set SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    equal: /home
+    state: present
+    reload: no
+  register: subst_eighth
+
+- assert:
+    that:
+    - subst_eighth is changed
+    - subst_eighth.equal == '/home'
+
+- name: Delete SELinux file context path substitution of foo
+  sefcontext:
+    path: /tmp/foo
+    state: absent
+    reload: no
+  register: subst_ninth
+
+- assert:
+    that:
+    - subst_ninth is changed
+
+- name: Delete SELinux file context path substitution of foo (again)
+  sefcontext:
+    path: /tmp/foo
+    state: absent
+    reload: no
+  register: subst_tenth
+
+- assert:
+    that:
+    - subst_ninth is not changed

--- a/tests/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/tests/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -23,6 +23,11 @@
     setype: httpd_sys_content_t
     state: absent
 
+- name: Ensure we start with a clean state
+  sefcontext:
+    path: /tmp/foo
+    state: absent
+
 - name: Set SELinux file context of foo/bar
   sefcontext:
     path: '/tmp/foo/bar(/.*)?'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1193.

Add support for path substitution mappings in the `sefcontext` module.

I would like to get feedback on this architecture that is quite a bit different from another (dead) PR #5189:
- Don't use new functions just for adding/deleting path substitutions. Modify the existing functions.
- How deletion is done has minor change - current playbooks continue to work as before:
  - Don't require the `setype` argument with `state=absent` - it is not really required for deletion and it was not even used in the old code.
  - If neither `setype` or `substitute` arg passed: delete both path substitutions and regular context mappings for `target` if either was found when deletion requested.
  - If `substitute` *was* passed with `state=absent` then delete only that equivalence if found (don't delete regular context mappings); if not found then return unchanged, if found but `target` substitutes some other path then return unchanged.
  - If `setype` *was* passed with `state=absent` then delete only existing context mappings (don't delete path substitutions), don't care about the `setype` matching the current mapping to delete (this is the old behavior which seems a bit loose).
 
Fixes #4564.

Change the incorrect `setype` in documentation example to a working label.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sefcontext

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Feedback please! It is the largest code change I have done yet so I really need feedback.

1. Should adding/deleting path substitutions be moved to their own functions instead? Does it matter?
2. Should deletion behavior be more strict?
    - Consider example `sefcontext setype=tmp_t target=/opt/tmp state=absent`: what if `/opt/tmp` is currently not mapped to `tmp_t`, say it's mapped to `opt_t` - in this case should the module just return `changed=false`? Or should it delete the mapping anyways? The old behavior is the latter and I've kept that unchanged. Personally I feel that it is wrong and would like to hear feedback on this.
4. The arg name `substitute`? I couldn't come up with a great name for it. The `man` page for `semanage-fcontext` talks about "path substitution" and the switch `-e` for this is called "equals". Better args names welcome: current comments seem to support `substitute` but there is also request to add `equal` as an alias (I would hesitate, perhaps unnecessarily, to add an alias to a new feature).

Also adds "attributes" block to documentation & some minor documentation improvements.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
