### PR TITLE
Run tests with EOL ansible-core versions in GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -112,19 +112,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_11
-    displayName: Sanity 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.11/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -176,17 +163,6 @@ stages:
           targets:
             - test: 2.6
             - test: 3.8
-  - stage: Units_2_11
-    displayName: Units 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.11/units/{0}/1
-          targets:
-            - test: 2.7
-            - test: 3.5
 
 ## Remote
   - stage: Remote_devel_extra_vms
@@ -279,22 +255,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_11
-    displayName: Remote 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.11/{0}
-          targets:
-            - name: RHEL 7.9
-              test: rhel/7.9
-            - name: RHEL 8.3
-              test: rhel/8.3
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_devel
@@ -371,24 +331,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Docker_2_11
-    displayName: Docker 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.11/linux/{0}
-          targets:
-            - name: Fedora 32
-              test: fedora32
-            - name: Fedora 33
-              test: fedora33
-            - name: Alpine 3
-              test: alpine3
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -452,46 +394,30 @@ stages:
           testFormat: 2.12/generic/{0}/1
           targets:
             - test: 3.8
-  - stage: Generic_2_11
-    displayName: Generic 2.11
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.11/generic/{0}/1
-          targets:
-            - test: 2.7
-            - test: 3.5
 
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
       - Sanity_devel
-      - Sanity_2_11
       - Sanity_2_12
       - Sanity_2_13
       - Sanity_2_14
       - Units_devel
-      - Units_2_11
       - Units_2_12
       - Units_2_13
       - Units_2_14
       - Remote_devel_extra_vms
       - Remote_devel
-      - Remote_2_11
       - Remote_2_12
       - Remote_2_13
       - Remote_2_14
       - Docker_devel
-      - Docker_2_11
       - Docker_2_12
       - Docker_2_13
       - Docker_2_14
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
-#      - Generic_2_11
 #      - Generic_2_12
 #      - Generic_2_13
 #      - Generic_2_14

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,0 +1,193 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# For the comprehensive list of the inputs supported by the ansible-community/ansible-test-gh-action GitHub Action, see
+# https://github.com/marketplace/actions/ansible-test
+
+name: EOL CI
+on:
+  # Run EOL CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
+  # Run EOL CI once per day (at 08:00 UTC)
+  schedule:
+    - cron: '0 8 * * *'
+
+concurrency:
+  # Make sure there is at most one active run per PR, but do not cancel any non-PR runs
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.event.number) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sanity:
+    name: EOL Sanity (Ⓐ${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible:
+          - '2.11'
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["2.9", "2.10", "2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    steps:
+      - name: Perform sanity testing
+        uses: felixfontein/ansible-test-gh-action@main
+        with:
+          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          pull-request-change-detection: 'true'
+          testing-type: sanity
+
+  units:
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["2.9", "2.10", "2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    name: EOL Units (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    strategy:
+      # As soon as the first unit test fails, cancel the others to free up the CI queue
+      fail-fast: true
+      matrix:
+        ansible:
+          - ''
+        python:
+          - ''
+        exclude:
+          - ansible: ''
+        include:
+          - ansible: '2.11'
+            python: '2.7'
+          - ansible: '2.11'
+            python: '3.5'
+
+    steps:
+      - name: >-
+          Perform unit testing against
+          Ansible version ${{ matrix.ansible }}
+        uses: felixfontein/ansible-test-gh-action@main
+        with:
+          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          pre-test-cmd: >-
+            mkdir -p ../../ansible
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
+          pull-request-change-detection: 'true'
+          target-python-version: ${{ matrix.python }}
+          testing-type: units
+
+  integration:
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ contains(fromJson(
+          '["2.9", "2.10", "2.11"]'
+      ), matrix.ansible) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    name: EOL I (Ⓐ${{ matrix.ansible }}+${{ matrix.docker }}+py${{ matrix.python }}:${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        ansible:
+          - ''
+        docker:
+          - ''
+        python:
+          - ''
+        target:
+          - ''
+        exclude:
+          - ansible: ''
+        include:
+          # 2.11
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.11'
+            docker: fedora32
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.11'
+            docker: fedora33
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.11'
+            docker: fedora33
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.11'
+            docker: fedora33
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.11'
+            docker: alpine3
+            python: ''
+            target: azp/posix/3/
+          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+          # - ansible: '2.11'
+          #   docker: default
+          #   python: '2.7'
+          #   target: azp/generic/1/
+          # - ansible: '2.11'
+          #   docker: default
+          #   python: '3.5'
+          #   target: azp/generic/2/
+
+    steps:
+      - name: >-
+          Perform integration testing against
+          Ansible version ${{ matrix.ansible }}
+          under Python ${{ matrix.python }}
+        uses: felixfontein/ansible-test-gh-action@main
+        with:
+          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-version: stable-${{ matrix.ansible }}
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          docker-image: ${{ matrix.docker }}
+          integration-continue-on-error: 'false'
+          integration-diff: 'false'
+          integration-retry-on-error: 'true'
+          pre-test-cmd: >-
+            mkdir -p ../../ansible
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git ../../ansible/posix
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git ../../community/crypto
+            ;
+            git clone --depth=1 --single-branch https://github.com/ansible-collections/community.internal_test_tools.git ../../community/internal_test_tools
+          pull-request-change-detection: 'true'
+          target: ${{ matrix.target }}
+          target-python-version: ${{ matrix.python }}
+          testing-type: integration

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 # Community General Collection
 
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
+[![EOL CI](https://github.com/ansible-collections/community.general/workflows/EOL%20CI/badge.svg?event=push)](https://github.com/ansible-collections/community.general/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -90,13 +90,9 @@ if [ "${script}" != "sanity" ] || [ "${test}" == "sanity/extra" ]; then
 fi
 
 if [ "${script}" != "sanity" ] && [ "${script}" != "units" ] && [ "${test}" != "sanity/extra" ]; then
-    CRYPTO_BRANCH=main
-    if [ "${script}" == "linux" ] && [[ "${test}" =~ "ubuntu1604/" ]]; then
-        CRYPTO_BRANCH=stable-1
-    fi
     # To prevent Python dependencies on other collections only install other collections for integration tests
     retry git clone --depth=1 --single-branch https://github.com/ansible-collections/ansible.posix.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/posix"
-    retry git clone --depth=1 --branch "${CRYPTO_BRANCH}" --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
+    retry git clone --depth=1 --single-branch https://github.com/ansible-collections/community.crypto.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/crypto"
     # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
     # retry ansible-galaxy -vvv collection install ansible.posix
     # retry ansible-galaxy -vvv collection install community.crypto


### PR DESCRIPTION
##### SUMMARY
community.crypto and community.docker are having this one for some time now. Since  is coming up, we also need this for community.general.

The main disadvantage of GHA over AZP is that these tests won't run automatically for new contributors. This requires maintainer interaction. Fortunately most things are already covered with the non-EOL ansible-core tests, so this shouldn't be too problematic.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
