### PR TITLE
feat(cargo): add locked option

### DIFF
--- a/changelogs/fragments/6134-add-locked-option-for-cargo.yml
+++ b/changelogs/fragments/6134-add-locked-option-for-cargo.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "cargo - add option ``locked`` which allows user to specify install the locked version of dependency instead of latest compatible version (https://github.com/ansible-collections/community.general/pull/6134)."

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -47,10 +47,11 @@ options:
   locked:
     description:
       - Install with locked dependencies.
+      - This is only used when installing packages.
     required: false
     type: bool
     default: false
-    version_added: 6.5.0
+    version_added: 7.5.0
   state:
     description:
       - The state of the Rust package.


### PR DESCRIPTION
##### SUMMARY
This PR introduces `locked` option to cargo module, allowing user to install with locked dependency.

Equivalent to `--locked` flag of `cargo install` command

The flag was already suggested at the original issue description: #3975

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
##### TODO
- [x] Add changelog fragment
- [ ] How to write integration test for this? I don't know if there's an easy way to check this.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/cargo.py