### PR TITLE
Align 'gitlab_runner' with GitLab's default access level.

### DIFF
--- a/changelogs/fragments/5925-align_gitlab_runner_access_level_default_with_gitlab.yml
+++ b/changelogs/fragments/5925-align_gitlab_runner_access_level_default_with_gitlab.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - gitlab_runner - the option ``access_level`` will lose its default value in community.general 8.0.0. From that version on, you have set this option to ``ref_protected`` explicitly, if you want to have a protected runner (https://github.com/ansible-collections/community.general/issues/5925).


### PR DESCRIPTION
##### SUMMARY
In order to align the module with GitLab's runner API, the option ``access_level`` will lose its default value in community.general 8.0.0. From that version on, you have set this option to ``ref_protected`` explicitly, if you want to have a protected runner, otherwise GitLab's default access level gets applied, which is ``not_protected``.

Because changing the default value requires a longer deprecation period, a deprecation message was added, that informs the user about the future change regarding module's behavior.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
gitlab_runner
