### PR TITLE
nmcli: add runner_fast_rate option

### DIFF
--- a/changelogs/fragments/6065-nmcli-add-runner-fast-rate-option.yml
+++ b/changelogs/fragments/6065-nmcli-add-runner-fast-rate-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - add support for ``team.runner-fast-rate`` parameter for ``team`` connections (https://github.com/ansible-collections/community.general/issues/6065).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -414,9 +414,9 @@ options:
     runner_fast_rate:
         description:
             - Option specifies the rate at which our link partner is asked to transmit LACPDU
-              packets. If this is true then packets will be sent once per second. Otherwise they
+              packets. If this is C(true) then packets will be sent once per second. Otherwise they
               will be sent every 30 seconds.
-            - Only allowed for lacp runner.
+            - Only allowed for C(lacp) runner.
         type: bool
         version_added: 6.5.0
     vlanid:
@@ -1627,11 +1627,11 @@ class Nmcli(object):
         elif self.type == 'team':
             options.update({
                 'team.runner': self.runner,
-                'team.runner-hwaddr-policy': self.runner_hwaddr_policy
+                'team.runner-hwaddr-policy': self.runner_hwaddr_policy,
             })
             if self.runner_fast_rate is not None:
                 options.update({
-                    'team.runner-fast-rate': self.runner_fast_rate
+                    'team.runner-fast-rate': self.runner_fast_rate,
                 })
         elif self.type == 'bridge-slave':
             options.update({

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -416,8 +416,9 @@ options:
             - Option specifies the rate at which our link partner is asked to transmit LACPDU
               packets. If this is true then packets will be sent once per second. Otherwise they
               will be sent every 30 seconds.
+            - Only allowed for lacp runner.
         type: bool
-        default: false
+        version_added: 6.5.0
     vlanid:
         description:
             - This is only used with VLAN - VLAN ID in range <0-4095>.
@@ -1626,9 +1627,12 @@ class Nmcli(object):
         elif self.type == 'team':
             options.update({
                 'team.runner': self.runner,
-                'team.runner-hwaddr-policy': self.runner_hwaddr_policy,
-                'team.runner-fast-rate': self.runner_fast_rate
+                'team.runner-hwaddr-policy': self.runner_hwaddr_policy
             })
+            if self.runner_fast_rate is not None:
+                options.update({
+                    'team.runner-fast-rate': self.runner_fast_rate
+                })
         elif self.type == 'bridge-slave':
             options.update({
                 'connection.slave-type': 'bridge',
@@ -2306,7 +2310,7 @@ def main():
             # team active-backup runner specific options
             runner_hwaddr_policy=dict(type='str', choices=['same_all', 'by_active', 'only_active']),
             # team lacp runner specific options
-            runner_fast_rate=dict(type='bool', default=False),
+            runner_fast_rate=dict(type='bool'),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),
@@ -2353,7 +2357,7 @@ def main():
     if nmcli.type == "team":
         if nmcli.runner_hwaddr_policy and not nmcli.runner == "activebackup":
             nmcli.module.fail_json(msg="Runner-hwaddr-policy is only allowed for runner activebackup")
-        if nmcli.runner_fast_rate and not nmcli.runner == "lacp":
+        if nmcli.runner_fast_rate is not None and nmcli.runner != "lacp":
             nmcli.module.fail_json(msg="runner-fast-rate is only allowed for runner lacp")
     # team-slave checks
     if nmcli.type == 'team-slave':

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -586,6 +586,14 @@ TESTCASE_TEAM = [
         'ifname': 'team0_non_existant',
         'state': 'present',
         '_ansible_check_mode': False,
+    },
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'state': 'present',
+        'runner_fast_rate': False,
+        '_ansible_check_mode': False,
     }
 ]
 
@@ -602,6 +610,7 @@ ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
 team.runner:                            roundrobin
+team.runner-fast-rate:                  no
 """
 
 TESTCASE_TEAM_HWADDR_POLICY_FAILS = [
@@ -614,6 +623,45 @@ TESTCASE_TEAM_HWADDR_POLICY_FAILS = [
         '_ansible_check_mode': False,
     }
 ]
+
+TESTCASE_TEAM_RUNNER_FAST_RATE = [
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'runner': 'lacp',
+        'runner_fast_rate': True,
+        'state': 'present',
+        '_ansible_check_mode': False,
+    }
+]
+
+TESTCASE_TEAM_RUNNER_FAST_RATE_FAILS = [
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'runner_fast_rate': True,
+        'state': 'present',
+        '_ansible_check_mode': False,
+    }
+]
+
+TESTCASE_TEAM_RUNNER_FAST_RATE_SHOW_OUTPUT = """\
+connection.id:                          non_existent_nw_device
+connection.interface-name:              team0_non_existant
+connection.autoconnect:                 yes
+connection.type:                        team
+ipv4.ignore-auto-dns:                   no
+ipv4.ignore-auto-routes:                no
+ipv4.never-default:                     no
+ipv4.may-fail:                          yes
+ipv6.method:                            auto
+ipv6.ignore-auto-dns:                   no
+ipv6.ignore-auto-routes:                no
+team.runner:                            lacp
+team.runner-fast-rate:                  yes
+"""
 
 TESTCASE_TEAM_SLAVE = [
     {
@@ -1437,6 +1485,13 @@ def mocked_team_connection_unchanged(mocker):
 
 
 @pytest.fixture
+def mocked_team_runner_fast_rate_connection_unchanged(mocker):
+    mocker_set(mocker,
+               connection_exists=True,
+               execute_return=(0, TESTCASE_TEAM_RUNNER_FAST_RATE_SHOW_OUTPUT, ""))
+
+
+@pytest.fixture
 def mocked_team_slave_connection_unchanged(mocker):
     mocker_set(mocker,
                connection_exists=True,
@@ -2245,6 +2300,63 @@ def test_team_connection_create_hwaddr_policy_fails(mocked_generic_connection_cr
     results = json.loads(out)
     assert results.get('failed')
     assert results['msg'] == "Runner-hwaddr-policy is only allowed for runner activebackup"
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_RUNNER_FAST_RATE, indirect=['patch_ansible_module'])
+def test_team_runner_fast_rate_connection_create(mocked_generic_connection_create, capfd):
+    """
+    Test : Team connection created with runner_fast_rate parameter
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'add'
+    assert args[0][3] == 'type'
+    assert args[0][4] == 'team'
+    assert args[0][5] == 'con-name'
+    assert args[0][6] == 'non_existent_nw_device'
+
+    for param in ['connection.autoconnect', 'connection.interface-name', 'team0_non_existant', 'team.runner', 'lacp', 'team.runner-fast-rate', 'yes']:
+        assert param in args[0]
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_RUNNER_FAST_RATE, indirect=['patch_ansible_module'])
+def test_team_runner_fast_rate_connection_unchanged(mocked_team_runner_fast_rate_connection_unchanged, capfd):
+    """
+    Test : Team connection unchanged with runner_fast_rate parameter
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get('failed')
+    assert not results['changed']
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_RUNNER_FAST_RATE_FAILS, indirect=['patch_ansible_module'])
+def test_team_connection_create_runner_fast_rate_fails(mocked_generic_connection_create, capfd):
+    """
+    Test : Team connection with runner_fast_rate enabled
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results.get('failed')
+    assert results['msg'] == "runner-fast-rate is only allowed for runner lacp"
 
 
 @pytest.mark.parametrize('patch_ansible_module', TESTCASE_TEAM_SLAVE, indirect=['patch_ansible_module'])
@@ -3947,6 +4059,8 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
                              choices=['broadcast', 'roundrobin', 'activebackup', 'loadbalance', 'lacp']),
             # team active-backup runner specific options
             runner_hwaddr_policy=dict(type='str', choices=['same_all', 'by_active', 'only_active']),
+            # team lacp runner specific options
+            runner_fast_rate=dict(type='bool', default=False),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -586,14 +586,6 @@ TESTCASE_TEAM = [
         'ifname': 'team0_non_existant',
         'state': 'present',
         '_ansible_check_mode': False,
-    },
-    {
-        'type': 'team',
-        'conn_name': 'non_existent_nw_device',
-        'ifname': 'team0_non_existant',
-        'state': 'present',
-        'runner_fast_rate': False,
-        '_ansible_check_mode': False,
     }
 ]
 
@@ -643,6 +635,32 @@ TESTCASE_TEAM_RUNNER_FAST_RATE_FAILS = [
         'ifname': 'team0_non_existant',
         'runner_fast_rate': True,
         'state': 'present',
+        '_ansible_check_mode': False,
+    },
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'state': 'present',
+        'runner_fast_rate': False,
+        '_ansible_check_mode': False,
+    },
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'state': 'present',
+        'runner': 'activebackup',
+        'runner_fast_rate': False,
+        '_ansible_check_mode': False,
+    },
+    {
+        'type': 'team',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'team0_non_existant',
+        'state': 'present',
+        'runner': 'activebackup',
+        'runner_fast_rate': True,
         '_ansible_check_mode': False,
     }
 ]

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -4078,7 +4078,7 @@ def test_bond_connection_unchanged(mocked_generic_connection_diff_check, capfd):
             # team active-backup runner specific options
             runner_hwaddr_policy=dict(type='str', choices=['same_all', 'by_active', 'only_active']),
             # team lacp runner specific options
-            runner_fast_rate=dict(type='bool', default=False),
+            runner_fast_rate=dict(type='bool'),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
This PR adds team.runner-fast-rate parameter support for nmcli module. Feature was requested in https://github.com/ansible-collections/community.general/issues/6065

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
plugins/modules/nmcli.py
