### PR TITLE
nmcli: add new addr_gen_mode6 options

### DIFF
--- a/changelogs/fragments/5974-nmcli_add_new_addr_gen_mode6_options.yml
+++ b/changelogs/fragments/5974-nmcli_add_new_addr_gen_mode6_options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Add 'default' and 'default-or-eui64' to the list of valid choices for nmcli addr_gen_mode6 parameter.
+  - nmcli - add ``default`` and ``default-or-eui64`` to the list of valid choices for ``addr_gen_mode6`` parameter (https://github.com/ansible-collections/community.general/pull/5974).

--- a/changelogs/fragments/5974-nmcli_add_new_addr_gen_mode6_options.yml
+++ b/changelogs/fragments/5974-nmcli_add_new_addr_gen_mode6_options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add 'default' and 'default-or-eui64' to the list of valid choices for nmcli addr_gen_mode6 parameter.

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -295,6 +295,7 @@ options:
     addr_gen_mode6:
         description:
             - Configure method for creating the address for use with IPv6 Stateless Address Autoconfiguration.
+            - C(default) and C(deafult-or-eui64) have been added in community.general 6.4.0.
         type: str
         choices: [default, default-or-eui64, eui64, stable-privacy]
         version_added: 4.2.0

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -295,7 +295,7 @@ options:
     addr_gen_mode6:
         description:
             - Configure method for creating the address for use with IPv6 Stateless Address Autoconfiguration.
-            - C(default) and C(deafult-or-eui64) have been added in community.general 6.4.0.
+            - C(default) and C(deafult-or-eui64) have been added in community.general 6.5.0.
         type: str
         choices: [default, default-or-eui64, eui64, stable-privacy]
         version_added: 4.2.0

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -296,7 +296,7 @@ options:
         description:
             - Configure method for creating the address for use with IPv6 Stateless Address Autoconfiguration.
         type: str
-        choices: [eui64, stable-privacy]
+        choices: [default, default-or-eui64, eui64, stable-privacy]
         version_added: 4.2.0
     mtu:
         description:
@@ -2244,7 +2244,7 @@ def main():
             route_metric6=dict(type='int'),
             method6=dict(type='str', choices=['ignore', 'auto', 'dhcp', 'link-local', 'manual', 'shared', 'disabled']),
             ip_privacy6=dict(type='str', choices=['disabled', 'prefer-public-addr', 'prefer-temp-addr', 'unknown']),
-            addr_gen_mode6=dict(type='str', choices=['eui64', 'stable-privacy']),
+            addr_gen_mode6=dict(type='str', choices=['default', 'default-or-eui64', 'eui64', 'stable-privacy']),
             # Bond Specific vars
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -3916,7 +3916,7 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
             route_metric6=dict(type='int'),
             method6=dict(type='str', choices=['ignore', 'auto', 'dhcp', 'link-local', 'manual', 'shared', 'disabled']),
             ip_privacy6=dict(type='str', choices=['disabled', 'prefer-public-addr', 'prefer-temp-addr', 'unknown']),
-            addr_gen_mode6=dict(type='str', choices=['eui64', 'stable-privacy']),
+            addr_gen_mode6=dict(type='str', choices=['default', 'default-or-eui64', 'eui64', 'stable-privacy']),
             # Bond Specific vars
             mode=dict(type='str', default='balance-rr',
                       choices=['802.3ad', 'active-backup', 'balance-alb', 'balance-rr', 'balance-tlb', 'balance-xor', 'broadcast']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addresses:

Fixes #5973.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Add 'default' and 'default-or-eui64' to the list of valid choices for nmcli addr_gen_mode6 parameter.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nmcli
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #5973.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
