### PR TITLE
Fixes #6112: community.general.gitlab_runner KeyError: 'access_level'

### DIFF
--- a/changelogs/fragments/6112-fix_key_error_in_gitlab_runner_creation_update.yml
+++ b/changelogs/fragments/6112-fix_key_error_in_gitlab_runner_creation_update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_runner - fix ``KeyError`` on runner creation and update (https://github.com/ansible-collections/community.general/issues/6112).

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -234,9 +234,8 @@ class GitLabRunner(object):
             'maximum_timeout': options['maximum_timeout'],
             'tag_list': options['tag_list'],
         }
-        if arguments['access_level'] is not None:
+        if options.get('access_level') is not None:
             arguments['access_level'] = options['access_level']
-
         # Because we have already call userExists in main()
         if self.runner_object is None:
             arguments['description'] = description
@@ -251,7 +250,7 @@ class GitLabRunner(object):
                 access_level_on_creation = False
 
             if not access_level_on_creation:
-                del arguments['access_level']
+                arguments.pop('access_level', None)
 
             runner = self.create_runner(arguments)
             changed = True


### PR DESCRIPTION
##### SUMMARY
The fix ensures that no 'KeyError' is raised, when 'access_level' is not provided as module parameter or when 'access_level_on_creation' is false.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>
##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner
