### PR TITLE
mssql_script: allow non-returning SQL statements

### DIFF
--- a/changelogs/fragments/6192-allow-empty-resultsets.yml
+++ b/changelogs/fragments/6192-allow-empty-resultsets.yml
@@ -1,3 +1,4 @@
 minor_changes:
-  - mssql_script_module - Handle error condition for empty resultsets to allow for non-returning SQL statements (eg. UPDATE/INSERT)
-  - mssql_script_module - Allow for "GO" statement to be mixed-case for scripts not using strict syntax
+  - mssql_script - handle error condition for empty resultsets to allow for non-returning SQL statements (for example ``UPDATE`` and ``INSERT``) (https://github.com/ansible-collections/community.general/pull/6457).
+  - mssql_script - allow for ``GO`` statement to be mixed-case for scripts not using strict syntax (https://github.com/ansible-collections/community.general/pull/6457).
+  - mssql_script - improve batching logic to allow a wider variety of input scripts. For example, SQL scripts slurped from Windows machines which may contain carriage return (''\r'') characters.

--- a/changelogs/fragments/6192-allow-empty-resultsets.yml
+++ b/changelogs/fragments/6192-allow-empty-resultsets.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - mssql_script_module - Handle error condition for empty resultsets to allow for non-returning SQL statements (eg. UPDATE/INSERT)
+  - mssql_script_module - Allow for "GO" statement to be mixed-case for scripts not using strict syntax

--- a/changelogs/fragments/6192-allow-empty-resultsets.yml
+++ b/changelogs/fragments/6192-allow-empty-resultsets.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - mssql_script - handle error condition for empty resultsets to allow for non-returning SQL statements (for example ``UPDATE`` and ``INSERT``) (https://github.com/ansible-collections/community.general/pull/6457).
   - mssql_script - allow for ``GO`` statement to be mixed-case for scripts not using strict syntax (https://github.com/ansible-collections/community.general/pull/6457).
-  - mssql_script - improve batching logic to allow a wider variety of input scripts. For example, SQL scripts slurped from Windows machines which may contain carriage return (''\r'') characters.
+  - mssql_script - improve batching logic to allow a wider variety of input scripts. For example, SQL scripts slurped from Windows machines which may contain carriage return (''\r'') characters (https://github.com/ansible-collections/community.general/pull/6457).

--- a/plugins/modules/mssql_script.py
+++ b/plugins/modules/mssql_script.py
@@ -323,7 +323,7 @@ def run_module():
                 query_results.append([])
             else:
                 error_msg = '%s: %s' % (type(e).__name__, str(e))
-                return module.fail_json(msg="query failed", query=query, error=error_msg, **result)
+                module.fail_json(msg="query failed", query=query, error=error_msg, **result)
 
     # ensure that the result is json serializable
     qry_results = json.loads(json.dumps(query_results, default=clean_output))

--- a/plugins/modules/mssql_script.py
+++ b/plugins/modules/mssql_script.py
@@ -281,10 +281,9 @@ def run_module():
         query_results_key = 'query_results_dict'
 
     # Process the script into batches
-    statements = script.split('\n')
     queries = []
     current_batch = []
-    for statement in statements:
+    for statement in script.splitlines(keepends=True):
         # Ignore the Byte Order Mark, if found
         if statement.strip() == '\uFEFF':
             continue
@@ -294,10 +293,10 @@ def run_module():
         if statement.strip().upper() != 'GO':
             current_batch.append(statement)
         else:
-            queries.append('\n'.join(current_batch))
+            queries.append(''.join(current_batch))
             current_batch = []
     if len(current_batch) > 0:
-        queries.append('\n'.join(current_batch))
+        queries.append(''.join(current_batch))
 
     result['changed'] = True
     if module.check_mode:

--- a/tests/integration/targets/mssql_script/tasks/main.yml
+++ b/tests/integration/targets/mssql_script/tasks/main.yml
@@ -13,6 +13,7 @@
 # docker run --name mssql-test -e "ACCEPT_EULA=Y" -e 'SA_PASSWORD={{ mssql_login_password }}' -p "{ mssql_port }"0:"{ mssql_port }" -d mcr.microsoft.com/mssql/server:2019-latest
 # ansible-test integration mssql_script  -v --allow-disabled
 
+<<<<<<< HEAD
 - name: Install pymssql
   ansible.builtin.pip:
     name:
@@ -48,6 +49,19 @@
     login_host: "{{ mssql_host }}"
     login_port: "{{ mssql_port }}"
     script: "SELECT 1"
+
+- name: Execute a malformed query
+  ws1cs.db.mssql_script:
+    login_user: "{{ mssql_login_user }}"
+    login_password: "{{ mssql_login_password }}"
+    login_host: "{{ mssql_host }}"
+    login_port: "{{ mssql_port }}"
+    script: "SELCT 1"
+  failed_when: false
+  register: bad_query
+- assert:
+    that:
+      - bad_query.error.startswith('ProgrammingError')
 
 - name: two batches with default output
   community.general.mssql_script:
@@ -134,6 +148,30 @@
       - result_batches_dict.query_results_dict[0] | length == 2  # two selects in first batch
       - result_batches_dict.query_results_dict[0][0] | length == 1  # one row in first select
       - result_batches_dict.query_results_dict[0][0][0]['b0s0'] == 'Batch 0 - Select 0'  # column 'b0s0' of first row
+
+- name: Multiple batches with no resultsets and mixed-case GO
+  ws1cs.db.mssql_script:
+    login_user: "{{ mssql_login_user }}"
+    login_password: "{{ mssql_login_password }}"
+    login_host: "{{ mssql_host }}"
+    login_port: "{{ mssql_port }}"
+    script: |
+      CREATE TABLE #integration56yH2 (c1 VARCHAR(10), c2 VARCHAR(10))
+      Go
+      INSERT INTO #integration56yH2 VALUES ('C1_VALUE1', 'C2_VALUE1')
+      gO
+      UPDATE #integration56yH2 SET c2 = 'C2_VALUE2' WHERE c1 = 'C1_VALUE1'
+      go
+      SELECT * from #integration56yH2
+      GO
+      DROP TABLE #integration56yH2
+  register: empty_batches
+- assert:
+    that:
+      - empty_batches.query_results | length == 5  # five batch results
+      - empty_batches.query_results[3][0] | length == 1  # one row in select
+      - empty_batches.query_results[3][0][0] | length == 2  # two columns in row
+      - empty_batches.query_results[3][0][0][1] == 'C2_VALUE2'  # value has been updated
 
 - name: Stored procedure may return multiple result sets
   community.general.mssql_script:

--- a/tests/integration/targets/mssql_script/tasks/main.yml
+++ b/tests/integration/targets/mssql_script/tasks/main.yml
@@ -50,7 +50,7 @@
     script: "SELECT 1"
 
 - name: Execute a malformed query
-  ws1cs.db.mssql_script:
+  community.general.mssql_script:
     login_user: "{{ mssql_login_user }}"
     login_password: "{{ mssql_login_password }}"
     login_host: "{{ mssql_host }}"
@@ -149,7 +149,7 @@
       - result_batches_dict.query_results_dict[0][0][0]['b0s0'] == 'Batch 0 - Select 0'  # column 'b0s0' of first row
 
 - name: Multiple batches with no resultsets and mixed-case GO
-  ws1cs.db.mssql_script:
+  community.general.mssql_script:
     login_user: "{{ mssql_login_user }}"
     login_password: "{{ mssql_login_password }}"
     login_host: "{{ mssql_host }}"

--- a/tests/integration/targets/mssql_script/tasks/main.yml
+++ b/tests/integration/targets/mssql_script/tasks/main.yml
@@ -13,7 +13,6 @@
 # docker run --name mssql-test -e "ACCEPT_EULA=Y" -e 'SA_PASSWORD={{ mssql_login_password }}' -p "{ mssql_port }"0:"{ mssql_port }" -d mcr.microsoft.com/mssql/server:2019-latest
 # ansible-test integration mssql_script  -v --allow-disabled
 
-<<<<<<< HEAD
 - name: Install pymssql
   ansible.builtin.pip:
     name:


### PR DESCRIPTION
- The current implementation fails out when certain statements or batches do not have resultsets - this limits the usefulness of the module
- Instead, it is known that statements without resultsets return then OperationalError exception with text "Statement not executed or executed statement has no resultset". We will utilize these facts to accept these statements
- The implementation also assumes that users will always use best- practices for the script syntax; that is, "GO" will always be capitalized but this is not strictly required -- update to allow "GO" to be any mixed-case
- Fixes #6192
