### PR TITLE
openbsd_pkg: set TERM to 'dumb' in execute_command

### DIFF
--- a/changelogs/fragments/6149-openbsd_pkg-term.yml
+++ b/changelogs/fragments/6149-openbsd_pkg-term.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openbsd_pkg - set TERM to 'dumb' in execute_command() to make module less dependant on TERM env set on ansible runner (https://github.com/ansible-collections/community.general/pull/6149).

--- a/changelogs/fragments/6149-openbsd_pkg-term.yml
+++ b/changelogs/fragments/6149-openbsd_pkg-term.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - openbsd_pkg - set TERM to 'dumb' in execute_command() to make module less dependant on TERM env set on ansible runner (https://github.com/ansible-collections/community.general/pull/6149).
+  - openbsd_pkg - set ``TERM`` to ``'dumb'`` in ``execute_command()`` to make module less dependant on the ``TERM`` environment variable set on the Ansible controller (https://github.com/ansible-collections/community.general/pull/6149).

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -152,7 +152,11 @@ def execute_command(cmd, module):
     # This makes run_command() use shell=False which we need to not cause shell
     # expansion of special characters like '*'.
     cmd_args = shlex.split(cmd)
-    return module.run_command(cmd_args)
+
+    # We set TERM to 'dumb' to keep pkg_add happy if the machine running
+    # ansible is using a TERM that the managed machine does not know about,
+    # e.g.: "No progress meter: failed termcap lookup on xterm-kitty".
+    return module.run_command(cmd_args, environ_update={'TERM': 'dumb'})
 
 
 # Function used to find out if a package is currently installed.


### PR DESCRIPTION
##### SUMMARY
Keeps pkg_add happy when someone running ansible is using a TERM that the managed OpenBSD host does not know about.

Fixes #5738.

Selection of specific TERM from discussion at
https://marc.info/?l=openbsd-tech&m=167290482630534&w=2

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openbsd_pkg

##### ADDITIONAL INFORMATION
Before change:
```paste below
$ TERM=xterm-kitty ansible -i hosts openbsd_pkg_tests -u root -m community.general.openbsd_pkg  -a 'name=jq state=present'
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: packaging Python module unavailable; unable to validate collection Ansible version requirements
X.X.X.X | FAILED! => {
    "build": false,
    "changed": false,
    "msg": "No progress meter: failed termcap lookup on xterm-kitty\n",
    "name": [
        "jq"
    ],
    "state": "present"
}
```

After change:
```
$ TERM=xterm-kitty ansible -i hosts openbsd_pkg_tests -u root -m community.general.openbsd_pkg  -a 'name=jq state=present'
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: packaging Python module unavailable; unable to validate collection Ansible version requirements
X.X.X.X | CHANGED => {
    "build": false,
    "changed": true,
    "name": [
        "jq"
    ],
    "state": "present"
}
```

I have run my test playbook (https://github.com/eest/openbsd_pkg-tests) with this change with a successful result.