### PR TITLE
redhat_subscription: manually unregister only when registered

### DIFF
--- a/changelogs/fragments/6259-redhat_subscription-fix-force.yaml
+++ b/changelogs/fragments/6259-redhat_subscription-fix-force.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - redhat_subscription - try to unregister only when already registered when ``force_register`` is specified
+    (https://github.com/ansible-collections/community.general/issues/6258,
+     https://github.com/ansible-collections/community.general/pull/6259).


### PR DESCRIPTION
##### SUMMARY

When registering using D-Bus and using a version of subscription-manager with an unimplemented `force` option, then unregister manually the system only if it is registered. `subscription-manager unregister` errors out when trying to unregister an already unregistered system.

Fixes #6258

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

Easy reproducer:
- RHEL 9 older than 9.2, or RHEL 8 older than 8.8, or RHEL 7 and older
- ensure the system is unregistered, and attempt to register with `force_register=true`

```yaml
- name: ensure unregistered
  redhat_subscription:
    state: absent

- name: ensure registered
  redhat_subscription:
    state: present
    force_register: true
    username: "your-username"
    password: "your-password"
    # or activationkey + org_id instead of username + password
```
