### PR TITLE
pipx: fix state=latest w/ install_deps=true

### DIFF
--- a/changelogs/fragments/6303-pipx-fix-state-latest-and-add-system-site-packages.yml
+++ b/changelogs/fragments/6303-pipx-fix-state-latest-and-add-system-site-packages.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pipx - fixed handling of ``install_deps=true`` with ``state=latest`` and ``state=upgrade`` (https://github.com/ansible-collections/community.general/pull/6303).

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -113,6 +113,7 @@ notes:
     - >
       This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR)
       passed using the R(environment Ansible keyword, playbooks_environment).
+    - This module requires C(pipx) version 0.16.2.1 or above.
     - Please note that C(pipx) requires Python 3.6 or above.
     - >
       This first implementation does not verify whether a specified version constraint has been installed or not.

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -57,7 +57,7 @@ options:
     install_deps:
         description:
             - Include applications of dependent packages.
-            - Only used when I(state=install), I(state=latest), I(state=upgrade), or I(state=inject).
+            - Only used when I(state=install), I(state=latest), or I(state=inject).
         type: bool
         default: false
     inject_packages:
@@ -256,7 +256,7 @@ class PipX(StateModuleHelper):
         if self.vars.force:
             self.changed = True
 
-        with self.runner('state include_injected index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
+        with self.runner('state include_injected index_url force editable pip_args name', check_mode_skip=True) as ctx:
             ctx.run()
             self._capture_results(ctx)
 
@@ -309,7 +309,7 @@ class PipX(StateModuleHelper):
                 ctx.run(state='install', name_source=[self.vars.name, self.vars.source])
                 self._capture_results(ctx)
 
-        with self.runner('state include_injected index_url install_deps force editable pip_args name', check_mode_skip=True) as ctx:
+        with self.runner('state include_injected index_url force editable pip_args name', check_mode_skip=True) as ctx:
             ctx.run(state='upgrade')
             self._capture_results(ctx)
 

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -53,6 +53,7 @@ notes:
     - >
       This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR)
       passed using the R(environment Ansible keyword, playbooks_environment).
+    - This module requires C(pipx) version 0.16.2.1 or above.
     - Please note that C(pipx) requires Python 3.6 or above.
     - See also the C(pipx) documentation at U(https://pypa.github.io/pipx/).
 author:

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -156,6 +156,19 @@
     name: tox
   register: uninstall_tox_latest_again
 
+- name: install application tox with deps
+  community.general.pipx:
+    state: latest
+    name: tox
+    install_deps: true
+  register: install_tox_with_deps
+
+- name: cleanup tox latest yet again
+  community.general.pipx:
+    state: absent
+    name: tox
+  register: uninstall_tox_again
+
 - name: check assertions tox latest
   assert:
     that:
@@ -170,6 +183,10 @@
       - install_tox_latest_with_preinstall_again_force is changed
       - install_tox_latest_with_preinstall_again_force.application.tox.version == latest_tox_version
       - uninstall_tox_latest_again is changed
+      - install_tox_with_deps is changed
+      - install_tox_with_deps.application.tox.version == latest_tox_version
+      - uninstall_tox_again is changed
+      - "'tox' not in uninstall_tox_again.application"
 
 ##############################################################################
 - name: ensure application ansible-lint is uninstalled


### PR DESCRIPTION
##### SUMMARY

- Document the minimum version of pipx (0.16.2.1) that works with both pipx and pipx_info modules.  I'm not changing the status quo; just documenting a preexisting limit since the pipx module was first introduced in f1807d3323f63b929bee6aa8f3eebfe614f83029, where (as today) the module relies on "pipx list --json --include-injected".  The same limitation applies to the pipx_info module since its introduction in 7ffe6539c0ba3a3c43c49ae8bfbb37213c9e95a1
- Fix a bug that prevents `state=latest` and `install_deps=true` from working, because the `pipx upgrade` command doesn't accept a `--include-deps` parameter, and hasn't since pipx 0.15. (It's safe to remove this since, per above, the module requires pipx 0.16.2.1).


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
pipx

##### ADDITIONAL INFORMATION

The failure that occurs with `install_deps=true` and `state=latest` looks like this:

```
- community.general.pipx:
    state: latest
    name: tox
    install_deps: true
```

```
fatal: [testhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/python3.10 -m pipx upgrade --include-deps tox", "msg": "usage: /usr/bin/python3.10 -m pipx [-h] [--version]\n                                   {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}\n                                   ...\n/usr/bin/python3.10 -m pipx: error: unrecognized arguments: --include-deps", "rc": 2, "stderr": "usage: /usr/bin/python3.10 -m pipx [-h] [--version]\n                                   {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}\n                                   ...\n/usr/bin/python3.10 -m pipx: error: unrecognized arguments: --include-deps\n", "stderr_lines": ["usage: /usr/bin/python3.10 -m pipx [-h] [--version]", "                                   {install,uninject,inject,upgrade,upgrade-all,uninstall,uninstall-all,reinstall,reinstall-all,list,run,runpip,ensurepath,environment,completions}", "                                   ...", "/usr/bin/python3.10 -m pipx: error: unrecognized arguments: --include-deps"], "stdout": "", "stdout_lines": []}
```
