### PR TITLE
New module git_subtree.py

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -509,6 +509,8 @@ files:
     maintainers: $team_ansible_core johanwiren
   $modules/git_config.py:
     maintainers: djmattyg007 mgedmin
+  $modules/git_subtree.py:
+    maintainers: riadhhamdi
   $modules/github_:
     maintainers: stpierre
   $modules/github_deploy_key.py:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -66,7 +66,6 @@ EXAMPLES = '''
     squash: true
     commit_message: "Add subtree from example/repo"
     working_directory: /path/to/main/repository
-    
 
 - name: Add/Pull a subtree to the main repository using ssh
   community.general.git_subtree:
@@ -76,7 +75,7 @@ EXAMPLES = '''
     squash: true
     commit_message: "Add subtree from example/repo using ssd"
     working_directory: /path/to/main/repository
-    
+
 - name: Add/Pull a subtree to the main repository using http and disabling git password prompt
   community.general.git_subtree:
     source: https://github.com/example/repo.git
@@ -87,7 +86,7 @@ EXAMPLES = '''
     working_directory: /path/to/main/repository
   environment:
     GIT_TERMINAL_PROMPT: 0
-    
+
 - name: Add/Pull multiple subtrees to the main repository using http and disabling git password prompt
   community.general.git_subtree:
     source: "{{ item.source }}"
@@ -113,7 +112,7 @@ EXAMPLES = '''
         squash: true
         ref: 1.0.4
         prefix: roles/role3
-        
+
 - name: Add/Pull a subtree with authentication (read only token)
   community.general.git_subtree:
     source: https://0auth:ghp_2234xxxxxxxxxx5@github.com/example/repo.git
@@ -164,10 +163,7 @@ def main():
             command.append('--squash')
         if commit_message:
             command.extend(['-m', commit_message])
-        try:
-            rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
-        except Exception as e:
-            module.fail_json(msg="Error running command %s" % e.cmd, rc=e.returncode)
+        rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
         mesg = stdout.strip()
         module.exit_json(
             changed=True,
@@ -184,11 +180,7 @@ def main():
             command.append('--squash')
         if commit_message:
             command.extend(['-m', commit_message])
-
-        try:
-            rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
-        except Exception as e:
-            module.fail_json(msg="Error running command %s" % e.cmd, rc=e.returncode)
+        rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
         if 'is already at commit' in stderr:
             mesg = stdout.strip()
             module.exit_json(

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Written by Riadh Hamdi <rhamdi@redhat.com> <ryadh.hamdi@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+module: git_subtree
+short_description: Ansible module that mimic git subtree add/pull in an idempotent way.
+description:
+    - This module mimics the functionality of the git subtree command by adding a subtree from a source repository to a subdirectory in the main repository.
+version_added: "2.16"
+author:
+    - Riadh Hamdi (@riadhhamdi) (rhamdi@redhat.com)
+options:
+    source:
+        description:
+            - The source repository to pull the subtree from.
+        required: true
+        type: str
+    ref:
+        description:
+            - The repository ref while adding or pulling subtree. Example a branch (main,develop..) of a specific tag
+        required: true
+        type: str
+    prefix:
+        description:
+            - The prefix to use for the subtree directory in the main repository.
+        required: true
+        type: str
+    squash:
+        description:
+            - A boolean flag indicating whether to squash the subtree history into a single commit in the main repository.
+        type: bool
+        default: false
+    commit_message:
+        description:
+            - The commit message to use when committing the subtree changes to the main repository.
+        default: ''
+        type: str
+    working_directory:
+        description:
+            - The working directory in which to execute the git command.
+        default: null
+        type: str
+'''
+
+EXAMPLES = '''
+- name: Add/Pull a subtree to the main repository using http
+  git_subtree:
+    source: https://github.com/example/repo.git
+    ref: main
+    prefix: mydirectory
+    squash: true
+    commit_message: "Add subtree from example/repo"
+    working_directory: /path/to/main/repository
+- name: Add/Pull a subtree to the main repository using ssh
+  git_subtree:
+    source: git@github.com/example/repo.git
+    ref: main
+    prefix: mydirectory/somesubdirectory
+    squash: true
+    commit_message: "Add subtree from example/repo using ssd"
+    working_directory: /path/to/main/repository
+- name: Add/Pull a subtree to the main repository using http and disabling git password prompt
+  git_subtree:
+    source: https://github.com/example/repo.git
+    ref: main
+    prefix: mydirectory/somesubdirectory
+    squash: true
+    commit_message: "Add subtree from example/repo using ssd"
+    working_directory: /path/to/main/repository
+  environment:
+    GIT_TERMINAL_PROMPT: 0
+- name: Add/Pull multiple subtrees to the main repository using http and disabling git password prompt
+  git_subtree:
+    source: "{{item.source}}"
+    ref: "{{item.ref}}"
+    prefix: "{{item.prefix}}"
+    squash: true
+    commit_message: "Adding role {{item.prefix}} to the collection"
+    working_directory: /path/to/main/collection_repository
+  environment:
+    GIT_TERMINAL_PROMPT: 0
+  vars:
+    roles_repositories:
+      - source: https://github.com/example/role1.git
+        squash: true
+        ref: main
+        prefix: roles/role1
+      - source: https://github.com/example/role2.git
+        squash: true
+        ref: develop
+        prefix: roles/role2
+      - source: https://github.com/example/role3.git
+        squash: true
+        ref: 1.0.4
+        prefix: roles/role3
+- name: Add/Pull a subtree with authentication (read only token)
+  git_subtree:
+    source: https://0auth:ghp_2234xxxxxxxxxx5@github.com/example/repo.git
+    ref: main
+    prefix: mydirectory/somesubdirectory
+    squash: true
+    commit_message: "Add subtree from example/repo using ssd"
+    working_directory: /path/to/main/repository
+  environment:
+    GIT_TERMINAL_PROMPT: 0
+'''
+
+RETURN = '''
+msg:
+  description: The response body content.
+  returned: on success
+  type: str
+  sample: "{}"
+'''
+
+import os
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            source=dict(required=True),
+            ref=dict(required=True),
+            prefix=dict(required=True),
+            squash=dict(type='bool', default=False),
+            commit_message=dict(default=''),
+            working_directory=dict(default=None)
+        ),
+        supports_check_mode=False,
+    )
+
+    source = module.params['source']
+    ref = module.params['ref']
+    prefix = module.params['prefix']
+    squash = module.params['squash']
+    commit_message = module.params['commit_message']
+    working_directory = module.params['working_directory']
+
+    if not os.path.exists(os.path.join(working_directory, prefix)):
+        command = ['git', 'subtree', 'add', '--prefix', prefix, source, ref]
+        if squash:
+            command.append('--squash')
+        if commit_message:
+            command.extend(['-m', commit_message])
+        try:
+            rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
+        except Exception as e:
+            module.fail_json(msg="Error running command %s" % e.cmd, rc=e.returncode)
+        mesg = stdout.strip()
+        module.exit_json(
+            changed=True,
+            failed=False,
+            msg='Added new subtree %s' % prefix,
+            stdout=mesg,
+            stderr='',
+            rc=rc
+        )
+    else:
+        # the subtree already exists, update it
+        command = ['git', 'subtree', 'pull', '--prefix', prefix, source, ref]
+        if squash:
+            command.append('--squash')
+        if commit_message:
+            command.extend(['-m', commit_message])
+
+        try:
+            rc, stdout, stderr = module.run_command(command, cwd=working_directory, check_rc=True)
+        except Exception as e:
+            module.fail_json(msg="Error running command %s" % e.cmd, rc=e.returncode)
+        if 'is already at commit' in stderr:
+            mesg = stdout.strip()
+            module.exit_json(
+                changed=False,
+                failed=False,
+                msg="skipped since already at commit",
+                stdout=mesg,
+                stderr='',
+                rc=rc
+            )
+        else:
+            mesg = stdout.strip()
+            module.exit_json(
+                changed=True,
+                msg='Updated existing subtree %s' % prefix,
+                stdout=mesg,
+                stderr='',
+                rc=rc
+            )
+    return True
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -16,6 +16,7 @@ description:
     - This module mimics the functionality of the C(git subtree) command by adding a subtree from a source repository to a subdirectory in the main repository.
 author:
     - Riadh Hamdi (@riadhhamdi) (rhamdi@redhat.com)
+version_added: 7.1.0
 options:
     source:
         description:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -138,7 +138,7 @@ def main():
             ref=dict(required=True),
             prefix=dict(required=True),
             squash=dict(type='bool', default=False),
-            commit_message=dict(default=''),
+            commit_message=dict(required=False),
             working_directory=dict(required=True)
         ),
         supports_check_mode=False,

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -46,7 +46,7 @@ options:
     working_directory:
         description:
             - The working directory in which to execute the git command.
-        default: null
+        required: true
         type: str
 extends_documentation_fragment:
   - community.general.attributes
@@ -145,7 +145,7 @@ def main():
             prefix=dict(required=True),
             squash=dict(type='bool', default=False),
             commit_message=dict(default=''),
-            working_directory=dict(default=None)
+            working_directory=dict(required=True)
         ),
         supports_check_mode=False,
     )

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: git_subtree
-short_description: Ansible module that mimic git subtree add/pull in an idempotent way.
+short_description: Manage git subtree addition and updating
 description:
     - This module mimics the functionality of the git subtree command by adding a subtree from a source repository to a subdirectory in the main repository.
 author:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -24,7 +24,8 @@ options:
         type: str
     ref:
         description:
-            - The repository ref while adding or pulling subtree. Example a branch (main,develop..) of a specific tag
+            - The repository ref while adding or pulling subtree.
+            - For example a branch (C(main), C(develop), ...) or a specific tag.
         required: true
         type: str
     prefix:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 module: git_subtree
 short_description: Manage git subtree addition and updating
 description:
-    - This module mimics the functionality of the git subtree command by adding a subtree from a source repository to a subdirectory in the main repository.
+    - This module mimics the functionality of the C(git subtree) command by adding a subtree from a source repository to a subdirectory in the main repository.
 author:
     - Riadh Hamdi (@riadhhamdi) (rhamdi@redhat.com)
 options:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -67,6 +67,7 @@ EXAMPLES = '''
     commit_message: "Add subtree from example/repo"
     working_directory: /path/to/main/repository
     
+
 - name: Add/Pull a subtree to the main repository using ssh
   community.general.git_subtree:
     source: git@github.com/example/repo.git

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Written by Riadh Hamdi <rhamdi@redhat.com> <ryadh.hamdi@gmail.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright Riadh Hamdi <ryadh.hamdi@gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -50,12 +50,12 @@ options:
         required: true
         type: str
 extends_documentation_fragment:
-  - community.general.attributes
+    - community.general.attributes
 attributes:
-  check_mode:
-    support: none
-  diff_mode:
-    support: none
+    check_mode:
+        support: none
+    diff_mode:
+        support: none
 '''
 
 EXAMPLES = '''
@@ -126,13 +126,7 @@ EXAMPLES = '''
     GIT_TERMINAL_PROMPT: 0
 '''
 
-RETURN = '''
-msg:
-  description: The response body content.
-  returned: on success
-  type: str
-  sample: "{}"
-'''
+RETURN = r''' # '''
 
 import os
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -59,7 +59,7 @@ attributes:
 
 EXAMPLES = '''
 - name: Add/Pull a subtree to the main repository using http
-  git_subtree:
+  community.general.git_subtree:
     source: https://github.com/example/repo.git
     ref: main
     prefix: mydirectory

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -12,7 +12,6 @@ module: git_subtree
 short_description: Ansible module that mimic git subtree add/pull in an idempotent way.
 description:
     - This module mimics the functionality of the git subtree command by adding a subtree from a source repository to a subdirectory in the main repository.
-version_added: "2.16"
 author:
     - Riadh Hamdi (@riadhhamdi) (rhamdi@redhat.com)
 options:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -48,6 +48,13 @@ options:
             - The working directory in which to execute the git command.
         default: null
         type: str
+extends_documentation_fragment:
+  - community.general.attributes
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -42,7 +42,6 @@ options:
     commit_message:
         description:
             - The commit message to use when committing the subtree changes to the main repository.
-        default: ''
         type: str
     working_directory:
         description:

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -66,16 +66,18 @@ EXAMPLES = '''
     squash: true
     commit_message: "Add subtree from example/repo"
     working_directory: /path/to/main/repository
+    
 - name: Add/Pull a subtree to the main repository using ssh
-  git_subtree:
+  community.general.git_subtree:
     source: git@github.com/example/repo.git
     ref: main
     prefix: mydirectory/somesubdirectory
     squash: true
     commit_message: "Add subtree from example/repo using ssd"
     working_directory: /path/to/main/repository
+    
 - name: Add/Pull a subtree to the main repository using http and disabling git password prompt
-  git_subtree:
+  community.general.git_subtree:
     source: https://github.com/example/repo.git
     ref: main
     prefix: mydirectory/somesubdirectory
@@ -84,8 +86,9 @@ EXAMPLES = '''
     working_directory: /path/to/main/repository
   environment:
     GIT_TERMINAL_PROMPT: 0
+    
 - name: Add/Pull multiple subtrees to the main repository using http and disabling git password prompt
-  git_subtree:
+  community.general.git_subtree:
     source: "{{item.source}}"
     ref: "{{item.ref}}"
     prefix: "{{item.prefix}}"
@@ -108,8 +111,9 @@ EXAMPLES = '''
         squash: true
         ref: 1.0.4
         prefix: roles/role3
+        
 - name: Add/Pull a subtree with authentication (read only token)
-  git_subtree:
+  community.general.git_subtree:
     source: https://0auth:ghp_2234xxxxxxxxxx5@github.com/example/repo.git
     ref: main
     prefix: mydirectory/somesubdirectory

--- a/plugins/modules/git_subtree.py
+++ b/plugins/modules/git_subtree.py
@@ -90,14 +90,15 @@ EXAMPLES = '''
     
 - name: Add/Pull multiple subtrees to the main repository using http and disabling git password prompt
   community.general.git_subtree:
-    source: "{{item.source}}"
-    ref: "{{item.ref}}"
-    prefix: "{{item.prefix}}"
+    source: "{{ item.source }}"
+    ref: "{{ item.ref }}"
+    prefix: "{{ item.prefix }}"
     squash: true
     commit_message: "Adding role {{item.prefix}} to the collection"
     working_directory: /path/to/main/collection_repository
   environment:
     GIT_TERMINAL_PROMPT: 0
+  loop: "{{ roles_repositories }}"
   vars:
     roles_repositories:
       - source: https://github.com/example/role1.git


### PR DESCRIPTION
New module git_subtree

##### SUMMARY
 Adds New module git_subtree

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that cdd/extend tests without code changes. -->
- New Module/Plugin Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
New module git_subtree 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
A new module git_subtree that mimic the git subtree command and make it in a idempotent way. 
The main goal is that users can manage their subtrees as code without paying attention to add/pull verbs and to the complex way the subtree is handled 

example of usage 

- name: Add/Pull a subtree to the main repository using ssh
  git_subtree:
    source: git@github.com/example/repo.git
    ref: main
    prefix: mydirectory/somesubdirectory
    squash: true
    commit_message: "Add subtree from example/repo using ssd"
    working_directory: /path/to/main/repository

```
