### PR TITLE
CI: Arch Linux now uses Python 3.11

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -390,7 +390,7 @@ stages:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
             - name: ArchLinux
-              test: archlinux/3.10
+              test: archlinux/3.11
             - name: CentOS Stream 8
               test: centos-stream8/3.9
           groups:


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-community/images/pull/56
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/43

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
