### PR TITLE
WIP: ssh_config: Add AddKeysToAgent option

### DIFF
--- a/changelogs/fragments/6030-ssh_config_add_keys_to_agent_option.yml
+++ b/changelogs/fragments/6030-ssh_config_add_keys_to_agent_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - new feature to set ``AddKeysToAgent`` option to ``yes`` or ``no``

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -49,8 +49,12 @@ options:
   host:
     description:
       - The endpoint this configuration is valid for.
-      - Can be an actual address on the internet or an alias that will
-        connect to the value of I(hostname).
+      - Can be an actual address on the internet, an alias that will
+        connect to the value of I(hostname), or "*" to match all hosts.
+      - If host is the wildcard "*" it is best to place it as the last
+        host since ssh goes with the first matching option. This will
+        make sure that any other host options take precedence over the
+        wildcard host.
     required: true
     type: str
   hostname:
@@ -112,6 +116,13 @@ EXAMPLES = r'''
     hostname: "github.com"
     identity_file: "/home/akasurde/.ssh/id_rsa"
     port: '2223'
+    state: present
+
+- name: Add a wildcard host in the configuration
+  community.general.ssh_config:
+    user: akasurde
+    host: "*"
+    forward_agent: true
     state: present
 
 - name: Delete a host from the configuration

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -93,6 +93,10 @@ options:
       - Sets the C(ForwardAgent) option.
     type: bool
     version_added: 4.0.0
+  add_keys_to_agent:
+    description:
+      - Sets the C(AddKeysToAgent) option.
+    type: bool
   ssh_config_file:
     description:
       - SSH config file.
@@ -122,7 +126,7 @@ EXAMPLES = r'''
   community.general.ssh_config:
     user: akasurde
     host: "*"
-    forward_agent: true
+    add_keys_to_agent: true
     state: present
 
 - name: Delete a host from the configuration
@@ -234,6 +238,10 @@ class SSHConfig():
             args['forward_agent'] = 'yes'
         if self.params['forward_agent'] is False:
             args['forward_agent'] = 'no'
+        if self.params['add_keys_to_agent'] is True:
+            args['add_keys_to_agent'] = 'yes'
+        if self.params['add_keys_to_agent'] is False:
+            args['add_keys_to_agent'] = 'no'
 
         config_changed = False
         hosts_changed = []
@@ -322,6 +330,7 @@ def main():
             port=dict(type='str'),
             proxycommand=dict(type='str', default=None),
             forward_agent=dict(type='bool'),
+            add_keys_to_agent=dict(type='bool'),
             remote_user=dict(type='str'),
             ssh_config_file=dict(default=None, type='path'),
             state=dict(type='str', default='present', choices=['present', 'absent']),

--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -223,5 +223,22 @@
       - short_name.hosts_changed == []
       - short_name.hosts_removed == []
 
+- name: Add a wildcard (*) host to apply settings to all hosts.
+  community.general.ssh_config:
+    ssh_config_file: "{{ ssh_config_test }}"
+    host: "*"
+    identity_file: '{{ ssh_private_key }}'
+    port: '2223'
+    state: present
+  register: wildcard_name
+
+- name: Check that wildcard name host is added and full and short name hosts are not updated
+  assert:
+    that:
+      - wildcard_name is changed
+      - wildcard_name.hosts_added == ["*"]
+      - wildcard_name.hosts_changed == []
+      - wildcard_name.hosts_removed == []
+
 - name: Include integration tests for additional options (e.g. proxycommand)
   include: 'options.yml'

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -15,6 +15,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add
@@ -44,6 +45,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add
@@ -62,6 +64,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     state: present
   register: options_add_again
@@ -84,6 +87,7 @@
     that:
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
@@ -92,6 +96,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     state: present
   register: options_update
@@ -112,6 +117,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     state: present
   register: options_update
@@ -135,6 +141,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
@@ -163,6 +170,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
@@ -209,4 +217,5 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"


### PR DESCRIPTION
##### SUMMARY
New feature to set AddKeysToAgent option via ssh_config module.

Fixes #4802

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
The change allows to set AddKeysToAgent option to either yes or no.

AddKeysToAgent is often set as a global option for all hosts in the ssh_config file. 
This PR includes a change to the docs and examples to demonstrate how to set a global option in ssh_config.
Global options should be set on ``Host *`` so that it applies to all hosts.
ssh uses the first found setting that matches the host so ``Host *`` should usually go at the bottom of the file so I have added that information to the docs.