### PR TITLE
ini_file: removing required=true for 'section' option

### DIFF
--- a/changelogs/fragments/6404-ini_file-section.yml
+++ b/changelogs/fragments/6404-ini_file-section.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ini_file - make ``section`` parameter not required so it is possible to pass ``null`` as a value. This only was possible in the past due to a bug in ansible-core that now has been fixed (https://github.com/ansible-collections/community.general/pull/6404)."

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -42,10 +42,9 @@ options:
     description:
       - Section name in INI file. This is added if I(state=present) automatically when
         a single value is being set.
-      - If left empty or set to C(null), the I(option) will be placed before the first I(section).
+      - If left empty, being omitted, or being set to C(null), the I(option) will be placed before the first I(section).
       - Using C(null) is also required if the config format does not support sections.
     type: str
-    required: true
   option:
     description:
       - If set (required for changing a I(value)), this is the name of the option.
@@ -430,7 +429,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['dest']),
-            section=dict(type='str', required=True),
+            section=dict(type='str'),
             option=dict(type='str'),
             value=dict(type='str'),
             values=dict(type='list', elements='str'),


### PR DESCRIPTION
##### SUMMARY
Apparently `null`/`None` was always a valid parameter. ansible-core only allowed this due to a bug that got fixed, so specifying `release: null` no longer works with that fix (https://github.com/ansible/ansible/pull/79677).

(This also breaks nightly CI.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ini_file
