### PR TITLE
community.general.osx_defaults: Include stderr in error messages

### DIFF
--- a/changelogs/fragments/6011-osx-defaults-errors.yml
+++ b/changelogs/fragments/6011-osx-defaults-errors.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - "osx_defaults - include stderr in error messages (https://github.com/ansible-collections/community.general/pull/6011)."

--- a/changelogs/fragments/6011-osx-defaults-errors.yml
+++ b/changelogs/fragments/6011-osx-defaults-errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "osx_defaults - include stderr in error messages (https://github.com/ansible-collections/community.general/pull/6011)."

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -71,8 +71,7 @@ notes:
 '''
 
 EXAMPLES = r'''
-# TODO: Describe what happens in each example
-
+# Set Boolean Valued Key for Application Domain
 - community.general.osx_defaults:
     domain: com.apple.Safari
     key: IncludeInternalDebugMenu
@@ -80,6 +79,7 @@ EXAMPLES = r'''
     value: true
     state: present
 
+# Set String Valued Key for Global Domain
 - community.general.osx_defaults:
     domain: NSGlobalDomain
     key: AppleMeasurementUnits
@@ -87,6 +87,7 @@ EXAMPLES = r'''
     value: Centimeters
     state: present
 
+# Set Int Valued Key for arbitrary plist
 - community.general.osx_defaults:
     domain: /Library/Preferences/com.apple.SoftwareUpdate
     key: AutomaticCheckEnabled
@@ -94,6 +95,7 @@ EXAMPLES = r'''
     value: 1
   become: true
 
+# Set Int Valued Key only for the current host
 - community.general.osx_defaults:
     domain: com.apple.screensaver
     host: currentHost
@@ -101,11 +103,13 @@ EXAMPLES = r'''
     type: int
     value: 1
 
+# Defaults to Global Domain and Setting value
 - community.general.osx_defaults:
     key: AppleMeasurementUnits
     type: string
     value: Centimeters
 
+# Setting an Array valued key
 - community.general.osx_defaults:
     key: AppleLanguages
     type: array
@@ -113,6 +117,7 @@ EXAMPLES = r'''
       - en
       - nl
 
+# Removing a key
 - community.general.osx_defaults:
     domain: com.geekchimp.macable
     key: ExampleKeyToRemove

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -71,53 +71,53 @@ notes:
 '''
 
 EXAMPLES = r'''
-# Set Boolean Valued Key for Application Domain
-- community.general.osx_defaults:
+- name: Set boolean valued key for application domain
+  community.general.osx_defaults:
     domain: com.apple.Safari
     key: IncludeInternalDebugMenu
     type: bool
     value: true
     state: present
 
-# Set String Valued Key for Global Domain
-- community.general.osx_defaults:
+- name: Set string valued key for global domain
+  community.general.osx_defaults:
     domain: NSGlobalDomain
     key: AppleMeasurementUnits
     type: string
     value: Centimeters
     state: present
 
-# Set Int Valued Key for arbitrary plist
-- community.general.osx_defaults:
+- name: Set int valued key for arbitrary plist
+  community.general.osx_defaults:
     domain: /Library/Preferences/com.apple.SoftwareUpdate
     key: AutomaticCheckEnabled
     type: int
     value: 1
   become: true
 
-# Set Int Valued Key only for the current host
-- community.general.osx_defaults:
+- name: Set int valued key only for the current host
+  community.general.osx_defaults:
     domain: com.apple.screensaver
     host: currentHost
     key: showClock
     type: int
     value: 1
 
-# Defaults to Global Domain and Setting value
-- community.general.osx_defaults:
+- name: Defaults to global domain and setting value
+  community.general.osx_defaults:
     key: AppleMeasurementUnits
     type: string
     value: Centimeters
 
-# Setting an Array valued key
-- community.general.osx_defaults:
+- name: Setting an array valued key
+  community.general.osx_defaults:
     key: AppleLanguages
     type: array
     value:
       - en
       - nl
 
-# Removing a key
+- name: Removing a key
 - community.general.osx_defaults:
     domain: com.geekchimp.macable
     key: ExampleKeyToRemove

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -118,7 +118,7 @@ EXAMPLES = r'''
       - nl
 
 - name: Removing a key
-- community.general.osx_defaults:
+  community.general.osx_defaults:
     domain: com.geekchimp.macable
     key: ExampleKeyToRemove
     state: absent

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -262,7 +262,7 @@ class OSXDefaults(object):
 
         # If the RC is not 0, then terrible happened! Ooooh nooo!
         if rc != 0:
-            raise OSXDefaultsException("An error occurred while reading key type from defaults: %s" % out)
+            raise OSXDefaultsException("An error occurred while reading key type from defaults: %s" % err)
 
         # Ok, lets parse the type from output
         data_type = out.strip().replace('Type is ', '')
@@ -273,9 +273,9 @@ class OSXDefaults(object):
         # Strip output
         out = out.strip()
 
-        # An non zero RC at this point is kinda strange...
+        # A non zero RC at this point is kinda strange...
         if rc != 0:
-            raise OSXDefaultsException("An error occurred while reading key value from defaults: %s" % out)
+            raise OSXDefaultsException("An error occurred while reading key value from defaults: %s" % err)
 
         # Convert string to list when type is array
         if data_type == "array":
@@ -313,13 +313,13 @@ class OSXDefaults(object):
                                                expand_user_and_vars=False)
 
         if rc != 0:
-            raise OSXDefaultsException('An error occurred while writing value to defaults: %s' % out)
+            raise OSXDefaultsException('An error occurred while writing value to defaults: %s' % err)
 
     def delete(self):
         """ Deletes defaults key from domain """
         rc, out, err = self.module.run_command(self._base_command() + ['delete', self.domain, self.key])
         if rc != 0:
-            raise OSXDefaultsException("An error occurred while deleting key from defaults: %s" % out)
+            raise OSXDefaultsException("An error occurred while deleting key from defaults: %s" % err)
 
     # /commands ----------------------------------------------------------- }}}
 


### PR DESCRIPTION
##### SUMMARY
Previously `community.general.osx_defaults` included the stdout in error messages when `defaults` returned a non-zero exit code. This was usually blank and not helpful. This PR changes it to include the stderr.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
osx_defaults

##### ADDITIONAL INFORMATION

Example:

This task results in an error without `become: true`
```yaml
- name: "Disable Automatic Quote Substitution"
  community.general.osx_defaults:
    state: present
    domain: NSGlobalDomain
    key: "NSAutomaticQuoteSubstitutionEnabled"
    type: bool
    value: false
```

Before: no helpful information is included in the error:
```
fatal: [host]: FAILED! => {"changed": false, "msg": "An error occurred while writing value to defaults: "}
```

After: stderr is included in the error
```
TASK [Disable Automatic Quote Substitution] ***************************************************************************************************
fatal: [host]: FAILED! => {"changed": false, "msg": "An error occurred while writing value to defaults: 2023-02-18 05:03:19.888 defaults[8711:1213879
2] Could not write domain Apple Global Domain; exiting\n"}
```

This does not change the case when the task is successful:

```yaml
- name: "Disable Automatic Quote Substitution"
  community.general.osx_defaults:
    state: present
    domain: NSGlobalDomain
    key: "NSAutomaticQuoteSubstitutionEnabled"
    type: bool
    value: false
  become: true
```

```
TASK [Disable Automatic Quote Substitution] ***************************************************************************************************
ok: [host]
```