### PR TITLE
Make sure that plugins/module_utils/deps.py is cleaned up before every test

### DIFF
--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -13,6 +13,8 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
 
+from ansible_collections.community.general.plugins.module_utils import deps
+
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
@@ -30,3 +32,8 @@ def patch_ansible_module(request, mocker):
         raise Exception('Malformed data to the patch_ansible_module pytest fixture')
 
     mocker.patch('ansible.module_utils.basic._ANSIBLE_ARGS', to_bytes(args))
+
+
+@pytest.fixture(autouse=True)
+def deps_cleanup():
+    deps._deps.clear()


### PR DESCRIPTION
##### SUMMARY
Fixes the problem where dependencies leak between modules.

Ref: https://github.com/ansible-collections/community.general/pull/6439#issuecomment-1527239948
Ref: https://github.com/ansible-collections/community.general/pull/6453

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit test global fixtures
