### PR TITLE
pipx: Add support for system_site_packages

### DIFF
--- a/changelogs/fragments/6308-pipx-add-system-site-packages.yml
+++ b/changelogs/fragments/6308-pipx-add-system-site-packages.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pipx - add ``system_site_packages`` parameter to give application access to system-wide packages (https://github.com/ansible-collections/community.general/pull/6308).

--- a/plugins/module_utils/pipx.py
+++ b/plugins/module_utils/pipx.py
@@ -39,6 +39,7 @@ def pipx_runner(module, command, **kwargs):
             include_injected=fmt.as_bool("--include-injected"),
             index_url=fmt.as_opt_val('--index-url'),
             python=fmt.as_opt_val('--python'),
+            system_site_packages=fmt.as_bool("--system-site-packages"),
             _list=fmt.as_fixed(['list', '--include-injected', '--json']),
             editable=fmt.as_bool("--editable"),
             pip_args=fmt.as_opt_val('--pip-args'),

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -89,6 +89,13 @@ options:
             - Python version to be used when creating the application virtual environment. Must be 3.6+.
             - Only used when I(state=install), I(state=latest), I(state=reinstall), or I(state=reinstall_all).
         type: str
+    system_site_packages:
+        description:
+            - Give application virtual environment access to the system site-packages directory.
+            - Only used when I(state=install) or I(state=latest).
+        type: bool
+        default: false
+        version_added: 6.6.0
     executable:
         description:
             - Path to the C(pipx) installed in the system.
@@ -176,6 +183,7 @@ class PipX(StateModuleHelper):
             include_injected=dict(type='bool', default=False),
             index_url=dict(type='str'),
             python=dict(type='str'),
+            system_site_packages=dict(type='bool', default=False),
             executable=dict(type='path'),
             editable=dict(type='bool', default=False),
             pip_args=dict(type='str'),
@@ -243,7 +251,7 @@ class PipX(StateModuleHelper):
     def state_install(self):
         if not self.vars.application or self.vars.force:
             self.changed = True
-            with self.runner('state index_url install_deps force python editable pip_args name_source', check_mode_skip=True) as ctx:
+            with self.runner('state index_url install_deps force python system_site_packages editable pip_args name_source', check_mode_skip=True) as ctx:
                 ctx.run(name_source=[self.vars.name, self.vars.source])
                 self._capture_results(ctx)
 
@@ -304,7 +312,7 @@ class PipX(StateModuleHelper):
     def state_latest(self):
         if not self.vars.application or self.vars.force:
             self.changed = True
-            with self.runner('state index_url install_deps force python editable pip_args name_source', check_mode_skip=True) as ctx:
+            with self.runner('state index_url install_deps force python system_site_packages editable pip_args name_source', check_mode_skip=True) as ctx:
                 ctx.run(state='install', name_source=[self.vars.name, self.vars.source])
                 self._capture_results(ctx)
 

--- a/tests/integration/targets/pipx/tasks/main.yml
+++ b/tests/integration/targets/pipx/tasks/main.yml
@@ -52,6 +52,34 @@
       - "'tox' not in uninstall_tox.application"
 
 ##############################################################################
+- name: install application tox with system-site-packages
+  community.general.pipx:
+    name: tox
+    system_site_packages: true
+  register: install_tox
+
+- name: get raw pipx_info
+  community.general.pipx_info:
+    include_raw: true
+  register: pipx_info_raw
+
+- name: uninstall application tox
+  community.general.pipx:
+    state: absent
+    name: tox
+  register: uninstall_tox
+
+- name: check assertions tox
+  assert:
+    that:
+      - install_tox is changed
+      - "'tox' in install_tox.application"
+      - pipx_info_raw is not changed
+      - "'--system-site-packages' in pipx_info_raw.raw_output.venvs.tox.metadata.venv_args"
+      - uninstall_tox is changed
+      - "'tox' not in uninstall_tox.application"
+
+##############################################################################
 - name: install application tox 3.24.0
   community.general.pipx:
     name: tox


### PR DESCRIPTION
##### SUMMARY

- Add `system_site_packages` module parameter to pipx, which gives an application's virtual environment access to the system-wide system-site-packages.  (This just corresponds to pipx's `--system-site-packages` parameter)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pipx

##### ADDITIONAL INFORMATION

Split off of #6303 per request
