### PR TITLE
Mark monit integration tests as unstable

### DIFF
--- a/tests/integration/targets/monit/aliases
+++ b/tests/integration/targets/monit/aliases
@@ -11,3 +11,4 @@ skip/freebsd
 skip/aix
 skip/python2.6  # python-daemon package used in integration tests requires >=2.7
 skip/rhel  # FIXME
+unstable  # TODO: the tests fail a lot; 'unstable' only requires them to pass when the module itself has been modified


### PR DESCRIPTION
##### SUMMARY
The monit integration tests fail *a lot*. This PR marks them as unstable. This makes them no longer run by default, but they still run when the module itself is modified. See https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html#unstable for details.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
monit
