### PR TITLE
Fix get_user_by_username in keycloak library

### DIFF
--- a/changelogs/fragments/6568-fix-get-user-by-username-in-keycloak-module-utils.yml
+++ b/changelogs/fragments/6568-fix-get-user-by-username-in-keycloak-module-utils.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak module utils - the function ``get_user_by_username`` now return the user representation or ``None`` as stated in the documentation (https://github.com/ansible-collections/community.general/pull/6758).

--- a/plugins/module_utils/identity/keycloak/keycloak.py
+++ b/plugins/module_utils/identity/keycloak/keycloak.py
@@ -747,8 +747,15 @@ class KeycloakAPI(object):
         users_url = URL_USERS.format(url=self.baseurl, realm=realm)
         users_url += '?username=%s&exact=true' % username
         try:
-            return json.loads(to_native(open_url(users_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
-                                                 validate_certs=self.validate_certs).read()))
+            userrep = None
+            users = json.loads(to_native(open_url(users_url, method='GET', headers=self.restheaders, timeout=self.connection_timeout,
+                                                  validate_certs=self.validate_certs).read()))
+            for user in users:
+                if user['username'] == username:
+                    userrep = user
+                    break
+            return userrep
+
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain the user for realm %s and username %s: %s'
                                       % (realm, username, str(e)))


### PR DESCRIPTION
##### SUMMARY
Method get_user_by_username in keycloak.py module_utils return a list of users but ion the documentation the method must return a user representation if found or None otherwise.
Thit PR fix this issue.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
keycloak.py in module_utils

##### ADDITIONAL INFORMATION

