### PR TITLE
Adding CheckiLORebootStatus functionality to ilo_redfish_command

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -587,7 +587,7 @@ files:
     ignore: jose-delarosa
     maintainers: $team_redfish
   $modules/ilo_:
-    ignore: jose-delarosa
+    ignore: jose-delarosa varini-hp
     maintainers: $team_redfish
   $modules/imc_rest.py:
     labels: cisco

--- a/plugins/module_utils/ilo_redfish_utils.py
+++ b/plugins/module_utils/ilo_redfish_utils.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible_collections.community.general.plugins.module_utils.redfish_utils import RedfishUtils
+import time
 
 
 class iLORedfishUtils(RedfishUtils):
@@ -228,3 +229,79 @@ class iLORedfishUtils(RedfishUtils):
         if not response['ret']:
             return response
         return {'ret': True, 'changed': True, 'msg': "Modified %s" % mgrattr['mgr_attr_name']}
+
+    def get_server_poststate(self):
+        # Get server details
+        response = self.get_request(self.root_uri + self.systems_uri)
+        if not response["ret"]:
+            return response
+        server_data = response["data"]
+
+        if "Hpe" in server_data["Oem"]:
+            return {
+                "ret": True,
+                "server_poststate": server_data["Oem"]["Hpe"]["PostState"]
+            }
+        else:
+            return {
+                "ret": True,
+                "server_poststate": server_data["Oem"]["Hp"]["PostState"]
+            }
+
+    def check_ilo_reboot_status(self, polling_interval=60, max_polling_time=1800):
+        # This method checks if OOB controller reboot is completed
+        time.sleep(10)
+
+        # Check server poststate
+        state = self.get_server_poststate()
+        if not state["ret"]:
+            return state
+
+        count = int(max_polling_time / polling_interval)
+        times = 0
+
+        # When server is powered OFF
+        pcount = 0
+        while state["server_poststate"] in ["PowerOff", "Off"] and pcount < 5:
+            time.sleep(10)
+            state = self.get_server_poststate()
+            if not state["ret"]:
+                return state
+
+            if state["server_poststate"] not in ["PowerOff", "Off"]:
+                break
+            pcount = pcount + 1
+        if state["server_poststate"] in ["PowerOff", "Off"]:
+            return {
+                "ret": False,
+                "changed": False,
+                "msg": "Server is powered OFF"
+            }
+
+        # When server is not rebooting
+        if state["server_poststate"] in ["InPostDiscoveryComplete", "FinishedPost"]:
+            return {
+                "ret": True,
+                "changed": False,
+                "msg": "Server is not rebooting"
+            }
+
+        while state["server_poststate"] not in ["InPostDiscoveryComplete", "FinishedPost"] and count > times:
+            state = self.get_server_poststate()
+            if not state["ret"]:
+                return state
+
+            if state["server_poststate"] in ["InPostDiscoveryComplete", "FinishedPost"]:
+                return {
+                    "ret": True,
+                    "changed": True,
+                    "msg": "Server reboot is completed"
+                }
+            time.sleep(polling_interval)
+            times = times + 1
+
+        return {
+            "ret": False,
+            "changed": False,
+            "msg": "Server Reboot has failed, server state: {state} ".format(state=state)
+        }

--- a/plugins/module_utils/ilo_redfish_utils.py
+++ b/plugins/module_utils/ilo_redfish_utils.py
@@ -248,7 +248,7 @@ class iLORedfishUtils(RedfishUtils):
                 "server_poststate": server_data["Oem"]["Hp"]["PostState"]
             }
 
-    def check_ilo_reboot_status(self, polling_interval=60, max_polling_time=1800):
+    def wait_for_ilo_reboot_completion(self, polling_interval=60, max_polling_time=1800):
         # This method checks if OOB controller reboot is completed
         time.sleep(10)
 

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ilo_redfish_command
 short_description: Manages Out-Of-Band controllers using Redfish APIs
-version_added: 6.5.0
+version_added: 6.6.0
 description:
   - Builds Redfish URIs locally and sends them to remote OOB controllers to
     perform an action.

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -65,7 +65,7 @@ author:
 '''
 
 EXAMPLES = '''
-  - name: Check iLO reboot status
+  - name: Wait for iLO Reboot Completion
     community.general.ilo_redfish_command:
       category: Systems
       command: WaitforiLORebootCompletion

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021-2022 Hewlett Packard Enterprise, Inc. All rights reserved.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: ilo_redfish_command
+short_description: Manages Out-Of-Band controllers using Redfish APIs
+version_added: 6.1.0
+description:
+  - Builds Redfish URIs locally and sends them to remote OOB controllers to
+    perform an action.
+options:
+  category:
+    required: true
+    description:
+      - Category to execute on OOB controller.
+    type: str
+    choices: ['Systems']
+  command:
+    required: true
+    description:
+      - List of commands to execute on OOB controller
+    type: list
+    elements: str
+  baseuri:
+    required: true
+    description:
+      - Base URI of OOB controller
+    type: str
+  username:
+    required: false
+    description:
+      - Username for authenticating to iLO.
+    type: str
+  password:
+    required: false
+    description:
+      - Password for authenticating to iLO.
+    type: str
+  auth_token:
+    required: false
+    description:
+      - Security token for authenticating to iLO.
+    type: str
+  timeout:
+    required: false
+    description:
+      - Timeout in seconds for HTTP requests to iLO.
+    default: 60
+    type: int
+author:
+  - Varni H P (@varini-hp)
+'''
+
+EXAMPLES = '''
+  - name: Check iLO reboot status
+    community.general.ilo_redfish_command:
+      category: Systems
+      command: CheckiLORebootStatus
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+'''
+
+RETURN = '''
+ilo_redfish_command:
+    description: Returns the status of the operation performed on the iLO.
+    type: dict
+    contains:
+        command:
+            description: Returns the output msg and whether the function executed successfully.
+            type: dict
+            contains:
+                ret:
+                    description: Return True/False based on whether the operation was performed succesfully.
+                    type: bool
+                msg:
+                    description: Status of the operation performed on the iLO.
+                    type: dict
+    returned: always
+'''
+
+# More will be added as module features are expanded
+CATEGORY_COMMANDS_ALL = {
+    "Systems": ["CheckiLORebootStatus"]
+}
+
+from ansible_collections.community.general.plugins.module_utils.ilo_redfish_utils import iLORedfishUtils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+
+def main():
+    result = {}
+    module = AnsibleModule(
+        argument_spec=dict(
+            category=dict(required=True, choices=list(CATEGORY_COMMANDS_ALL.keys())),
+            command=dict(required=True, type='list', elements='str'),
+            baseuri=dict(required=True),
+            timeout=dict(type="int", default=60),
+            username=dict(),
+            password=dict(no_log=True),
+            auth_token=dict(no_log=True)
+        ),
+        required_together=[
+            ('username', 'password'),
+        ],
+        required_one_of=[
+            ('username', 'auth_token'),
+        ],
+        mutually_exclusive=[
+            ('username', 'auth_token'),
+        ],
+        supports_check_mode=False
+    )
+
+    category = module.params['category']
+    command_list = module.params['command']
+
+    # admin credentials used for authentication
+    creds = {'user': module.params['username'],
+             'pswd': module.params['password'],
+             'token': module.params['auth_token']}
+
+    timeout = module.params['timeout']
+
+    # Build root URI
+    root_uri = "https://" + module.params['baseuri']
+    rf_utils = iLORedfishUtils(creds, root_uri, timeout, module)
+
+    # Check that Category is valid
+    if category not in CATEGORY_COMMANDS_ALL:
+        module.fail_json(msg=to_native(
+            "Invalid Category '%s'. Valid Categories = %s" % (category, list(CATEGORY_COMMANDS_ALL.keys()))))
+
+    # Check that all commands are valid
+    for cmd in command_list:
+        # Fail if even one command given is invalid
+        if cmd not in CATEGORY_COMMANDS_ALL[category]:
+            module.fail_json(
+                msg=to_native("Invalid Command '%s'. Valid Commands = %s" % (cmd, CATEGORY_COMMANDS_ALL[category])))
+
+    if category == "Systems":
+        # execute only if we find a System resource
+
+        result = rf_utils._find_systems_resource()
+        if result['ret'] is False:
+            module.fail_json(msg=to_native(result['msg']))
+
+        for command in command_list:
+            if command == "CheckiLORebootStatus":
+                result[command] = rf_utils.check_ilo_reboot_status()
+
+    # Return data back or fail with proper message
+    if not result[command]['ret']:
+        module.fail_json(msg=result)
+
+    changed = result[command].get('changed', False)
+    module.exit_json(ilo_redfish_command=result, changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -31,7 +31,7 @@ options:
   command:
     required: true
     description:
-      - List of commands to execute on OOB controller
+      - List of commands to execute on OOB controller.
     type: list
     elements: str
   baseuri:

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ilo_redfish_command
 short_description: Manages Out-Of-Band controllers using Redfish APIs
-version_added: 6.1.0
+version_added: 6.5.0
 description:
   - Builds Redfish URIs locally and sends them to remote OOB controllers to
     perform an action.

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -15,10 +15,10 @@ description:
   - Builds Redfish URIs locally and sends them to remote OOB controllers to
     perform an action.
 attributes:
-    check_mode:
-        support: none
-    diff_mode:
-        support: none
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 options:
   category:
     required: true

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -19,6 +19,8 @@ attributes:
     support: none
   diff_mode:
     support: none
+extends_documentation_fragment:
+  - community.general.attributes
 options:
   category:
     required: true

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -37,7 +37,7 @@ options:
   baseuri:
     required: true
     description:
-      - Base URI of OOB controller
+      - Base URI of OOB controller.
     type: str
   username:
     required: false

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -86,7 +86,7 @@ ilo_redfish_command:
                     type: bool
                 msg:
                     description: Status of the operation performed on the iLO.
-                    type: dict
+                    type: str
     returned: always
 '''
 

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -14,6 +14,11 @@ version_added: 6.1.0
 description:
   - Builds Redfish URIs locally and sends them to remote OOB controllers to
     perform an action.
+attributes:
+    check_mode:
+        support: none
+    diff_mode:
+        support: none
 options:
   category:
     required: true

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -66,7 +66,7 @@ EXAMPLES = '''
   - name: Check iLO reboot status
     community.general.ilo_redfish_command:
       category: Systems
-      command: CheckiLORebootStatus
+      command: WaitforiLORebootCompletion
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -92,7 +92,7 @@ ilo_redfish_command:
 
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
-    "Systems": ["CheckiLORebootStatus"]
+    "Systems": ["WaitforiLORebootCompletion"]
 }
 
 from ansible_collections.community.general.plugins.module_utils.ilo_redfish_utils import iLORedfishUtils
@@ -158,8 +158,8 @@ def main():
             module.fail_json(msg=to_native(result['msg']))
 
         for command in command_list:
-            if command == "CheckiLORebootStatus":
-                result[command] = rf_utils.check_ilo_reboot_status()
+            if command == "WaitforiLORebootCompletion":
+                result[command] = rf_utils.wait_for_ilo_reboot_completion()
 
     # Return data back or fail with proper message
     if not result[command]['ret']:

--- a/plugins/modules/ilo_redfish_command.py
+++ b/plugins/modules/ilo_redfish_command.py
@@ -79,7 +79,7 @@ ilo_redfish_command:
     description: Returns the status of the operation performed on the iLO.
     type: dict
     contains:
-        command:
+        WaitforiLORebootCompletion:
             description: Returns the output msg and whether the function executed successfully.
             type: dict
             contains:

--- a/tests/integration/targets/ilo_redfish_command/aliases
+++ b/tests/integration/targets/ilo_redfish_command/aliases
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported

--- a/tests/integration/targets/ilo_redfish_command/tasks/main.yml
+++ b/tests/integration/targets/ilo_redfish_command/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Wait for iLO Reboot Completion
+  community.general.ilo_redfish_command:
+    category: Systems
+    command: WaitforiLORebootCompletion
+    baseuri: "{{ baseuri }}"
+    username: "{{ username }}"
+    password: "{{ password }}"


### PR DESCRIPTION
SUMMARY
This was previously raised as part of [5582](https://github.com/ansible-collections/community.general/pull/5582). Raising this separately as these functionalities are independent of the others in that PR and can be merged as the other functionalities still seem to have a few open questions. Will be removing this functionality from the old PR.

ISSUE TYPE
- New Module/Plugin Pull Request

COMPONENT NAME
ilo_redfish_command.py

ADDITIONAL INFORMATION
The respective functions for the modules have been added to ilo_redfish_utils.py
