### PR TITLE
redhat_subscription: fix D-Bus option for environments on CentOS

### DIFF
--- a/changelogs/fragments/6275-redhat_subscription-fix-environments-centos.yaml
+++ b/changelogs/fragments/6275-redhat_subscription-fix-environments-centos.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - redhat_subscription - use the right D-Bus options for environments when registering
+    a CentOS Stream 8 system and using ``environment``
+    (https://github.com/ansible-collections/community.general/pull/6275).


### PR DESCRIPTION
##### SUMMARY

Factorize the current logic to determine whether use `environments` as D-Bus registration option (rather than `environment`) in an own function, so it is easier to read it and maintain it.

With the small helper function in place, extend the logic to support CentOS: it is in practice the same as the RHEL one, with an additional check to support CentOS Stream 8 (which is a rolling release, and not versioned).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription

##### ADDITIONAL INFORMATION

Register a CentOS Stream 8 system to a registration server that supports environments (typically Satellite):

```yaml
- redhat_subscription:
    state: present
    username: "your-username"
    password: "your-password"
    # or activationkey + org_id instead of username + password
    environment: "environment-id"
```