### PR TITLE
stop passing loader/dataloader since it has been deprecated by ansible

### DIFF
--- a/changelogs/fragments/6074-loader_in_listify.yml.yml
+++ b/changelogs/fragments/6074-loader_in_listify.yml.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - calls to listify_lookup_plugin_terms in core do not pass in loader/dataloader anymore (https://github.com/ansible-collections/community.general/pull/6074).

--- a/changelogs/fragments/6074-loader_in_listify.yml.yml
+++ b/changelogs/fragments/6074-loader_in_listify.yml.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - calls to listify_lookup_plugin_terms in core do not pass in loader/dataloader anymore (https://github.com/ansible-collections/community.general/pull/6074).
+  - cartesian and flattened lookup plugins - adjust to parameter deprecation in ansible-core 2.14's ``listify_lookup_plugin_terms`` helper function (https://github.com/ansible-collections/community.general/pull/6074).

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -66,7 +66,7 @@ class LookupModule(LookupBase):
         """
         results = []
         for x in terms:
-            intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
+            intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=None)
             results.append(intermediate)
         return results
 

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
                 intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
             except TypeError:
                 # The loader argument is deprecated in ansible-core 2.14+. Fall back to
-                # pre-2.14 behavior for older Ansible versions.
+                # pre-2.14 behavior for older ansible-core versions.
                 intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=self._loader)
             results.append(intermediate)
         return results

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -66,7 +66,7 @@ class LookupModule(LookupBase):
         """
         results = []
         for x in terms:
-            intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=self._loader)
+            intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
             results.append(intermediate)
         return results
 

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -66,7 +66,12 @@ class LookupModule(LookupBase):
         """
         results = []
         for x in terms:
-            intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=None)
+            try:
+                intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
+            except TypeError:
+                # The loader argument is deprecated in Ansible-base 2.14+. Fall back to
+                # pre-2.14 behavior for older Ansible versions.
+                intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=self._loader)
             results.append(intermediate)
         return results
 

--- a/plugins/lookup/cartesian.py
+++ b/plugins/lookup/cartesian.py
@@ -69,7 +69,7 @@ class LookupModule(LookupBase):
             try:
                 intermediate = listify_lookup_plugin_terms(x, templar=self._templar)
             except TypeError:
-                # The loader argument is deprecated in Ansible-base 2.14+. Fall back to
+                # The loader argument is deprecated in ansible-core 2.14+. Fall back to
                 # pre-2.14 behavior for older Ansible versions.
                 intermediate = listify_lookup_plugin_terms(x, templar=self._templar, loader=self._loader)
             results.append(intermediate)

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -67,7 +67,7 @@ class LookupModule(LookupBase):
 
             if isinstance(term, string_types):
                 # convert a variable to a list
-                term2 = listify_lookup_plugin_terms(term, templar=self._templar)
+                term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=None)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [term]:
                     term = term2

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
                 try:
                     term2 = listify_lookup_plugin_terms(term, templar=self._templar)
                 except TypeError:
-                    # The loader argument is deprecated in Ansible-base 2.14+. Fall back to
+                    # The loader argument is deprecated in ansible-core 2.14+. Fall back to
                     # pre-2.14 behavior for older Ansible versions.
                     term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=self._loader)
                 # but avoid converting a plain string to a list of one string

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -71,7 +71,7 @@ class LookupModule(LookupBase):
                     term2 = listify_lookup_plugin_terms(term, templar=self._templar)
                 except TypeError:
                     # The loader argument is deprecated in ansible-core 2.14+. Fall back to
-                    # pre-2.14 behavior for older Ansible versions.
+                    # pre-2.14 behavior for older ansible-core versions.
                     term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=self._loader)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [term]:

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -67,7 +67,7 @@ class LookupModule(LookupBase):
 
             if isinstance(term, string_types):
                 # convert a variable to a list
-                term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=self._loader)
+                term2 = listify_lookup_plugin_terms(term, templar=self._templar)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [term]:
                     term = term2

--- a/plugins/lookup/flattened.py
+++ b/plugins/lookup/flattened.py
@@ -67,7 +67,12 @@ class LookupModule(LookupBase):
 
             if isinstance(term, string_types):
                 # convert a variable to a list
-                term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=None)
+                try:
+                    term2 = listify_lookup_plugin_terms(term, templar=self._templar)
+                except TypeError:
+                    # The loader argument is deprecated in Ansible-base 2.14+. Fall back to
+                    # pre-2.14 behavior for older Ansible versions.
+                    term2 = listify_lookup_plugin_terms(term, templar=self._templar, loader=self._loader)
                 # but avoid converting a plain string to a list of one string
                 if term2 != [term]:
                     term = term2


### PR DESCRIPTION
##### SUMMARY
remove deprecated passing of loader to `listify_lookup_plugin_terms`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- cartesian
- flattened

##### ADDITIONAL INFORMATION
Passing the load was deprecated in Ansible (https://github.com/ansible/ansible/pull/78244). This PR updates the code to remove the  currently displayed deprecation warning.

Example playbook:
```yaml
- hosts: localhost
  gather_facts: False
  tasks:
    - name: test
      debug:
        msg: "{{ item }}"
      with_community.general.flattened:
        - a
        - b
        - c
```

which produces the output:
```
# ansible-playbook /test.yml

PLAY [localhost] **********************************************************************************************************************************************************************************************************************************

TASK [test] ***************************************************************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: "listify_lookup_plugin_terms" does not use "dataloader" anymore, the ability to pass it in will be removed in future versions. This feature will be removed in version 2.18. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
ok: [localhost] => (item=a) => {
    "msg": "a"
}
ok: [localhost] => (item=b) => {
    "msg": "b"
}
ok: [localhost] => (item=c) => {
    "msg": "c"
}

PLAY RECAP ****************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
