### PR TITLE
github_webhook: Don't include secret in the config if it's absent

### DIFF
--- a/changelogs/fragments/5994-github-webhook-secret.yml
+++ b/changelogs/fragments/5994-github-webhook-secret.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - github_webhook - fix always changed state when no secret is provided (https://github.com/ansible-collections/community.general/pull/5994).

--- a/plugins/modules/github_webhook.py
+++ b/plugins/modules/github_webhook.py
@@ -154,12 +154,17 @@ from ansible.module_utils.common.text.converters import to_native
 
 
 def _create_hook_config(module):
-    return {
+    hook_config = {
         "url": module.params["url"],
         "content_type": module.params["content_type"],
-        "secret": module.params.get("secret"),
         "insecure_ssl": "1" if module.params["insecure_ssl"] else "0"
     }
+
+    secret = module.params.get("secret")
+    if secret is not None and len(secret) > 0:
+      hook_config["secret"] = secret
+
+    return hook_config
 
 
 def create_hook(repo, module):

--- a/plugins/modules/github_webhook.py
+++ b/plugins/modules/github_webhook.py
@@ -161,7 +161,7 @@ def _create_hook_config(module):
     }
 
     secret = module.params.get("secret")
-    if secret is not None and len(secret) > 0:
+    if secret:
         hook_config["secret"] = secret
 
     return hook_config

--- a/plugins/modules/github_webhook.py
+++ b/plugins/modules/github_webhook.py
@@ -162,7 +162,7 @@ def _create_hook_config(module):
 
     secret = module.params.get("secret")
     if secret is not None and len(secret) > 0:
-      hook_config["secret"] = secret
+        hook_config["secret"] = secret
 
     return hook_config
 


### PR DESCRIPTION
##### SUMMARY
Currently if you don't have a secret for the hook, the module will always report `changed` status even after multiple runs. This change adds secret to the config only if user specifies it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
github_webhook

##### ADDITIONAL INFORMATION
I've tested the change locally:
- if user doesn't provide secret - it doesn't report `changed` state anymore on the second run
- if user provides empty secret - it doesn't report `changed` state anymore on the second run
- if there was a secret before, and user doesn't provide a secret in the task - it will remove the secret (same as before this change)