### PR TITLE
added handling of zypper exitcode 102: ZYPPER_EXIT_INF_REBOOT_NEEDED

### DIFF
--- a/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
+++ b/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zypper - added handling of zypper exitcode 102. Changed state is set correctly now and rc 102 is still preserved to be evaluated by the playbook.
+  - zypper - added handling of zypper exitcode 102. Changed state is set correctly now and rc 102 is still preserved to be evaluated by the playbook (https://github.com/ansible-collections/community.general/pull/6534).

--- a/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
+++ b/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zypper - added handling of zypper exitcode 102. Changed state is set correctly now and rc 102 is still preserved to be evaluated by the plaxbook.
+  - zypper - added handling of zypper exitcode 102. Changed state is set correctly now and rc 102 is still preserved to be evaluated by the playbook.

--- a/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
+++ b/changelogs/fragments/6534-zypper-exitcode-102-handled.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zypper - added handling of zypper exitcode 102. Changed state is set correctly now and rc 102 is still preserved to be evaluated by the plaxbook.

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -329,7 +329,7 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
         # 0: success
         # 106: signature verification failed
         # 102: ZYPPER_EXIT_INF_REBOOT_NEEDED - Returned after a successful installation of a patch which requires reboot of computer.
-        # 103: zypper was upgraded, run same command again        
+        # 103: zypper was upgraded, run same command again
         if packages is None:
             firstrun = True
             packages = {}

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -324,11 +324,12 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
             m.fail_json(msg=errmsg, rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
         else:
             return {}, rc, stdout, stderr
-    elif rc in [0, 106, 103]:
+    elif rc in [0, 102, 103, 106]:
         # zypper exit codes
         # 0: success
         # 106: signature verification failed
-        # 103: zypper was upgraded, run same command again
+        # 102: ZYPPER_EXIT_INF_REBOOT_NEEDED - Returned after a successful installation of a patch which requires reboot of computer.
+        # 103: zypper was upgraded, run same command again        
         if packages is None:
             firstrun = True
             packages = {}
@@ -587,12 +588,12 @@ def main():
         elif state in ['installed', 'present', 'latest']:
             packages_changed, retvals = package_present(module, name, state == 'latest')
 
-    retvals['changed'] = retvals['rc'] == 0 and bool(packages_changed)
+    retvals['changed'] = retvals['rc'] in [0, 102] and bool(packages_changed)
 
     if module._diff:
         set_diff(module, retvals, packages_changed)
 
-    if retvals['rc'] != 0:
+    if retvals['rc'] not in [0, 102]:
         module.fail_json(msg="Zypper run failed.", **retvals)
 
     if not retvals['changed']:


### PR DESCRIPTION
added handling of zypper exitcode 102: ZYPPER_EXIT_INF_REBOOT_NEEDED - Returned after a successful installation of a patch which requires reboot of computer.

##### SUMMARY

This code was not treated at all by the module and therefore considered a faillure and the changed status was never set.

After my fix the exitcode 102 will be treated exactly like 0 by the module internally, and the changed status will be reported correctly.

However, since I preserve the rc 102 in the retvals to allow the playbook to react to the requested reboot, the task must still include a "register" and a "failed_when" property to pass as OK in this event.

Example:
```
  tasks:
    - name: Apply patches on OpenSUSE/SUSE Linux
      zypper:
        name: '*'
        state: latest
        type: patch
        extra_args_precommand: '--non-interactive-include-reboot-patches'
      register: zypper_cmd
      failed_when: zypper_cmd.rc not in [0, 102]

    - name: Reboot the SUSE/OpenSUSE box if kernel updated
      reboot:
        msg: "Reboot initiated by Ansible for kernel updates"
        connect_timeout: 5
        reboot_timeout: 300
        pre_reboot_delay: 10
        post_reboot_delay: 30
        test_command: uptime
      when: zypper_cmd.rc == 102

```

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zypper

##### ADDITIONAL INFORMATION
When used to do updates of the type "patch" the zypper module failed in case the updates were successfull, but resulted in the system needing a reboot. In that case the changed status was not correctly set.  After my fix the task will still be treated a faillure by ansible unless you treat the rc 102 in a failed_when statement as shown above, but the changed state will be correctly set.
