### PR TITLE
Fixed XenOrchestra inventory plugin failing due to not checking response ID.

### DIFF
--- a/changelogs/fragments/6227-xen-orchestra-check-response-id.yml
+++ b/changelogs/fragments/6227-xen-orchestra-check-response-id.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - xenorchestra inventory plugin - fix failure to receive objects from server due to not checking the id of the response. (https://github.com/ansible-collections/community.general/pull/6227)
+  - xenorchestra inventory plugin - fix failure to receive objects from server due to not checking the id of the response (https://github.com/ansible-collections/community.general/pull/6227).

--- a/changelogs/fragments/6227-xen-orchestra-check-response-id.yml
+++ b/changelogs/fragments/6227-xen-orchestra-check-response-id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - xenorchestra inventory plugin - fix failure to receive objects from server due to not checking the id of the response. (https://github.com/ansible-collections/community.general/pull/6227)

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -141,9 +141,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     CALL_TIMEOUT = 100
     """Number of 1/10ths of a second to wait before method call times out."""
-    def call(self, method: str, params: dict) -> dict:
+
+    def call(self, method, params):
         """Calls a method on the XO server with the provided parameters."""
-        id = int(self.pointer)
+        id = self.pointer
         self.conn.send(json.dumps({
             'id': id,
             'jsonrpc': '2.0',

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -139,7 +139,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.conn = create_connection(
             '{0}://{1}/api/'.format(proto, xoa_api_host), sslopt=sslopt)
 
-
     CALL_TIMEOUT = 100
     """Number of 1/10ths of a second to wait before method call times out."""
     def call(self, method: str, params: dict) -> dict:
@@ -163,7 +162,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         raise AnsibleError(
             f'Method call {method} timed out after {self.CALL_TIMEOUT / 10} seconds.')
-
 
     def login(self, user, password):
         result = self.call('session.signIn', {

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -162,7 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 waited += 1
 
         raise AnsibleError(
-            f'Method call {method} timed out after {self.CALL_TIMEOUT / 10} seconds.')
+            'Method call {method} timed out after {timeout} seconds.'.format(method=method, timeout=self.CALL_TIMEOUT / 10))
 
     def login(self, user, password):
         result = self.call('session.signIn', {

--- a/plugins/inventory/xen_orchestra.py
+++ b/plugins/inventory/xen_orchestra.py
@@ -78,6 +78,7 @@ compose:
 
 import json
 import ssl
+from time import sleep
 
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
@@ -138,21 +139,43 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.conn = create_connection(
             '{0}://{1}/api/'.format(proto, xoa_api_host), sslopt=sslopt)
 
+
+    CALL_TIMEOUT = 100
+    """Number of 1/10ths of a second to wait before method call times out."""
+    def call(self, method: str, params: dict) -> dict:
+        """Calls a method on the XO server with the provided parameters."""
+        id = int(self.pointer)
+        self.conn.send(json.dumps({
+            'id': id,
+            'jsonrpc': '2.0',
+            'method': method,
+            'params': params
+        }))
+
+        waited = 0
+        while waited < self.CALL_TIMEOUT:
+            response = json.loads(self.conn.recv())
+            if 'id' in response and response['id'] == id:
+                return response
+            else:
+                sleep(0.1)
+                waited += 1
+
+        raise AnsibleError(
+            f'Method call {method} timed out after {self.CALL_TIMEOUT / 10} seconds.')
+
+
     def login(self, user, password):
-        payload = {'id': self.pointer, 'jsonrpc': '2.0', 'method': 'session.signIn', 'params': {
-            'username': user, 'password': password}}
-        self.conn.send(json.dumps(payload))
-        result = json.loads(self.conn.recv())
+        result = self.call('session.signIn', {
+            'username': user, 'password': password
+        })
 
         if 'error' in result:
             raise AnsibleError(
                 'Could not connect: {0}'.format(result['error']))
 
     def get_object(self, name):
-        payload = {'id': self.pointer, 'jsonrpc': '2.0',
-                   'method': 'xo.getAllObjects', 'params': {'filter': {'type': name}}}
-        self.conn.send(json.dumps(payload))
-        answer = json.loads(self.conn.recv())
+        answer = self.call('xo.getAllObjects', {'filter': {'type': name}})
 
         if 'error' in answer:
             raise AnsibleError(


### PR DESCRIPTION
##### SUMMARY
I ran into an issue where about 1/3 of the time, when using the XenOrchestra inventory plugin, the process would fail due to the first response from the XO server received being unrelated to the request. This can be easily fixed by checking that the response ID is the same as the request ID, which is what this change does.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xen_orchestra inventory

##### ADDITIONAL INFORMATION
The messages from the server that cause the issue vary, but one that I noticed frequently is shown below:
```
{
  "jsonrpc": "2.0",
  "method": "all",
  "params": {
    "type": "exit",
    "items": {
      "eb859a79-1725-eecd-67e6-b9bf941205e4": 0
    }
  }
}
```

Before change:
```
[ansible@ansible-machine ~]$ ansible-inventory -i /etc/ansible/xen_orchestra.yml --graph
[WARNING]:  * Failed to parse /etc/ansible/xen_orchestra.yml with ansible_collections.community.general.plugins.inventory.xen_orchestra plugin: 'result'
[WARNING]: Unable to parse /etc/ansible/xen_orchestra.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
@all:
  |--@ungrouped:
```

After change:
```
[ansible@ansible-machine ~]$ ansible-inventory -i /etc/ansible/xen_orchestra.yml --graph                                                                   @all:
  |--@halted:                                                                                                                                                              
  |  |--027c4638-0ad1-aab3-bc38-0c34a0009058                                                                                                                            
  |  |--02ddbd9b-af42-bab1-6811-e1e22ba719bf                                                                                                                             
  |  |--058c4616-ee04-b310-7aa8-95fb0aedab08
...
```

