### PR TITLE
nmcli: Treat order as significant when comparing address lists

### DIFF
--- a/changelogs/fragments/6048-nmcli-addres-order.yml
+++ b/changelogs/fragments/6048-nmcli-addres-order.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli module - order is significant for lists of addresses (https://github.com/ansible-collections/community.general/pull/6048).

--- a/changelogs/fragments/6048-nmcli-addres-order.yml
+++ b/changelogs/fragments/6048-nmcli-addres-order.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli module - order is significant for lists of addresses (https://github.com/ansible-collections/community.general/pull/6048).
+  - nmcli - order is significant for lists of addresses (https://github.com/ansible-collections/community.general/pull/6048).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2130,8 +2130,12 @@ class Nmcli(object):
 
             if isinstance(current_value, list) and isinstance(value, list):
                 # compare values between two lists
-                if sorted(current_value) != sorted(value):
-                    changed = True
+                if key in ('ipv4.addresses', 'ipv6.addresses'):
+                    # The order of IP addresses matters because the first one
+                    # is the default source address for outbound connections.
+                    changed |= current_value != value
+                else:
+                    changed |= sorted(current_value) != sorted(value)
             elif all([key == self.mtu_setting, self.type == 'dummy', current_value is None, value == 'auto', self.mtu is None]):
                 value = None
             else:


### PR DESCRIPTION
Don't sort the old and new values for ipv4.addresses and ipv6.addresses before comparing them, because order matters in these parameters: the first address specified is the default source address for outbound connections.

##### SUMMARY

The `nmcli` module (before this change) treated the order of IPv4 or IPv6 addresses for an interface as insignificant, i.e., it would not consider it a change for the order of these addresses to change. This is not correct, since the first address for an interface is the default address for outbound connections, so order matters. The change in this PR continues to treat order as insignificant for other list settings, but treats order as significant for ipv4.addresses and ipv6.addresses.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli