### PR TITLE
opkg: remove useless default value for force

### DIFF
--- a/changelogs/fragments/6513-opkg-default-force.yml
+++ b/changelogs/fragments/6513-opkg-default-force.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - opkg - remove default value ``""`` for parameter ``force`` as it causes the same behaviour of not having that parameter (https://github.com/ansible-collections/community.general/pull/6513).

--- a/changelogs/fragments/6513-opkg-default-force.yml
+++ b/changelogs/fragments/6513-opkg-default-force.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opkg - remove default value ``""`` for parameter ``force`` as it causes the same behaviour of not having that parameter (https://github.com/ansible-collections/community.general/pull/6513).

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -46,6 +46,8 @@ options:
     force:
         description:
             - The C(opkg --force) parameter used.
+            - Passing C("") as value and not passing any value at all have bothe
+              the same effect of B(not) using any C(--force-) parameter.
         choices:
             - ""
             - "depends"

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -46,7 +46,7 @@ options:
     force:
         description:
             - The C(opkg --force) parameter used.
-            - Passing C("") as value and not passing any value at all have bothe
+            - Passing C("") as value and not passing any value at all have both
               the same effect of B(not) using any C(--force-) parameter.
         choices:
             - ""

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -58,7 +58,6 @@ options:
             - "remove"
             - "checksum"
             - "removal-of-dependent-packages"
-        default: ""
         type: str
     update_cache:
         description:
@@ -114,8 +113,8 @@ class Opkg(StateModuleHelper):
         argument_spec=dict(
             name=dict(aliases=["pkg"], required=True, type="list", elements="str"),
             state=dict(default="present", choices=["present", "installed", "absent", "removed"]),
-            force=dict(default="", choices=["", "depends", "maintainer", "reinstall", "overwrite", "downgrade", "space", "postinstall", "remove",
-                                            "checksum", "removal-of-dependent-packages"]),
+            force=dict(choices=["", "depends", "maintainer", "reinstall", "overwrite", "downgrade", "space",
+                                "postinstall", "remove", "checksum", "removal-of-dependent-packages"]),
             update_cache=dict(default=False, type='bool'),
         ),
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module has a legacy value `""` for the `force` parameter. When `force=""` the module does not pass any CLI "force" option to the underlying `opkg` command. The same happens if `force=null`. 

So, the option `""` and it being marked as default value is something that was arguably created to artificially indicate that the parameter is optional.

This PR removes the default, and given that both values `""` and `null` will trigger the same behaviour in the module, this change is completely transparent to users.

A follow-up PR will then deprecate the option `""`, on the account that some users may be calling the module explicitly passing the empty string as parameter.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
opkg
