### PR TITLE
cloudflare_dns: Fix setting SRV records with a root level entry

### DIFF
--- a/changelogs/fragments/5972-cloudflare-dns-srv-record.yml
+++ b/changelogs/fragments/5972-cloudflare-dns-srv-record.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "cloudflare_dns - fixed the possiblity of setting a root-level SRV DNS record (https://github.com/ansible-collections/community.general/pull/5972)."

--- a/changelogs/fragments/5972-cloudflare-dns-srv-record.yml
+++ b/changelogs/fragments/5972-cloudflare-dns-srv-record.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "cloudflare_dns - fixed the possiblity of setting a root-level SRV DNS record (https://github.com/ansible-collections/community.general/pull/5972)."
+  - "cloudflare_dns - fixed the idempotency for SRV DNS records (https://github.com/ansible-collections/community.general/pull/5972)."

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -694,14 +694,10 @@ class CloudflareAPI(object):
                 "port": params['port'],
                 "weight": params['weight'],
                 "priority": params['priority'],
-                "name": params['record'][:-len('.' + params['zone'])],
+                "name": params['record'],
                 "proto": params['proto'],
                 "service": params['service']
             }
-
-            if len(srv_data['name']) == 0:
-                # Name is a required API field that needs to be set in case of a root record entry
-                srv_data['name'] = params['zone']
 
             new_record = {"type": params['type'], "ttl": params['ttl'], 'data': srv_data}
             search_value = str(params['weight']) + '\t' + str(params['port']) + '\t' + params['value']

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -698,6 +698,11 @@ class CloudflareAPI(object):
                 "proto": params['proto'],
                 "service": params['service']
             }
+
+            if len(srv_data['name']) == 0:
+                # Name is a required API field that needs to be set in case of a root record entry
+                srv_data['name'] = params['zone']
+
             new_record = {"type": params['type'], "ttl": params['ttl'], 'data': srv_data}
             search_value = str(params['weight']) + '\t' + str(params['port']) + '\t' + params['value']
             search_record = params['service'] + '.' + params['proto'] + '.' + params['record']


### PR DESCRIPTION
##### SUMMARY

This fixes a bug in the cloudflare_dns module where setting a root-level SRV record resulted in a `400 Bad Request`. After some debugging apparently the following line removes the zone suffix from the record:

https://github.com/ansible-collections/community.general/blob/de193ac1bf1c2336d8b9e465e28093cb20bb14c1/plugins/modules/cloudflare_dns.py#L690

Say, input data `params['record'] = example.com` and `params['zone'] = example.com` then name will be empty, which is not accepted by the Cloudflare API. Since the intention was to set a root-level entry, this PR ensures that in that specific case `name` will be equals to the zone.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
