### PR TITLE
Replace deprecated error with BadZipFile

### DIFF
--- a/changelogs/fragments/6180-replace-deprecated-badzipfile.yml
+++ b/changelogs/fragments/6180-replace-deprecated-badzipfile.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``BadZipfile`` (with a small ``f``) has been deprecated since Python 3.2, use ``BadZipFile`` (big ``F``) instead, added in 3.2 (https://github.com/ansible-collections/community.general/pull/6180)."

--- a/changelogs/fragments/6180-replace-deprecated-badzipfile.yml
+++ b/changelogs/fragments/6180-replace-deprecated-badzipfile.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "``BadZipfile`` (with a small ``f``) has been deprecated since Python 3.2, use ``BadZipFile`` (big ``F``) instead, added in 3.2 (https://github.com/ansible-collections/community.general/pull/6180)."
+  - "archive - avoid deprecated exception class on Python 3 (https://github.com/ansible-collections/community.general/pull/6180)."

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -198,6 +198,10 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils import six
 
+try:  # python 3.2+
+    from zipfile import BadZipFile  # type: ignore[attr-defined]
+except ImportError:  # older python
+    from zipfile import BadZipfile as BadZipFile
 
 LZMA_IMP_ERR = None
 if six.PY3:
@@ -534,7 +538,7 @@ class ZipArchive(Archive):
             archive = zipfile.ZipFile(_to_native_ascii(path), 'r')
             checksums = set((info.filename, info.CRC) for info in archive.infolist())
             archive.close()
-        except zipfile.BadZipfile:
+        except zipfile.BadZipFile:
             checksums = set()
         return checksums
 

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -538,7 +538,7 @@ class ZipArchive(Archive):
             archive = zipfile.ZipFile(_to_native_ascii(path), 'r')
             checksums = set((info.filename, info.CRC) for info in archive.infolist())
             archive.close()
-        except zipfile.BadZipFile:
+        except BadZipFile:
             checksums = set()
         return checksums
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437


##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

archive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See also https://github.com/ansible/ansible/pull/80198.