### PR TITLE
terraform: The main idea of this commit is to slightly simplify execution logic and provide plan also for absent state

### DIFF
--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -362,7 +362,7 @@ def remove_workspace(bin_path, project_path, workspace):
     _workspace_cmd(bin_path, project_path, 'delete', workspace)
 
 
-def build_plan(command, project_path, state_file, state, plan_file=None):
+def build_plan(command, project_path, state_file, state, plan_file):
     plan_command = command[:]
     plan_command.extend(['-out', plan_file])
     plan_command.extend(_state_args(state_file))


### PR DESCRIPTION
##### SUMMARY
I'm removing **destroy** command - the module will execute terraform plan and apply based on the **state**. The reason is that we now run also plan for **absent** state + we can also apply plan which will destroy resources. This is pretty helpful when running in **check and verbose mode** (arguments --check and -vvv). Additionally the module created temporary file for terraform plan. However the temporary file was never deleted. For that reason the module returns plan file path a.k.a temporary file path to the user every time so it can be inspected based on the need. I also think that plan file path shouldn't be required for **planned** state based on the previous comments.

Additional minor changes:
- function preflight_validation:

1) There was added if condition for terraform version in a commit 1400051890cbf5674c2aa4939f9c716a0f3e4bd8 with comment:

```
    removed the append of variables in terraform validate because this is deprecated in Terraform 0.15. See: https://github.com/hashicorp/terraform/blob/v0.15/CHANGELOG.md >> The -var and -var-file options are no longer available on terraform validate. These were deprecated and have had no effect since Terraform v0.12
```
However I don't see any reason why we should pass variables into init ...

 2) Removing arguments which aren't needed anymore: version, variables_args. Argument plan_file wasn't used even before my changes ...

- Removing function **get_version**. It isn't needed anymore e.g. we run apply also in a case of destroy and there aren't breaking changes between versions.
- Workspace selection and function **init_plugins** - there is commit fc2b1aac4aca701f3e87706266ac2e32a905d9fe with comment:

```
bugfix: init command when default workspace doesn't exists
```

  I move execution of **init_plugins** after workspace selection so we should be safe here I guess ... Also adjusting the comment in the documentation because the note about ENV variable applied only to init which isn't the case anymore.
- Removing not used rc, out, err return values from module.run_command where applicable ...
- Adjusting formatting here and there to increase readability ...

##### ISSUE TYPE
This slightly address #5848 and fixes #3700.
I'm using this version of module and I also did simple testing with terraform version 0.14.
So far so good.

##### COMPONENT NAME
terraform.py

