### PR TITLE
Move ansible-core 2.12 to EOL CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -112,19 +112,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_12
-    displayName: Sanity 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.12/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -173,17 +160,6 @@ stages:
           testFormat: 2.13/units/{0}/1
           targets:
             - test: 2.7
-            - test: 3.8
-  - stage: Units_2_12
-    displayName: Units 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.12/units/{0}/1
-          targets:
-            - test: 2.6
             - test: 3.8
 
 ## Remote
@@ -269,22 +245,6 @@ stages:
               test: macos/12.0
             - name: RHEL 8.5
               test: rhel/8.5
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Remote_2_12
-    displayName: Remote 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}
-          targets:
-            - name: macOS 11.1
-              test: macos/11.1
-            - name: RHEL 8.4
-              test: rhel/8.4
             - name: FreeBSD 13.0
               test: freebsd/13.0
           groups:
@@ -361,24 +321,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Docker_2_12
-    displayName: Docker 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/linux/{0}
-          targets:
-            - name: CentOS 6
-              test: centos6
-            - name: Fedora 34
-              test: fedora34
-            - name: Ubuntu 18.04
-              test: ubuntu1804
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Community Docker
   - stage: Docker_community_devel
@@ -442,45 +384,30 @@ stages:
           testFormat: 2.13/generic/{0}/1
           targets:
             - test: 3.9
-  - stage: Generic_2_12
-    displayName: Generic 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.12/generic/{0}/1
-          targets:
-            - test: 3.8
 
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
       - Sanity_devel
-      - Sanity_2_12
       - Sanity_2_13
       - Sanity_2_14
       - Sanity_2_15
       - Units_devel
-      - Units_2_12
       - Units_2_13
       - Units_2_14
       - Units_2_15
       - Remote_devel_extra_vms
       - Remote_devel
-      - Remote_2_12
       - Remote_2_13
       - Remote_2_14
       - Remote_2_15
       - Docker_devel
-      - Docker_2_12
       - Docker_2_13
       - Docker_2_14
       - Docker_2_15
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
-#      - Generic_2_12
 #      - Generic_2_13
 #      - Generic_2_14
 #      - Generic_2_15

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Perform sanity testing
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pull-request-change-detection: 'true'
@@ -82,7 +82,7 @@ jobs:
           Ansible version ${{ matrix.ansible }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           pre-test-cmd: >-
@@ -172,7 +172,7 @@ jobs:
           under Python ${{ matrix.python }}
         uses: felixfontein/ansible-test-gh-action@main
         with:
-          ansible-core-github-repository-slug: felixfontein/ansible
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
           docker-image: ${{ matrix.docker }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         ansible:
           - '2.11'
+          - '2.12'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -75,6 +76,10 @@ jobs:
             python: '2.7'
           - ansible: '2.11'
             python: '3.5'
+          - ansible: '2.12'
+            python: '2.6'
+          - ansible: '2.12'
+            python: '3.8'
 
     steps:
       - name: >-
@@ -163,7 +168,49 @@ jobs:
           # - ansible: '2.11'
           #   docker: default
           #   python: '3.5'
-          #   target: azp/generic/2/
+          #   target: azp/generic/1/
+          # 2.12
+          - ansible: '2.12'
+            docker: centos6
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.12'
+            docker: centos6
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.12'
+            docker: centos6
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.12'
+            docker: fedora34
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.12'
+            docker: fedora34
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.12'
+            docker: fedora34
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.12'
+            docker: ubuntu1804
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.12'
+            docker: ubuntu1804
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.12'
+            docker: ubuntu1804
+            python: ''
+            target: azp/posix/3/
+          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+          # - ansible: '2.12'
+          #   docker: default
+          #   python: '3.8'
+          #   target: azp/generic/1/
 
     steps:
       - name: >-


### PR DESCRIPTION
##### SUMMARY
ansible-core 2.12 is EOL since the release of ansible-core 2.15.0.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
