### PR TITLE
fix typo in `terraform` docs

### DIFF
--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -218,7 +218,7 @@ EXAMPLES = """
   community.general.terraform:
     project_path: '{{ project_dir }}'
     state: present
-    camplex_vars: true
+    complex_vars: true
     variables:
       vm_name: "{{ inventory_hostname }}"
       vm_vcpus: 2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The [Docs](https://docs.ansible.com/ansible/latest/collections/community/general/terraform_module.html) have a typo in the examples. `camplex_vars` should be spelled `complex_vars`. 

Since many people are copy-and-pasting from docs and modify them to their needs this typo is an annoyance for users.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
trivial:
  - terraform - fix typo in docs `camplex_vars` -> `complex_vars`

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.terraform
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
just fixing a typo in docs
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
