### PR TITLE
rhsm modules: cleanly fail when not run as root

### DIFF
--- a/changelogs/fragments/6211-rhsm-require-root.yml
+++ b/changelogs/fragments/6211-rhsm-require-root.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - redhat_subscription, rhsm_release, rhsm_repository - cleanly fail when not running as root,
+    rather than hanging on an interactive ``console-helper`` prompt; they all interact with
+    ``subscription-manager``, which already requires to be run as root
+    (https://github.com/ansible-collections/community.general/issues/734,
+     https://github.com/ansible-collections/community.general/pull/6211).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -24,6 +24,8 @@ notes:
       I(server_proxy_hostname), I(server_proxy_port), I(server_proxy_user) and
       I(server_proxy_password) are no longer taken from the C(/etc/rhsm/rhsm.conf)
       config file and default to None.
+    - It is possible to interact with C(subscription-manager) only as root,
+      so root permissions are required to successfully run this module.
 requirements:
     - subscription-manager
     - Optionally the C(dbus) Python library; this is usually included in the OS
@@ -291,7 +293,7 @@ subscribed_pool_ids:
 '''
 
 from os.path import isfile
-from os import unlink
+from os import getuid, unlink
 import re
 import shutil
 import tempfile
@@ -1073,6 +1075,11 @@ def main():
                             ['pool', 'pool_ids']],
         required_if=[['state', 'present', ['username', 'activationkey', 'token'], True]],
     )
+
+    if getuid() != 0:
+        module.fail_json(
+            msg="Interacting with subscription-manager requires root permissions ('become: true')"
+        )
 
     rhsm.module = module
     state = module.params['state']

--- a/plugins/modules/rhsm_release.py
+++ b/plugins/modules/rhsm_release.py
@@ -18,6 +18,8 @@ notes:
   - This module will fail on an unregistered system.
     Use the C(redhat_subscription) module to register a system
     prior to setting the RHSM release.
+  - It is possible to interact with C(subscription-manager) only as root,
+    so root permissions are required to successfully run this module.
 requirements:
   - Red Hat Enterprise Linux 6+ with subscription-manager installed
 extends_documentation_fragment:
@@ -63,6 +65,7 @@ current_release:
 
 from ansible.module_utils.basic import AnsibleModule
 
+import os
 import re
 
 # Matches release-like values such as 7.2, 5.10, 6Server, 8
@@ -108,6 +111,11 @@ def main():
         ),
         supports_check_mode=True
     )
+
+    if os.getuid() != 0:
+        module.fail_json(
+            msg="Interacting with subscription-manager requires root permissions ('become: true')"
+        )
 
     target_release = module.params['release']
 

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -29,6 +29,8 @@ def patch_redhat_subscription(mocker):
                  return_value='/testbin/subscription-manager')
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.Rhsm._can_connect_to_dbus',
                  return_value=False)
+    mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.getuid',
+                 return_value=0)
 
 
 @pytest.mark.parametrize('patch_ansible_module', [{}], indirect=['patch_ansible_module'])

--- a/tests/unit/plugins/modules/test_rhsm_release.py
+++ b/tests/unit/plugins/modules/test_rhsm_release.py
@@ -30,9 +30,16 @@ class RhsmRepositoryReleaseModuleTestCase(ModuleTestCase):
         self.get_bin_path = self.mock_get_bin_path.start()
         self.get_bin_path.return_value = '/testbin/subscription-manager'
 
+        # subscription-manager needs to be run as root
+        self.mock_os_getuid = patch('ansible_collections.community.general.plugins.modules.rhsm_release.'
+                                    'os.getuid')
+        self.os_getuid = self.mock_os_getuid.start()
+        self.os_getuid.return_value = 0
+
     def tearDown(self):
         self.mock_run_command.stop()
         self.mock_get_bin_path.stop()
+        self.mock_os_getuid.stop()
         super(RhsmRepositoryReleaseModuleTestCase, self).tearDown()
 
     def module_main(self, exit_exc):


### PR DESCRIPTION
##### SUMMARY

`subscription-manager` on RHEL installs a symlink in `/usr/bin` to `console-helper` (part of usermode), which triggers an interactive prompt for root credentials when run as user. It seems that `console-helper` does not handle well non-interactive contexts (e.g. without a TTY for input), and thus it will hang waiting for input when run as user in an Ansible task.

Since `subscription-manager` requires root already anyway (and it will fail when explicitly run as user), then apply the same logic locally on all the modules that interact with it: `redhat_subscription`, `rhsm_release`, and `rhsm_repository`.

Fixes #734

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

A simple reproducer is running any of `redhat_subscription`, `rhsm_release`, or `rhsm_repository` without any privilege escalation (i.e. `become`).