### PR TITLE
BOTMETA.yml: put the label redhat_subscription back

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1042,8 +1042,9 @@ files:
     ignore: jose-delarosa
     maintainers: $team_redfish TSKushal
   $modules/redhat_subscription.py:
-    maintainers: $team_rhsm
     ignore: barnabycourt alikins kahowell
+    labels: redhat_subscription
+    maintainers: $team_rhsm
   $modules/redis.py:
     maintainers: slok
   $modules/redis_data.py:


### PR DESCRIPTION
##### SUMMARY
revert of https://github.com/ansible-collections/community.general/pull/6354

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
BOTMETA.yml