### PR TITLE
Add attributes for modules with action plugin

### DIFF
--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -15,6 +15,9 @@ module: iptables_state
 short_description: Save iptables state into a file or restore it from a file
 version_added: '1.1.0'
 author: quidame (@quidame)
+extends_documentation_fragment:
+  - community.general.attributes
+  - community.general.attributes.flow
 description:
   - C(iptables) is used to set up, maintain, and inspect the tables of IP
     packet filter rules in the Linux kernel.
@@ -36,7 +39,15 @@ notes:
     still happen if it shall happen, but you will experience a connection
     timeout instead of more relevant info returned by the module after its
     failure.
-  - This module supports I(check_mode).
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+  action:
+    support: full
+  async:
+    support: full
 options:
   counters:
     description:

--- a/plugins/modules/shutdown.py
+++ b/plugins/modules/shutdown.py
@@ -15,8 +15,20 @@ notes:
   - C(PATH) is ignored on the remote node when searching for the C(shutdown) command. Use I(search_paths)
     to specify locations to search if the default paths do not work.
 description:
-    - Shut downs a machine.
+  - Shut downs a machine.
 version_added: "1.1.0"
+extends_documentation_fragment:
+  - community.general.attributes
+  - community.general.attributes.flow
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+  action:
+    support: full
+  async:
+    support: full
 options:
   delay:
     description:


### PR DESCRIPTION
##### SUMMARY
This docs PR adds basic attributes (`check_mode` and `diff_mode`) and some extended attributes (`action` and `async`) to modules that come with action plugins.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various
