### PR TITLE
pids tests: 'some-' is not that a unique pattern.

### DIFF
--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -43,15 +43,14 @@
 - name: Compile fake 'sleep' binary
   command: cc {{ remote_tmp_dir }}/sleeper.c -o {{ remote_tmp_dir }}/{{ random_name }}
 
-- name: Copy helper script
-  copy:
+- name: Copy templated helper script
+  template:
     src: obtainpid.sh
     dest: "{{ remote_tmp_dir }}/obtainpid.sh"
     mode: 0755
 
 - name: "Run the fake 'sleep' binary"
-  command: "sh {{ remote_tmp_dir }}/obtainpid.sh '{{ remote_tmp_dir }}/{{ random_name }}' '{{ remote_tmp_dir }}/obtainpid.txt'"
-
+  command: sh {{ remote_tmp_dir }}/obtainpid.sh
   async: 100
   poll: 0
 

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: "Picking a random process name"
   set_fact:
-    random_name: some-random-long-name-{{ 99999999 | random }}
+    random_name: some-random-long-name-{{ 10000000000 + (9999999999 | random) }}
 
 - name: Copy the fake 'sleep' source code
   copy:
@@ -66,17 +66,17 @@
 
 - name: "Checking that exact non-substring matches are required"
   pids:
-    name: "{{ random_name[0:5] }}"
+    name: "{{ random_name[0:25] }}"
   register: exactpidmatch
 
 - name: "Checking that patterns can be used with the pattern option"
   pids:
-    pattern: "{{ random_name[0:5] }}"
+    pattern: "{{ random_name[0:25] }}"
   register: pattern_pid_match
 
 - name: "Checking that case-insensitive patterns can be used with the pattern option"
   pids:
-    pattern: "{{ random_name[0:5] | upper }}"
+    pattern: "{{ random_name[0:25] | upper }}"
     ignore_case: true
   register: caseinsensitive_pattern_pid_match
 

--- a/tests/integration/targets/pids/tasks/main.yml
+++ b/tests/integration/targets/pids/tasks/main.yml
@@ -90,6 +90,15 @@
     src:  "{{ remote_tmp_dir }}/obtainpid.txt"
   register: newpid
 
+- name: Gather all processes to make debugging easier
+  command: ps aux
+  register: result
+  no_log: true
+
+- name: List all processes to make debugging easier
+  debug:
+    var: result.stdout_lines
+
 - name: "Verify that the Process IDs (PIDs) returned is not empty and also equal to the PIDs obtained in console"
   assert:
     that:

--- a/tests/integration/targets/pids/templates/obtainpid.sh
+++ b/tests/integration/targets/pids/templates/obtainpid.sh
@@ -3,5 +3,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"$1" 100 &
-echo "$!" > "$2"
+"{{ remote_tmp_dir }}/{{ random_name }}" 100 &
+echo "$!" > "{{ remote_tmp_dir }}/obtainpid.txt"


### PR DESCRIPTION
##### SUMMARY
Currently the pids integration tests fail on FreeBSD since apparently there are more processes that contain the pattern `some-`.

Let's make the collision less likely.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pids
