### PR TITLE
Add attributes to oneandone, ovh, and rackspace modules

### DIFF
--- a/plugins/modules/oneandone_firewall_policy.py
+++ b/plugins/modules/oneandone_firewall_policy.py
@@ -12,8 +12,15 @@ DOCUMENTATION = '''
 module: oneandone_firewall_policy
 short_description: Configure 1&1 firewall policy
 description:
-     - Create, remove, reconfigure, update firewall policies.
-       This module has a dependency on 1and1 >= 1.0
+  - Create, remove, reconfigure, update firewall policies.
+    This module has a dependency on 1and1 >= 1.0.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/oneandone_load_balancer.py
+++ b/plugins/modules/oneandone_load_balancer.py
@@ -12,8 +12,15 @@ DOCUMENTATION = '''
 module: oneandone_load_balancer
 short_description: Configure 1&1 load balancer
 description:
-     - Create, remove, update load balancers.
-       This module has a dependency on 1and1 >= 1.0
+  - Create, remove, update load balancers.
+    This module has a dependency on 1and1 >= 1.0.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/oneandone_monitoring_policy.py
+++ b/plugins/modules/oneandone_monitoring_policy.py
@@ -12,9 +12,16 @@ DOCUMENTATION = '''
 module: oneandone_monitoring_policy
 short_description: Configure 1&1 monitoring policy
 description:
-     - Create, remove, update monitoring policies
-       (and add/remove ports, processes, and servers).
-       This module has a dependency on 1and1 >= 1.0
+  - Create, remove, update monitoring policies
+    (and add/remove ports, processes, and servers).
+    This module has a dependency on 1and1 >= 1.0.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/oneandone_private_network.py
+++ b/plugins/modules/oneandone_private_network.py
@@ -12,8 +12,15 @@ DOCUMENTATION = '''
 module: oneandone_private_network
 short_description: Configure 1&1 private networking
 description:
-     - Create, remove, reconfigure, update a private network.
-       This module has a dependency on 1and1 >= 1.0
+  - Create, remove, reconfigure, update a private network.
+    This module has a dependency on 1and1 >= 1.0.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/oneandone_public_ip.py
+++ b/plugins/modules/oneandone_public_ip.py
@@ -12,8 +12,15 @@ DOCUMENTATION = '''
 module: oneandone_public_ip
 short_description: Configure 1&1 public IPs
 description:
-     - Create, update, and remove public IPs.
-       This module has a dependency on 1and1 >= 1.0
+  - Create, update, and remove public IPs.
+    This module has a dependency on 1and1 >= 1.0.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/oneandone_server.py
+++ b/plugins/modules/oneandone_server.py
@@ -12,8 +12,15 @@ DOCUMENTATION = '''
 module: oneandone_server
 short_description: Create, destroy, start, stop, and reboot a 1&1 Host server
 description:
-     - Create, destroy, update, start, stop, and reboot a 1&1 Host server.
-       When the server is created it can optionally wait for it to be 'running' before returning.
+  - Create, destroy, update, start, stop, and reboot a 1&1 Host server.
+    When the server is created it can optionally wait for it to be 'running' before returning.
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
   state:
     description:

--- a/plugins/modules/ovh_ip_failover.py
+++ b/plugins/modules/ovh_ip_failover.py
@@ -23,6 +23,13 @@ notes:
       key as described into U(https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/)
 requirements:
     - ovh >=  0.4.8
+extends_documentation_fragment:
+    - community.general.attributes
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 options:
     name:
         required: true

--- a/plugins/modules/ovh_ip_loadbalancing_backend.py
+++ b/plugins/modules/ovh_ip_loadbalancing_backend.py
@@ -22,6 +22,13 @@ notes:
       key as described into U(https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/)
 requirements:
     - ovh >  0.3.5
+extends_documentation_fragment:
+    - community.general.attributes
+attributes:
+    check_mode:
+        support: none
+    diff_mode:
+        support: none
 options:
     name:
         required: true

--- a/plugins/modules/ovh_monthly_billing.py
+++ b/plugins/modules/ovh_monthly_billing.py
@@ -18,6 +18,13 @@ short_description: Manage OVH monthly billing
 description:
     - Enable monthly billing on OVH cloud intances (be aware OVH does not allow to disable it).
 requirements: [ "ovh" ]
+extends_documentation_fragment:
+    - community.general.attributes
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
 options:
     project_id:
         required: true

--- a/plugins/modules/rax.py
+++ b/plugins/modules/rax.py
@@ -15,6 +15,11 @@ short_description: Create / delete an instance in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud instance and optionally
        waits for it to be 'running'.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   auto_increment:
     description:
@@ -177,7 +182,8 @@ notes:
     In the case of deletion, the returned data structure will have C(action)
     set to C(delete), and the oldest servers in the group will be deleted.
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_cbs.py
+++ b/plugins/modules/rax_cbs.py
@@ -14,6 +14,11 @@ module: rax_cbs
 short_description: Manipulate Rackspace Cloud Block Storage Volumes
 description:
      - Manipulate Rackspace Cloud Block Storage Volumes
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   description:
     type: str
@@ -73,7 +78,8 @@ author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+    - community.general.rackspace.openstack
+    - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_cbs_attachments.py
+++ b/plugins/modules/rax_cbs_attachments.py
@@ -14,6 +14,11 @@ module: rax_cbs_attachments
 short_description: Manipulate Rackspace Cloud Block Storage Volume Attachments
 description:
      - Manipulate Rackspace Cloud Block Storage Volume Attachments
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   device:
     type: str
@@ -52,7 +57,8 @@ author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+    - community.general.rackspace.openstack
+    - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_cdb.py
+++ b/plugins/modules/rax_cdb.py
@@ -16,6 +16,11 @@ description:
   - creates / deletes or resize a Rackspace Cloud Databases instance
     and optionally waits for it to be 'running'. The name option needs to be
     unique since it's used to identify the instance.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   name:
     type: str
@@ -63,8 +68,9 @@ options:
     default: 300
 author: "Simon JAILLET (@jails)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_cdb_database.py
+++ b/plugins/modules/rax_cdb_database.py
@@ -13,6 +13,11 @@ module: rax_cdb_database
 short_description: Create / delete a database in the Cloud Databases
 description:
   - create / delete a database in the Cloud Databases.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   cdb_id:
     type: str
@@ -42,8 +47,9 @@ options:
     default: present
 author: "Simon JAILLET (@jails)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_cdb_user.py
+++ b/plugins/modules/rax_cdb_user.py
@@ -14,6 +14,11 @@ module: rax_cdb_user
 short_description: Create / delete a Rackspace Cloud Database
 description:
   - create / delete a database in the Cloud Databases.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   cdb_id:
     type: str
@@ -51,8 +56,9 @@ options:
     default: present
 author: "Simon JAILLET (@jails)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_clb.py
+++ b/plugins/modules/rax_clb.py
@@ -14,6 +14,11 @@ module: rax_clb
 short_description: Create / delete a load balancer in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud load balancer.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   algorithm:
     type: str
@@ -105,8 +110,9 @@ author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_clb_nodes.py
+++ b/plugins/modules/rax_clb_nodes.py
@@ -14,6 +14,11 @@ module: rax_clb_nodes
 short_description: Add, modify and remove nodes from a Rackspace Cloud Load Balancer
 description:
   - Adds, modifies and removes nodes from a Rackspace Cloud Load Balancer
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   address:
     type: str
@@ -85,8 +90,9 @@ options:
       - Virtualenv to execute this module in
 author: "Lukasz Kawczynski (@neuroid)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_clb_ssl.py
+++ b/plugins/modules/rax_clb_ssl.py
@@ -13,6 +13,11 @@ module: rax_clb_ssl
 short_description: Manage SSL termination for a Rackspace Cloud Load Balancer
 description:
 - Set up, reconfigure, or remove SSL termination for an existing load balancer.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   loadbalancer:
     type: str
@@ -75,8 +80,9 @@ options:
     default: 300
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_dns.py
+++ b/plugins/modules/rax_dns.py
@@ -14,6 +14,11 @@ module: rax_dns
 short_description: Manage domains on Rackspace Cloud DNS
 description:
      - Manage domains on Rackspace Cloud DNS
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   comment:
     type: str
@@ -46,8 +51,9 @@ notes:
     the Rackspace CloudDNS API"
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_dns_record.py
+++ b/plugins/modules/rax_dns_record.py
@@ -14,6 +14,11 @@ module: rax_dns_record
 short_description: Manage DNS records on Rackspace Cloud DNS
 description:
      - Manage DNS records on Rackspace Cloud DNS
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   comment:
     type: str
@@ -92,8 +97,9 @@ notes:
   - C(PTR) record support was added in version 1.7
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_files.py
+++ b/plugins/modules/rax_files.py
@@ -14,6 +14,11 @@ module: rax_files
 short_description: Manipulate Rackspace Cloud Files Containers
 description:
   - Manipulate Rackspace Cloud Files Containers
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   clear_meta:
     description:
@@ -75,8 +80,9 @@ options:
        - Sets an object to be presented as the HTTP index page when accessed by the CDN URL
 author: "Paul Durivage (@angstwad)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_files_objects.py
+++ b/plugins/modules/rax_files_objects.py
@@ -14,6 +14,11 @@ module: rax_files_objects
 short_description: Upload, download, and delete objects in Rackspace Cloud Files
 description:
   - Upload, download, and delete objects in Rackspace Cloud Files.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   clear_meta:
     description:
@@ -76,8 +81,9 @@ options:
     default: file
 author: "Paul Durivage (@angstwad)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_identity.py
+++ b/plugins/modules/rax_identity.py
@@ -14,6 +14,11 @@ module: rax_identity
 short_description: Load Rackspace Cloud Identity
 description:
      - Verifies Rackspace Cloud credentials and returns identity information
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -26,7 +31,8 @@ author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_keypair.py
+++ b/plugins/modules/rax_keypair.py
@@ -14,6 +14,11 @@ module: rax_keypair
 short_description: Create a keypair for use with Rackspace Cloud Servers
 description:
      - Create a keypair for use with Rackspace Cloud Servers
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   name:
     type: str
@@ -38,7 +43,8 @@ notes:
     keypair you must first delete and then recreate.
   - The ability to specify a file path for the public key was added in 1.7
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_meta.py
+++ b/plugins/modules/rax_meta.py
@@ -14,6 +14,11 @@ module: rax_meta
 short_description: Manipulate metadata for Rackspace Cloud Servers
 description:
      - Manipulate metadata for Rackspace Cloud Servers
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   address:
     type: str
@@ -35,7 +40,8 @@ options:
       - A hash of metadata to associate with the instance
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_mon_alarm.py
+++ b/plugins/modules/rax_mon_alarm.py
@@ -19,6 +19,11 @@ description:
   notifications. Rackspace monitoring module flow | rax_mon_entity ->
   rax_mon_check -> rax_mon_notification -> rax_mon_notification_plan ->
   *rax_mon_alarm*
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -71,7 +76,8 @@ options:
       keys and values between 1 and 255 characters long.
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_mon_check.py
+++ b/plugins/modules/rax_mon_check.py
@@ -20,6 +20,11 @@ description:
   monitor. Rackspace monitoring module flow | rax_mon_entity ->
   *rax_mon_check* -> rax_mon_notification -> rax_mon_notification_plan ->
   rax_mon_alarm
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -115,7 +120,8 @@ options:
       results. Must be less than the period.
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_mon_entity.py
+++ b/plugins/modules/rax_mon_entity.py
@@ -18,6 +18,11 @@ description:
   provide a convenient, centralized place to store IP addresses. Rackspace
   monitoring module flow | *rax_mon_entity* -> rax_mon_check ->
   rax_mon_notification -> rax_mon_notification_plan -> rax_mon_alarm
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   label:
     type: str
@@ -53,7 +58,8 @@ options:
       long.
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_mon_notification.py
+++ b/plugins/modules/rax_mon_notification.py
@@ -17,6 +17,11 @@ description:
   channel that can be used to communicate alarms, such as email, webhooks, or
   PagerDuty. Rackspace monitoring module flow | rax_mon_entity -> rax_mon_check ->
   *rax_mon_notification* -> rax_mon_notification_plan -> rax_mon_alarm
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -46,7 +51,8 @@ options:
     required: true
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_mon_notification_plan.py
+++ b/plugins/modules/rax_mon_notification_plan.py
@@ -18,6 +18,11 @@ description:
   associating existing rax_mon_notifications with severity levels. Rackspace
   monitoring module flow | rax_mon_entity -> rax_mon_check ->
   rax_mon_notification -> *rax_mon_notification_plan* -> rax_mon_alarm
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -52,7 +57,8 @@ options:
       valid rax_mon_notification ids.
 author: Ash Wilson (@smashwilson)
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_network.py
+++ b/plugins/modules/rax_network.py
@@ -14,6 +14,11 @@ module: rax_network
 short_description: Create / delete an isolated network in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud isolated network.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   state:
     type: str
@@ -36,7 +41,8 @@ author:
   - "Christopher H. Laco (@claco)"
   - "Jesse Keating (@omgjlk)"
 extends_documentation_fragment:
-- community.general.rackspace.openstack
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_queue.py
+++ b/plugins/modules/rax_queue.py
@@ -14,6 +14,11 @@ module: rax_queue
 short_description: Create / delete a queue in Rackspace Public Cloud
 description:
      - creates / deletes a Rackspace Public Cloud queue.
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   name:
     type: str
@@ -31,8 +36,9 @@ author:
     - "Christopher H. Laco (@claco)"
     - "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_scaling_group.py
+++ b/plugins/modules/rax_scaling_group.py
@@ -14,6 +14,11 @@ module: rax_scaling_group
 short_description: Manipulate Rackspace Cloud Autoscale Groups
 description:
     - Manipulate Rackspace Cloud Autoscale Groups
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   config_drive:
     description:
@@ -122,8 +127,9 @@ options:
     default: 300
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 

--- a/plugins/modules/rax_scaling_policy.py
+++ b/plugins/modules/rax_scaling_policy.py
@@ -14,6 +14,11 @@ module: rax_scaling_policy
 short_description: Manipulate Rackspace Cloud Autoscale Scaling Policy
 description:
     - Manipulate Rackspace Cloud Autoscale Scaling Policy
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   at:
     type: str
@@ -77,8 +82,9 @@ options:
     default: present
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
-- community.general.rackspace
-- community.general.rackspace.openstack
+  - community.general.rackspace
+  - community.general.rackspace.openstack
+  - community.general.attributes
 
 '''
 


### PR DESCRIPTION
##### SUMMARY
This docs PR adds basic attributes (`check_mode` and `diff_mode`) to some modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various
