### PR TITLE
[stable-4] pkgng: skip jail tests also on FreeBSD 12.3

### DIFF
--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -497,6 +497,9 @@
   # NOTE: FreeBSD 12.0 test runner receives a "connection reset by peer" after ~20% downloaded so we are
   #       only running this on 12.1 or higher
   #
+  # NOTE: FreeBSD 12.3 fails with some kernel mismatch for packages
+  #       (someone with FreeBSD knowledge has to take a look)
+  #
   # NOTE: FreeBSD 13.0 fails to update the package catalogue for unknown reasons (someone with FreeBSD
   #       knowledge has to take a look)
   #
@@ -504,7 +507,7 @@
   #       knowledge has to take a look)
   #
   when: >-
-    (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('13.0', '<'))
+    (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('12.3', '<'))
     or ansible_distribution_version is version('13.2', '>=')
   block:
     - name: Setup testjail


### PR DESCRIPTION
##### SUMMARY
Skip jail tests also on FreeBSD 12.3.

Backport of #6313.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pkgng
