### PR TITLE
add xorder_discovery parameter

### DIFF
--- a/changelogs/fragments/6045-xorder-discovery.yml
+++ b/changelogs/fragments/6045-xorder-discovery.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ldap modules - add ``xorder_discovery`` option (https://github.com/ansible-collections/community.general/issues/6045)

--- a/changelogs/fragments/6045-xorder-discovery.yml
+++ b/changelogs/fragments/6045-xorder-discovery.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap modules - add ``xorder_discovery`` option (https://github.com/ansible-collections/community.general/issues/6045)
+  - ldap modules - add ``xorder_discovery`` option (https://github.com/ansible-collections/community.general/issues/6045, https://github.com/ansible-collections/community.general/pull/6109).

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -67,13 +67,13 @@ options:
     version_added: "2.0.0"
   xorder_discovery:
     description:
-      - Set the behavior on how to process Xordered DNs
+      - Set the behavior on how to process Xordered DNs.
       - C(enable) will perform a C(ONELEVEL) search below the superior RDN to find the matching DN.
-      - C(disable) will always use the DN unmodified (as passed by the C(dn) parameter)
-      - C(auto) will only perform a search if the first RDN does not contain an index number (C({x}))
+      - C(disable) will always use the DN unmodified (as passed by the I(dn) parameter).
+      - C(auto) will only perform a search if the first RDN does not contain an index number (C({x})).
       - Possible choices are C(enable), C(auto), C(disable).
     type: str
     choices: ['enable', 'auto', 'disable']
     default: auto
-    version_added: "6.5.0"
+    version_added: "6.4.0"
 '''

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -65,4 +65,15 @@ options:
     choices: ['external', 'gssapi']
     default: external
     version_added: "2.0.0"
+  xorder_discovery:
+    description:
+      - Set the behavior on how to process Xordered DNs
+      - C(enable) will perform a C(ONELEVEL) search below the superior RDN to find the matching DN.
+      - C(disable) will always use the DN unmodified (as passed by the C(dn) parameter)
+      - C(auto) will only perform a search if the first RDN does not contain an index number (C({x}))
+      - Possible choices are C(enable), C(auto), C(disable).
+    type: str
+    choices: ['enable', 'auto', 'disable']
+    default: auto
+    version_added: "6.5.0"
 '''

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import re
 import traceback
 from ansible.module_utils.common.text.converters import to_native
 
@@ -39,6 +40,7 @@ def gen_specs(**specs):
         'start_tls': dict(default=False, type='bool'),
         'validate_certs': dict(default=True, type='bool'),
         'sasl_class': dict(choices=['external', 'gssapi'], default='external', type='str'),
+        'xorder_discovery': dict(choices=['enable', 'auto', 'disable'], default='auto', type='str'),
     })
 
     return specs
@@ -55,12 +57,16 @@ class LdapGeneric(object):
         self.start_tls = self.module.params['start_tls']
         self.verify_cert = self.module.params['validate_certs']
         self.sasl_class = self.module.params['sasl_class']
+        self.xorder_discovery = self.module.params['xorder_discovery']
 
         # Establish connection
         self.connection = self._connect_to_ldap()
 
-        # Try to find the X_ORDERed version of the DN
-        self.dn = self._find_dn()
+        if self.xorder_discovery == "enable" or (self.xorder_discovery == "auto" and not self._xorder_dn()):
+            # Try to find the X_ORDERed version of the DN
+            self.dn = self._find_dn()
+        else:
+            self.dn = self.module.params['dn']
 
     def fail(self, msg, exn):
         self.module.fail_json(
@@ -113,3 +119,11 @@ class LdapGeneric(object):
             self.fail("Cannot bind to the server.", e)
 
         return connection
+
+    def _xorder_dn(self):
+        # match X_ORDERed DNs
+        regex = "\w+=\{\d+\}.+"
+        if re.match(regex, self.module.params['dn']):
+            return True
+        else:
+            return False

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -123,7 +123,4 @@ class LdapGeneric(object):
     def _xorder_dn(self):
         # match X_ORDERed DNs
         regex = r"\w+=\{\d+\}.+"
-        if re.match(regex, self.module.params['dn']):
-            return True
-        else:
-            return False
+        return re.match(regex, self.module.params['dn']) is not None

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -122,7 +122,7 @@ class LdapGeneric(object):
 
     def _xorder_dn(self):
         # match X_ORDERed DNs
-        regex = "\w+=\{\d+\}.+"
+        regex = r"\w+=\{\d+\}.+"
         if re.match(regex, self.module.params['dn']):
             return True
         else:

--- a/plugins/modules/ldap_search.py
+++ b/plugins/modules/ldap_search.py
@@ -135,7 +135,6 @@ class LdapSearch(LdapGeneric):
     def __init__(self, module):
         LdapGeneric.__init__(self, module)
 
-        self.dn = self.module.params['dn']
         self.filterstr = self.module.params['filter']
         self.attrlist = []
         self._load_scope()


### PR DESCRIPTION
This PR adds the `xorder_discovery` parameter to the ldap modules. This new parameter controls the behavior of searching for DNs with ordering information (xorder). 

Fixes https://github.com/ansible-collections/community.general/issues/6045


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ldap modules

