### PR TITLE
modules/proxmox_kvm: initial support for online migrations

### DIFF
--- a/changelogs/fragments/6448-proxmox-kvm-migration-support.yml
+++ b/changelogs/fragments/6448-proxmox-kvm-migration-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - adds ``migrate`` parameter to manage online migrations between hosts (https://github.com/ansible-collections/community.general/pull/6448)

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -270,6 +270,11 @@ options:
       - Memory size in MB for instance.
       - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(512).
     type: int
+  migrate:
+    description:
+      - Migrate the VM on I(node) if it is on another node.
+    type: bool
+    default: false
   migrate_downtime:
     description:
       - Sets maximum tolerated downtime (in seconds) for migrations.
@@ -800,6 +805,15 @@ EXAMPLES = '''
     name: spynal
     node: sabrewulf
     revert: 'template,cpulimit'
+
+- name: Migrate VM on second node
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    name: spynal
+    node: sabrewulf-2
+    migrate: True
 '''
 
 RETURN = '''
@@ -1062,6 +1076,16 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             return False
         return True
 
+    def migrate_vm(self, vm, target_node):
+        vmid = vm['vmid']
+        proxmox_node = self.proxmox_api.nodes(vm['node'])
+        taskid = proxmox_node.qemu(vmid).migrate.post(vmid=vmid, node=vm['node'], target=target_node, online=1)
+        if not self.wait_for_task(vm['node'], taskid):
+            self.module.fail_json(msg='Reached timeout while waiting for migrating VM. Last line in task before timeout: %s' %
+                                  proxmox_node.tasks(taskid).log.get()[:1])
+            return False
+        return True
+
 
 def main():
     module_args = proxmox_auth_argument_spec()
@@ -1109,6 +1133,7 @@ def main():
         lock=dict(choices=['migrate', 'backup', 'snapshot', 'rollback']),
         machine=dict(type='str'),
         memory=dict(type='int'),
+        migrate=dict(type='bool', default=False),
         migrate_downtime=dict(type='int'),
         migrate_speed=dict(type='int'),
         name=dict(type='str'),
@@ -1168,6 +1193,7 @@ def main():
     cpu = module.params['cpu']
     cores = module.params['cores']
     delete = module.params['delete']
+    migrate = module.params['migrate']
     memory = module.params['memory']
     name = module.params['name']
     newid = module.params['newid']
@@ -1209,7 +1235,7 @@ def main():
     # If vmid is not defined then retrieve its value from the vm name,
     # the cloned vm name or retrieve the next free VM id from ProxmoxAPI.
     if not vmid:
-        if state == 'present' and not update and not clone and not delete and not revert:
+        if state == 'present' and not update and not clone and not delete and not revert and not migrate:
             try:
                 vmid = proxmox.get_nextvmid()
             except Exception:
@@ -1255,6 +1281,18 @@ def main():
             module.exit_json(changed=True, vmid=vmid, msg="Settings has reverted on VM {0} with vmid {1}".format(name, vmid))
         except Exception as e:
             module.fail_json(vmid=vmid, msg='Unable to revert settings on VM {0} with vmid {1}: Maybe is not a pending task...   '.format(name, vmid) + str(e))
+
+    if migrate:
+        try:
+            vm = proxmox.get_vm(vmid)
+            vm_node = vm['node']
+            if node != vm_node:
+                proxmox.migrate_vm(vm, node)
+                module.exit_json(changed=True, vmid=vmid, msg="VM {0} has been migrated from {1} to {2}".format(vmid, vm_node, node))
+            else:
+                module.exit_json(changed=False, vmid=vmid, msg="VM {0} is already on {1}".format(vmid, node))
+        except Exception as e:
+            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0} from {1} to {2}...   '.format(vmid, vm_node, node) + str(e))
 
     if state == 'present':
         try:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -275,6 +275,7 @@ options:
       - Migrate the VM on I(node) if it is on another node.
     type: bool
     default: false
+    version_added: 7.0.0
   migrate_downtime:
     description:
       - Sets maximum tolerated downtime (in seconds) for migrations.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -272,7 +272,7 @@ options:
     type: int
   migrate:
     description:
-      - Migrate the VM on I(node) if it is on another node.
+      - Migrate the VM to I(node) if it is on another node.
     type: bool
     default: false
     version_added: 7.0.0

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -814,7 +814,7 @@ EXAMPLES = '''
     api_host: helldorado
     name: spynal
     node: sabrewulf-2
-    migrate: True
+    migrate: true
 '''
 
 RETURN = '''

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1293,7 +1293,7 @@ def main():
             else:
                 module.exit_json(changed=False, vmid=vmid, msg="VM {0} is already on {1}".format(vmid, node))
         except Exception as e:
-            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0} from {1} to {2}...   '.format(vmid, vm_node, node) + str(e))
+            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0} from {1} to {2}: {3}'.format(vmid, vm_node, node, e))
 
     if state == 'present':
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I found myself wanting to use the `proxmox_kvm`module to migrate VM on different hosts, so I propose this change to do that by adding the `migrate` option, which is `False`by default (to prevent any breaking of existing playbooks).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox_kvm
