### PR TITLE
Minor bitwarden plugin req. docs addition

### DIFF
--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -12,6 +12,8 @@ DOCUMENTATION = """
     requirements:
       - bw (command line utility)
       - be logged into bitwarden
+      - bitwarden vault unlocked
+      - C(BW_SESSION) environment variable set
     short_description: Retrieve secrets from Bitwarden
     version_added: 5.4.0
     description:


### PR DESCRIPTION
##### SUMMARY
The Bitwarden CLI requires a `login` followed by an `unlock` operation. The later will display a message regarding setting (and exporting) the `$BW_SESSION` env. var. When using the `bitwarden` lookup plugin, having the env. var. set and available (exported) to Ansible is critical. Without it, the plugin will simply return the error:

`Bitwarden Vault locked. Run 'bw unlock'.`

Make this clearer in the requirement documentation.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
bitwarden

##### ADDITIONAL INFORMATION

Example error with vault unlocked (`bw unlock`) but doing a `unset BW_SESSION` before running the playbook.

```paste below
TASK [debug] ************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'community.general.bitwarden'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Bitwarden Vault locked. Run 'bw unlock'.. Bitwarden Vault locked. Run 'bw unlock'."}
```

With the vault unlocked and `export BW_SESSION=<secret value>` the playbook works perfectly.