### PR TITLE
dconf: three minor but useful fixes

### DIFF
--- a/changelogs/fragments/6206-dconf-booleans.yml
+++ b/changelogs/fragments/6206-dconf-booleans.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "dconf - be forgiving about boolean values: convert them to GVariant booleans automatically (https://github.com/ansible-collections/community.general/pull/6206)."

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -288,6 +288,10 @@ class DconfPreference(object):
 
         Returns True if the two values are equal.
         """
+        if canonical_value is None:
+            # It's unset in dconf database, so anything the user is trying to
+            # set is a change.
+            return False
         try:
             variant1 = Variant.parse(None, canonical_value)
             variant2 = Variant.parse(variant1.get_type(), user_value)

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -353,7 +353,7 @@ class DconfPreference(object):
         rc, out, err = dbus_wrapper.run_command(command)
 
         if rc != 0:
-            self.module.fail_json(msg='dconf failed while write the value with error: %s' % err,
+            self.module.fail_json(msg='dconf failed while writing key %s, value %s with error: %s' % (key, value, err),
                                   out=out,
                                   err=err)
 


### PR DESCRIPTION
##### SUMMARY
There are three commits in this PR.

The first is a minor follow-up to #6049 to handle an edge case I didn't anticipate: what happens when the user attempts to set a value which is currently completely unset in the dconf database. We need to handle this explicitly because the GVariant parser throws a TypeError if we attempt to parse None. I don't think this should have a changelog fragment because I don't believe the changes in #6049 have been released yet (please correct me if I'm wrong).

The second is a trivial improvement to an error message which I don't think deserves a changelog entry either. It's just making an error message slightly more verbose to assist in debugging failures. This is mostly of interest to developers of the module, frankly, not to end users.

The third probably does deserve a changelog fragment: I'm adding some intelligence to handle boolean values properly instead of just failing. I'll submit a changelog fragment for that as soon as I have the PR number.
##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
dconf