### PR TITLE
Don't require api_password when api_token_id is used in proxmox_tasks_info

### DIFF
--- a/changelogs/fragments/6554-proxmox-tasks-info-fix-required-password.yaml
+++ b/changelogs/fragments/6554-proxmox-tasks-info-fix-required-password.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - proxmox_tasks_info - remove ``api_user`` + ``api_password`` constraint from ``required_together`` as it causes to require ``api_password`` even when api token param is used (https://github.com/ansible-collections/community.general/issues/6201).
+  - proxmox_tasks_info - remove ``api_user`` + ``api_password`` constraint from ``required_together`` as it causes to require ``api_password`` even when API token param is used (https://github.com/ansible-collections/community.general/issues/6201).

--- a/changelogs/fragments/6554-proxmox-tasks-info-fix-required-password.yaml
+++ b/changelogs/fragments/6554-proxmox-tasks-info-fix-required-password.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_tasks_info - remove ``api_user`` + ``api_password`` constraint from ``required_together`` as it causes to require ``api_password`` even when api token param is used (https://github.com/ansible-collections/community.general/issues/6201).

--- a/plugins/modules/proxmox_tasks_info.py
+++ b/plugins/modules/proxmox_tasks_info.py
@@ -160,8 +160,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=module_args,
-        required_together=[('api_token_id', 'api_token_secret'),
-                           ('api_user', 'api_password')],
+        required_together=[('api_token_id', 'api_token_secret')],
         required_one_of=[('api_password', 'api_token_id')],
         supports_check_mode=True)
     result = dict(changed=False)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Fixes #6201.

As `api_user` is always required then using it in required_together constraint leads to unwanted behavior when `api_password` is also always needed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_tasks_info

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Output Before the change

```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "api_host": "localhost",
            "api_password": null,
            "api_token_id": "root-token",
            "api_token_secret": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_user": "root@pam",
            "node": "pve",
            "task": null,
            "validate_certs": false
        }
    },
    "msg": "parameters are required together: api_user, api_password"
}
```

Output After

```
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "api_host": "localhost",
            "api_password": null,
            "api_token_id": "root-token",
            "api_token_secret": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_user": "root@pam",
            "node": "pve",
            "task": null,
            "validate_certs": false
        }
    },
    "proxmox_tasks": []
}
```
