### PR TITLE
Allow keeping consumed pools in redhat_subscription module

### DIFF
--- a/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
+++ b/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
@@ -3,4 +3,4 @@ minor_changes:
   - redhat_subscription - add ``keep_consumed_pools`` parameters to keep
     currently consumed subscriptions when subscribing with ``pool_ids``
     (https://github.com/ansible-collections/community.general/issues/3871,
-    https://github.com/ansible-collections/community.general/pull/6566)
+    https://github.com/ansible-collections/community.general/pull/6566).

--- a/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
+++ b/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - redhat_subscription - add ``remove_consumed_pools`` parameters to handle currently consumed subscriptions

--- a/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
+++ b/changelogs/fragments/6566-redhat-subscription-remove-consumed-pools-option.yaml
@@ -1,3 +1,6 @@
 ---
 minor_changes:
-  - redhat_subscription - add ``remove_consumed_pools`` parameters to handle currently consumed subscriptions
+  - redhat_subscription - add ``keep_consumed_pools`` parameters to keep
+    currently consumed subscriptions when subscribing with ``pool_ids``
+    (https://github.com/ansible-collections/community.general/issues/3871,
+    https://github.com/ansible-collections/community.general/pull/6566)

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -155,6 +155,13 @@ options:
         default: []
         type: list
         elements: raw
+    remove_consumed_pools:
+        description:
+            - |
+              When using I(pool_ids), remove the currently consumed subscription. Set to C(true) by default to
+              keep the existing behaviour. When set to false, only add the listed pools if needed.
+        type: bool
+        default: true
     consumer_type:
         description:
             - The type of unit to register, defaults to system
@@ -853,7 +860,7 @@ class Rhsm(RegistrationBase):
         return {'changed': changed, 'subscribed_pool_ids': subscribed_pool_ids,
                 'unsubscribed_serials': serials}
 
-    def update_subscriptions_by_pool_ids(self, pool_ids):
+    def update_subscriptions_by_pool_ids(self, pool_ids, remove_consumed_pools):
         changed = False
         consumed_pools = RhsmPools(self.module, consumed=True)
 
@@ -865,7 +872,7 @@ class Rhsm(RegistrationBase):
             existing_pools[pool_id] = quantity_used
 
             quantity = pool_ids.get(pool_id, 0)
-            if quantity is not None and quantity != quantity_used:
+            if quantity is not None and quantity != quantity_used and remove_consumed_pools:
                 serials_to_remove.append(p.Serial)
 
         serials = self.unsubscribe(serials=serials_to_remove)
@@ -1080,6 +1087,7 @@ def main():
             'environment': {},
             'pool': {'default': '^$'},
             'pool_ids': {'default': [], 'type': 'list', 'elements': 'raw'},
+            'remove_consumed_pools': {'default': True, 'type': 'bool'},
             'consumer_type': {},
             'consumer_name': {},
             'consumer_id': {},
@@ -1146,6 +1154,7 @@ def main():
         else:
             pool_id, quantity = value, None
         pool_ids[pool_id] = quantity
+    remove_consumed_pools = module.params['remove_consumed_pools']
     consumer_type = module.params["consumer_type"]
     consumer_name = module.params["consumer_name"]
     consumer_id = module.params["consumer_id"]
@@ -1183,7 +1192,7 @@ def main():
             if pool != '^$' or pool_ids:
                 try:
                     if pool_ids:
-                        result = rhsm.update_subscriptions_by_pool_ids(pool_ids)
+                        result = rhsm.update_subscriptions_by_pool_ids(pool_ids, remove_consumed_pools)
                     else:
                         result = rhsm.update_subscriptions(pool)
                 except Exception as e:

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -159,9 +159,10 @@ options:
         description:
             - |
               When using I(pool_ids), remove the currently consumed subscription. Set to C(true) by default to
-              keep the existing behaviour. When set to false, only add the listed pools if needed.
+              keep the existing behavior. When set to false, only add the listed pools if needed.
         type: bool
         default: true
+        version_added: 7.1.0
     consumer_type:
         description:
             - The type of unit to register, defaults to system


### PR DESCRIPTION
##### SUMMARY

Fixes #3871

While trying to add a new subscription / product / repo from our internal Foreman instance to some machines, I noticed that all currently consumed subscription got removed. This PR adds a boolean `remove_consumed_pools` option to the `redhat_subscription` module to change that behavior and keep existing assigned / consumed subscriptions.

The implementation is really naive as I am not really familiar with ansible modules.

The default value is set to `True` to keep the existing module behavior.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redhat_subscription

