### PR TITLE
Fixes #5907: gitlab_runner is not idempotent on first run after runner creation

### DIFF
--- a/changelogs/fragments/5907-fix-gitlab_runner-not-idempotent.yml
+++ b/changelogs/fragments/5907-fix-gitlab_runner-not-idempotent.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gitlab_runner - add new boolean option ``access_level_on_creation``. It controls, whether the value of ``access_level`` is used for runner registration or not. The option ``access_level`` has been ignored on registration so far and was only used on updates (https://github.com/ansible-collections/community.general/issues/5907, https://github.com/ansible-collections/community.general/pull/5908).
+deprecated_features:
+  - gitlab_runner - the default of the new option ``access_level_on_creation`` will change from ``false`` to ``true`` in community.general 7.0.0. This will cause ``access_level`` to be used during runner registration as well, and not only during updates (https://github.com/ansible-collections/community.general/pull/5908).


### PR DESCRIPTION
##### SUMMARY
This fix introduces the new boolean option ``access_level_on_creation``. It controls, whether the value of ``access_level`` is used for runner registration or not. The option ``access_level`` has been ignored on registration so far and was only used on updates. The user is informed by a deprecation warning, if the option is unspecified. For reasons of compatibility ``false`` is assumed in that case. The option ``access_level_on_creation`` will switch to ``true`` in community.general 7.0.0.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner
