### PR TITLE
ipaenabledflag should use bool type value

### DIFF
--- a/changelogs/fragments/6567-ipaenabledflag-type.yml
+++ b/changelogs/fragments/6567-ipaenabledflag-type.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - value of ipaenabledflag should be boolean type (https://github.com/ansible-collections/community.general/issues/5894).
+  - ipa_hbacrule - value of ``ipaenabledflag`` should be boolean type (https://github.com/ansible-collections/community.general/issues/5894).

--- a/changelogs/fragments/6567-ipaenabledflag-type.yml
+++ b/changelogs/fragments/6567-ipaenabledflag-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - value of ipaenabledflag should be boolean type (https://github.com/ansible-collections/community.general/issues/5894).

--- a/plugins/modules/ipa_hbacrule.py
+++ b/plugins/modules/ipa_hbacrule.py
@@ -232,9 +232,9 @@ def ensure(module, client):
     state = module.params['state']
 
     if state in ['present', 'enabled']:
-        ipaenabledflag = 'TRUE'
+        ipaenabledflag = True
     else:
-        ipaenabledflag = 'FALSE'
+        ipaenabledflag = False
 
     host = module.params['host']
     hostcategory = module.params['hostcategory']


### PR DESCRIPTION
##### SUMMARY
Fix issue: #5894

The value of `ipaenabledflag` in hbacrule returned from ipa server is boolean, for example:
```json
{
   'accessruletype': ['allow'], 
   'objectclass': ['ipaassociation', 'ipahbacrule'], 
   'ipaenabledflag': [True],
   ...
}
```

The value used for comparison with it was string, for example, "TRUE"
This would make the [ipa_hbacrule.py](https://github.com/ansible-collections/community.general/blob/29790df583ff5b7c6d0487bde57e27e37e9c423f/plugins/modules/ipa_hbacrule.py#L267) mistakenly treat there was difference and unnecessarily update the hbacrule.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/ipa_hbacrule.py
