### PR TITLE
keycloak: Add option to create authentication sub-flow of type 'form flow'

### DIFF
--- a/changelogs/fragments/6318-add-form-flow.yml
+++ b/changelogs/fragments/6318-add-form-flow.yml
@@ -2,4 +2,4 @@ bugfixes:
   - "keycloak - improve error messages (https://github.com/ansible-collections/community.general/pull/6318)."
 
 minor_changes:
-  - "keycloak_authentication - Add flow type option to sub flows to allow the creation of 'form-flow' sub flows like in keycloak's built-in registration flow (https://github.com/ansible-collections/community.general/pull/6318)."
+  - "keycloak_authentication - add flow type option to sub flows to allow the creation of 'form-flow' sub flows like in Keycloak's built-in registration flow (https://github.com/ansible-collections/community.general/pull/6318)."

--- a/changelogs/fragments/6318-add-form-flow.yml
+++ b/changelogs/fragments/6318-add-form-flow.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - "keycloak - Improve error messages (https://github.com/ansible-collections/community.general/pull/6318)."
+
+minor_changes:
+  - "keycloak_authentication - Add flow type option to sub flows to allow the creation of 'form-flow' sub flows like in keycloak's built-in registration flow (https://github.com/ansible-collections/community.general/pull/6318)."

--- a/changelogs/fragments/6318-add-form-flow.yml
+++ b/changelogs/fragments/6318-add-form-flow.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - "keycloak - Improve error messages (https://github.com/ansible-collections/community.general/pull/6318)."
+  - "keycloak - improve error messages (https://github.com/ansible-collections/community.general/pull/6318)."
 
 minor_changes:
   - "keycloak_authentication - Add flow type option to sub flows to allow the creation of 'form-flow' sub flows like in keycloak's built-in registration flow (https://github.com/ansible-collections/community.general/pull/6318)."

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1822,7 +1822,7 @@ class KeycloakAPI(object):
         except Exception as e:
             self.module.fail_json(msg="Unable to add authenticationConfig %s: %s" % (executionId, str(e)))
 
-    def create_subflow(self, subflowName, flowAlias, realm='master'):
+    def create_subflow(self, subflowName, flowAlias, realm='master', flowType='basic-flow'):
         """ Create new sublow on the flow
 
         :param subflowName: name of the subflow to create
@@ -1833,7 +1833,7 @@ class KeycloakAPI(object):
             newSubFlow = {}
             newSubFlow["alias"] = subflowName
             newSubFlow["provider"] = "registration-page-form"
-            newSubFlow["type"] = "basic-flow"
+            newSubFlow["type"] = flowType
             open_url(
                 URL_AUTHENTICATION_FLOW_EXECUTIONS_FLOW.format(
                     url=self.baseurl,

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1872,7 +1872,7 @@ class KeycloakAPI(object):
             self.module.fail_json(msg="Unable to create new execution '%s' %s: %s: %s %s" %
                                   (flowAlias, execution["providerId"], repr(e), ";".join([e.url, e.msg, str(e.code), str(e.hdrs)]), str(newExec)))
         except Exception as e:
-            self.module.fail_json(msg="Unable to create new execution %s: %s" % (execution["provider"], str(e)))
+            self.module.fail_json(msg="Unable to create new execution '%s' %s: %s" % (flowAlias, execution["providerId"], repr(e)))
 
     def change_execution_priority(self, executionId, diff, realm='master'):
         """ Raise or lower execution priority of diff time

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1795,6 +1795,9 @@ class KeycloakAPI(object):
                 data=json.dumps(updatedExec),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
+        except HTTPError as e:
+            self.module.fail_json(msg="Unable to update execution '%s': %s: %s %s" %
+                                      (flowAlias, repr(e), ";".join([e.url, e.msg, str(e.code), str(e.hdrs)]), str(updatedExec)))
         except Exception as e:
             self.module.fail_json(msg="Unable to update executions %s: %s" % (updatedExec, str(e)))
 
@@ -1865,6 +1868,9 @@ class KeycloakAPI(object):
                 data=json.dumps(newExec),
                 timeout=self.connection_timeout,
                 validate_certs=self.validate_certs)
+        except HTTPError as e:
+            self.module.fail_json(msg="Unable to create new execution '%s' %s: %s: %s %s" %
+                                  (flowAlias, execution["providerId"], repr(e), ";".join([e.url, e.msg, str(e.code), str(e.hdrs)]), str(newExec)))
         except Exception as e:
             self.module.fail_json(msg="Unable to create new execution %s: %s" % (execution["provider"], str(e)))
 

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -82,6 +82,7 @@ options:
             subFlowType:
                 description:
                     - For new subflows, optionally specify the type.
+                    - Is only used at creation.
                 choices: ["basic-flow", "form-flow"]
                 default: "basic-flow"
                 type: str

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -85,6 +85,7 @@ options:
                 choices: ["basic-flow", "form-flow"]
                 default: "basic-flow"
                 type: str
+                version_added: 6.6.0
     state:
         description:
             - Control if the authentication flow must exists or not.

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -272,7 +272,7 @@ def create_or_update_executions(kc, config, realm='master'):
                 exec_index = find_exec_in_executions(new_exec, existing_executions)
                 if exec_index != -1:
                     # Remove key that doesn't need to be compared with existing_exec
-                    exclude_key = ["flowAlias"]
+                    exclude_key = ["flowAlias", "subFlowType"]
                     for index_key, key in enumerate(new_exec, start=0):
                         if new_exec[key] is None:
                             exclude_key.append(key)
@@ -290,7 +290,7 @@ def create_or_update_executions(kc, config, realm='master'):
                     id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
                     after += str(new_exec) + '\n'
                 elif new_exec["displayName"] is not None:
-                    kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm, flowType=new_exec['subFlowType'])
+                    kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm, flowType=new_exec["subFlowType"])
                     exec_found = True
                     exec_index = new_exec_index
                     id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -79,6 +79,12 @@ options:
                 description:
                     - Priority order of the execution.
                 type: int
+            subFlowType:
+                description:
+                    - For new subflows, optionally specify the type.
+                choices: ["basic-flow", "form-flow"]
+                default: "basic-flow"
+                type: str
     state:
         description:
             - Control if the authentication flow must exists or not.
@@ -282,7 +288,7 @@ def create_or_update_executions(kc, config, realm='master'):
                     id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
                     after += str(new_exec) + '\n'
                 elif new_exec["displayName"] is not None:
-                    kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm)
+                    kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm, flowType=new_exec['subFlowType'])
                     exec_found = True
                     exec_index = new_exec_index
                     id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
@@ -299,7 +305,7 @@ def create_or_update_executions(kc, config, realm='master'):
                             kc.add_authenticationConfig_to_execution(updated_exec["id"], new_exec["authenticationConfig"], realm=realm)
                         for key in new_exec:
                             # remove unwanted key for the next API call
-                            if key != "flowAlias" and key != "authenticationConfig":
+                            if key not in ("flowAlias", "authenticationConfig", "subFlowType"):
                                 updated_exec[key] = new_exec[key]
                         if new_exec["requirement"] is not None:
                             kc.update_authentication_executions(flow_alias_parent, updated_exec, realm=realm)
@@ -334,6 +340,7 @@ def main():
                                           flowAlias=dict(type='str'),
                                           authenticationConfig=dict(type='dict'),
                                           index=dict(type='int'),
+                                          subFlowType=dict(choices=["basic-flow", "form-flow"], default='basic-flow', type='str'),
                                       )),
         state=dict(choices=["absent", "present"], default='present'),
         force=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To create something like keycloak's built-in registration flow,
we need to create a subflow with the type 'form-flow'.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_authentication
##### ADDITIONAL INFORMATION
Additionally, this adds some detail to the error message created on keycloak API exceptions, i.e.
fields from the HTTPError exception. This is optional.

Another patch fixes an Exception when formatting an error message.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
