### PR TITLE
snap_alias: fix regex expression when listing aliases

### DIFF
--- a/changelogs/fragments/6361-snap-alias-regex-bugfix.yml
+++ b/changelogs/fragments/6361-snap-alias-regex-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - snap_alias - module would only recognize snap names containing letter, numbers or the underscore character, failing to identify valid snap names such as ``lxd.lxc`` (https://github.com/ansible-collections/community.general/pull/6361).

--- a/plugins/modules/snap_alias.py
+++ b/plugins/modules/snap_alias.py
@@ -98,7 +98,7 @@ _state_map = dict(
 
 
 class SnapAlias(StateModuleHelper):
-    _RE_ALIAS_LIST = re.compile(r"^(?P<snap>[\w-]+)\s+(?P<alias>[\w-]+)\s+.*$")
+    _RE_ALIAS_LIST = re.compile(r"^(?P<snap>[\S]+)\s+(?P<alias>[\w-]+)\s+.*$")
 
     module = dict(
         argument_spec={
@@ -142,7 +142,10 @@ class SnapAlias(StateModuleHelper):
             return results
 
         with self.runner("state name", check_rc=True, output_process=process) as ctx:
-            return ctx.run(state="info")
+            aliases = ctx.run(state="info")
+            if self.verbosity >= 4:
+                self.vars.get_aliases_run_info = ctx.run_info
+            return aliases
 
     def _get_aliases_for(self, name):
         return self._get_aliases().get(name, [])

--- a/plugins/modules/snap_alias.py
+++ b/plugins/modules/snap_alias.py
@@ -98,7 +98,7 @@ _state_map = dict(
 
 
 class SnapAlias(StateModuleHelper):
-    _RE_ALIAS_LIST = re.compile(r"^(?P<snap>[\S]+)\s+(?P<alias>[\w-]+)\s+.*$")
+    _RE_ALIAS_LIST = re.compile(r"^(?P<snap>\S+)\s+(?P<alias>[\w-]+)\s+.*$")
 
     module = dict(
         argument_spec={

--- a/tests/integration/targets/snap_alias/aliases
+++ b/tests/integration/targets/snap_alias/aliases
@@ -11,4 +11,3 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/docker
-skip/ubuntu  # FIXME!


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While testing integration tests for ubuntu bumped into an error because the regular expression expected snap names to match `[\w-]+` but in Ubuntu there comes one named `lxd.lxc`. Replacing with `\S+`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
snap_alias
