### PR TITLE
New lookup plug-in: Bitwarden Secrets Manager

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -204,6 +204,8 @@ files:
     maintainers: ddelnano shinuza
   $lookups/:
     labels: lookups
+  $lookups/bitwarden_secrets_manager.py:
+    maintainers: jantari
   $lookups/bitwarden.py:
     maintainers: lungj
   $lookups/cartesian.py: {}

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
     requirements:
       - bws (command line utility)
     short_description: Retrieve secrets from Bitwarden Secrets Manager
-    version_added: 6.6.0
+    version_added: 7.0.0
     description:
       - Retrieve secrets from Bitwarden Secrets Manager.
     options:

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -23,7 +23,10 @@ DOCUMENTATION = """
         type: list
         elements: str
       bws_access_token:
-        description: A BWS access token to use for this lookup.
+        description: The BWS access token to use for this lookup.
+        env:
+          - name: BWS_ACCESS_TOKEN
+        required: true
         type: str
 """
 
@@ -66,7 +69,6 @@ RETURN = """
     elements: raw
 """
 
-import os
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleError
@@ -121,12 +123,6 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         bws_access_token = self.get_option('bws_access_token')
-
-        if not bws_access_token:
-            bws_access_token = os.getenv('BWS_ACCESS_TOKEN')
-
-        if not bws_access_token:
-            raise AnsibleError("No access token. Pass the bws_access_token parameter or set the BWS_ACCESS_TOKEN environment variable.")
 
         return [_bitwarden.get_secret(term, bws_access_token) for term in terms]
 

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = """
     name: bitwarden_secrets_manager
     author:
-      - @jantari
+      - jantari (@jantari)
     requirements:
       - bws (command line utility)
     short_description: Retrieve secrets from Bitwarden Secrets Manager
@@ -35,13 +35,22 @@ EXAMPLES = """
 - name: "Get a secret passing an explicit access token for authentication"
   ansible.builtin.debug:
     msg: >-
-      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token="9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg==") }}
+      {{
+        lookup(
+          "community.general.bitwarden_secrets_manager",
+          "2bc23e48-4932-40de-a047-5524b7ddc972",
+          bws_access_token="9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg=="
+        )
+      }}
 
 - name: "Get two different secrets each using a different access token for authentication"
   ansible.builtin.debug:
     msg:
-      - '{{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token="9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg==") }}'
-      - '{{ lookup("community.general.bitwarden_secrets_manager", "9d89af4c-eb5d-41f5-bb0f-4ae81215c768", bws_access_token="1.69b72797-6ea9-4687-a11e-848e41a30ae6.YW5zaWJsZSBpcyBncmVhdD8K:YW5zaWJsZSBpcyBncmVhdAo=") }}'
+      - '{{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token=token1) }}'
+      - '{{ lookup("community.general.bitwarden_secrets_manager", "9d89af4c-eb5d-41f5-bb0f-4ae81215c768", bws_access_token=token2) }}'
+  vars:
+    token1: "9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg=="
+    token2: "1.69b72797-6ea9-4687-a11e-848e41a30ae6.YW5zaWJsZSBpcyBncmVhdD8K:YW5zaWJsZSBpcyBncmVhdAo="
 
 - name: "Get just the value of a secret"
   ansible.builtin.debug:
@@ -116,7 +125,7 @@ class LookupModule(LookupBase):
             bws_access_token = os.getenv('BWS_ACCESS_TOKEN')
 
         if not bws_access_token:
-            raise AnsibleError("No access token for Bitwarden Secrets Manager. Pass the bws_access_token parameter or set the BWS_ACCESS_TOKEN environment variable.")
+            raise AnsibleError("No access token. Pass the bws_access_token parameter or set the BWS_ACCESS_TOKEN environment variable.")
 
         return [_bitwarden.get_secret(term, bws_access_token) for term in terms]
 

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -31,12 +31,12 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-- name: "Get a secret relying on the BWS_ACCESS_TOKEN environment variable for authentication"
+- name: Get a secret relying on the BWS_ACCESS_TOKEN environment variable for authentication
   ansible.builtin.debug:
     msg: >-
       {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972") }}
 
-- name: "Get a secret passing an explicit access token for authentication"
+- name: Get a secret passing an explicit access token for authentication
   ansible.builtin.debug:
     msg: >-
       {{
@@ -47,7 +47,7 @@ EXAMPLES = """
         )
       }}
 
-- name: "Get two different secrets each using a different access token for authentication"
+- name: Get two different secrets each using a different access token for authentication
   ansible.builtin.debug:
     msg:
       - '{{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token=token1) }}'
@@ -56,10 +56,10 @@ EXAMPLES = """
     token1: "9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg=="
     token2: "1.69b72797-6ea9-4687-a11e-848e41a30ae6.YW5zaWJsZSBpcyBncmVhdD8K:YW5zaWJsZSBpcyBncmVhdAo="
 
-- name: "Get just the value of a secret"
+- name: Get just the value of a secret
   ansible.builtin.debug:
     msg: >-
-      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972")[0].value }}
+      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972").value }}
 """
 
 RETURN = """

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -77,11 +77,11 @@ from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
 
 
-class BitwardenException(AnsibleError):
+class BitwardenSecretsManagerException(AnsibleError):
     pass
 
 
-class Bitwarden(object):
+class BitwardenSecretsManager(object):
 
     def __init__(self, path='bws'):
         self._cli_path = path
@@ -95,7 +95,7 @@ class Bitwarden(object):
         out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()
         if rc != expected_rc:
-            raise BitwardenException(err)
+            raise BitwardenSecretsManagerException(err)
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 
     def get_secret(self, secret_id, bws_access_token):
@@ -121,7 +121,7 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         bws_access_token = self.get_option('bws_access_token')
 
-        return [_bitwarden.get_secret(term, bws_access_token) for term in terms]
+        return [_bitwarden_secrets_manager.get_secret(term, bws_access_token) for term in terms]
 
 
-_bitwarden = Bitwarden()
+_bitwarden_secrets_manager = BitwardenSecretsManager()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: bitwarden_secrets_manager
+    author:
+      - @jantari
+    requirements:
+      - bws (command line utility)
+    short_description: Retrieve secrets from Bitwarden Secrets Manager
+    version_added: ?.?.?
+    description:
+      - Retrieve secrets from Bitwarden Secrets Manager.
+    options:
+      _terms:
+        description: Secret ID(s) to fetch values for.
+        required: true
+        type: list
+        elements: str
+      bws_access_token:
+        description: A BWS access token to use for this lookup.
+        type: str
+"""
+
+EXAMPLES = """
+- name: "Get a secret relying on the BWS_ACCESS_TOKEN environment variable for authentication"
+  ansible.builtin.debug:
+    msg: >-
+      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972") }}
+
+- name: "Get a secret passing an explicit access token for authentication"
+  ansible.builtin.debug:
+    msg: >-
+      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token="9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg==") }}
+
+- name: "Get two different secrets each using a different access token for authentication"
+  ansible.builtin.debug:
+    msg:
+      - '{{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972", bws_access_token="9.4f570d14-4b54-42f5-bc07-60f4450b1db5.YmluYXJ5LXNvbWV0aGluZy0xMjMK:d2h5IGhlbGxvIHRoZXJlCg==") }}'
+      - '{{ lookup("community.general.bitwarden_secrets_manager", "9d89af4c-eb5d-41f5-bb0f-4ae81215c768", bws_access_token="1.69b72797-6ea9-4687-a11e-848e41a30ae6.YW5zaWJsZSBpcyBncmVhdD8K:YW5zaWJsZSBpcyBncmVhdAo=") }}'
+
+- name: "Get just the value of a secret"
+  ansible.builtin.debug:
+    msg: >-
+      {{ lookup("community.general.bitwarden_secrets_manager", "2bc23e48-4932-40de-a047-5524b7ddc972")[0].value }}
+"""
+
+RETURN = """
+  _raw:
+    description: List containing the secret JSON object. Guaranteed to be of length 1.
+    type: list
+    elements: raw
+"""
+
+import os
+from subprocess import Popen, PIPE
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.parsing.ajson import AnsibleJSONDecoder
+from ansible.plugins.lookup import LookupBase
+
+
+class BitwardenException(AnsibleError):
+    pass
+
+
+class Bitwarden(object):
+
+    def __init__(self, path='bws'):
+        self._cli_path = path
+
+    @property
+    def cli_path(self):
+        return self._cli_path
+
+    def _run(self, args, stdin=None, expected_rc=0):
+        p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        out, err = p.communicate(to_bytes(stdin))
+        rc = p.wait()
+        if rc != expected_rc:
+            raise BitwardenException(err)
+        return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
+
+    def get_secret(self, secret_id, bws_access_token):
+        """Get and return the secret with the given secret_id.
+        """
+
+        # Prepare set of params for Bitwarden Secrets Manager CLI
+        # Color output was not always disabled correctly with the default 'auto' setting so explicitly disable it.
+        params = [
+            '--color', 'no',
+            '--access-token', bws_access_token,
+            'get', 'secret', secret_id
+        ]
+
+        out, err = self._run(params)
+
+        # This includes things that matched in different fields.
+        initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
+
+        return [initial_matches]
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+        bws_access_token = self.get_option('bws_access_token')
+
+        if not bws_access_token:
+            bws_access_token = os.getenv('BWS_ACCESS_TOKEN')
+
+        if not bws_access_token:
+            raise AnsibleError("No access token for Bitwarden Secrets Manager. Pass the bws_access_token parameter or set the BWS_ACCESS_TOKEN environment variable.")
+
+        return [_bitwarden.get_secret(term, bws_access_token) for term in terms]
+
+
+_bitwarden = Bitwarden()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -71,18 +71,15 @@ RETURN = """
 
 from subprocess import Popen, PIPE
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
 
-
-class BitwardenSecretsManagerException(AnsibleError):
+class BitwardenSecretsManagerException(AnsibleLookupError):
     pass
 
-
 class BitwardenSecretsManager(object):
-
     def __init__(self, path='bws'):
         self._cli_path = path
 
@@ -114,14 +111,11 @@ class BitwardenSecretsManager(object):
 
         return AnsibleJSONDecoder().raw_decode(out)[0]
 
-
 class LookupModule(LookupBase):
-
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         bws_access_token = self.get_option('bws_access_token')
+        _bitwarden_secrets_manager = BitwardenSecretsManager()
 
         return [_bitwarden_secrets_manager.get_secret(term, bws_access_token) for term in terms]
 
-
-_bitwarden_secrets_manager = BitwardenSecretsManager()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -64,9 +64,9 @@ EXAMPLES = """
 
 RETURN = """
   _raw:
-    description: List containing the secret JSON object. Guaranteed to be of length 1.
+    description: List containing one or more secrets.
     type: list
-    elements: raw
+    elements: dict
 """
 
 from subprocess import Popen, PIPE
@@ -112,10 +112,7 @@ class Bitwarden(object):
 
         out, err = self._run(params)
 
-        # This includes things that matched in different fields.
-        initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
-
-        return [initial_matches]
+        return AnsibleJSONDecoder().raw_decode(out)[0]
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -89,7 +89,7 @@ class BitwardenSecretsManager(object):
     def cli_path(self):
         return self._cli_path
 
-    def _run(self, args, stdin=None, expected_rc=0):
+    def _run(self, args, stdin=None):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         out, err = p.communicate(stdin)
         rc = p.wait()
@@ -108,7 +108,7 @@ class BitwardenSecretsManager(object):
         ]
 
         out, err, rc = self._run(params)
-        if rc != expected_rc:
+        if rc != 0:
             raise BitwardenSecretsManagerException(to_text(err))
 
         return AnsibleJSONDecoder().raw_decode(out)[0]

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -72,7 +72,7 @@ RETURN = """
 from subprocess import Popen, PIPE
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
 
@@ -91,10 +91,10 @@ class BitwardenSecretsManager(object):
 
     def _run(self, args, stdin=None, expected_rc=0):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        out, err = p.communicate(to_bytes(stdin))
+        out, err = p.communicate(stdin)
         rc = p.wait()
         if rc != expected_rc:
-            raise BitwardenSecretsManagerException(err)
+            raise BitwardenSecretsManagerException(to_text(err))
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 
     def get_secret(self, secret_id, bws_access_token):
@@ -120,5 +120,6 @@ class LookupModule(LookupBase):
         bws_access_token = self.get_option('bws_access_token')
 
         return [_bitwarden_secrets_manager.get_secret(term, bws_access_token) for term in terms]
+
 
 _bitwarden_secrets_manager = BitwardenSecretsManager()

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# (c) 2023, jantari (https://github.com/jantari)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
@@ -12,7 +13,7 @@ DOCUMENTATION = """
     requirements:
       - bws (command line utility)
     short_description: Retrieve secrets from Bitwarden Secrets Manager
-    version_added: ?.?.?
+    version_added: 6.6.0
     description:
       - Retrieve secrets from Bitwarden Secrets Manager.
     options:

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -76,8 +76,10 @@ from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.plugins.lookup import LookupBase
 
+
 class BitwardenSecretsManagerException(AnsibleLookupError):
     pass
+
 
 class BitwardenSecretsManager(object):
     def __init__(self, path='bws'):
@@ -111,6 +113,7 @@ class BitwardenSecretsManager(object):
 
         return AnsibleJSONDecoder().raw_decode(out)[0]
 
+
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
@@ -118,4 +121,3 @@ class LookupModule(LookupBase):
         _bitwarden_secrets_manager = BitwardenSecretsManager()
 
         return [_bitwarden_secrets_manager.get_secret(term, bws_access_token) for term in terms]
-

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
     requirements:
       - bws (command line utility)
     short_description: Retrieve secrets from Bitwarden Secrets Manager
-    version_added: 7.0.0
+    version_added: 7.2.0
     description:
       - Retrieve secrets from Bitwarden Secrets Manager.
     options:

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2023, jantari (https://github.com/jantari)
+# Copyright (c) 2023, jantari (https://github.com/jantari)
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -93,9 +93,7 @@ class BitwardenSecretsManager(object):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         out, err = p.communicate(stdin)
         rc = p.wait()
-        if rc != expected_rc:
-            raise BitwardenSecretsManagerException(to_text(err))
-        return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
+        return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict'), rc
 
     def get_secret(self, secret_id, bws_access_token):
         """Get and return the secret with the given secret_id.
@@ -109,7 +107,9 @@ class BitwardenSecretsManager(object):
             'get', 'secret', secret_id
         ]
 
-        out, err = self._run(params)
+        out, err, rc = self._run(params)
+        if rc != expected_rc:
+            raise BitwardenSecretsManagerException(to_text(err))
 
         return AnsibleJSONDecoder().raw_decode(out)[0]
 

--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -118,6 +118,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)
         bws_access_token = self.get_option('bws_access_token')
-        _bitwarden_secrets_manager = BitwardenSecretsManager()
 
         return [_bitwarden_secrets_manager.get_secret(term, bws_access_token) for term in terms]
+
+_bitwarden_secrets_manager = BitwardenSecretsManager()

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -55,7 +55,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager(self):
         # Getting a secret by its id should return the full secret info
-        self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123'))
+        self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123')[0])
 
     @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager_no_match(self):

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -43,7 +43,7 @@ MOCK_SECRETS = [
 
 class MockBitwardenSecretsManager(BitwardenSecretsManager):
 
-    def _run(self, args, stdin=None, expected_rc=0):
+    def _run(self, args, stdin=None):
         # secret_id is the last argument passed to the bws CLI
         secret_id = args[-1]
         rc = 0

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -62,4 +62,3 @@ class TestLookupModule(unittest.TestCase):
         # Getting a nonexistant secret id throws exception
         with self.assertRaises(AnsibleLookupError):
             self.lookup.run(['nonexistant_id'], bws_access_token='123')
-

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -52,12 +52,12 @@ class TestLookupModule(unittest.TestCase):
     def setUp(self):
         self.lookup = lookup_loader.get('community.general.bitwarden_secrets_manager')
 
-    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager.BitwardenSecretsManager', new=MockBitwardenSecretsManager())
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager(self):
         # Getting a secret by its id should return the full secret info
         self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123'))
 
-    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager.BitwardenSecretsManager', new=MockBitwardenSecretsManager())
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager_no_match(self):
         # Getting a nonexistant secret id throws exception
         with self.assertRaises(AnsibleLookupError):

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -56,7 +56,7 @@ class MockBitwardenSecretsManager(BitwardenSecretsManager):
             err = "simulated bws CLI error: 404 no secret with such id"
         elif len(found_secrets) == 1:
             rc = 0
-            # The real bws CLI will only ever return one secret for the "get secret <secret-id>" command
+            # The real bws CLI will only ever return one secret / json object for the "get secret <secret-id>" command
             out = json.dumps(found_secrets[0])
         else:
             # This should never happen unless there's an error in the test MOCK_SECRETS.
@@ -74,7 +74,7 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager(self):
         # Getting a secret by its id should return the full secret info
-        self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123')[0])
+        self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123'))
 
     @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager._bitwarden_secrets_manager', new=MockBitwardenSecretsManager())
     def test_bitwarden_secrets_manager_no_match(self):

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -43,8 +43,21 @@ MOCK_SECRETS = [
 
 class MockBitwardenSecretsManager(BitwardenSecretsManager):
 
-    def get_secret(self, secret_id, bws_access_token):
-        return list(filter(lambda record: record["id"] == secret_id, MOCK_SECRETS))
+    def _run(self, args, stdin=None, expected_rc=0):
+        # secret_id is the last argument passed to the bws CLI
+        secret_id = args[-1]
+        rc = 0
+        err = ""
+        out = list(filter(lambda record: record["id"] == secret_id, MOCK_SECRETS))
+
+        if len(out) == 0:
+            err = "simulated bws CLI error: 404 no secret with such id"
+            rc = 1
+
+        # The real bws CLI will only ever return one secret for the "get secret <secret-id>" command
+        out = out[0]
+
+        return out, err, rc
 
 
 class TestLookupModule(unittest.TestCase):

--- a/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
+++ b/tests/unit/plugins/lookup/test_bitwarden_secrets_manager.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, jantari (https://github.com/jantari)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import patch
+
+from ansible.errors import AnsibleLookupError
+from ansible.plugins.loader import lookup_loader
+from ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager import BitwardenSecretsManager
+
+
+MOCK_SECRETS = [
+    {
+        "object": "secret",
+        "id": "ababc4a8-c242-4e54-bceb-77d17cdf2e07",
+        "organizationId": "3c33066c-a0bf-4e70-9a3c-24cda6aaddd5",
+        "projectId": "81869439-bfe5-442f-8b4e-b172e68b0ab2",
+        "key": "TEST_SECRET",
+        "value": "1234supersecret5678",
+        "note": "A test secret to use when developing the ansible bitwarden_secrets_manager lookup plugin",
+        "creationDate": "2023-04-23T13:13:37.7507017Z",
+        "revisionDate": "2023-04-23T13:13:37.7507017Z"
+    },
+    {
+        "object": "secret",
+        "id": "d4b7c8fa-fc95-40d7-a13c-6e186ee69d53",
+        "organizationId": "3c33066c-a0bf-4e70-9a3c-24cda6aaddd5",
+        "projectId": "81869439-bfe5-442f-8b4e-b172e68b0ab2",
+        "key": "TEST_SECRET_2",
+        "value": "abcd_such_secret_very_important_efgh",
+        "note": "notes go here",
+        "creationDate": "2023-04-23T13:26:44.0392906Z",
+        "revisionDate": "2023-04-23T13:26:44.0392906Z"
+    }
+]
+
+
+class MockBitwardenSecretsManager(BitwardenSecretsManager):
+
+    def get_secret(self, secret_id, bws_access_token):
+        return list(filter(lambda record: record["id"] == secret_id, MOCK_SECRETS))
+
+
+class TestLookupModule(unittest.TestCase):
+
+    def setUp(self):
+        self.lookup = lookup_loader.get('community.general.bitwarden_secrets_manager')
+
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager.BitwardenSecretsManager', new=MockBitwardenSecretsManager())
+    def test_bitwarden_secrets_manager(self):
+        # Getting a secret by its id should return the full secret info
+        self.assertEqual([MOCK_SECRETS[0]], self.lookup.run(['ababc4a8-c242-4e54-bceb-77d17cdf2e07'], bws_access_token='123'))
+
+    @patch('ansible_collections.community.general.plugins.lookup.bitwarden_secrets_manager.BitwardenSecretsManager', new=MockBitwardenSecretsManager())
+    def test_bitwarden_secrets_manager_no_match(self):
+        # Getting a nonexistant secret id throws exception
+        with self.assertRaises(AnsibleLookupError):
+            self.lookup.run(['nonexistant_id'], bws_access_token='123')
+


### PR DESCRIPTION
##### SUMMARY

Support for looking up a secret by ID on Bitwarden Secrets Manager (https://bitwarden.com/de-DE/products/secrets-manager/).

##### ISSUE TYPE

- New Module/Plugin Pull Request

##### COMPONENT NAME

`bitwarden_secrets_manager`

##### ADDITIONAL INFORMATION

BWS is a more automation-oriented product from Bitwarden. It is currently in beta and is not yet available for self-hosting. Therefore there is no ability to specify a custom server URL in this lookup plugin (initially). This lookup has been tested to work. All secret IDs and access tokens in the examples are dummys.

Also of note, technically there is an SDK for Bitwarden Secrets Manager:

https://bitwarden.com/help/secrets-manager-sdk/ and https://github.com/bitwarden/sdk

using this would be more robust instead of calling the CLI, but there are no Python bindings for the SDK yet. This lookup plugin could be updated in the future when a Python library is available.

This lookup plugin was built using the existing bitwarden lookup as a starting point: https://github.com/ansible-collections/community.general/pull/5012 so the code will look very similar, if simpler because it has less features.

If this is something that would be accepted at all, I can add tests. But I wanted to confirm first whether adding this lookup would be acceptable at all.