### PR TITLE
Shutdown systemd without sysv

### DIFF
--- a/changelogs/fragments/6171-shutdown-using-systemd.yml
+++ b/changelogs/fragments/6171-shutdown-using-systemd.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - shutdown - if no shutdown commands are found in the `search_paths` then the module will attempt to shutdown the system using `systemctl shutdown` (https://github.com/ansible-collections/community.general/issues/4269).

--- a/changelogs/fragments/6171-shutdown-using-systemd.yml
+++ b/changelogs/fragments/6171-shutdown-using-systemd.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - shutdown - if no shutdown commands are found in the `search_paths` then the module will attempt to shutdown the system using `systemctl shutdown` (https://github.com/ansible-collections/community.general/issues/4269).
+  - shutdown - if no shutdown commands are found in the ``search_paths`` then the module will attempt to shutdown the system using ``systemctl shutdown`` (https://github.com/ansible-collections/community.general/issues/4269, https://github.com/ansible-collections/community.general/pull/6171).

--- a/changelogs/fragments/6171-shutdown-using-systemd.yml
+++ b/changelogs/fragments/6171-shutdown-using-systemd.yml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
   - shutdown - if no shutdown commands are found in the `search_paths` then the module will attempt to shutdown the system using `systemctl shutdown` (https://github.com/ansible-collections/community.general/issues/4269).

--- a/changelogs/fragments/6171-shutdown-using-systemd.yml
+++ b/changelogs/fragments/6171-shutdown-using-systemd.yml
@@ -1,0 +1,2 @@
+bugfix:
+  - shutdown - if no shutdown commands are found in the `search_paths` then the module will attempt to shutdown the system using `systemctl shutdown` (https://github.com/ansible-collections/community.general/issues/4269).

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -164,7 +164,7 @@ class ActionModule(ActionBase):
                     delay_sec=delay_sec,
                     delay_min=delay_sec // 60,
                     message=shutdown_message
-                    )
+                )
             )
 
     def perform_shutdown(self, task_vars, distribution):

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -150,7 +150,7 @@ class ActionModule(ActionBase):
                     'Could not find command "{0}" in search paths: {1} or systemctl command in search paths: {2}, unable to shutdown.'.
                     format(shutdown_bin, search_paths, systemctl_search_paths))  # we give up here
             else:
-                return "{0} poweroff".format(full_path[0]) # done, since we cannot use args with systemd shutdown
+                return "{0} poweroff".format(full_path[0])  # done, since we cannot use args with systemd shutdown
 
         # systemd case taken care of, here we add args to the command
         args = self._get_value_from_facts('SHUTDOWN_COMMAND_ARGS', distribution, 'DEFAULT_SHUTDOWN_COMMAND_ARGS')
@@ -159,11 +159,11 @@ class ActionModule(ActionBase):
         shutdown_message = self._task.args.get('msg', self.DEFAULT_SHUTDOWN_MESSAGE)
         return '{0} {1}'. \
             format(
-            full_path[0],
-            args.format(
-                delay_sec=delay_sec,
-                delay_min=delay_sec // 60,
-                message=shutdown_message
+                full_path[0],
+                args.format(
+                    delay_sec=delay_sec,
+                    delay_min=delay_sec // 60,
+                    message=shutdown_message
             )
         )
 

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -103,7 +103,7 @@ class ActionModule(ActionBase):
         except KeyError as ke:
             raise AnsibleError('Failed to get distribution information. Missing "{0}" in output.'.format(ke.args[0]))
 
-    def get_full_shutdown_command(self, task_vars, distribution):
+    def get_shutdown_command(self, task_vars, distribution):
         def find_command(command, find_search_paths):
             display.debug('{action}: running find module looking in {paths} to get path for "{command}"'.format(
                 action=self._task.action,
@@ -169,7 +169,7 @@ class ActionModule(ActionBase):
     def perform_shutdown(self, task_vars, distribution):
         result = {}
         shutdown_result = {}
-        shutdown_command_exec = get_full_shutdown_command(self, task_vars, distribution)
+        shutdown_command_exec = self.get_shutdown_command(task_vars, distribution)
 
         self.cleanup(force=True)
         try:

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -146,7 +146,7 @@ class ActionModule(ActionBase):
             systemctl_search_paths = ['/bin', '/usr/bin']
             full_path = find_command('systemctl', systemctl_search_paths)  # find the path to the systemctl command
             if not full_path:  # if we couldn't find systemctl
-                raise AnsibleError('Unable to find systemctl command in search paths: {1}.'.
+                raise AnsibleError('Unable to find systemctl command in search paths: {0}.'.
                                    format(systemctl_search_paths))  # we give up here
             else:
                 return full_path[0]  # done, since we cannot use args with systemd shutdown

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -164,8 +164,8 @@ class ActionModule(ActionBase):
                     delay_sec=delay_sec,
                     delay_min=delay_sec // 60,
                     message=shutdown_message
+                    )
             )
-        )
 
     def perform_shutdown(self, task_vars, distribution):
         result = {}

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -146,12 +146,12 @@ class ActionModule(ActionBase):
             systemctl_search_paths = ['/bin', '/usr/bin']
             full_path = find_command('systemctl', systemctl_search_paths)  # find the path to the systemctl command
             if not full_path:  # if we couldn't find systemctl
-                raise AnsibleError('Unable to find systemctl command in search paths: {1}.'.format(
-                    shutdown_bin, systemctl_search_paths))  # we give up here
+                raise AnsibleError('Unable to find systemctl command in search paths: {1}.'.
+                                   format(systemctl_search_paths))  # we give up here
             else:
                 return full_path[0]  # done, since we cannot use args with systemd shutdown
 
-        # systemd case taken care of, here we add args to the command 
+        # systemd case taken care of, here we add args to the command
         args = self._get_value_from_facts('SHUTDOWN_COMMAND_ARGS', distribution, 'DEFAULT_SHUTDOWN_COMMAND_ARGS')
         # Convert seconds to minutes. If less that 60, set it to 0.
         delay_sec = self.delay

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -144,7 +144,10 @@ class ActionModule(ActionBase):
 
         full_path = [x['path'] for x in find_result['files']]
         if not full_path:
-            raise AnsibleError('Unable to find command "{0}" in search paths: {1}'.format(shutdown_bin, search_paths))
+            display.vvv('Unable to find command "{0}" in search paths: {1}, will attempt a shutdown using systemd '
+                        'directly '.format(shutdown_bin, search_paths))
+            self._shutdown_command = 'systemctl poweroff'
+            return self._shutdown_command
         self._shutdown_command = full_path[0]
         return self._shutdown_command
 
@@ -153,6 +156,9 @@ class ActionModule(ActionBase):
         shutdown_result = {}
         shutdown_command = self.get_shutdown_command(task_vars, distribution)
         shutdown_command_args = self.get_shutdown_command_args(distribution)
+        if shutdown_command == 'systemctl poweroff':
+            display.vvv('attempting to shutdown using systemd poweroff command')
+            shutdown_command_args = ''
         shutdown_command_exec = '{0} {1}'.format(shutdown_command, shutdown_command_args)
 
         self.cleanup(force=True)

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
@@ -80,13 +81,6 @@ class ActionModule(ActionBase):
                     getattr(self, default_value))))
         return value
 
-    def get_shutdown_command_args(self, distribution):
-        args = self._get_value_from_facts('SHUTDOWN_COMMAND_ARGS', distribution, 'DEFAULT_SHUTDOWN_COMMAND_ARGS')
-        # Convert seconds to minutes. If less that 60, set it to 0.
-        delay_sec = self.delay
-        shutdown_message = self._task.args.get('msg', self.DEFAULT_SHUTDOWN_MESSAGE)
-        return args.format(delay_sec=delay_sec, delay_min=delay_sec // 60, message=shutdown_message)
-
     def get_distribution(self, task_vars):
         # FIXME: only execute the module if we don't already have the facts we need
         distribution = {}
@@ -101,14 +95,32 @@ class ActionModule(ActionBase):
                     to_native(module_output['module_stdout']).strip(),
                     to_native(module_output['module_stderr']).strip()))
             distribution['name'] = module_output['ansible_facts']['ansible_distribution'].lower()
-            distribution['version'] = to_text(module_output['ansible_facts']['ansible_distribution_version'].split('.')[0])
+            distribution['version'] = to_text(
+                module_output['ansible_facts']['ansible_distribution_version'].split('.')[0])
             distribution['family'] = to_text(module_output['ansible_facts']['ansible_os_family'].lower())
             display.debug("{action}: distribution: {dist}".format(action=self._task.action, dist=distribution))
             return distribution
         except KeyError as ke:
             raise AnsibleError('Failed to get distribution information. Missing "{0}" in output.'.format(ke.args[0]))
 
-    def get_shutdown_command(self, task_vars, distribution):
+    def get_full_shutdown_command(self, task_vars, distribution):
+        def find_command(command, find_search_paths):
+            display.debug('{action}: running find module looking in {paths} to get path for "{command}"'.format(
+                action=self._task.action,
+                command=command,
+                paths=find_search_paths))
+            find_result = self._execute_module(
+                task_vars=task_vars,
+                # prevent collection search by calling with ansible.legacy (still allows library/ override of find)
+                module_name='ansible.legacy.find',
+                module_args={
+                    'paths': find_search_paths,
+                    'patterns': [shutdown_bin],
+                    'file_type': 'any'
+                }
+            )
+            return [x['path'] for x in find_result['files']]
+
         shutdown_bin = self._get_value_from_facts('SHUTDOWN_COMMANDS', distribution, 'DEFAULT_SHUTDOWN_COMMAND')
         default_search_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']
         search_paths = self._task.args.get('search_paths', default_search_paths)
@@ -127,51 +139,52 @@ class ActionModule(ActionBase):
         except TypeError:
             raise AnsibleError(err_msg.format(search_paths))
 
-        display.debug('{action}: running find module looking in {paths} to get path for "{command}"'.format(
-            action=self._task.action,
-            command=shutdown_bin,
-            paths=search_paths))
-        find_result = self._execute_module(
-            task_vars=task_vars,
-            # prevent collection search by calling with ansible.legacy (still allows library/ override of find)
-            module_name='ansible.legacy.find',
-            module_args={
-                'paths': search_paths,
-                'patterns': [shutdown_bin],
-                'file_type': 'any'
-            }
-        )
-
-        full_path = [x['path'] for x in find_result['files']]
-        if not full_path:
+        full_path = find_command(shutdown_bin, search_paths)  # find the path to the shutdown command
+        if not full_path:  # if we could not find the shutdown command
             display.vvv('Unable to find command "{0}" in search paths: {1}, will attempt a shutdown using systemd '
-                        'directly '.format(shutdown_bin, search_paths))
-            self._shutdown_command = 'systemctl poweroff'
-            return self._shutdown_command
-        self._shutdown_command = full_path[0]
-        return self._shutdown_command
+                        'directly.'.format(shutdown_bin, search_paths))  # tell the user we will try with systemd
+            systemctl_search_paths = ['/bin', '/usr/bin']
+            full_path = find_command('systemctl', systemctl_search_paths)  # find the path to the systemctl command
+            if not full_path:  # if we couldn't find systemctl
+                raise AnsibleError('Unable to find systemctl command in search paths: {1}.'.format(
+                    shutdown_bin, systemctl_search_paths))  # we give up here
+            else:
+                return full_path[0]  # done, since we cannot use args with systemd shutdown
+
+        # systemd case taken care of, here we add args to the command 
+        args = self._get_value_from_facts('SHUTDOWN_COMMAND_ARGS', distribution, 'DEFAULT_SHUTDOWN_COMMAND_ARGS')
+        # Convert seconds to minutes. If less that 60, set it to 0.
+        delay_sec = self.delay
+        shutdown_message = self._task.args.get('msg', self.DEFAULT_SHUTDOWN_MESSAGE)
+        return '{0} {1}'. \
+            format(
+                full_path[0],
+                args.format(
+                    delay_sec=delay_sec,
+                    delay_min=delay_sec // 60,
+                    message=shutdown_message
+                )
+            )
 
     def perform_shutdown(self, task_vars, distribution):
         result = {}
         shutdown_result = {}
-        shutdown_command = self.get_shutdown_command(task_vars, distribution)
-        shutdown_command_args = self.get_shutdown_command_args(distribution)
-        if shutdown_command == 'systemctl poweroff':
-            display.vvv('attempting to shutdown using systemd poweroff command')
-            shutdown_command_args = ''
-        shutdown_command_exec = '{0} {1}'.format(shutdown_command, shutdown_command_args)
+        shutdown_command_exec = get_full_shutdown_command(self, task_vars, distribution)
 
         self.cleanup(force=True)
         try:
             display.vvv("{action}: shutting down server...".format(action=self._task.action))
-            display.debug("{action}: shutting down server with command '{command}'".format(action=self._task.action, command=shutdown_command_exec))
+            display.debug("{action}: shutting down server with command '{command}'".
+                          format(action=self._task.action, command=shutdown_command_exec))
             if self._play_context.check_mode:
                 shutdown_result['rc'] = 0
             else:
                 shutdown_result = self._low_level_execute_command(shutdown_command_exec, sudoable=self.DEFAULT_SUDOABLE)
         except AnsibleConnectionFailure as e:
             # If the connection is closed too quickly due to the system being shutdown, carry on
-            display.debug('{action}: AnsibleConnectionFailure caught and handled: {error}'.format(action=self._task.action, error=to_text(e)))
+            display.debug(
+                '{action}: AnsibleConnectionFailure caught and handled: {error}'.format(action=self._task.action,
+                                                                                        error=to_text(e)))
             shutdown_result['rc'] = 0
 
         if shutdown_result['rc'] != 0:

--- a/plugins/modules/shutdown.py
+++ b/plugins/modules/shutdown.py
@@ -14,7 +14,7 @@ short_description: Shut down a machine
 notes:
   - C(PATH) is ignored on the remote node when searching for the C(shutdown) command. Use I(search_paths)
     to specify locations to search if the default paths do not work.
-    - The I(msg) and I(delay) options are not supported when a shutdown command is not found in I(search_paths), instead
+  - The I(msg) and I(delay) options are not supported when a shutdown command is not found in I(search_paths), instead
     the module will attempt to shutdown the system by calling C(systemctl shutdown).
 description:
   - Shut downs a machine.

--- a/plugins/modules/shutdown.py
+++ b/plugins/modules/shutdown.py
@@ -14,7 +14,7 @@ short_description: Shut down a machine
 notes:
   - C(PATH) is ignored on the remote node when searching for the C(shutdown) command. Use I(search_paths)
     to specify locations to search if the default paths do not work.
-  - The msg and delay options are not supported when a shutdown command is not found in I(search_paths), instead
+    - The I(msg) and I(delay) options are not supported when a shutdown command is not found in I(search_paths), instead
     the module will attempt to shutdown the system by calling C(systemctl shutdown).
 description:
   - Shut downs a machine.

--- a/plugins/modules/shutdown.py
+++ b/plugins/modules/shutdown.py
@@ -14,6 +14,8 @@ short_description: Shut down a machine
 notes:
   - C(PATH) is ignored on the remote node when searching for the C(shutdown) command. Use I(search_paths)
     to specify locations to search if the default paths do not work.
+  - The msg and delay options are not supported when a shutdown command is not found in I(search_paths), instead
+    the module will attempt to shutdown the system by calling C(systemctl shutdown).
 description:
   - Shut downs a machine.
 version_added: "1.1.0"

--- a/tests/integration/targets/shutdown/aliases
+++ b/tests/integration/targets/shutdown/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
+destructive

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -9,25 +9,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-- name: Get file stat for /sbin/shutdown 
-  stat:
-    path: "/sbin/shutdown"
-  register: sbin_shutdown 
-
-- name: Get file stat for /usr/sbin/shutdown 
-  stat:
-    path: "/usr/sbin/shutdown"
-  register: usr_sbin_shutdown 
-
-- name: Get file stat for /usr/local/sbin/shutdown 
-  stat:
-    path: "/usr/local/sbin/shutdown"
-  register: usr_local_sbin_shutdown 
-
-- name: debug stat
-  debug:
-    msg: " {{ sbin_shutdown.stat.exists }}"
-
 - name: Execute shutdown with custom message and delay
   community.general.shutdown:
     delay: 100

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -7,11 +7,11 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-- name: Install systemd-sysv on Ubuntu 18 and Debian
+#
+- name: Ensure that systemd-sysv is absent in Ubuntu 18 and Debian
   apt:
     name: systemd-sysv
-    state: present
+    state: absent
   when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')
   register: systemd_sysv_install
 
@@ -86,8 +86,8 @@
       - '"-d 0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_system == 'VMKernel'
 
-- name: Remove systemd-sysv in ubuntu 18 in case it has been installed in test
+- name: Install systemd-sysv in Ubuntu 18 and Debian in case it has been removed in test
   apt:
     name: systemd-sysv
-    state: absent
+    state: present 
   when: systemd_sysv_install is changed

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -111,10 +111,14 @@
   community.general.shutdown:
   register: shutdown_result
   check_mode: true
-  when: '"systemd-sysv" not in ansible_facts.packages'
+  when: 
+    - '"systemd-sysv" not in ansible_facts.packages'
+    - "(ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')"
 
 - name: Install systemd_sysv in case it has been removed in test
   apt:
     name: systemd-sysv
     state: present
-  when: systemd_sysv_install is changed
+  when:
+    - "systemd_sysv_install is changed"
+    - "(ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')"

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -22,7 +22,7 @@
   register: shutdown_result_minus
   check_mode: true
 
-- name: Verify Custom Message except Alpine, AIX, or non-sysv shutdown command
+- name: Verify Custom Message except Alpine, AIX
   assert:
     that:
       - '"Custom Message" in shutdown_result["shutdown_command"]'
@@ -31,7 +31,7 @@
   when:
     - 'ansible_os_family not in ["Alpine", "AIX"]'
 
-- name: Verify shutdown command is present except Alpine, AIX, or non-sysv shutdown command
+- name: Verify shutdown command is present except Alpine or AIX
   assert:
     that: '"shutdown" in shutdown_result["shutdown_command"]'
   when:
@@ -84,3 +84,22 @@
       - '"-d 100" in shutdown_result["shutdown_command"]'
       - '"-d 0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_system == 'VMKernel'
+
+- name: Ensure that systemd-sysv is absent in Ubuntu 18 and Debian
+  apt:
+    name: sytemd-sysv
+    state: absent
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')
+  register: systemd_sysv_install
+
+- name: Execute shutdown if no systemd-sysv
+  community.general.shutdown:
+  register: shutdown_result
+  check_mode: true
+  when: systemd_sysv_install is changed
+
+- name: Install systemd_sysv in case it has been removed in test
+  apt:
+    name: systemd-sysv
+    state: present
+  when: systemd_sysv_install is changed

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -8,12 +8,25 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-- name: Ensure that systemd-sysv is absent in Ubuntu 18 and Debian
-  apt:
-    name: systemd-sysv
-    state: absent
-  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')
-  register: systemd_sysv_install
+
+- name: Get file stat for /sbin/shutdown 
+  stat:
+    path: "/sbin/shutdown"
+  register: sbin_shutdown 
+
+- name: Get file stat for /usr/sbin/shutdown 
+  stat:
+    path: "/usr/sbin/shutdown"
+  register: usr_sbin_shutdown 
+
+- name: Get file stat for /usr/local/sbin/shutdown 
+  stat:
+    path: "/usr/local/sbin/shutdown"
+  register: usr_local_sbin_shutdown 
+
+- name: debug stat
+  debug:
+    msg: " {{ sbin_shutdown.stat.exists }}"
 
 - name: Execute shutdown with custom message and delay
   community.general.shutdown:
@@ -28,18 +41,23 @@
   register: shutdown_result_minus
   check_mode: true
 
-- name: Verify Custom Message except Alpine, AIX
+- name: Verify Custom Message except Alpine, AIX, or non-sysv shutdown command
   assert:
     that:
       - '"Custom Message" in shutdown_result["shutdown_command"]'
       - '"Shut down initiated by Ansible" in shutdown_result_minus["shutdown_command"]'
       - '"Custom Message" not in shutdown_result_minus["shutdown_command"]'
-  when: ansible_os_family not in ['Alpine', 'AIX']
+  when:
+    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
+    - 'ansible_os_family not in ["Alpine", "AIX"]'
 
-- name: Verify shutdown command is present except Alpine, VMKernel
+- name: Verify shutdown command is present except Alpine, AIX, or non-sysv shutdown command
   assert:
     that: '"shutdown" in shutdown_result["shutdown_command"]'
-  when: ansible_os_family != 'Alpine' and ansible_system != 'VMKernel'
+  when:
+    - "ansible_os_family != 'Alpine'"
+    - "ansible_system != 'VMKernel'"
+    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
 
 - name: Verify shutdown command is present in Alpine
   assert:
@@ -56,7 +74,10 @@
     that:
       - '"-h 1" in shutdown_result["shutdown_command"]'
       - '"-h 0" in shutdown_result_minus["shutdown_command"]'
-  when: ansible_system == 'Linux' and ansible_os_family != 'Alpine'
+  when:
+    - "ansible_system == 'Linux'"
+    - "ansible_os_family != 'Alpine'"
+    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
 
 - name: Verify shutdown delay is present in minutes in Void, MacOSX, OpenBSD
   assert:
@@ -86,8 +107,3 @@
       - '"-d 0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_system == 'VMKernel'
 
-- name: Install systemd-sysv in Ubuntu 18 and Debian in case it has been removed in test
-  apt:
-    name: systemd-sysv
-    state: present 
-  when: systemd_sysv_install is changed

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -112,13 +112,13 @@
   register: shutdown_result
   check_mode: true
   when: 
-    - '"systemd-sysv" not in ansible_facts.packages'
     - "(ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')"
+    - '"systemd-sysv" not in ansible_facts.packages'
 
 - name: Install systemd_sysv in case it has been removed in test
   apt:
     name: systemd-sysv
     state: present
   when:
-    - "systemd_sysv_install is changed"
     - "(ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')"
+    - "systemd_sysv_install is changed"

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -106,4 +106,3 @@
       - '"-d 100" in shutdown_result["shutdown_command"]'
       - '"-d 0" in shutdown_result_minus["shutdown_command"]'
   when: ansible_system == 'VMKernel'
-

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -30,25 +30,33 @@
       - '"Custom Message" not in shutdown_result_minus["shutdown_command"]'
   when:
     - 'ansible_os_family not in ["Alpine", "AIX"]'
+    - '"systemctl" not in shutdown_result["shutdown_command"]'
+    - '"systemctl" not in shutdown_result_minus["shutdown_command"]'
 
-- name: Verify shutdown command is present except Alpine or AIX
+- name: Verify shutdown command is present except Alpine or AIX or systemd
   assert:
     that: '"shutdown" in shutdown_result["shutdown_command"]'
   when:
     - "ansible_os_family != 'Alpine'"
     - "ansible_system != 'VMKernel'"
+    - '"systemctl" not in shutdown_result["shutdown_command"]'
 
-- name: Verify shutdown command is present in Alpine
+- name: Verify shutdown command is present in Alpine except systemd
   assert:
     that: '"poweroff" in shutdown_result["shutdown_command"]'
-  when: ansible_os_family == 'Alpine'
+  when: 
+    - "ansible_os_family == 'Alpine'"
+    - '"systemctl" not in shutdown_result["shutdown_command"]'
 
-- name: Verify shutdown command is present in VMKernel
+
+- name: Verify shutdown command is present in VMKernel except systemd
   assert:
     that: '"halt" in shutdown_result["shutdown_command"]'
-  when: ansible_system == 'VMKernel'
+  when: 
+    - "ansible_system == 'VMKernel'"
+    - '"systemctl" not in shutdown_result["shutdown_command"]'
 
-- name: Verify shutdown delay is present in minutes in Linux
+- name: Verify shutdown delay is present in minutes in Linux except systemd
   assert:
     that:
       - '"-h 1" in shutdown_result["shutdown_command"]'
@@ -56,6 +64,8 @@
   when:
     - "ansible_system == 'Linux'"
     - "ansible_os_family != 'Alpine'"
+    - '"systemctl" not in shutdown_result["shutdown_command"]'
+    - '"systemctl" not in shutdown_result_minus["shutdown_command"]'
 
 - name: Verify shutdown delay is present in minutes in Void, MacOSX, OpenBSD
   assert:
@@ -92,11 +102,16 @@
   when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')
   register: systemd_sysv_install
 
+- name: Gather package facts
+  package_facts:
+    manager: apt
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '>=')) or (ansible_distribution == 'Debian')
+
 - name: Execute shutdown if no systemd-sysv
   community.general.shutdown:
   register: shutdown_result
   check_mode: true
-  when: systemd_sysv_install is changed
+  when: '"systemd-sysv" not in ansible_facts.packages'
 
 - name: Install systemd_sysv in case it has been removed in test
   apt:

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -29,7 +29,6 @@
       - '"Shut down initiated by Ansible" in shutdown_result_minus["shutdown_command"]'
       - '"Custom Message" not in shutdown_result_minus["shutdown_command"]'
   when:
-    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
     - 'ansible_os_family not in ["Alpine", "AIX"]'
 
 - name: Verify shutdown command is present except Alpine, AIX, or non-sysv shutdown command
@@ -38,7 +37,6 @@
   when:
     - "ansible_os_family != 'Alpine'"
     - "ansible_system != 'VMKernel'"
-    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
 
 - name: Verify shutdown command is present in Alpine
   assert:
@@ -58,7 +56,6 @@
   when:
     - "ansible_system == 'Linux'"
     - "ansible_os_family != 'Alpine'"
-    - 'sbin_shutdown.stat.exists or usr_sbin_shutdown.stat.exists or usr_local_sbin_shutdown.stat.exists'
 
 - name: Verify shutdown delay is present in minutes in Void, MacOSX, OpenBSD
   assert:


### PR DESCRIPTION
##### SUMMARY
This PR fixes #4269, allowing Linux systems without shutdown commands to be shutdown using systemd directly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
shutdown

##### ADDITIONAL INFORMATION
I've added a conditional that sets `systemd poweroff` with no arguments to be the shutdown command only if there are are no matching `search_paths`. Note that I used `systemd poweroff` not `systemctl isolate poweroff.target` as mentioned in the [relevant manual page](https://www.freedesktop.org/software/systemd/man/systemd-halt.service.html). The only risk introduced by this change is that a user expects the system to shut down with a message or at a future time, but the system does not have the required command, it will shut down immediately (ignoring the arguments). I believe that this is acceptable, as this behavior is already present in Alpine. The risk is documented in the module notes.

