### PR TITLE
respawn copr module when dnf is missing

### DIFF
--- a/changelogs/fragments/6522-copr-respawn.yaml
+++ b/changelogs/fragments/6522-copr-respawn.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "copr - respawn module to use the system python interpreter when the ``dnf`` python module is not available in ``ansible_python_interpreter``
+    (https://github.com/ansible-collections/community.general/pull/6522)."

--- a/plugins/modules/copr.py
+++ b/plugins/modules/copr.py
@@ -97,20 +97,12 @@ except ImportError:
     DNF_IMP_ERR = traceback.format_exc()
     HAS_DNF_PACKAGES = False
 
+from ansible.module_utils.common import respawn
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils import distro  # pylint: disable=import-error
 from ansible.module_utils.basic import AnsibleModule  # pylint: disable=import-error
 from ansible.module_utils.urls import open_url  # pylint: disable=import-error
-
-HAS_RESPAWN_UTIL = False
-if not HAS_DNF_PACKAGES:
-    try:
-        from ansible.module_utils.common import respawn
-    except ImportError:
-        pass
-    else:
-        HAS_RESPAWN_UTIL = True
 
 
 def _respawn_dnf():
@@ -483,8 +475,7 @@ def run_module():
     params = module.params
 
     if not HAS_DNF_PACKAGES:
-        if HAS_RESPAWN_UTIL:
-            _respawn_dnf()
+        _respawn_dnf()
         module.fail_json(msg=missing_required_lib("dnf"), exception=DNF_IMP_ERR)
 
     CoprModule.ansible_module = module

--- a/tests/integration/targets/copr/tasks/main.yml
+++ b/tests/integration/targets/copr/tasks/main.yml
@@ -10,12 +10,6 @@
       ansible_distribution == 'Fedora'
       or (ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
           and ansible_distribution_major_version | int >= 8)
-    # The copr module imports dnf which is only available for the system Python
-    # interpreter.
-    - >
-      not (ansible_distribution == 'CentOS' and
-           ansible_distribution_major_version | int == 8 and not
-           ansible_python_version.startswith('3.6'))
   block:
   - debug: var=copr_chroot
   - name: enable copr project


### PR DESCRIPTION
##### SUMMARY

copr - respawn module to use the system python interpreter when the ``dnf`` python module is not available in ``ansible_python_interpreter``

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
copr

##### ADDITIONAL INFORMATION

Fixes downstream bug https://bugzilla.redhat.com/2203513

Can we backport this to stable-6 and stable-7 so it shows up in ansible 7 and 8? I plan to backport this to the EPEL 8 and 9 ansible-collection-community-general RPM packages that currently contain upstream EOL versions[^1].

[^1]: We're updating to upstream supported versions prior to the next RHEL minor release.