### PR TITLE
Fix code formatting in documentation of dconf.py

### DIFF
--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -49,8 +49,8 @@ notes:
     I(value="'myvalue'") - with single quotes as part of the Ansible parameter
     value.
   - When using loops in combination with a value like
-    :code:`"[('xkb', 'us'), ('xkb', 'se')]"`, you need to be aware of possible
-    type conversions. Applying a filter :code:`"{{ item.value | string }}"`
+    C("[('xkb', 'us'), ('xkb', 'se')]"), you need to be aware of possible
+    type conversions. Applying a filter C("{{ item.value | string }}")
     to the parameter variable can avoid potential conversion problems.
   - The easiest way to figure out exact syntax/value you need to provide for a
     key is by making the configuration change in application affected by the

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -50,7 +50,7 @@ notes:
     value.
   - When using loops in combination with a value like
     "[('xkb', 'us'), ('xkb', 'se')]", you need to be aware of possible
-    type conversions. Applying a filter "{{ item.value | string }}"
+    type conversions. Applying a filter C({{ item.value | string }})
     to the parameter variable can avoid potential conversion problems.
   - The easiest way to figure out exact syntax/value you need to provide for a
     key is by making the configuration change in application affected by the

--- a/plugins/modules/dconf.py
+++ b/plugins/modules/dconf.py
@@ -49,8 +49,8 @@ notes:
     I(value="'myvalue'") - with single quotes as part of the Ansible parameter
     value.
   - When using loops in combination with a value like
-    C("[('xkb', 'us'), ('xkb', 'se')]"), you need to be aware of possible
-    type conversions. Applying a filter C("{{ item.value | string }}")
+    "[('xkb', 'us'), ('xkb', 'se')]", you need to be aware of possible
+    type conversions. Applying a filter "{{ item.value | string }}"
     to the parameter variable can avoid potential conversion problems.
   - The easiest way to figure out exact syntax/value you need to provide for a
     key is by making the configuration change in application affected by the


### PR DESCRIPTION
##### SUMMARY
Here https://docs.ansible.com/ansible/latest/collections/community/general/dconf_module.html incorrect `:code:` syntax was used to enclose code snippets, which resulted in rendering issues.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.general.dconf module