### PR TITLE
mas: disable sign-in check for macOS 12+

### DIFF
--- a/changelogs/fragments/6520-mas-disable-signin.yaml
+++ b/changelogs/fragments/6520-mas-disable-signin.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "mas - disable sign-in check for macOS 12+ as ``mas account`` is non-functional (https://github.com/ansible-collections/community.general/pull/6520)."

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -54,7 +54,7 @@ requirements:
     - "mas-cli (U(https://github.com/mas-cli/mas)) 1.5.0+ available as C(mas) in the bin path"
     - The Apple ID to use already needs to be signed in to the Mac App Store (check with C(mas account)).
     - The feature of "checking if user is signed in" is disabled for anyone using macOS 12.0+.
-    - User need to sign in via the Mac App Store GUI beforehand for anyone using macOS 12.0+ due to https://github.com/mas-cli/mas/issues/417
+    - Users need to sign in via the Mac App Store GUI beforehand for anyone using macOS 12.0+ due to U(https://github.com/mas-cli/mas/issues/417).
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -111,6 +111,7 @@ from ansible_collections.community.general.plugins.module_utils.version import L
 import platform
 WORKING_MAC_VERSION_MAS_ACCOUNT = '11.0'
 
+
 class Mas(object):
 
     def __init__(self, module):
@@ -161,14 +162,12 @@ class Mas(object):
 
     def check_signin(self):
         ''' Verifies that the user is signed in to the Mac App Store '''
-        
         # Only check this once per execution
         if self._checked_signin:
-            return
-        
+            return        
         if is_version_greater(self._mac_version, WORKING_MAC_VERSION_MAS_ACCOUNT):
             # Checking if user is signed-in is disabled due to https://github.com/mas-cli/mas/issues/417
-            print('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')
+            self.module.log('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')
         else:
             rc, out, err = self.run(['account'])
             if out.split("\n", 1)[0].rstrip() == 'Not signed in':
@@ -309,10 +308,10 @@ def main():
 if __name__ == '__main__':
     main()
 
+
 def is_version_greater(version, reference_version):
     version_parts = [int(part) for part in version.split('.')]
     reference_parts = [int(part) for part in reference_version.split('.')]
-    
     if version_parts > reference_parts:
         return True
     else:

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -120,7 +120,7 @@ class Mas(object):
         # Initialize data properties
         self.mas_path = self.module.get_bin_path('mas')
         self._checked_signin = False
-        self._mac_version = platform.mac_ver()[0]
+        self._mac_version = platform.mac_ver()[0] or '0.0'
         self._installed = None  # Populated only if needed
         self._outdated = None   # Populated only if needed
         self.count_install = 0

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -109,7 +109,7 @@ import os
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 import platform
-WORKING_MAC_VERSION_MAS_ACCOUNT = '11.0'
+NOT_WORKING_MAC_VERSION_MAS_ACCOUNT = '12.0'
 
 
 class Mas(object):

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -165,7 +165,7 @@ class Mas(object):
         # Only check this once per execution
         if self._checked_signin:
             return
-        if LooseVersion(self._mac_version) > LooseVersion(WORKING_MAC_VERSION_MAS_ACCOUNT):
+        if LooseVersion(self._mac_version) >= LooseVersion(NOT_WORKING_MAC_VERSION_MAS_ACCOUNT):
             # Checking if user is signed-in is disabled due to https://github.com/mas-cli/mas/issues/417
             self.module.log('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')
         else:

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -159,15 +159,6 @@ class Mas(object):
         if rc != 0 or not out.strip() or LooseVersion(out.strip()) < LooseVersion('1.5.0'):
             self.module.fail_json(msg='`mas` tool in version 1.5.0+ needed, got ' + out.strip())
 
-    def is_version_greater(version, reference_version):
-        version_parts = [int(part) for part in version.split('.')]
-        reference_parts = [int(part) for part in reference_version.split('.')]
-        
-        if version_parts > reference_parts:
-            return True
-        else:
-            return False
-
     def check_signin(self):
         ''' Verifies that the user is signed in to the Mac App Store '''
         
@@ -175,7 +166,7 @@ class Mas(object):
         if self._checked_signin:
             return
         
-        if self.is_version_greater(self._mac_version, WORKING_MAC_VERSION_MAS_ACCOUNT):
+        if is_version_greater(self._mac_version, WORKING_MAC_VERSION_MAS_ACCOUNT):
             # Checking if user is signed-in is disabled due to https://github.com/mas-cli/mas/issues/417
             print('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')
         else:
@@ -317,3 +308,12 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+def is_version_greater(version, reference_version):
+    version_parts = [int(part) for part in version.split('.')]
+    reference_parts = [int(part) for part in reference_version.split('.')]
+    
+    if version_parts > reference_parts:
+        return True
+    else:
+        return False

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -53,7 +53,7 @@ requirements:
     - macOS 10.11+
     - "mas-cli (U(https://github.com/mas-cli/mas)) 1.5.0+ available as C(mas) in the bin path"
     - The Apple ID to use already needs to be signed in to the Mac App Store (check with C(mas account)).
-    - The feature of `checking if user is signed in` is disabled for anyone using macOS 12.0+
+    - The feature of "checking if user is signed in" is disabled for anyone using macOS 12.0+.
     - User need to sign in via the Mac App Store GUI beforehand for anyone using macOS 12.0+ due to https://github.com/mas-cli/mas/issues/417
 '''
 

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -164,7 +164,7 @@ class Mas(object):
         ''' Verifies that the user is signed in to the Mac App Store '''
         # Only check this once per execution
         if self._checked_signin:
-            return        
+            return
         if is_version_greater(self._mac_version, WORKING_MAC_VERSION_MAS_ACCOUNT):
             # Checking if user is signed-in is disabled due to https://github.com/mas-cli/mas/issues/417
             self.module.log('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')

--- a/plugins/modules/mas.py
+++ b/plugins/modules/mas.py
@@ -165,7 +165,7 @@ class Mas(object):
         # Only check this once per execution
         if self._checked_signin:
             return
-        if is_version_greater(self._mac_version, WORKING_MAC_VERSION_MAS_ACCOUNT):
+        if LooseVersion(self._mac_version) > LooseVersion(WORKING_MAC_VERSION_MAS_ACCOUNT):
             # Checking if user is signed-in is disabled due to https://github.com/mas-cli/mas/issues/417
             self.module.log('WARNING: You must be signed in via the Mac App Store GUI beforehand else error will occur')
         else:
@@ -307,12 +307,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-def is_version_greater(version, reference_version):
-    version_parts = [int(part) for part in version.split('.')]
-    reference_parts = [int(part) for part in reference_version.split('.')]
-    if version_parts > reference_parts:
-        return True
-    else:
-        return False


### PR DESCRIPTION
##### SUMMARY
Feature Implementation of Issue - https://github.com/ansible-collections/community.general/issues/6519

Fixes #6519 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mas

##### ADDITIONAL INFORMATION
Disabling the sign-in check when trying to install or upgrade an app via mas via Ansible for anyone using Mac 12.0+. More details can be found in the issue