### PR TITLE
deps module utils: add function failed() to retrieve dependencies check result

### DIFF
--- a/changelogs/fragments/6383-deps-failed.yml
+++ b/changelogs/fragments/6383-deps-failed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - deps module utils - add function ``failed()`` providing the ability to check the dependency check result without triggering an exception (https://github.com/ansible-collections/community.general/pull/6383).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add function `failed()` to module `deps`, providing the ability to check the dependency check result without triggering an exception.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/deps.py
