### PR TITLE
nmcli: fixed idempotency issue when config bridge connection

### DIFF
--- a/changelogs/fragments/3216-nmcli-bridge-idempotency-fix.yml
+++ b/changelogs/fragments/3216-nmcli-bridge-idempotency-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fixed idempotency issue for bridge connections. Module forced default value of 'bridge.priority' to nmcli if not set; if 'bridge.stp' is disabled nmcli ignores it and keep default (https://github.com/ansible-collections/community.general/issues/3216, https://github.com/ansible-collections/community.general/issues/4683).

--- a/changelogs/fragments/3216-nmcli-bridge-idempotency-fix.yml
+++ b/changelogs/fragments/3216-nmcli-bridge-idempotency-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - fixed idempotency issue for bridge connections. Module forced default value of 'bridge.priority' to nmcli if not set; if 'bridge.stp' is disabled nmcli ignores it and keep default (https://github.com/ansible-collections/community.general/issues/3216, https://github.com/ansible-collections/community.general/issues/4683).
+  - nmcli - fixed idempotency issue for bridge connections. Module forced default value of ``bridge.priority`` to nmcli if not set; if ``bridge.stp`` is disabled nmcli ignores it and keep default (https://github.com/ansible-collections/community.general/issues/3216, https://github.com/ansible-collections/community.general/issues/4683).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1615,6 +1615,10 @@ class Nmcli(object):
                 'bridge.priority': self.priority,
                 'bridge.stp': self.stp,
             })
+            # priority make sense when stp enabed, otherwise nmcli keeps bridge-priority to 32768 regrdless of input.
+            # force ignoring to save idempotency
+            if self.stp:
+                options.update({'bridge.priority': self.priority})
         elif self.type == 'team':
             options.update({
                 'team.runner': self.runner,


### PR DESCRIPTION
##### SUMMARY
If `bridge.stp` is set to `no` in nmcli it accepts any value of `bridge.priority` but holds it's own default value. This causes any task with defined `priority` option to be "changed" anyway.

For now, `bridge.priority` participate in configure only when user defined `stp` as `true`.

  * Fixes #4683 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli
