### PR TITLE
Restrict jail tests for sysrc to certain FreeBSD versions

### DIFF
--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -139,10 +139,12 @@
     ##
     - name: Test within jail
       #
-      # NOTE: FreeBSD 12.0 test runner receives a "connection reset by peer" after ~20% downloaded so we are
-      #       only running this on 12.1 or higher
+      # NOTE: currently fails with FreeBSD 12 with minor version less than 4
+      # NOTE: currently fails with FreeBSD 13 with minor version less than 1
       #
-      when: ansible_distribution_version is version('12.01', '>=')
+      when: >-
+        ansible_distribution_version is version('12.4', '>=') and ansible_distribution_version is version('13', '<')
+        or ansible_distribution_version is version('13.1', '>=')
       block:
         - name: Setup testjail
           include: setup-testjail.yml


### PR DESCRIPTION
##### SUMMARY
Setting up the jail fails for some FreeBSD versions.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sysrc tests
