### PR TITLE
portage: fix changed_use and newuse not triggering rebuilds (#6008)

### DIFF
--- a/changelogs/fragments/6548-portage-changed_use-newuse.yml
+++ b/changelogs/fragments/6548-portage-changed_use-newuse.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - portage - fix ``changed_use`` and ``newuse`` not triggering rebuilds (https://github.com/ansible-collections/community.general/issues/6008)

--- a/changelogs/fragments/6548-portage-changed_use-newuse.yml
+++ b/changelogs/fragments/6548-portage-changed_use-newuse.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - portage - fix ``changed_use`` and ``newuse`` not triggering rebuilds (https://github.com/ansible-collections/community.general/issues/6008)
+  - portage - fix ``changed_use`` and ``newuse`` not triggering rebuilds (https://github.com/ansible-collections/community.general/issues/6008, https://github.com/ansible-collections/community.general/pull/6548).

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -333,9 +333,9 @@ def emerge_packages(module, packages):
     """Run emerge command against given list of atoms."""
     p = module.params
 
-    if p['noreplace'] and not (p['update'] or p['state'] == 'latest'):
+    if p['noreplace'] and not p['changed_use'] and not p['newuse'] and not (p['update'] or p['state'] == 'latest'):
         for package in packages:
-            if p['noreplace'] and not query_package(module, package, 'emerge'):
+            if p['noreplace'] and not p['changed_use'] and not p['newuse'] and not query_package(module, package, 'emerge'):
                 break
         else:
             module.exit_json(changed=False, msg='Packages already present.')


### PR DESCRIPTION
##### SUMMARY
This PR provides a fix for the options `changed_use` and `newuse` of the `portage` module.

fixes #6008

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
portage

##### ADDITIONAL INFORMATION
The `changed_use` and `newuse` options did not trigger rebuilds of packages, since the `portage` module did not take them into account when deciding whether to call `emerge` or not.
I simply added both options to the conditional.

Another approach would be to simply remove the conditional and *always* run `emerge`.
This would avoid further issues with similar options (if there are any) and result in more consistent output, at the expense of performance.

Before:
```
ansible -m portage -a 'package=installkernel-gentoo state=present changed_use=true' gentoo-test
gentoo-test | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/sbin/python3.11"
    },
    "changed": false,
    "msg": "Packages already present."
}
```
(identical output with `--check`, all despite the fact that a USE flag for `installkernel-gentoo` changed)

After:
```
ansible -m portage -a 'package=installkernel-gentoo state=present changed_use=true' gentoo-test --check
gentoo-test | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/sbin/python3.11"
    },
    "changed": true,
    "cmd": [
        "/usr/sbin/emerge",
        "--changed-use",
        "--noreplace",
        "--ask=n",
        "--pretend",
        "installkernel-gentoo"
    ],
    "msg": "Packages would be installed.",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "\nThese are the packages that would be merged, in order:\n\nCalculating dependencies  ... done!\nDependency resolution took 2.10 s.\n\n[ebuild   R    ] sys-kernel/installkernel-gentoo-7  USE=\"grub*\" \n\n * IMPORTANT: 11 news items need reading for repository 'gentoo'.\n * Use eselect news read to view new items.\n\n",
    "stdout_lines": [
        "",
        "These are the packages that would be merged, in order:",
        "",
        "Calculating dependencies  ... done!",
        "Dependency resolution took 2.10 s.",
        "",
        "[ebuild   R    ] sys-kernel/installkernel-gentoo-7  USE=\"grub*\" ",
        "",
        " * IMPORTANT: 11 news items need reading for repository 'gentoo'.",
        " * Use eselect news read to view new items.",
        ""
    ]
}
```

```
ansible -m portage -a 'package=installkernel-gentoo state=present changed_use=true' gentoo-test
gentoo-test | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/sbin/python3.11"
    },
    "changed": true,
    "cmd": [
        "/usr/sbin/emerge",
        "--changed-use",
        "--noreplace",
        "--ask=n",
        "installkernel-gentoo"
    ],
    "msg": "Packages installed.",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Calculating dependencies  \n * IMPORTANT: 11 news items need reading for repository 'gentoo'.\n * Use eselect news read to view new items.\n\n.... done!\nDependency resolution took 6.89 s.\n\n>>> Verifying ebuild manifests\n>>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.21, 1.07, 1.01\n>>> Emerging (1 of 1) sys-kernel/installkernel-gentoo-7::gentoo\n>>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.21, 1.07, 1.01\n>>> Installing (1 of 1) sys-kernel/installkernel-gentoo-7::gentoo\n>>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.41, 1.12, 1.03\n>>> Jobs: 0 of 1 complete                           Load avg: 1.41, 1.12, 1.03\n>>> Recording sys-kernel/installkernel-gentoo in \"world\" favorites file...\n>>> Jobs: 0 of 1 complete                           Load avg: 1.45, 1.14, 1.04\n>>> Jobs: 1 of 1 complete                           Load avg: 1.45, 1.14, 1.04\n\n\n * Regenerating GNU info directory index...\n * Processed 102 info files.\n\n * IMPORTANT: 11 news items need reading for repository 'gentoo'.\n * Use eselect news read to view new items.\n\n",
    "stdout_lines": [
        "Calculating dependencies  ",
        " * IMPORTANT: 11 news items need reading for repository 'gentoo'.",
        " * Use eselect news read to view new items.",
        "",
        ".... done!",
        "Dependency resolution took 6.89 s.",
        "",
        ">>> Verifying ebuild manifests",
        ">>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.21, 1.07, 1.01",
        ">>> Emerging (1 of 1) sys-kernel/installkernel-gentoo-7::gentoo",
        ">>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.21, 1.07, 1.01",
        ">>> Installing (1 of 1) sys-kernel/installkernel-gentoo-7::gentoo",
        ">>> Jobs: 0 of 1 complete, 1 running                Load avg: 1.41, 1.12, 1.03",
        ">>> Jobs: 0 of 1 complete                           Load avg: 1.41, 1.12, 1.03",
        ">>> Recording sys-kernel/installkernel-gentoo in \"world\" favorites file...",
        ">>> Jobs: 0 of 1 complete                           Load avg: 1.45, 1.14, 1.04",
        ">>> Jobs: 1 of 1 complete                           Load avg: 1.45, 1.14, 1.04",
        "",
        "",
        " * Regenerating GNU info directory index...",
        " * Processed 102 info files.",
        "",
        " * IMPORTANT: 11 news items need reading for repository 'gentoo'.",
        " * Use eselect news read to view new items.",
        ""
    ]
}
```

```
ansible -m portage -a 'package=installkernel-gentoo state=present changed_use=true' gentoo-test --check
gentoo-test | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/sbin/python3.11"
    },
    "changed": false,
    "cmd": [
        "/usr/sbin/emerge",
        "--changed-use",
        "--noreplace",
        "--ask=n",
        "--pretend",
        "installkernel-gentoo"
    ],
    "msg": "No packages installed.",
    "rc": 0,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "\nThese are the packages that would be merged, in order:\n\nCalculating dependencies  ... done!\nDependency resolution took 1.09 s.\n\n\n * IMPORTANT: 11 news items need reading for repository 'gentoo'.\n * Use eselect news read to view new items.\n\n",
    "stdout_lines": [
        "",
        "These are the packages that would be merged, in order:",
        "",
        "Calculating dependencies  ... done!",
        "Dependency resolution took 1.09 s.",
        "",
        "",
        " * IMPORTANT: 11 news items need reading for repository 'gentoo'.",
        " * Use eselect news read to view new items.",
        ""
    ]
}
```
In particular, the `msg` in check mode changed from `Packages already present.` to `No packages installed.` when the package(s) in question would not be rebuilt.