### PR TITLE
Add -no-color argument to terraform validation

### DIFF
--- a/changelogs/fragments/5843-terraform-validate-no-color.yml
+++ b/changelogs/fragments/5843-terraform-validate-no-color.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- terraform module - disable ANSI escape sequences during validation phase (https://github.com/ansible-collections/community.general/pull/5843).

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -299,9 +299,9 @@ def preflight_validation(bin_path, project_path, version, variables_args=None, p
     if not os.path.isdir(project_path):
         module.fail_json(msg="Path for Terraform project '{0}' doesn't exist on this host - check the path and try again please.".format(project_path))
     if LooseVersion(version) < LooseVersion('0.15.0'):
-        rc, out, err = module.run_command([bin_path, 'validate'] + variables_args, check_rc=True, cwd=project_path)
+        module.run_command([bin_path, 'validate', '-no-color'] + variables_args, check_rc=True, cwd=project_path)
     else:
-        rc, out, err = module.run_command([bin_path, 'validate'], check_rc=True, cwd=project_path)
+        module.run_command([bin_path, 'validate', '-no-color'], check_rc=True, cwd=project_path)
 
 
 def _state_args(state_file):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When terraform validation step failed, ansible produced output with ANSI escape codes due to missing `-no-color` argument
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #5816 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before: 
```paste below
{..., "msg": "\u001b[31m╷\u001b[0m\u001b[0m\n\u001b[31m│\u001b[0m \u001b[0m\u001b[1m\u001b[31mError: ...
```
After: 
```paste below
{..., "msg": "\nError: ...
```
