### PR TITLE
Inspq keycloak role composites

### DIFF
--- a/changelogs/fragments/6469-add-composites-support-for-keycloak-role.yml
+++ b/changelogs/fragments/6469-add-composites-support-for-keycloak-role.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_role - Add composite roles support for realm and client roles (https://github.com/ansible-collections/community.general/pull/6469).
+  - keycloak_role - add composite roles support for realm and client roles (https://github.com/ansible-collections/community.general/pull/6469).

--- a/changelogs/fragments/6469-add-composites-support-for-keycloak-role.yml
+++ b/changelogs/fragments/6469-add-composites-support-for-keycloak-role.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_role - Add composite roles support for realm and client roles (https://github.com/ansible-collections/community.general/pull/6469).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1767,7 +1767,7 @@ class KeycloakAPI(object):
                 existing_composite_client = None
                 for existing_composite in existing_composites:
                     if existing_composite["clientRole"]:
-                        existing_composite_client = self.get_client_by_id(existing_composite["containerId"])
+                        existing_composite_client = self.get_client_by_id(existing_composite["containerId"], realm=realm)
                         if ("client_id" in composite
                                 and composite['client_id'] is not None
                                 and existing_composite_client["clientId"] == composite["client_id"]
@@ -1787,7 +1787,7 @@ class KeycloakAPI(object):
                                 composites_to_be_created.append(client_role)
                                 break
                     else:
-                        realm_role = self.get_realm_role(name=composite["name"])
+                        realm_role = self.get_realm_role(name=composite["name"], realm=realm)
                         composites_to_be_created.append(realm_role)
                 elif composite_found and 'state' in composite and composite['state'] == 'absent':
                     if "client_id" in composite and composite['client_id'] is not None:
@@ -1797,7 +1797,7 @@ class KeycloakAPI(object):
                                 composites_to_be_deleted.append(client_role)
                                 break
                     else:
-                        realm_role = self.get_realm_role(name=composite["name"])
+                        realm_role = self.get_realm_role(name=composite["name"], realm=realm)
                         composites_to_be_deleted.append(realm_role)
 
             if len(composites_to_be_created) > 0:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1716,18 +1716,12 @@ class KeycloakAPI(object):
                         client_roles = self.get_client_roles(clientid=composite['client_id'], realm=realm)
                         for client_role in client_roles:
                             if client_role['name'] == composite['name']:
-                                f = open('/tmp/client_role.json','w')
-                                f.write(json.dumps(client_role))
-                                f.close()
                                 composites_to_be_created.append(client_role)
                                 break
                     else:
                         realm_role = self.get_realm_role(name=composite["name"])
                         composites_to_be_created.append(realm_role)
             if len(composites_to_be_created) > 0:
-                f = open('/tmp/composites_to_be_created.json','w')
-                f.write(json.dumps(composites_to_be_created))
-                f.close()
                 # create new composites
                 open_url(composite_url, method='POST', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                     data=json.dumps(composites_to_be_created), validate_certs=self.validate_certs)

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -208,7 +208,7 @@ def is_struct_included(struct1, struct2, exclude=None):
             Return True if all element of dict 1 are present in dict 2, return false otherwise.
     """
     if isinstance(struct1, list) and isinstance(struct2, list):
-        if len(struct1) == 0 and len(struct2) == 0:
+        if not struct1 and not struct2:
             return True
         found = False
         for item1 in struct1:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1695,7 +1695,8 @@ class KeycloakAPI(object):
                 del rolerep["composites"]
             role_response = open_url(role_url, method='PUT', http_agent=self.http_agent, headers=self.restheaders, timeout=self.connection_timeout,
                                      data=json.dumps(rolerep), validate_certs=self.validate_certs)
-            self.update_role_composites(rolerep=rolerep, composites=composites, realm=realm)
+            if composites is not None:
+                self.update_role_composites(rolerep=rolerep, composites=composites, realm=realm)
             return role_response
         except Exception as e:
             self.module.fail_json(msg='Could not update role %s in realm %s: %s'

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -1757,7 +1757,6 @@ class KeycloakAPI(object):
                                       % (rolerep['name'], realm, str(e)))
 
     def update_role_composites(self, rolerep, composites, clientid=None, realm='master'):
-        if composites is not None:
             # Get existing composites
             existing_composites = self.get_role_composites(rolerep=rolerep, clientid=clientid, realm=realm)
             composites_to_be_created = []

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -229,7 +229,7 @@ def is_struct_included(struct1, struct2, exclude=None):
                 return False
         return found
     elif isinstance(struct1, dict) and isinstance(struct2, dict):
-        if len(struct1) == 0 and len(struct2) == 0:
+        if not struct1 and not struct2:
             return True
         try:
             for key in struct1:

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -210,24 +210,17 @@ def is_struct_included(struct1, struct2, exclude=None):
     if isinstance(struct1, list) and isinstance(struct2, list):
         if not struct1 and not struct2:
             return True
-        found = False
         for item1 in struct1:
-            found = False
-            if isinstance(item1, list) or isinstance(item1, dict):
-                found1 = False
+            if isinstance(item1, (list, dict)):
                 for item2 in struct2:
                     if is_struct_included(item1, item2, exclude):
-                        found1 = True
-                if found1:
-                    found = True
+                        break
+                else:
+                    return False
             else:
                 if item1 not in struct2:
                     return False
-                else:
-                    found = True
-            if not found:
-                return False
-        return found
+        return True
     elif isinstance(struct1, dict) and isinstance(struct2, dict):
         if not struct1 and not struct2:
             return True

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -90,6 +90,7 @@ options:
         default: []
         type: list
         elements: dict
+        version_added: 7.0.0
         suboptions:
             name:
                 description:

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -354,6 +354,9 @@ def main():
             kc.create_client_role(desired_role, clientid, realm)
             after_role = kc.get_client_role(name, clientid, realm)
 
+        if after_role['composite']:
+            after_role['composites'] = kc.get_role_composites(rolerep=after_role, clientid=clientid, realm=realm)
+
         result['end_state'] = after_role
 
         result['msg'] = 'Role {name} has been created'.format(name=name)
@@ -368,7 +371,7 @@ def main():
                 for composite in composites:
                     before_composite = {}
                     if composite['clientRole']:
-                        composite_client = kc.get_client_by_id(id=composite['containerId'])
+                        composite_client = kc.get_client_by_id(id=composite['containerId'], realm=realm)
                         before_composite['client_id'] = composite_client['clientId']
                     else:
                         before_composite['client_id'] = None
@@ -401,6 +404,8 @@ def main():
             else:
                 kc.update_client_role(desired_role, clientid, realm)
                 after_role = kc.get_client_role(name, clientid, realm)
+            if after_role['composite']:
+                after_role['composites'] = kc.get_role_composites(rolerep=after_role, clientid=clientid, realm=realm)
 
             result['end_state'] = after_role
 

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -99,6 +99,14 @@ options:
                     - Client ID if the role is a client role. Do not include this option for a REALM role.
                     - Use the client id we can see in the Keycloak console, not the technical id of the client.
                 type: str
+            state:
+                description:
+                    - Create the composite if present, remove it if absent.
+                type: str
+                choices:
+                    - present
+                    - absent
+                default: present
 
 extends_documentation_fragment:
     - community.general.keycloak
@@ -234,7 +242,8 @@ def main():
 
     composites_spec = dict(
         name=dict(type='str', required=True),
-        client_id=dict(type='str', alias='clientId')
+        client_id=dict(type='str', alias='clientId'),
+        state=dict(type='str', default='present', choices=['present', 'absent'])
     )
 
     meta_args = dict(

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -82,7 +82,7 @@ options:
             - If C(true), the role is a composition of other realm and/or client role.
         default: false
         type: bool
-        version_added: 7.0.0
+        version_added: 7.1.0
     composites:
         description:
             - List of roles to include to the composite realm role.

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -82,6 +82,7 @@ options:
             - If C(true), the role is a composition of other realm and/or client role.
         default: false
         type: bool
+        version_added: 7.0.0
     composites:
         description:
             - List of roles to include to the composite realm role.

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -86,7 +86,7 @@ options:
     composites:
         description:
             - List of roles to include to the composite realm role.
-            - If the composite role is a client role, the clientId (not id of the client) must be specified.
+            - If the composite role is a client role, the C(clientId) (not ID of the client) must be specified.
         default: []
         type: list
         elements: dict

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -100,7 +100,7 @@ options:
             client_id:
                 description:
                     - Client ID if the role is a client role. Do not include this option for a REALM role.
-                    - Use the client id we can see in the Keycloak console, not the technical id of the client.
+                    - Use the client ID you can see in the Keycloak console, not the technical ID of the client.
                 type: str
                 required: false
                 aliases:

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -79,7 +79,7 @@ options:
             - Values may be single values (e.g. a string) or a list of strings.
     composite:
         description:
-            - If true, the role is a composition of other realm and/or client role.
+            - If C(true), the role is a composition of other realm and/or client role.
         default: false
         type: bool
     composites:

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -314,12 +314,7 @@ def main():
         new_param_value = module.params.get(param)
         old_value = before_role[param] if param in before_role else None
         if new_param_value != old_value:
-            if isinstance(param, dict):
-                changeset[camel(param)] = copy.deepcopy(new_param_value)
-            elif isinstance(param, list):
-                changeset[camel(param)] = new_param_value.copy()
-            else:
-                changeset[camel(param)] = new_param_value
+            changeset[camel(param)] = copy.deepcopy(new_param_value)
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_role = copy.deepcopy(before_role)

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -79,7 +79,7 @@ options:
             - Values may be single values (e.g. a string) or a list of strings.
     composite:
         description:
-            - If C(true), the role is a composition of other realm and/or client role.
+            - If V(true), the role is a composition of other realm and/or client role.
         default: false
         type: bool
         version_added: 7.1.0

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -308,12 +308,6 @@ def main():
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_role = copy.deepcopy(before_role)
     desired_role.update(changeset)
-    f1 = open("/tmp/changeset.json", "w")
-    f1.write(str(changeset))
-    f1.close()
-    f2 = open("/tmp/desired.json", 'w')
-    f2.write(str(desired_role))
-    f2.close()
 
     result['proposed'] = changeset
     result['existing'] = before_role

--- a/plugins/modules/keycloak_role.py
+++ b/plugins/modules/keycloak_role.py
@@ -90,7 +90,7 @@ options:
         default: []
         type: list
         elements: dict
-        version_added: 7.0.0
+        version_added: 7.1.0
         suboptions:
             name:
                 description:

--- a/tests/integration/targets/keycloak_role/README.md
+++ b/tests/integration/targets/keycloak_role/README.md
@@ -1,0 +1,20 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+# Running keycloak_user module integration test
+
+To run Keycloak user module's integration test, start a keycloak server using Docker or Podman:
+
+    podman|docker run -d --rm --name mykeycloak -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=password quay.io/keycloak/keycloak:latest start-dev --http-relative-path /auth
+
+Source Ansible env-setup from ansible github repository
+
+Run integration tests:
+
+    ansible-test integration keycloak_role --python 3.10 --allow-unsupported
+
+Cleanup:
+
+    podman|docker stop mykeycloak

--- a/tests/integration/targets/keycloak_role/tasks/main.yml
+++ b/tests/integration/targets/keycloak_role/tasks/main.yml
@@ -248,3 +248,236 @@
     that:
       - result is not changed
       - result.end_state == {}
+
+- name: Create realm role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert realm role is created with composites
+  assert:
+    that:
+      - result is changed
+      - result.end_state.composites | length == 3
+
+- name: Change realm role with composites no change
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert realm role with composites have not changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state.composites | length == 3
+
+- name: Remove composite from realm role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites_with_absent }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert composite was removed from realm role with composites
+  assert:
+    that:
+      - result is changed
+      - result.end_state.composites | length == 2
+
+- name: Delete realm role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ keycloak_role_name }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert realm role deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Delete absent realm role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ keycloak_role_name }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert not changed and realm role absent
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}
+
+- name: Create client role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    client_id: "{{ client_id }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert client role is created with composites
+  assert:
+    that:
+      - result is changed
+      - result.end_state.composites | length == 3
+
+- name: Change client role with composites no change
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    client_id: "{{ client_id }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert client role with composites have not changed
+  assert:
+    that:
+      - result is not changed
+      - result.end_state.composites | length == 3
+
+- name: Remove composite from client role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    name: "{{ keycloak_role_name }}"
+    client_id: "{{ client_id }}"
+    realm: "{{ realm }}"
+    description: "{{ keycloak_role_description }}"
+    composite: "{{ keycloak_role_composite }}"
+    composites: "{{ keycloak_role_composites_with_absent }}"
+    state: present
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert composite was removed from client role with composites
+  assert:
+    that:
+      - result is changed
+      - result.end_state.composites | length == 2
+
+- name: Delete client role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ keycloak_role_name }}"
+    client_id: "{{ client_id }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert client role deleted
+  assert:
+    that:
+      - result is changed
+      - result.end_state == {}
+
+- name: Delete absent client role with composites
+  community.general.keycloak_role:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    name: "{{ keycloak_role_name }}"
+    client_id: "{{ client_id }}"
+    state: absent
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert not changed and client role absent
+  assert:
+    that:
+      - result is not changed
+      - result.end_state == {}

--- a/tests/integration/targets/keycloak_role/vars/main.yml
+++ b/tests/integration/targets/keycloak_role/vars/main.yml
@@ -12,3 +12,30 @@ client_id: myclient
 role: myrole
 description_1: desc 1
 description_2: desc 2
+
+keycloak_role_name: test
+keycloak_role_description: test
+keycloak_role_composite: true
+keycloak_role_composites:
+  - name: view-clients 
+    client_id: "realm-management"
+    state: present
+  - name: query-clients 
+    client_id: "realm-management"
+    state: present
+  - name: offline_access
+    state: present
+keycloak_client_id: test-client
+keycloak_client_name: test-client
+keycloak_client_description: This is a client for testing purpose
+role_state: present
+
+keycloak_role_composites_with_absent:
+  - name: view-clients 
+    client_id: "realm-management"
+    state: present
+  - name: query-clients 
+    client_id: "realm-management"
+    state: present
+  - name: offline_access
+    state: absent

--- a/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_module_utils.py
+++ b/tests/unit/plugins/module_utils/identity/keycloak/test_keycloak_module_utils.py
@@ -1,0 +1,103 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import is_struct_included
+
+
+class KeycloakIsStructIncludedTestCase(unittest.TestCase):
+    dict1 = dict(
+        test1='test1',
+        test2=dict(
+            test1='test1',
+            test2='test2'
+        ),
+        test3=['test1', dict(test='test1', test2='test2')]
+    )
+    dict2 = dict(
+        test1='test1',
+        test2=dict(
+            test1='test1',
+            test2='test2',
+            test3='test3'
+        ),
+        test3=['test1', dict(test='test1', test2='test2'), 'test3'],
+        test4='test4'
+    )
+    dict3 = dict(
+        test1='test1',
+        test2=dict(
+            test1='test1',
+            test2='test23',
+            test3='test3'
+        ),
+        test3=['test1', dict(test='test1', test2='test23'), 'test3'],
+        test4='test4'
+    )
+
+    dict5 = dict(
+        test1='test1',
+        test2=dict(
+            test1=True,
+            test2='test23',
+            test3='test3'
+        ),
+        test3=['test1', dict(test='test1', test2='test23'), 'test3'],
+        test4='test4'
+    )
+
+    dict6 = dict(
+        test1='test1',
+        test2=dict(
+            test1='true',
+            test2='test23',
+            test3='test3'
+        ),
+        test3=['test1', dict(test='test1', test2='test23'), 'test3'],
+        test4='test4'
+    )
+    dict7 = [
+        {
+            'roles': ['view-clients', 'view-identity-providers', 'view-users', 'query-realms', 'manage-users'],
+            'clientid': 'master-realm'
+        },
+        {
+            'roles': ['manage-account', 'view-profile', 'manage-account-links'],
+            'clientid': 'account'
+        }
+    ]
+    dict8 = [
+        {
+            'roles': ['view-clients', 'query-realms', 'view-users'],
+            'clientid': 'master-realm'
+        },
+        {
+            'roles': ['manage-account-links', 'view-profile', 'manage-account'],
+            'clientid': 'account'
+        }
+    ]
+
+    def test_trivial(self):
+        self.assertTrue(is_struct_included(self.dict1, self.dict1))
+
+    def test_equals_with_dict2_bigger_than_dict1(self):
+        self.assertTrue(is_struct_included(self.dict1, self.dict2))
+
+    def test_not_equals_with_dict2_bigger_than_dict1(self):
+        self.assertFalse(is_struct_included(self.dict2, self.dict1))
+
+    def test_not_equals_with_dict1_different_than_dict3(self):
+        self.assertFalse(is_struct_included(self.dict1, self.dict3))
+
+    def test_equals_with_dict5_contain_bool_and_dict6_contain_true_string(self):
+        self.assertFalse(is_struct_included(self.dict5, self.dict6))
+        self.assertFalse(is_struct_included(self.dict6, self.dict5))
+
+    def test_not_equals_dict7_dict8_compare_dict7_with_list_bigger_than_dict8_but_reverse_equals(self):
+        self.assertFalse(is_struct_included(self.dict7, self.dict8))
+        self.assertTrue(is_struct_included(self.dict8, self.dict7))

--- a/tests/unit/plugins/modules/test_keycloak_role.py
+++ b/tests/unit/plugins/modules/test_keycloak_role.py
@@ -21,7 +21,9 @@ from ansible.module_utils.six import StringIO
 
 
 @contextmanager
-def patch_keycloak_api(get_realm_role, create_realm_role=None, update_realm_role=None, delete_realm_role=None):
+def patch_keycloak_api(get_realm_role=None, create_realm_role=None, update_realm_role=None, delete_realm_role=None,
+                       get_client_role=None, create_client_role=None, update_client_role=None, delete_client_role=None,
+                       get_client_by_id=None, get_role_composites=None):
     """Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
 
     Patches the `login` and `_post_json` methods
@@ -41,7 +43,15 @@ def patch_keycloak_api(get_realm_role, create_realm_role=None, update_realm_role
         with patch.object(obj, 'create_realm_role', side_effect=create_realm_role) as mock_create_realm_role:
             with patch.object(obj, 'update_realm_role', side_effect=update_realm_role) as mock_update_realm_role:
                 with patch.object(obj, 'delete_realm_role', side_effect=delete_realm_role) as mock_delete_realm_role:
-                    yield mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role
+                    with patch.object(obj, 'get_client_role', side_effect=get_client_role) as mock_get_client_role:
+                        with patch.object(obj, 'create_client_role', side_effect=create_client_role) as mock_create_client_role:
+                            with patch.object(obj, 'update_client_role', side_effect=update_client_role) as mock_update_client_role:
+                                with patch.object(obj, 'delete_client_role', side_effect=delete_client_role) as mock_delete_client_role:
+                                    with patch.object(obj, 'get_client_by_id', side_effect=get_client_by_id) as mock_get_client_by_id:
+                                        with patch.object(obj, 'get_role_composites', side_effect=get_role_composites) as mock_get_role_composites:
+                                            yield mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role, \
+                                                mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role, \
+                                                mock_get_client_by_id, mock_get_role_composites
 
 
 def get_response(object_with_future_response, method, get_id_call_count):
@@ -125,7 +135,9 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_realm_role=return_value_absent, create_realm_role=return_value_created) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role):
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
@@ -179,7 +191,9 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role):
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
@@ -233,13 +247,149 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role):
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
         self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_create_with_composites_when_present_no_change(self):
+        """Update without change a realm role"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            'validate_certs': True,
+            'realm': 'realm-name',
+            'name': 'role-name',
+            'description': 'role-description',
+            'composite': True,
+            'composites': [
+                {
+                    'client_id': 'client_1',
+                    'name': 'client-role1'
+                },
+                {
+                    'name': 'realm-role-1'
+                }
+            ]
+
+        }
+        return_value_present = [
+            {
+                "attributes": {},
+                "clientRole": False,
+                "composite": True,
+                "containerId": "realm-name",
+                "description": "role-description",
+                "id": "90f1cdb6-be88-496e-89c6-da1fb6bc6966",
+                "name": "role-name",
+            },
+            {
+                "attributes": {},
+                "clientRole": False,
+                "composite": True,
+                "containerId": "realm-name",
+                "description": "role-description",
+                "id": "90f1cdb6-be88-496e-89c6-da1fb6bc6966",
+                "name": "role-name",
+            }
+        ]
+        return_value_updated = [None]
+        return_get_role_composites = [
+            [
+                {
+                    'clientRole': True,
+                    'containerId': 'c4367fac-f427-11ed-8e2f-aff070d20f0e',
+                    'name': 'client-role1'
+                },
+                {
+                    'clientRole': False,
+                    'containerId': 'realm-name',
+                    'name': 'realm-role-1'
+                }
+            ]
+        ]
+        return_get_client_by_client_id = [
+            {
+                "id": "de152444-f126-4a7a-8273-4ee1544133ad",
+                "clientId": "client_1",
+                "name": "client_1",
+                "description": "client_1",
+                "surrogateAuthRequired": False,
+                "enabled": True,
+                "alwaysDisplayInConsole": False,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                    "http://localhost:8080/*",
+                ],
+                "webOrigins": [
+                    "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": False,
+                "consentRequired": False,
+                "standardFlowEnabled": True,
+                "implicitFlowEnabled": False,
+                "directAccessGrantsEnabled": False,
+                "serviceAccountsEnabled": False,
+                "publicClient": False,
+                "frontchannelLogout": False,
+                "protocol": "openid-connect",
+                "attributes": {
+                    "backchannel.logout.session.required": "true",
+                    "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": True,
+                "nodeReRegistrationTimeout": -1,
+                "defaultClientScopes": [
+                    "web-origins",
+                    "acr",
+                    "profile",
+                    "roles",
+                    "email"
+                ],
+                "optionalClientScopes": [
+                    "address",
+                    "phone",
+                    "offline_access",
+                    "microprofile-jwt"
+                ]
+            }
+        ]
+
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(get_realm_role=return_value_present, update_realm_role=return_value_updated,
+                                    get_client_by_id=return_get_client_by_client_id,
+                                    get_role_composites=return_get_role_composites) \
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
+        self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_get_client_by_client_id.mock_calls), 1)
+        self.assertEqual(len(mock_get_role_composites.mock_calls), 1)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
@@ -268,7 +418,9 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role):
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
@@ -312,12 +464,216 @@ class TestKeycloakRealmRole(ModuleTestCase):
 
         with mock_good_connection():
             with patch_keycloak_api(get_realm_role=return_value_absent, delete_realm_role=return_value_deleted) \
-                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role):
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_delete_realm_role.mock_calls), 1)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+
+class TestKeycloakClientRole(ModuleTestCase):
+    def setUp(self):
+        super(TestKeycloakClientRole, self).setUp()
+        self.module = keycloak_role
+
+    def test_create_client_role_with_composites_when_absent(self):
+        """Update with change a realm role"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            'validate_certs': True,
+            'realm': 'realm-name',
+            'client_id': 'client-name',
+            'name': 'role-name',
+            'description': 'role-description',
+            'composite': True,
+            'composites': [
+                {
+                    'client_id': 'client_1',
+                    'name': 'client-role1'
+                },
+                {
+                    'name': 'realm-role-1'
+                }
+            ]
+        }
+        return_get_client_role = [
+            None,
+            {
+                "attributes": {},
+                "clientRole": True,
+                "composite": True,
+                "composites": [
+                    {
+                        'client': {
+                            'client1': ['client-role1']
+                        }
+                    },
+                    {
+                        'realm': ['realm-role-1']
+                    }
+                ],
+                "containerId": "9ae25ec2-f40a-11ed-9261-b3bacf720f69",
+                "description": "role-description",
+                "id": "90f1cdb6-be88-496e-89c6-da1fb6bc6966",
+                "name": "role-name",
+            }
+        ]
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(get_client_role=return_get_client_role) \
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_get_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_get_client_role.mock_calls), 2)
+        self.assertEqual(len(mock_create_client_role.mock_calls), 1)
+        self.assertEqual(len(mock_update_client_role.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_create_client_role_with_composites_when_present_no_change(self):
+        """Update with change a realm role"""
+
+        module_args = {
+            'auth_keycloak_url': 'http://keycloak.url/auth',
+            'auth_password': 'admin',
+            'auth_realm': 'master',
+            'auth_username': 'admin',
+            'auth_client_id': 'admin-cli',
+            'validate_certs': True,
+            'realm': 'realm-name',
+            'client_id': 'client-name',
+            'name': 'role-name',
+            'description': 'role-description',
+            'composite': True,
+            'composites': [
+                {
+                    'client_id': 'client_1',
+                    'name': 'client-role1'
+                },
+                {
+                    'name': 'realm-role-1'
+                }
+            ]
+        }
+        return_get_client_role = [
+            {
+                "attributes": {},
+                "clientRole": True,
+                "composite": True,
+                "containerId": "9ae25ec2-f40a-11ed-9261-b3bacf720f69",
+                "description": "role-description",
+                "id": "90f1cdb6-be88-496e-89c6-da1fb6bc6966",
+                "name": "role-name",
+            }
+        ]
+        return_get_role_composites = [
+            [
+                {
+                    'clientRole': True,
+                    'containerId': 'c4367fac-f427-11ed-8e2f-aff070d20f0e',
+                    'name': 'client-role1'
+                },
+                {
+                    'clientRole': False,
+                    'containerId': 'realm-name',
+                    'name': 'realm-role-1'
+                }
+            ]
+        ]
+        return_get_client_by_client_id = [
+            {
+                "id": "de152444-f126-4a7a-8273-4ee1544133ad",
+                "clientId": "client_1",
+                "name": "client_1",
+                "description": "client_1",
+                "surrogateAuthRequired": False,
+                "enabled": True,
+                "alwaysDisplayInConsole": False,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                    "http://localhost:8080/*",
+                ],
+                "webOrigins": [
+                    "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": False,
+                "consentRequired": False,
+                "standardFlowEnabled": True,
+                "implicitFlowEnabled": False,
+                "directAccessGrantsEnabled": False,
+                "serviceAccountsEnabled": False,
+                "publicClient": False,
+                "frontchannelLogout": False,
+                "protocol": "openid-connect",
+                "attributes": {
+                    "backchannel.logout.session.required": "true",
+                    "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": True,
+                "nodeReRegistrationTimeout": -1,
+                "defaultClientScopes": [
+                    "web-origins",
+                    "acr",
+                    "profile",
+                    "roles",
+                    "email"
+                ],
+                "optionalClientScopes": [
+                    "address",
+                    "phone",
+                    "offline_access",
+                    "microprofile-jwt"
+                ]
+            }
+        ]
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+
+        with mock_good_connection():
+            with patch_keycloak_api(get_client_role=return_get_client_role, get_client_by_id=return_get_client_by_client_id,
+                                    get_role_composites=return_get_role_composites) \
+                    as (mock_get_realm_role, mock_create_realm_role, mock_update_realm_role, mock_delete_realm_role,
+                        mock_get_client_role, mock_create_client_role, mock_update_client_role, mock_delete_client_role,
+                        mock_get_client_by_client_id, mock_get_role_composites):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        self.assertEqual(len(mock_get_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
+        self.assertEqual(len(mock_get_client_role.mock_calls), 1)
+        self.assertEqual(len(mock_create_client_role.mock_calls), 0)
+        self.assertEqual(len(mock_update_client_role.mock_calls), 0)
+        self.assertEqual(len(mock_get_client_by_client_id.mock_calls), 1)
+        self.assertEqual(len(mock_get_role_composites.mock_calls), 1)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)

--- a/tests/unit/plugins/modules/test_keycloak_role.py
+++ b/tests/unit/plugins/modules/test_keycloak_role.py
@@ -237,7 +237,7 @@ class TestKeycloakRealmRole(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_realm_role.mock_calls), 2)
+        self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
         self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
 

--- a/tests/unit/plugins/modules/test_keycloak_role.py
+++ b/tests/unit/plugins/modules/test_keycloak_role.py
@@ -237,7 +237,7 @@ class TestKeycloakRealmRole(ModuleTestCase):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
-        self.assertEqual(len(mock_get_realm_role.mock_calls), 1)
+        self.assertEqual(len(mock_get_realm_role.mock_calls), 2)
         self.assertEqual(len(mock_create_realm_role.mock_calls), 0)
         self.assertEqual(len(mock_update_realm_role.mock_calls), 0)
 


### PR DESCRIPTION
##### SUMMARY
Add support for composites roles for Keycloak. 
Composites can be managed for realm and client roles through the keycloak_role module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_role.py

