### PR TITLE
modules/portage: fix usage with withbdeps: false

### DIFF
--- a/changelogs/fragments/6456-fix-portage-withbdeps-false.yml
+++ b/changelogs/fragments/6456-fix-portage-withbdeps-false.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "portage - update the logic for generating the emerge command arguments to ensure that ``withbdeps: false`` results in a passing an ``n`` argument with the ``--with-bdeps`` emerge flag (https://github.com/ansible-collections/community.general/issues/6451, https://github.com/ansible-collections/community.general/pull/6456)."

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -383,14 +383,12 @@ def emerge_packages(module, packages):
             """Fallback to default: don't use this argument at all."""
             continue
 
-        if not flag_val:
+        """Add the --flag=value pair."""
+        if isinstance(flag_val, bool):
+            args.extend((arg, to_native('y' if flag_val else 'n')))
+        elif not flag_val:
             """If the value is 0 or 0.0: add the flag, but not the value."""
             args.append(arg)
-            continue
-
-        """Add the --flag=value pair."""
-        if isinstance(p[flag], bool):
-            args.extend((arg, to_native('y' if flag_val else 'n')))
         else:
             args.extend((arg, to_native(flag_val)))
 


### PR DESCRIPTION
##### SUMMARY
Using ``withbdeps: false`` was causing the underlying emerge command to fail due to not passing an argument to the ``--with-bdeps`` flag.  Fix by updating the logic for generating the emerge command arguments to ensure that ``withbdeps: false`` results in a passing an ``n`` argument with the ``--with-bdeps`` emerge flag.

Fixes #6451.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
portage