### PR TITLE
redhat_subscription: use D-Bus for registration if possible

### DIFF
--- a/changelogs/fragments/6122-redhat_subscription-subscribe-via-dbus.yaml
+++ b/changelogs/fragments/6122-redhat_subscription-subscribe-via-dbus.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - redhat_subscription - the registration is done using the D-Bus ``rhsm`` service instead of spawning a ``subscription-manager register`` command, if possible;
+    this avoids passing plain-text credentials as arguments to ``subscription-manager register``, which can be seen while that command runs
+    (https://github.com/ansible-collections/community.general/pull/6122).

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -27,6 +27,8 @@ def patch_redhat_subscription(mocker):
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.unlink', return_value=True)
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.AnsibleModule.get_bin_path',
                  return_value='/testbin/subscription-manager')
+    mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.Rhsm._can_connect_to_dbus',
+                 return_value=False)
 
 
 @pytest.mark.parametrize('patch_ansible_module', [{}], indirect=['patch_ansible_module'])


### PR DESCRIPTION
##### SUMMARY

subscription-manager currently does not have a way to get credentials (username, password, activation keys, organization ID) in a secure way: the existing command line parameters can be easily spotted when running a process listing while 'subscription-manager register' runs. There is a D-Bus service, which is used by e.g. cockpit and Anaconda to interface with RHSM (at least for registration and common queries).

Try to perform the registration using D-Bus, in a way very similar to the work done in convert2rhel [1] (with my help):
- try to do a simple signal test to check whether the system bus works; inspired by the login in the dconf module
- pass most of the options as registration options; for the few that are not part of the registration, execute 'subscription-manager' manually
- add quirks for differently working (or not) registration options for the D-Bus `Register*()` methods depending on the version of RHEL
- `subscription-manager register` is used only in case the signal test is not working; silent fallback in case of D-Bus errors during the registration is not done on purpose to avoid silent fallback to a less secure registration

[1] https://github.com/oamg/convert2rhel/pull/540/

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

There should be no behaviour change for the module.