### PR TITLE
dconf - Try to find a Python interpreter that has gi.repository.GLib

### DIFF
--- a/changelogs/fragments/6491-dconf-respawn.yml
+++ b/changelogs/fragments/6491-dconf-respawn.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - dconf - If ``gi.repository.GLib`` is missing, try to respawn in a Python interpreter that has it (https://github.com/ansible-collections/community.general/pull/6491).
+  - dconf - if ``gi.repository.GLib`` is missing, try to respawn in a Python interpreter that has it (https://github.com/ansible-collections/community.general/pull/6491).

--- a/changelogs/fragments/6491-dconf-respawn.yml
+++ b/changelogs/fragments/6491-dconf-respawn.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dconf - If ``gi.repository.GLib`` is missing, try to respawn in a Python interpreter that has it (https://github.com/ansible-collections/community.general/pull/6491).

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -156,30 +156,14 @@ from ansible_collections.community.general.plugins.module_utils import deps
 
 # Python 2 doesn't have ModuleNotFoundError
 try:
-    import_errors = (AttributeError, ImportError, ModuleNotFoundError)
+    import_errors = (ImportError, ModuleNotFoundError)
 except NameError:
-    import_errors = (AttributeError, ImportError,)
+    import_errors = (ImportError,)
 
 glib_module_name = 'gi.repository.GLib'
 
 try:
-    # Note: When you call `__import__` without `fromlist`, it returns the
-    # top-level module object, even if you tell it to import a submodule. In
-    # others words, `__import__("gi.repository.GLib")` returns the `gi` module
-    # object, not the `gi.repository.GLib` module object.
-    # On the other hand, when you call it _with_ `fromlist`, it returns the
-    # module object the particular symbols you listed are being imported from.
-    # We're taking advantage of that here.
-    # Of note: You don't get an error when you specify a nonexistent symbol
-    # in `fromlist`, so it doesn't really matter what we list in it, but just
-    # to avoid confusion (and in case that behavior changes later) we are
-    # listing the symbols that we actually want to import. This, by the way, is
-    # why `AttributeError` is listed above in `import_errors`, so that we'll
-    # catch it if it turns out that either `Variant` or `GError` is
-    # unexpectedly missing.
-    mod = __import__(glib_module_name, fromlist=('Variant', 'GError'))
-    Variant = mod.Variant
-    GError = mod.GError
+    from gi.repository.GLib import Variant, GError
 except import_errors:
     Variant = None
     GError = AttributeError

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -154,17 +154,11 @@ from ansible.module_utils.common.respawn import (
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.general.plugins.module_utils import deps
 
-# Python 2 doesn't have ModuleNotFoundError
-try:
-    import_errors = (ImportError, ModuleNotFoundError)
-except NameError:
-    import_errors = (ImportError,)
-
 glib_module_name = 'gi.repository.GLib'
 
 try:
     from gi.repository.GLib import Variant, GError
-except import_errors:
+except ImportError:
     Variant = None
     GError = AttributeError
 


### PR DESCRIPTION
##### SUMMARY
If we're invoked in a Python interpreter that doesn't have access to `gi.repository.GLib`, try to find one that does and respawn the task in that interpreter.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dconf

##### ADDITIONAL INFORMATION
As suggested by @felixfontein in https://github.com/ansible-collections/community.general/pull/6049#issuecomment-1454676802 .