### PR TITLE
zfs_delegate_admin: fix: zfs allow cannot parse unknown uid/gid

### DIFF
--- a/changelogs/fragments/5943-zfs_delegate_admin-fix-zfs-allow-cannot-parse-unknown-uid-gid.yml
+++ b/changelogs/fragments/5943-zfs_delegate_admin-fix-zfs-allow-cannot-parse-unknown-uid-gid.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zfs_delegate_admin - zfs allow output can now be parsed when uids/gids are not known to the host system (https://github.com/ansible-collections/community.general/pull/5943).

--- a/plugins/modules/zfs_delegate_admin.py
+++ b/plugins/modules/zfs_delegate_admin.py
@@ -177,6 +177,9 @@ class ZfsDelegateAdmin(object):
             scope = linemap.get(line, scope)
             if not scope:
                 continue
+            if ' (unknown: ' in line:
+                line = line.replace('(unknown: ', '', 1)
+                line = line.replace(')', '', 1)
             try:
                 if line.startswith('\tuser ') or line.startswith('\tgroup '):
                     ent_type, ent, cur_perms = line.split()


### PR DESCRIPTION
When setting allow permissions for particular users or groups there will be circumstances when that user is not known to the host system.

In that case the output of `zfs allow <pool/dataset>` looks similar to this:

  $ sudo zfs allow tank/test
  ---- Permissions on tank/test ---------------------------------------
  Local+Descendent permissions:
    user (unknown: 1002) hold
    user zfsuser receive

The fix in this commit removes ` (unknown: `+`)` from the output leaving only the uid/gid.

This allows the current parser to continue even if the uid/gid is not known.

This situation occurs most often when moving a zpool from one system to another that may not have the same users/groups. Simply adding permissions to a user/group and then deleting the user/group from the system will cause this situation to occur.

##### SUMMARY
Fixes #5941

Removing ` (unknown: ` + `)` from `line` allows the user to remove and permissions to uids or gids even if the host system is unaware of an actual user/group by that name.

Ideally, openzfs could modify the `zfs allow` command to allow for machine readable output like most of the zfs commands available: e.g. `-H -o name,permissions,entity`.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
community.general.zfs_delegate_admin

##### ADDITIONAL INFORMATION


Testing
```
  tasks:

  - name: remove all perms
    community.general.zfs_delegate_admin:
      name: tank/test
      users: "zfsuser,1002"
      groups: 2000
      permissions: send,hold
      recursive: yes
      state: absent

  - ansible.builtin.command:
      cmd: zfs allow tank/test
    register: o1

  - debug:
      msg: "{{ o1.stdout.split('\n') }}"

  - name: add perm
    community.general.zfs_delegate_admin:
      name: tank/test
      users: "zfsuser,1002"
      groups: 2000
      permissions: send
      recursive: yes
      state: present

  - ansible.builtin.command:
      cmd: zfs allow tank/test
    register: o2

  - debug:
      msg: "{{ o2.stdout.split('\n') }}"

  - name: remove perm
    community.general.zfs_delegate_admin:
      name: tank/test
      users: "zfsuser,1002"
      groups: 2000
      permissions: send
      recursive: yes
      state: absent

  - ansible.builtin.command:
      cmd: zfs allow tank/test
    register: o3

  - debug:
      msg: "{{ o3.stdout.split('\n') }}"
```
```
$ ansible-playbook a.yml -l machine-a

PLAY [all] *************************************************************************************************

TASK [Gathering Facts] *************************************************************************************
ok: [machine-a]

TASK [remove all perms] ************************************************************************************
changed: [machine-a]

TASK [ansible.builtin.command] *****************************************************************************
changed: [machine-a]

TASK [debug] ***********************************************************************************************
ok: [machine-a] => {
    "msg": [
        ""
    ]
}

TASK [add perm] ********************************************************************************************
changed: [machine-a]

TASK [ansible.builtin.command] *****************************************************************************
changed: [machine-a]

TASK [debug] ***********************************************************************************************
ok: [machine-a] => {
    "msg": [
        "---- Permissions on tank/test ----------------------------------------",
        "Local+Descendent permissions:",
        "\tuser (unknown: 1002) send",
        "\tuser zfsuser send",
        "\tgroup (unknown: 2000) send"
    ]
}

TASK [remove perm] *****************************************************************************************
changed: [machine-a]

TASK [ansible.builtin.command] *****************************************************************************
changed: [machine-a]

TASK [debug] ***********************************************************************************************
ok: [machine-a] => {
    "msg": [
        ""
    ]
}

PLAY RECAP *************************************************************************************************
machine-a                      : ok=10   changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```