### PR TITLE
Add worklog functionality to jira module

### DIFF
--- a/changelogs/fragments/6210-add-worklog-functionality-to-jira.yml
+++ b/changelogs/fragments/6210-add-worklog-functionality-to-jira.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jira - add worklog functionality (https://github.com/ansible-collections/community.general/issues/6209, https://github.com/ansible-collections/community.general/pull/6210).

--- a/tests/integration/targets/jira/tasks/main.yml
+++ b/tests/integration/targets/jira/tasks/main.yml
@@ -67,6 +67,24 @@
     that:
       - assign is changed
 
+- name: Worklog on issue
+  community.general.jira:
+    uri: '{{ server }}'
+    username: '{{ user }}'
+    password: '{{ pass }}'
+    issue: '{{ issue.meta.key }}'
+    operation: worklog
+    comment: Worklog
+    fields:
+      timeSpentSeconds: 1200
+  register: worklog
+- name: assert worklog -> with comment
+  assert:
+    that:
+      - worklog is changed
+      - worklog.meta.comment == 'Worklog'
+      - worklog.meta.timeSpentSeconds == 1200
+
 - name: transition -> Resolved with comment
   community.general.jira:
     uri: "{{ uri }}"


### PR DESCRIPTION
##### SUMMARY
This adds the functionality to jira be able to add worklog comments.

Fixes #6209

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.jira

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Worklog on issue
  community.general.jira:
    uri: '{{ server }}'
    username: '{{ user }}'
    password: '{{ pass }}'
    issue: '{{ issue.meta.key }}'
    operation: worklog
    comment: A worklog added by Ansible
    fields:
      timeSpentSeconds: 12000
```
