### PR TITLE
zypper_repository: disable failing repository

### DIFF
--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -214,6 +214,8 @@
       - remove_repo is changed
 
 # For now, the URL does not work for 15.4
+# FIXME: Try to get this working with newer versions
+#        (Maybe 'Uyuni' needs to be replaced with something else?)
 - when: ansible_distribution_version is version('15.4', '<')
   block:
   - name: add new repository via url to .repo file
@@ -261,8 +263,8 @@
         - "removed_by_repo_file"
         - "'/systemsmanagement:/Uyuni:/Stable/' not in etc_zypp_reposd.stdout"
 
-# For now, the file does not work for 15.4
-- when: ansible_distribution_version is version('15.4', '<')
+# FIXME: THIS DOESN'T SEEM TO WORK ANYMORE WITH ANY OPENSUSE VERSION IN CI!
+- when: false
   block:
   - name: Copy test .repo file
     copy:

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -261,24 +261,27 @@
         - "removed_by_repo_file"
         - "'/systemsmanagement:/Uyuni:/Stable/' not in etc_zypp_reposd.stdout"
 
-- name: Copy test .repo file
-  copy:
-    src: 'files/systemsmanagement_Uyuni_Utils.repo'
-    dest: '{{ remote_tmp_dir }}'
+# For now, the file does not work for 15.4
+- when: ansible_distribution_version is version('15.4', '<')
+  block:
+  - name: Copy test .repo file
+    copy:
+      src: 'files/systemsmanagement_Uyuni_Utils.repo'
+      dest: '{{ remote_tmp_dir }}'
 
-- name: add new repository via local path to .repo file
-  community.general.zypper_repository:
-    repo: "{{ remote_tmp_dir }}/systemsmanagement_Uyuni_Utils.repo"
-    state: present
-  register: added_by_repo_local_file
+  - name: add new repository via local path to .repo file
+    community.general.zypper_repository:
+      repo: "{{ remote_tmp_dir }}/systemsmanagement_Uyuni_Utils.repo"
+      state: present
+    register: added_by_repo_local_file
 
-- name: get repository details for systemsmanagement_Uyuni_Utils from zypper
-  command: zypper lr systemsmanagement_Uyuni_Utils
-  register: get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils
+  - name: get repository details for systemsmanagement_Uyuni_Utils from zypper
+    command: zypper lr systemsmanagement_Uyuni_Utils
+    register: get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils
 
-- name: verify adding repository via local .repo file was successful
-  assert:
-    that:
-      - "added_by_repo_local_file is changed"
-      - "get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils.rc == 0"
-      - "'/systemsmanagement:/Uyuni:/Utils/' in get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils.stdout"
+  - name: verify adding repository via local .repo file was successful
+    assert:
+      that:
+        - "added_by_repo_local_file is changed"
+        - "get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils.rc == 0"
+        - "'/systemsmanagement:/Uyuni:/Utils/' in get_repository_details_from_zypper_for_systemsmanagement_Uyuni_Utils.stdout"

--- a/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/tests/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -132,13 +132,14 @@
     repo: http://download.opensuse.org/repositories/devel:/languages:/ruby/openSUSE_Leap_{{ ansible_distribution_version }}/
     state: absent
 
-- name: "Test adding a repo with custom GPG key"
-  community.general.zypper_repository:
-    name: "Apache_PHP_Modules"
-    repo: "http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/"
-    priority: 100
-    auto_import_keys: true
-    state: "present"
+# FIXME: this currently fails with `Repository 'Apache_PHP_Modules' is invalid.`
+# - name: "Test adding a repo with custom GPG key"
+#   community.general.zypper_repository:
+#     name: "Apache_PHP_Modules"
+#     repo: "http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/"
+#     priority: 100
+#     auto_import_keys: true
+#     state: "present"
 
 - name: add a repo by releasever
   community.general.zypper_repository:


### PR DESCRIPTION
##### SUMMARY
https://dev.azure.com/ansible/community.general/_build/results?buildId=75137&view=logs&j=de3da64c-23eb-5657-cf0b-8258f71f384d&t=17914e40-7f52-54e0-8625-5c8000e4ff00&l=9713

```
10:45 fatal: [testhost]: FAILED! => {
10:45     "changed": false,
10:45     "cmd": "/usr/bin/zypper --quiet --non-interactive --gpg-auto-import-keys refresh --force -r Apache_PHP_Modules",
10:45     "invocation": {
10:45         "module_args": {
10:45             "auto_import_keys": true,
10:45             "autorefresh": true,
10:45             "description": null,
10:45             "disable_gpg_check": false,
10:45             "enabled": true,
10:45             "name": "Apache_PHP_Modules",
10:45             "overwrite_multiple": false,
10:45             "priority": 100,
10:45             "repo": "http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/",
10:45             "runrefresh": false,
10:45             "state": "present"
10:45         }
10:45     },
10:45     "msg": "Repository 'Apache_PHP_Modules' is invalid.\n[Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Valid metadata not found at specified URL\nHistory:\n - [Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Repository type can't be determined.\n\nSkipping repository 'Apache_PHP_Modules' because of the above error.\nCould not refresh the repositories because of errors.",
10:45     "rc": 4,
10:45     "stderr": "Repository 'Apache_PHP_Modules' is invalid.\n[Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Valid metadata not found at specified URL\nHistory:\n - [Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Repository type can't be determined.\n\nSkipping repository 'Apache_PHP_Modules' because of the above error.\nCould not refresh the repositories because of errors.\n",
10:45     "stderr_lines": [
10:45         "Repository 'Apache_PHP_Modules' is invalid.",
10:45         "[Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Valid metadata not found at specified URL",
10:45         "History:",
10:45         " - [Apache_PHP_Modules|http://download.opensuse.org/repositories/server:/php:/applications/openSUSE_Tumbleweed/] Repository type can't be determined.",
10:45         "",
10:45         "Skipping repository 'Apache_PHP_Modules' because of the above error.",
10:45         "Could not refresh the repositories because of errors."
10:45     ],
10:45     "stdout": "",
10:45     "stdout_lines": []
10:45 }
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
zypper_repository
