### PR TITLE
redhat_subscription: use required_together for activationkey + org_id

### DIFF
--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -1069,6 +1069,7 @@ def main():
             }
         },
         required_together=[['username', 'password'],
+                           ['activationkey', 'org_id'],
                            ['server_proxy_hostname', 'server_proxy_port'],
                            ['server_proxy_user', 'server_proxy_password']],
         mutually_exclusive=[['activationkey', 'username'],
@@ -1100,8 +1101,6 @@ def main():
     auto_attach = module.params['auto_attach']
     activationkey = module.params['activationkey']
     org_id = module.params['org_id']
-    if activationkey and not org_id:
-        module.fail_json(msg='org_id is required when using activationkey')
     environment = module.params['environment']
     pool = module.params['pool']
     pool_ids = {}


### PR DESCRIPTION
##### SUMMARY

Use the `required_together` mechanism of `AnsibleModule` to ensure automatically that `org_id` is also specified when `activationkey` is specified, rather than doing it manually.

There should be no behaviour change.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

redhat_subscription