### PR TITLE
mail: add Message-Id to mail headers

### DIFF
--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -246,6 +246,7 @@ def main():
             subtype=dict(type='str', default='plain', choices=['html', 'plain']),
             secure=dict(type='str', default='try', choices=['always', 'never', 'starttls', 'try']),
             timeout=dict(type='int', default=20),
+            message_id=dict(type='str', aliases=['Message-ID'])
         ),
         required_together=[['password', 'username']],
     )
@@ -267,7 +268,8 @@ def main():
     subtype = module.params.get('subtype')
     secure = module.params.get('secure')
     timeout = module.params.get('timeout')
-
+    message_id = module.params.get('message_id')
+    
     code = 0
     secure_state = False
     sender_phrase, sender_addr = parseaddr(sender)
@@ -341,6 +343,8 @@ def main():
     msg['From'] = formataddr((sender_phrase, sender_addr))
     msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = Header(subject, charset)
+    if message_id:
+      msg['Message-ID'] = make_msgid(domain=message_id)    
     msg.preamble = "Multipart message"
 
     for header in headers:


### PR DESCRIPTION
##### SUMMARY
<!— Your description here –>
Add Message-Id to the headers to avoid servers to see our mails as spams

##### ISSUE TYPE

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We have generated and added the message-ID field that is mandatory for some mail servers


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module/Plugin Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
