### PR TITLE
Set User-Agent for API requests to DNSimple

### DIFF
--- a/changelogs/fragments/5927-set-user-agent-dnsimple.yml
+++ b/changelogs/fragments/5927-set-user-agent-dnsimple.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "Set custom User-Agent for API requests to DNSimple (https://github.com/ansible-collections/community.general/pull/5927)."
+  - "dnsimple - set custom User-Agent for API requests to DNSimple (https://github.com/ansible-collections/community.general/pull/5927)."

--- a/changelogs/fragments/5927-set-user-agent-dnsimple.yml
+++ b/changelogs/fragments/5927-set-user-agent-dnsimple.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Set custom User-Agent for API requests to DNSimple (https://github.com/ansible-collections/community.general/pull/5927)."

--- a/plugins/modules/dnsimple.py
+++ b/plugins/modules/dnsimple.py
@@ -168,7 +168,7 @@ class DNSimpleV2():
     def dnsimple_client(self):
         """creates a dnsimple client object"""
         if self.account_email and self.account_api_token:
-            client = Client(sandbox=self.sandbox, email=self.account_email, access_token=self.account_api_token)
+            client = Client(sandbox=self.sandbox, email=self.account_email, access_token=self.account_api_token, user_agent="ansible.community")
         else:
             msg = "Option account_email or account_api_token not provided. " \
                   "Dnsimple authentiction with a .dnsimple config file is not " \

--- a/plugins/modules/dnsimple.py
+++ b/plugins/modules/dnsimple.py
@@ -168,7 +168,7 @@ class DNSimpleV2():
     def dnsimple_client(self):
         """creates a dnsimple client object"""
         if self.account_email and self.account_api_token:
-            client = Client(sandbox=self.sandbox, email=self.account_email, access_token=self.account_api_token, user_agent="ansible.community")
+            client = Client(sandbox=self.sandbox, email=self.account_email, access_token=self.account_api_token, user_agent="ansible/community.general")
         else:
             msg = "Option account_email or account_api_token not provided. " \
                   "Dnsimple authentiction with a .dnsimple config file is not " \


### PR DESCRIPTION
##### SUMMARY

## What is the problem?

At present the default user agent is used in API requests: `dnsimple-python/*`. This makes it impossible for us at DNSimple to identify active community projects that are using our API, and how to best support them.

## What has changed

With this PR the user agent is changed to: `ansible dnsimple-python/*` which serves to both identify API usage from the project and also give us debugging data to assist with customer support requests.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`dnsimple`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
