### PR TITLE
Add 'inventory_hostname' to the jail plugin documentation

### DIFF
--- a/changelogs/fragments/6118-jail-plugin-fix-default-inventory_hostname.yml
+++ b/changelogs/fragments/6118-jail-plugin-fix-default-inventory_hostname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "jail connection plugin - add ``inventory_hostname`` to vars under ``remote_addr``. This is needed for compatibility with ansible-core 2.13 (https://github.com/ansible-collections/community.general/pull/6118)."

--- a/plugins/connection/jail.py
+++ b/plugins/connection/jail.py
@@ -22,6 +22,7 @@ DOCUMENTATION = '''
             - Path to the jail
         default: inventory_hostname
         vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: ansible_jail_host
       remote_user:


### PR DESCRIPTION
##### SUMMARY

On FreeBSD, using the jail connection plugin will print the following warning when processing each task:

`[WARNING]: The "jail" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string`

This was already fixed in other plugins by including "inventory_hostname" in the documentation string.

See for example 5e5af45 and 905f9ec.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- jail.py