### PR TITLE
Add append option to ipa_hostgroup module

### DIFF
--- a/changelogs/fragments/6203-add-append-option-to-ipa-hostgroup.yml
+++ b/changelogs/fragments/6203-add-append-option-to-ipa-hostgroup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ipa hostgroup - add ``append`` parameter for adding a new hosts to existing hostgroups without changing existing hostgroup members (https://github.com/ansible-collections/community.general/pull/6203).

--- a/changelogs/fragments/6203-add-append-option-to-ipa-hostgroup.yml
+++ b/changelogs/fragments/6203-add-append-option-to-ipa-hostgroup.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ipa hostgroup - add ``append`` parameter for adding a new hosts to existing hostgroups without changing existing hostgroup members (https://github.com/ansible-collections/community.general/pull/6203).
+  - ipa_hostgroup - add ``append`` parameter for adding a new hosts to existing hostgroups without changing existing hostgroup members (https://github.com/ansible-collections/community.general/pull/6203).

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -26,6 +26,7 @@ options:
     - If C(false), only the listed I(host) will be in I(hostgroup), removing any other hosts.
     default: false
     type: bool
+    version_added: 6.6.0
   cn:
     description:
     - Name of host-group.

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -203,8 +203,7 @@ def main():
                          description=dict(type='str'),
                          host=dict(type='list', elements='str'),
                          hostgroup=dict(type='list', elements='str'),
-                         state=dict(type='str', default='present',
-                         choices=['present', 'absent', 'enabled', 'disabled']),
+                         state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']),
                          append=dict(type='bool', default=False))
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -24,7 +24,7 @@ options:
     description:
     - If C(yes), add the listed I(host) to the I(hostgroup).
     - If C(no), only the listed I(host) will be in I(hostgroup), removing any other hosts.
-    default: no
+    default: false
     type: bool
   cn:
     description:

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -22,8 +22,8 @@ attributes:
 options:
   append:
     description:
-    - If C(yes), add the listed I(host) to the I(hostgroup).
-    - If C(no), only the listed I(host) will be in I(hostgroup), removing any other hosts.
+    - If C(true), add the listed I(host) to the I(hostgroup).
+    - If C(false), only the listed I(host) will be in I(hostgroup), removing any other hosts.
     default: false
     type: bool
   cn:

--- a/plugins/modules/ipa_hostgroup.py
+++ b/plugins/modules/ipa_hostgroup.py
@@ -20,6 +20,12 @@ attributes:
   diff_mode:
     support: none
 options:
+  append:
+    description:
+    - If C(yes), add the listed I(host) to the I(hostgroup).
+    - If C(no), only the listed I(host) will be in I(hostgroup), removing any other hosts.
+    default: no
+    type: bool
   cn:
     description:
     - Name of host-group.
@@ -147,6 +153,7 @@ def ensure(module, client):
     state = module.params['state']
     host = module.params['host']
     hostgroup = module.params['hostgroup']
+    append = module.params['append']
 
     ipa_hostgroup = client.hostgroup_find(name=name)
     module_hostgroup = get_hostgroup_dict(description=module.params['description'])
@@ -168,14 +175,18 @@ def ensure(module, client):
                     client.hostgroup_mod(name=name, item=data)
 
         if host is not None:
-            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []), [item.lower() for item in host],
-                                            client.hostgroup_add_host, client.hostgroup_remove_host) or changed
+            changed = client.modify_if_diff(name, ipa_hostgroup.get('member_host', []),
+                                            [item.lower() for item in host],
+                                            client.hostgroup_add_host,
+                                            client.hostgroup_remove_host,
+                                            append=append) or changed
 
         if hostgroup is not None:
             changed = client.modify_if_diff(name, ipa_hostgroup.get('member_hostgroup', []),
                                             [item.lower() for item in hostgroup],
                                             client.hostgroup_add_hostgroup,
-                                            client.hostgroup_remove_hostgroup) or changed
+                                            client.hostgroup_remove_hostgroup,
+                                            append=append) or changed
 
     else:
         if ipa_hostgroup:
@@ -192,7 +203,9 @@ def main():
                          description=dict(type='str'),
                          host=dict(type='list', elements='str'),
                          hostgroup=dict(type='list', elements='str'),
-                         state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']))
+                         state=dict(type='str', default='present',
+                         choices=['present', 'absent', 'enabled', 'disabled']),
+                         append=dict(type='bool', default=False))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)


### PR DESCRIPTION
#### SUMMARY
Add `append` option to ipa_hostgroup module which allow to add new hosts to existing hostgroup without deleting existing hostgroup members.

Fixes: #6187 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
`community.general.ipa_hostgroup`


<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
