### PR TITLE
Fix Yarn global not working without explicit executable path

### DIFF
--- a/changelogs/fragments/6138-fix-yarn-global.yml
+++ b/changelogs/fragments/6138-fix-yarn-global.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yarn - fix ``global=true`` to not fail when `executable` wasn't specified (https://github.com/ansible-collections/community.general/pull/6132)

--- a/plugins/modules/yarn.py
+++ b/plugins/modules/yarn.py
@@ -179,14 +179,10 @@ class Yarn(object):
         self.registry = kwargs['registry']
         self.production = kwargs['production']
         self.ignore_scripts = kwargs['ignore_scripts']
+        self.executable = kwargs['executable']
 
         # Specify a version of package if version arg passed in
         self.name_version = None
-
-        if kwargs['executable']:
-            self.executable = kwargs['executable'].split(' ')
-        else:
-            self.executable = [module.get_bin_path('yarn', True)]
 
         if kwargs['version'] and self.name is not None:
             self.name_version = self.name + '@' + str(self.version)
@@ -328,7 +324,6 @@ def main():
     version = module.params['version']
     globally = module.params['global']
     production = module.params['production']
-    executable = module.params['executable']
     registry = module.params['registry']
     state = module.params['state']
     ignore_scripts = module.params['ignore_scripts']
@@ -345,9 +340,14 @@ def main():
     if state == 'latest':
         version = 'latest'
 
+    if module.params['executable']:
+      executable = module.params['executable'].split(' ')
+    else:
+      executable = [module.get_bin_path('yarn', True)]
+
     # When installing globally, use the defined path for global node_modules
     if globally:
-        _rc, out, _err = module.run_command([executable, 'global', 'dir'], check_rc=True)
+        _rc, out, _err = module.run_command(executable + ['global', 'dir'], check_rc=True)
         path = out.strip()
 
     yarn = Yarn(module,

--- a/plugins/modules/yarn.py
+++ b/plugins/modules/yarn.py
@@ -341,9 +341,9 @@ def main():
         version = 'latest'
 
     if module.params['executable']:
-      executable = module.params['executable'].split(' ')
+        executable = module.params['executable'].split(' ')
     else:
-      executable = [module.get_bin_path('yarn', True)]
+        executable = [module.get_bin_path('yarn', True)]
 
     # When installing globally, use the defined path for global node_modules
     if globally:

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -104,6 +104,16 @@
         PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
       register: yarn_install_old_package
 
+    - name: 'Again but without explicit executable path'
+      yarn:
+        path: '{{ remote_tmp_dir }}'
+        name: left-pad
+        version: 1.1.0
+        state: present
+      environment:
+        PATH: '{{ yarn_bin_path }}:{{ node_bin_path }}:{{ ansible_env.PATH }}'
+      register: yarn_install_old_package
+
     - assert:
         that:
           - yarn_install_old_package is changed

--- a/tests/integration/targets/yarn/tasks/run.yml
+++ b/tests/integration/targets/yarn/tasks/run.yml
@@ -104,6 +104,10 @@
         PATH: '{{ node_bin_path }}:{{ ansible_env.PATH }}'
       register: yarn_install_old_package
 
+    - assert:
+        that:
+          - yarn_install_old_package is changed
+
     - name: 'Again but without explicit executable path'
       yarn:
         path: '{{ remote_tmp_dir }}'
@@ -112,11 +116,6 @@
         state: present
       environment:
         PATH: '{{ yarn_bin_path }}:{{ node_bin_path }}:{{ ansible_env.PATH }}'
-      register: yarn_install_old_package
-
-    - assert:
-        that:
-          - yarn_install_old_package is changed
 
     - name: 'Upgrade old package'
       yarn:


### PR DESCRIPTION
##### SUMMARY

Fixes #6132.

PR #5829 added a call to `yarn global dir` to select the correct global directory, but this ran before the default value of the `executable` param was set from the `PATH`.

This PR moves that logic out of the `Yarn` class initializer so the executable is identified just before it's needed.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME

yarn
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION

See https://github.com/ansible-collections/community.general/issues/6132 for repro.

(Also cc @JohnDaly as this probably affects y'all)