### PR TITLE
providerType should be defaulted for keycloak_user_federation mappers

### DIFF
--- a/changelogs/fragments/5863-providerType-defaulted-keycloak_userfed-mappers.yml
+++ b/changelogs/fragments/5863-providerType-defaulted-keycloak_userfed-mappers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation - make ``org.keycloak.storage.ldap.mappers.LDAPStorageMapper`` the default value for mappers ``providerType`` (https://github.com/ansible-collections/community.general/pull/5863).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -451,8 +451,9 @@ options:
 
             providerType:
                 description:
-                    - Component type for this mapper (only supported value is C(org.keycloak.storage.ldap.mappers.LDAPStorageMapper)).
+                    - Component type for this mapper.
                 type: str
+                default: org.keycloak.storage.ldap.mappers.LDAPStorageMapper
 
             config:
                 description:
@@ -776,7 +777,7 @@ def main():
         name=dict(type='str'),
         parentId=dict(type='str'),
         providerId=dict(type='str'),
-        providerType=dict(type='str'),
+        providerType=dict(type='str', default='org.keycloak.storage.ldap.mappers.LDAPStorageMapper'),
         config=dict(type='dict'),
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
So called "mappers" which are special subcomponents of keycloak user federations (used to manage how ldap groups/users are mapped to keycloak groups/users) have the following json structure:

```
{
  "name": "...",
  "providerId": "...",
  "providerType": "...",
  "config": {
      [...]
  }
}
```

From this fields the one called `providerType` has nearly always the value `org.keycloak.storage.ldap.mappers.LDAPStorageMapper`, according to current docu it is actually the only supported value here (which is a bit weird, more on this in the additional section), so it would make sense to make it a default.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
Feature Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/keycloak_user_federation.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Besides proposing to set a default for `providerType` I also removed the part of its docu which says the new default value is the only supported one. I would argue it is confusing and from the ansible perspective also not true as the module does nothing special with this value or even the whole mapper subdict except for passing it upstream as is and comparing values key by key. It might be still true for the upstream API but even that can possibly change.
