### PR TITLE
proxmox_kvm | Expose timeout param to stopped state

### DIFF
--- a/changelogs/fragments/6570-handle-shutdown-timeout.yaml
+++ b/changelogs/fragments/6570-handle-shutdown-timeout.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - proxmox_kvm - re-use ``timeout`` module param to forcefully shutdown a virtual machine when ``state`` is ``stopped``. Fixes request (https://github.com/ansible-collections/community.general/issues/6257).
+  - proxmox_kvm - re-use ``timeout`` module param to forcefully shutdown a virtual machine when ``state`` is ``stopped`` (https://github.com/ansible-collections/community.general/issues/6257).

--- a/changelogs/fragments/6570-handle-shutdown-timeout.yaml
+++ b/changelogs/fragments/6570-handle-shutdown-timeout.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_kvm - re-use ``timeout`` module param to forcefully shutdown a virtual machine when ``state`` is ``stopped``. Fixes request (https://github.com/ansible-collections/community.general/issues/6257).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1288,7 +1288,7 @@ def main():
             else:
                 module.exit_json(changed=False, vmid=vmid, msg="VM {0} is already on {1}".format(vmid, node))
         except Exception as e:
-            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0}: {3}'.format(vmid, e))
+            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0} from {1} to {2}: {3}'.format(vmid, vm_node, node, e))
 
     if state == 'present':
         try:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -480,7 +480,7 @@ options:
   timeout:
     description:
       - Timeout for operations.
-      - When used with I(stopped) C(state) the option set a graceful timeout for VM stop after which a VM will be forcefully stopped.
+      - When used with I(stopped) C(state) the option sets a graceful timeout for VM stop after which a VM will be forcefully stopped.
     type: int
     default: 30
   update:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -480,7 +480,7 @@ options:
   timeout:
     description:
       - Timeout for operations.
-      - When used with I(stopped) C(state) the option sets a graceful timeout for VM stop after which a VM will be forcefully stopped.
+      - When used with I(state=stopped) the option sets a graceful timeout for VM stop after which a VM will be forcefully stopped.
     type: int
     default: 30
   update:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -444,7 +444,7 @@ options:
       - Indicates desired state of the instance.
       - If C(current), the current state of the VM will be fetched. You can access it with C(results.status)
     type: str
-    choices: ['present', 'started', 'absent', 'stopped', 'restarted','current']
+    choices: ['present', 'started', 'absent', 'stopped', 'restarted', 'current']
     default: present
   storage:
     description:
@@ -480,6 +480,7 @@ options:
   timeout:
     description:
       - Timeout for operations.
+      - When used with I(stopped) C(state) the option set a graceful timeout for VM stop after which a VM will be forcefully stopped.
     type: int
     default: 30
   update:
@@ -889,6 +890,9 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
 
     def wait_for_task(self, node, taskid):
         timeout = self.module.params['timeout']
+        if self.module.params['state'] == 'stopped':
+            # Increase task timeout in case of stopped state to be sure it waits longer than VM stop operation itself
+            timeout += 10
 
         while timeout:
             if self.api_task_ok(node, taskid):
@@ -1058,10 +1062,10 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             return False
         return True
 
-    def stop_vm(self, vm, force):
+    def stop_vm(self, vm, force, timeout):
         vmid = vm['vmid']
         proxmox_node = self.proxmox_api.nodes(vm['node'])
-        taskid = proxmox_node.qemu(vmid).status.shutdown.post(forceStop=(1 if force else 0))
+        taskid = proxmox_node.qemu(vmid).status.shutdown.post(forceStop=(1 if force else 0), timeout=timeout)
         if not self.wait_for_task(vm['node'], taskid):
             self.module.fail_json(msg='Reached timeout while waiting for stopping VM. Last line in task before timeout: %s' %
                                   proxmox_node.tasks(taskid).log.get()[:1])
@@ -1284,7 +1288,7 @@ def main():
             else:
                 module.exit_json(changed=False, vmid=vmid, msg="VM {0} is already on {1}".format(vmid, node))
         except Exception as e:
-            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0} from {1} to {2}: {3}'.format(vmid, vm_node, node, e))
+            module.fail_json(vmid=vmid, msg='Unable to migrate VM {0}: {3}'.format(vmid, e))
 
     if state == 'present':
         try:
@@ -1293,7 +1297,7 @@ def main():
             elif proxmox.get_vmid(name, ignore_missing=True) and not (update or clone):
                 module.exit_json(changed=False, vmid=proxmox.get_vmid(name), msg="VM with name <%s> already exists" % name)
             elif not node:
-                module.fail.json(msg='node is mandatory for creating/updating VM')
+                module.fail_json(msg='node is mandatory for creating/updating VM')
             elif update and not any([vmid, name]):
                 module.fail_json(msg='vmid or name is mandatory for updating VM')
             elif not proxmox.get_node(node):
@@ -1409,7 +1413,7 @@ def main():
             if vm['status'] == 'stopped':
                 module.exit_json(changed=False, vmid=vmid, msg="VM %s is already stopped" % vmid, **status)
 
-            if proxmox.stop_vm(vm, force=module.params['force']):
+            if proxmox.stop_vm(vm, force=module.params['force'], timeout=module.params['timeout']):
                 module.exit_json(changed=True, vmid=vmid, msg="VM %s is shutting down" % vmid, **status)
         except Exception as e:
             module.fail_json(vmid=vmid, msg="stopping of VM %s failed with exception: %s" % (vmid, e), **status)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Forcefully stop virtual machine using timeout param for proxmox vm
shutdown api call.
Fixes #6257.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Feature Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_kvm

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before fix(default timeout 30 seconds)
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "acpi": null,
            "agent": null,
            "api_host": "localhost",
            "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_token_id": null,
            "api_token_secret": null,
            "api_user": "root@pam",
            "archive": null,
            "args": null,
            "autostart": null,
            "balloon": null,
            "bios": null,
            "boot": null,
            "bootdisk": null,
            "cicustom": null,
            "cipassword": null,
            "citype": null,
            "ciuser": null,
            "clone": null,
            "cores": null,
            "cpu": null,
            "cpulimit": null,
            "cpuunits": null,
            "delete": null,
            "description": null,
            "digest": null,
            "efidisk0": null,
            "force": true,
            "format": null,
            "freeze": null,
            "full": true,
            "hostpci": null,
            "hotplug": null,
            "hugepages": null,
            "ide": null,
            "ipconfig": null,
            "keyboard": null,
            "kvm": null,
            "localtime": null,
            "lock": null,
            "machine": null,
            "memory": null,
            "migrate": false,
            "migrate_downtime": null,
            "migrate_speed": null,
            "name": "pxe.home.arpa",
            "nameservers": null,
            "net": null,
            "newid": null,
            "node": "pve",
            "numa": null,
            "numa_enabled": null,
            "onboot": null,
            "ostype": null,
            "parallel": null,
            "pool": null,
            "protection": null,
            "proxmox_default_behavior": "no_defaults",
            "reboot": null,
            "revert": null,
            "sata": null,
            "scsi": null,
            "scsihw": null,
            "searchdomains": null,
            "serial": null,
            "shares": null,
            "skiplock": null,
            "smbios": null,
            "snapname": null,
            "sockets": null,
            "sshkeys": null,
            "startdate": null,
            "startup": null,
            "state": "stopped",
            "storage": null,
            "tablet": null,
            "tags": null,
            "target": null,
            "tdf": null,
            "template": null,
            "timeout": 30,
            "update": false,
            "validate_certs": false,
            "vcpus": null,
            "vga": null,
            "virtio": null,
            "vmid": null,
            "watchdog": null
        }
    },
    "msg": "Reached timeout while waiting for stopping VM. Last line in task before timeout: [{'t': 'no content', 'n': 1}]"
}

PLAY RECAP *************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

ansible-playbook testmod.yml -vvvv  3.78s user 1.11s system 15% cpu 32.210 total
```
After fix(timeout set to 10 seconds)
```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "acpi": null,
            "agent": null,
            "api_host": "localhost",
            "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "api_token_id": null,
            "api_token_secret": null,
            "api_user": "root@pam",
            "archive": null,
            "args": null,
            "autostart": null,
            "balloon": null,
            "bios": null,
            "boot": null,
            "bootdisk": null,
            "cicustom": null,
            "cipassword": null,
            "citype": null,
            "ciuser": null,
            "clone": null,
            "cores": null,
            "cpu": null,
            "cpulimit": null,
            "cpuunits": null,
            "delete": null,
            "description": null,
            "digest": null,
            "efidisk0": null,
            "force": true,
            "format": null,
            "freeze": null,
            "full": true,
            "hostpci": null,
            "hotplug": null,
            "hugepages": null,
            "ide": null,
            "ipconfig": null,
            "keyboard": null,
            "kvm": null,
            "localtime": null,
            "lock": null,
            "machine": null,
            "memory": null,
            "migrate": false,
            "migrate_downtime": null,
            "migrate_speed": null,
            "name": "pxe.home.arpa",
            "nameservers": null,
            "net": null,
            "newid": null,
            "node": "pve",
            "numa": null,
            "numa_enabled": null,
            "onboot": null,
            "ostype": null,
            "parallel": null,
            "pool": null,
            "protection": null,
            "proxmox_default_behavior": "no_defaults",
            "reboot": null,
            "revert": null,
            "sata": null,
            "scsi": null,
            "scsihw": null,
            "searchdomains": null,
            "serial": null,
            "shares": null,
            "skiplock": null,
            "smbios": null,
            "snapname": null,
            "sockets": null,
            "sshkeys": null,
            "startdate": null,
            "startup": null,
            "state": "stopped",
            "storage": null,
            "tablet": null,
            "tags": null,
            "target": null,
            "tdf": null,
            "template": null,
            "timeout": 10,
            "update": false,
            "validate_certs": false,
            "vcpus": null,
            "vga": null,
            "virtio": null,
            "vmid": null,
            "watchdog": null
        }
    },
    "msg": "VM 100 is shutting down",
    "status": "running",
    "vmid": 100
}

PLAY RECAP *************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

ANSIBLE_COLLECTIONS_PATHS=~/src/ansible/collections/ ansible-playbook  -vvvv  2.68s user 0.85s system 23% cpu 15.074 total

```
