### PR TITLE
iso_customize: fix integration test

### DIFF
--- a/tests/integration/targets/iso_create/tasks/main.yml
+++ b/tests/integration/targets/iso_create/tasks/main.yml
@@ -10,7 +10,6 @@
 - name: install pycdlib
   pip:
     name: pycdlib
-    # state: latest
     extra_args: "-c {{ remote_constraints }}"
   register: install_pycdlib
 - debug: var=install_pycdlib

--- a/tests/integration/targets/iso_customize/tasks/iso_customize_exception.yml
+++ b/tests/integration/targets/iso_customize/tasks/iso_customize_exception.yml
@@ -17,16 +17,6 @@
   register: customized_result
   failed_when: customized_result.msg.find('does not exist') == -1
 
-# Test: Get MODULE FAILURE when no add files data and no delete files data
-- name: "Testcase:: no add files data and no delete files data"
-  community.general.iso_customize:
-    src_iso: "{{ test_dir }}/test1.iso"
-    dest_iso: "{{ test_dir }}/iso_customize_nodata.iso"
-    # delete_files:
-    # add_files:
-  register: customized_result
-  failed_when: customized_result.msg.find("MODULE FAILURE") == -1
-
 # Test: nothing is changed when no options "add files" and "delete files"
 - block:
     - name: "Testcase: no options 'add files' and 'delete files'"

--- a/tests/integration/targets/iso_customize/tasks/iso_customize_exception.yml
+++ b/tests/integration/targets/iso_customize/tasks/iso_customize_exception.yml
@@ -22,8 +22,8 @@
   community.general.iso_customize:
     src_iso: "{{ test_dir }}/test1.iso"
     dest_iso: "{{ test_dir }}/iso_customize_nodata.iso"
-    delete_files:
-    add_files:
+    # delete_files:
+    # add_files:
   register: customized_result
   failed_when: customized_result.msg.find("MODULE FAILURE") == -1
 


### PR DESCRIPTION
##### SUMMARY
Passing `null` is no longer valid for random parameters.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
iso_customize
