### PR TITLE
archive: Generate crc32 over 16MiB chunks

### DIFF
--- a/changelogs/fragments/6199-archive-generate-checksum-in-chunks.yml
+++ b/changelogs/fragments/6199-archive-generate-checksum-in-chunks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - archive - reduce ram usage by generating crc32 checksum over chunks

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -608,7 +608,10 @@ class TarArchive(Archive):
                 # The python implementations of gzip, bz2, and lzma do not support restoring compressed files
                 # to their original names so only file checksum is returned
                 f = self._open_compressed_file(_to_native_ascii(path), 'r')
-                checksums = set([(b'', crc32(f.read()))])
+                checksum = 0
+                while (chunk := f.read(16 * 1024 * 1024)) :
+                    checksum = crc32(chunk, checksum)
+                checksums = set([(b'', crc32(checksum))]
                 f.close()
             except Exception:
                 checksums = set()


### PR DESCRIPTION
##### SUMMARY
Running crc32 over the whole content of the compressed file potentially requires a lot of RAM. The crc32 function in zlib allows for calculating the checksum in chunks. This changes the code to calculate the checksum over 16 MiB chunks instead. 16 MiB is the value also used by shutil.copyfileobj().

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #6272

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
archive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
