### PR TITLE
proxmox_kvm: support for tpmstate0 parameter

### DIFF
--- a/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
+++ b/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - added support for tpmstate0 parameter to configure TPM (Trusted Platform Module) disk. TPM is required for Windows 11 installations.

--- a/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
+++ b/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - added support for tpmstate0 parameter to configure TPM (Trusted Platform Module) disk. TPM is required for Windows 11 installations.
+  - proxmox_kvm - added support for tpmstate0 parameter to configure TPM (Trusted Platform Module) disk. TPM is required for Windows 11 installations (https://github.com/ansible-collections/community.general/pull/6533).

--- a/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
+++ b/changelogs/fragments/6533-proxmox_kvm-tpmstate0-support.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - added support for tpmstate0 parameter to configure TPM (Trusted Platform Module) disk. TPM is required for Windows 11 installations (https://github.com/ansible-collections/community.general/pull/6533).
+  - proxmox_kvm - added support for ``tpmstate0`` parameter to configure TPM (Trusted Platform Module) disk. TPM is required for Windows 11 installations (https://github.com/ansible-collections/community.general/pull/6533).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: community
 name: general
-version: 7.1.1
+version: 7.1.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: community
 name: general
-version: 7.1.0
+version: 7.1.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -482,7 +482,7 @@ options:
       - Timeout for operations.
     type: int
     default: 30
-  tpmstate:
+  tpmstate0:
     description:
       - A hash/dictionary of options for the Trusted Platform Module disk.
       - A TPM state disk is required for Windows 11 installations.
@@ -967,8 +967,8 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                 del kwargs['ide']
             if 'efidisk0' in kwargs:
                 del kwargs['efidisk0']
-            if 'tpmstate' in kwargs:
-                del kwargs['tpmstate']
+            if 'tpmstate0' in kwargs:
+                del kwargs['tpmstate0']
             if 'net' in kwargs:
                 del kwargs['net']
             if 'force' in kwargs:
@@ -996,9 +996,9 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                                       if 'storage' != k])
             kwargs['efidisk0'] = efidisk0_str
 
-        # Flatten tpmstate option to a string so that it's a string which is what Proxmoxer and the API expect
-        if 'tpmstate' in kwargs:
-            kwargs['tmpstate'] = '{storage}:1,version=v{version}'.format(storage=kwargs['tmpstate'].pop('storage'), version=kwargs['tmpstate'].pop('version'))
+        # Flatten tpmstate0 option to a string so that it's a string which is what Proxmoxer and the API expect
+        if 'tpmstate0' in kwargs:
+            kwargs['tpmstate0'] = '{storage}:1,version=v{version}'.format(storage=kwargs['tpmstate0'].pop('storage'), version=kwargs['tpmstate0'].pop('version'))
 
         # Convert all dict in kwargs to elements.
         # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n]
@@ -1185,7 +1185,11 @@ def main():
         tdf=dict(type='bool'),
         template=dict(type='bool'),
         timeout=dict(type='int', default=30),
-        tpmstate=dict(type='dict'),
+        tpmstate0=dict(type='dict',
+                       options=dict(
+                           storage=dict(type='str'),
+                           version=dict(type='str', choices=['2.0', '1.2'])
+                       )),
         update=dict(type='bool', default=False),
         vcpus=dict(type='int'),
         vga=dict(choices=['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
@@ -1379,6 +1383,7 @@ def main():
                               target=module.params['target'],
                               tdf=module.params['tdf'],
                               template=module.params['template'],
+                              tpmstate0=module.params['tpmstate0'],
                               vcpus=module.params['vcpus'],
                               vga=module.params['vga'],
                               virtio=module.params['virtio'],

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -999,8 +999,8 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         # Flatten tpmstate0 option to a string so that it's a string which is what Proxmoxer and the API expect
         if 'tpmstate0' in kwargs:
             kwargs['tpmstate0'] = '{storage}:1,version=v{version}'.format(
-                storage=kwargs['tpmstate0'].pop('storage'),
-                version=kwargs['tpmstate0'].pop('version')
+                storage=kwargs['tpmstate0'].get('storage'),
+                version=kwargs['tpmstate0'].get('version')
             )
 
         # Convert all dict in kwargs to elements.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -497,7 +497,7 @@ options:
         type: str
         choices: ['1.2', '2.0']
     type: dict
-    version_added: 7.2.0
+    version_added: 7.1.0
   update:
     description:
       - If C(true), the VM will be updated with new value.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -489,7 +489,7 @@ options:
     suboptions:
       storage:
         description:
-          - C(storage) is the storage identifier where to create the disk.
+          - O(tmpstate0.storage) is the storage identifier where to create the disk.
         type: str
       version:
         description:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -497,7 +497,7 @@ options:
           - The TPM version to use.
         type: str
         choices: ['1.2', '2.0']
-        required: true
+        default: 2.0
     type: dict
     version_added: 7.1.0
   update:
@@ -1193,7 +1193,7 @@ def main():
         tpmstate0=dict(type='dict',
                        options=dict(
                            storage=dict(type='str', required=True),
-                           version=dict(type='str', choices=['2.0', '1.2'], required=True)
+                           version=dict(type='str', choices=['2.0', '1.2'], default='2.0')
                        )),
         update=dict(type='bool', default=False),
         vcpus=dict(type='int'),

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -489,7 +489,7 @@ options:
     suboptions:
       storage:
         description:
-          - O(tmpstate0.storage) is the storage identifier where to create the disk.
+          - O(tpmstate0.storage) is the storage identifier where to create the disk.
         type: str
         required: true
       version:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -496,7 +496,7 @@ options:
           - The TPM version to use.
         type: str
         choices: ['1.2', '2.0']
-    version_added: 6.5.1
+    version_added: 7.1.1
   update:
     description:
       - If C(true), the VM will be updated with new value.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -497,7 +497,7 @@ options:
           - The TPM version to use.
         type: str
         choices: ['1.2', '2.0']
-        default: 2.0
+        default: '2.0'
     type: dict
     version_added: 7.1.0
   update:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -482,7 +482,7 @@ options:
       - Timeout for operations.
     type: int
     default: 30
-  tmpstate:
+  tpmstate:
     description:
       - A hash/dictionary of options for the Trusted Platform Module disk.
       - A TPM state disk is required for Windows 11 installations.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -954,7 +954,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             urlencoded_ssh_keys = quote(kwargs['sshkeys'], safe='')
             kwargs['sshkeys'] = str(urlencoded_ssh_keys)
 
-        # If update, don't update disk (virtio, efidisk0, ide, sata, scsi) and network interface
+        # If update, don't update disk (virtio, efidisk0, tpmstate0, ide, sata, scsi) and network interface
         # pool parameter not supported by qemu/<vmid>/config endpoint on "update" (PVE 6.2) - only with "create"
         if update:
             if 'virtio' in kwargs:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -491,11 +491,13 @@ options:
         description:
           - O(tmpstate0.storage) is the storage identifier where to create the disk.
         type: str
+        required: true
       version:
         description:
           - The TPM version to use.
         type: str
         choices: ['1.2', '2.0']
+        required: true
     type: dict
     version_added: 7.1.0
   update:
@@ -1190,8 +1192,8 @@ def main():
         timeout=dict(type='int', default=30),
         tpmstate0=dict(type='dict',
                        options=dict(
-                           storage=dict(type='str'),
-                           version=dict(type='str', choices=['2.0', '1.2'])
+                           storage=dict(type='str', required=True),
+                           version=dict(type='str', choices=['2.0', '1.2'], required=True)
                        )),
         update=dict(type='bool', default=False),
         vcpus=dict(type='int'),

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -998,7 +998,10 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
         # Flatten tpmstate0 option to a string so that it's a string which is what Proxmoxer and the API expect
         if 'tpmstate0' in kwargs:
-            kwargs['tpmstate0'] = '{storage}:1,version=v{version}'.format(storage=kwargs['tpmstate0'].pop('storage'), version=kwargs['tpmstate0'].pop('version'))
+            kwargs['tpmstate0'] = '{storage}:1,version=v{version}'.format(
+                storage=kwargs['tpmstate0'].pop('storage'),
+                version=kwargs['tpmstate0'].pop('version')
+            )
 
         # Convert all dict in kwargs to elements.
         # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n]

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -496,7 +496,8 @@ options:
           - The TPM version to use.
         type: str
         choices: ['1.2', '2.0']
-    version_added: 7.1.1
+    type: dict
+    version_added: 7.2.0
   update:
     description:
       - If C(true), the VM will be updated with new value.
@@ -997,7 +998,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
         # Flatten tpmstate option to a string so that it's a string which is what Proxmoxer and the API expect
         if 'tpmstate' in kwargs:
-            kwargs['tmpstate'] = '{}:1,version=v{}'.format(kwargs['tmpstate'].pop('storage'), kwargs['tmpstate'].pop('version'))
+            kwargs['tmpstate'] = '{storage}:1,version=v{version}'.format(storage=kwargs['tmpstate'].pop('storage'), version=kwargs['tmpstate'].pop('version'))
 
         # Convert all dict in kwargs to elements.
         # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n]


### PR DESCRIPTION
##### SUMMARY
Adds the tpmstate0 parameter, which is a hash containing two options (storage and version) to configure the TPM state disk. The TPM (Trusted Platform Module) is required for Windows 11 installations.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
changed: [localhost] => {
    "changed": true,
    "devices": {
        "sata0": "STOR1:253/vm-253-disk-1.qcow2",
        "sata1": "local:iso/Win11_22H2_English_x64v1_UEFI.iso"
    },
    "invocation": {
        "module_args": {
            "acpi": null,
            "agent": "True",
            "api_host": "pve1.domain.com",
            "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_token_id": null,
            "api_token_secret": null,
            "api_user": "root@pam",
            "archive": null,
            "args": null,
            "autostart": true,
            "balloon": 8192,
            "bios": "ovmf",
            "boot": "cdn",
            "bootdisk": "sata0",
            "cicustom": null,
            "cipassword": null,
            "citype": null,
            "ciuser": null,
            "clone": null,
            "cores": 4,
            "cpu": "host",
            "cpulimit": null,
            "cpuunits": null,
            "delete": null,
            "description": null,
            "digest": null,
            "efidisk0": {
                "efitype": "4m",
                "format": "qcow2",
                "pre_enrolled_keys": true
            },
            "force": null,
            "format": null,
            "freeze": null,
            "full": true,
            "hostpci": null,
            "hotplug": null,
            "hugepages": null,
            "ide": null,
            "ipconfig": null,
            "keyboard": null,
            "kvm": true,
            "localtime": null,
            "lock": null,
            "machine": "q35",
            "memory": 8192,
            "migrate": false,
            "migrate_downtime": null,
            "migrate_speed": null,
            "name": "rdp.testautom8",
            "net": {
                "net0": "e1000,bridge=vmbr0,firewall=1"
            },
            "newid": null,
            "node": "pve1",
            "numa": null,
            "numa_enabled": null,
            "onboot": true,
            "ostype": "win11",
            "parallel": null,
            "pool": "rdp",
            "protection": null,
            "proxmox_default_behavior": "no_defaults",
            "reboot": null,
            "revert": null,
            "sata": {
                "sata0": "STOR1:420,format=qcow2",
                "sata1": "local:iso/Win11_22H2_English_x64v1_UEFI.iso,media=cdrom"
            },
            "scsi": null,
            "scsihw": "virtio-scsi-single",
            "serial": null,
            "shares": null,
            "skiplock": null,
            "smbios": null,
            "snapname": null,
            "sockets": null,
            "sshkeys": null,
            "startdate": null,
            "startup": null,
            "state": "present",
            "storage": null,
            "tablet": null,
            "tags": null,
            "target": null,
            "tdf": null,
            "template": null,
            "timeout": 300,
            "update": false,
            "validate_certs": false,
            "vcpus": null,
            "vga": null,
            "virtio": null,
            "vmid": null,
            "watchdog": null
        }
    },
    "mac": {
        "net0": "72:FF:2E:5B:26:BD"
    },
    "msg": "VM rdp.testautom8 with vmid 253 deployed",
    "vmid": 253
}
```

After
```
changed: [localhost] => {
    "changed": true,
    "devices": {
        "sata0": "STOR1:253/vm-253-disk-1.qcow2",
        "sata1": "local:iso/Win11_22H2_English_x64v1_UEFI.iso"
    },
    "invocation": {
        "module_args": {
            "acpi": null,
            "agent": "True",
            "api_host": "pve1.domain.com",
            "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_token_id": null,
            "api_token_secret": null,
            "api_user": "root@pam",
            "archive": null,
            "args": null,
            "autostart": true,
            "balloon": 8192,
            "bios": "ovmf",
            "boot": "cdn",
            "bootdisk": "sata0",
            "cicustom": null,
            "cipassword": null,
            "citype": null,
            "ciuser": null,
            "clone": null,
            "cores": 4,
            "cpu": "host",
            "cpulimit": null,
            "cpuunits": null,
            "delete": null,
            "description": null,
            "digest": null,
            "efidisk0": {
                "efitype": "4m",
                "format": "qcow2",
                "pre_enrolled_keys": true
            },
            "force": null,
            "format": null,
            "freeze": null,
            "full": true,
            "hostpci": null,
            "hotplug": null,
            "hugepages": null,
            "ide": null,
            "ipconfig": null,
            "keyboard": null,
            "kvm": true,
            "localtime": null,
            "lock": null,
            "machine": "q35",
            "memory": 8192,
            "migrate": false,
            "migrate_downtime": null,
            "migrate_speed": null,
            "name": "rdp.testautom8",
            "net": {
                "net0": "e1000,bridge=vmbr0,firewall=1"
            },
            "newid": null,
            "node": "pve1",
            "numa": null,
            "numa_enabled": null,
            "onboot": true,
            "ostype": "win11",
            "parallel": null,
            "pool": "rdp",
            "protection": null,
            "proxmox_default_behavior": "no_defaults",
            "reboot": null,
            "revert": null,
            "sata": {
                "sata0": "STOR1:420,format=qcow2",
                "sata1": "local:iso/Win11_22H2_English_x64v1_UEFI.iso,media=cdrom"
            },
            "scsi": null,
            "scsihw": "virtio-scsi-single",
            "serial": null,
            "shares": null,
            "skiplock": null,
            "smbios": null,
            "snapname": null,
            "sockets": null,
            "sshkeys": null,
            "startdate": null,
            "startup": null,
            "state": "present",
            "storage": null,
            "tablet": null,
            "tags": null,
            "target": null,
            "tdf": null,
            "template": null,
            "timeout": 300,
            "tpmstate0": {
                "storage": "STOR1",
                "version": "2.0"
            },
            "update": false,
            "validate_certs": false,
            "vcpus": null,
            "vga": null,
            "virtio": null,
            "vmid": null,
            "watchdog": null
        }
    },
    "mac": {
        "net0": "26:B9:C9:35:AF:74"
    },
    "msg": "VM rdp.testautom8 with vmid 253 deployed",
    "vmid": 253
}
```