### PR TITLE
Fix influxdb_user grants in check mode

### DIFF
--- a/changelogs/fragments/6111-influxdb_user-check-mode.yaml
+++ b/changelogs/fragments/6111-influxdb_user-check-mode.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - influxdb_user - Fix running in check mode when the user doesn't exist yet.
+  - influxdb_user - fix running in check mode when the user does not exist yet (https://github.com/ansible-collections/community.general/pull/6111).

--- a/changelogs/fragments/6111-influxdb_user-check-mode.yaml
+++ b/changelogs/fragments/6111-influxdb_user-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - influxdb_user - Fix running in check mode when the user doesn't exist yet.

--- a/plugins/modules/influxdb_user.py
+++ b/plugins/modules/influxdb_user.py
@@ -174,8 +174,14 @@ def drop_user(module, client, user_name):
 def set_user_grants(module, client, user_name, grants):
     changed = False
 
+    current_grants = []
     try:
         current_grants = client.get_list_privileges(user_name)
+    except influx.exceptions.InfluxDBClientError as e:
+        if not module.check_mode or 'user not found' not in e.content:
+            module.fail_json(msg=e.content)
+
+    try:
         parsed_grants = []
         # Fix privileges wording
         for i, v in enumerate(current_grants):


### PR DESCRIPTION
##### SUMMARY
When running in check mode, `influxdb_user` will return error when the user doesn't exist yet, instead of reporting `changed` state.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
influxdb_user
