### PR TITLE
Adding `open` option to nmap

### DIFF
--- a/changelogs/fragments/6200-adding-open-option-to-nmap.yml
+++ b/changelogs/fragments/6200-adding-open-option-to-nmap.yml
@@ -1,2 +1,2 @@
 minor_changes:
-    - nmap invetory plugin - add new option ``open`` for only returning open ports (https://github.com/ansible-collections/community.general/pull/6200).
+    - nmap inventory plugin - add new option ``open`` for only returning open ports (https://github.com/ansible-collections/community.general/pull/6200).

--- a/changelogs/fragments/6200-adding-open-option-to-nmap.yml
+++ b/changelogs/fragments/6200-adding-open-option-to-nmap.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - nmap invetory plugin - add new option ``open`` for only returning open ports (https://github.com/ansible-collections/community.general/pull/6200).

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,10 +37,8 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - For example, you could pass
-                    C(22) for a single port
-                    C(1-65535) for a range of ports
-                    C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all
+                - For example, you could pass C(22) for a single port, C(1-65535) for a range of ports,
+                  or C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
             type: string
             version_added: 6.5.0
         ports:

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -37,12 +37,14 @@ DOCUMENTATION = '''
         port:
             description:
                 - Only scan specific port or port range (C(-p)).
-                - For example, you could pass C(22) for a single port, C(1-65535) for a range of ports,
-                  or C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all.
+                - For example, you could pass
+                    C(22) for a single port
+                    C(1-65535) for a range of ports
+                    C(U:53,137,T:21-25,139,8080,S:9) to check port 53 with UDP, ports 21-25 with TCP, port 9 with SCTP, and ports 137, 139, and 8080 with all
             type: string
             version_added: 6.5.0
         ports:
-            description: Enable/disable scanning for open ports
+            description: Enable/disable scanning ports.
             type: boolean
             default: true
         ipv4:
@@ -67,6 +69,11 @@ DOCUMENTATION = '''
             type: boolean
             default: false
             version_added: 6.1.0
+        open:
+            description: Only show open (or possibly open) ports.
+            type: boolean
+            default: false
+            version_added: 6.5.0
         dns_resolve:
             description: Whether to always (C(true)) or never (C(false)) do DNS resolution.
             type: boolean
@@ -212,6 +219,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             if self._options['icmp_timestamp']:
                 cmd.append('-PP')
+
+            if self._options['open']:
+                cmd.append('--open')
 
             cmd.append(self._options['address'])
             try:

--- a/plugins/inventory/nmap.py
+++ b/plugins/inventory/nmap.py
@@ -68,7 +68,7 @@ DOCUMENTATION = '''
             default: false
             version_added: 6.1.0
         open:
-            description: Only show open (or possibly open) ports.
+            description: Only scan for open (or possibly open) ports.
             type: boolean
             default: false
             version_added: 6.5.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This will add in the `--open` option for the `nmap` inventory plugin.  Currently the port scan (`-sP`) just scans ports and returns results from _all_ ports, regardless of if they are closed.  The `open` option will all for only open ports to be returned.  This will also clarify this by removing the "open ports" mention in the current `ports` argument.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`community.general.nmap` `--open` option

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
nmap -p 22 --open 192.160.0.0/24
```
