### PR TITLE
Add support to Bitwarden Lookup for filtering results by collection (#5849)

### DIFF
--- a/changelogs/fragments/5851-lookup-bitwarden-add-filter-by-collection-id-parameter.yml
+++ b/changelogs/fragments/5851-lookup-bitwarden-add-filter-by-collection-id-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lookup - bitwarden - implement filtering results by collectionId parameter (https://github.com/ansible-collections/community.general/issues/5849).

--- a/changelogs/fragments/5851-lookup-bitwarden-add-filter-by-collection-id-parameter.yml
+++ b/changelogs/fragments/5851-lookup-bitwarden-add-filter-by-collection-id-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lookup - bitwarden - implement filtering results by collectionId parameter (https://github.com/ansible-collections/community.general/issues/5849).
+  - bitwarden lookup plugin - implement filtering results by ``collection_id`` parameter (https://github.com/ansible-collections/community.general/issues/5849).

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -113,7 +113,7 @@ class Bitwarden(object):
         params = ['list', 'items', '--search', search_value]
 
         if collection_id:
-            params.extend(['--collection_id', collection_id])
+            params.extend(['--collectionid', collection_id])
 
         out, err = self._run(params)
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -28,11 +28,12 @@ DOCUMENTATION = """
         default: name
         version_added: 5.7.0
       field:
-        description: Field to fetch; leave unset to fetch whole response.
+        description: Field to fetch. Leave unset to fetch whole response.
         type: str
       collectionId:
-        description: Collection ID to filter results by collection; leave unset to skip filtering.
+        description: Collection ID to filter results by collection. Leave unset to skip filtering.
         type: str
+        version_added: 6.3.0
 """
 
 EXAMPLES = """

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -147,6 +147,8 @@ class LookupModule(LookupBase):
         if not _bitwarden.unlocked:
             raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
 
+        raise AnsibleError(collection_id)
+
         return [_bitwarden.get_field(field, term, search_field, collection_id) for term in terms]
 
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -50,7 +50,7 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: >-
       {{ lookup('community.general.bitwarden', 'a_test', field='password', collectionId='bafba515-af11-47e6-abe3-af1200cd18b2') }}
-      
+
 - name: "Get full Bitwarden record named 'a_test'"
   ansible.builtin.debug:
     msg: >-

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -107,7 +107,12 @@ class Bitwarden(object):
     def _get_matches(self, search_value, search_field, collection_id):
         """Return matching records whose search_field is equal to key.
         """
-        out, err = self._run(['list', 'items', '--search', search_value, '--collectionid', collection_id])
+        params = ['list', 'items', '--search', search_value]
+
+        if collection_id:
+            params.extend(['--collectionid', collection_id])
+
+        out, err = self._run(params)
 
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
@@ -115,7 +120,7 @@ class Bitwarden(object):
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 
-    def get_field(self, field, search_value, search_field="name", collection_id=""):
+    def get_field(self, field, search_value, search_field="name", collection_id=None):
         """Return a list of the specified field for records whose search_field match search_value and filtered by collection.
 
         If field is None, return the whole record for each match.
@@ -146,8 +151,6 @@ class LookupModule(LookupBase):
         collection_id = self.get_option('collectionId')
         if not _bitwarden.unlocked:
             raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
-
-        raise AnsibleError(collection_id)
 
         return [_bitwarden.get_field(field, term, search_field, collection_id) for term in terms]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -107,6 +107,8 @@ class Bitwarden(object):
     def _get_matches(self, search_value, search_field, collection_id):
         """Return matching records whose search_field is equal to key.
         """
+
+        # Prepare set of params for Bitwarden CLI
         params = ['list', 'items', '--search', search_value]
 
         if collection_id:
@@ -121,7 +123,8 @@ class Bitwarden(object):
         return [item for item in initial_matches if item[search_field] == search_value]
 
     def get_field(self, field, search_value, search_field="name", collection_id=None):
-        """Return a list of the specified field for records whose search_field match search_value and filtered by collection.
+        """Return a list of the specified field for records whose search_field match search_value
+        and filtered by collection if collection has been provided.
 
         If field is None, return the whole record for each match.
         """

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -30,7 +30,7 @@ DOCUMENTATION = """
       field:
         description: Field to fetch. Leave unset to fetch whole response.
         type: str
-      collectionId:
+      collection_id:
         description: Collection ID to filter results by collection. Leave unset to skip filtering.
         type: str
         version_added: 6.3.0
@@ -50,7 +50,7 @@ EXAMPLES = """
 - name: "Get 'password' from Bitwarden record named 'a_test' from collection"
   ansible.builtin.debug:
     msg: >-
-      {{ lookup('community.general.bitwarden', 'a_test', field='password', collectionId='bafba515-af11-47e6-abe3-af1200cd18b2') }}
+      {{ lookup('community.general.bitwarden', 'a_test', field='password', collection_id='bafba515-af11-47e6-abe3-af1200cd18b2') }}
 
 - name: "Get full Bitwarden record named 'a_test'"
   ansible.builtin.debug:
@@ -113,7 +113,7 @@ class Bitwarden(object):
         params = ['list', 'items', '--search', search_value]
 
         if collection_id:
-            params.extend(['--collectionid', collection_id])
+            params.extend(['--collection_id', collection_id])
 
         out, err = self._run(params)
 
@@ -152,7 +152,7 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         field = self.get_option('field')
         search_field = self.get_option('search')
-        collection_id = self.get_option('collectionId')
+        collection_id = self.get_option('collection_id')
         if not _bitwarden.unlocked:
             raise AnsibleError("Bitwarden Vault locked. Run 'bw unlock'.")
 

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -113,7 +113,7 @@ class MockBitwarden(Bitwarden):
 
     unlocked = True
 
-    def _get_matches(self, search_value, search_field="name"):
+    def _get_matches(self, search_value, search_field="name", collection_id=None):
         return list(filter(lambda record: record[search_field] == search_value, MOCK_RECORDS))
 
 


### PR DESCRIPTION
Allow user to filter search results from bit warden by collection id. If collection id is not provided, bit warden cli will not use any filtering