### PR TITLE
pipx: add testcase w/ env vars PIPX_xxxx

### DIFF
--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -95,7 +95,9 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the R(environment Ansible keyword, playbooks_environment).
+    - >
+      This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR)
+      passed using the R(environment Ansible keyword, playbooks_environment).
     - Please note that C(pipx) requires Python 3.6 or above.
     - >
       This first implementation does not verify whether a specified version constraint has been installed or not.

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -95,7 +95,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the `environment` Ansible keyword.
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the R(environment Ansible keyword, playbooks_environment).
     - Please note that C(pipx) requires Python 3.6 or above.
     - >
       This first implementation does not verify whether a specified version constraint has been installed or not.

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -95,7 +95,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR).
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the `environment` Ansible keyword.
     - Please note that C(pipx) requires Python 3.6 or above.
     - >
       This first implementation does not verify whether a specified version constraint has been installed or not.

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -95,6 +95,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR).
     - Please note that C(pipx) requires Python 3.6 or above.
     - >
       This first implementation does not verify whether a specified version constraint has been installed or not.

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -50,7 +50,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the `environment` Ansible keyword.
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the R(environment Ansible keyword, playbooks_environment).
     - Please note that C(pipx) requires Python 3.6 or above.
     - See also the C(pipx) documentation at U(https://pypa.github.io/pipx/).
 author:

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -50,7 +50,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR).
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the `environment` Ansible keyword.
     - Please note that C(pipx) requires Python 3.6 or above.
     - See also the C(pipx) documentation at U(https://pypa.github.io/pipx/).
 author:

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -50,7 +50,9 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
-    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR) passed using the R(environment Ansible keyword, playbooks_environment).
+    - >
+      This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR)
+      passed using the R(environment Ansible keyword, playbooks_environment).
     - Please note that C(pipx) requires Python 3.6 or above.
     - See also the C(pipx) documentation at U(https://pypa.github.io/pipx/).
 author:

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -50,6 +50,7 @@ options:
 notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
+    - This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR).
     - Please note that C(pipx) requires Python 3.6 or above.
     - See also the C(pipx) documentation at U(https://pypa.github.io/pipx/).
 author:

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -230,3 +230,30 @@
         that:
           - install_jupyter is changed
           - '"ipython" in install_jupyter.stdout'
+
+##############################################################################
+- name: ensure /opt/pipx
+  ansible.builtin.file:
+    path: /opt/pipx
+    state: directory
+    mode: 0755
+
+- name: install tox site-wide
+  community.general.pipx:
+    name: tox
+    state: latest
+  register: install_tox_sitewide
+  environment:
+    PIPX_HOME: /opt/pipx
+    PIPX_BIN_DIR: /usr/local/bin
+
+- name: stat /usr/local/bin/tox
+  ansible.builtin.stat:
+    path: /usr/local/bin/tox
+  register: usrlocaltox
+
+- name: check assertions
+  ansible.builtin.assert:
+    that:
+      - install_tox_sitewide is changed
+      - usrlocaltox.stat.exists


### PR DESCRIPTION
##### SUMMARY
Adds a testcase to demonstrate how the `pipx` module can be used with the environment variables `PIPX_*`, specifically for  site-wide installation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #5813 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pipx
pipx_info