### PR TITLE
pipx: Allow injected modules to add apps

### DIFF
--- a/changelogs/fragments/6198-pipx-inject-install-apps.yml
+++ b/changelogs/fragments/6198-pipx-inject-install-apps.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pipx module - optional ``install_apps`` parameter added to install applications from injected packages (https://github.com/ansible-collections/community.general/issues/6198).

--- a/changelogs/fragments/6198-pipx-inject-install-apps.yml
+++ b/changelogs/fragments/6198-pipx-inject-install-apps.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pipx module - optional ``install_apps`` parameter added to install applications from injected packages (https://github.com/ansible-collections/community.general/issues/6198).
+  - pipx - optional ``install_apps`` parameter added to install applications from injected packages (https://github.com/ansible-collections/community.general/pull/6198).

--- a/plugins/module_utils/pipx.py
+++ b/plugins/module_utils/pipx.py
@@ -32,6 +32,7 @@ def pipx_runner(module, command, **kwargs):
             state=fmt.as_map(_state_map),
             name=fmt.as_list(),
             name_source=fmt.as_func(fmt.unpack_args(lambda n, s: [s] if s else [n])),
+            install_apps=fmt.as_bool("--include-apps"),
             install_deps=fmt.as_bool("--include-deps"),
             inject_packages=fmt.as_list(),
             force=fmt.as_bool("--force"),

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -53,6 +53,7 @@ options:
             - Only used when I(state=inject).
         type: bool
         default: false
+        version_added: 6.5.0
     install_deps:
         description:
             - Include applications of dependent packages.

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -47,10 +47,16 @@ options:
               If the application source, such as a package with version specifier, or an URL,
               directory or any other accepted specification. See C(pipx) documentation for more details.
             - When specified, the C(pipx) command will use I(source) instead of I(name).
+    install_apps:
+        description:
+            - Add apps from the injected packages.
+            - Only used when I(state=inject).
+        type: bool
+        default: false
     install_deps:
         description:
             - Include applications of dependent packages.
-            - Only used when I(state=install) or I(state=upgrade).
+            - Only used when I(state=install), I(state=upgrade), or I(state=inject).
         type: bool
         default: false
     inject_packages:
@@ -161,6 +167,7 @@ class PipX(StateModuleHelper):
                                 'inject', 'upgrade', 'upgrade_all', 'reinstall', 'reinstall_all', 'latest']),
             name=dict(type='str'),
             source=dict(type='str'),
+            install_apps=dict(type='bool', default=False),
             install_deps=dict(type='bool', default=False),
             inject_packages=dict(type='list', elements='str'),
             force=dict(type='bool', default=False),
@@ -271,7 +278,7 @@ class PipX(StateModuleHelper):
             self.do_raise("Trying to inject packages into a non-existent application: {0}".format(self.vars.name))
         if self.vars.force:
             self.changed = True
-        with self.runner('state index_url force editable pip_args name inject_packages', check_mode_skip=True) as ctx:
+        with self.runner('state index_url install_apps install_deps force editable pip_args name inject_packages', check_mode_skip=True) as ctx:
             ctx.run()
             self._capture_results(ctx)
 

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -189,7 +189,7 @@
     inject_packages:
       - black
       - licenses
-    include_apps: true
+    install_apps: true
   register: inject_pkgs_ansible_lint
 
 - name: cleanup ansible-lint

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -187,10 +187,17 @@
     state: inject
     name: ansible-lint
     inject_packages:
-      - black
       - licenses
-    install_apps: true
   register: inject_pkgs_ansible_lint
+
+- name: inject packages with apps
+  community.general.pipx:
+    state: inject
+    name: ansible-lint
+    inject_packages:
+      - black
+    install_apps: true
+  register: inject_pkgs_apps_ansible_lint
 
 - name: cleanup ansible-lint
   community.general.pipx:
@@ -205,6 +212,9 @@
       - inject_pkgs_ansible_lint is changed
       - '"ansible-lint" in inject_pkgs_ansible_lint.application'
       - '"licenses" in inject_pkgs_ansible_lint.application["ansible-lint"]["injected"]'
+      - inject_pkgs_apps_ansible_lint is changed
+      - '"ansible-lint" in inject_pkgs_apps_ansible_lint.application'
+      - '"black" in inject_pkgs_apps_ansible_lint.application["ansible-lint"]["injected"]'
       - uninstall_ansible_lint is changed
 
 ##############################################################################

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -187,7 +187,9 @@
     state: inject
     name: ansible-lint
     inject_packages:
+      - black
       - licenses
+    include_apps: true
   register: inject_pkgs_ansible_lint
 
 - name: cleanup ansible-lint


### PR DESCRIPTION
Add support for `pipx inject`'s `--include-apps` parameter.

##### SUMMARY
Add support to the pipx module so that `state=inject` can cause pipx to include applications from the specified app into $PATH.

For instance, I currently have an ansible install with ansible-lint injected, and I want ansible-lint in $PATH.  I can achieve that manually, but I can't codify it (cleanly) in my ansible playbooks.

```
pipx install --include-deps ansible
pipx inject ansible --include-apps ansible-lint[yamllint]
```

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pipx

##### ADDITIONAL INFORMATION
