### PR TITLE
homebrew: respect greedy flag for cask upgrade_all

### DIFF
--- a/changelogs/fragments/6267-homebrew-cask-upgrade-all-greedy.yml
+++ b/changelogs/fragments/6267-homebrew-cask-upgrade-all-greedy.yml
@@ -1,2 +1,2 @@
-bugfixes:
-  - homebrew_cask - allows passing --greedy option to upgrade_all
+minor_changes:
+  - homebrew_cask - allows passing ``--greedy`` option to ``upgrade_all`` (https://github.com/ansible-collections/community.general/pull/6267).

--- a/changelogs/fragments/6267-homebrew-cask-upgrade-all-greedy.yml
+++ b/changelogs/fragments/6267-homebrew-cask-upgrade-all-greedy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew_cask - allows passing --greedy option to upgrade_all

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -78,9 +78,9 @@ options:
   greedy:
     description:
     - Upgrade casks that auto update.
-    - Passes --greedy to brew cask outdated when checking
+    - Passes C(--greedy) to C(brew outdated --cask) when checking
       if an installed cask has a newer version available,
-      or to brew cask upgrade when upgrading all casks.
+      or to C(brew upgrade --cask) when upgrading all casks.
     type: bool
     default: false
 '''

--- a/plugins/modules/homebrew_cask.py
+++ b/plugins/modules/homebrew_cask.py
@@ -79,7 +79,8 @@ options:
     description:
     - Upgrade casks that auto update.
     - Passes --greedy to brew cask outdated when checking
-      if an installed cask has a newer version available.
+      if an installed cask has a newer version available,
+      or to brew cask upgrade when upgrading all casks.
     type: bool
     default: false
 '''
@@ -127,6 +128,11 @@ EXAMPLES = '''
 - name: Upgrade all casks
   community.general.homebrew_cask:
     upgrade_all: true
+
+- name: Upgrade all casks with greedy option
+  community.general.homebrew_cask:
+    upgrade_all: true
+    greedy: true
 
 - name: Upgrade given cask with force option
   community.general.homebrew_cask:
@@ -580,6 +586,9 @@ class HomebrewCask(object):
             cmd = [self.brew_path, 'upgrade', '--cask']
         else:
             cmd = [self.brew_path, 'cask', 'upgrade']
+
+        if self.greedy:
+            cmd = cmd + ['--greedy']
 
         rc, out, err = '', '', ''
 


### PR DESCRIPTION
##### SUMMARY
The homebrew_cask upgrade_all action should respect the greedy option.

So far the greedy flag was only parsed when upgrading a given cask. With this PR it can also be used when upgrading all installed casks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew_cask