### PR TITLE
one_vm: fix syntax error when creating VMs with a more complex template

### DIFF
--- a/changelogs/fragments/6294-fix-one_vm-instantiation.yml
+++ b/changelogs/fragments/6294-fix-one_vm-instantiation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - one_vm - fix syntax error when creating VMs with a more complex template (https://github.com/ansible-collections/community.general/issues/6225).

--- a/plugins/module_utils/opennebula.py
+++ b/plugins/module_utils/opennebula.py
@@ -45,6 +45,8 @@ def render(to_render):
     """Converts dictionary to OpenNebula template."""
     def recurse(to_render):
         for key, value in sorted(to_render.items()):
+            if value is None:
+                continue
             if isinstance(value, dict):
                 yield '{0:}=[{1:}]'.format(key, ','.join(recurse(value)))
                 continue

--- a/plugins/module_utils/opennebula.py
+++ b/plugins/module_utils/opennebula.py
@@ -52,6 +52,9 @@ def render(to_render):
                 for item in value:
                     yield '{0:}=[{1:}]'.format(key, ','.join(recurse(item)))
                 continue
+            if isinstance(value, str):
+                yield '{0:}="{1:}"'.format(key, value.replace('\\', '\\\\').replace('"', '\\"'))
+                continue
             yield '{0:}="{1:}"'.format(key, value)
     return '\n'.join(recurse(to_render))
 

--- a/tests/unit/plugins/module_utils/test_opennebula.py
+++ b/tests/unit/plugins/module_utils/test_opennebula.py
@@ -75,6 +75,17 @@ RENDER_VALID = [
             NIC=[NAME="NIC1",NETWORK_ID="1"]
         ''').strip()
     ),
+    (
+        {
+            'SCHED_REQUIREMENTS': 'CLUSTER_ID="100"',
+            'BACKSLASH_ESCAPED': "this is escaped: \\n; this isn't: \"\nend",
+        },
+        textwrap.dedent('''
+            BACKSLASH_ESCAPED="this is escaped: \\\\n; this isn't: \\"
+            end"
+            SCHED_REQUIREMENTS="CLUSTER_ID=\\"100\\""
+        ''').strip()
+    )
 ]
 
 

--- a/tests/unit/plugins/module_utils/test_opennebula.py
+++ b/tests/unit/plugins/module_utils/test_opennebula.py
@@ -77,6 +77,7 @@ RENDER_VALID = [
     ),
     (
         {
+            'EMPTY_VALUE': None,
             'SCHED_REQUIREMENTS': 'CLUSTER_ID="100"',
             'BACKSLASH_ESCAPED': "this is escaped: \\n; this isn't: \"\nend",
         },
@@ -85,7 +86,7 @@ RENDER_VALID = [
             end"
             SCHED_REQUIREMENTS="CLUSTER_ID=\\"100\\""
         ''').strip()
-    )
+    ),
 ]
 
 


### PR DESCRIPTION
##### SUMMARY
with more complex templates that make use of quoted strings the new `render` method fails to produce a template that is accepted by OpenNebula.  ==> escape double quotes in strings to make OpenNebula happy again.

I also tested whether newlines need to be escaped, looks like they are fine as they are.

Fixes #6225

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
one_vm

##### ADDITIONAL INFORMATION

tested on an old opennebula 5.12 cluster, but from what I can tell the opennebula version doesn't matter here ;-)