### PR TITLE
Adding support for `-p` option to specify port(s) to scan

### DIFF
--- a/changelogs/fragments/6165-nmap-port.yml
+++ b/changelogs/fragments/6165-nmap-port.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - nmap invetory plugin - add new option ``port`` for port specific scan (https://github.com/ansible-collections/community.general/pull/6165).
+ - nmap inventory plugin - add new option ``port`` for port specific scan (https://github.com/ansible-collections/community.general/pull/6165).

--- a/changelogs/fragments/6165-nmap-port.yml
+++ b/changelogs/fragments/6165-nmap-port.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - nmap invetory plugin - add new option ``port`` for port specific scan (https://github.com/ansible-collections/community.general/pull/6165)

--- a/changelogs/fragments/6165-nmap-port.yml
+++ b/changelogs/fragments/6165-nmap-port.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - nmap invetory plugin - add new option ``port`` for port specific scan (https://github.com/ansible-collections/community.general/pull/6165)
+ - nmap invetory plugin - add new option ``port`` for port specific scan (https://github.com/ansible-collections/community.general/pull/6165).

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -41,8 +41,7 @@ DOCUMENTATION = '''
                     C(22) for a single port
                     C(1-65535) for a range of ports
                     C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all
-            type: list
-            elements: string
+            type: string
             version_added: 6.5.0
         ports:
             description: Enable/disable scanning for open ports
@@ -191,7 +190,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if self._options['port']:
                 cmd.append('-p')
-                cmd.append(','.join(self._options['port']))
+                cmd.append(self._options['port'])
 
             if not self._options['ports']:
                 cmd.append('-sP')

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -178,6 +178,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if self._options['port']:
                 cmd.append('-p')
+                cmd.append(','.join(self._options['port']))
 
             if not self._options['ports']:
                 cmd.append('-sP')

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,7 +37,10 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - "For example, you could pass C(22) for a single port, C(1-65535) for a range of ports, or C(U:53,111,137,T:21-25,80,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 111, 137, 80, 139, and 8080 with all protocols."
+                - For example, you could pass
+                    C(22) for a single port
+                    C(1-65535) for a range of ports
+                    C(U:53,111,137,T:21-25,80,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 111, 137, 80, 139, and 8080 with all.
             type: list
             elements: string
             version_added: 6.5.0

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -88,6 +88,13 @@ plugin: community.general.nmap
 sudo: true
 strict: false
 address: 192.168.0.0/24
+
+plugin: community.general.nmap
+address: 192.168.0.0/24
+exclude: 192.168.0.1, web.example.com
+port: 22, 443
+groups:
+  web_servers: "ports | selectattr('port', 'equalto', '443')"
 '''
 
 import os

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -38,7 +38,8 @@ DOCUMENTATION = '''
             description:
                 - Only scan specific port or port range (C(-p)).
                 - Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))
-            type: string
+            type: list
+            elements: string
         ports:
             description: Enable/disable scanning for open ports
             type: boolean

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))
+                - "Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))"
             type: list
             elements: string
         ports:

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - "Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))"
+                - "For example, you could pass C(22) for a single port, C(1-65535) for a range of ports, or C(U:53,111,137,T:21-25,80,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 111, 137, 80, 139, and 8080 with all protocols."
             type: list
             elements: string
             version_added: 6.5.0

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,10 +37,8 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - For example, you could pass
-                    C(22) for a single port
-                    C(1-65535) for a range of ports
-                    C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all
+                - For example, you could pass C(22) for a single port, C(1-65535) for a range of ports,
+                  or C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
             type: string
             version_added: 6.5.0
         ports:

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - Ex: 22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9
+                - Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))
             type: string
         ports:
             description: Enable/disable scanning for open ports

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -40,6 +40,7 @@ DOCUMENTATION = '''
                 - "Ex: (C(22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9))"
             type: list
             elements: string
+            version_added: 6.5.0
         ports:
             description: Enable/disable scanning for open ports
             type: boolean

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -89,6 +89,7 @@ sudo: true
 strict: false
 address: 192.168.0.0/24
 
+# an nmap scan specifying ports and classifying results to an inventory group
 plugin: community.general.nmap
 address: 192.168.0.0/24
 exclude: 192.168.0.1, web.example.com

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -34,6 +34,11 @@ DOCUMENTATION = '''
             description: list of addresses to exclude
             type: list
             elements: string
+        port:
+            description:
+                - Only scan specific port or port range (C(-p)).
+                - Ex: 22; 1-65535; U:53,111,137,T:21-25,80,139,8080,S:9
+            type: string
         ports:
             description: Enable/disable scanning for open ports
             type: boolean
@@ -170,6 +175,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if self._options['sudo']:
                 cmd.insert(0, 'sudo')
+
+            if self._options['port']:
+                cmd.append('-p')
 
             if not self._options['ports']:
                 cmd.append('-sP')

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -40,7 +40,7 @@ DOCUMENTATION = '''
                 - For example, you could pass
                     C(22) for a single port
                     C(1-65535) for a range of ports
-                    C(U:53,111,137,T:21-25,80,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 111, 137, 80, 139, and 8080 with all.
+                    C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all
             type: list
             elements: string
             version_added: 6.5.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
`community.general.nmap` -p option

##### ADDITIONAL INFORMATION
Nmap does not scan all ports, for instance `623`.  This allows for ports to be specified.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
nmap 10.0.1.60 -p 623,22
```
