### PR TITLE
dig lookup: fix DNSKEY's algorithm handling

### DIFF
--- a/changelogs/fragments/5914-dig-dnskey.yml
+++ b/changelogs/fragments/5914-dig-dnskey.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dig lookup plugin - correctly handle DNSKEY record type's ``algorithm`` field (https://github.com/ansible-collections/community.general/pull/5914)."

--- a/plugins/lookup/dig.py
+++ b/plugins/lookup/dig.py
@@ -230,7 +230,7 @@ def make_rdata_dict(rdata):
         NSEC3PARAM: ['algorithm', 'flags', 'iterations', 'salt'],
         PTR: ['target'],
         RP: ['mbox', 'txt'],
-        # RRSIG: ['algorithm', 'labels', 'original_ttl', 'expiration', 'inception', 'signature'],
+        # RRSIG: ['type_covered', 'algorithm', 'labels', 'original_ttl', 'expiration', 'inception', 'key_tag', 'signer', 'signature'],
         SOA: ['mname', 'rname', 'serial', 'refresh', 'retry', 'expire', 'minimum'],
         SPF: ['strings'],
         SRV: ['priority', 'weight', 'port', 'target'],
@@ -251,6 +251,8 @@ def make_rdata_dict(rdata):
 
             if rdata.rdtype == DS and f == 'digest':
                 val = dns.rdata._hexify(rdata.digest).replace(' ', '')
+            if rdata.rdtype == DNSKEY and f == 'algorithm':
+                val = int(val)
             if rdata.rdtype == DNSKEY and f == 'key':
                 val = dns.rdata._base64ify(rdata.key).replace(' ', '')
             if rdata.rdtype == NSEC3PARAM and f == 'salt':


### PR DESCRIPTION
##### SUMMARY
With dnspython 2.0.0+, `algorithm` of DNSKEY rdata is an enum type and no longer an int. Explicitly converting it to `int` makes sure that it is an integer.

Try `ansible localhost -m debug -a 'msg={{ q("dig", "com", qtype="DNSKEY", flat=0) }}'` with and without this PR, then you get
```
    "msg": [
        {
            "algorithm": 8,
            "class": "IN",
            "flags": 257,
            "key": "AQPDzldNmMvZFX4NcNJ0uEnKDg7tmv/F3MyQR0lpBmVcNcsIszxNFxsBfKNW9JYCYqpik8366LE7VbIcNRzfp2h9OO8HRl+H+E08zauK8k7evWEmu/6od+2boggPoiEfGNyvNPaSI7FOIroDsnw/taggzHRX1Z7SOiOiPWPNIwSUyWOZ79VmcQ1GLkC6NlYvG3HwYmynQv6oFwGv/KELSw7ZSdrbTQ0HXvZbqMUI7BaMskmvgm1G7oKZ1YiF7O9ioVNc0+7ASbqmZN7Z98EGU/Qh2K/BgUe8Hs0XVcdPKrtyYnoQHd2ynKPcMMlTEih2/2HDHjRPJ2aywIpKNnv4oPo/",
            "owner": "com.",
            "protocol": 3,
            "ttl": 86362,
            "type": "DNSKEY"
        },
        {
            "algorithm": 8,
            "class": "IN",
            "flags": 256,
            "key": "AwEAAb+cCgnkrABgFJ67lulzA/rJtcnjALB/gP3Q33PdpNl3VoW/V0GWzo99F7I7FyK/lpRTgoPp2pe2DRtoocL9XhqVoEDDV04KPk6kJXacSpltf9xu/j+sJElOGz/cWzAxIN2sTJxsRyNRwenTLJLd1pLDqB80hB25he9/d2bwmuWhC7l7mHrXr0RgvkxGGSeP/k0MQg7JGzl1mC+P/yqwx6E=",
            "owner": "com.",
            "protocol": 3,
            "ttl": 86362,
            "type": "DNSKEY"
        }
    ]
```
vs
```
    "msg": "[{'flags': 256, 'algorithm': <Algorithm.RSASHA256: 8>, 'protocol': 3, 'key': 'AwEAAb+cCgnkrABgFJ67lulzA/rJtcnjALB/gP3Q33PdpNl3VoW/V0GWzo99F7I7FyK/lpRTgoPp2pe2DRtoocL9XhqVoEDDV04KPk6kJXacSpltf9xu/j+sJElOGz/cWzAxIN2sTJxsRyNRwenTLJLd1pLDqB80hB25he9/d2bwmuWhC7l7mHrXr0RgvkxGGSeP/k0MQg7JGzl1mC+P/yqwx6E=', 'owner': 'com.', 'type': 'DNSKEY', 'ttl': 86400, 'class': 'IN'}, {'flags': 257, 'algorithm': <Algorithm.RSASHA256: 8>, 'protocol': 3, 'key': 'AQPDzldNmMvZFX4NcNJ0uEnKDg7tmv/F3MyQR0lpBmVcNcsIszxNFxsBfKNW9JYCYqpik8366LE7VbIcNRzfp2h9OO8HRl+H+E08zauK8k7evWEmu/6od+2boggPoiEfGNyvNPaSI7FOIroDsnw/taggzHRX1Z7SOiOiPWPNIwSUyWOZ79VmcQ1GLkC6NlYvG3HwYmynQv6oFwGv/KELSw7ZSdrbTQ0HXvZbqMUI7BaMskmvgm1G7oKZ1YiF7O9ioVNc0+7ASbqmZN7Z98EGU/Qh2K/BgUe8Hs0XVcdPKrtyYnoQHd2ynKPcMMlTEih2/2HDHjRPJ2aywIpKNnv4oPo/', 'owner': 'com.', 'type': 'DNSKEY', 'ttl': 86400, 'class': 'IN'}]"
```

(I also updated the RRSIG field name list, while being at it.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dig lookup plugin
