### PR TITLE
add external user support to ipa_group module

### DIFF
--- a/changelogs/fragments/5897-ipa_group-add-external-users.yml
+++ b/changelogs/fragments/5897-ipa_group-add-external-users.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - implement adding external users in ipa_group module
+  - ipa_group - allow to add and remove external users with the ``external_user`` option (https://github.com/ansible-collections/community.general/pull/5897).

--- a/changelogs/fragments/5897-ipa_group-add-external-users.yml
+++ b/changelogs/fragments/5897-ipa_group-add-external-users.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - implement adding external users in ipa_group module

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -66,8 +66,8 @@ options:
     elements: str
   external_user:
     description:
-    - List of external users assigned to this group
-    - Behaves identically to I(user) with respect to I(append) attribute
+    - List of external users assigned to this group.
+    - Behaves identically to I(user) with respect to I(append) attribute.
     - List entries can be in C(DOMAIN\\username) or SID format.
     - Unless SIDs are provided, the module will always attempt to make changes even if the group already has all the users.
     - This is because only SIDs are returned by IPA query.

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -144,7 +144,7 @@ EXAMPLES = r'''
    external: true
    append: true
    external_user:
-   - MYDOMAIN\john
+   - MYDOMAIN\\john
    ipa_host: ipa.example.com
    ipa_user: admin
    ipa_pass: topsecret

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -291,7 +291,7 @@ def ensure(module, client):
             changed = client.modify_if_diff(name, ipa_group.get('ipaexternalmember', []), external_user,
                                             client.group_add_member_externaluser,
                                             client.group_remove_member_externaluser,
-                                            append=append) or changed                                
+                                            append=append) or changed
     else:
         if ipa_group:
             changed = True

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -68,7 +68,7 @@ options:
     description:
     - List of external users assigned to this group
     - Behaves identically to I(user) with respect to I(append) attribute
-    - List entries can be in DOMAIN\username or SID format.
+    - List entries can be in C(DOMAIN\\username) or SID format.
     - Unless SIDs are provided, ipa_group will always attempt to make changes even if the group already has all the users.
     - This is because only SIDs are returned by IPA query.
     - I(external=true) is needed for this option to work.

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -70,7 +70,7 @@ options:
     - Behaves identically to I(user) with respect to I(append) attribute.
     - List entries can be in C(DOMAIN\\username) or SID format.
     - Unless SIDs are provided, the module will always attempt to make changes even if the group already has all the users.
-    - This is because only SIDs are returned by IPA query.
+      This is because only SIDs are returned by IPA query.
     - I(external=true) is needed for this option to work.
     type: list
     elements: str

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -69,7 +69,7 @@ options:
     - List of external users assigned to this group
     - Behaves identically to I(user) with respect to I(append) attribute
     - List entries can be in C(DOMAIN\\username) or SID format.
-    - Unless SIDs are provided, ipa_group will always attempt to make changes even if the group already has all the users.
+    - Unless SIDs are provided, the module will always attempt to make changes even if the group already has all the users.
     - This is because only SIDs are returned by IPA query.
     - I(external=true) is needed for this option to work.
     type: list

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -68,10 +68,12 @@ options:
     description:
     - List of external users assigned to this group
     - Behaves identically to I(user) with respect to I(append) attribute
-    - List entries can be in DOMAIN\username format but unless SIDs are provided, this module will always attempt to make changes even if the group already has all the users. This is because only SIDs are returned by IPA query.
+    - List entries can be in DOMAIN\username or SID format.
+    - Unless SIDs are provided, ipa_group will always attempt to make changes even if the group already has all the users.
+    - This is because only SIDs are returned by IPA query.
     - I(external=true) is needed for this option to work.
     type: list
-    elements: str   
+    elements: str
   state:
     description:
     - State to ensure
@@ -205,7 +207,7 @@ class GroupIPAClient(IPAClient):
 
     def group_remove_member_user(self, name, item):
         return self.group_remove_member(name=name, item={'user': item})
-    
+
     def group_remove_member_externaluser(self, name, item):
         return self.group_remove_member(name=name, item={'ipaexternalmember': item})
 
@@ -286,11 +288,10 @@ def ensure(module, client):
                                             append=append) or changed
 
         if external_user is not None:
-            changed = client.modify_if_diff(name,
-                ipa_group.get('ipaexternalmember', []), external_user,
+            changed = client.modify_if_diff(name, ipa_group.get('ipaexternalmember', []), external_user,
                                             client.group_add_member_externaluser,
                                             client.group_remove_member_externaluser,
-                                            append=append) or changed                                    
+                                            append=append) or changed                                
     else:
         if ipa_group:
             changed = True

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -64,6 +64,14 @@ options:
     - If option is omitted assigned users will not be checked or changed.
     type: list
     elements: str
+  external_user:
+    description:
+    - List of external users assigned to this group
+    - Behaves identically to I(user) with respect to I(append) attribute
+    - List entries can be in DOMAIN\username format but unless SIDs are provided, this module will always attempt to make changes even if the group already has all the users. This is because only SIDs are returned by IPA query.
+    - I(external=true) is needed for this option to work.
+    type: list
+    elements: str   
   state:
     description:
     - State to ensure
@@ -116,6 +124,28 @@ EXAMPLES = r'''
     ipa_user: admin
     ipa_pass: topsecret
 
+- name: Add external user to a group
+  community.general.ipa_group:
+   name: developers
+   external: true
+   append: true
+   external_user:
+   - S-1-5-21-123-1234-12345-63421
+   ipa_host: ipa.example.com
+   ipa_user: admin
+   ipa_pass: topsecret
+
+- name: Add a user from MYDOMAIN
+  community.general.ipa_group:
+   name: developers
+   external: true
+   append: true
+   external_user:
+   - MYDOMAIN\john
+   ipa_host: ipa.example.com
+   ipa_user: admin
+   ipa_pass: topsecret
+
 - name: Ensure group is absent
   community.general.ipa_group:
     name: sysops
@@ -164,6 +194,9 @@ class GroupIPAClient(IPAClient):
     def group_add_member_user(self, name, item):
         return self.group_add_member(name=name, item={'user': item})
 
+    def group_add_member_externaluser(self, name, item):
+        return self.group_add_member(name=name, item={'ipaexternalmember': item})
+
     def group_remove_member(self, name, item):
         return self._post_json(method='group_remove_member', name=name, item=item)
 
@@ -172,6 +205,9 @@ class GroupIPAClient(IPAClient):
 
     def group_remove_member_user(self, name, item):
         return self.group_remove_member(name=name, item={'user': item})
+    
+    def group_remove_member_externaluser(self, name, item):
+        return self.group_remove_member(name=name, item={'ipaexternalmember': item})
 
 
 def get_group_dict(description=None, external=None, gid=None, nonposix=None):
@@ -208,11 +244,18 @@ def ensure(module, client):
     name = module.params['cn']
     group = module.params['group']
     user = module.params['user']
+    external = module.params['external']
+    external_user = module.params['external_user']
     append = module.params['append']
 
-    module_group = get_group_dict(description=module.params['description'], external=module.params['external'],
-                                  gid=module.params['gidnumber'], nonposix=module.params['nonposix'])
+    module_group = get_group_dict(description=module.params['description'],
+                                  external=external,
+                                  gid=module.params['gidnumber'],
+                                  nonposix=module.params['nonposix'])
     ipa_group = client.group_find(name=name)
+
+    if (not (external or external_user is None)):
+        module.fail_json("external_user can only be set if external = True")
 
     changed = False
     if state == 'present':
@@ -242,6 +285,12 @@ def ensure(module, client):
                                             client.group_remove_member_user,
                                             append=append) or changed
 
+        if external_user is not None:
+            changed = client.modify_if_diff(name,
+                ipa_group.get('ipaexternalmember', []), external_user,
+                                            client.group_add_member_externaluser,
+                                            client.group_remove_member_externaluser,
+                                            append=append) or changed                                    
     else:
         if ipa_group:
             changed = True
@@ -256,6 +305,7 @@ def main():
     argument_spec.update(cn=dict(type='str', required=True, aliases=['name']),
                          description=dict(type='str'),
                          external=dict(type='bool'),
+                         external_user=dict(type='list', elements='str'),
                          gidnumber=dict(type='str', aliases=['gid']),
                          group=dict(type='list', elements='str'),
                          nonposix=dict(type='bool'),

--- a/plugins/modules/ipa_group.py
+++ b/plugins/modules/ipa_group.py
@@ -74,6 +74,7 @@ options:
     - I(external=true) is needed for this option to work.
     type: list
     elements: str
+    version_added: 6.3.0
   state:
     description:
     - State to ensure


### PR DESCRIPTION
##### SUMMARY
 ipa_group module allows declaring a group as external but doesn't allow adding external members. This pull request implements adding 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_group
