### PR TITLE
Keycloak: Authentication management (flows and required actions)

### DIFF
--- a/changelogs/fragments/6616-keycloak-authentication.yml
+++ b/changelogs/fragments/6616-keycloak-authentication.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - keycloak authentication plugin - refactor of existing plugin, while adding expanded support for authentication flows, executions (steps and sub-flows) and required actions (https://github.com/ansible-collections/community.general/pull/6616).

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -18,7 +18,7 @@ description:
     - It can also add or update an authentication execution to a flow (step or sub-flow). Deletion is not supported.
     - This module also supports registration, update and deletion of an authentication required action.
 
-version_added: "7.0.0"
+version_added: "3.3.0"
 
 attributes:
     check_mode:
@@ -32,6 +32,7 @@ options:
             - Assign the authentication flow to be used by a realm authentication flow.
         choices: [ "browserFlow", "clientAuthenticationFlow", "directGrantFlow", "dockerAuthenticationFlow", "registrationFlow", "resetCredentialsFlow" ]
         type: str
+        version_added: 7.1.0
     config:
         description:
             - Configuration for a configurable authentication flow.
@@ -40,19 +41,24 @@ options:
                 description:
                     - Unique name of the configuration.
                 type: str
+                version_added: 7.1.0
             config:
                 description:
                     - The inner parameters of the configuration specific to the authentication execution.
                 type: dict
+                version_added: 7.1.0
             id:
                 description:
                     - ID of the configuration used for updating.
                 type: str
+                version_added: 7.1.0
         type: dict
+        version_added: 7.1.0
     copy_from:
         description:
             - Unique name of the authentication flow to copy from.
         type: str
+        version_added: 7.1.0
     execution:
         description:
             - Authentication execution (step or sub-flow) of the authentication flow.
@@ -61,66 +67,81 @@ options:
                 description:
                     - Name of the authentication execution taken from its configuration.
                 type: str
+                version_added: 7.1.0
             authenticationConfig:
                 description:
                     - ID of the authentication execution's configuration.
                 type: str
+                version_added: 7.1.0
             authenticationFlow:
                 description:
                     - Indicates, if the authentication execution is a step (false) or a sub-flow (true).
                 required: true
                 type: bool
+                version_added: 7.1.0
             configurable:
                 description:
                     - Indicates, if the authentication execution is configurable (depends on the provider).
                 type: bool
+                version_added: 7.1.0
             description:
                 description:
                     - Description of the authentication execution.
                 type: str
+                version_added: 7.1.0
             displayName:
                 description:
                     - Display name of the authentication execution.
                 type: str
+                version_added: 7.1.0
             flowId:
                 description:
                     - ID of the authentication execution sub-flow.
                 type: str
+                version_added: 7.1.0
             id:
                 description:
                     - ID of the authentication execution (step or sub-flow).
                 type: str
+                version_added: 7.1.0
             index:
                 description:
                     - The priortiy of an inner authentication execution of its outer authentication execution.
                 type: int
+                version_added: 7.1.0
             level:
                 description:
                     - The priority of the authentication execution in the authentication flow.
                 type: int
+                version_added: 7.1.0
             providerId:
                 description:
                     - ID (specific name) of the provider.
                 required: true
                 type: str
+                version_added: 7.1.0
             requirement:
                 choices: [ "REQUIRED", "ALTERNATIVE", "DISABLED", "CONDITIONAL" ]
                 default: "DISABLED"
                 description:
                     - Indicates the requirement of the authentication flow.
                 type: str
+                version_added: 7.1.0
             requirementChoices:
                 elements: str
                 description:
                     - A list of requirement choices of the authentication execution.
                 type: list
+                version_added: 7.1.0
             flowType:
                 choices: [ "basic-flow", "client-flow" ]
                 default: "basic-flow"
                 description:
                     - Indicates the flow type of the authentication execution (sub-flow).
                 type: str
+                version_added: 7.1.0
         type: dict
+        version_added: 7.1.0
     flow:
         description:
             - Authentication flow.
@@ -130,36 +151,44 @@ options:
                     - Unique name of the authentication flow.
                 required: true
                 type: str
+                version_added: 7.1.0
             builtIn:
                 default: false
                 description:
                     - Indicates, if the authentication is built-in or not.
                 type: bool
+                version_added: 7.1.0
             description:
                 description:
                     - Description of the authentication flow.
                 type: str
+                version_added: 7.1.0
             id:
                 description:
                     - ID of the authentication flow.
                 type: str
+                version_added: 7.1.0
             providerId:
                 choices: [ "basic-flow", "client-flow" ]
                 default: "basic-flow"
                 description:
                     - Indicates, if the authentication flow is a basic or a client flow.
                 type: str
+                version_added: 7.1.0
             topLevel:
                 default: true
                 description:
                     - Indicates, if the authentication flow is top-level or not.
                 type: bool
+                version_added: 7.1.0
         type: dict
+        version_added: 7.1.0
     realm:
         description:
             - Name of the realm, to which the authentication is modified using this module.
         required: true
         type: str
+        version_added: 7.1.0
     required_action:
         description:
             - Authentication required action.
@@ -169,33 +198,41 @@ options:
                     - Unique name of the required action.
                 required: true
                 type: str
+                version_added: 7.1.0
             config:
                 description:
                     - Configuration for the required action.
                 type: dict
+                version_added: 7.1.0
             defaultAction:
                 default: false
                 description:
                     - Indicates, if any new user will have the required action assigned to it.
                 type: bool
+                version_added: 7.1.0
             enabled:
                 default: false
                 description:
                     - Indicates, if the required action is enabled or not.
                 type: bool
+                version_added: 7.1.0
             name:
                 description:
                     - Displayed name of the required action.
                 type: str
+                version_added: 7.1.0
             priority:
                 description:
                     - Priority of the required action.
                 type: int
+                version_added: 7.1.0
             providerId:
                 description:
                     - Provider ID of the required action.
                 type: str
+                version_added: 7.1.0
         type: dict
+        version_added: 7.1.0
     state:
         choices: [ "absent", "present" ]
         description:

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -14,10 +14,11 @@ module: keycloak_authentication
 short_description: Configure authentication in Keycloak
 
 description:
-    - This module actually can only make a copy of an existing authentication flow, add an execution to it and configure it.
-    - It can also delete the flow.
+    - This module supports creation, making a copy, deletion and configuration of an authentication flow.
+    - It can also add or update an authentication execution to a flow (step or sub-flow). Deletion is not supported.
+    - This module also supports registration, update and deletion of an authentication required action.
 
-version_added: "3.3.0"
+version_added: "7.0.0"
 
 attributes:
     check_mode:
@@ -26,78 +27,181 @@ attributes:
         support: full
 
 options:
-    realm:
+    bind_flow:
         description:
-            - The name of the realm in which is the authentication.
-        required: true
+            - Assign the authentication flow to be used by a realm authentication flow.
+        choices: [ "browserFlow", "clientAuthenticationFlow", "directGrantFlow", "dockerAuthenticationFlow", "registrationFlow", "resetCredentialsFlow" ]
         type: str
-    alias:
+    config:
         description:
-            - Alias for the authentication flow.
-        required: true
-        type: str
-    description:
-        description:
-            - Description of the flow.
-        type: str
-    providerId:
-        description:
-            - C(providerId) for the new flow when not copied from an existing flow.
-        type: str
-    copyFrom:
-        description:
-            - C(flowAlias) of the authentication flow to use for the copy.
-        type: str
-    authenticationExecutions:
-        description:
-            - Configuration structure for the executions.
-        type: list
-        elements: dict
+            - Configuration for a configurable authentication flow.
         suboptions:
-            providerId:
+            alias:
                 description:
-                    - C(providerID) for the new flow when not copied from an existing flow.
+                    - Unique name of the configuration.
                 type: str
-            displayName:
+            config:
                 description:
-                    - Name of the execution or subflow to create or update.
+                    - The inner parameters of the configuration specific to the authentication execution.
+                type: dict
+            id:
+                description:
+                    - ID of the configuration used for updating.
                 type: str
-            requirement:
+        type: dict
+    copy_from:
+        description:
+            - Unique name of the authentication flow to copy from.
+        type: str
+    execution:
+        description:
+            - Authentication execution (step or sub-flow) of the authentication flow.
+        suboptions:
+            alias:
                 description:
-                    - Control status of the subflow or execution.
-                choices: [ "REQUIRED", "ALTERNATIVE", "DISABLED", "CONDITIONAL" ]
-                type: str
-            flowAlias:
-                description:
-                    - Alias of parent flow.
+                    - Name of the authentication execution taken from its configuration.
                 type: str
             authenticationConfig:
                 description:
-                    - Describe the config of the authentication.
-                type: dict
+                    - ID of the authentication execution's configuration.
+                type: str
+            authenticationFlow:
+                description:
+                    - Indicates, if the authentication execution is a step (false) or a sub-flow (true).
+                required: true
+                type: bool
+            configurable:
+                description:
+                    - Indicates, if the authentication execution is configurable (depends on the provider).
+                type: bool
+            description:
+                description:
+                    - Description of the authentication execution.
+                type: str
+            displayName:
+                description:
+                    - Display name of the authentication execution.
+                type: str
+            flowId:
+                description:
+                    - ID of the authentication execution sub-flow.
+                type: str
+            id:
+                description:
+                    - ID of the authentication execution (step or sub-flow).
+                type: str
             index:
                 description:
-                    - Priority order of the execution.
+                    - The priortiy of an inner authentication execution of its outer authentication execution.
                 type: int
-            subFlowType:
+            level:
                 description:
-                    - For new subflows, optionally specify the type.
-                    - Is only used at creation.
-                choices: ["basic-flow", "form-flow"]
-                default: "basic-flow"
+                    - The priority of the authentication execution in the authentication flow.
+                type: int
+            providerId:
+                description:
+                    - ID (specific name) of the provider.
+                required: true
                 type: str
-                version_added: 6.6.0
-    state:
+            requirement:
+                choices: [ "REQUIRED", "ALTERNATIVE", "DISABLED", "CONDITIONAL" ]
+                default: "DISABLED"
+                description:
+                    - Indicates the requirement of the authentication flow.
+                type: str
+            requirementChoices:
+                elements: str
+                description:
+                    - A list of requirement choices of the authentication execution.
+                type: list
+            flowType:
+                choices: [ "basic-flow", "client-flow" ]
+                default: "basic-flow"
+                description:
+                    - Indicates the flow type of the authentication execution (sub-flow).
+                type: str
+        type: dict
+    flow:
         description:
-            - Control if the authentication flow must exists or not.
-        choices: [ "present", "absent" ]
-        default: present
+            - Authentication flow.
+        suboptions:
+            alias:
+                description:
+                    - Unique name of the authentication flow.
+                required: true
+                type: str
+            builtIn:
+                default: false
+                description:
+                    - Indicates, if the authentication is built-in or not.
+                type: bool
+            description:
+                description:
+                    - Description of the authentication flow.
+                type: str
+            id:
+                description:
+                    - ID of the authentication flow.
+                type: str
+            providerId:
+                choices: [ "basic-flow", "client-flow" ]
+                default: "basic-flow"
+                description:
+                    - Indicates, if the authentication flow is a basic or a client flow.
+                type: str
+            topLevel:
+                default: true
+                description:
+                    - Indicates, if the authentication flow is top-level or not.
+                type: bool
+        type: dict
+    realm:
+        description:
+            - Name of the realm, to which the authentication is modified using this module.
+        required: true
         type: str
-    force:
-        type: bool
-        default: false
+    required_action:
         description:
-            - If C(true), allows to remove the authentication flow and recreate it.
+            - Authentication required action.
+        suboptions:
+            alias:
+                description:
+                    - Unique name of the required action.
+                required: true
+                type: str
+            config:
+                description:
+                    - Configuration for the required action.
+                type: dict
+            defaultAction:
+                default: false
+                description:
+                    - Indicates, if any new user will have the required action assigned to it.
+                type: bool
+            enabled:
+                default: false
+                description:
+                    - Indicates, if the required action is enabled or not.
+                type: bool
+            name:
+                description:
+                    - Displayed name of the required action.
+                type: str
+            priority:
+                description:
+                    - Priority of the required action.
+                type: int
+            providerId:
+                description:
+                    - Provider ID of the required action.
+                type: str
+        type: dict
+    state:
+        choices: [ "absent", "present" ]
+        description:
+            - Control if the realm authentication is going to be updated (creation/update) or deleted.
+        required: true
+        type: str
 
 extends_documentation_fragment:
     - community.general.keycloak
@@ -109,77 +213,116 @@ author:
 '''
 
 EXAMPLES = '''
-    - name: Create an authentication flow from first broker login and add an execution to it.
+    - name: Create an authentication flow with a configurable execution step with a configuration to it, and add assign it to a realm authentication flow.
       community.general.keycloak_authentication:
-        auth_keycloak_url: http://localhost:8080/auth
-        auth_realm: master
-        auth_username: admin
-        auth_password: password
-        realm: master
-        alias: "Copy of first broker login"
-        copyFrom: "first broker login"
-        authenticationExecutions:
-          - providerId: "test-execution1"
-            requirement: "REQUIRED"
-            authenticationConfig:
-              alias: "test.execution1.property"
-              config:
-                test1.property: "value"
-          - providerId: "test-execution2"
-            requirement: "REQUIRED"
-            authenticationConfig:
-              alias: "test.execution2.property"
-              config:
-                test2.property: "value"
-        state: present
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        bind_flow: "resetCredentialsFlow"
+        config:
+          alias: "Require OTP for password reset"
+          config:
+            defaultOtpOutcome: "force"
+            otpControlAttribute: "force"
+        execution:
+          authenticationFlow: False
+          displayName: "Conditional OTP Form"
+          providerId: "auth-conditional-otp-form"
+          requirement: "REQUIRED"
+        flow:
+          alias: "test_flow"
+          description: "This is a test flow."
+        realm: "master"
+        state: "present"
 
-    - name: Re-create the authentication flow
+    - name: Add an authentication execution sub-flow to the newly created authentication flow.
       community.general.keycloak_authentication:
-        auth_keycloak_url: http://localhost:8080/auth
-        auth_realm: master
-        auth_username: admin
-        auth_password: password
-        realm: master
-        alias: "Copy of first broker login"
-        copyFrom: "first broker login"
-        authenticationExecutions:
-          - providerId: "test-provisioning"
-            requirement: "REQUIRED"
-            authenticationConfig:
-              alias: "test.provisioning.property"
-              config:
-                test.provisioning.property: "value"
-        state: present
-        force: true
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        execution:
+          alias: "test_sub_flow"
+          authenticationFlow: True
+          description: "This is a test sub-flow."
+          providerId: "registration-page-form"
+          type: "basic-flow"
+        flow:
+          alias: "test_flow"
+        realm: "master"
+        state: "present"
 
-    - name: Create an authentication flow with subflow containing an execution.
+    - name: Add an authentication execution step to the newly created authentication execution sub-flow.
       community.general.keycloak_authentication:
-        auth_keycloak_url: http://localhost:8080/auth
-        auth_realm: master
-        auth_username: admin
-        auth_password: password
-        realm: master
-        alias: "Copy of first broker login"
-        copyFrom: "first broker login"
-        authenticationExecutions:
-          - providerId: "test-execution1"
-            requirement: "REQUIRED"
-          - displayName: "New Subflow"
-            requirement: "REQUIRED"
-          - providerId: "auth-cookie"
-            requirement: "REQUIRED"
-            flowAlias: "New Sublow"
-        state: present
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        execution:
+          authenticationFlow: False
+          providerId: "reset-credentials-choose-user"
+          requirement: "REQUIRED"
+        flow:
+          alias: "test_sub_flow"
+        realm: "master"
+        state: "present"
 
-    - name: Remove authentication.
+    - name: Delete the authentication flow.
       community.general.keycloak_authentication:
-        auth_keycloak_url: http://localhost:8080/auth
-        auth_realm: master
-        auth_username: admin
-        auth_password: password
-        realm: master
-        alias: "Copy of first broker login"
-        state: absent
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        flow:
+          alias: "test_flow"
+        realm: "master"
+        state: "absent"
+
+    - name: Register a new required action.
+      community.general.keycloak_authentication:
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        realm: "master"
+        require_action:
+          alias: "test_required_action"
+          name: "Test Required Action"
+          enabled: true
+          defaultAction: false
+          priority: 999
+        state: "present"
+
+    - name: Update the newly registered required action.
+      community.general.keycloak_authentication:
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        realm: "master"
+        require_action:
+          alias: "test_flow"
+          priority: 111
+        state: "present"
+
+    - name: Delete the updated registered required action.
+      community.general.keycloak_authentication:
+        auth_client_id: "admin-cli"
+        auth_keycloak_url: "http://localhost:8080"
+        auth_password: "password"
+        auth_realm: "master"
+        auth_username: "admin"
+        realm: "master"
+        require_action:
+          alias: "test_required_action"
+        state: "absent"
 '''
 
 RETURN = '''
@@ -221,103 +364,8 @@ end_state:
 '''
 
 from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak \
-    import KeycloakAPI, keycloak_argument_spec, get_token, KeycloakError, is_struct_included
+    import KeycloakAPI, keycloak_argument_spec, get_token, KeycloakError
 from ansible.module_utils.basic import AnsibleModule
-
-
-def find_exec_in_executions(searched_exec, executions):
-    """
-    Search if exec is contained in the executions.
-    :param searched_exec: Execution to search for.
-    :param executions: List of executions.
-    :return: Index of the execution, -1 if not found..
-    """
-    for i, existing_exec in enumerate(executions, start=0):
-        if ("providerId" in existing_exec and "providerId" in searched_exec and
-                existing_exec["providerId"] == searched_exec["providerId"] or
-                "displayName" in existing_exec and "displayName" in searched_exec and
-                existing_exec["displayName"] == searched_exec["displayName"]):
-            return i
-    return -1
-
-
-def create_or_update_executions(kc, config, realm='master'):
-    """
-    Create or update executions for an authentication flow.
-    :param kc: Keycloak API access.
-    :param config: Representation of the authentication flow including it's executions.
-    :param realm: Realm
-    :return: tuple (changed, dict(before, after)
-        WHERE
-        bool changed indicates if changes have been made
-        dict(str, str) shows state before and after creation/update
-    """
-    try:
-        changed = False
-        after = ""
-        before = ""
-        if "authenticationExecutions" in config:
-            # Get existing executions on the Keycloak server for this alias
-            existing_executions = kc.get_executions_representation(config, realm=realm)
-            for new_exec_index, new_exec in enumerate(config["authenticationExecutions"], start=0):
-                if new_exec["index"] is not None:
-                    new_exec_index = new_exec["index"]
-                exec_found = False
-                # Get flowalias parent if given
-                if new_exec["flowAlias"] is not None:
-                    flow_alias_parent = new_exec["flowAlias"]
-                else:
-                    flow_alias_parent = config["alias"]
-                # Check if same providerId or displayName name between existing and new execution
-                exec_index = find_exec_in_executions(new_exec, existing_executions)
-                if exec_index != -1:
-                    # Remove key that doesn't need to be compared with existing_exec
-                    exclude_key = ["flowAlias", "subFlowType"]
-                    for index_key, key in enumerate(new_exec, start=0):
-                        if new_exec[key] is None:
-                            exclude_key.append(key)
-                    # Compare the executions to see if it need changes
-                    if not is_struct_included(new_exec, existing_executions[exec_index], exclude_key) or exec_index != new_exec_index:
-                        exec_found = True
-                        before += str(existing_executions[exec_index]) + '\n'
-                    id_to_update = existing_executions[exec_index]["id"]
-                    # Remove exec from list in case 2 exec with same name
-                    existing_executions[exec_index].clear()
-                elif new_exec["providerId"] is not None:
-                    kc.create_execution(new_exec, flowAlias=flow_alias_parent, realm=realm)
-                    exec_found = True
-                    exec_index = new_exec_index
-                    id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
-                    after += str(new_exec) + '\n'
-                elif new_exec["displayName"] is not None:
-                    kc.create_subflow(new_exec["displayName"], flow_alias_parent, realm=realm, flowType=new_exec["subFlowType"])
-                    exec_found = True
-                    exec_index = new_exec_index
-                    id_to_update = kc.get_executions_representation(config, realm=realm)[exec_index]["id"]
-                    after += str(new_exec) + '\n'
-                if exec_found:
-                    changed = True
-                    if exec_index != -1:
-                        # Update the existing execution
-                        updated_exec = {
-                            "id": id_to_update
-                        }
-                        # add the execution configuration
-                        if new_exec["authenticationConfig"] is not None:
-                            kc.add_authenticationConfig_to_execution(updated_exec["id"], new_exec["authenticationConfig"], realm=realm)
-                        for key in new_exec:
-                            # remove unwanted key for the next API call
-                            if key not in ("flowAlias", "authenticationConfig", "subFlowType"):
-                                updated_exec[key] = new_exec[key]
-                        if new_exec["requirement"] is not None:
-                            kc.update_authentication_executions(flow_alias_parent, updated_exec, realm=realm)
-                        diff = exec_index - new_exec_index
-                        kc.change_execution_priority(updated_exec["id"], diff, realm=realm)
-                        after += str(kc.get_executions_representation(config, realm=realm)[new_exec_index]) + '\n'
-        return changed, dict(before=before, after=after)
-    except Exception as e:
-        kc.module.fail_json(msg='Could not create or update executions for authentication flow %s in realm %s: %s'
-                            % (config["alias"], realm, str(e)))
 
 
 def main():
@@ -329,34 +377,112 @@ def main():
     argument_spec = keycloak_argument_spec()
 
     meta_args = dict(
+        bind_flow=dict(
+            type='str',
+            choices=[
+                "browserFlow",
+                "clientAuthenticationFlow",
+                "directGrantFlow",
+                "dockerAuthenticationFlow",
+                "registrationFlow",
+                "resetCredentialsFlow",
+            ]
+        ),
+        config=dict(
+            type='dict',
+            options=dict(
+                alias=dict(type='str'),
+                config=dict(type='dict'),
+                id=dict(type='str')
+            )
+        ),
+        copy_from=dict(type='str'),
+        execution=dict(
+            type='dict',
+            options=dict(
+                alias=dict(type='str'),
+                authenticationConfig=dict(type='str'),
+                authenticationFlow=dict(type='bool', required=True),
+                configurable=dict(type='bool'),
+                description=dict(type='str'),
+                displayName=dict(type='str'),
+                flowId=dict(type='str'),
+                id=dict(type='str'),
+                index=dict(type='int'),
+                level=dict(type='int'),
+                providerId=dict(type='str', required=True),
+                requirement=dict(
+                    type='str',
+                    default='DISABLED',
+                    choices=[
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                        "CONDITIONAL"
+                    ]
+                ),
+                requirementChoices=dict(
+                    elements="str",
+                    type="list",
+                ),
+                flowType=dict(
+                    type='str',
+                    default='basic-flow',
+                    choices=[
+                        "basic-flow",
+                        "client-flow",
+                    ]
+                ),
+            )
+        ),
+        flow=dict(
+            type='dict',
+            options=dict(
+                alias=dict(type='str', required=True),
+                builtIn=dict(type='bool', default=False),
+                description=dict(type='str'),
+                id=dict(type='str'),
+                providerId=dict(
+                    type='str',
+                    default='basic-flow',
+                    choices=[
+                        'basic-flow',
+                        'client-flow',
+                    ]
+                ),
+                topLevel=dict(type='bool', default=True)
+            )
+        ),
         realm=dict(type='str', required=True),
-        alias=dict(type='str', required=True),
-        providerId=dict(type='str'),
-        description=dict(type='str'),
-        copyFrom=dict(type='str'),
-        authenticationExecutions=dict(type='list', elements='dict',
-                                      options=dict(
-                                          providerId=dict(type='str'),
-                                          displayName=dict(type='str'),
-                                          requirement=dict(choices=["REQUIRED", "ALTERNATIVE", "DISABLED", "CONDITIONAL"], type='str'),
-                                          flowAlias=dict(type='str'),
-                                          authenticationConfig=dict(type='dict'),
-                                          index=dict(type='int'),
-                                          subFlowType=dict(choices=["basic-flow", "form-flow"], default='basic-flow', type='str'),
-                                      )),
-        state=dict(choices=["absent", "present"], default='present'),
-        force=dict(type='bool', default=False),
+        required_action=dict(
+            type='dict',
+            options=dict(
+                alias=dict(type='str', required=True),
+                config=dict(type='dict'),
+                defaultAction=dict(type='bool', default=False),
+                enabled=dict(type='bool', default=False),
+                name=dict(type='str'),
+                priority=dict(type='int'),
+                providerId=dict(type='str')
+            )
+        ),
+        state=dict(
+            type='str',
+            choices=['absent', 'present'],
+            required=True
+        ),
     )
 
     argument_spec.update(meta_args)
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True,
-                           required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
-                           required_together=([['auth_realm', 'auth_username', 'auth_password']])
-                           )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=([['token', 'auth_realm', 'auth_username', 'auth_password']]),
+        required_together=([['auth_realm', 'auth_username', 'auth_password']])
+    )
 
-    result = dict(changed=False, msg='', flow={})
+    result = dict(changed=False, msg='', end_state={}, diff=dict(before={}, after={}))
 
     # Obtain access token, initialize API
     try:
@@ -366,115 +492,481 @@ def main():
 
     kc = KeycloakAPI(module, connection_header)
 
+    # Convenience variables
+    bind_flow = module.params.get('bind_flow')
+    desired_config = module.params.get('config')
+    copy_from = module.params.get('copy_from')
+    desired_execution = module.params.get('execution')
+    desired_flow = module.params.get('flow')
+    desired_required_action = module.params.get('required_action')
     realm = module.params.get('realm')
     state = module.params.get('state')
-    force = module.params.get('force')
 
-    new_auth_repr = {
-        "alias": module.params.get("alias"),
-        "copyFrom": module.params.get("copyFrom"),
-        "providerId": module.params.get("providerId"),
-        "authenticationExecutions": module.params.get("authenticationExecutions"),
-        "description": module.params.get("description"),
-        "builtIn": module.params.get("builtIn"),
-        "subflow": module.params.get("subflow"),
-    }
+    # Delete unused parameters
+    dicts = [desired_execution, desired_flow, desired_required_action]
+    for d in dicts:
+        if d is not None:
+            for k in list(d.keys()):
+                if d[k] is None:
+                    del d[k]
 
-    auth_repr = kc.get_authentication_flow_by_alias(alias=new_auth_repr["alias"], realm=realm)
+    if state == 'present':
+        # Handle authentication flow
+        if desired_flow:
+            # Get authentication flow
+            before_flow = kc.get_authentication_flow_by_alias(
+                alias=desired_flow['alias'],
+                realm=realm
+            )
 
-    # Cater for when it doesn't exist (an empty dict)
-    if not auth_repr:
-        if state == 'absent':
-            # Do nothing and exit
-            if module._diff:
-                result['diff'] = dict(before='', after='')
-            result['changed'] = False
-            result['end_state'] = {}
-            result['msg'] = new_auth_repr["alias"] + ' absent'
-            module.exit_json(**result)
+            if before_flow:
+                # Get authentication executions
+                before_executions = kc.get_authentication_executions(
+                    alias=desired_flow['alias'],
+                    realm=realm
+                )
+            else:
+                before_executions = []
 
-        elif state == 'present':
-            # Process a creation
-            result['changed'] = True
+            # Update
+            if before_flow:
+                # Fill in parameters
+                for k, v in before_flow.items():
+                    if k not in desired_flow or desired_flow[k] is None:
+                        desired_flow[k] = v
 
-            if module._diff:
-                result['diff'] = dict(before='', after=new_auth_repr)
+                # Differences found
+                if desired_flow != before_flow:
+                    if not module.check_mode:
+                        kc.update_authentication_flow(
+                            realm=realm,
+                            id=desired_flow['id'],
+                            flow=desired_flow
+                        )
 
-            if module.check_mode:
-                module.exit_json(**result)
+                        desired_flow = kc.get_authentication_flow_by_alias(
+                            alias=desired_flow['alias'],
+                            realm=realm
+                        )
 
-            # If copyFrom is defined, create authentication flow from a copy
-            if "copyFrom" in new_auth_repr and new_auth_repr["copyFrom"] is not None:
-                auth_repr = kc.copy_auth_flow(config=new_auth_repr, realm=realm)
-            else:  # Create an empty authentication flow
-                auth_repr = kc.create_empty_auth_flow(config=new_auth_repr, realm=realm)
+                    if module._diff:
+                        result['diff']['before']["flow"] = before_flow
+                        result['diff']['after']["flow"] = desired_flow
 
-            # If the authentication still not exist on the server, raise an exception.
-            if auth_repr is None:
-                result['msg'] = "Authentication just created not found: " + str(new_auth_repr)
-                module.fail_json(**result)
+                    result['changed'] = True
+                    result['end_state']["flow"] = desired_flow
+            # Create
+            else:
+                # Create from a copy
+                if copy_from:
+                    if not module.check_mode:
+                        kc.copy_authentication_flow(
+                            alias=copy_from,
+                            name=desired_flow['alias'],
+                            realm=realm
+                        )
+                else:
+                    if not module.check_mode:
+                        kc.create_authentication_flow(
+                            flow=desired_flow,
+                            realm=realm
+                        )
 
-            # Configure the executions for the flow
-            create_or_update_executions(kc=kc, config=new_auth_repr, realm=realm)
+                    desired_flow = kc.get_authentication_flow_by_alias(
+                        alias=desired_flow['alias'],
+                        realm=realm
+                    )
 
-            # Get executions created
-            exec_repr = kc.get_executions_representation(config=new_auth_repr, realm=realm)
-            if exec_repr is not None:
-                auth_repr["authenticationExecutions"] = exec_repr
-            result['end_state'] = auth_repr
-
-    else:
-        if state == 'present':
-            # Process an update
-
-            if force:  # If force option is true
-                # Delete the actual authentication flow
-                result['changed'] = True
                 if module._diff:
-                    result['diff'] = dict(before=auth_repr, after=new_auth_repr)
-                if module.check_mode:
-                    module.exit_json(**result)
-                kc.delete_authentication_flow_by_id(id=auth_repr["id"], realm=realm)
-                # If copyFrom is defined, create authentication flow from a copy
-                if "copyFrom" in new_auth_repr and new_auth_repr["copyFrom"] is not None:
-                    auth_repr = kc.copy_auth_flow(config=new_auth_repr, realm=realm)
-                else:  # Create an empty authentication flow
-                    auth_repr = kc.create_empty_auth_flow(config=new_auth_repr, realm=realm)
-                # If the authentication still not exist on the server, raise an exception.
-                if auth_repr is None:
-                    result['msg'] = "Authentication just created not found: " + str(new_auth_repr)
-                    module.fail_json(**result)
-            # Configure the executions for the flow
+                    result['diff']['before']['flow'] = {}
+                    result['diff']['after']['flow'] = desired_flow
 
-            if module.check_mode:
-                module.exit_json(**result)
-            changed, diff = create_or_update_executions(kc=kc, config=new_auth_repr, realm=realm)
-            result['changed'] |= changed
+                result['changed'] = True
+                result['end_state']['flow'] = desired_flow
 
-            if module._diff:
-                result['diff'] = diff
+            # Bind flow
+            if bind_flow:
+                # Get realm info
+                realm_info = kc.get_realm_info_by_id(
+                    realm=realm
+                )
 
-            # Get executions created
-            exec_repr = kc.get_executions_representation(config=new_auth_repr, realm=realm)
-            if exec_repr is not None:
-                auth_repr["authenticationExecutions"] = exec_repr
-            result['end_state'] = auth_repr
+                # Not assigned yet
+                if (
+                    (bind_flow in realm_info and realm_info[bind_flow] != desired_flow['alias']) or
+                    bind_flow not in realm_info
+                ):
+                    if not module.check_mode:
+                        kc.update_realm(
+                            realmrep={
+                                bind_flow: desired_flow['alias']
+                            },
+                            realm=realm
+                        )
 
+                        if module._diff:
+                            result['diff']['before']['bind_flow'] = {
+                                bind_flow: realm_info[bind_flow]
+                            }
+                            result['diff']['after']['bind_flow'] = {
+                                bind_flow: desired_flow['alias']
+                            }
+
+                    result['changed'] = True
+                    result['end_state']['bind_flow'] = {
+                        bind_flow: desired_flow['alias']
+                    }
+
+            # Handle authentication execution (step and sub-flow)
+            if desired_execution:
+                # Try to find closest match
+                found_match = False
+                if before_executions:
+                    # Search using ID or flow ID
+                    for before_execution in before_executions:
+                        if (
+                            'id' in desired_execution and 'id' in before_execution and
+                            desired_execution['id'] == before_execution['id']
+                        ) or (
+                            'flowId' in desired_execution and 'flowId' in before_execution and
+                            desired_execution['flowId'] == before_execution['flowId']
+                        ):
+                            found_match = True
+                            break
+
+                    if not found_match:
+                        # Search using index and level
+                        for before_execution in before_executions:
+                            if (
+                                'index' in desired_execution and 'index' in before_execution and
+                                'level' in desired_execution and 'level' in before_execution and
+                                desired_execution['index'] == before_execution['index'] and
+                                desired_execution['level'] == before_execution['level']
+                            ):
+                                found_match = True
+                                break
+
+                    if not found_match:
+                        # Search using displayName
+                        for before_execution in before_executions:
+                            if (
+                                'displayName' in desired_execution and 'displayName' in before_execution and
+                                desired_execution['displayName'] == before_execution['displayName']
+                            ):
+                                found_match = True
+                                break
+
+                    # Update
+                    if found_match:
+                        # Sanitize authentication execution step (authenticationFlow not needed during update)
+                        del desired_execution['authenticationFlow']
+
+                        # Fill in parameters
+                        for k, v in before_execution.items():
+                            if k not in desired_execution or desired_execution[k] is None:
+                                desired_execution[k] = v
+
+                        # Sanitize
+                        del desired_execution['flowType']
+
+                        # Differences found
+                        if desired_execution != before_execution:
+                            if not module.check_mode:
+                                kc.update_authentication_execution(
+                                    alias=desired_flow['alias'],
+                                    rep=desired_execution,
+                                    realm=realm
+                                )
+
+                                # Handle priority (index) increase/decrease
+                                if before_execution['index'] - desired_execution['index'] != 0:
+                                    kc.change_execution_priority(
+                                        executionId=desired_execution['id'],
+                                        diff=before_execution['index'] - desired_execution['index'],
+                                        realm=realm
+                                    )
+
+                            if module._diff:
+                                result['diff']['before']['execution'] = before_execution
+
+                            result['changed'] = True
+
+                # Create (also not found)
+                if found_match is False:
+                    if not module.check_mode:
+                        # Sub-Flow
+                        if desired_execution['authenticationFlow']:
+                            data = {}
+                            if 'alias' in desired_execution:
+                                data['alias'] = desired_execution['alias']
+                            else:
+                                data['alias'] = desired_execution['displayName']
+                            data['provider'] = 'registration-page-form'
+                            data['type'] = desired_execution['flowType']
+                            kc.create_authentication_execution_subflow(
+                                alias=desired_flow['alias'],
+                                data=data,
+                                realm=realm
+                            )
+
+                            # Find the newly create authentication execution
+                            before_executions = kc.get_authentication_executions(
+                                alias=desired_flow['alias'],
+                                realm=realm
+                            )
+
+                            for index, before_execution in enumerate(before_executions):
+                                parentFound = False
+
+                                # Looking for parent flow (sub-flow)
+                                if (
+                                    'authenticationFlow' in before_execution and before_execution['authenticationFlow'] and
+                                    before_execution['displayName'] == desired_flow['alias']
+                                ):
+                                    parentFound = True
+                                    parentLevel = before_execution['level']
+
+                                if parentFound:
+                                    # Level difference found
+                                    if before_execution == parentLevel:
+                                        # Get the previous one
+                                        before_execution = before_executions[index]
+                                        break
+                        # Step
+                        else:
+                            data = {}
+                            data['provider'] = desired_execution['providerId']
+                            kc.create_authentication_execution_step(
+                                alias=desired_flow['alias'],
+                                data=data,
+                                realm=realm
+                            )
+
+                            # Get the newly created authentication execution step
+                            before_execution = kc.get_authentication_executions(
+                                alias=desired_flow['alias'],
+                                realm=realm
+                            )[-1]
+
+                        # Sanitize
+                        del desired_execution['flowType']
+                        del desired_execution['authenticationFlow']
+
+                        # Fill in parameters
+                        for k, v in before_execution.items():
+                            if k not in desired_execution or desired_execution[k] is None:
+                                desired_execution[k] = v
+
+                        kc.update_authentication_execution(
+                            alias=desired_flow['alias'],
+                            rep=desired_execution,
+                            realm=realm
+                        )
+
+                        # Handle priority (index) increase/decrease
+                        if before_execution['index'] - desired_execution['index'] != 0:
+                            kc.change_execution_priority(
+                                executionId=desired_execution['id'],
+                                diff=before_execution['index'] - desired_execution['index'],
+                                realm=realm
+                            )
+
+                    if module._diff:
+                        result['diff']['before']['execution'] = {}
+
+                    result['changed'] = True
+
+                # Handle authentication execution configuration (only if configurable)
+                if desired_config and 'configurable' in desired_execution and desired_execution['configurable']:
+                    # Update
+                    if 'authenticationConfig' in desired_execution and desired_execution['authenticationConfig']:
+                        before_config = kc.get_authenticator_config(
+                            id=desired_execution['authenticationConfig'],
+                            realm=realm
+                        )
+
+                        # Fill in parameters
+                        for k, v in before_config.items():
+                            if k not in desired_config or desired_config[k] is None:
+                                desired_config[k] = v
+
+                        # Differences found
+                        if desired_config != before_config:
+                            if not module.check_mode:
+                                kc.update_authenticator_config(
+                                    id=desired_config['id'],
+                                    rep=desired_config,
+                                    realm=realm
+                                )
+
+                            if module._diff:
+                                result['diff']['before']['config'] = before_config
+                    # Create
+                    else:
+                        if not module.check_mode:
+                            kc.create_authenticator_config(
+                                executionId=desired_execution['id'],
+                                rep=desired_config,
+                                realm=realm
+                            )
+
+                        if module._diff:
+                            result['diff']['before']['config'] = {}
+
+                    # Get the latest version of the authentication execution
+                    desired_execution = list(
+                        filter(lambda execution: execution['id'] == desired_execution['id'], kc.get_authentication_executions(
+                            alias=desired_flow['alias'],
+                            realm=realm
+                        ))
+                    )[0]
+
+                    # Get the lastest version of the authenticator configuration
+                    desired_config = kc.get_authenticator_config(
+                        id=desired_execution['authenticationConfig'],
+                        realm=realm
+                    )
+
+                    if module._diff:
+                        result['diff']['after']['config'] = desired_config
+
+                    result['changed'] = True
+                    result['end_state']['config'] = desired_config
+
+                # Get the latest version of the authentication execution
+                desired_execution = list(
+                    filter(lambda execution: execution['id'] == desired_execution['id'], kc.get_authentication_executions(
+                        alias=desired_flow['alias'],
+                        realm=realm
+                    ))
+                )[0]
+
+                if module._diff:
+                    result['diff']['execution']['after'] = desired_execution
+
+                result['end_state']['execution'] = desired_execution
+
+        # Handle required action
+        if desired_required_action:
+            # Get required action
+            before_required_action = kc.get_required_action(
+                alias=desired_required_action['alias'],
+                realm=realm
+            )
+
+            # Update
+            if before_required_action:
+                # Fill in parameters
+                for k, v in before_required_action.items():
+                    if k not in desired_required_action or desired_required_action[k] is None:
+                        desired_required_action[k] = v
+
+                # Differences found
+                if desired_required_action != before_required_action:
+                    if module._diff:
+                        result['diff']['before']['required_action'] = before_required_action
+                        result['diff']['after']['required_action'] = desired_required_action
+
+                    if not module.check_mode:
+                        kc.update_required_action(
+                            alias=desired_required_action['alias'],
+                            realm=realm,
+                            rep=desired_required_action
+                        )
+
+                    result['changed'] = True
+                    result['end_state']['required_action'] = desired_required_action
+            # Register
+            else:
+                # Use the alias as the name of the required action if not provided
+                if 'name' not in desired_required_action:
+                    desired_required_action['name'] = desired_required_action['alias']
+
+                # providerId == alias, so set it, if it's not already
+                if 'providerId' not in desired_required_action:
+                    desired_required_action['providerId'] = desired_required_action['alias']
+
+                if not module.check_mode:
+                    kc.register_required_action(
+                        rep=desired_required_action,
+                        realm=realm
+                    )
+
+                # Get the newly registered required action
+                before_required_action = kc.get_required_action(
+                    alias=desired_required_action['alias'],
+                    realm=realm
+                )
+
+                # Fill in parameters
+                for k, v in before_required_action.items():
+                    if k not in desired_required_action or desired_required_action[k] is None:
+                        desired_required_action[k] = v
+
+                if module._diff:
+                    result['diff']['before']['required_action'] = {}
+                    result['diff']['after']['required_action'] = desired_required_action
+
+                result['changed'] = True
+                result['end_state']['required_action'] = desired_required_action
+    else:
+        # Handling flow and executions
+        if desired_flow:
+            # Get authentication flow:
+            before_flow = kc.get_authentication_flow_by_alias(
+                alias=desired_flow['alias'],
+                realm=realm
+            )
+
+            # Delete
+            if before_flow:
+                if module._diff:
+                    result['diff']['before']['required_action'] = before_flow
+                    result['diff']['after']['required_action'] = {}
+
+                if not module.check_mode:
+                    kc.delete_authentication_flow_by_id(
+                        id=before_flow['id'],
+                        realm=realm
+                    )
+
+                result['changed'] = True
+                result['end_state']['authentication_flow'] = {}
+
+        # Handle required action
+        if desired_required_action:
+            # Get required action
+            before_required_action = kc.get_required_action(
+                alias=desired_required_action['alias'],
+                realm=realm
+            )
+
+            # Delete
+            if before_required_action:
+                if module._diff:
+                    result['diff']['before']['required_action'] = before_required_action
+                    result['diff']['after']['required_action'] = {}
+
+                if not module.check_mode:
+                    kc.delete_required_action(
+                        alias=desired_required_action['alias'],
+                        realm=realm
+                    )
+
+                result['changed'] = True
+                result['end_state']['required_action'] = {}
+
+    # Handle msg
+    if result['changed']:
+        if module.check_mode:
+            result['msg'] = 'Authentication would be updated'
         else:
-            # Process a deletion (because state was not 'present')
-            result['changed'] = True
-
-            if module._diff:
-                result['diff'] = dict(before=auth_repr, after='')
-
-            if module.check_mode:
-                module.exit_json(**result)
-
-            # delete it
-            kc.delete_authentication_flow_by_id(id=auth_repr["id"], realm=realm)
-
-            result['msg'] = 'Authentication flow: {alias} id: {id} is deleted'.format(alias=new_auth_repr['alias'],
-                                                                                      id=auth_repr["id"])
+            result['msg'] = 'Authentication updated'
+    else:
+        if module.check_mode:
+            result['msg'] = 'Authentication would not be updated'
+        else:
+            result['msg'] = 'Authentication not updated'
 
     module.exit_json(**result)
 

--- a/tests/unit/plugins/modules/test_keycloak_authentication.py
+++ b/tests/unit/plugins/modules/test_keycloak_authentication.py
@@ -21,9 +21,29 @@ from ansible.module_utils.six import StringIO
 
 
 @contextmanager
-def patch_keycloak_api(get_authentication_flow_by_alias=None, copy_auth_flow=None, create_empty_auth_flow=None,
-                       get_executions_representation=None, delete_authentication_flow_by_id=None):
-    """Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
+def patch_keycloak_api(
+    get_authentication_flow_by_alias=None,
+    get_authentication_executions=None,
+    update_authentication_flow=None,
+    copy_authentication_flow=None,
+    create_authentication_flow=None,
+    get_realm_info_by_id=None,
+    update_realm=None,
+    update_authentication_execution=None,
+    change_execution_priority=None,
+    create_authentication_execution_subflow=None,
+    create_authentication_execution_step=None,
+    get_authenticator_config=None,
+    update_authenticator_config=None,
+    create_authenticator_config=None,
+    get_required_action=None,
+    update_required_action=None,
+    register_required_action=None,
+    delete_authentication_flow_by_id=None,
+    delete_required_action=None,
+):
+    """
+    Mock context manager for patching the methods in PwPolicyIPAClient that contact the IPA server
 
     Patches the `login` and `_post_json` methods
 
@@ -38,18 +58,122 @@ def patch_keycloak_api(get_authentication_flow_by_alias=None, copy_auth_flow=Non
     """
 
     obj = keycloak_authentication.KeycloakAPI
-    with patch.object(obj, 'get_authentication_flow_by_alias', side_effect=get_authentication_flow_by_alias) \
-            as mock_get_authentication_flow_by_alias:
-        with patch.object(obj, 'copy_auth_flow', side_effect=copy_auth_flow) \
-                as mock_copy_auth_flow:
-            with patch.object(obj, 'create_empty_auth_flow', side_effect=create_empty_auth_flow) \
-                    as mock_create_empty_auth_flow:
-                with patch.object(obj, 'get_executions_representation', return_value=get_executions_representation) \
-                        as mock_get_executions_representation:
-                    with patch.object(obj, 'delete_authentication_flow_by_id', side_effect=delete_authentication_flow_by_id) \
-                            as mock_delete_authentication_flow_by_id:
-                        yield mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow, \
-                            mock_get_executions_representation, mock_delete_authentication_flow_by_id
+    with patch.object(
+        obj,
+        'get_authentication_flow_by_alias',
+        side_effect=get_authentication_flow_by_alias
+    ) as mock_get_authentication_flow_by_alias:
+        with patch.object(
+            obj,
+            'get_authentication_executions',
+            side_effect=get_authentication_executions
+        ) as mock_get_authentication_executions:
+            with patch.object(
+                obj,
+                'update_authentication_flow',
+                side_effect=update_authentication_flow
+            ) as mock_update_authentication_flow:
+                with patch.object(
+                    obj,
+                    'copy_authentication_flow',
+                    side_effect=copy_authentication_flow
+                ) as mock_copy_authentication_flow:
+                    with patch.object(
+                        obj,
+                        'create_authentication_flow',
+                        side_effect=create_authentication_flow
+                    ) as mock_create_authentication_flow:
+                        with patch.object(
+                            obj,
+                            'get_realm_info_by_id',
+                            side_effect=get_realm_info_by_id
+                        ) as mock_get_realm_info_by_id:
+                            with patch.object(
+                                obj,
+                                'update_realm',
+                                side_effect=update_realm
+                            ) as mock_update_realm:
+                                with patch.object(
+                                    obj,
+                                    'update_authentication_execution',
+                                    side_effect=update_authentication_execution
+                                ) as mock_update_authentication_execution:
+                                    with patch.object(
+                                        obj,
+                                        'change_execution_priority',
+                                        side_effect=change_execution_priority
+                                    ) as mock_change_execution_priority:
+                                        with patch.object(
+                                            obj,
+                                            'create_authentication_execution_subflow',
+                                            side_effect=create_authentication_execution_subflow
+                                        ) as mock_create_authentication_execution_subflow:
+                                            with patch.object(
+                                                obj,
+                                                'create_authentication_execution_step',
+                                                side_effect=create_authentication_execution_step
+                                            ) as mock_create_authentication_execution_step:
+                                                with patch.object(
+                                                    obj,
+                                                    'get_authenticator_config',
+                                                    side_effect=get_authenticator_config
+                                                ) as mock_get_authenticator_config:
+                                                    with patch.object(
+                                                        obj,
+                                                        'update_authenticator_config',
+                                                        side_effect=update_authenticator_config
+                                                    ) as mock_update_authenticator_config:
+                                                        with patch.object(
+                                                            obj,
+                                                            'create_authenticator_config',
+                                                            side_effect=create_authenticator_config
+                                                        ) as mock_create_authenticator_config:
+                                                            with patch.object(
+                                                                obj,
+                                                                'get_required_action',
+                                                                side_effect=get_required_action
+                                                            ) as mock_get_required_action:
+                                                                with patch.object(
+                                                                    obj,
+                                                                    'update_required_action',
+                                                                    side_effect=update_required_action
+                                                                ) as mock_update_required_action:
+                                                                    with patch.object(
+                                                                        obj,
+                                                                        'register_required_action',
+                                                                        side_effect=register_required_action
+                                                                    ) as mock_register_required_action:
+                                                                        with patch.object(
+                                                                            obj,
+                                                                            'delete_authentication_flow_by_id',
+                                                                            side_effect=delete_authentication_flow_by_id
+                                                                        ) as mock_delete_authentication_flow_by_id:
+                                                                            with patch.object(
+                                                                                obj,
+                                                                                'delete_required_action',
+                                                                                side_effect=delete_required_action
+                                                                            ) as mock_delete_required_action:
+                                                                                yield (
+                                                                                    mock_get_authentication_flow_by_alias,
+                                                                                    mock_get_authentication_executions,
+                                                                                    mock_update_authentication_flow,
+                                                                                    mock_copy_authentication_flow,
+                                                                                    mock_create_authentication_flow,
+                                                                                    mock_get_realm_info_by_id,
+                                                                                    mock_update_realm,
+                                                                                    mock_update_authentication_execution,
+                                                                                    mock_change_execution_priority,
+                                                                                    mock_create_authentication_execution_subflow,
+                                                                                    mock_create_authentication_execution_step,
+                                                                                    mock_get_authenticator_config,
+                                                                                    mock_update_authenticator_config,
+                                                                                    mock_create_authenticator_config,
+                                                                                    mock_get_required_action,
+                                                                                    mock_update_required_action,
+                                                                                    mock_register_required_action,
+                                                                                    mock_delete_authentication_flow_by_id,
+                                                                                    mock_delete_required_action,
+                                                                                )
 
 
 def get_response(object_with_future_response, method, get_id_call_count):
@@ -98,522 +222,1189 @@ class TestKeycloakAuthentication(ModuleTestCase):
         super(TestKeycloakAuthentication, self).setUp()
         self.module = keycloak_authentication
 
-    def test_create_auth_flow_from_copy(self):
-        """Add a new authentication flow from copy of an other flow"""
+    def test_create_authentication_flow(self):
+        """Add a new authentication flow."""
 
         module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'copyFrom': 'first broker login',
-            'authenticationExecutions': [
-                {
-                    'providerId': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                },
-            ],
-            'state': 'present',
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "bind_flow": "clientAuthenticationFlow",
+            "execution": {
+                "authenticationFlow": False,
+                "displayName": "Reset Password",
+                "providerId": "reset-password",
+                "requirement": "REQUIRED",
+            },
+            "flow": {
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+            },
+            "realm": "master",
+            "state": "present",
         }
-        return_value_auth_flow_before = [{}]
-        return_value_copied = [{
-            'id': '2ac059fc-c548-414f-9c9e-84d42bd4944e',
-            'alias': 'first broker login',
-            'description': 'browser based authentication',
-            'providerId': 'basic-flow',
-            'topLevel': True,
-            'builtIn': False,
-            'authenticationExecutions': [
-                {
-                    'authenticator': 'auth-cookie',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 10,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
-                },
-            ],
-        }]
-        return_value_executions_after = [
+
+        return_value_authentication_flow = [
+            {},
             {
-                'id': 'b678e30c-8469-40a7-8c21-8d0cda76a591',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Identity Provider Redirector',
-                'requirementChoices': ['REQUIRED', 'DISABLED'],
-                'configurable': True,
-                'providerId': 'identity-provider-redirector',
-                'level': 0,
-                'index': 0
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [],
             },
             {
-                'id': 'fdc208e9-c292-48b7-b7d1-1d98315ee893',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Cookie',
-                'requirementChoices': [
-                    'REQUIRED',
-                    'ALTERNATIVE',
-                    'DISABLED'
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [
+                    {
+                        "authenticator": "reset-password",
+                        "requirement": "REQUIRED",
+                        "priority": 0,
+                        "authenticatorFlow": False,
+                        "userSetupAllowed": False,
+                    },
                 ],
-                'configurable': False,
-                'providerId': 'auth-cookie',
-                'level': 0,
-                'index': 1
             },
         ]
+
+        return_value_authentication_execution = [
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "DISABLED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+            ],
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+            ],
+        ]
+
+        # Truncated realm info
+        return_value_realm_info = [
+            {
+                "clientAuthenticationFlow": ""
+            },
+        ]
+
         changed = True
 
         set_module_args(module_args)
 
         # Run the module
-
         with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before, copy_auth_flow=return_value_copied,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+            with patch_keycloak_api(
+                get_authentication_flow_by_alias=return_value_authentication_flow,
+                get_authentication_executions=return_value_authentication_execution,
+                get_realm_info_by_id=return_value_realm_info,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         # Verify number of call on each mock
-        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 1)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 2)
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 2)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 2)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 1)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_update_realm.mock_calls), 1)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 1)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 1)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
 
-    def test_create_auth_flow_from_copy_idempotency(self):
-        """Add an already existing authentication flow from copy of an other flow to test idempotency"""
+    def test_create_authentication_flow_idempotency(self):
+        """Add a new authentication flow, even though it already exists."""
 
         module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'copyFrom': 'first broker login',
-            'authenticationExecutions': [
-                {
-                    'providerId': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                },
-            ],
-            'state': 'present',
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "bind_flow": "clientAuthenticationFlow",
+            "execution": {
+                "authenticationFlow": False,
+                "displayName": "Reset Password",
+                "providerId": "reset-password",
+                "requirement": "REQUIRED",
+            },
+            "flow": {
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+            },
+            "realm": "master",
+            "state": "present",
         }
-        return_value_auth_flow_before = [{
-            'id': '71275d5e-e11f-4be4-b119-0abfa87987a4',
-            'alias': 'Test create authentication flow copy',
-            'description': '',
-            'providerId': 'basic-flow',
-            'topLevel': True,
-            'builtIn': False,
-            'authenticationExecutions': [
-                {
-                    'authenticator': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 0,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
-                },
-                {
-                    'authenticator': 'auth-cookie',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 0,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
-                },
-            ],
-        }]
-        return_value_executions_after = [
+
+        return_value_authentication_flow = [
             {
-                'id': 'b678e30c-8469-40a7-8c21-8d0cda76a591',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Identity Provider Redirector',
-                'requirementChoices': ['REQUIRED', 'DISABLED'],
-                'configurable': True,
-                'providerId': 'identity-provider-redirector',
-                'level': 0,
-                'index': 0
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [],
             },
             {
-                'id': 'fdc208e9-c292-48b7-b7d1-1d98315ee893',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Cookie',
-                'requirementChoices': [
-                    'REQUIRED',
-                    'ALTERNATIVE',
-                    'DISABLED'
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [
+                    {
+                        "authenticator": "reset-password",
+                        "requirement": "REQUIRED",
+                        "priority": 0,
+                        "authenticatorFlow": False,
+                        "userSetupAllowed": False,
+                    },
                 ],
-                'configurable': False,
-                'providerId': 'auth-cookie',
-                'level': 0,
-                'index': 1
             },
         ]
+
+        return_value_authentication_execution = [
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+            ],
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+            ],
+        ]
+
+        # Truncated realm info
+        return_value_realm_info = [
+            {
+                "clientAuthenticationFlow": "Test create authentication flow"
+            },
+        ]
+
         changed = False
 
         set_module_args(module_args)
 
         # Run the module
-
         with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+            with patch_keycloak_api(
+                get_authentication_flow_by_alias=return_value_authentication_flow,
+                get_authentication_executions=return_value_authentication_execution,
+                get_realm_info_by_id=return_value_realm_info,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 2)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 2)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
 
-    def test_create_auth_flow_without_copy(self):
-        """Add authentication without copy"""
+    def test_update_authentication_flow_add_execution_subflow(self):
+        """Update an existing authentication flow by adding a new authentication execution sub-flow."""
 
         module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'authenticationExecutions': [
-                {
-                    'providerId': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                    'authenticationConfig': {
-                        'alias': 'name',
-                        'config': {
-                            'defaultProvider': 'value'
-                        },
-                    },
-                },
-            ],
-            'state': 'present',
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "execution": {
+                "authenticationFlow": True,
+                "displayName": "Browser - Conditional OTP",
+                "providerId": "registration-page-form",
+                "requirement": "REQUIRED",
+            },
+            "flow": {
+                "alias": "Test create authentication flow",
+            },
+            "realm": "master",
+            "state": "present",
         }
-        return_value_auth_flow_before = [{}]
-        return_value_created_empty_flow = [
+
+        return_value_authentication_flow = [
             {
-                "alias": "Test of the keycloak_auth module",
-                "authenticationExecutions": [],
-                "builtIn": False,
-                "description": "",
-                "id": "513f5baa-cc42-47bf-b4b6-1d23ccc0a67f",
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
                 "providerId": "basic-flow",
-                "topLevel": True
-            },
-        ]
-        return_value_executions_after = [
-            {
-                'id': 'b678e30c-8469-40a7-8c21-8d0cda76a591',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Identity Provider Redirector',
-                'requirementChoices': ['REQUIRED', 'DISABLED'],
-                'configurable': True,
-                'providerId': 'identity-provider-redirector',
-                'level': 0,
-                'index': 0
-            },
-        ]
-        changed = True
-
-        set_module_args(module_args)
-
-        # Run the module
-
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
-
-        # Verify number of call on each mock
-        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 1)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
-        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
-
-        # Verify that the module's changed status matches what is expected
-        self.assertIs(exec_info.exception.args[0]['changed'], changed)
-
-    def test_update_auth_flow_adding_exec(self):
-        """Update authentication flow by adding execution"""
-
-        module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'authenticationExecutions': [
-                {
-                    'providerId': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                    'authenticationConfig': {
-                        'alias': 'name',
-                        'config': {
-                            'defaultProvider': 'value'
-                        },
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [
+                    {
+                        "authenticator": "reset-password",
+                        "requirement": "REQUIRED",
+                        "priority": 0,
+                        "authenticatorFlow": False,
+                        "userSetupAllowed": False,
                     },
-                },
-            ],
-            'state': 'present',
-        }
-        return_value_auth_flow_before = [{
-            'id': '71275d5e-e11f-4be4-b119-0abfa87987a4',
-            'alias': 'Test create authentication flow copy',
-            'description': '',
-            'providerId': 'basic-flow',
-            'topLevel': True,
-            'builtIn': False,
-            'authenticationExecutions': [
-                {
-                    'authenticator': 'auth-cookie',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 0,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
-                },
-            ],
-        }]
-        return_value_executions_after = [
-            {
-                'id': 'b678e30c-8469-40a7-8c21-8d0cda76a591',
-                'requirement': 'DISABLED',
-                'displayName': 'Identity Provider Redirector',
-                'requirementChoices': ['REQUIRED', 'DISABLED'],
-                'configurable': True,
-                'providerId': 'identity-provider-redirector',
-                'level': 0,
-                'index': 0
+                ],
             },
             {
-                'id': 'fdc208e9-c292-48b7-b7d1-1d98315ee893',
-                'requirement': 'ALTERNATIVE',
-                'displayName': 'Cookie',
-                'requirementChoices': [
-                    'REQUIRED',
-                    'ALTERNATIVE',
-                    'DISABLED'
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [
+                    {
+                        "authenticator": "reset-password",
+                        "requirement": "REQUIRED",
+                        "priority": 0,
+                        "authenticatorFlow": False,
+                        "userSetupAllowed": False,
+                    },
+                    {
+                        "authenticatorFlow": True,
+                        "requirement": "ALTERNATIVE",
+                        "priority": 1,
+                        "autheticatorFlow": True,
+                        "flowAlias": "Browser - Conditional OTP",
+                        "userSetupAllowed": False,
+                    }
                 ],
-                'configurable': False,
-                'providerId': 'auth-cookie',
-                'level': 0,
-                'index': 1
             },
         ]
-        changed = True
 
-        set_module_args(module_args)
-
-        # Run the module
-
-        with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
-                with self.assertRaises(AnsibleExitJson) as exec_info:
-                    self.module.main()
-
-        # Verify number of call on each mock
-        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
-        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
-
-        # Verify that the module's changed status matches what is expected
-        self.assertIs(exec_info.exception.args[0]['changed'], changed)
-
-    def test_delete_auth_flow(self):
-        """Delete authentication flow"""
-
-        module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'state': 'absent',
-        }
-        return_value_auth_flow_before = [{
-            'id': '71275d5e-e11f-4be4-b119-0abfa87987a4',
-            'alias': 'Test create authentication flow copy',
-            'description': '',
-            'providerId': 'basic-flow',
-            'topLevel': True,
-            'builtIn': False,
-            'authenticationExecutions': [
+        return_value_authentication_execution = [
+            [
                 {
-                    'authenticator': 'auth-cookie',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 0,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
                 },
             ],
-        }]
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+                {
+                    "id": "d0c3d9fa-92c7-4b90-a1c1-515ccea9a0ee",
+                    "requirement": "DISABLED",
+                    "displayName": "Browser - Conditional OTP",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                        "CONDITIONAL",
+                    ],
+                    "configurable": False,
+                    "authenticationFlow": True,
+                    "flowId": "9491b181-450a-4753-b563-5900eb9d957b",
+                    "level": 1,
+                    "index": 1,
+                },
+            ],
+            [
+                {
+                    "id": "91113e19-2808-42c5-9749-d9c16e4b8c5e",
+                    "requirement": "REQUIRED",
+                    "displayName": "Reset Password",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                    ],
+                    "configurable": False,
+                    "providerId": "reset-password",
+                    "level": 0,
+                    "index": 0,
+                },
+                {
+                    "id": "d0c3d9fa-92c7-4b90-a1c1-515ccea9a0ee",
+                    "requirement": "REQUIRED",
+                    "displayName": "Browser - Conditional OTP",
+                    "requirementChoices": [
+                        "REQUIRED",
+                        "ALTERNATIVE",
+                        "DISABLED",
+                        "CONDITIONAL",
+                    ],
+                    "configurable": False,
+                    "authenticationFlow": True,
+                    "flowId": "9491b181-450a-4753-b563-5900eb9d957b",
+                    "level": 0,
+                    "index": 1,
+                },
+            ],
+        ]
+
         changed = True
 
         set_module_args(module_args)
 
         # Run the module
-
         with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+            with patch_keycloak_api(
+                get_authentication_flow_by_alias=return_value_authentication_flow,
+                get_authentication_executions=return_value_authentication_execution,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 0)
-        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 3)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 1)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 1)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
 
-    def test_delete_auth_flow_idempotency(self):
-        """Delete second time authentication flow to test idempotency"""
+    def test_delete_authentication_flow(self):
+        """Delete an existing authentication flow."""
 
         module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'state': 'absent',
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "flow": {
+                "alias": "Test create authentication flow",
+            },
+            "realm": "master",
+            "state": "absent",
         }
-        return_value_auth_flow_before = [{}]
+
+        return_value_authentication_flow = [
+            {
+                "id": "b0c64a16-acf6-4600-9dfc-db37a4801d9d",
+                "alias": "Test create authentication flow",
+                "description": "This is a test authentication flow.",
+                "providerId": "basic-flow",
+                "topLevel": True,
+                "builtIn": False,
+                "authenticationExecutions": [
+                    {
+                        "authenticator": "reset-password",
+                        "requirement": "REQUIRED",
+                        "priority": 0,
+                        "authenticatorFlow": False,
+                        "userSetupAllowed": False,
+                    },
+                ],
+            },
+        ]
+
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_authentication_flow_by_alias=return_value_authentication_flow,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_delete_authentication_flow_idempotency(self):
+        """Delete a non-existing authentication flow."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "flow": {
+                "alias": "Test create authentication flow",
+            },
+            "realm": "master",
+            "state": "absent",
+        }
+
+        return_value_authentication_flow = [
+            {},
+        ]
+
         changed = False
 
         set_module_args(module_args)
 
         # Run the module
-
         with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+            with patch_keycloak_api(
+                get_authentication_flow_by_alias=return_value_authentication_flow,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         # Verify number of call on each mock
         self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
         self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)
 
-    def test_force_update_auth_flow(self):
-        """Delete authentication flow and create new one"""
+    def test_register_required_action(self):
+        """Register a new required action."""
 
         module_args = {
-            'auth_keycloak_url': 'http://keycloak.url/auth',
-            'auth_username': 'admin',
-            'auth_password': 'admin',
-            'auth_realm': 'master',
-            'realm': 'realm-name',
-            'alias': 'Test create authentication flow copy',
-            'authenticationExecutions': [
-                {
-                    'providerId': 'identity-provider-redirector',
-                    'requirement': 'ALTERNATIVE',
-                    'authenticationConfig': {
-                        'alias': 'name',
-                        'config': {
-                            'defaultProvider': 'value'
-                        },
-                    },
-                },
-            ],
-            'state': 'present',
-            'force': 'yes',
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+            },
+            "realm": "master",
+            "state": "present",
         }
-        return_value_auth_flow_before = [{
-            'id': '71275d5e-e11f-4be4-b119-0abfa87987a4',
-            'alias': 'Test create authentication flow copy',
-            'description': '',
-            'providerId': 'basic-flow',
-            'topLevel': True,
-            'builtIn': False,
-            'authenticationExecutions': [
-                {
-                    'authenticator': 'auth-cookie',
-                    'requirement': 'ALTERNATIVE',
-                    'priority': 0,
-                    'userSetupAllowed': False,
-                    'autheticatorFlow': False
-                },
-            ],
-        }]
-        return_value_created_empty_flow = [
+
+        return_value_required_action = [
+            {},
             {
-                "alias": "Test of the keycloak_auth module",
-                "authenticationExecutions": [],
-                "builtIn": False,
-                "description": "",
-                "id": "513f5baa-cc42-47bf-b4b6-1d23ccc0a67f",
-                "providerId": "basic-flow",
-                "topLevel": True
+                "alias": "TEST_REQUIRED_ACTION",
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "defaultAction": False,
+                "priority": 0,
+                "config": {},
             },
         ]
-        return_value_executions_after = [
-            {
-                'id': 'b678e30c-8469-40a7-8c21-8d0cda76a591',
-                'requirement': 'DISABLED',
-                'displayName': 'Identity Provider Redirector',
-                'requirementChoices': ['REQUIRED', 'DISABLED'],
-                'configurable': True,
-                'providerId': 'identity-provider-redirector',
-                'level': 0,
-                'index': 0
-            },
-        ]
+
         changed = True
 
         set_module_args(module_args)
 
         # Run the module
-
         with mock_good_connection():
-            with patch_keycloak_api(get_authentication_flow_by_alias=return_value_auth_flow_before,
-                                    get_executions_representation=return_value_executions_after, create_empty_auth_flow=return_value_created_empty_flow) \
-                    as (mock_get_authentication_flow_by_alias, mock_copy_auth_flow, mock_create_empty_auth_flow,
-                        mock_get_executions_representation, mock_delete_authentication_flow_by_id):
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
                 with self.assertRaises(AnsibleExitJson) as exec_info:
                     self.module.main()
 
         # Verify number of call on each mock
-        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 1)
-        self.assertEqual(len(mock_copy_auth_flow.mock_calls), 0)
-        self.assertEqual(len(mock_create_empty_auth_flow.mock_calls), 1)
-        self.assertEqual(len(mock_get_executions_representation.mock_calls), 3)
-        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 1)
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 2)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_register_required_action_idempotency(self):
+        """Register a new required action, even though it already is registered."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+            },
+            "realm": "master",
+            "state": "present",
+        }
+
+        return_value_required_action = [
+            {
+                "alias": "TEST_REQUIRED_ACTION",
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "defaultAction": False,
+                "priority": 0,
+                "config": {},
+            },
+        ]
+
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_update_required_action(self):
+        """Updated a registered required action."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+                "enabled": False,
+            },
+            "realm": "master",
+            "state": "present",
+        }
+
+        return_value_required_action = [
+            {
+                "alias": "TEST_REQUIRED_ACTION",
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "defaultAction": False,
+                "priority": 0,
+                "config": {},
+            },
+        ]
+
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_update_required_action_idempotency(self):
+        """Updated a registered required action, even though nothing is going to be updated."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+            },
+            "realm": "master",
+            "state": "present",
+        }
+
+        return_value_required_action = [
+            {
+                "alias": "TEST_REQUIRED_ACTION",
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "defaultAction": False,
+                "priority": 0,
+                "config": {},
+            },
+        ]
+
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_delete_required_action(self):
+        """Delete a registered required action."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+            },
+            "realm": "master",
+            "state": "absent",
+        }
+
+        return_value_required_action = [
+            {
+                "alias": "TEST_REQUIRED_ACTION",
+                "name": "Test required action",
+                "providerId": "TEST_REQUIRED_ACTION",
+                "enabled": True,
+                "defaultAction": False,
+                "priority": 0,
+                "config": {},
+            },
+        ]
+
+        changed = True
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 1)
+
+        # Verify that the module's changed status matches what is expected
+        self.assertIs(exec_info.exception.args[0]['changed'], changed)
+
+    def test_delete_required_action_idempotency(self):
+        """Delete a not registered required action."""
+
+        module_args = {
+            "auth_client_id": "admin-cli",
+            "auth_keycloak_url": "http://keycloak.url/auth",
+            "auth_password": "admin",
+            "auth_realm": "master",
+            "auth_username": "admin",
+            "required_action": {
+                "alias": "TEST_REQUIRED_ACTION",
+            },
+            "realm": "master",
+            "state": "absent",
+        }
+
+        return_value_required_action = [
+            {},
+        ]
+
+        changed = False
+
+        set_module_args(module_args)
+
+        # Run the module
+        with mock_good_connection():
+            with patch_keycloak_api(
+                get_required_action=return_value_required_action,
+            ) as (
+                mock_get_authentication_flow_by_alias,
+                mock_get_authentication_executions,
+                mock_update_authentication_flow,
+                mock_copy_authentication_flow,
+                mock_create_authentication_flow,
+                mock_get_realm_info_by_id,
+                mock_update_realm,
+                mock_update_authentication_execution,
+                mock_change_execution_priority,
+                mock_create_authentication_execution_subflow,
+                mock_create_authentication_execution_step,
+                mock_get_authenticator_config,
+                mock_update_authenticator_config,
+                mock_create_authenticator_config,
+                mock_get_required_action,
+                mock_update_required_action,
+                mock_register_required_action,
+                mock_delete_authentication_flow_by_id,
+                mock_delete_required_action,
+            ):
+                with self.assertRaises(AnsibleExitJson) as exec_info:
+                    self.module.main()
+
+        # Verify number of call on each mock
+        self.assertEqual(len(mock_get_authentication_flow_by_alias.mock_calls), 0)
+        self.assertEqual(len(mock_get_authentication_executions.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_copy_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_flow.mock_calls), 0)
+        self.assertEqual(len(mock_get_realm_info_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_update_realm.mock_calls), 0)
+        self.assertEqual(len(mock_update_authentication_execution.mock_calls), 0)
+        self.assertEqual(len(mock_change_execution_priority.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_subflow.mock_calls), 0)
+        self.assertEqual(len(mock_create_authentication_execution_step.mock_calls), 0)
+        self.assertEqual(len(mock_get_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_update_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_create_authenticator_config.mock_calls), 0)
+        self.assertEqual(len(mock_get_required_action.mock_calls), 1)
+        self.assertEqual(len(mock_update_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_register_required_action.mock_calls), 0)
+        self.assertEqual(len(mock_delete_authentication_flow_by_id.mock_calls), 0)
+        self.assertEqual(len(mock_delete_required_action.mock_calls), 0)
 
         # Verify that the module's changed status matches what is expected
         self.assertIs(exec_info.exception.args[0]['changed'], changed)


### PR DESCRIPTION
##### SUMMARY
This is basically a complete rework of the current **keycloak_authentication** module, that until now, was quite limited (in the way of handling and searching for the right flow or execution). With this new module you can:
- Flow:
  - Create, create a new flow from a copy of an existing flow, update a flow, and delete a flow.
  - Add or update an execution (step or sub-flow).
- Required action:
  - Register, update and delete a required action.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_authentication

##### ADDITIONAL INFORMATION
Deletion of an execution (step or sub-flow) is still not supported. (Might add later on.)

The biggest issue I've found, is that Keycloak has a really cumbersome way of identifying different flows and executions. If the user doesn't have the ID, there's no guarantee, that the user can find the exact one (since there can be duplicates of some executions differing only by ID, etc.). This module thus does a "best-effort" search, by using the input parameters of the user, and tries to find the closest match (which is also an improvement of the previous version of this module).

Some new or reworked methods for calling the Keycloak API are introduced (**keycloak** module). Also, a new set of unit tests is included (**test_keycloak_authentication**).