### PR TITLE
Add new project features to API

### DIFF
--- a/changelogs/fragments/5985-add-new-gitlab-api-features.yml
+++ b/changelogs/fragments/5985-add-new-gitlab-api-features.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - gitlab_project - add ``releases_access_level``,``environments_access_level``,``feature_flags_access_level``,``infrastructure_access_level``, ``monitor_access_level`` and ``security_and_compliance_access_level`` options (https://github.com/ansible-collections/community.general/pull/5986).
-

--- a/changelogs/fragments/5985-add-new-gitlab-api-features.yml
+++ b/changelogs/fragments/5985-add-new-gitlab-api-features.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - gitlab_project - add ``releases_access_level``,``environments_access_level``,``feature_flags_access_level``,``infrastructure_access_level``, ``monitor_access_level`` and ``security_and_compliance_access_level`` options (https://github.com/ansible-collections/community.general/pull/5986).
+

--- a/changelogs/fragments/5985-add-new-gitlab-api-features.yml
+++ b/changelogs/fragments/5985-add-new-gitlab-api-features.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - gitlab_project - add ``releases_access_level``,``environments_access_level``,``feature_flags_access_level``,``infrastructure_access_level``, ``monitor_access_level`` and ``security_and_compliance_access_level`` options (https://github.com/ansible-collections/community.general/pull/5986).
+  - gitlab_project - add ``releases_access_level``, ``environments_access_level``, ``feature_flags_access_level``, ``infrastructure_access_level``, ``monitor_access_level``, and ``security_and_compliance_access_level`` options (https://github.com/ansible-collections/community.general/pull/5986).

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -196,6 +196,54 @@ options:
     type: str
     choices: ["private", "disabled", "enabled"]
     version_added: "6.2.0"
+  releases_access_level:
+    description:
+      - C(private) means that accessing release is allowed only to project members.
+      - C(disabled) means that accessing release is disabled.
+      - C(enabled) means that accessing release is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  environments_access_level:
+    description:
+      - C(private) means that deployment to environment is allowed only to project members.
+      - C(disabled) means that deployment to environment is disabled.
+      - C(enabled) means that deployment to environment is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  feature_flags_access_level:
+    description:
+      - C(private) means that feature rollout is allowed only to project members.
+      - C(disabled) means that feature rollout is disabled.
+      - C(enabled) means that feature rollout is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  infrastructure_access_level:
+    description:
+      - C(private) means that configuring infrastructure is allowed only to project members.
+      - C(disabled) means that configuring infrastructure is disabled.
+      - C(enabled) means that configuring infrastructure is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  monitor_access_level:
+    description:
+      - C(private) means that monitoring health is allowed only to project members.
+      - C(disabled) means that monitoring health is disabled.
+      - C(enabled) means that monitoring health is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
+  security_and_compliance_access_level:
+    description:
+      - C(private) means that accessing security and complicance tab is allowed only to project members.
+      - C(disabled) means that accessing security and complicance tab is disabled.
+      - C(enabled) means that accessing security and complicance tab is enabled.
+    type: str
+    choices: ["private", "disabled", "enabled"]
+    version_added: "6.4.0"
 '''
 
 EXAMPLES = r'''
@@ -314,6 +362,12 @@ class GitLabProject(object):
             'builds_access_level': options['builds_access_level'],
             'forking_access_level': options['forking_access_level'],
             'container_registry_access_level': options['container_registry_access_level'],
+            'releases_access_level': options['releases_access_level'],
+            'environments_access_level': options['environments_access_level'],
+            'feature_flags_access_level': options['feature_flags_access_level'],
+            'infrastructure_access_level': options['infrastructure_access_level'],
+            'monitor_access_level': options['monitor_access_level'],
+            'security_and_compliance_access_level': options['security_and_compliance_access_level'],
         }
         # Because we have already call userExists in main()
         if self.project_object is None:
@@ -447,6 +501,12 @@ def main():
         builds_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
         forking_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
         container_registry_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        releases_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        environments_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        feature_flags_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        infrastructure_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        monitor_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
+        security_and_compliance_access_level=dict(type='str', choices=['private', 'disabled', 'enabled']),
     ))
 
     module = AnsibleModule(
@@ -497,6 +557,12 @@ def main():
     builds_access_level = module.params['builds_access_level']
     forking_access_level = module.params['forking_access_level']
     container_registry_access_level = module.params['container_registry_access_level']
+    releases_access_level = module.params['releases_access_level']
+    environments_access_level = module.params['environments_access_level']
+    feature_flags_access_level = module.params['feature_flags_access_level']
+    infrastructure_access_level = module.params['infrastructure_access_level']
+    monitor_access_level = module.params['monitor_access_level']
+    security_and_compliance_access_level = module.params['security_and_compliance_access_level']
 
     if default_branch and not initialize_with_readme:
         module.fail_json(msg="Param default_branch need param initialize_with_readme set to true")
@@ -569,6 +635,12 @@ def main():
             "builds_access_level": builds_access_level,
             "forking_access_level": forking_access_level,
             "container_registry_access_level": container_registry_access_level,
+            "releases_access_level": releases_access_level,
+            "environments_access_level": environments_access_level,
+            "feature_flags_access_level": feature_flags_access_level,
+            "infrastructure_access_level": infrastructure_access_level,
+            "monitor_access_level": monitor_access_level,
+            "security_and_compliance_access_level": security_and_compliance_access_level,
         }):
 
             module.exit_json(changed=True, msg="Successfully created or updated the project %s" % project_name, project=gitlab_project.project_object._attrs)


### PR DESCRIPTION
##### SUMMARY

Fixes #5985 

Added support for  `releases_access_level`, `environments_access_level`, `feature_flags_access_level`, `infrastructure_access_level`, `monitor_access_level` and `security_and_compliance_access_level` options(these are defined here in [gitlab's documentation](https://docs.gitlab.com/ee/api/projects.html#create-project))

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
gitlab_project

##### ADDITIONAL INFORMATION
Example of project creation using new fields:

```yml
- name: Setup gitlab project
  community.general.gitlab_project:
    api_url: https://gitlab.example.com/
    validate_certs: true
    api_username: dj-wasabi
    api_password: "MySecretPassword"
    name: my_project
    group: ansible
    releases_access_level: enabled
    environments_access_level: disabled
    feature_flags_access_level: disabled
    infrastructure_access_level: disabled
    monitor_access_level: disabled
    security_and_compliance_access_level: disabled
    state: present
  delegate_to: localhost
```
