### PR TITLE
stormssh tests: do not install newer cryptography

### DIFF
--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -5,7 +5,9 @@
 
 - name: Install required libs
   pip:
-    name: stormssh
+    name:
+      - stormssh
+      - 'paramiko<3.0.0'
     state: present
     extra_args: "-c {{ remote_constraints }}"
 


### PR DESCRIPTION
##### SUMMARY
Hopefully unbreaks CI on Fedora 33.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
