### PR TITLE
Remove skornehl as maintainer for datadog_monitor

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -440,7 +440,7 @@ files:
     labels: datadog_event
     maintainers: n0ts
   $modules/datadog_monitor.py:
-    maintainers: skornehl
+    ignore: skornehl
   $modules/dconf.py:
     maintainers: azaghal
   $modules/deploy_helper.py:


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-collections/community.general/issues/5823#issuecomment-1386718799

@skornehl if you still want to step down as a maintainer for datadog_monitor, please approve this PR.

In any case, thanks again for creating and maintaining this module for all this time! :)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
datadog_monitor
BOTMETA.yml
