### PR TITLE
nmcli: added new module option 'slave_type' to allow create non-ethernet slave connections

### DIFF
--- a/changelogs/fragments/473-nmcli-slave-type-implemented.yml
+++ b/changelogs/fragments/473-nmcli-slave-type-implemented.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - new module option 'slave_type' added to allow creation of various types of slave devices (https://github.com/ansible-collections/community.general/issues/473).

--- a/changelogs/fragments/473-nmcli-slave-type-implemented.yml
+++ b/changelogs/fragments/473-nmcli-slave-type-implemented.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - new module option 'slave_type' added to allow creation of various types of slave devices (https://github.com/ansible-collections/community.general/issues/473).
+  - nmcli - new module option ``slave_type`` added to allow creation of various types of slave devices (https://github.com/ansible-collections/community.general/issues/473).

--- a/changelogs/fragments/473-nmcli-slave-type-implemented.yml
+++ b/changelogs/fragments/473-nmcli-slave-type-implemented.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - new module option ``slave_type`` added to allow creation of various types of slave devices (https://github.com/ansible-collections/community.general/issues/473).
+  - nmcli - new module option ``slave_type`` added to allow creation of various types of slave devices (https://github.com/ansible-collections/community.general/issues/473, https://github.com/ansible-collections/community.general/pull/6108).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1624,18 +1624,6 @@ class Nmcli(object):
             if self.master is None and self.slave_type is not None:
                 self.module.fail_json(msg="'master' option is required when 'slave_type' is specified.")
 
-    @property
-    def hairpin(self):
-        if self._hairpin is None:
-            self.module.deprecate(
-                "Parameter 'hairpin' default value will change from true to false in community.general 7.0.0. "
-                "Set the value explicitly to suppress this warning.",
-                version='7.0.0', collection_name='community.general',
-            )
-            # Should be False in 7.0.0 but then that should be in argument_specs
-            self._hairpin = True
-        return self._hairpin
-
     def execute_command(self, cmd, use_unsafe_shell=False, data=None):
         if isinstance(cmd, list):
             cmd = [to_text(item) for item in cmd]
@@ -1964,7 +1952,7 @@ class Nmcli(object):
     @property
     def slave_conn_type(self):
         return self.type in (
-            'ethertnet',
+            'ethernet',
             'bridge',
             'bond',
             'vlan',

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2476,6 +2476,7 @@ def main():
                             ['routes4_extended', 'routes4'],
                             ['routes6_extended', 'routes6']],
         required_if=[("type", "wifi", [("ssid")])],
+        required_by={"master": "slave-type"},
         supports_check_mode=True,
     )
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -85,7 +85,7 @@ options:
         version_added: 5.8.0
     slave_type:
         description:
-            - Type of the device of this slave's master connection (eg, "bond").
+            - Type of the device of this slave's master connection (for example C(bond)).
             - Mandatory if I(master) is defined.
         type: str
         choices: [ 'bond', 'bridge', 'team' ]

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1941,6 +1941,12 @@ class Nmcli(object):
     @property
     def slave_conn_type(self):
         return self.type in (
+            'ethertnet',
+            'bridge',
+            'bond',
+            'vlan',
+            'team',
+            'wifi',
             'bond-slave',
             'bridge-slave',
             'team-slave',

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -67,7 +67,7 @@ options:
             - Type C(wireguard) is added in community.general 4.3.0.
             - Type C(vpn) is added in community.general 5.1.0.
             - Using C(bond-slave), C(bridge-slave) or C(team-slave) implies C(ethernet) connection type with corresponding C(slave_type) option.
-            - If you want to control non-ethernet connection attached to C(bond), C(bridge) or C(team) consider using C(slave_type) option. 
+            - If you want to control non-ethernet connection attached to C(bond), C(bridge) or C(team) consider using C(slave_type) option.
         type: str
         choices: [ bond, bond-slave, bridge, bridge-slave, dummy, ethernet, generic, gre, infiniband, ipip, macvlan, sit, team, team-slave, vlan, vxlan,
             wifi, gsm, wireguard, vpn ]

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -86,7 +86,7 @@ options:
     slave_type:
         description:
             - Type of the device of this slave's master connection (eg, "bond").
-            - If I(master) defined this option is mandatory.
+            - Mandatory if I(master) is defined.
         type: str
         choices: [ 'bond', 'bridge', 'team' ]
         version_added: 6.6.0

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -66,7 +66,7 @@ options:
             - Type C(macvlan) is added in community.general 6.6.0.
             - Type C(wireguard) is added in community.general 4.3.0.
             - Type C(vpn) is added in community.general 5.1.0.
-            - Using C(bond-slave), C(bridge-slave) or C(team-slave) implies C(ethernet) connection type with corresponding C(slave_type) option.
+            - Using C(bond-slave), C(bridge-slave) or C(team-slave) implies C(ethernet) connection type with corresponding I(slave_type) option.
             - If you want to control non-ethernet connection attached to C(bond), C(bridge) or C(team) consider using C(slave_type) option.
         type: str
         choices: [ bond, bond-slave, bridge, bridge-slave, dummy, ethernet, generic, gre, infiniband, ipip, macvlan, sit, team, team-slave, vlan, vxlan,

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1614,7 +1614,10 @@ class Nmcli(object):
 
         self.edit_commands = []
 
-        # Additional validation of options set passed to module that cannot be implemented in module's argspecs.
+        self.extra_options_validation()
+
+    def extra_options_validation(self):
+        """ Additional validation of options set passed to module that cannot be implemented in module's argspecs. """
         if self.type not in ("bridge-slave", "team-slave", "bond-slave"):
             if self.master is not None and self.slave_type is None:
                 self.module.fail_json(msg="'slave_type' option is required when 'master' is specified.")

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -89,7 +89,7 @@ options:
             - Mandatory if I(master) is defined.
         type: str
         choices: [ 'bond', 'bridge', 'team' ]
-        version_added: 6.6.0
+        version_added: 7.0.0
     master:
         description:
             - Master <master (ifname, or connection UUID or conn_name) of bridge, team, bond master connection profile.

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2476,7 +2476,7 @@ def main():
                             ['routes4_extended', 'routes4'],
                             ['routes6_extended', 'routes6']],
         required_if=[("type", "wifi", [("ssid")])],
-        required_by={"master": "slave-type"},
+        required_by={"master": "slave_type"},
         supports_check_mode=True,
     )
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -86,7 +86,6 @@ options:
     slave_type:
         description:
             - Type of the device of this slave's master connection (for example C(bond)).
-            - Mandatory if I(master) is defined.
         type: str
         choices: [ 'bond', 'bridge', 'team' ]
         version_added: 7.0.0
@@ -1619,8 +1618,6 @@ class Nmcli(object):
     def extra_options_validation(self):
         """ Additional validation of options set passed to module that cannot be implemented in module's argspecs. """
         if self.type not in ("bridge-slave", "team-slave", "bond-slave"):
-            if self.master is not None and self.slave_type is None:
-                self.module.fail_json(msg="'slave_type' option is required when 'master' is specified.")
             if self.master is None and self.slave_type is not None:
                 self.module.fail_json(msg="'master' option is required when 'slave_type' is specified.")
 

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -89,7 +89,7 @@ options:
             - If I(master) defined this option is mandatory.
         type: str
         choices: [ 'bond', 'bridge', 'team' ]
-        version_added: 6.4.0
+        version_added: 6.6.0
     master:
         description:
             - Master <master (ifname, or connection UUID or conn_name) of bridge, team, bond master connection profile.

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4031,6 +4031,7 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
             state=dict(type='str', required=True, choices=['absent', 'present']),
             conn_name=dict(type='str', required=True),
             master=dict(type='str'),
+            slave_type=dict(type=str, choices=['bond', 'bridge', 'team']),
             ifname=dict(type='str'),
             type=dict(type='str',
                       choices=[

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4259,3 +4259,294 @@ def test_macvlan_mod(mocked_generic_connection_modify, capfd):
     results = json.loads(out)
     assert not results.get('failed')
     assert results['changed']
+
+
+TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION = [
+    {
+        'type': 'ethernet',
+        'conn_name': 'fake_conn',
+        'ifname': 'fake_eth0',
+        'state': 'present',
+        'slave_type': 'bridge',
+        'master': 'fake_br0',
+        '_ansible_check_mode': False,
+    }
+]
+
+
+TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      --
+connection.slave-type:                  --
+802-3-ethernet.mtu:                     auto
+"""
+
+
+TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION_UNCHANGED_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      fake_br0
+connection.slave-type:                  bridge
+802-3-ethernet.mtu:                     auto
+"""
+
+
+@pytest.fixture
+def mocked_slave_type_bridge_create(mocker):
+    mocker_set(mocker,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION, indirect=['patch_ansible_module'])
+def test_create_slave_type_bridge(mocked_slave_type_bridge_create, capfd):
+    """
+    Test : slave for bridge created
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'add'
+    assert args[0][3] == 'type'
+    assert args[0][4] == 'ethernet'
+    assert args[0][5] == 'con-name'
+    assert args[0][6] == 'fake_conn'
+    con_master_index = args[0].index('connection.master')
+    slave_type_index = args[0].index('connection.slave-type')
+    assert args[0][con_master_index + 1] == 'fake_br0'
+    assert args[0][slave_type_index + 1] == 'bridge'
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.fixture
+def mocked_create_slave_type_bridge_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION_UNCHANGED_SHOW_OUTPUT, ""))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_BRIDGE_CONNECTION, indirect=['patch_ansible_module'])
+def test_slave_type_bridge_unchanged(mocked_create_slave_type_bridge_unchanged, capfd):
+    """
+    Test : Existent slave for bridge unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+
+TESTCASE_SLAVE_TYPE_BOND_CONNECTION = [
+    {
+        'type': 'ethernet',
+        'conn_name': 'fake_conn',
+        'ifname': 'fake_eth0',
+        'state': 'present',
+        'slave_type': 'bond',
+        'master': 'fake_bond0',
+        '_ansible_check_mode': False,
+    }
+]
+
+
+TESTCASE_SLAVE_TYPE_BOND_CONNECTION_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      --
+connection.slave-type:                  --
+802-3-ethernet.mtu:                     auto
+"""
+
+
+TESTCASE_SLAVE_TYPE_BOND_CONNECTION_UNCHANGED_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      fake_bond0
+connection.slave-type:                  bond
+802-3-ethernet.mtu:                     auto
+"""
+
+
+@pytest.fixture
+def mocked_slave_type_bond_create(mocker):
+    mocker_set(mocker,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_SLAVE_TYPE_BOND_CONNECTION_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_BOND_CONNECTION, indirect=['patch_ansible_module'])
+def test_create_slave_type_bond(mocked_slave_type_bond_create, capfd):
+    """
+    Test : slave for bond created
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'add'
+    assert args[0][3] == 'type'
+    assert args[0][4] == 'ethernet'
+    assert args[0][5] == 'con-name'
+    assert args[0][6] == 'fake_conn'
+    con_master_index = args[0].index('connection.master')
+    slave_type_index = args[0].index('connection.slave-type')
+    assert args[0][con_master_index + 1] == 'fake_bond0'
+    assert args[0][slave_type_index + 1] == 'bond'
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.fixture
+def mocked_create_slave_type_bond_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_SLAVE_TYPE_BOND_CONNECTION_UNCHANGED_SHOW_OUTPUT, ""))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_BOND_CONNECTION, indirect=['patch_ansible_module'])
+def test_slave_type_bond_unchanged(mocked_create_slave_type_bond_unchanged, capfd):
+    """
+    Test : Existent slave for bridge unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+
+TESTCASE_SLAVE_TYPE_TEAM_CONNECTION = [
+    {
+        'type': 'ethernet',
+        'conn_name': 'fake_conn',
+        'ifname': 'fake_eth0',
+        'state': 'present',
+        'slave_type': 'team',
+        'master': 'fake_team0',
+        '_ansible_check_mode': False,
+    }
+]
+
+
+TESTCASE_SLAVE_TYPE_TEAM_CONNECTION_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      --
+connection.slave-type:                  --
+802-3-ethernet.mtu:                     auto
+"""
+
+
+TESTCASE_SLAVE_TYPE_TEAM_CONNECTION_UNCHANGED_SHOW_OUTPUT = """\
+connection.id:                          fake_conn
+connection.type:                        802-3-ethernet
+connection.interface-name:              fake_eth0
+connection.autoconnect:                 yes
+connection.master:                      fake_team0
+connection.slave-type:                  team
+802-3-ethernet.mtu:                     auto
+"""
+
+
+@pytest.fixture
+def mocked_slave_type_team_create(mocker):
+    mocker_set(mocker,
+               execute_return=None,
+               execute_side_effect=(
+                   (0, TESTCASE_SLAVE_TYPE_TEAM_CONNECTION_SHOW_OUTPUT, ""),
+                   (0, "", ""),
+               ))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_TEAM_CONNECTION, indirect=['patch_ansible_module'])
+def test_create_slave_type_team(mocked_slave_type_team_create, capfd):
+    """
+    Test : slave for bond created
+    """
+
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'add'
+    assert args[0][3] == 'type'
+    assert args[0][4] == 'ethernet'
+    assert args[0][5] == 'con-name'
+    assert args[0][6] == 'fake_conn'
+    con_master_index = args[0].index('connection.master')
+    slave_type_index = args[0].index('connection.slave-type')
+    assert args[0][con_master_index + 1] == 'fake_team0'
+    assert args[0][slave_type_index + 1] == 'team'
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.fixture
+def mocked_create_slave_type_team_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_SLAVE_TYPE_TEAM_CONNECTION_UNCHANGED_SHOW_OUTPUT, ""))
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_SLAVE_TYPE_TEAM_CONNECTION, indirect=['patch_ansible_module'])
+def test_slave_type_team_unchanged(mocked_create_slave_type_team_unchanged, capfd):
+    """
+    Test : Existent slave for bridge unchanged
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']


### PR DESCRIPTION
##### SUMMARY
* Adding `slave_type` option have discussed in several issues:
  * #2943 
  * Fixes #473 

Without it module makes impossible to create non-ethernet interfaces (eg bond, vlan) attached to bridges. From nmcli side this options already deprecated.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
* argspecs updated
* docs updated
* tests updated
* added several examples
* added warning message in case of using `type` = `bridge-slave`. In my opinion this `type` is very problematic due to it has non-obviousness results.
