### PR TITLE
Add support for setenv parameters

### DIFF
--- a/changelogs/fragments/5883-sudoers-add-support-for-setenv-parameter.yml
+++ b/changelogs/fragments/5883-sudoers-add-support-for-setenv-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - sudoers - add ``setenv`` parameters to support passing environment variables via sudo. (https://github.com/ansible-collections/community.general/pull/5883)

--- a/tests/integration/targets/sudoers/tasks/main.yml
+++ b/tests/integration/targets/sudoers/tasks/main.yml
@@ -145,6 +145,20 @@
     src: "{{ sudoers_path }}/my-sudo-rule-7"
   register: rule_7_contents
 
+- name: Create rule with setenv parameters
+  community.general.sudoers:
+    name: my-sudo-rule-8
+    state: present
+    user: alice
+    commands: /usr/local/bin/command
+    setenv: true
+  register: rule_8
+
+- name: Grab contents of my-sudo-rule-8
+  ansible.builtin.slurp:
+    src: "{{ sudoers_path }}/my-sudo-rule-8"
+  register: rule_8_contents
+
 - name: Revoke rule 1
   community.general.sudoers:
     name: my-sudo-rule-1
@@ -202,7 +216,6 @@
   when: ansible_os_family != 'Darwin'
   register: edge_case_3
   
-  
 - name: Revoke non-existing rule
   community.general.sudoers:
     name: non-existing-rule
@@ -243,6 +256,7 @@
       - "rule_5_contents['content'] | b64decode == 'alice ALL=NOPASSWD: /usr/local/bin/command\n'"
       - "rule_6_contents['content'] | b64decode == 'alice ALL=(bob)NOPASSWD: /usr/local/bin/command\n'"
       - "rule_7_contents['content'] | b64decode == 'alice host-1=NOPASSWD: /usr/local/bin/command\n'"
+      - "rule_8_contents['content'] | b64decode == 'alice ALL=NOPASSWD:SETENV: /usr/local/bin/command\n'"
 
 - name: Check revocation stat
   ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY

During the configuration of sudo rights regarding a Python app I created, I needed to allow my user to keep their environments variables while running it. This can be done by using `sudo -E [command to run]`. 

To allow this in our sudoers files we need to pass a parameters. However while the sudoers modules allowed to pass nopasswd, it did not allowed to pass the `setenv` parameters. This PR aims to allow it. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

```
minor_changes:
  - sudoers - add `setenv` parameters to support passing environments variables via sudo.
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sudoers

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
%mygroup ALL=NOPASSWD:SETENV: /usr/local/bin/testing
```
