### PR TITLE
ansible_galaxy_install: added token parameter

### DIFF
--- a/changelogs/fragments/6046-ansible_galaxy_install-token-parameter.yml
+++ b/changelogs/fragments/6046-ansible_galaxy_install-token-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible_galaxy_install - added `token` parameter to authenticate with e.g. GitLab access tokens (https://github.com/ansible-collections/community.general/pull/6046)

--- a/plugins/modules/ansible_galaxy_install.py
+++ b/plugins/modules/ansible_galaxy_install.py
@@ -219,7 +219,7 @@ class AnsibleGalaxyInstall(ModuleHelper):
     output_params = ('token', 'type', 'name', 'dest', 'requirements_file', 'force', 'no_deps')
     module = dict(
         argument_spec=dict(
-            token=dict(type='str'),
+            token=dict(type='str', no_log=True),
             type=dict(type='str', choices=('collection', 'role', 'both'), required=True),
             name=dict(type='str'),
             requirements_file=dict(type='path'),

--- a/plugins/modules/ansible_galaxy_install.py
+++ b/plugins/modules/ansible_galaxy_install.py
@@ -27,6 +27,11 @@ notes:
 requirements:
   - Ansible 2.9, ansible-base 2.10, or ansible-core 2.11 or newer
 options:
+  token:
+    description:
+      - The Ansible Galaxy API key which can be found at https://galaxy.ansible.com/me/preferences.
+      - Can be used to install collections and roles from private git repositories.
+    type: str
   type:
     description:
       - The type of installation performed by C(ansible-galaxy).
@@ -113,9 +118,19 @@ EXAMPLES = """
     name: community.network:3.0.2
     force: true
 
+- name: Install collection from private git repository
+  community.general.ansible_galaxy_install:
+    token: "{{ token_variable }}"
+    type: collection
+    requirements_file: requirements.yml
+
 """
 
 RETURN = """
+  token:
+    description: The value of the I(token) parameter.
+    type: str
+    returned: always
   type:
     description: The value of the I(type) parameter.
     type: str
@@ -201,9 +216,10 @@ class AnsibleGalaxyInstall(ModuleHelper):
     ansible_version = None
     is_ansible29 = None
 
-    output_params = ('type', 'name', 'dest', 'requirements_file', 'force', 'no_deps')
+    output_params = ('token', 'type', 'name', 'dest', 'requirements_file', 'force', 'no_deps')
     module = dict(
         argument_spec=dict(
+            token=dict(type='str'),
             type=dict(type='str', choices=('collection', 'role', 'both'), required=True),
             name=dict(type='str'),
             requirements_file=dict(type='path'),
@@ -221,6 +237,7 @@ class AnsibleGalaxyInstall(ModuleHelper):
 
     command = 'ansible-galaxy'
     command_args_formats = dict(
+        token=fmt.as_opt_val('--token'),
         type=fmt.as_func(lambda v: [] if v == 'both' else [v]),
         galaxy_cmd=fmt.as_list(),
         requirements_file=fmt.as_opt_val('-r'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added `token` parameter to install collections from private git repositories and authenticate with e.g. GitLab personal access tokens.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ansible_galaxy_install

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**requirements.yml**
```yaml
collections:
  - name: "https://gitlab.com/my-orga/private.collection.git"
    type: git
```
**task example**
```yaml
- name: Install collections
  community.general.ansible_galaxy_install:
    token: "{{ token_variable }}"
    type: collection
    requirements_file: requirements.yml
```
