### PR TITLE
plugins/inventory/cobbler: Add option to use system name for inventory

### DIFF
--- a/changelogs/fragments/6502-cobbler-inventory_hostname.yml
+++ b/changelogs/fragments/6502-cobbler-inventory_hostname.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - cobbler inventory plugin - add ``inventory_hostname`` option to allow using the system name for the inventory hostname (https://github.com/ansible-collections/community.general/pull/6502).
+  - cobbler inventory plugin - add warning for systems with empty profiles (https://github.com/ansible-collections/community.general/pull/6502).

--- a/changelogs/fragments/6502-cobbler-inventory_hostname.yml
+++ b/changelogs/fragments/6502-cobbler-inventory_hostname.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cobbler inventory plugin - add ``inventory_hostname`` option to allow using the system name for the inventory hostname (https://github.com/ansible-collections/community.general/pull/6502).

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -56,6 +56,15 @@ DOCUMENTATION = '''
         default: []
         elements: str
         version_added: 4.4.0
+      inventory_hostname:
+        description:
+          - What to use for the ansible inventory hostname.
+          - By default the networking hostname is used if defined, otherwise the DNS name of the management or first non-static interface.
+          - If set to I(system), the cobbler system name is used.
+        type: str
+        choices: [ 'hostname', 'system' ]
+        default: hostname
+        version_added: 7.1.0
       group_by:
         description: Keys to group hosts by
         type: list
@@ -201,6 +210,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
         self.exclude_profiles = self.get_option('exclude_profiles')
         self.include_profiles = self.get_option('include_profiles')
         self.group_by = self.get_option('group_by')
+        self.inventory_hostname = self.get_option('inventory_hostname')
 
         for profile in self._get_profiles():
             if profile['parent']:
@@ -238,7 +248,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         for host in self._get_systems():
             # Get the FQDN for the host and add it to the right groups
-            hostname = host['hostname']  # None
+            if self.inventory_hostname == 'system':
+                hostname = host['name']  # None
+            else:
+                hostname = host['hostname']  # None
             interfaces = host['interfaces']
 
             if self._exclude_profile(host['profile']):

--- a/plugins/inventory/cobbler.py
+++ b/plugins/inventory/cobbler.py
@@ -275,8 +275,11 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
             self.display.vvvv('Added host %s hostname %s\n' % (host['name'], hostname))
 
             # Add host to profile group
-            group_name = self._add_safe_group_name(host['profile'], child=hostname)
-            self.display.vvvv('Added host %s to profile group %s\n' % (hostname, group_name))
+            if host['profile'] != '':
+                group_name = self._add_safe_group_name(host['profile'], child=hostname)
+                self.display.vvvv('Added host %s to profile group %s\n' % (hostname, group_name))
+            else:
+                self.display.warning('Host %s has an empty profile\n' % (hostname))
 
             # Add host to groups specified by group_by fields
             for group_by in self.group_by:


### PR DESCRIPTION
hostname (#6492)
Add warning for systems with empty profiles

##### SUMMARY
Fixes: #6492
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/cobbler.py

##### ADDITIONAL INFORMATION
To use cobbler system names in the inventory, in your cobbler.yml use:
```paste below
plugin: cobbler
url: https://cobbler/cobbler_api
inventory_hostname: system
```
