### PR TITLE
Feature/cloudflare dns caa support

### DIFF
--- a/changelogs/fragments/5910-cloudflareDNS-CAA-support.yml
+++ b/changelogs/fragments/5910-cloudflareDNS-CAA-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - community.general.cloudflare_dns - add CAA record support (https://github.com/ansible-collections/community.general/issues/5910).
+  - cloudflare_dns - add CAA record support (https://github.com/ansible-collections/community.general/issues/5910, https://github.com/ansible-collections/community.general/pull/5911).

--- a/changelogs/fragments/5910-cloudflareDNS-CAA-support.yml
+++ b/changelogs/fragments/5910-cloudflareDNS-CAA-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - community.general.cloudflare_dns - add CAA record support (https://github.com/ansible-collections/community.general/issues/5910).

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -650,7 +650,7 @@ class CloudflareAPI(object):
                     if not self.module.check_mode:
                         result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(rr['zone_id'], rr['id']), 'DELETE')
             else:
-                if ((rr['type'] == 'CAA') and (rr['data']['tag'] != params['caa_tag'])):
+                if rr['type'] == 'CAA' and rr['data']['tag'] != params['caa_tag']:
                     break
 
                 self.changed = True

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -48,12 +48,11 @@ options:
     type: int
   caa_tag:
     description:
+    - defines the scope of the record/uri posible options are C(issue) only allow specific hostnames
+    - or C(issuewild) to only allow wildcards or C(iodef) Send violation reports to URL (http:, https:, or mailto:)
     - Required for I(type=CAA)
-    - issue: Only allow specific hostnames
-    - issuewild: Only allow wildcards
-    - iodef: Send violation reports to URL (http:, https:, or mailto:)
     type: str
-    choices: [ issue, issuewild, iodef ]
+    choices: [ 'issue', 'issuewild', 'iodef' ]
     default: issue
   cert_usage:
     description:
@@ -426,7 +425,7 @@ class CloudflareAPI(object):
         if (self.type in ['CNAME', 'NS', 'MX', 'SRV']) and (self.value is not None):
             self.value = self.value.rstrip('.').lower()
 
-        if (self.type in ['AAAA','CAA']) and (self.value is not None):
+        if (self.type in ['AAAA', 'CAA']) and (self.value is not None):
             self.value = self.value.lower()
 
         if (self.type == 'SRV'):
@@ -649,7 +648,7 @@ class CloudflareAPI(object):
                         result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(rr['zone_id'], rr['id']), 'DELETE')
             else:
                 if ((rr['type'] == 'CAA') and (rr['data']['tag'] != params['caa_tag'])):
-                  break
+                    break
 
                 self.changed = True
                 if not self.module.check_mode:

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -48,12 +48,14 @@ options:
     type: int
   caa_tag:
     description:
-    - defines the scope of the record/uri posible options are C(issue) only allow specific hostnames
-    - or C(issuewild) to only allow wildcards or C(iodef) Send violation reports to URL (http:, https:, or mailto:)
-    - Required for I(type=CAA)
+    - Defines the scope of the record.
+    - Posible options are C(issue) to only allow specific hostnames, C(issuewild) to only allow wildcards,
+      or C(iodef) to send violation reports to a URI (C(http:), C(https:), or C(mailto:)).
+    - Required for I(type=CAA).
     type: str
     choices: [ 'issue', 'issuewild', 'iodef' ]
     default: issue
+    version_added: 6.3.0
   cert_usage:
     description:
     - Certificate usage number.
@@ -139,6 +141,7 @@ options:
     description:
       - The type of DNS record to create. Required if I(state=present).
       - I(type=DS), I(type=SSHFP) and I(type=TLSA) added in Ansible 2.7.
+      - I(type=CAA) was added in community.general 6.3.0.
     type: str
     choices: [ A, AAAA, CAA, CNAME, DS, MX, NS, SPF, SRV, SSHFP, TLSA, TXT ]
   value:
@@ -273,7 +276,7 @@ EXAMPLES = r'''
     hash_type: 2
     value: B4EB5AC4467D2DFB3BAF9FB9961DC1B6FED54A58CDFAA3E465081EC86F89BFAB
 
-- name: Create a CAA
+- name: Create a CAA record to allow certificate issuance from Let's Encrypt
   community.general.cloudflare_dns:
     api_token: dummyapitoken
     zone: example.net
@@ -866,7 +869,6 @@ def main():
             ('state', 'absent', ['record']),
             ('type', 'SRV', ['proto', 'service']),
             ('type', 'TLSA', ['proto', 'port']),
-            ('type', 'CAA', ['caa_tag']),
         ],
     )
 


### PR DESCRIPTION
##### SUMMARY
I have only extended the existing module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.cloudflare_dns

##### ADDITIONAL INFORMATION
It is possible to add a CAA record for Certificate Authority pinning as a DNS record
The Cloudflare API makes this also possible but it is not documented in the api

It is possible to do it manualy
``` shell
curl -X POST "https://api.cloudflare.com/client/v4/zones/{ZONEID}/dns_records" \
     -H "Authorization: Bearer {TOKEN}" \
     -H "Content-Type: application/json" \
     --data '{"type":"CAA","name":"{ZONE}","ttl":1,"proxied":false, "data":{"flags": 0, "tag": "issue", "value": "letsencrypt.org"} }'
```
