### PR TITLE
redhat_subscription: use CLI when using environments

### DIFF
--- a/changelogs/fragments/6319-redhat_subscription-fix-environment-parameter.yaml
+++ b/changelogs/fragments/6319-redhat_subscription-fix-environment-parameter.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - redhat_subscription - do not use D-Bus for registering when ``environment`` is specified,
+    so it possible to specify again the environment names for registering,
+    as the D-Bus APIs work only with IDs
+    (https://github.com/ansible-collections/community.general/pull/6319).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -461,8 +461,10 @@ class Rhsm(RegistrationBase):
               * Exception - if any error occurs during the registration
         '''
         # There is no support for token-based registration in the D-Bus API
-        # of rhsm, so always use the CLI in that case.
-        if not token and self._can_connect_to_dbus():
+        # of rhsm, so always use the CLI in that case;
+        # also, since the specified environments are names, and the D-Bus APIs
+        # require IDs for the environments, use the CLI also in that case
+        if not token and not environment and self._can_connect_to_dbus():
             self._register_using_dbus(was_registered, username, password, auto_attach,
                                       activationkey, org_id, consumer_type,
                                       consumer_name, consumer_id,


### PR DESCRIPTION
##### SUMMARY

It turns out that the 'environments' that the D-Bus Register*() APIs accept are the IDs of the environments, and not the user-facing names of the environments (which is what the module has been accepting so far).

Since there is no easy way to do the mapping manually, for now use again the subscription-manager CLI for registering when environments are specified.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription
