### PR TITLE
Redfish: Add workaround to SetBiosAttributes for Gigabyte systems that do not implement Redfish Settings properly

### DIFF
--- a/changelogs/fragments/6433-redfish-ami-bios-settings-workaround.yml
+++ b/changelogs/fragments/6433-redfish-ami-bios-settings-workaround.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - redfish_utils - add workaround to ``SetBiosAttributes`` for systems with firmware from AMI that do not properly implement ``@Redfish.Settings`` (https://github.com/ansible-collections/community.general/issues/6433).

--- a/changelogs/fragments/6433-redfish-gigabyte-bios-settings-workaround.yml
+++ b/changelogs/fragments/6433-redfish-gigabyte-bios-settings-workaround.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - redfish_utils - add workaround to ``SetBiosAttributes`` for Gigabyte systems that do not properly implement ``@Redfish.Settings`` (https://github.com/ansible-collections/community.general/issues/6433).

--- a/changelogs/fragments/6433-redfish-gigabyte-bios-settings-workaround.yml
+++ b/changelogs/fragments/6433-redfish-gigabyte-bios-settings-workaround.yml
@@ -1,2 +1,0 @@
-bugfixes:
-    - redfish_utils - add workaround to ``SetBiosAttributes`` for Gigabyte systems that do not properly implement ``@Redfish.Settings`` (https://github.com/ansible-collections/community.general/issues/6433).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1924,7 +1924,14 @@ class RedfishUtils(object):
         # Get the SettingsObject URI to apply the attributes
         set_bios_attr_uri = data.get("@Redfish.Settings", {}).get("SettingsObject", {}).get("@odata.id")
         if set_bios_attr_uri is None:
-            return {'ret': False, 'msg': "Settings resource for BIOS attributes not found."}
+            # WORKAROUND
+            # Some Gigabyte systems do not implement @Redfish.Settings, but
+            # implement the settings resource.
+            vendor = self._get_vendor()['Vendor']
+            if vendor == 'Gigabyte':
+                set_bios_attr_uri = bios_uri + "/SD"
+            else:
+                return {'ret': False, 'msg': "Settings resource for BIOS attributes not found."}
 
         # Construct payload and issue PATCH command
         payload = {"Attributes": attrs_to_patch}

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1925,10 +1925,10 @@ class RedfishUtils(object):
         set_bios_attr_uri = data.get("@Redfish.Settings", {}).get("SettingsObject", {}).get("@odata.id")
         if set_bios_attr_uri is None:
             # WORKAROUND
-            # Some Gigabyte systems do not implement @Redfish.Settings, but
-            # implement the settings resource.
+            # Some systems with firmware from AMI do not implement
+            # @Redfish.Settings, but implement the settings resource.
             vendor = self._get_vendor()['Vendor']
-            if vendor == 'Gigabyte':
+            if vendor == 'AMI':
                 set_bios_attr_uri = bios_uri + "/SD"
             else:
                 return {'ret': False, 'msg': "Settings resource for BIOS attributes not found."}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
"Bios" resources in Redfish use a settings resource to stage settings to apply. Gigabyte systems do not implement the `@Redfish.Settings` property to direct the client to the settings resource, but do indeed have the settings resource if you know the correct URI. This adds workaround logic specific to Gigabyte systems to go directly to the settings resource.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #6433

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This is a draft; I do not have access to a Gigabyte system to test this change. @felixfontein please do not merge this until there is confirmation this resolves the issue.

@sseekamp would you be able to test this change for me?
