### PR TITLE
CmdRunner module utils: deprecate format method `as_default_type()`

### DIFF
--- a/changelogs/fragments/6601-cmdrunner-deprecate-default-type.yml
+++ b/changelogs/fragments/6601-cmdrunner-deprecate-default-type.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - CmdRunner module utils - deprecate ``cmd_runner_fmt.as_default_type()`` formatter (https://github.com/ansible-collections/community.general/pull/6601).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -147,6 +147,11 @@ class _Format(object):
 
     @staticmethod
     def as_default_type(_type, arg="", ignore_none=None):
+        #
+        # DEPRECATION: This method is deprecated and will be removed in community.general 10.0.0
+        #
+        # Instead of using the implicit formats provided here, use the explicit necessary format method.
+        #
         fmt = _Format
         if _type == "dict":
             return fmt.as_func(lambda d: ["--{0}={1}".format(*a) for a in iteritems(d)], ignore_none=ignore_none)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deprecate `cmd_runner_fmt.as_default_type()`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/cmd_runner.py
