### PR TITLE
icinga2_host: make use of templates and template vars

### DIFF
--- a/changelogs/fragments/6286-icinga2_host-template-and-template-vars.yml
+++ b/changelogs/fragments/6286-icinga2_host-template-and-template-vars.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "icinga2_host - fix the data structure sent to Icinga to make use of host templates and template vars (https://github.com/ansible-collections/community.general/pull/6286)"
+  - "icinga2_host - fix the data structure sent to Icinga to make use of host templates and template vars (https://github.com/ansible-collections/community.general/pull/6286)."

--- a/changelogs/fragments/6286-icinga2_host-template-and-template-vars.yml
+++ b/changelogs/fragments/6286-icinga2_host-template-and-template-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "icinga2_host - fix the data structure sent to Icinga to make use of host templates and template vars (https://github.com/ansible-collections/community.general/pull/6286)"

--- a/plugins/modules/icinga2_host.py
+++ b/plugins/modules/icinga2_host.py
@@ -256,9 +256,8 @@ def main():
     state = module.params["state"]
     name = module.params["name"]
     zone = module.params["zone"]
-    template = [name]
     if module.params["template"]:
-        template.append(module.params["template"])
+        template = [module.params["template"]]
     check_command = module.params["check_command"]
     ip = module.params["ip"]
     display_name = module.params["display_name"]
@@ -273,20 +272,18 @@ def main():
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % (e))
 
     data = {
+        'templates': template,
         'attrs': {
             'address': ip,
             'display_name': display_name,
             'check_command': check_command,
             'zone': zone,
-            'vars': {
-                'made_by': "ansible",
-            },
-            'templates': template,
+            'vars.made_by': "ansible"
         }
     }
 
-    if variables:
-        data['attrs']['vars'].update(variables)
+    for key, value in variables.items():
+        data['attrs']['vars.' + key] = value
 
     changed = False
     if icinga.exists(name):

--- a/plugins/modules/icinga2_host.py
+++ b/plugins/modules/icinga2_host.py
@@ -256,6 +256,7 @@ def main():
     state = module.params["state"]
     name = module.params["name"]
     zone = module.params["zone"]
+    template = []
     if module.params["template"]:
         template = [module.params["template"]]
     check_command = module.params["check_command"]


### PR DESCRIPTION
##### SUMMARY

Currently, the `template` parameter of the icinga2_host module is not sent correctly to Icinga, which results in the impossibility to use host templates when using this module.
This is due to an incorrect data structure, see [this example with curl](https://icinga.com/blog/2020/07/02/creating-a-host-through-the-icinga-2-api/) for the correct data structure.

This PR fixes it by submitting the correct data structure to the Icinga API.

This PR also enables inheritance of the template vars to the created host. In the current code, the whole `vars` array is sent to Icinga, which causes Icinga to ignore vars declared in the template. In this PR's code, the `vars` array is not redefined, each variable is send to Icinga as `vars.key = value`:

Current code : `vars = { distro = Debian } // redefines the vars array, we lose the template vars`
PR's code: `vars.distro = Debian // append vars.distro to the vars array, we keep inherited vars`

Fixes #3905.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

icinga2_host module

##### ADDITIONAL INFORMATION
