### PR TITLE
Add ipbase_info module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -623,7 +623,7 @@ files:
     maintainers: bregman-arie
   $modules/ipa_:
     maintainers: $team_ipa
-  $modules/ipbase_facts.py:
+  $modules/ipbase_info.py:
     maintainers: dominikkukacka
   $modules/ipa_pwpolicy.py:
     maintainers: adralioh

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -623,6 +623,8 @@ files:
     maintainers: bregman-arie
   $modules/ipa_:
     maintainers: $team_ipa
+  $modules/ipbase_facts.py:
+    maintainers: dominikkukacka
   $modules/ipa_pwpolicy.py:
     maintainers: adralioh
   $modules/ipa_service.py:

--- a/plugins/modules/ipbase_facts.py
+++ b/plugins/modules/ipbase_facts.py
@@ -1,13 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright (c) 2023, Dominik Kukacka <dominik.kukacka@gmail.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.basic import AnsibleModule
 __metaclass__ = type
 
 
@@ -110,6 +108,9 @@ ansible_facts:
       type: str
       sample: "America/Los_Angeles"
 '''
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.urls import fetch_url
 
 
 USER_AGENT = 'ansible-ipbase-module/0.0.1'

--- a/plugins/modules/ipbase_facts.py
+++ b/plugins/modules/ipbase_facts.py
@@ -165,8 +165,7 @@ class IpbaseFacts(object):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            http_agent=dict(default=USER_AGENT),
-            timeout=dict(type='int', default=10),
+            http_agent=dict(default=USER_AGENT)
         ),
         supports_check_mode=True,
     )

--- a/plugins/modules/ipbase_facts.py
+++ b/plugins/modules/ipbase_facts.py
@@ -111,8 +111,10 @@ ansible_facts:
       sample: "America/Los_Angeles"
 '''
 
+
 USER_AGENT = 'ansible-ipbase-module/0.0.1'
 BASE_URL = 'https://api.ipbase.com/v2/info?hostname=1'
+
 
 class IpbaseFacts(object):
 

--- a/plugins/modules/ipbase_facts.py
+++ b/plugins/modules/ipbase_facts.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023, Dominik Kukacka <dominik.kukacka@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ipbase_facts
+short_description: Retrieve IP geolocation and other facts of a host's IP address
+description:
+  - "Retrieve IP geolocation and other facts of a host's IP address using the ipbase.com API"
+author: "Dominik Kukacka (@dominikkukacka)"
+extends_documentation_fragment:
+  - community.general.attributes
+  - community.general.attributes.facts
+  - community.general.attributes.facts_module
+options:
+  http_agent:
+    description:
+      - Set http user agent
+    required: false
+    default: "ansible-ipbase-module/0.0.1"
+    type: str
+notes:
+  - "Check http://ipbase.com/ for more information"
+'''
+
+EXAMPLES = '''
+# Retrieve IP geolocation and other facts of a host's IP address
+- name: Get IP geolocation information
+  community.general.ipbase_facts:
+'''
+
+RETURN = '''
+ansible_facts:
+  description: "Dictionary of ip facts for a host's IP address"
+  returned: changed
+  type: complex
+  contains:
+    ip:
+      description: "Public IP address of the host"
+      type: str
+      sample: "1.1.1.1"
+    hostname:
+      description: The hostname of the IP address
+      type: str
+      sample: "one.one.one.one"
+    continent_code:
+      description: ISO 3166-1 alpha-2 continent code
+      type: str
+      sample: "NA"
+    continent_name:
+      description: The continent name
+      type: str
+      sample: "North America"
+    country_code:
+      description: ISO 3166-1 alpha-2 country code
+      type: str
+      sample: "US"
+    country_name:
+      description: The country name
+      type: str
+      sample: "United States"
+    is_in_european_union:
+      description: Is the country in the European Union?
+      type: bool
+      sample: true
+    region_code:
+      description: ISO 3166-2 alpha-2 region code
+      type: str
+      sample: "US-CA"
+    region_name:
+      description: State or province name
+      type: str
+      sample: "California"
+    city_name:
+      description: City name
+      type: str
+      sample: "Los Angeles"
+    latitude:
+      description: Latitude of the location
+      type: float
+      sample: 34.053611755371094
+    longitude:
+      description: Longitude of the location
+      type: float
+      sample: -118.24549865722656
+    as_name:
+      description: "The autonomous system name (AS name)"
+      type: str
+      sample: "Cloudflare, Inc."
+    as_number:
+      description: "The autonomous system number (ASN)"
+      type: int
+      sample: 13335
+    zip:
+      description: Zip code
+      type: str
+      sample: "90012"
+    timezone:
+      description: "Timezone ID"
+      type: str
+      sample: "America/Los_Angeles"
+'''
+
+USER_AGENT = 'ansible-ipbase-module/0.0.1'
+BASE_URL = 'https://api.ipbase.com/v2/info?hostname=1'
+
+class IpbaseFacts(object):
+
+    def __init__(self, module):
+        self.module = module
+
+    def info(self):
+        response, info = fetch_url(
+            self.module, BASE_URL, force=True, timeout=10)
+
+        try:
+            info['status'] == 200
+        except AssertionError:
+            self.module.fail_json(msg='Could not get {0} page, '
+                                  'check for connectivity!'.format(BASE_URL))
+        else:
+            try:
+                content = response.read()
+                parsedData = self.module.from_json(content.decode('utf8'))
+
+                result = dict(
+                    ip=parsedData['data']['ip'],
+                    hostname=parsedData['data']['hostname'],
+                    continent=parsedData['data']['location']['continent']['name'],
+                    continent_code=parsedData['data']['location']['continent']['code'],
+                    country=parsedData['data']['location']['country']['name'],
+                    country_code=parsedData['data']['location']['country']['alpha2'],
+                    is_in_european_union=parsedData['data']['location']['country']['is_in_european_union'],
+                    region=parsedData['data']['location']['region']['name'],
+                    region_code=parsedData['data']['location']['region']['alpha2'],
+                    city=parsedData['data']['location']['city']['name'],
+                    zip=parsedData['data']['location']['zip'],
+                    latitude=parsedData['data']['location']['latitude'],
+                    longitude=parsedData['data']['location']['longitude'],
+                    timezone=parsedData['data']['timezone']['id'],
+                    as_name=parsedData['data']['connection']['organization'],
+                    as_number=parsedData['data']['connection']['asn'],
+                )
+
+            except ValueError:
+                self.module.fail_json(
+                    msg='Failed to parse the ipbase.com response: '
+                    '{0} {1}'.format(BASE_URL, content))
+            else:
+                return result
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            http_agent=dict(default=USER_AGENT),
+            timeout=dict(type='int', default=10),
+        ),
+        supports_check_mode=True,
+    )
+
+    ipbase = IpbaseFacts(module)
+    ipbase_result = dict(
+        changed=False,
+        ansible_facts=ipbase.info()
+    )
+    module.exit_json(**ipbase_result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -32,7 +32,7 @@ options:
     type: str
   hostname:
     description:
-      - "If the hostname parameter is set to 1, the API response will contain the hostname of the IP."
+      - "If the hostname parameter is set to C(true), the API response will contain the hostname of the IP."
     required: false
     type: bool
     default: false

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -24,11 +24,10 @@ options:
     description:
       - "The IP you want to get the info for."
     required: false
-    default: "The primary outgoing IP address of the host."
     type: str
   apikey:
     description:
-      - "The api key for the request if you need more requests."
+      - "The apikey for the request if you need more requests."
     required: false
     type: str
 notes:

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -40,7 +40,7 @@ EXAMPLES = '''
   community.general.ipbase_info:
   register: my_ip_info
 
-- name: "Get IP geolocation information of a specific IP
+- name: "Get IP geolocation information of a specific IP"
   community.general.ipbase_info:
     ip: "8.8.8.8"
   register: my_ip_info

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -79,7 +79,7 @@ USER_AGENT = 'ansible-ipbase-module/0.1.0'
 BASE_URL = 'https://api.ipbase.com/v2/info?hostname=1'
 
 
-class IpbaseFacts(object):
+class IpbaseInfo(object):
 
     def __init__(self, module):
         self.module = module
@@ -154,7 +154,7 @@ def main():
     ip = module.params['ip']
     apikey = module.params['apikey']
 
-    ipbase = IpbaseFacts(module)
+    ipbase = IpbaseInfo(module)
     module.exit_json(**ipbase.info(ip, apikey))
 
 

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -47,9 +47,8 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
----
 data:
-    description: The data retrieved from ipbase.com.
+    description: "The data retrieved from ipbase.com."
     returned: success
     type: dict
     sample: {

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -108,7 +108,11 @@ class IpbaseInfo(object):
             else:
                 return result
 
-    def info(self, ip, apikey):
+    def info(self):
+
+        ip = self.module.params['ip']
+        apikey = self.module.params['apikey']
+
         url = BASE_URL
         if ip:
             url += '&ip=' + str(ip)
@@ -151,11 +155,8 @@ def main():
         supports_check_mode=True,
     )
 
-    ip = module.params['ip']
-    apikey = module.params['apikey']
-
     ipbase = IpbaseInfo(module)
-    module.exit_json(**ipbase.info(ip, apikey))
+    module.exit_json(**ipbase.info())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -27,12 +27,12 @@ options:
     type: str
   apikey:
     description:
-      - "The apikey for the request if you need more requests."
+      - "The API key for the request if you need more requests."
     required: false
     type: str
   hostname:
     description:
-      - "If the hostname parameter is set to 1, the API response will contain the hostname of the ip."
+      - "If the hostname parameter is set to 1, the API response will contain the hostname of the IP."
     required: false
     type: bool
     default: false
@@ -69,7 +69,7 @@ EXAMPLES = '''
 
 RETURN = '''
 data:
-  description: "Json parsed response from ipbase.com. Please refer to U(https://ipbase.com/docs/info) for more information."
+  description: "JSON parsed response from ipbase.com. Please refer to U(https://ipbase.com/docs/info) for the detailled structure of the response."
   returned: success
   type: dict
   sample: {
@@ -242,7 +242,7 @@ class IpbaseInfo(object):
                 'User-Agent': USER_AGENT,
             })
 
-        if (info['status'] != 200):
+        if info['status'] != 200:
             self.module.fail_json(msg='The API request to ipbase.com returned an error status code {0}'.format(info['status']))
         else:
             try:

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
   community.general.ipbase_info:
     ip: "8.8.8.8"
     apikey: "xxxxxxxxxxxxxxxxxxxxxx"
-    hostname: True
+    hostname: true
     language: "de"
   register: my_ip_info
 

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -26,85 +26,93 @@ options:
     required: false
     default: "The primary outgoing IP address of the host."
     type: str
+  apikey:
+    description:
+      - "The api key for the request if you need more requests."
+    required: false
+    type: str
 notes:
   - "Check U(https://ipbase.com/) for more information."
 '''
 
 EXAMPLES = '''
-# Retrieve IP geolocation and other facts of a host's IP address
 - name: "Get IP geolocation information of the primary outgoing IP"
   community.general.ipbase_info:
+  register: my_ip_info
 
 - name: "Get IP geolocation information of a specific IP
   community.general.ipbase_info:
     ip: "8.8.8.8"
+  register: my_ip_info
 '''
 
 RETURN = '''
-ip:
-  description: "Public IP address of the host."
-  type: str
-  sample: "1.1.1.1"
-hostname:
-  description: "The hostname of the IP address."
-  type: str
-  sample: "one.one.one.one"
-continent_code:
-  description: The ISO 3166-1 alpha-2 continent code."
-  type: str
-  sample: "NA"
-continent_name:
-  description: "The continent name."
-  type: str
-  sample: "North America"
-country_code:
-  description: "The ISO 3166-1 alpha-2 country code."
-  type: str
-  sample: "US"
-country_name:
-  description: "The country name."
-  type: str
-  sample: "United States"
-is_in_european_union:
-  description: "Is the country in the European Union?"
-  type: bool
-  sample: true
-region_code:
-  description: "The ISO 3166-2 alpha-2 region code."
-  type: str
-  sample: "US-CA"
-region_name:
-  description: "The state or province name."
-  type: str
-  sample: "California"
-city_name:
-  description: City name
-  type: str
-  sample: "Los Angeles"
-latitude:
-  description: "The latitude of the location."
-  type: float
-  sample: 34.053611755371094
-longitude:
-  description: "The longitude of the location."
-  type: float
-  sample: -118.24549865722656
-as_name:
-  description: "The autonomous system name (AS name)"
-  type: str
-  sample: "Cloudflare, Inc."
-as_number:
-  description: "The autonomous system number (ASN)"
-  type: int
-  sample: 13335
-zip:
-  description: "The zip code."
-  type: str
-  sample: "90012"
-timezone:
-  description: "The timezone ID."
-  type: str
-  sample: "America/Los_Angeles"
+---
+data:
+  ip:
+    description: "Public IP address of the host."
+    type: str
+    sample: "1.1.1.1"
+  hostname:
+    description: "The hostname of the IP address."
+    type: str
+    sample: "one.one.one.one"
+  continent_code:
+    description: The ISO 3166-1 alpha-2 continent code."
+    type: str
+    sample: "NA"
+  continent_name:
+    description: "The continent name."
+    type: str
+    sample: "North America"
+  country_code:
+    description: "The ISO 3166-1 alpha-2 country code."
+    type: str
+    sample: "US"
+  country_name:
+    description: "The country name."
+    type: str
+    sample: "United States"
+  is_in_european_union:
+    description: "Is the country in the European Union?"
+    type: bool
+    sample: true
+  region_code:
+    description: "The ISO 3166-2 alpha-2 region code."
+    type: str
+    sample: "US-CA"
+  region_name:
+    description: "The state or province name."
+    type: str
+    sample: "California"
+  city_name:
+    description: "The city name."
+    type: str
+    sample: "Los Angeles"
+  latitude:
+    description: "The latitude of the location."
+    type: float
+    sample: 34.053611755371094
+  longitude:
+    description: "The longitude of the location."
+    type: float
+    sample: -118.24549865722656
+  as_name:
+    description: "The autonomous system name (AS name)"
+    type: str
+    sample: "Cloudflare, Inc."
+  as_number:
+    description: "The autonomous system number (ASN)"
+    type: int
+    sample: 13335
+  zip:
+    description: "The zip code."
+    type: str
+    sample: "90012"
+  timezone:
+    description: "The timezone ID."
+    type: str
+    sample: "America/Los_Angeles"
 '''
 from ansible.module_utils.basic import AnsibleModule
 
@@ -120,10 +128,13 @@ class IpbaseFacts(object):
     def __init__(self, module):
         self.module = module
 
-    def info(self, ip):
+    def info(self, ip, apikey):
         url = BASE_URL
         if ip:
             url += '&ip=' + str(ip)
+
+        if apikey:
+            url += '&apikey=' + str(apikey)
 
         response, info = fetch_url(
             self.module,
@@ -135,7 +146,7 @@ class IpbaseFacts(object):
                 'User-Agent': USER_AGENT,
             })
 
-        if(info['status'] != 200):
+        if (info['status'] != 200):
             self.module.fail_json(msg='The API request to ipbase.com returned an error status code {0}'.format(info['status']))
         else:
             try:
@@ -166,12 +177,13 @@ class IpbaseFacts(object):
                     msg='Failed to parse the ipbase.com response: '
                     '{0} {1}'.format(url, content))
             else:
-                return result
+                return dict(data=result)
 
 
 def main():
     module_args = dict(
         ip=dict(type='str', required=False, no_log=False),
+        apikey=dict(type='str', required=False, no_log=True),
     )
 
     module = AnsibleModule(
@@ -180,9 +192,10 @@ def main():
     )
 
     ip = module.params['ip']
+    apikey = module.params['apikey']
 
     ipbase = IpbaseFacts(module)
-    module.exit_json(**ipbase.info(ip))
+    module.exit_json(**ipbase.info(ip, apikey))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -49,71 +49,29 @@ EXAMPLES = '''
 RETURN = '''
 ---
 data:
-  ip:
-    description: "Public IP address of the host."
-    type: str
-    sample: "1.1.1.1"
-  hostname:
-    description: "The hostname of the IP address."
-    type: str
-    sample: "one.one.one.one"
-  continent_code:
-    description: The ISO 3166-1 alpha-2 continent code."
-    type: str
-    sample: "NA"
-  continent_name:
-    description: "The continent name."
-    type: str
-    sample: "North America"
-  country_code:
-    description: "The ISO 3166-1 alpha-2 country code."
-    type: str
-    sample: "US"
-  country_name:
-    description: "The country name."
-    type: str
-    sample: "United States"
-  is_in_european_union:
-    description: "Is the country in the European Union?"
-    type: bool
-    sample: true
-  region_code:
-    description: "The ISO 3166-2 alpha-2 region code."
-    type: str
-    sample: "US-CA"
-  region_name:
-    description: "The state or province name."
-    type: str
-    sample: "California"
-  city_name:
-    description: "The city name."
-    type: str
-    sample: "Los Angeles"
-  latitude:
-    description: "The latitude of the location."
-    type: float
-    sample: 34.053611755371094
-  longitude:
-    description: "The longitude of the location."
-    type: float
-    sample: -118.24549865722656
-  as_name:
-    description: "The autonomous system name (AS name)"
-    type: str
-    sample: "Cloudflare, Inc."
-  as_number:
-    description: "The autonomous system number (ASN)"
-    type: int
-    sample: 13335
-  zip:
-    description: "The zip code."
-    type: str
-    sample: "90012"
-  timezone:
-    description: "The timezone ID."
-    type: str
-    sample: "America/Los_Angeles"
+    description: The data retrieved from ipbase.com.
+    returned: success
+    type: dict
+    sample: {
+        "as_name": "T-Mobile Austria GmbH",
+        "as_number": 8412,
+        "city": "Vienna",
+        "continent": "Europe",
+        "continent_code": "EU",
+        "country": "Austria",
+        "country_code": "AT",
+        "hostname": "81-223-100.100.static.upcbusiness.at",
+        "ip": "81.223.100.100",
+        "is_in_european_union": true,
+        "latitude": 48.1861686706543,
+        "longitude": 16.403240203857422,
+        "region": "Vienna",
+        "region_code": "AT-9",
+        "timezone": "Europe/Vienna",
+        "zip": "1030"
+    }
 '''
+
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils.urls import fetch_url

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -10,19 +10,19 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: ipbase_info
-version_added: 7.0.0
-short_description: Retrieve IP geolocation and other facts of a host's IP address
+module: "ipbase_info"
+version_added: "7.0.0"
+short_description: "Retrieve IP geolocation and other facts of a host's IP address using the ipbase.com API"
 description:
   - "Retrieve IP geolocation and other facts of a host's IP address using the ipbase.com API"
 author: "Dominik Kukacka (@dominikkukacka)"
 extends_documentation_fragment:
-  - community.general.attributes
-  - community.general.attributes.info_module
+  - "community.general.attributes"
+  - "community.general.attributes.info_module"
 options:
   ip:
     description:
-      - "The IP you want to get the info for."
+      - "The IP you want to get the info for. If not specified the API will detect the IP automatically."
     required: false
     type: str
   apikey:
@@ -30,6 +30,18 @@ options:
       - "The apikey for the request if you need more requests."
     required: false
     type: str
+  hostname:
+    description:
+      - "If the hostname parameter is set to 1, the API response will contain the hostname of the ip."
+    required: false
+    type: bool
+    default: false
+  language:
+    description:
+      - "An ISO Alpha 2 Language Code for localizing the IP data"
+    required: false
+    type: str
+    default: "en"
 notes:
   - "Check U(https://ipbase.com/) for more information."
 '''
@@ -43,40 +55,175 @@ EXAMPLES = '''
   community.general.ipbase_info:
     ip: "8.8.8.8"
   register: my_ip_info
+
+
+- name: "Get IP geolocation information of a specific IP with all other possible parameters"
+  community.general.ipbase_info:
+    ip: "8.8.8.8"
+    apikey: "xxxxxxxxxxxxxxxxxxxxxx"
+    hostname: True
+    language: "de"
+  register: my_ip_info
+
 '''
 
 RETURN = '''
 data:
-    description: "The data retrieved from ipbase.com."
-    returned: success
-    type: dict
-    sample: {
-        "as_name": "T-Mobile Austria GmbH",
-        "as_number": 8412,
-        "city": "Vienna",
-        "continent": "Europe",
-        "continent_code": "EU",
-        "country": "Austria",
-        "country_code": "AT",
-        "hostname": "81-223-100.100.static.upcbusiness.at",
-        "ip": "81.223.100.100",
-        "is_in_european_union": true,
-        "latitude": 48.1861686706543,
-        "longitude": 16.403240203857422,
-        "region": "Vienna",
-        "region_code": "AT-9",
-        "timezone": "Europe/Vienna",
-        "zip": "1030"
+  description: "Json parsed response from ipbase.com. Please refer to U(https://ipbase.com/docs/info) for more information."
+  returned: success
+  type: dict
+  sample: {
+    "ip": "1.1.1.1",
+    "hostname": "one.one.one.one",
+    "type": "v4",
+    "range_type": {
+      "type": "PUBLIC",
+      "description": "Public address"
+    },
+    "connection": {
+      "asn": 13335,
+      "organization": "Cloudflare, Inc.",
+      "isp": "APNIC Research and Development",
+      "range": "1.1.1.1/32"
+    },
+    "location": {
+      "geonames_id": 5332870,
+      "latitude": 34.053611755371094,
+      "longitude": -118.24549865722656,
+      "zip": "90012",
+      "continent": {
+        "code": "NA",
+        "name": "North America",
+        "name_translated": "North America"
+      },
+      "country": {
+        "alpha2": "US",
+        "alpha3": "USA",
+        "calling_codes": [
+          "+1"
+        ],
+        "currencies": [
+          {
+            "symbol": "$",
+            "name": "US Dollar",
+            "symbol_native": "$",
+            "decimal_digits": 2,
+            "rounding": 0,
+            "code": "USD",
+            "name_plural": "US dollars"
+          }
+        ],
+        "emoji": "...",
+        "ioc": "USA",
+        "languages": [
+          {
+            "name": "English",
+            "name_native": "English"
+          }
+        ],
+        "name": "United States",
+        "name_translated": "United States",
+        "timezones": [
+          "America/New_York",
+          "America/Detroit",
+          "America/Kentucky/Louisville",
+          "America/Kentucky/Monticello",
+          "America/Indiana/Indianapolis",
+          "America/Indiana/Vincennes",
+          "America/Indiana/Winamac",
+          "America/Indiana/Marengo",
+          "America/Indiana/Petersburg",
+          "America/Indiana/Vevay",
+          "America/Chicago",
+          "America/Indiana/Tell_City",
+          "America/Indiana/Knox",
+          "America/Menominee",
+          "America/North_Dakota/Center",
+          "America/North_Dakota/New_Salem",
+          "America/North_Dakota/Beulah",
+          "America/Denver",
+          "America/Boise",
+          "America/Phoenix",
+          "America/Los_Angeles",
+          "America/Anchorage",
+          "America/Juneau",
+          "America/Sitka",
+          "America/Metlakatla",
+          "America/Yakutat",
+          "America/Nome",
+          "America/Adak",
+          "Pacific/Honolulu"
+        ],
+        "is_in_european_union": false,
+        "fips": "US",
+        "geonames_id": 6252001,
+        "hasc_id": "US",
+        "wikidata_id": "Q30"
+      },
+      "city": {
+        "fips": "644000",
+        "alpha2": null,
+        "geonames_id": 5368753,
+        "hasc_id": null,
+        "wikidata_id": "Q65",
+        "name": "Los Angeles",
+        "name_translated": "Los Angeles"
+      },
+      "region": {
+        "fips": "US06",
+        "alpha2": "US-CA",
+        "geonames_id": 5332921,
+        "hasc_id": "US.CA",
+        "wikidata_id": "Q99",
+        "name": "California",
+        "name_translated": "California"
+      }
+    },
+    "tlds": [
+      ".us"
+    ],
+    "timezone": {
+      "id": "America/Los_Angeles",
+      "current_time": "2023-05-04T04:30:28-07:00",
+      "code": "PDT",
+      "is_daylight_saving": true,
+      "gmt_offset": -25200
+    },
+    "security": {
+      "is_anonymous": false,
+      "is_datacenter": false,
+      "is_vpn": false,
+      "is_bot": false,
+      "is_abuser": true,
+      "is_known_attacker": true,
+      "is_proxy": false,
+      "is_spam": false,
+      "is_tor": false,
+      "is_icloud_relay": false,
+      "threat_score": 100
+    },
+    "domains": {
+      "count": 10943,
+      "domains": [
+        "eliwise.academy",
+        "accountingprose.academy",
+        "pistola.academy",
+        "1and1-test-ntlds-fr.accountant",
+        "omnergy.africa"
+      ]
     }
+  }
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils.urls import fetch_url
 
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
-USER_AGENT = 'ansible-ipbase-module/0.1.0'
-BASE_URL = 'https://api.ipbase.com/v2/info?hostname=1'
+
+USER_AGENT = 'ansible-community.general.ipbase_info/0.1.0'
+BASE_URL = 'https://api.ipbase.com/v2/info'
 
 
 class IpbaseInfo(object):
@@ -112,42 +259,36 @@ class IpbaseInfo(object):
 
         ip = self.module.params['ip']
         apikey = self.module.params['apikey']
+        hostname = self.module.params['hostname']
+        language = self.module.params['language']
 
         url = BASE_URL
+
+        params = {}
         if ip:
-            url += '&ip=' + str(ip)
+            params['ip'] = ip
 
         if apikey:
-            url += '&apikey=' + str(apikey)
+            params['apikey'] = apikey
 
-        response = self._get_url_data(url)
+        if hostname:
+            params['hostname'] = 1
 
-        result = dict(
-            ip=response['data']['ip'],
-            hostname=response['data']['hostname'],
-            continent=response['data']['location']['continent']['name'],
-            continent_code=response['data']['location']['continent']['code'],
-            country=response['data']['location']['country']['name'],
-            country_code=response['data']['location']['country']['alpha2'],
-            is_in_european_union=response['data']['location']['country']['is_in_european_union'],
-            region=response['data']['location']['region']['name'],
-            region_code=response['data']['location']['region']['alpha2'],
-            city=response['data']['location']['city']['name'],
-            zip=response['data']['location']['zip'],
-            latitude=response['data']['location']['latitude'],
-            longitude=response['data']['location']['longitude'],
-            timezone=response['data']['timezone']['id'],
-            as_name=response['data']['connection']['organization'],
-            as_number=response['data']['connection']['asn'],
-        )
+        if language:
+            params['language'] = language
 
-        return dict(data=result)
+        if params:
+            url += '?' + urlencode(params)
+
+        return self._get_url_data(url)
 
 
 def main():
     module_args = dict(
         ip=dict(type='str', required=False, no_log=False),
         apikey=dict(type='str', required=False, no_log=True),
+        hostname=dict(type='bool', required=False, no_log=False, default=False),
+        language=dict(type='str', required=False, no_log=False, default='en'),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -84,14 +84,7 @@ class IpbaseFacts(object):
     def __init__(self, module):
         self.module = module
 
-    def info(self, ip, apikey):
-        url = BASE_URL
-        if ip:
-            url += '&ip=' + str(ip)
-
-        if apikey:
-            url += '&apikey=' + str(apikey)
-
+    def _get_url_data(self, url):
         response, info = fetch_url(
             self.module,
             url,
@@ -107,33 +100,44 @@ class IpbaseFacts(object):
         else:
             try:
                 content = response.read()
-                parsedData = self.module.from_json(content.decode('utf8'))
-
-                result = dict(
-                    ip=parsedData['data']['ip'],
-                    hostname=parsedData['data']['hostname'],
-                    continent=parsedData['data']['location']['continent']['name'],
-                    continent_code=parsedData['data']['location']['continent']['code'],
-                    country=parsedData['data']['location']['country']['name'],
-                    country_code=parsedData['data']['location']['country']['alpha2'],
-                    is_in_european_union=parsedData['data']['location']['country']['is_in_european_union'],
-                    region=parsedData['data']['location']['region']['name'],
-                    region_code=parsedData['data']['location']['region']['alpha2'],
-                    city=parsedData['data']['location']['city']['name'],
-                    zip=parsedData['data']['location']['zip'],
-                    latitude=parsedData['data']['location']['latitude'],
-                    longitude=parsedData['data']['location']['longitude'],
-                    timezone=parsedData['data']['timezone']['id'],
-                    as_name=parsedData['data']['connection']['organization'],
-                    as_number=parsedData['data']['connection']['asn'],
-                )
-
+                result = self.module.from_json(content.decode('utf8'))
             except ValueError:
                 self.module.fail_json(
                     msg='Failed to parse the ipbase.com response: '
                     '{0} {1}'.format(url, content))
             else:
-                return dict(data=result)
+                return result
+
+    def info(self, ip, apikey):
+        url = BASE_URL
+        if ip:
+            url += '&ip=' + str(ip)
+
+        if apikey:
+            url += '&apikey=' + str(apikey)
+
+        response = self._get_url_data(url)
+
+        result = dict(
+            ip=response['data']['ip'],
+            hostname=response['data']['hostname'],
+            continent=response['data']['location']['continent']['name'],
+            continent_code=response['data']['location']['continent']['code'],
+            country=response['data']['location']['country']['name'],
+            country_code=response['data']['location']['country']['alpha2'],
+            is_in_european_union=response['data']['location']['country']['is_in_european_union'],
+            region=response['data']['location']['region']['name'],
+            region_code=response['data']['location']['region']['alpha2'],
+            city=response['data']['location']['city']['name'],
+            zip=response['data']['location']['zip'],
+            latitude=response['data']['location']['latitude'],
+            longitude=response['data']['location']['longitude'],
+            timezone=response['data']['timezone']['id'],
+            as_name=response['data']['connection']['organization'],
+            as_number=response['data']['connection']['asn'],
+        )
+
+        return dict(data=result)
 
 
 def main():

--- a/plugins/modules/ipbase_info.py
+++ b/plugins/modules/ipbase_info.py
@@ -8,105 +8,110 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 DOCUMENTATION = '''
 ---
-module: ipbase_facts
+module: ipbase_info
+version_added: 7.0.0
 short_description: Retrieve IP geolocation and other facts of a host's IP address
 description:
   - "Retrieve IP geolocation and other facts of a host's IP address using the ipbase.com API"
 author: "Dominik Kukacka (@dominikkukacka)"
 extends_documentation_fragment:
   - community.general.attributes
-  - community.general.attributes.facts
-  - community.general.attributes.facts_module
+  - community.general.attributes.info_module
 options:
+  ip:
+    description:
+      - "The IP you want to get the info for."
+    required: false
+    default: "The primary outgoing IP address of the host."
+    type: str
   http_agent:
     description:
-      - Set http user agent
+      - "HTTP user agent to use."
     required: false
     default: "ansible-ipbase-module/0.0.1"
     type: str
 notes:
-  - "Check http://ipbase.com/ for more information"
+  - "Check U(https://ipbase.com/) for more information."
 '''
 
 EXAMPLES = '''
 # Retrieve IP geolocation and other facts of a host's IP address
-- name: Get IP geolocation information
-  community.general.ipbase_facts:
+- name: "Get IP geolocation information of the primary outgoing IP"
+  community.general.ipbase_info:
+
+- name: "Get IP geolocation information of a specific IP (and set a custom http user agent)"
+  community.general.ipbase_info:
+    ip: "8.8.8.8"
+    http_agent: "my-user-agent/0.0.0"
 '''
 
 RETURN = '''
-ansible_facts:
-  description: "Dictionary of ip facts for a host's IP address"
-  returned: changed
-  type: complex
-  contains:
-    ip:
-      description: "Public IP address of the host"
-      type: str
-      sample: "1.1.1.1"
-    hostname:
-      description: The hostname of the IP address
-      type: str
-      sample: "one.one.one.one"
-    continent_code:
-      description: ISO 3166-1 alpha-2 continent code
-      type: str
-      sample: "NA"
-    continent_name:
-      description: The continent name
-      type: str
-      sample: "North America"
-    country_code:
-      description: ISO 3166-1 alpha-2 country code
-      type: str
-      sample: "US"
-    country_name:
-      description: The country name
-      type: str
-      sample: "United States"
-    is_in_european_union:
-      description: Is the country in the European Union?
-      type: bool
-      sample: true
-    region_code:
-      description: ISO 3166-2 alpha-2 region code
-      type: str
-      sample: "US-CA"
-    region_name:
-      description: State or province name
-      type: str
-      sample: "California"
-    city_name:
-      description: City name
-      type: str
-      sample: "Los Angeles"
-    latitude:
-      description: Latitude of the location
-      type: float
-      sample: 34.053611755371094
-    longitude:
-      description: Longitude of the location
-      type: float
-      sample: -118.24549865722656
-    as_name:
-      description: "The autonomous system name (AS name)"
-      type: str
-      sample: "Cloudflare, Inc."
-    as_number:
-      description: "The autonomous system number (ASN)"
-      type: int
-      sample: 13335
-    zip:
-      description: Zip code
-      type: str
-      sample: "90012"
-    timezone:
-      description: "Timezone ID"
-      type: str
-      sample: "America/Los_Angeles"
+ip:
+  description: "Public IP address of the host."
+  type: str
+  sample: "1.1.1.1"
+hostname:
+  description: "The hostname of the IP address."
+  type: str
+  sample: "one.one.one.one"
+continent_code:
+  description: The ISO 3166-1 alpha-2 continent code."
+  type: str
+  sample: "NA"
+continent_name:
+  description: "The continent name."
+  type: str
+  sample: "North America"
+country_code:
+  description: "The ISO 3166-1 alpha-2 country code."
+  type: str
+  sample: "US"
+country_name:
+  description: "The country name."
+  type: str
+  sample: "United States"
+is_in_european_union:
+  description: "Is the country in the European Union?"
+  type: bool
+  sample: true
+region_code:
+  description: "The ISO 3166-2 alpha-2 region code."
+  type: str
+  sample: "US-CA"
+region_name:
+  description: "The state or province name."
+  type: str
+  sample: "California"
+city_name:
+  description: City name
+  type: str
+  sample: "Los Angeles"
+latitude:
+  description: "The latitude of the location."
+  type: float
+  sample: 34.053611755371094
+longitude:
+  description: "The longitude of the location."
+  type: float
+  sample: -118.24549865722656
+as_name:
+  description: "The autonomous system name (AS name)"
+  type: str
+  sample: "Cloudflare, Inc."
+as_number:
+  description: "The autonomous system number (ASN)"
+  type: int
+  sample: 13335
+zip:
+  description: "The zip code."
+  type: str
+  sample: "90012"
+timezone:
+  description: "The timezone ID."
+  type: str
+  sample: "America/Los_Angeles"
 '''
 from ansible.module_utils.basic import AnsibleModule
 
@@ -122,9 +127,13 @@ class IpbaseFacts(object):
     def __init__(self, module):
         self.module = module
 
-    def info(self):
+    def info(self, ip):
+        url = BASE_URL
+        if ip:
+            url = '{0}{1}'.format(BASE_URL, ip)
+
         response, info = fetch_url(
-            self.module, BASE_URL, force=True, timeout=10)
+            self.module, url, force=True, timeout=10)
 
         try:
             info['status'] == 200
@@ -164,19 +173,20 @@ class IpbaseFacts(object):
 
 
 def main():
+    module_args = dict(
+        http_agent=dict(default=USER_AGENT),
+        ip=dict(type='str', required=False, no_log=False),
+    )
+
     module = AnsibleModule(
-        argument_spec=dict(
-            http_agent=dict(default=USER_AGENT)
-        ),
+        argument_spec=module_args,
         supports_check_mode=True,
     )
 
+    ip = module.params['ip']
+
     ipbase = IpbaseFacts(module)
-    ipbase_result = dict(
-        changed=False,
-        ansible_facts=ipbase.info()
-    )
-    module.exit_json(**ipbase_result)
+    module.exit_json(**ipbase.info(ip))
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -197,11 +197,11 @@ def test_info(mocker):
     module.params = params
 
     IpbaseInfo._get_url_data = mocker.Mock()
-    IpbaseInfo._get_url_data.return_value = json.load(IPBASE_DATA['response'])
+    IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'])
     jenkins_plugin = IpbaseInfo(module)
 
     json_data = jenkins_plugin.info()
 
-    result = json.load(IPBASE_DATA['result'])
+    result = json.loads(IPBASE_DATA['result'])
 
     assert json_data == result

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -40,7 +40,7 @@ IPBASE_DATA = {
 {
   "data": {
     "ip": "1.1.1.1",
-    "hostname": null,
+    "hostname": "one.one.one.one",
     "type": "v4",
     "range_type": {
       "type": "PUBLIC",

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -13,7 +13,6 @@ from ansible_collections.community.general.tests.unit.compat import unittest
 from ansible_collections.community.general.tests.unit.compat.mock import Mock
 
 
-
 IPBASE_DATA = {
     "result": b"""
 {
@@ -185,9 +184,7 @@ IPBASE_DATA = {
 }
 
 
-
 class TestIpbase(unittest.TestCase):
-
     def test_info(self,):
         "test the json data extraction"
 

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -196,12 +196,12 @@ class TestIpbase(unittest.TestCase):
         module.params = params
 
         IpbaseInfo._get_url_data = Mock()
-        IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'])
+        IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'].decode("utf-8"))
         jenkins_plugin = IpbaseInfo(module)
 
         json_data = jenkins_plugin.info()
 
-        result = json.loads(IPBASE_DATA['result'])
+        result = json.loads(IPBASE_DATA['result'].decode("utf-8"))
 
         self.maxDiff = None
         self.assertDictEqual(json_data, result)

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -197,7 +197,7 @@ def test_info(mocker):
     module.params = params
 
     IpbaseInfo._get_url_data = mocker.Mock()
-    IpbaseInfo._get_url_data.return_value = str(IPBASE_DATA['response'])
+    IpbaseInfo._get_url_data.return_value = json.load(IPBASE_DATA['response'])
     jenkins_plugin = IpbaseInfo(module)
 
     json_data = jenkins_plugin.info()

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -9,10 +9,9 @@ __metaclass__ = type
 import json
 
 from ansible_collections.community.general.plugins.modules.ipbase_info import IpbaseInfo
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import Mock
 
-
-def pass_function(*args, **kwargs):
-    pass
 
 
 IPBASE_DATA = {
@@ -186,22 +185,25 @@ IPBASE_DATA = {
 }
 
 
-def test_info(mocker):
-    "test the json data extraction"
 
-    params = {
-        "ip": "1.1.1.1",
-        "apikey": "aaa"
-    }
-    module = mocker.Mock()
-    module.params = params
+class TestIpbase(unittest.TestCase):
 
-    IpbaseInfo._get_url_data = mocker.Mock()
-    IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'])
-    jenkins_plugin = IpbaseInfo(module)
+    def test_info(self,):
+        "test the json data extraction"
 
-    json_data = jenkins_plugin.info()
+        params = {
+            "ip": "1.1.1.1",
+            "apikey": "aaa"
+        }
+        module = Mock()
+        module.params = params
 
-    result = json.loads(IPBASE_DATA['result'])
+        IpbaseInfo._get_url_data = Mock()
+        IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'])
+        jenkins_plugin = IpbaseInfo(module)
 
-    assert json_data == result
+        json_data = jenkins_plugin.info()
+
+        result = json.loads(IPBASE_DATA['result'])
+
+        self.assertEqual(json_data, result)

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from io import BytesIO
+
+from ansible_collections.community.general.plugins.modules.ipbase_info import IpbaseInfo
+
+
+def pass_function(*args, **kwargs):
+    pass
+
+
+IPBASE_DATA = {
+    "result": b"""
+{
+  "data": {
+    "as_name": "Cloudflare, Inc.",
+    "as_number": 13335,
+    "city": "Los Angeles",
+    "continent": "North America",
+    "continent_code": "NA",
+    "country": "United States",
+    "country_code": "US",
+    "hostname": "one.one.one.one",
+    "ip": "1.1.1.1",
+    "is_in_european_union": false,
+    "latitude": 34.053611755371094,
+    "longitude": -118.24549865722656,
+    "region": "California",
+    "region_code": "US-CA",
+    "timezone": "America/Los_Angeles",
+    "zip": "90012"
+  }
+}
+""",
+    "response": b"""
+{
+  "data": {
+    "ip": "1.1.1.1",
+    "hostname": null,
+    "type": "v4",
+    "range_type": {
+      "type": "PUBLIC",
+      "description": "Public address"
+    },
+    "connection": {
+      "asn": 13335,
+      "organization": "Cloudflare, Inc.",
+      "isp": "APNIC Research and Development",
+      "range": "1.1.1.1/32"
+    },
+    "location": {
+      "geonames_id": 5332870,
+      "latitude": 34.053611755371094,
+      "longitude": -118.24549865722656,
+      "zip": "90012",
+      "continent": {
+        "code": "NA",
+        "name": "North America",
+        "name_translated": "North America"
+      },
+      "country": {
+        "alpha2": "US",
+        "alpha3": "USA",
+        "calling_codes": [
+          "+1"
+        ],
+        "currencies": [
+          {
+            "symbol": "$",
+            "name": "US Dollar",
+            "symbol_native": "$",
+            "decimal_digits": 2,
+            "rounding": 0,
+            "code": "USD",
+            "name_plural": "US dollars"
+          }
+        ],
+        "emoji": "...",
+        "ioc": "USA",
+        "languages": [
+          {
+            "name": "English",
+            "name_native": "English"
+          }
+        ],
+        "name": "United States",
+        "name_translated": "United States",
+        "timezones": [
+          "America/New_York",
+          "America/Detroit",
+          "America/Kentucky/Louisville",
+          "America/Kentucky/Monticello",
+          "America/Indiana/Indianapolis",
+          "America/Indiana/Vincennes",
+          "America/Indiana/Winamac",
+          "America/Indiana/Marengo",
+          "America/Indiana/Petersburg",
+          "America/Indiana/Vevay",
+          "America/Chicago",
+          "America/Indiana/Tell_City",
+          "America/Indiana/Knox",
+          "America/Menominee",
+          "America/North_Dakota/Center",
+          "America/North_Dakota/New_Salem",
+          "America/North_Dakota/Beulah",
+          "America/Denver",
+          "America/Boise",
+          "America/Phoenix",
+          "America/Los_Angeles",
+          "America/Anchorage",
+          "America/Juneau",
+          "America/Sitka",
+          "America/Metlakatla",
+          "America/Yakutat",
+          "America/Nome",
+          "America/Adak",
+          "Pacific/Honolulu"
+        ],
+        "is_in_european_union": false,
+        "fips": "US",
+        "geonames_id": 6252001,
+        "hasc_id": "US",
+        "wikidata_id": "Q30"
+      },
+      "city": {
+        "fips": "644000",
+        "alpha2": null,
+        "geonames_id": 5368753,
+        "hasc_id": null,
+        "wikidata_id": "Q65",
+        "name": "Los Angeles",
+        "name_translated": "Los Angeles"
+      },
+      "region": {
+        "fips": "US06",
+        "alpha2": "US-CA",
+        "geonames_id": 5332921,
+        "hasc_id": "US.CA",
+        "wikidata_id": "Q99",
+        "name": "California",
+        "name_translated": "California"
+      }
+    },
+    "tlds": [
+      ".us"
+    ],
+    "timezone": {
+      "id": "America/Los_Angeles",
+      "current_time": "2023-05-04T04:30:28-07:00",
+      "code": "PDT",
+      "is_daylight_saving": true,
+      "gmt_offset": -25200
+    },
+    "security": {
+      "is_anonymous": false,
+      "is_datacenter": false,
+      "is_vpn": false,
+      "is_bot": false,
+      "is_abuser": true,
+      "is_known_attacker": true,
+      "is_proxy": false,
+      "is_spam": false,
+      "is_tor": false,
+      "is_icloud_relay": false,
+      "threat_score": 100
+    },
+    "domains": {
+      "count": 10943,
+      "domains": [
+        "eliwise.academy",
+        "accountingprose.academy",
+        "pistola.academy",
+        "1and1-test-ntlds-fr.accountant",
+        "omnergy.africa"
+      ]
+    }
+  }
+}
+"""
+}
+
+
+def test_info(mocker):
+    "test the json data extraction"
+
+    params = {
+        "ip": "1.1.1.1",
+        "apikey": "aaa"
+    }
+    module = mocker.Mock()
+    module.params = params
+
+    IpbaseInfo._get_url_data = mocker.Mock()
+    IpbaseInfo._get_url_data.return_value = BytesIO(IPBASE_DATA['response'])
+    jenkins_plugin = IpbaseInfo(module)
+
+    json_data = jenkins_plugin.info(params["ip"], params["apikey"])
+
+    assert json_data == IPBASE_DATA['result']

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -169,8 +169,8 @@ class TestIpbase(unittest.TestCase):
         params = {
             "ip": "1.1.1.1",
             "apikey": "aaa",
-            "lanugage": "de",
             "hostname": True,
+            "language": "de",
         }
         module = Mock()
         module.params = params

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from io import BytesIO
+import json
 
 from ansible_collections.community.general.plugins.modules.ipbase_info import IpbaseInfo
 
@@ -197,9 +197,11 @@ def test_info(mocker):
     module.params = params
 
     IpbaseInfo._get_url_data = mocker.Mock()
-    IpbaseInfo._get_url_data.return_value = BytesIO(IPBASE_DATA['response'])
+    IpbaseInfo._get_url_data.return_value = str(IPBASE_DATA['response'])
     jenkins_plugin = IpbaseInfo(module)
 
-    json_data = jenkins_plugin.info(params["ip"], params["apikey"])
+    json_data = jenkins_plugin.info()
 
-    assert json_data == IPBASE_DATA['result']
+    result = json.load(IPBASE_DATA['result'])
+
+    assert json_data == result

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -203,4 +203,5 @@ class TestIpbase(unittest.TestCase):
 
         result = json.loads(IPBASE_DATA['result'])
 
-        self.assertEqual(json_data, result)
+        self.maxDiff = None
+        self.assertDictEqual(json_data, result)

--- a/tests/unit/plugins/modules/test_ipbase.py
+++ b/tests/unit/plugins/modules/test_ipbase.py
@@ -14,28 +14,6 @@ from ansible_collections.community.general.tests.unit.compat.mock import Mock
 
 
 IPBASE_DATA = {
-    "result": b"""
-{
-  "data": {
-    "as_name": "Cloudflare, Inc.",
-    "as_number": 13335,
-    "city": "Los Angeles",
-    "continent": "North America",
-    "continent_code": "NA",
-    "country": "United States",
-    "country_code": "US",
-    "hostname": "one.one.one.one",
-    "ip": "1.1.1.1",
-    "is_in_european_union": false,
-    "latitude": 34.053611755371094,
-    "longitude": -118.24549865722656,
-    "region": "California",
-    "region_code": "US-CA",
-    "timezone": "America/Los_Angeles",
-    "zip": "90012"
-  }
-}
-""",
     "response": b"""
 {
   "data": {
@@ -190,18 +168,20 @@ class TestIpbase(unittest.TestCase):
 
         params = {
             "ip": "1.1.1.1",
-            "apikey": "aaa"
+            "apikey": "aaa",
+            "lanugage": "de",
+            "hostname": True,
         }
         module = Mock()
         module.params = params
 
+        data = json.loads(IPBASE_DATA['response'].decode("utf-8"))
+
         IpbaseInfo._get_url_data = Mock()
-        IpbaseInfo._get_url_data.return_value = json.loads(IPBASE_DATA['response'].decode("utf-8"))
+        IpbaseInfo._get_url_data.return_value = data
         jenkins_plugin = IpbaseInfo(module)
 
         json_data = jenkins_plugin.info()
 
-        result = json.loads(IPBASE_DATA['result'].decode("utf-8"))
-
         self.maxDiff = None
-        self.assertDictEqual(json_data, result)
+        self.assertDictEqual(json_data, data)


### PR DESCRIPTION
##### SUMMARY
I added a module to get geolocation data for the host IP from ipbase.com. 
Additional to the geolocation data, it also returns data about the AS, timezone, and a flag if the server is in the European Union which is quit useful.


##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
ipbase_fact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [localhost] => {
    "msg": {
        "ansible_facts": {
            "as_name": "T-Mobile Austria GmbH",
            "as_number": 8412,
            "city": "Vienna",
            "continent": "Europe",
            "continent_code": "EU",
            "country": "Austria",
            "country_code": "AT",
            "hostname": "81-223-100-100.static.upcbusiness.at",
            "ip": "81.223.100.100",
            "is_in_european_union": true,
            "latitude": 48.1861686706543,
            "longitude": 16.403240203857422,
            "region": "Vienna",
            "region_code": "AT-9",
            "timezone": "Europe/Vienna",
            "zip": "1030"
        },
        "changed": false,
        "failed": false
    }
}
```
