### PR TITLE
nmcli: Fix bond option xmit_hash_policy

### DIFF
--- a/changelogs/fragments/6527-nmcli-bond-fix-xmit_hash_policy.yml
+++ b/changelogs/fragments/6527-nmcli-bond-fix-xmit_hash_policy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fix bond option xmit_hash_policy (https://github.com/ansible-collections/community.general/pull/6527).

--- a/changelogs/fragments/6527-nmcli-bond-fix-xmit_hash_policy.yml
+++ b/changelogs/fragments/6527-nmcli-bond-fix-xmit_hash_policy.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - fix bond option xmit_hash_policy (https://github.com/ansible-collections/community.general/pull/6527).
+  - nmcli - fix bond option ``xmit_hash_policy`` (https://github.com/ansible-collections/community.general/pull/6527).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2119,6 +2119,9 @@ class Nmcli(object):
                 if key in self.SECRET_OPTIONS:
                     self.edit_commands += ['set %s %s' % (key, value)]
                     continue
+                if key == 'xmit_hash_policy':
+                    cmd.extend(['+bond.options', 'xmit_hash_policy=%s' % value])
+                    continue
                 cmd.extend([key, value])
 
         return self.execute_command(cmd)

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -500,6 +500,7 @@ TESTCASE_BOND = [
         'conn_name': 'non_existent_nw_device',
         'ifname': 'bond_non_existant',
         'mode': 'active-backup',
+        'xmit_hash_policy': 'layer3+4',
         'ip4': '10.10.10.10/24',
         'gw4': '10.10.10.1',
         'state': 'present',
@@ -522,7 +523,7 @@ ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
-bond.options:                           mode=active-backup,primary=non_existent_primary
+bond.options:                           mode=active-backup,primary=non_existent_primary,xmit_hash_policy=layer3+4
 """
 
 TESTCASE_BRIDGE = [
@@ -1897,7 +1898,8 @@ def test_bond_connection_create(mocked_generic_connection_create, capfd):
 
     for param in ['ipv4.gateway', 'primary', 'connection.autoconnect',
                   'connection.interface-name', 'bond_non_existant',
-                  'mode', 'active-backup', 'ipv4.addresses']:
+                  'mode', 'active-backup', 'ipv4.addresses',
+                  '+bond.options', 'xmit_hash_policy=layer3+4']:
         assert param in args[0]
 
     out, err = capfd.readouterr()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is no alias option for configure `xmit_hash_policy` param for bond interface, we need to set it via `+bond.option` key.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #5861
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
nmcli

