### PR TITLE
lxd: fix #6204

### DIFF
--- a/changelogs/fragments/6232-fix-lxd-cert-authentication.yml
+++ b/changelogs/fragments/6232-fix-lxd-cert-authentication.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lxd inventory - bugfix to authenticate client certificates at the server (https://github.com/ansible-collections/community.general/issues/6204)

--- a/changelogs/fragments/6232-fix-lxd-cert-authentication.yml
+++ b/changelogs/fragments/6232-fix-lxd-cert-authentication.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - lxd inventory - bugfix to authenticate client certificates at the server (https://github.com/ansible-collections/community.general/issues/6204)
+  - lxd inventory plugin - bugfix to authenticate client certificates at the server (https://github.com/ansible-collections/community.general/issues/6204).

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -107,6 +107,14 @@ plugin: community.general.lxd
 url: unix:/var/snap/lxd/common/lxd/unix.socket
 type_filter: both
 
+# simple lxd.yml including virtual machines and containers
+plugin: community.general.lxd
+url: "https://example.com:8443"
+type_filter: both
+client_cert: "~/.config/lxc/client.crt"
+client_key: "~/.config/lxc/client.key"
+trust_password: "SUPERSECRET"
+
 # grouping lxd.yml
 groupby:
   locationBerlin:

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -1031,9 +1031,10 @@ class InventoryModule(BaseInventoryPlugin):
             None
         Returns:
             None"""
-
         if len(self.data) == 0:  # If no data is injected by unittests open socket
             self.socket = self._connect_to_socket()
+            if self.trust_password is not None and self.url.startswith('https:'):
+                self.socket.authenticate(self.trust_password)
             self.get_instance_data(self._get_instances())
             self.get_network_data(self._get_networks())
 
@@ -1044,8 +1045,6 @@ class InventoryModule(BaseInventoryPlugin):
             self.cleandata()
 
         self.extract_information_from_instance_configs()
-
-        # self.display.vvv(self.save_json_data([os.path.abspath(__file__)]))
 
         self.build_inventory()
 

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -57,16 +57,16 @@ class LXDClient(object):
         self.debug = debug
         self.logs = []
         if url.startswith('https:'):
-            try: 
+            try:
                 with open(cert_file, 'r') as fh:
                     self.cert_file = cert_file
-            except FileNotFoundError: 
+            except FileNotFoundError:
                 raise LXDClientException('The certificate "{0}" does not exist.'.format(cert_file))
 
-            try: 
+            try:
                 with open(key_file, 'r') as fh:
                     self.key_file = key_file
-            except FileNotFoundError: 
+            except FileNotFoundError:
                 raise LXDClientException('The certificate key "{0}" does not exist.'.format(key_file))
 
             parts = generic_urlparse(urlparse(self.url))

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -137,8 +137,10 @@ class LXDClient(object):
             err = resp_json.get('error', None)
         return err
 
+
 def default_key_file():
     return os.path.expanduser('~/.config/lxc/client.key')
+
 
 def default_cert_file():
     return os.path.expanduser('~/.config/lxc/client.crt')

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -57,17 +57,17 @@ class LXDClient(object):
         self.debug = debug
         self.logs = []
         if url.startswith('https:'):
-            try:
+            try: 
                 with open(cert_file, 'r') as fh:
                     self.cert_file = cert_file
-            except FileNotFoundError:
-                raise LXDClientException('The certificate is not valid.')
+            except FileNotFoundError: 
+                raise LXDClientException('The certificate "{0}" does not exist.'.format(cert_file))
 
-            try:
+            try: 
                 with open(key_file, 'r') as fh:
                     self.key_file = key_file
-            except FileNotFoundError:
-                raise LXDClientException('The certificate key is not valid.')
+            except FileNotFoundError: 
+                raise LXDClientException('The certificate key "{0}" does not exist.'.format(key_file))
 
             parts = generic_urlparse(urlparse(self.url))
             ctx = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Small bugfixes:
  - module_utils/lxd.py: 
    - python3.10 ssl no longer allow to connect with self-signed certificates by "create_default_context", so switched to "_create_unverified_context".
    - Add a check if the certificate and the key exist

  - inventory/lxd.py:
    - Add authenticate. This adds the client certificate to the trust store on the server. The trust password is required to add the client certificate.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6204

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- lxd inventory
- maybe all lxd plugins using module_utils/lxd.py

##### ADDITIONAL INFORMATION
The inventory plugin could not add the cerifikate to the truststore. If the user had done this via the cli, the plugin could build an inventory via https, otherwise only the locale socket worked.

The behavior of the Python3.10 SSL library was changed so that a change was necessary for self-signed certificates.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ansible-inventory -i lxd.yml --list
[WARNING]: * Failed to parse /home/me/inventory-lxd/lxd.yml with auto plugin: [Errno 2] No such file or directory
[WARNING]: * Failed to parse /home/me/inventory-lxd/lxd.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory
[WARNING]: * Failed to parse /home/me/inventory-lxd/lxd.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending in ':' is not
allowed, this character is reserved to provide a port.
[WARNING]: Unable to parse /home/me/inventory-lxd/lxd.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
{
"_meta": {
"hostvars": {}
},
"all": {
"children": [
"ungrouped"
]
}
}
```
Now:
```
$ ansible-inventory -i ../ansible_house_keeping/lxd.yml --list
{
    "_meta": {
        "hostvars": {
            "test": {
                "ansible_connection": "ssh",
                "ansible_host": "192.168.178.10",
                "ansible_lxd_location": "gramophone",
                "ansible_lxd_os": "ubuntu",
                "ansible_lxd_profile": [
                    "publicbridge"
                ],
                "ansible_lxd_project": "default",
                "ansible_lxd_release": "kinetic",
                "ansible_lxd_state": "running",
                "ansible_lxd_type": "container"
            },
}
```