### PR TITLE
Redfish: Removed basic auth header when performing a GET on the service root and POST to the session collection

### DIFF
--- a/changelogs/fragments/5886-redfish-correct-basic-auth-usage-on-session-creation.yml
+++ b/changelogs/fragments/5886-redfish-correct-basic-auth-usage-on-session-creation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_utils - Removed basic auth HTTP header when perforing a GET on the service root resource and when performing a POST to the session collection (https://github.com/ansible-collections/community.general/issues/5886)

--- a/changelogs/fragments/5886-redfish-correct-basic-auth-usage-on-session-creation.yml
+++ b/changelogs/fragments/5886-redfish-correct-basic-auth-usage-on-session-creation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_utils - Removed basic auth HTTP header when perforing a GET on the service root resource and when performing a POST to the session collection (https://github.com/ansible-collections/community.general/issues/5886)
+  - redfish_utils - removed basic auth HTTP header when performing a GET on the service root resource and when performing a POST to the session collection (https://github.com/ansible-collections/community.general/issues/5886).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Redfish services do not expect authorization headers when performing a POST to the session collection. The expectation is credentials are in the request body. While the specification is silent on how services behave when authorization headers are present in this request, the guidance for clients is to not provide the header.

The change here removes the authorization header on two conditions:
* When performing a GET on the service root (/redfish/v1/): this is an unauthenticated resource and is used for discovery prior to logging into the system.
* When performing a POST on the session collection (/redfish/v1/SessionService/Sessions).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #5886 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
On some systems, using the Redfish command "CreateSessions" will result in an error (as shown in #5886).

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "HTTP Error 415 on POST request to 'https://<REDACTED>/redfish/v1/SessionService/Sessions', extended message: 'A general error has occurred. See Resolution for information on how to resolve the error.'"}
```

After:
```
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "failed": false,
        "msg": "Action was successful",
        "return_values": {},
        "session": {
            "token": "66de70083fccd78fcbd200d9341473b7",
            "uri": "/redfish/v1/SessionService/Sessions/70"
        }
    }
}
```