### PR TITLE
opentelemetry: add span event attributes

### DIFF
--- a/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
+++ b/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - opentelemetry - Add span attributes in the span event (https://github.com/ansible-collections/community.general/pull/6531).
+  - opentelemetry callback plugin - add span attributes in the span event (https://github.com/ansible-collections/community.general/pull/6531).

--- a/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
+++ b/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opentelemetry - Add task name and hostname attributes in the span event (https://github.com/ansible-collections/community.general/pull/6531).

--- a/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
+++ b/changelogs/fragments/6531-opentelemetry-add-event-attributes.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - opentelemetry - Add task name and hostname attributes in the span event (https://github.com/ansible-collections/community.general/pull/6531).
+  - opentelemetry - Add span attributes in the span event (https://github.com/ansible-collections/community.general/pull/6531).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -337,7 +337,7 @@ class OpenTelemetrySource(object):
         self.add_attributes_for_service_map_if_possible(span, task_data)
         # Send logs
         if not disable_logs:
-            span.add_event(task_data.dump, attributes={"ansible.task.name": name, "ansible.task.host.name": host_data.name})
+            span.add_event(task_data.dump, attributes=attributes)
         span.end(end_time=host_data.finish)
 
     def set_span_attributes(self, span, attributes):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -330,7 +330,7 @@ class OpenTelemetrySource(object):
         self.add_attributes_for_service_map_if_possible(span, task_data)
         # Send logs
         if not disable_logs:
-            span.add_event(task_data.dump)
+            span.add_event(task_data.dump, attributes={"ansible.task.name": name, "ansible.task.host.name": host_data.name})
         span.end(end_time=host_data.finish)
 
     def set_span_attribute(self, span, attributeName, attributeValue):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -83,7 +83,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_opentelemetry
             key: disable_attributes_in_logs
-        version_added: 6.6.2
+        version_added: 7.1.0
     requirements:
       - opentelemetry-api (Python library)
       - opentelemetry-exporter-otlp (Python library)


### PR DESCRIPTION
##### SUMMARY

Enable populating span attributes to event attributes with OpenTelemetry in order to allow logs correlations with traces.

This is quite handy when the OTEL ventor does not show those details in the UI directly.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
`opentelemetry`

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/community.general/pull/4175 was the original implementation.

Closes https://github.com/ansible-collections/community.general/issues/6526

Given

```yaml
---
- name: MyPlabook
  hosts: localhost
  connection: local

  roles:
  - role: myrole
  tasks:
  - name: MyTask2
    uri:
      url: https://www.elastic.co
      return_content: no
    register: webpage

```


And if I run with the logs:

```bash
OTEL_SERVICE_NAME=test-ansible \
OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
OTEL_EXPORTER_OTLP_INSECURE=true \
ansible-playbook -i hosts my-playbook.yml
```

Produces

![Kapture 2023-05-17 at 22 57 46](https://github.com/ansible-collections/community.general/assets/2871786/91b14c80-dde9-485f-89e4-65ae6934d03f)

<img width="1335" alt="image" src="https://github.com/ansible-collections/community.general/assets/2871786/2880fb5d-a455-4e40-bc42-f378ce8999f3">



And if I run setting the attributes in the logs to false:

```bash
OTEL_SERVICE_NAME=test-ansible \
OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317 \
OTEL_EXPORTER_OTLP_INSECURE=true \
ANSIBLE_OPENTELEMETRY_DISABLE_ATTRIBUTES_IN_LOGS=false \
ansible-playbook -i hosts my-playbook.yml
```

Produces

<img width="1394" alt="image" src="https://github.com/ansible-collections/community.general/assets/2871786/d0b87cd3-fc8b-42d8-805c-df1773461dde">
