### PR TITLE
Add skip_tags option to Puppet module

### DIFF
--- a/changelogs/fragments/6293-add-puppet-skip-tags-option.yaml
+++ b/changelogs/fragments/6293-add-puppet-skip-tags-option.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - puppet module - add new options ``skip_tags`` to exclude certain tagged resources during a puppet agent or apply (https://github.com/ansible-collections/community.general/pull/6293).
+  

--- a/changelogs/fragments/6293-add-puppet-skip-tags-option.yaml
+++ b/changelogs/fragments/6293-add-puppet-skip-tags-option.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - puppet module - add new options ``skip_tags`` to exclude certain tagged resources during a puppet agent or apply (https://github.com/ansible-collections/community.general/pull/6293).
+  - puppet - add new options ``skip_tags`` to exclude certain tagged resources during a puppet agent or apply (https://github.com/ansible-collections/community.general/pull/6293).
   

--- a/plugins/module_utils/puppet.py
+++ b/plugins/module_utils/puppet.py
@@ -96,6 +96,7 @@ def puppet_runner(module):
             confdir=cmd_runner_fmt.as_opt_val("--confdir"),
             environment=cmd_runner_fmt.as_opt_val("--environment"),
             tags=cmd_runner_fmt.as_func(lambda v: ["--tags", ",".join(v)]),
+            skip_tags=cmd_runner_fmt.as_func(lambda v: ["--skip_tags", ",".join(v)]),
             certname=cmd_runner_fmt.as_opt_eq_val("--certname"),
             noop=cmd_runner_fmt.as_func(noop_func),
             use_srv_records=cmd_runner_fmt.as_map({

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -86,6 +86,7 @@ options:
       - A list of puppet tags to be excluded.
     type: list
     elements: str
+    version_added: 6.6.0
   execute:
     description:
       - Execute a specific piece of Puppet code.

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -81,6 +81,11 @@ options:
       - A list of puppet tags to be used.
     type: list
     elements: str
+  skip_tags:
+    description:
+      - A list of puppet tags to be excluded.
+    type: list
+    elements: str
   execute:
     description:
       - Execute a specific piece of Puppet code.
@@ -143,6 +148,8 @@ EXAMPLES = r'''
     tags:
     - update
     - nginx
+    skip_tags:
+    - service
 
 - name: Run puppet agent in noop mode
   community.general.puppet:
@@ -198,6 +205,7 @@ def main():
             environment=dict(type='str'),
             certname=dict(type='str'),
             tags=dict(type='list', elements='str'),
+            skip_tags=dict(type='list', elements='str'),
             execute=dict(type='str'),
             summarize=dict(type='bool', default=False),
             debug=dict(type='bool', default=False),
@@ -232,11 +240,11 @@ def main():
     runner = puppet_utils.puppet_runner(module)
 
     if not p['manifest'] and not p['execute']:
-        args_order = "_agent_fixed puppetmaster show_diff confdir environment tags certname noop use_srv_records"
+        args_order = "_agent_fixed puppetmaster show_diff confdir environment tags skip_tags certname noop use_srv_records"
         with runner(args_order) as ctx:
             rc, stdout, stderr = ctx.run()
     else:
-        args_order = "_apply_fixed logdest modulepath environment certname tags noop _execute summarize debug verbose"
+        args_order = "_apply_fixed logdest modulepath environment certname tags skip_tags noop _execute summarize debug verbose"
         with runner(args_order) as ctx:
             rc, stdout, stderr = ctx.run(_execute=[p['execute'], p['manifest']])
 

--- a/tests/unit/plugins/modules/test_puppet.py
+++ b/tests/unit/plugins/modules/test_puppet.py
@@ -102,6 +102,30 @@ TEST_CASES = [
             "changed": False,
         }
     ],
+    [
+        {
+            "skip_tags": ["d", "e", "f"]
+        },
+        {
+            "id": "puppet_agent_skip_tags_def",
+            "run_command.calls": [
+                (
+                    ["/testbin/puppet", "config", "print", "agent_disabled_lockfile"],
+                    {"environ_update": {"LANGUAGE": "C", "LC_ALL": "C"}, "check_rc": False},
+                    (0, "blah, anything", "",),  # output rc, out, err
+                ),
+                (
+                    [
+                        "/testbin/timeout", "-s", "9", "30m", "/testbin/puppet", "agent", "--onetime", "--no-daemonize",
+                        "--no-usecacheonfailure", "--no-splay", "--detailed-exitcodes", "--verbose", "--color", "0", "--skip_tags", "d,e,f"
+                    ],
+                    {"environ_update": {"LANGUAGE": "C", "LC_ALL": "C"}, "check_rc": False},
+                    (0, "", "",),  # output rc, out, err
+                ),
+            ],
+            "changed": False,
+        }
+    ]
 ]
 TEST_CASES_IDS = [item[1]["id"] for item in TEST_CASES]
 


### PR DESCRIPTION
##### SUMMARY
Add a new option to `skip_tags` ([reference](https://www.puppet.com/docs/puppet/7/configuration.html#skip-tags)) to the Puppet module for Ansible to exclude certain tagged resources during a puppet agent or apply.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.general.puppet module`

##### ADDITIONAL INFORMATION
First PR here, so hopefully I have everything in order.  Thanks in advance for your review and consideration.
