### PR TITLE
pkgng: skip jail tests also on FreeBSD 12.3

### DIFF
--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -501,8 +501,11 @@
   # NOTE: FreeBSD 12.0 test runner receives a "connection reset by peer" after ~20% downloaded so we are
   #       only running this on 12.1 or higher
   #
+  # NOTE: FreeBSD 12.3 fails with some kernel mismatch for packages
+  #       (someone with FreeBSD knowledge has to take a look)
+  #
   # NOTE: FreeBSD 12.4 fails to update repositories because it cannot load certificates from /usr/share/keys/pkg/trusted
-  #       knowledge has to take a look)
+  #       (someone with FreeBSD knowledge has to take a look)
   #
   # NOTE: FreeBSD 13.0 fails to update the package catalogue for unknown reasons (someone with FreeBSD
   #       knowledge has to take a look)
@@ -513,7 +516,7 @@
   # See also
   # https://github.com/ansible-collections/community.general/issues/5795
   when: >-
-    (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('12.4', '<'))
+    (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('12.3', '<'))
     or ansible_distribution_version is version('13.2', '>=')
   block:
     - name: Setup testjail


### PR DESCRIPTION
##### SUMMARY
They currently fail:
- https://dev.azure.com/ansible/community.general/_build/results?buildId=73613&view=logs&j=c12a8e90-c78d-5d96-c83c-8beac118ca9b&t=0da6623a-06d0-5789-1f6f-991060dffcb9&l=12432
- https://dev.azure.com/ansible/community.general/_build/results?buildId=73633&view=logs&j=c12a8e90-c78d-5d96-c83c-8beac118ca9b&t=0da6623a-06d0-5789-1f6f-991060dffcb9&l=12445
- https://dev.azure.com/ansible/community.general/_build/results?buildId=73634&view=logs&j=c12a8e90-c78d-5d96-c83c-8beac118ca9b&t=0da6623a-06d0-5789-1f6f-991060dffcb9&l=12443

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pkgng integration tests
