### PR TITLE
pipx: document parameters supported with state=latest, and fix include_injected parameter

### DIFF
--- a/changelogs/fragments/6212-pipx-include-injected.yml
+++ b/changelogs/fragments/6212-pipx-include-injected.yml
@@ -1,2 +1,2 @@
-bugfixes:
-  - pipx - Ensure ``include_injected`` parameter works with ``state=upgrade`` and ``state=latest`` (https://github.com/ansible-collections/community.general/pull/6212).
+minor_changes:
+  - pipx - ensure ``include_injected`` parameter works with ``state=upgrade`` and ``state=latest`` (https://github.com/ansible-collections/community.general/pull/6212).

--- a/changelogs/fragments/6212-pipx-include-injected.yml
+++ b/changelogs/fragments/6212-pipx-include-injected.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pipx - Ensure ``include_injected`` parameter works with ``state=upgrade`` and ``state=latest`` (https://github.com/ansible-collections/community.general/pull/6212).

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -76,7 +76,7 @@ options:
         description:
             - Upgrade the injected packages along with the application.
             - Only used when I(state=upgrade), I(state=upgrade_all), or I(state=latest).
-            - I(state=upgrade) and I(state=latest) added in community.general 6.5.0.
+            - This is used with I(state=upgrade) and I(state=latest) since community.general 6.5.0.
         type: bool
         default: false
     index_url:

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -76,7 +76,7 @@ options:
         description:
             - Upgrade the injected packages along with the application.
             - Only used when I(state=upgrade), I(state=upgrade_all), or I(state=latest).
-            - This is used with I(state=upgrade) and I(state=latest) since community.general 6.5.0.
+            - This is used with I(state=upgrade) and I(state=latest) since community.general 6.6.0.
         type: bool
         default: false
     index_url:

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -75,7 +75,8 @@ options:
     include_injected:
         description:
             - Upgrade the injected packages along with the application.
-            - Only used when I(state=upgrade) or I(state=upgrade_all).
+            - Only used when I(state=upgrade), I(state=upgrade_all), or I(state=latest).
+            - I(state=upgrade) and I(state=latest) added in community.general 6.5.0.
         type: bool
         default: false
     index_url:
@@ -254,7 +255,7 @@ class PipX(StateModuleHelper):
         if self.vars.force:
             self.changed = True
 
-        with self.runner('state index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
+        with self.runner('state include_injected index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
             ctx.run()
             self._capture_results(ctx)
 
@@ -307,7 +308,7 @@ class PipX(StateModuleHelper):
                 ctx.run(state='install', name_source=[self.vars.name, self.vars.source])
                 self._capture_results(ctx)
 
-        with self.runner('state index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
+        with self.runner('state include_injected index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
             ctx.run(state='upgrade')
             self._capture_results(ctx)
 

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -57,7 +57,7 @@ options:
     install_deps:
         description:
             - Include applications of dependent packages.
-            - Only used when I(state=install), I(state=upgrade), or I(state=inject).
+            - Only used when I(state=install), I(state=latest), I(state=upgrade), or I(state=inject).
         type: bool
         default: false
     inject_packages:
@@ -69,7 +69,7 @@ options:
     force:
         description:
             - Force modification of the application's virtual environment. See C(pipx) for details.
-            - Only used when I(state=install), I(state=upgrade), I(state=upgrade_all), or I(state=inject).
+            - Only used when I(state=install), I(state=upgrade), I(state=upgrade_all), I(state=latest), or I(state=inject).
         type: bool
         default: false
     include_injected:
@@ -81,12 +81,12 @@ options:
     index_url:
         description:
             - Base URL of Python Package Index.
-            - Only used when I(state=install), I(state=upgrade), or I(state=inject).
+            - Only used when I(state=install), I(state=upgrade), I(state=latest), or I(state=inject).
         type: str
     python:
         description:
             - Python version to be used when creating the application virtual environment. Must be 3.6+.
-            - Only used when I(state=install), I(state=reinstall), or I(state=reinstall_all).
+            - Only used when I(state=install), I(state=latest), I(state=reinstall), or I(state=reinstall_all).
         type: str
     executable:
         description:


### PR DESCRIPTION
##### SUMMARY

Improve the pipx module so the documentation matches what attributes are allowed with which `state`s.

- Document which parameters are allowed with `state=latest` (everything supported with either `state=install` or `state=upgrade`)
- Fix `include_injected` so that it works with `state=upgrade` and `state=latest`


This depends on #6198. Happy to keep it as a separate PR or fold it into that one.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
pipx

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->