### PR TITLE
nmcli: fixed idempotency issue with 'may_fail4' when 'method' is 'disabled'

### DIFF
--- a/changelogs/fragments/0000-nmcli-ipv4-mayfail-idempotency-fix.yml
+++ b/changelogs/fragments/0000-nmcli-ipv4-mayfail-idempotency-fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - nmcli - fixed idempotency issue when module params is set to 'may_fail4'='false' and 'method4'='disabled'; in this case nmcli ignores change and keeps their own default value 'yes' (PR_HERE).

--- a/changelogs/fragments/0000-nmcli-ipv4-mayfail-idempotency-fix.yml
+++ b/changelogs/fragments/0000-nmcli-ipv4-mayfail-idempotency-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fixed idempotency issue when module params is set to 'may_fail4'='false' and 'method4'='disabled'; in this case nmcli ignores change and keeps their own default value 'yes' (PR_HERE).

--- a/changelogs/fragments/6106-nmcli-ipv4-mayfail-idempotency-fix.yml
+++ b/changelogs/fragments/6106-nmcli-ipv4-mayfail-idempotency-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - fixed idempotency issue when module params is set to 'may_fail4'='false' and 'method4'='disabled'; in this case nmcli ignores change and keeps their own default value 'yes' (https://github.com/ansible-collections/community.general/pull/6106).
+  - nmcli - fixed idempotency issue when module params is set to ``may_fail4=false`` and ``method4=disabled``; in this case nmcli ignores change and keeps their own default value ``yes`` (https://github.com/ansible-collections/community.general/pull/6106).

--- a/changelogs/fragments/6106-nmcli-ipv4-mayfail-idempotency-fix.yml
+++ b/changelogs/fragments/6106-nmcli-ipv4-mayfail-idempotency-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fixed idempotency issue when module params is set to 'may_fail4'='false' and 'method4'='disabled'; in this case nmcli ignores change and keeps their own default value 'yes' (https://github.com/ansible-collections/community.general/pull/6106).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -197,6 +197,7 @@ options:
     may_fail4:
         description:
             - If you need I(ip4) configured before C(network-online.target) is reached, set this option to C(false).
+            - This option applies when C(method4) is not C(disabled).
         type: bool
         default: true
         version_added: 3.3.0
@@ -1576,6 +1577,10 @@ class Nmcli(object):
                 'ipv6.ip6-privacy': self.ip_privacy6,
                 'ipv6.addr-gen-mode': self.addr_gen_mode6
             })
+            # when 'method' is disabled the 'may_fail' no make sense but accepted by nmcli with keeping 'yes'
+            # force ignoring to save idempotency
+            if self.ipv4_method and self.ipv4_method != 'disabled':
+                options.update({'ipv4.may-fail': self.may_fail4})
 
         # Layer 2 options.
         if self.mac:


### PR DESCRIPTION
##### SUMMARY
If `method4` was `disabled`, this option has no effect - nmcli accepts it, but keeps it's own default value. Task marked changed always because of `diff` with default value and passed to module.
Now option `ipv4.may-fail` participate in configuration process only when user defined `method4` as non-`disabled`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli
