### PR TITLE
nmcli: fixed inability to change mtu on vlan connection

### DIFF
--- a/changelogs/fragments/4387-nmcli-mtu-for-vlan-connection-fix.yml
+++ b/changelogs/fragments/4387-nmcli-mtu-for-vlan-connection-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - implemented changing mtu value on vlan interfaces (https://github.com/ansible-collections/community.general/issues/4387).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1772,6 +1772,7 @@ class Nmcli(object):
             'dummy',
             'ethernet',
             'team-slave',
+            'vlan',
         )
 
     @property

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -663,6 +663,7 @@ ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
 vlan.id:                                10
+802-3-ethernet.mtu:                     auto
 """
 
 TESTCASE_VXLAN = [


### PR DESCRIPTION
##### SUMMARY
* Changing MTU for `vlan` interface types was impossible because this logic just was not provided. I define `vlan` type in list of mtu_interfaces.
  * Fixes #4387

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
One testcase updated.