### PR TITLE
Redfish iDRAC: Allow for specifying an exact manager with 'resource_id' for CreateBiosConfigJob

### DIFF
--- a/changelogs/fragments/2090-idrac-redfish-resource-id-fix.yml
+++ b/changelogs/fragments/2090-idrac-redfish-resource-id-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - idrac_redfish_command - allow user to specify ``resource_id`` for ``CreateBiosConfigJob`` to specify an exact manager (https://github.com/ansible-collections/community.general/issues/2090).

--- a/plugins/modules/idrac_redfish_command.py
+++ b/plugins/modules/idrac_redfish_command.py
@@ -199,7 +199,20 @@ def main():
 
     if category == "Systems":
         # execute only if we find a System resource
+        # NOTE: Currently overriding the usage of 'data_modification' due to
+        # how 'resource_id' is processed.  In the case of CreateBiosConfigJob,
+        # we interact with BOTH systems and managers, so you currently cannot
+        # specify a single 'resource_id' to make both '_find_systems_resource'
+        # and '_find_managers_resource' return success.  Since
+        # CreateBiosConfigJob doesn't use the matched 'resource_id' for a
+        # system regardless of what's specified, disabling the 'resource_id'
+        # inspection for the next call allows a specific manager to be
+        # specified with 'resource_id'.  If we ever need to expand the input
+        # to inspect a specific system and manager in parallel, this will need
+        # updates.
+        rf_utils.data_modification = False
         result = rf_utils._find_systems_resource()
+        rf_utils.data_modification = True
         if result['ret'] is False:
             module.fail_json(msg=to_native(result['msg']))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
'CreateBiosConfigJob' is unique in that it relies on discovering systems and managers. All other commands so far rely on one or the other. So, when a user specifies a 'resource_id' in which to perform the operation, it will always fail one of the checks for a matching system or manager. Since CreateBiosConfigJob only relies on operating upon the first system in the system collection (and not an exact system matching 'resource_id'), the change will only perform 'resource_id' matching on the manager.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #2090 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
idrac_redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sample playbook:

```
---
- hosts: all
  gather_facts: false
  vars:
    username: <REDACTED>
    password: <REDACTED>
    baseuri: <REDACTED>
    default_uri_timeout: 5
    default_uri_retries: 5
  tasks:
  - name: BIOS Job
    community.general.idrac_redfish_command:
      category: Systems
      command: CreateBiosConfigJob
      resource_id: iDRAC.Embedded.1
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
    retries: "{{ default_uri_retries }}"
    register: redfish_results
  - debug:
      var: redfish_results
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
PLAY [all] *******************************************************************************************************************************************

TASK [BIOS Job] **************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "Manager resource iDRAC.Embedded.1 not found"}

PLAY RECAP *******************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After:
```
PLAY [all] *******************************************************************************************************************************************

TASK [BIOS Job] **************************************************************************************************************************************
changed: [localhost]

TASK [debug] *****************************************************************************************************************************************
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "failed": false,
        "msg": "Action was successful"
    }
}

PLAY RECAP *******************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```