### PR TITLE
MH mh/mixins/deps.py: deprecation

### DIFF
--- a/changelogs/fragments/6465-mh-deps-deprecation.yml
+++ b/changelogs/fragments/6465-mh-deps-deprecation.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - ModuleHelper module_utils - ``deps`` mixin for MH classes deprecated in favour of using the ``deps`` module_utils (https://github.com/ansible-collections/community.general/pull/6465).

--- a/plugins/module_utils/mh/mixins/deps.py
+++ b/plugins/module_utils/mh/mixins/deps.py
@@ -38,6 +38,12 @@ class DependencyCtxMgr(object):
 
 
 class DependencyMixin(ModuleHelperBase):
+    """
+    THIS CLASS IS BEING DEPRECATED.
+    See the deprecation notice in ``DependencyMixin.fail_on_missing_deps()`` below.
+
+    Mixin for mapping module options to running a CLI command with its arguments.
+    """
     _dependencies = []
 
     @classmethod
@@ -46,6 +52,12 @@ class DependencyMixin(ModuleHelperBase):
         return cls._dependencies[-1]
 
     def fail_on_missing_deps(self):
+        self.module.deprecate(
+            'The DependencyMixin is being deprecated. '
+            'Modules should use community.general.plugins.module_utils.deps instead.',
+            version='9.0.0',
+            collection_name='community.general',
+        )
         for d in self._dependencies:
             if not d.has_it:
                 self.module.fail_json(changed=False,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deprecate the dependency mixin for MH in favour of using `module_utils.deps`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/mh/mixins/deps.py

