### PR TITLE
ini_file: Don't creates new file instead of following symlink

### DIFF
--- a/changelogs/fragments/ini_file-preserve-symlink.yml
+++ b/changelogs/fragments/ini_file-preserve-symlink.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "ini_file - Follow the symlinks instead of replacing them (https://github.com/ansible-collections/community.general/issues/6470)."
+  - "ini_file - add the ``follow`` paramter to follow the symlinks instead of replacing them (https://github.com/ansible-collections/community.general/pull/6546)."

--- a/changelogs/fragments/ini_file-preserve-symlink.yml
+++ b/changelogs/fragments/ini_file-preserve-symlink.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "ini_file - Follow the symlinks instead of replacing them (https://github.com/ansible-collections/community.general/issues/6470)."

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -112,10 +112,10 @@ options:
   follow:
     description:
     - This flag indicates that filesystem links, if they exist, should be followed.
-    - I(follow=yes) and I(state=link) can modify I(src) when combined with parameters such as I(mode).
+    - I(follow=true) can modify I(src) when combined with parameters such as I(mode).
     type: bool
-    default: no
-    version_added: 7.2.0
+    default: false
+    version_added: 7.1.0
 notes:
    - While it is possible to add an I(option) without specifying a I(value), this makes no sense.
    - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.

--- a/tests/integration/targets/ini_file/tasks/tests/04-symlink.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/04-symlink.yml
@@ -1,0 +1,46 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+- name: Create a file
+  ansible.builtin.copy:
+    content: |
+      [main]
+      foo=BAR
+    dest: "{{ remote_tmp_dir }}/my_original_file.ini"
+- name: Create a symbolic link
+  ansible.builtin.file:
+    src: "{{ remote_tmp_dir }}/my_original_file.ini"
+    dest: "{{ remote_tmp_dir }}/symlink.ini"
+    state: link
+
+- name: Set a value
+  community.general.ini_file:
+    path: "{{ remote_tmp_dir }}/symlink.ini"
+    section: main
+    option: proxy
+    value: 'http://proxy.myorg.org:3128'
+  register: result
+- ansible.builtin.assert:
+    that:
+      - result is changed
+- name: Set a value (idempotency)
+  community.general.ini_file:
+    path: "{{ remote_tmp_dir }}/symlink.ini"
+    section: main
+    option: proxy
+    value: 'http://proxy.myorg.org:3128'
+  register: result
+- ansible.builtin.assert:
+    that:
+      - "not (result is changed)"
+- name: Set a value (on the final file)
+  community.general.ini_file:
+    path: "{{ remote_tmp_dir }}/my_original_file.ini"
+    section: main
+    option: proxy
+    value: 'http://proxy.myorg.org:3128'
+  register: result
+- ansible.builtin.assert:
+    that:
+      - "not (result is changed)"

--- a/tests/integration/targets/ini_file/tasks/tests/04-symlink.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/04-symlink.yml
@@ -2,21 +2,33 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-- name: Create a file
-  ansible.builtin.copy:
-    content: |
-      [main]
-      foo=BAR
-    dest: "{{ remote_tmp_dir }}/my_original_file.ini"
-- name: Create a symbolic link
-  ansible.builtin.file:
-    src: "{{ remote_tmp_dir }}/my_original_file.ini"
-    dest: "{{ remote_tmp_dir }}/symlink.ini"
-    state: link
 
-- name: Set a value
+- block: &prepare
+  - name: Create the final file
+    ansible.builtin.copy:
+      content: |
+        [main]
+        foo=BAR
+      dest: my_original_file.ini
+  - name: Clean up symlink.ini
+    ansible.builtin.file:
+      path: symlink.ini
+      state: absent
+  - name: Create a symbolic link
+    ansible.builtin.file:
+      src: my_original_file.ini
+      dest: symlink.ini
+      state: link
+
+- name: Set the proxy key on the symlink which will be converted as a file
   community.general.ini_file:
-    path: "{{ remote_tmp_dir }}/symlink.ini"
+    path: symlink.ini
+    section: main
+    option: proxy
+    value: 'http://proxy.myorg.org:3128'
+- name: Set the proxy key on the final file that is still unchanged
+  community.general.ini_file:
+    path: my_original_file.ini
     section: main
     option: proxy
     value: 'http://proxy.myorg.org:3128'
@@ -24,19 +36,20 @@
 - ansible.builtin.assert:
     that:
       - result is changed
-- name: Set a value (idempotency)
+
+# With follow
+- block: *prepare
+- name: Set the proxy key on the symlink which will be preserved
   community.general.ini_file:
-    path: "{{ remote_tmp_dir }}/symlink.ini"
+    path: symlink.ini
     section: main
     option: proxy
     value: 'http://proxy.myorg.org:3128'
+    follow: true
   register: result
-- ansible.builtin.assert:
-    that:
-      - "not (result is changed)"
-- name: Set a value (on the final file)
+- name: Set the proxy key on the target directly that was changed in the previous step
   community.general.ini_file:
-    path: "{{ remote_tmp_dir }}/my_original_file.ini"
+    path: my_original_file.ini
     section: main
     option: proxy
     value: 'http://proxy.myorg.org:3128'


### PR DESCRIPTION
##### SUMMARY

This is a bug fix that address a situation where `community.general.ini_file` was destroying symlinks instead of updating of updating their targets.

If `poth` points on a symlink and `follow` is true, the `ini_file` plugin will preserve the symlink and modify the target file.

Closes: #6470

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

ini_file