### PR TITLE
rhsm_release: removing required=true for 'release' option

### DIFF
--- a/changelogs/fragments/6401-rhsm_release-required.yml
+++ b/changelogs/fragments/6401-rhsm_release-required.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "rhsm_release - make ``release`` parameter not required so it is possible to pass ``null`` as a value. This only was possible in the past due to a bug in ansible-core that now has been fixed (https://github.com/ansible-collections/community.general/pull/6401)."

--- a/plugins/modules/rhsm_release.py
+++ b/plugins/modules/rhsm_release.py
@@ -32,8 +32,8 @@ attributes:
 options:
   release:
     description:
-      - RHSM release version to use (use null to unset)
-    required: true
+      - RHSM release version to use.
+      - To unset either pass C(null) for this option, or omit this option.
     type: str
 author:
   - Sean Myers (@seandst)
@@ -43,17 +43,17 @@ EXAMPLES = '''
 # Set release version to 7.1
 - name: Set RHSM release version
   community.general.rhsm_release:
-      release: "7.1"
+    release: "7.1"
 
 # Set release version to 6Server
 - name: Set RHSM release version
   community.general.rhsm_release:
-      release: "6Server"
+    release: "6Server"
 
 # Unset release version
 - name: Unset RHSM release release
   community.general.rhsm_release:
-      release: null
+    release: null
 '''
 
 RETURN = '''
@@ -107,7 +107,7 @@ def set_release(module, release):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            release=dict(type='str', required=True),
+            release=dict(type='str'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
##### SUMMARY
Apparently `null`/`None` was always a valid parameter. ansible-core only allowed this due to a bug that got fixed, so specifying `release: null` no longer works with that fix (https://github.com/ansible/ansible/pull/79677).

(This also breaks nightly CI.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rhsm_release
