### PR TITLE
dig lookup: support CAA record type

### DIFF
--- a/changelogs/fragments/5913-dig-caa.yml
+++ b/changelogs/fragments/5913-dig-caa.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "dig lookup plugin - support CAA record type (https://github.com/ansible-collections/community.general/pull/5913)."

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -35,9 +35,10 @@ DOCUMENTATION = '''
         description:
             - Record type to query.
             - C(DLV) has been removed in community.general 6.0.0.
+            - C(CAA) has been added in community.general 6.3.0.
         type: str
         default: 'A'
-        choices: [A, ALL, AAAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC, MX, NAPTR, NS, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, TLSA, TXT]
+        choices: [A, ALL, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC, MX, NAPTR, NS, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, TLSA, TXT]
       flat:
         description: If 0 each record is returned as a dictionary, otherwise a string.
         type: int
@@ -198,7 +199,7 @@ try:
     import dns.resolver
     import dns.reversename
     import dns.rdataclass
-    from dns.rdatatype import (A, AAAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC,
+    from dns.rdatatype import (A, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC,
                                MX, NAPTR, NS, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP, TLSA, TXT)
     HAVE_DNS = True
 except ImportError:
@@ -218,6 +219,7 @@ def make_rdata_dict(rdata):
     supported_types = {
         A: ['address'],
         AAAA: ['address'],
+        CAA: ['flags', 'tag', 'value'],
         CNAME: ['target'],
         DNAME: ['target'],
         DNSKEY: ['flags', 'algorithm', 'protocol', 'key'],

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -130,6 +130,12 @@ RETURN = """
        AAAA:
            description:
                - address
+       CAA:
+           description:
+               - flags
+               - tag
+               - value
+           version_added: 6.3.0
        CNAME:
            description:
                - target


### PR DESCRIPTION
##### SUMMARY
I borrowed some code from the dig lookup in https://github.com/ansible-collections/community.dns/pull/133 and noticed that CAA records aren't supported by the dig lookup yet.

Since this is easy to fix, here we go :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
dig lookup plugin
