### PR TITLE
Fixes #5143: xfs_quota fails to initialize new project quotas

### DIFF
--- a/changelogs/fragments/5143-fix-xfs-quota-project-init.yml
+++ b/changelogs/fragments/5143-fix-xfs-quota-project-init.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - xfs_quota - in case of a project quota, the call to ``xfs_quota`` did not initialize/reset the project (https://github.com/ansible-collections/community.general/issues/5143).

--- a/plugins/modules/xfs_quota.py
+++ b/plugins/modules/xfs_quota.py
@@ -300,31 +300,35 @@ def main():
                         prj_set = False
                         break
 
-        if not prj_set and not module.check_mode:
-            cmd = "project -s"
-            rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
-            if rc != 0:
-                result["cmd"] = cmd
-                result["rc"] = rc
-                result["stdout"] = stdout
-                result["stderr"] = stderr
-                module.fail_json(
-                    msg="Could not get quota realtime block report.", **result
-                )
+        if state == "present" and not prj_set:
+            if not module.check_mode:
+                cmd = "project -s %s" % name
+                rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
+                if rc != 0:
+                    result["cmd"] = cmd
+                    result["rc"] = rc
+                    result["stdout"] = stdout
+                    result["stderr"] = stderr
+                    module.fail_json(
+                        msg="Could not get quota realtime block report.", **result
+                    )
 
             result["changed"] = True
 
-        elif not prj_set and module.check_mode:
-            result["changed"] = True
+        elif state == "absent" and prj_set and name != quota_default:
+            if not module.check_mode:
+                cmd = "project -C %s" % name
+                rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
+                if rc != 0:
+                    result["cmd"] = cmd
+                    result["rc"] = rc
+                    result["stdout"] = stdout
+                    result["stderr"] = stderr
+                    module.fail_json(
+                        msg="Failed to clear managed tree from project quota control.", **result
+                    )
 
-    # Set limits
-    if state == "absent":
-        bhard = 0
-        bsoft = 0
-        ihard = 0
-        isoft = 0
-        rtbhard = 0
-        rtbsoft = 0
+            result["changed"] = True
 
     current_bsoft, current_bhard = quota_report(
         module, xfs_quota_bin, mountpoint, name, quota_type, "b"
@@ -335,6 +339,23 @@ def main():
     current_rtbsoft, current_rtbhard = quota_report(
         module, xfs_quota_bin, mountpoint, name, quota_type, "rtb"
     )
+
+    # Set limits
+    if state == "absent":
+        bhard = 0
+        bsoft = 0
+        ihard = 0
+        isoft = 0
+        rtbhard = 0
+        rtbsoft = 0
+
+        # Ensure that a non-existing quota does not trigger a change
+        current_bsoft = current_bsoft if current_bsoft is not None else 0
+        current_bhard = current_bhard if current_bhard is not None else 0
+        current_isoft = current_isoft if current_isoft is not None else 0
+        current_ihard = current_ihard if current_ihard is not None else 0
+        current_rtbsoft = current_rtbsoft if current_rtbsoft is not None else 0
+        current_rtbhard = current_rtbhard if current_rtbhard is not None else 0
 
     result["xfs_quota"] = dict(
         bsoft=current_bsoft,
@@ -370,23 +391,21 @@ def main():
         limit.append("rtbhard=%s" % rtbhard)
         result["rtbhard"] = int(rtbhard)
 
-    if len(limit) > 0 and not module.check_mode:
-        if name == quota_default:
-            cmd = "limit %s -d %s" % (type_arg, " ".join(limit))
-        else:
-            cmd = "limit %s %s %s" % (type_arg, " ".join(limit), name)
+    if len(limit) > 0:
+        if not module.check_mode:
+            if name == quota_default:
+                cmd = "limit %s -d %s" % (type_arg, " ".join(limit))
+            else:
+                cmd = "limit %s %s %s" % (type_arg, " ".join(limit), name)
 
-        rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
-        if rc != 0:
-            result["cmd"] = cmd
-            result["rc"] = rc
-            result["stdout"] = stdout
-            result["stderr"] = stderr
-            module.fail_json(msg="Could not set limits.", **result)
+            rc, stdout, stderr = exec_quota(module, xfs_quota_bin, cmd, mountpoint)
+            if rc != 0:
+                result["cmd"] = cmd
+                result["rc"] = rc
+                result["stdout"] = stdout
+                result["stderr"] = stderr
+                module.fail_json(msg="Could not set limits.", **result)
 
-        result["changed"] = True
-
-    elif len(limit) > 0 and module.check_mode:
         result["changed"] = True
 
     module.exit_json(**result)

--- a/tests/integration/targets/xfs_quota/tasks/pquota.yml
+++ b/tests/integration/targets/xfs_quota/tasks/pquota.yml
@@ -123,7 +123,7 @@
   - name: Assert project limits results for xft_quotaval after re-apply
     assert:
       that:
-      - test_pquota_project_after.changed
+      - test_pquota_project_after is not changed
   - name: Reset default project limits
     xfs_quota:
       mountpoint: '{{ remote_tmp_dir }}/pquota'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
This fix ensures that in case of a project quota, the corresponding project gets initialized, if required.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
xfs_quota

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This is an attempt to re-submit and improve [#5144](https://github.com/ansible-collections/community.general/pull/5144), in order to get this issue finally fixed.
