### PR TITLE
dnsimple_info: remove extraneous importorskip from test

### DIFF
--- a/tests/unit/plugins/modules/test_dnsimple_info.py
+++ b/tests/unit/plugins/modules/test_dnsimple_info.py
@@ -13,7 +13,6 @@ from ansible_collections.community.general.tests.unit.plugins.modules.utils impo
 from httmock import response
 from httmock import with_httmock
 from httmock import urlmatch
-import pytest
 
 
 @urlmatch(netloc='(.)*dnsimple.com(.)*',

--- a/tests/unit/plugins/modules/test_dnsimple_info.py
+++ b/tests/unit/plugins/modules/test_dnsimple_info.py
@@ -16,9 +16,6 @@ from httmock import urlmatch
 import pytest
 
 
-dnsimple = pytest.importorskip('dnsimple_info')
-
-
 @urlmatch(netloc='(.)*dnsimple.com(.)*',
           path='/v2/[0-9]*/zones/')
 def zones_resp(url, request):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Unit test for `dnsimple_info` was trying to import (or otherwise skip the test) the python package `dnsimple`, but that was never actually used.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
dnsimple_info
