### PR TITLE
snap_alias: refactor code out to module utils

### DIFF
--- a/changelogs/fragments/6441-snap_alias-refactor.yml
+++ b/changelogs/fragments/6441-snap_alias-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - snap_alias - refactor code to module utils (https://github.com/ansible-collections/community.general/pull/6441).

--- a/plugins/module_utils/snap.py
+++ b/plugins/module_utils/snap.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, Alexei Znamensky <russoz@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.community.general.plugins.module_utils.cmd_runner import CmdRunner, cmd_runner_fmt
+
+
+_alias_state_map = dict(
+    present='alias',
+    absent='unalias',
+    info='aliases',
+)
+
+
+def snap_runner(module, **kwargs):
+    runner = CmdRunner(
+        module,
+        module.get_bin_path("snap"),
+        arg_formats=dict(
+            state_alias=cmd_runner_fmt.as_map(_alias_state_map),
+            name=cmd_runner_fmt.as_list(),
+            alias=cmd_runner_fmt.as_list(),
+        ),
+        check_rc=False,
+        **kwargs
+    )
+    return runner


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Minor refactor in `snap_alias`, moving the `CmdRunner` object creation to module utils. This will later be reused by the `snap` module and the upcoming `snap_info` one.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
snap_alias
