### PR TITLE
ldap moduls: add optional ca_cert_file option

### DIFF
--- a/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
+++ b/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap modules - add ``ca_cert_file`` option (https://github.com/ansible-collections/community.general/pull/xyz).
+  - ldap modules - add ``ca_cert_file`` option (https://github.com/ansible-collections/community.general/pull/6185).

--- a/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
+++ b/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap modules - add ``ca_cert_file`` option (https://github.com/ansible-collections/community.general/pull/6185).
+  - ldap modules - add ``ca_path`` option (https://github.com/ansible-collections/community.general/pull/6185).

--- a/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
+++ b/changelogs/fragments/xxxx-ldap-ca-cert-file.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ldap modules - add ``ca_cert_file`` option (https://github.com/ansible-collections/community.general/pull/xyz).

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -24,7 +24,7 @@ options:
       - The password to use with I(bind_dn).
     type: str
     default: ''
-  ca_cert_file:
+  ca_path:
     description:
       - Set the path to PEM file with CA certs.
     type: path

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -24,6 +24,11 @@ options:
       - The password to use with I(bind_dn).
     type: str
     default: ''
+  ca_cert_file:
+    description:
+      - Set the path to PEM file with CA certs
+    type: str
+    version_added: "6.5.0"
   dn:
     required: true
     description:

--- a/plugins/doc_fragments/ldap.py
+++ b/plugins/doc_fragments/ldap.py
@@ -26,8 +26,8 @@ options:
     default: ''
   ca_cert_file:
     description:
-      - Set the path to PEM file with CA certs
-    type: str
+      - Set the path to PEM file with CA certs.
+    type: path
     version_added: "6.5.0"
   dn:
     required: true

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -34,7 +34,7 @@ def gen_specs(**specs):
     specs.update({
         'bind_dn': dict(),
         'bind_pw': dict(default='', no_log=True),
-        'ca_cert_file': dict(type='path'),
+        'ca_path': dict(type='path'),
         'dn': dict(required=True),
         'referrals_chasing': dict(type='str', default='anonymous', choices=['disabled', 'anonymous']),
         'server_uri': dict(default='ldapi:///'),
@@ -53,7 +53,7 @@ class LdapGeneric(object):
         self.module = module
         self.bind_dn = self.module.params['bind_dn']
         self.bind_pw = self.module.params['bind_pw']
-        self.ca_cert_file = self.module.params['ca_cert_file']
+        self.ca_path = self.module.params['ca_path']
         self.referrals_chasing = self.module.params['referrals_chasing']
         self.server_uri = self.module.params['server_uri']
         self.start_tls = self.module.params['start_tls']
@@ -99,8 +99,8 @@ class LdapGeneric(object):
         if not self.verify_cert:
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
-        if self.ca_cert_file:
-            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.ca_cert_file)
+        if self.ca_path:
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.ca_path)
 
         connection = ldap.initialize(self.server_uri)
 

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -34,7 +34,7 @@ def gen_specs(**specs):
     specs.update({
         'bind_dn': dict(),
         'bind_pw': dict(default='', no_log=True),
-        'ca_cert_file': dict(type="str"),
+        'ca_cert_file': dict(type='path'),
         'dn': dict(required=True),
         'referrals_chasing': dict(type='str', default='anonymous', choices=['disabled', 'anonymous']),
         'server_uri': dict(default='ldapi:///'),

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -34,6 +34,7 @@ def gen_specs(**specs):
     specs.update({
         'bind_dn': dict(),
         'bind_pw': dict(default='', no_log=True),
+        'ca_cert_file': dict(type="str"),
         'dn': dict(required=True),
         'referrals_chasing': dict(type='str', default='anonymous', choices=['disabled', 'anonymous']),
         'server_uri': dict(default='ldapi:///'),
@@ -52,6 +53,7 @@ class LdapGeneric(object):
         self.module = module
         self.bind_dn = self.module.params['bind_dn']
         self.bind_pw = self.module.params['bind_pw']
+        self.ca_cert_file = self.module.params['ca_cert_file']
         self.referrals_chasing = self.module.params['referrals_chasing']
         self.server_uri = self.module.params['server_uri']
         self.start_tls = self.module.params['start_tls']
@@ -96,6 +98,9 @@ class LdapGeneric(object):
     def _connect_to_ldap(self):
         if not self.verify_cert:
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+
+        if self.ca_cert_file:
+            ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.ca_cert_file)
 
         connection = ldap.initialize(self.server_uri)
 


### PR DESCRIPTION
##### SUMMARY
This PR adds a `ca_cert_file` option to the ldap modules. This option can be used to specify a ca certificate used to verify ldap tls connections.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ldap modules

##### ADDITIONAL INFORMATION

I wasn't sure how to name the changelog fragment, since this PR does not address an existing issue
