### PR TITLE
Suppress urllib3 InsecureRequestWarnings when `validate_certs` option is false

### DIFF
--- a/changelogs/fragments/5915-suppress-urllib3-insecure-request-warnings.yml
+++ b/changelogs/fragments/5915-suppress-urllib3-insecure-request-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - Suppress urllib3 InsecureRequestWarnings when validate_certs option is false.
+  - proxmox - suppress urllib3 ``InsecureRequestWarnings`` when ``validate_certs`` option is ``false`` (https://github.com/ansible-collections/community.general/pull/5931).

--- a/changelogs/fragments/5915-suppress-urllib3-insecure-request-warnings.yml
+++ b/changelogs/fragments/5915-suppress-urllib3-insecure-request-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - Suppress urllib3 InsecureRequestWarnings when validate_certs option is false.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -277,6 +277,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             credentials = urlencode({'username': self.proxmox_user, 'password': self.proxmox_password, })
 
             a = self._get_session()
+            
+            if a.verify is False:
+                from requests.packages.urllib3 import disable_warnings
+                disable_warnings()
+            
             ret = a.post('%s/api2/json/access/ticket' % self.proxmox_url, data=credentials)
 
             json = ret.json()

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -277,11 +277,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             credentials = urlencode({'username': self.proxmox_user, 'password': self.proxmox_password, })
 
             a = self._get_session()
-            
+
             if a.verify is False:
                 from requests.packages.urllib3 import disable_warnings
                 disable_warnings()
-            
+
             ret = a.post('%s/api2/json/access/ticket' % self.proxmox_url, data=credentials)
 
             json = ret.json()


### PR DESCRIPTION
##### SUMMARY

It's clear that the user would know the possible risk when he or she chose to turn off the option, so the warning message could be ignored and make the output clean.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

`community.general.proxmox`