### PR TITLE
Remove --app by flatpak check if already installed (ansible-collectio…

### DIFF
--- a/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
+++ b/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
@@ -1,8 +1,2 @@
-bugfix:
-  - >
-  flatpak - fixes idempotency detection issues. In some
-  cases the module could fail to properly detect already existing flatpaks
-  because of a parameter witch only checks the installed apps.
-  (https://github.com/ansible-collections/community.general/pull/6289)
-
-  
+bugfixes:
+  - flatpak - fixes idempotency detection issues. In some cases the module could fail to properly detect already existing flatpaks because of a parameter witch only checks the installed apps. (https://github.com/ansible-collections/community.general/pull/6289).

--- a/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
+++ b/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - flatpak - fixes idempotency detection issues. In some cases the module could fail to properly detect already existing flatpaks because of a parameter witch only checks the installed apps. (https://github.com/ansible-collections/community.general/pull/6289).
+  - flatpak - fixes idempotency detection issues. In some cases the module could fail to properly detect already existing Flatpaks because of a parameter witch only checks the installed apps (https://github.com/ansible-collections/community.general/pull/6289).

--- a/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
+++ b/changelogs/fragments/6289-bugfix-flatpak-check-if-already-installed.yml
@@ -1,0 +1,8 @@
+bugfix:
+  - >
+  flatpak - fixes idempotency detection issues. In some
+  cases the module could fail to properly detect already existing flatpaks
+  because of a parameter witch only checks the installed apps.
+  (https://github.com/ansible-collections/community.general/pull/6289)
+
+  

--- a/plugins/modules/flatpak.py
+++ b/plugins/modules/flatpak.py
@@ -215,7 +215,7 @@ def uninstall_flat(module, binary, names, method):
 
 def flatpak_exists(module, binary, names, method):
     """Check if the flatpaks are installed."""
-    command = [binary, "list", "--{0}".format(method), "--app"]
+    command = [binary, "list", "--{0}".format(method)]
     output = _flatpak_command(module, False, command)
     installed = []
     not_installed = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, when installing a Flatpak, the command "flatpak list --[user|system] --app" is used to test whether the package is already installed or not. But since not every package is an app, packages like "org.gtk.Gtk3theme.Matcha-dark-sea" or "org.kde.KStyle.Adwaita" are not listed and are therefore not considered as installed.
Removing the "--app" option fix this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6265
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
flatpak module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
