### PR TITLE
CI: include has finally been removed in ansible-core devel

### DIFF
--- a/tests/integration/targets/apache2_module/tasks/main.yml
+++ b/tests/integration/targets/apache2_module/tasks/main.yml
@@ -29,7 +29,7 @@
       shell: apache2ctl -M | sort
       register: modules_before
     - name: include only on supported systems
-      include: actualtest.yml
+      include_tasks: actualtest.yml
   always:
     - name: get list of enabled modules
       shell: apache2ctl -M | sort
@@ -47,6 +47,6 @@
   # centos/RHEL does not have a2enmod/a2dismod
 
 - name: include misleading warning test
-  include: 635-apache2-misleading-warning.yml
+  include_tasks: 635-apache2-misleading-warning.yml
   when: ansible_os_family in ['Debian']
   # Suse has mpm_event module compiled within the base apache2

--- a/tests/integration/targets/influxdb_user/tasks/main.yml
+++ b/tests/integration/targets/influxdb_user/tasks/main.yml
@@ -8,5 +8,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: tests.yml
+- include_tasks: tests.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/tests/integration/targets/locale_gen/tasks/main.yml
+++ b/tests/integration/targets/locale_gen/tasks/main.yml
@@ -8,5 +8,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: 'locale_gen.yml'
+- include_tasks: 'locale_gen.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/tests/integration/targets/mqtt/tasks/main.yml
+++ b/tests/integration/targets/mqtt/tasks/main.yml
@@ -8,7 +8,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: ubuntu.yml
+- include_tasks: ubuntu.yml
   when: 
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release not in ['focal', 'jammy']

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -11,9 +11,9 @@
 - when: ansible_os_family == 'Archlinux'
   block:
     # Add more tests here by including more task files:
-    - include: 'basic.yml'
-    - include: 'package_urls.yml'
-    - include: 'remove_nosave.yml'
-    - include: 'update_cache.yml'
-    - include: 'locally_installed_package.yml'
-    - include: 'reason.yml'
+    - include_tasks: 'basic.yml'
+    - include_tasks: 'package_urls.yml'
+    - include_tasks: 'remove_nosave.yml'
+    - include_tasks: 'update_cache.yml'
+    - include_tasks: 'locally_installed_package.yml'
+    - include_tasks: 'reason.yml'

--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -522,7 +522,7 @@
     or ansible_distribution_version is version('13.3', '>=')
   block:
     - name: Setup testjail
-      include: setup-testjail.yml
+      include_tasks: setup-testjail.yml
 
     - name: Install package in jail as rootdir
       include_tasks: install_single_package.yml

--- a/tests/integration/targets/sefcontext/tasks/main.yml
+++ b/tests/integration/targets/sefcontext/tasks/main.yml
@@ -17,5 +17,5 @@
     msg: SELinux is {{ ansible_selinux.status }}
   when: ansible_selinux is defined and ansible_selinux != False
 
-- include: sefcontext.yml
+- include_tasks: sefcontext.yml
   when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'

--- a/tests/integration/targets/sensu_handler/tasks/main.yml
+++ b/tests/integration/targets/sensu_handler/tasks/main.yml
@@ -122,8 +122,8 @@
       - failure is failed
       - "'the following are missing: type' in failure['msg']"
 
-- include: pipe.yml
-- include: tcp.yml
-- include: udp.yml
-- include: set.yml
-- include: transport.yml
+- include_tasks: pipe.yml
+- include_tasks: tcp.yml
+- include_tasks: udp.yml
+- include_tasks: set.yml
+- include_tasks: transport.yml

--- a/tests/integration/targets/setup_influxdb/tasks/main.yml
+++ b/tests/integration/targets/setup_influxdb/tasks/main.yml
@@ -8,5 +8,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: setup.yml
+- include_tasks: setup.yml
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'

--- a/tests/integration/targets/setup_mosquitto/tasks/main.yml
+++ b/tests/integration/targets/setup_mosquitto/tasks/main.yml
@@ -8,5 +8,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: ubuntu.yml
+- include_tasks: ubuntu.yml
   when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -36,4 +36,4 @@
 - when: ansible_os_family == "Archlinux"
   block:
     - name: ArchLinux specific setup
-      include: archlinux.yml
+      include_tasks: archlinux.yml

--- a/tests/integration/targets/ssh_config/tasks/main.yml
+++ b/tests/integration/targets/ssh_config/tasks/main.yml
@@ -242,4 +242,4 @@
       - short_name.hosts_removed == []
 
 - name: Include integration tests for additional options (e.g. proxycommand, proxyjump)
-  include: 'options.yml'
+  include_tasks: 'options.yml'

--- a/tests/integration/targets/sysrc/tasks/main.yml
+++ b/tests/integration/targets/sysrc/tasks/main.yml
@@ -147,7 +147,7 @@
         or ansible_distribution_version is version('13.1', '>=')
       block:
         - name: Setup testjail
-          include: setup-testjail.yml
+          include_tasks: setup-testjail.yml
 
         - name: Enable nginx in test jail
           sysrc:

--- a/tests/integration/targets/xattr/tasks/main.yml
+++ b/tests/integration/targets/xattr/tasks/main.yml
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup
-  include: setup.yml
+  include_tasks: setup.yml
 
 - name: Check availability of xattr support
   command: setfattr -n user.foo {{ test_file }}
@@ -17,5 +17,5 @@
   register: xattr
 
 - name: Test
-  include: test.yml
+  include_tasks: test.yml
   when: xattr is not failed

--- a/tests/integration/targets/yarn/tasks/main.yml
+++ b/tests/integration/targets/yarn/tasks/main.yml
@@ -11,7 +11,7 @@
 
 # ============================================================
 
-- include: run.yml
+- include_tasks: run.yml
   vars:
     nodejs_version: '{{ item.node_version }}'
     nodejs_path: 'node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}'

--- a/tests/integration/targets/zypper/tasks/main.yml
+++ b/tests/integration/targets/zypper/tasks/main.yml
@@ -11,5 +11,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: 'zypper.yml'
+- include_tasks: 'zypper.yml'
   when: ansible_os_family == 'Suse'

--- a/tests/integration/targets/zypper_repository/tasks/main.yml
+++ b/tests/integration/targets/zypper_repository/tasks/main.yml
@@ -9,5 +9,5 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- include: 'test.yml'
+- include_tasks: 'test.yml'
   when: ansible_os_family == 'Suse'

--- a/tests/integration/targets/zypper_repository/tasks/test.yml
+++ b/tests/integration/targets/zypper_repository/tasks/test.yml
@@ -11,7 +11,7 @@
   command: zypper -n ref
 
 - block:
-    - include: 'zypper_repository.yml'
+    - include_tasks: 'zypper_repository.yml'
   always:
     - name: remove repositories added during test
       community.general.zypper_repository:


### PR DESCRIPTION
##### SUMMARY
It's still used in integration tests. Let's get rid of it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
