### PR TITLE
New module: gitlab_merge_request.py

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -532,6 +532,8 @@ files:
     notify: jlozadad
   $modules/gitlab_branch.py:
     maintainers: paytroff
+  $modules/gitlab_merge_request.py:
+    maintainers: zvaraondrej
   $modules/gitlab_project_variable.py:
     maintainers: markuman
   $modules/gitlab_instance_variable.py:

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -360,10 +360,6 @@ def main():
     if not r_target_branch:
         module.fail_json(msg="Destination branch {b} not exist.".format(b=r_target_branch))
 
-    r_target_branch = this_gitlab.get_branch(target_branch)
-    if not r_target_branch:
-        module.fail_json(msg="Destination branch {b} not exist.".format(b=r_target_branch))
-
     this_mr = this_gitlab.get_mr(title, source_branch, target_branch, state_filter)
 
     if state == "present":

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -19,9 +19,9 @@ version_added: 7.1.0
 description:
   - Creates a merge request if it does not exist.
   - When a merge request does exist, it will be updated if the provided parameters are different.
-  - When a merge request does exist and I(state=absent), the merge request will be deleted.
-  - Existing merge requests are matched based on I(title), I(source_branch), I(target_branch),
-    and I(state_filter) filters.
+  - When a merge request does exist and O(state=absent), the merge request will be deleted.
+  - Existing merge requests are matched based on O(title), O(source_branch), O(target_branch),
+    and O(state_filter) filters.
 author:
   - zvaraondrej (@zvaraondrej)
 requirements:
@@ -69,7 +69,7 @@ options:
   description:
     description:
       - A description for the merge request.
-      - Gets overriden by a content of file specified at I(description_path), if found.
+      - Gets overriden by a content of file specified at O(description_path), if found.
     type: str
   description_path:
     description:
@@ -99,7 +99,7 @@ options:
     type: str
   reviewer_ids:
     description:
-      - Comma separated list of reviewers usernames omitting "@" character.
+      - Comma separated list of reviewers usernames omitting C(@) character.
       - Set to empty string to unassign all reviewers.
     type: str
 '''

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -14,14 +14,14 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: gitlab_merge_request
-short_description: Create, update or delete a merge requests.
-version_added: 4.2.0
+short_description: Create, update, or delete a merge requests
+version_added: 7.1.0
 description:
-  - This module allows to create, update or merge requests.
+  - This module allows to create, update, or merge requests.
 author:
   - zvaraondrej (@zvaraondrej)
 requirements:
-  - python >= 2.7
+  - Python >= 2.7
   - python-gitlab >= 2.3.0
 extends_documentation_fragment:
   - community.general.auth_basic
@@ -65,13 +65,13 @@ options:
   description:
     description:
       - A description for the merge request.
-      - Gets overriden by a content of file specified at description_path, if found.
+      - Gets overriden by a content of file specified at I(description_path), if found.
     type: str
   description_path:
     description:
       - A path of file containing merge request's description.
-      - Accepts markdown formatted files.
-    type: str
+      - Accepts MarkDown formatted files.
+    type: path
   labels:
     description:
       - Comma separated list of label names.
@@ -92,7 +92,7 @@ options:
     default: opened
   assignee_ids:
     description:
-      - Comma separated list of assignees usernames omitting "@" character.
+      - Comma separated list of assignees usernames omitting C(@) character.
       - Set to empty string to unassign all assignees.
     type: str
   reviewer_ids:

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -361,9 +361,8 @@ def main():
     if state == "present":
         if description_path:
             try:
-                f = open(description_path, 'rb')
-                description = to_text(f.read(), errors='surrogate_or_strict')
-                f.close()
+                with open(description_path, 'rb') as f:
+                    description = to_text(f.read(), errors='surrogate_or_strict')
             except IOError as e:
                 module.fail_json(msg='Cannot open {0}: {1}'.format(description_path, e))
 

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -196,14 +196,18 @@ class GitlabMergeRequest(object):
     @param username Name of the user
     '''
     def get_user(self, username):
+        users = []
         try:
-            users = self.project.users.list(username=username, all=True)
+            users = [user for user in self.project.users.list(username=username, all=True) if user.username == username]
         except gitlab.exceptions.GitlabGetError as e:
             self._module.fail_json(msg="Failed to list the users: %s" % to_native(e))
 
-        for user in users:
-            if (user.username == username):
-                return user
+        if len(users) > 1:
+            self._module.fail_json(msg="Multiple Users matched search criteria.")
+        elif len(users) < 1:
+            self._module.fail_json(msg="No User matched search criteria.")
+        else:
+            return users[0]
 
     '''
     @param users List of usernames

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -18,8 +18,9 @@ short_description: Create, update, or delete GitLab merge requests
 version_added: 7.1.0
 description:
   - Creates a merge request if it does not exist.
-  - When a merge request does exist, it will be updated if the provided parameters are different.
-  - When a merge request does exist and O(state=absent), the merge request will be deleted.
+  - When a single merge request does exist, it will be updated if the provided parameters are different.
+  - When a single merge request does exist and O(state=absent), the merge request will be deleted.
+  - When multiple merge requests are detected, the task fails.
   - Existing merge requests are matched based on O(title), O(source_branch), O(target_branch),
     and O(state_filter) filters.
 author:
@@ -366,6 +367,8 @@ def main():
             except IOError as e:
                 module.fail_json(msg='Cannot open {0}: {1}'.format(description_path, e))
 
+        # sorting necessary in order to properly detect changes, as we don't want to get false positive
+        # results due to differences in ids ordering; see `mr_has_changed()`
         assignee_ids = sorted(this_gitlab.get_user_ids(assignee_ids.split(","))) if assignee_ids else []
         reviewer_ids = sorted(this_gitlab.get_user_ids(reviewer_ids.split(","))) if reviewer_ids else []
         labels = sorted(labels.split(",")) if labels else []

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -1,0 +1,361 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021, Lennert Mertens (lennert@nubera.be)
+# Copyright (c) 2021, Werner Dijkerman (ikben@werner-dijkerman.nl)
+# Copyright (c) 2015, Werner Dijkerman (ikben@werner-dijkerman.nl)
+# Copyright (c) 2019, Guillaume Martinez (lunik@tiwabbit.fr)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+module: gitlab_merge_request
+short_description: Create or delete a branch
+version_added: 4.2.0
+description:
+  - This module allows to create or delete branches.
+author:
+  - paytroff (@paytroff)
+requirements:
+  - python >= 2.7
+  - python-gitlab >= 2.3.0
+extends_documentation_fragment:
+  - community.general.auth_basic
+  - community.general.gitlab
+  - community.general.attributes
+
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
+
+options:
+  state:
+    description:
+      - Create or delete branch.
+    default: present
+    type: str
+    choices: ["present", "absent"]
+  project:
+    description:
+      - The path or name of the project.
+    required: true
+    type: str
+  branch:
+    description:
+      - The name of the branch that needs to be created.
+    required: true
+    type: str
+  ref_branch:
+    description:
+      - Reference branch to create from.
+      - This must be specified if I(state=present).
+    type: str
+'''
+
+
+EXAMPLES = '''
+- name: Create branch branch2 from main
+  community.general.gitlab_merge_request:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    project: "group1/project1"
+    branch: branch2
+    ref_branch: main
+    state: present
+
+- name: Delete branch branch2
+  community.general.gitlab_merge_request:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    project: "group1/project1"
+    branch: branch2
+    state: absent
+
+'''
+
+RETURN = '''
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.api import basic_auth_argument_spec
+from ansible.module_utils.common.text.converters import to_native, to_text
+
+from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
+from ansible_collections.community.general.plugins.module_utils.gitlab import (
+    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+)
+
+
+class GitlabMergeRequest(object):
+
+    def __init__(self, module, project_path, gitlab_instance):
+        self.repo = gitlab_instance
+        self._module = module
+        self.project = self.get_project(project_path)
+
+    '''
+    @param project_path Name of the project
+    '''
+    def get_project(self, project_path):
+        try:
+            return self.repo.projects.get(project_path)
+        except gitlab.exceptions.GitlabGetError as e:
+            self._module.fail_json(msg="Failed to get the project: %s" % to_native(e))
+
+    '''
+   @param branch Name of the branch
+   '''
+    def get_branch(self, branch):
+        try:
+            return self.project.branches.get(branch)
+        except gitlab.exceptions.GitlabGetError as e:
+            self._module.fail_json(msg="Failed to get the branch: %s" % to_native(e))
+
+
+    '''
+    @param title Title of the Merge Request
+    @param source_branch Merge Request's source branch
+    @param target_branch Merge Request's target branch
+    @param state_filter Merge Request's state to filter on
+    '''
+    def get_mr(self, title, source_branch, target_branch, state_filter):
+        mrs = []
+        try:
+            mrs = self.project.mergerequests.list(search=title, source_branch=source_branch, target_branch=target_branch, state=state_filter)
+        except gitlab.exceptions.GitlabGetError as e:
+            self._module.fail_json(msg="Failed to list the Merge Request: %s" % to_native(e))
+
+        if len(mrs) > 1:
+            self._module.fail_json(msg="Multiple Merge Requests matched search criteria.")
+        if len(mrs) == 1:
+            try:
+               return self.project.mergerequests.get(id=mrs[0].iid)
+            except gitlab.exceptions.GitlabGetError as e:
+                self._module.fail_json(msg="Failed to get the Merge Request: %s" % to_native(e))
+
+    def get_user(self, username):
+        try:
+            users = self.project.users.list(search=username, all=True)
+        except gitlab.exceptions.GitlabGetError as e:
+            self._module.fail_json(msg="Failed to list the users: %s" % to_native(e))
+
+        for user in users:
+            if (user.username == username):
+                return user
+
+    def get_users(self, users):
+        return [self.get_user(user) for user in users]
+
+
+    def get_user_id(self, user):
+        return user.id
+
+    '''
+    @param options Options of the Merge Request
+    '''
+    def create_mr(self, options):
+        if self._module.check_mode:
+            self._module.exit_json(changed=True, msg="Successfully created the Merge Request %s" % options.title)
+
+        try:
+            return self.project.mergerequests.create(options)
+        except gitlab.exceptions.GitlabCreateError as e:
+            self._module.fail_json(msg="Failed to create Merge Request: %s " % to_native(e))
+
+
+    '''
+    @param mr Merge Request object to delete
+    '''
+    def delete_mr(self, mr):
+        if self._module.check_mode:
+            self._module.exit_json(changed=True, msg="Successfully deleted the Merge Request %s" % mr.title)
+
+        try:
+            mr.delete()
+        except gitlab.exceptions.GitlabDeleteError as e:
+            self._module.fail_json(msg="Failed to delete Merge Request: %s " % to_native(e))
+
+    '''
+    @param mr Merge Request object to update
+    '''
+    def update_mr(self, mr, options):
+        if self._module.check_mode:
+            self._module.exit_json(changed=True, msg="Successfully updated the Merge Request %s" % mr.title)
+
+        try:
+            # mr.save()
+            self.project.mergerequests.update(mr.iid, options)
+        except (gitlab.exceptions.GitlabUpdateError) as e:
+            self._module.fail_json(msg="Failed to update Merge Request: %s " % to_native(e))
+
+    def update_mr_options(self, mr, options):
+        changed = False
+        print("HERE2")
+        print(mr)
+        for key, value in options.items():
+            if value is not None:
+                # see https://gitlab.com/gitlab-org/gitlab-foss/-/issues/27355
+                if key == 'remove_source_branch':
+                    key = 'force_remove_source_branch'
+
+                if key == 'assignee_ids' or key == 'assignee_id':
+                    key = 'assignees'
+
+                if key == 'labels':
+                    # new_value = self.sort_labels(options[key])
+                    # original_val = getattr(mr, key).sort()
+                    # original_val.sort()
+                    if options[key] != getattr(mr, key).sort():
+                        setattr(mr, key, options[key])
+                        changed = True
+
+                elif getattr(mr, key) != value:
+                    setattr(mr, key, value)
+                    changed = True
+
+        return (changed, mr)
+
+    def sort_labels(self, labels):
+        return labels.split(",").sort()
+
+def main():
+    argument_spec = basic_auth_argument_spec()
+    argument_spec.update(auth_argument_spec())
+    argument_spec.update(
+        project_path=dict(type='str', required=True),
+        source_branch=dict(type='str', required=True),
+        target_branch=dict(type='str', required=True),
+        title=dict(type='str', required=True),
+        description=dict(description='str', required=False),
+        labels=dict(type='str', required=False),
+        description_path=dict(type='str', required=False),
+        remove_source_branch=dict(type='bool', default=False, required=False),
+        state_filter=dict(type='str', default="opened", choices=["opened", "closed", "locked", "merged"]),
+        assignee_ids=dict(type='str', required=False),
+        reviewer_ids=dict(type='str', required=False),
+        state=dict(type='str', default="present", choices=["absent", "present"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['api_username', 'api_token'],
+            ['api_username', 'api_oauth_token'],
+            ['api_username', 'api_job_token'],
+            ['api_token', 'api_oauth_token'],
+            ['api_token', 'api_job_token'],
+            ['description', 'description_path'],
+        ],
+        required_together=[
+            ['api_username', 'api_password'],
+        ],
+        required_one_of=[
+            ['api_username', 'api_token', 'api_oauth_token', 'api_job_token']
+        ],
+        required_if=[
+            ['state', 'present', ['source_branch', 'target_branch', 'title'], True],
+        ],
+        supports_check_mode=True
+    )
+    ensure_gitlab_package(module)
+
+    project_path = module.params['project_path']
+    source_branch = module.params['source_branch']
+    target_branch = module.params['target_branch']
+    title = module.params['title']
+    description = module.params['description']
+    labels = module.params['labels']
+    description_path = module.params['description_path']
+    remove_source_branch = module.params['remove_source_branch']
+    state_filter = module.params['state_filter']
+    assignee_ids = module.params['assignee_ids']
+    reviewer_ids = module.params['reviewer_ids']
+    state = module.params['state']
+
+    gitlab_version = gitlab.__version__
+    if LooseVersion(gitlab_version) < LooseVersion('2.3.0'):
+        module.fail_json(msg="community.general.gitlab_proteched_branch requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
+                             " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
+
+    gitlab_instance = gitlab_authentication(module)
+    this_gitlab = GitlabMergeRequest(module=module, project_path=project_path, gitlab_instance=gitlab_instance)
+
+    r_source_branch = this_gitlab.get_branch(source_branch)
+    if not r_source_branch:
+        module.fail_json(msg="Source branch {b} not exist.".format(b=r_source_branch))
+
+    r_target_branch = this_gitlab.get_branch(target_branch)
+    if not r_target_branch:
+        module.fail_json(msg="Destination branch {b} not exist.".format(b=r_target_branch))
+
+    r_target_branch = this_gitlab.get_branch(target_branch)
+    if not r_target_branch:
+        module.fail_json(msg="Destination branch {b} not exist.".format(b=r_target_branch))
+
+    this_mr = this_gitlab.get_mr(title, source_branch, target_branch, state_filter)
+
+    if state == "present":
+        if description_path:
+            try:
+                f = open(description_path, 'rb')
+                description = to_text(f.read(), errors='surrogate_or_strict')
+                f.close()
+            except IOError as e:
+                module.fail_json(msg='Cannot open {0}: {1}'.format(description_path, e))
+
+        if assignee_ids:
+            assignee_ids = [this_gitlab.get_user_id(user) for user in this_gitlab.get_users(assignee_ids.split(","))]
+
+        if reviewer_ids:
+            reviewer_ids = [this_gitlab.get_user_id(user) for user in this_gitlab.get_users(reviewer_ids.split(","))]
+
+        if not this_mr:
+            # TODO check docs
+            options = {
+                "source_branch": source_branch,
+                "target_branch": target_branch,
+                "title": title,
+                "description": description,
+                "labels": this_gitlab.sort_labels(labels),
+                "remove_source_branch": remove_source_branch,
+                "reviewer_ids": reviewer_ids,
+                "assignee_ids": assignee_ids,
+            }
+
+            this_gitlab.create_mr(options)
+            module.exit_json(changed=True, msg="Created the Merge Request {t} from branch {d} to branch {s}.".format(t=title,d=target_branch,s=source_branch))
+        else:
+
+            options = {
+                "target_branch": target_branch,
+                "title": title,
+                "description": description,
+                "labels": this_gitlab.sort_labels(labels),
+                "remove_source_branch": remove_source_branch,
+                "reviewer_ids": reviewer_ids,
+                "assignee_ids": assignee_ids,
+            }
+
+            changed, mr = this_gitlab.update_mr_options(this_mr, options)
+            print("HERE")
+            print(mr)
+            if changed:
+                this_gitlab.update_mr(mr, options)
+                module.exit_json(changed=True, msg="Merge Request {t} from branch {d} to branch {s} updated.".format(t=title,d=target_branch,s=source_branch))
+            else:
+                module.exit_json(changed=False, msg="Merge Request {t} from branch {d} to branch {s} already exist".format(t=title, d=target_branch, s=source_branch))
+    elif this_mr and state == "absent":
+        this_gitlab.delete_mr(this_mr)
+        module.exit_json(changed=True, msg="Merge Request {t} from branch {d} to branch {s} deleted.".format(t=title,d=target_branch,s=source_branch))
+    else:
+        module.exit_json(changed=False, msg="No changes are needed.")
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -244,7 +244,7 @@ class GitlabMergeRequest(object):
             self._module.exit_json(changed=True, msg="Successfully deleted the Merge Request %s" % mr["title"])
 
         try:
-            mr.delete()
+            return mr.delete()
         except gitlab.exceptions.GitlabDeleteError as e:
             self._module.fail_json(msg="Failed to delete Merge Request: %s " % to_native(e))
 
@@ -392,8 +392,11 @@ def main():
         if not this_mr:
             options["source_branch"] = source_branch
 
-            this_gitlab.create_mr(options)
-            module.exit_json(changed=True, msg="Created the Merge Request {t} from branch {d} to branch {s}.".format(t=title, d=target_branch, s=source_branch))
+            mr = this_gitlab.create_mr(options)
+            module.exit_json(
+                changed=True, msg="Created the Merge Request {t} from branch {d} to branch {s}.".format(t=title, d=target_branch, s=source_branch),
+                mr=mr.asdict()
+            )
         else:
             if this_gitlab.mr_has_changed(this_mr, options):
                 mr = this_gitlab.update_mr(this_mr, options)
@@ -407,8 +410,11 @@ def main():
                     mr=this_mr.asdict()
                 )
     elif this_mr and state == "absent":
-        this_gitlab.delete_mr(this_mr)
-        module.exit_json(changed=True, msg="Merge Request {t} from branch {d} to branch {s} deleted.".format(t=title, d=target_branch, s=source_branch))
+        mr = this_gitlab.delete_mr(this_mr)
+        module.exit_json(
+            changed=True, msg="Merge Request {t} from branch {d} to branch {s} deleted.".format(t=title, d=target_branch, s=source_branch),
+            mr=mr
+        )
     else:
         module.exit_json(changed=False, msg="No changes are needed.", mr=this_mr.asdict())
 

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -14,10 +14,14 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: gitlab_merge_request
-short_description: Create, update, or delete a merge requests
+short_description: Create, update, or delete GitLab merge requests
 version_added: 7.1.0
 description:
-  - This module allows to create, update, or merge requests.
+  - Creates a merge request if it does not exist.
+  - When a merge request does exist, it will be updated if the provided parameters are different.
+  - When a merge request does exist and I(state=absent), the merge request will be deleted.
+  - Existing merge requests are matched based on I(title), I(source_branch), I(target_branch),
+    and I(state_filter) filters.
 author:
   - zvaraondrej (@zvaraondrej)
 requirements:
@@ -85,8 +89,6 @@ options:
   state_filter:
     description:
       - Filter specifying state of merge requests while searching.
-      - If empty string, merge requests of all states are searched.
-      - Possible values are "opened", "closed", "locked", "merged" or empty string.
     type: str
     choices: ["opened", "closed", "locked", "merged"]
     default: opened
@@ -136,12 +138,6 @@ msg:
   returned: always
   type: str
   sample: "Success"
-
-error:
-  description: API object.
-  returned: failed
-  type: str
-  sample: "400: path is already in use"
 
 mr:
   description: API object.
@@ -299,7 +295,7 @@ def main():
         title=dict(type='str', required=True),
         description=dict(type='str', required=False),
         labels=dict(type='str', default="", required=False),
-        description_path=dict(type='str', required=False),
+        description_path=dict(type='path', required=False),
         remove_source_branch=dict(type='bool', default=False, required=False),
         state_filter=dict(type='str', default="opened", choices=["opened", "closed", "locked", "merged"]),
         assignee_ids=dict(type='str', required=False),

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -385,25 +385,25 @@ def main():
 
             mr = this_gitlab.create_mr(options)
             module.exit_json(
-                changed=True, msg="Created the Merge Request {t} from branch {d} to branch {s}.".format(t=title, d=target_branch, s=source_branch),
+                changed=True, msg="Created the Merge Request {t} from branch {s} to branch {d}.".format(t=title, d=target_branch, s=source_branch),
                 mr=mr.asdict()
             )
         else:
             if this_gitlab.mr_has_changed(this_mr, options):
                 mr = this_gitlab.update_mr(this_mr, options)
                 module.exit_json(
-                    changed=True, msg="Merge Request {t} from branch {d} to branch {s} updated.".format(t=title, d=target_branch, s=source_branch),
+                    changed=True, msg="Merge Request {t} from branch {s} to branch {d} updated.".format(t=title, d=target_branch, s=source_branch),
                     mr=mr
                 )
             else:
                 module.exit_json(
-                    changed=False, msg="Merge Request {t} from branch {d} to branch {s} already exist".format(t=title, d=target_branch, s=source_branch),
+                    changed=False, msg="Merge Request {t} from branch {s} to branch {d} already exist".format(t=title, d=target_branch, s=source_branch),
                     mr=this_mr.asdict()
                 )
     elif this_mr and state == "absent":
         mr = this_gitlab.delete_mr(this_mr)
         module.exit_json(
-            changed=True, msg="Merge Request {t} from branch {d} to branch {s} deleted.".format(t=title, d=target_branch, s=source_branch),
+            changed=True, msg="Merge Request {t} from branch {s} to branch {d} deleted.".format(t=title, d=target_branch, s=source_branch),
             mr=mr
         )
     else:

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -197,7 +197,7 @@ class GitlabMergeRequest(object):
     '''
     def get_user(self, username):
         try:
-            users = self.project.users.list(search=username, all=True)
+            users = self.project.users.list(username=username, all=True)
         except gitlab.exceptions.GitlabGetError as e:
             self._module.fail_json(msg="Failed to list the users: %s" % to_native(e))
 

--- a/tests/integration/targets/gitlab_merge_request/aliases
+++ b/tests/integration/targets/gitlab_merge_request/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+gitlab/ci
+disabled

--- a/tests/integration/targets/gitlab_merge_request/defaults/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/defaults/main.yml
@@ -10,3 +10,6 @@ gitlab_project_group: ansible_test_group
 gitlab_host: ansible_test_host
 gitlab_api_token: ansible_test_api_token
 gitlab_labels: ansible_test_label
+gitlab_assignee_ids: ansible_test_assignee_ids
+gitlab_description_path: ansible_test_description_path
+

--- a/tests/integration/targets/gitlab_merge_request/defaults/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+gitlab_source_branch: ansible_test_source_branch
+gitlab_target_branch: ansible_test_target_project
+gitlab_project_name: ansible_test_project
+gitlab_project_group: ansible_test_group
+gitlab_host: ansible_test_host
+gitlab_api_token: ansible_test_api_token
+gitlab_labels: ansible_test_label

--- a/tests/integration/targets/gitlab_merge_request/defaults/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/defaults/main.yml
@@ -12,4 +12,3 @@ gitlab_api_token: ansible_test_api_token
 gitlab_labels: ansible_test_label
 gitlab_assignee_ids: ansible_test_assignee_ids
 gitlab_description_path: ansible_test_description_path
-

--- a/tests/integration/targets/gitlab_merge_request/files/description.md
+++ b/tests/integration/targets/gitlab_merge_request/files/description.md
@@ -1,0 +1,3 @@
+### Description
+
+Merge Request test description

--- a/tests/integration/targets/gitlab_merge_request/files/description.md
+++ b/tests/integration/targets/gitlab_merge_request/files/description.md
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 ### Description
 
 Merge Request test description

--- a/tests/integration/targets/gitlab_merge_request/files/description.md
+++ b/tests/integration/targets/gitlab_merge_request/files/description.md
@@ -1,6 +1,8 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
 
 ### Description
 

--- a/tests/integration/targets/gitlab_merge_request/tasks/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/tasks/main.yml
@@ -1,0 +1,125 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install required libs
+  pip:
+    name: python-gitlab
+    state: present
+
+- name: Create {{ gitlab_project_name }}
+  gitlab_project:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: true
+    api_token: "{{ gitlab_api_token }}"
+    name: "{{ gitlab_project_name }}"
+    group: "{{ gitlab_project_group }}"
+    default_branch: "{{ gitlab_target_branch }}"
+    initialize_with_readme: true
+    state: present
+
+- name: Create branch {{ gitlab_source_branch }}
+  gitlab_branch:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_api_token }}"
+    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+    branch: "{{ gitlab_source_branch }}"
+    ref_branch: "{{ gitlab_target_branch }}"
+    state: present
+
+- name: Create Merge Request
+  gitlab_merge_request:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_api_token }}"
+    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+    source_branch: "{{gitlab_source_branch}}"
+    target_branch: "{{gitlab_target_branch}}"
+    title: "Ansible test merge request"
+    description: "Test description"
+    labels: ""
+    state_filter: "opened"
+    assignee_ids: ""
+    reviewer_ids: ""
+    remove_source_branch: True
+    state: present
+  register: gitlab_merge_request_create
+
+- name: Test Merge Request Created
+  assert:
+    that:
+      - gitlab_merge_request_create is changed
+
+- name: Create Merge Request ( Idempotency test )
+  gitlab_merge_request:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_api_token }}"
+    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+    source_branch: "{{gitlab_source_branch}}"
+    target_branch: "{{gitlab_target_branch}}"
+    title: "Ansible test merge request"
+    description: "Test description"
+    labels: ""
+    state_filter: "opened"
+    assignee_ids: ""
+    reviewer_ids: ""
+    remove_source_branch: True
+    state: present
+  register: gitlab_merge_request_create_idempotence
+
+- name: Test module is idempotent
+  assert:
+    that:
+      - gitlab_merge_request_create_idempotence is not changed
+
+- name: Update Merge Request Labels Test
+  gitlab_merge_request:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_api_token }}"
+    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+    source_branch: "{{gitlab_source_branch}}"
+    target_branch: "{{gitlab_target_branch}}"
+    title: "Ansible test merge request"
+    description: "Test description"
+    labels: "{{ gitlab_labels }}"
+    state_filter: "opened"
+    assignee_ids: ""
+    reviewer_ids: ""
+    remove_source_branch: True
+    state: present
+  register: gitlab_merge_request_udpate_labels
+
+- name: Test merge request updated with labels
+  assert:
+    that:
+      - gitlab_merge_request_udpate_labels.mr.labels[0] == "{{ gitlab_labels }}"
+
+- name: Delete Merge Request
+  gitlab_merge_request:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_api_token }}"
+    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+    source_branch: "{{gitlab_source_branch}}"
+    target_branch: "{{gitlab_target_branch}}"
+    title: "Ansible test merge request"
+    state: absent
+  register: gitlab_merge_request_delete
+
+- name: Test merge request is deleted
+  assert:
+    that:
+      - gitlab_merge_request_delete is changed
+
+- name: Clean up {{ gitlab_project_name }}
+  gitlab_project:
+    api_url: "{{ gitlab_host }}"
+    validate_certs: false
+    api_token: "{{ gitlab_api_token }}"
+    name: "{{ gitlab_project_name }}"
+    group: "{{ gitlab_project_group }}"
+    state: absent

--- a/tests/integration/targets/gitlab_merge_request/tasks/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/tasks/main.yml
@@ -100,7 +100,7 @@
       that:
         - gitlab_merge_request_udpate.mr.labels[0] == "{{ gitlab_labels }}"
         - gitlab_merge_request_udpate.mr.assignees[0].username == "{{ gitlab_assignee_ids }}"
-        - gitlab_merge_request_udpate.mr.description == "### Description\n\nMerge Request test description"
+        - "'### Description\n\nMerge Request test description' in gitlab_merge_request_udpate.mr.description"
 
   - name: Delete Merge Request
     gitlab_merge_request:

--- a/tests/integration/targets/gitlab_merge_request/tasks/main.yml
+++ b/tests/integration/targets/gitlab_merge_request/tasks/main.yml
@@ -13,113 +13,117 @@
     name: python-gitlab
     state: present
 
-- name: Create {{ gitlab_project_name }}
-  gitlab_project:
-    api_url: "{{ gitlab_host }}"
-    validate_certs: true
-    api_token: "{{ gitlab_api_token }}"
-    name: "{{ gitlab_project_name }}"
-    group: "{{ gitlab_project_group }}"
-    default_branch: "{{ gitlab_target_branch }}"
-    initialize_with_readme: true
-    state: present
+- block:
+  - name: Create {{ gitlab_project_name }}
+    gitlab_project:
+      api_url: "{{ gitlab_host }}"
+      validate_certs: true
+      api_token: "{{ gitlab_api_token }}"
+      name: "{{ gitlab_project_name }}"
+      group: "{{ gitlab_project_group }}"
+      default_branch: "{{ gitlab_target_branch }}"
+      initialize_with_readme: true
+      state: present
 
-- name: Create branch {{ gitlab_source_branch }}
-  gitlab_branch:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_api_token }}"
-    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
-    branch: "{{ gitlab_source_branch }}"
-    ref_branch: "{{ gitlab_target_branch }}"
-    state: present
+  - name: Create branch {{ gitlab_source_branch }}
+    gitlab_branch:
+      api_url: "{{ gitlab_host }}"
+      api_token: "{{ gitlab_api_token }}"
+      project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+      branch: "{{ gitlab_source_branch }}"
+      ref_branch: "{{ gitlab_target_branch }}"
+      state: present
 
-- name: Create Merge Request
-  gitlab_merge_request:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_api_token }}"
-    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
-    source_branch: "{{gitlab_source_branch}}"
-    target_branch: "{{gitlab_target_branch}}"
-    title: "Ansible test merge request"
-    description: "Test description"
-    labels: ""
-    state_filter: "opened"
-    assignee_ids: ""
-    reviewer_ids: ""
-    remove_source_branch: True
-    state: present
-  register: gitlab_merge_request_create
+  - name: Create Merge Request
+    gitlab_merge_request:
+      api_url: "{{ gitlab_host }}"
+      api_token: "{{ gitlab_api_token }}"
+      project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+      source_branch: "{{gitlab_source_branch}}"
+      target_branch: "{{gitlab_target_branch}}"
+      title: "Ansible test merge request"
+      description: "Test description"
+      labels: ""
+      state_filter: "opened"
+      assignee_ids: ""
+      reviewer_ids: ""
+      remove_source_branch: True
+      state: present
+    register: gitlab_merge_request_create
 
-- name: Test Merge Request Created
-  assert:
-    that:
-      - gitlab_merge_request_create is changed
+  - name: Test Merge Request Created
+    assert:
+      that:
+        - gitlab_merge_request_create is changed
 
-- name: Create Merge Request ( Idempotency test )
-  gitlab_merge_request:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_api_token }}"
-    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
-    source_branch: "{{gitlab_source_branch}}"
-    target_branch: "{{gitlab_target_branch}}"
-    title: "Ansible test merge request"
-    description: "Test description"
-    labels: ""
-    state_filter: "opened"
-    assignee_ids: ""
-    reviewer_ids: ""
-    remove_source_branch: True
-    state: present
-  register: gitlab_merge_request_create_idempotence
+  - name: Create Merge Request ( Idempotency test )
+    gitlab_merge_request:
+      api_url: "{{ gitlab_host }}"
+      api_token: "{{ gitlab_api_token }}"
+      project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+      source_branch: "{{gitlab_source_branch}}"
+      target_branch: "{{gitlab_target_branch}}"
+      title: "Ansible test merge request"
+      description: "Test description"
+      labels: ""
+      state_filter: "opened"
+      assignee_ids: ""
+      reviewer_ids: ""
+      remove_source_branch: True
+      state: present
+    register: gitlab_merge_request_create_idempotence
 
-- name: Test module is idempotent
-  assert:
-    that:
-      - gitlab_merge_request_create_idempotence is not changed
+  - name: Test module is idempotent
+    assert:
+      that:
+        - gitlab_merge_request_create_idempotence is not changed
 
-- name: Update Merge Request Labels Test
-  gitlab_merge_request:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_api_token }}"
-    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
-    source_branch: "{{gitlab_source_branch}}"
-    target_branch: "{{gitlab_target_branch}}"
-    title: "Ansible test merge request"
-    description: "Test description"
-    labels: "{{ gitlab_labels }}"
-    state_filter: "opened"
-    assignee_ids: ""
-    reviewer_ids: ""
-    remove_source_branch: True
-    state: present
-  register: gitlab_merge_request_udpate_labels
+  - name: Update Merge Request Test
+    gitlab_merge_request:
+      api_url: "{{ gitlab_host }}"
+      api_token: "{{ gitlab_api_token }}"
+      project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+      source_branch: "{{gitlab_source_branch}}"
+      target_branch: "{{gitlab_target_branch}}"
+      title: "Ansible test merge request"
+      description_path: "{{gitlab_description_path}}"
+      labels: "{{ gitlab_labels }}"
+      state_filter: "opened"
+      assignee_ids: "{{ gitlab_assignee_ids }}"
+      reviewer_ids: ""
+      remove_source_branch: True
+      state: present
+    register: gitlab_merge_request_udpate
 
-- name: Test merge request updated with labels
-  assert:
-    that:
-      - gitlab_merge_request_udpate_labels.mr.labels[0] == "{{ gitlab_labels }}"
+  - name: Test merge request updated
+    assert:
+      that:
+        - gitlab_merge_request_udpate.mr.labels[0] == "{{ gitlab_labels }}"
+        - gitlab_merge_request_udpate.mr.assignees[0].username == "{{ gitlab_assignee_ids }}"
+        - gitlab_merge_request_udpate.mr.description == "### Description\n\nMerge Request test description"
 
-- name: Delete Merge Request
-  gitlab_merge_request:
-    api_url: "{{ gitlab_host }}"
-    api_token: "{{ gitlab_api_token }}"
-    project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
-    source_branch: "{{gitlab_source_branch}}"
-    target_branch: "{{gitlab_target_branch}}"
-    title: "Ansible test merge request"
-    state: absent
-  register: gitlab_merge_request_delete
+  - name: Delete Merge Request
+    gitlab_merge_request:
+      api_url: "{{ gitlab_host }}"
+      api_token: "{{ gitlab_api_token }}"
+      project: "{{ gitlab_project_group }}/{{ gitlab_project_name }}"
+      source_branch: "{{gitlab_source_branch}}"
+      target_branch: "{{gitlab_target_branch}}"
+      title: "Ansible test merge request"
+      state: absent
+    register: gitlab_merge_request_delete
 
-- name: Test merge request is deleted
-  assert:
-    that:
-      - gitlab_merge_request_delete is changed
+  - name: Test merge request is deleted
+    assert:
+      that:
+        - gitlab_merge_request_delete is changed
 
-- name: Clean up {{ gitlab_project_name }}
-  gitlab_project:
-    api_url: "{{ gitlab_host }}"
-    validate_certs: false
-    api_token: "{{ gitlab_api_token }}"
-    name: "{{ gitlab_project_name }}"
-    group: "{{ gitlab_project_group }}"
-    state: absent
+  always:
+  - name: Clean up {{ gitlab_project_name }}
+    gitlab_project:
+      api_url: "{{ gitlab_host }}"
+      validate_certs: false
+      api_token: "{{ gitlab_api_token }}"
+      name: "{{ gitlab_project_name }}"
+      group: "{{ gitlab_project_group }}"
+      state: absent


### PR DESCRIPTION
##### SUMMARY

A new Ansible module `gitlab_merge_request` for creating, updating, or deleting GitLab's merge requests.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module/Plugin Pull Request

##### COMPONENT NAME
`gitlab_merge_request`

##### ADDITIONAL INFORMATION

A new Ansible module `gitlab_merge_request` for creating, updating, or deleting GitLab's merge request resources utilizing [python-gitlab](https://python-gitlab.readthedocs.io/en/stable/) library. This work is based on previously available GitLab-related modules in the collection. To the best of my knowledge, a similar module for manipulating Gitlab's merge requests is missing from the collection.
