### PR TITLE
onepassword: ignore errors from "op account get"

### DIFF
--- a/changelogs/fragments/5942-onepassword-ignore-errors-from-op-account-get.yml
+++ b/changelogs/fragments/5942-onepassword-ignore-errors-from-op-account-get.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- onepassword - Changed to ignore errors from "op account get" calls (https://github.com/ansible-collections/community.general/pull/5942). Previously, errors would prevent auto-signin code from executing.

--- a/changelogs/fragments/5942-onepassword-ignore-errors-from-op-account-get.yml
+++ b/changelogs/fragments/5942-onepassword-ignore-errors-from-op-account-get.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- onepassword - Changed to ignore errors from "op account get" calls (https://github.com/ansible-collections/community.general/pull/5942). Previously, errors would prevent auto-signin code from executing.
+- onepassword lookup plugin - Changed to ignore errors from "op account get" calls. Previously, errors would prevent auto-signin code from executing (https://github.com/ansible-collections/community.general/pull/5942).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -488,7 +488,7 @@ class OnePassCLIv2(OnePassCLIBase):
                 account = "{subdomain}.{domain}".format(subdomain=self.subdomain, domain=self.domain)
                 args.extend(["--account", account])
 
-            rc, out, err = self._run(args)
+            rc, out, err = self._run(args, ignore_errors=True)
 
             return not bool(rc)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using the onepassword lookup plugin, part of the flow is to determine if you are signed in.  This is performed in an api version specific function called assert_logged_in() documented as "Check whether a login session exists" which uses the command `op account get`.  When you are not in fact signed in, this cli can return an error which is currently not ignored and can cause the lookup plugin to fail at that point rather than correctly returning the status to indicate that you are not signed in and proceed to signin using the parameters passed for that purpose.

This change passes the `ignore_errors=True` parameter to the _run function so that the return code can be used to indicate you are not signed in when an error occurs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
changelog fragment

bugfixes:
  - onepassword - Changed to ignore errors from "op account get" calls.  Previously, errors would prevent auto-signin code from executing.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/lookup/onepassword.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
ansible task
- line breaks and indentation added for clarity
- all signin values changed from valid ones
- mysecret is not defined to show the proper result saying it does not exist
```
- name: Load value from 1Password
  set_fact:
    op_fact: "{{ lookup('community.general.onepassword', 'mysecret',
                                     master_password='my_master_password',
                                     secret_key='my_secret_key',
                                     subdomain='my_subdomain',
                                     username='my_username') }}"
```
before fix applied
```paste below
fatal: [playbook-secrets]: FAILED! => {
    "msg": "[ERROR] 2023/02/05 11:46:22 You are not currently signed in. Please run `op signin --help` for instructions\n"
}
```
after fix applied
```
fatal: [playbook-secrets]: FAILED! => {
    "msg": "[ERROR] 2023/02/05 11:42:50 \"mysecret\" isn't an item. Specify the item with its UUID, name, or domain.\n"
}
```
cli behavior when not signed in
```
$ op account get 
[ERROR] 2023/02/05 11:47:04 You are not currently signed in. Please run `op signin --help` for instructions
$ echo $?
1
```
