### PR TITLE
ini_file: try using inactive option before creating a new one

### DIFF
--- a/changelogs/fragments/ini_file-use-inactive-options-when-possible.yml
+++ b/changelogs/fragments/ini_file-use-inactive-options-when-possible.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix a bug where the inactive options were not used when possible.

--- a/changelogs/fragments/ini_file-use-inactive-options-when-possible.yml
+++ b/changelogs/fragments/ini_file-use-inactive-options-when-possible.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix a bug where the inactive options were not used when possible.
+  - ini_file - fix a bug where the inactive options were not used when possible (https://github.com/ansible-collections/community.general/pull/6575).

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -316,14 +316,14 @@ def do_ini(module, filename, section=None, option=None, values=None,
         # override option with no value to option with value if not allow_no_value
         if len(values) > 0:
             for index, line in enumerate(section_lines):
-                if not changed_lines[index] and match_active_opt(option, line):
+                if not changed_lines[index] and match_opt(option, line):
                     newline = assignment_format % (option, values.pop(0))
                     (changed, msg) = update_section_line(changed, section_lines, index, changed_lines, newline, msg)
                     if len(values) == 0:
                         break
         # remove all remaining option occurrences from the rest of the section
         for index in range(len(section_lines) - 1, 0, -1):
-            if not changed_lines[index] and match_active_opt(option, section_lines[index]):
+            if not changed_lines[index] and match_opt(option, section_lines[index]):
                 del section_lines[index]
                 del changed_lines[index]
                 changed = True

--- a/tests/integration/targets/ini_file/tasks/tests/02-values.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/02-values.yml
@@ -579,8 +579,8 @@
       [section1]
       var1 = aaa
       # comment in section
-      var2 = foo
-      # var2 = bar
+      # var2 = some value
+      # comment after section
 
       [section2]
       var3 = ccc
@@ -613,8 +613,8 @@
       [section1]
       var1 = aaa
       # comment in section
-      var2 = foo
-      # var2 = bar
+      # var2 = some value
+      # comment after section
 
       [section2]
       var3 = ccc
@@ -629,14 +629,13 @@
       - content22 == expected22
 
 
-- name: "test-values 23 - Ensure 'var2=[foo, foobar]' is 'present' in section '[section1]'"
+- name: "test-values 23 - Ensure 'var2=foo' is 'present' in section '[section1]', replacing commented option 'var2=some value'"
   ini_file:
     path: "{{ output_file }}"
     section: section1
     option: var2
     values: 
       - foo
-      - foobar
     state: present
   register: result23
 
@@ -647,7 +646,6 @@
 
 - name: test-values 23 - set expected content and get current ini file content
   set_fact:
-    content23: "{{ output_content.content | b64decode }}"
     expected23: |
       
       # Some comment to test
@@ -659,12 +657,14 @@
       var1 = aaa
       # comment in section
       var2 = foo
-      var2 = foobar
+      # comment after section
 
       [section2]
       var3 = ccc
       # comment after section
-- name: test-values 23 - assert 'changed' and msg 'option added' and content is as expected
+    content23: "{{ output_content.content | b64decode }}"
+
+- name: test-values 23 - assert 'changed' and msg 'option changed' and content is as expected
   assert:
     that:
       - result23 is changed
@@ -672,14 +672,13 @@
       - content23 == expected23
 
 
-- name: "test-values 24 - Ensure 'var2=[foo, foobar, bar]' is 'present' in section '[section1]' replacing commented option 'var2=bar'"
+- name: "test-values 24 - Ensure 'var2=[foo, foobar]' is 'present' in section '[section1]'"
   ini_file:
     path: "{{ output_file }}"
     section: section1
     option: var2
-    values: 
+    values:
       - foo
-      - bar
       - foobar
     state: present
   register: result24
@@ -691,7 +690,6 @@
 
 - name: test-values 24 - set expected content and get current ini file content
   set_fact:
-    content24: "{{ output_content.content | b64decode }}"
     expected24: |
       
       # Some comment to test
@@ -704,12 +702,14 @@
       # comment in section
       var2 = foo
       var2 = foobar
-      var2 = bar
+      # comment after section
 
       [section2]
       var3 = ccc
       # comment after section
-- name: test-values 24 - assert 'added' and msg 'option changed' and content is as expected
+    content24: "{{ output_content.content | b64decode }}"
+
+- name: test-values 24 - assert 'changed' and msg 'option added' and content is as expected
   assert:
     that:
       - result24 is changed

--- a/tests/integration/targets/ini_file/tasks/tests/02-values.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/02-values.yml
@@ -660,7 +660,6 @@
       # comment in section
       var2 = foo
       var2 = foobar
-      # var2 = bar
 
       [section2]
       var3 = ccc
@@ -669,7 +668,7 @@
   assert:
     that:
       - result23 is changed
-      - result23.msg == 'option added'
+      - result23.msg == 'option changed'
       - content23 == expected23
 
 
@@ -714,7 +713,7 @@
   assert:
     that:
       - result24 is changed
-      - result24.msg == 'option changed'
+      - result24.msg == 'option added'
       - content24 == expected24
 
 

--- a/tests/integration/targets/ini_file/tasks/tests/02-values.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/02-values.yml
@@ -453,7 +453,7 @@
       - content17 == expected17
 
 
-- name: "test-values 18 - Ensure 'beverage=coke' is 'abesent' in section '[drinks]'"
+- name: "test-values 18 - Ensure 'beverage=coke' is 'absent' in section '[drinks]'"
   ini_file:
     path: "{{ output_file }}"
     section: drinks
@@ -483,7 +483,7 @@
       - content18 == expected18
 
 
-- name: "test-values 19 - Ensure non-existant 'beverage=coke' is 'abesent' in section '[drinks]'"
+- name: "test-values 19 - Ensure non-existent 'beverage=coke' is 'absent' in section '[drinks]'"
   ini_file:
     path: "{{ output_file }}"
     section: drinks


### PR DESCRIPTION
##### SUMMARY

Not sure if this is a bug or not, but it definitely impacts specific scenarios. 

Code change updates the behavior of attempting to utilize already existing options that are commented out (i.e. inactive) by making them active with the new value, before creating a new option which leads to having both inactive and active options. 

It is considered a bug fix because of the default `php-fpm.conf` configuration which looks like this:

```ini
[global]
...
; Time limit for child processes to wait for a reaction on signals from master.
; Available units: s(econds), m(inutes), h(ours), or d(ays)
; Default Unit: seconds
; Default Value: 0
;process_control_timeout = 0

; ...

include=/etc/php/8.1/fpm/pool.d/*.conf
```

where the `pool.d/*.conf` is introducing a new section called `[www]` after the include.

With the original code, the following task:

```yaml
ini_file:
    path: /etc/php/8.1/fpm/php-fpm.conf
    section: global
    option: process_control_timeout
    value: '30'
```

would produce the following output

```ini
[global]
...
; Time limit for child processes to wait for a reaction on signals from master.
; Available units: s(econds), m(inutes), h(ours), or d(ays)
; Default Unit: seconds
; Default Value: 0
;process_control_timeout = 0

; ...

include=/etc/php/8.1/fpm/pool.d/*.conf
process_control_timeout = 30
```

leading to process_control_timeout being applied to `[www]` section instead of `[general]`, whereas the updated code will produce the following:

```ini
[global]
...
; Time limit for child processes to wait for a reaction on signals from master.
; Available units: s(econds), m(inutes), h(ours), or d(ays)
; Default Unit: seconds
; Default Value: 0
process_control_timeout = 30

; ...

include=/etc/php/8.1/fpm/pool.d/*.conf
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ini_file

##### ADDITIONAL INFORMATION

