### PR TITLE
Support for simpleinit-msb init system

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1179,6 +1179,8 @@ files:
     ignore: ryansb
   $modules/shutdown.py:
     maintainers: nitzmahone samdoran aminvakil
+  $modules/simpleinit_msb.py:
+    maintainers: vaygr
   $modules/sl_vm.py:
     maintainers: mcltn
   $modules/slack.py:

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -215,7 +215,7 @@ class SimpleinitMSB(object):
 
         rc_state, stdout, stderr = self.execute_command("%s %s" % (svc_cmd, self.action))
 
-        return(rc_state, stdout, stderr)
+        return (rc_state, stdout, stderr)
 
 
 def main():

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -42,7 +42,7 @@ options:
             commands unless necessary.  V(restarted) will always bounce the
             service.  V(reloaded) will always reload.
           - At least one of O(state) and O(enabled) are required.
-          - Note that reloaded will start the
+          - Note that V(reloaded) will start the
             service if it is not already started, even if your chosen init
             system would not normally.
     enabled:

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -77,24 +77,10 @@ EXAMPLES = '''
     enabled: yes
 '''
 
-import glob
 import os
-import platform
 import re
-import select
-import shlex
-import string
-import subprocess
-import tempfile
-import time
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.service import fail_if_missing
 
 
 class SimpleinitMSB(object):

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -14,7 +14,8 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: simpleinit_msb
-short_description: manage services on Source Mage GNU/Linux
+short_description: Manage services on Source Mage GNU/Linux
+version_added: 7.1.0
 description:
     - Controls services on remote hosts using simpleinit-msb
 author: "Vlad Glagolev (@vaygr)"

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -38,10 +38,11 @@ options:
         required: false
         choices: [ running, started, stopped, restarted, reloaded ]
         description:
-          - C(started)/C(stopped) are idempotent actions that will not run
-            commands unless necessary.  C(restarted) will always bounce the
-            service.  C(reloaded) will always reload. B(At least one of state
-            and enabled are required.) Note that reloaded will start the
+          - V(started)/V(stopped) are idempotent actions that will not run
+            commands unless necessary.  V(restarted) will always bounce the
+            service.  V(reloaded) will always reload.
+          - At least one of O(state) and O(enabled) are required.
+          - Note that reloaded will start the
             service if it is not already started, even if your chosen init
             system would not normally.
     enabled:

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -192,25 +192,6 @@ class SimpleinitMSB(object):
 
         return (rc, out, err)
 
-        #
-        # If we've gotten to the end, the service needs to be updated
-        #
-        self.changed = True
-
-        args = (self.telinit_cmd, self.name, action)
-
-        if self.module.check_mode:
-            self.module.exit_json(changed=self.changed)
-
-        (rc, out, err) = self.execute_command("%s %s %s" % args)
-        if rc != 0:
-            if err:
-                self.module.fail_json(msg="Error when trying to %s %s: rc=%s %s" % (action, self.name, rc, err))
-            else:
-                self.module.fail_json(msg="Failure for %s %s: rc=%s %s" % (action, self.name, rc, out))
-
-        return (rc, out, err)
-
     def service_exists(self):
         (rc, out, err) = self.execute_command("%s list" % self.telinit_cmd)
 

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -17,7 +17,7 @@ module: simpleinit_msb
 short_description: Manage services on Source Mage GNU/Linux
 version_added: 7.1.0
 description:
-    - Controls services on remote hosts using simpleinit-msb
+    - Controls services on remote hosts using C(simpleinit-msb).
 author: "Vlad Glagolev (@vaygr)"
 extends_documentation_fragment:
     - community.general.attributes

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -54,8 +54,8 @@ options:
 '''
 
 EXAMPLES = '''
-# Example action to start service httpd, if not running
-- community.general.simpleinit_msb:
+- name: Example action to start service httpd, if not running
+  community.general.simpleinit_msb:
     name: httpd
     state: started
 

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -216,7 +216,7 @@ class SimpleinitMSB(object):
 
         service_exists = False
 
-        rex = re.compile('^\w+\s+%s$' % self.name)
+        rex = re.compile(r'^\w+\s+%s$' % self.name)
 
         for line in out.splitlines():
             if rex.match(line):

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -43,8 +43,8 @@ options:
             service if it is not already started, even if your chosen init
             system wouldn't normally.
     enabled:
+        type: bool
         required: false
-        choices: [ "yes", "no" ]
         description:
         - Whether the service should start on boot. B(At least one of state and
           enabled are required.)
@@ -89,15 +89,15 @@ class SimpleinitMSB(object):
     """
 
     def __init__(self, module):
-        self.module         = module
-        self.name           = module.params['name']
-        self.state          = module.params['state']
-        self.enable         = module.params['enabled']
-        self.changed        = False
-        self.running        = None
-        self.action         = None
-        self.telinit_cmd    = None
-        self.svc_change     = False
+        self.module = module
+        self.name = module.params['name']
+        self.state = module.params['state']
+        self.enable = module.params['enabled']
+        self.changed = False
+        self.running = None
+        self.action = None
+        self.telinit_cmd = None
+        self.svc_change = False
 
     def execute_command(self, cmd):
         return self.module.run_command(cmd)
@@ -238,10 +238,10 @@ class SimpleinitMSB(object):
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            name = dict(required=True, aliases=['service']),
-            state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
-            enabled = dict(type='bool'),
+        argument_spec=dict(
+            name=dict(required=True, aliases=['service']),
+            state=dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
+            enabled=dict(type='bool'),
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled']],

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -33,6 +33,7 @@ options:
         required: true
         aliases: ['service']
     state:
+        type: str
         required: false
         choices: [ running, started, stopped, restarted, reloaded ]
         description:

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -83,6 +83,7 @@ import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.service import daemonize
 
 
 class SimpleinitMSB(object):
@@ -101,8 +102,11 @@ class SimpleinitMSB(object):
         self.telinit_cmd = None
         self.svc_change = False
 
-    def execute_command(self, cmd):
-        return self.module.run_command(cmd)
+    def execute_command(self, cmd, daemon=False):
+        if not daemon:
+            return self.module.run_command(cmd)
+        else:
+            return daemonize(self.module, cmd)
 
     def check_service_changed(self):
         if self.state and self.running is None:
@@ -214,7 +218,7 @@ class SimpleinitMSB(object):
 
         svc_cmd = "%s run %s" % (self.telinit_cmd, self.name)
 
-        rc_state, stdout, stderr = self.execute_command("%s %s" % (svc_cmd, self.action))
+        rc_state, stdout, stderr = self.execute_command("%s %s" % (svc_cmd, self.action), daemon=True)
 
         return (rc_state, stdout, stderr)
 

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016-2023, Vlad Glagolev <scm@vaygr.net>
+#
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: simpleinit_msb
+short_description: manage services on Source Mage GNU/Linux
+description:
+    - Controls services on remote hosts using simpleinit-msb
+author: "Vlad Glagolev (@vaygr)"
+extends_documentation_fragment:
+    - community.general.attributes
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+options:
+    name:
+        type: str
+        description:
+            - Name of the service.
+        required: true
+        aliases: ['service']
+    state:
+        required: false
+        choices: [ started, stopped, restarted, reloaded ]
+        description:
+          - C(started)/C(stopped) are idempotent actions that will not run
+            commands unless necessary.  C(restarted) will always bounce the
+            service.  C(reloaded) will always reload. B(At least one of state
+            and enabled are required.) Note that reloaded will start the
+            service if it is not already started, even if your chosen init
+            system wouldn't normally.
+    enabled:
+        required: false
+        choices: [ "yes", "no" ]
+        description:
+        - Whether the service should start on boot. B(At least one of state and
+          enabled are required.)
+'''
+
+EXAMPLES = '''
+# Example action to start service httpd, if not running
+- community.general.simpleinit_msb:
+    name: httpd
+    state: started
+
+# Example action to stop service httpd, if running
+- community.general.simpleinit_msb:
+    name: httpd
+    state: stopped
+
+# Example action to restart service httpd, in all cases
+- community.general.simpleinit_msb:
+    name: httpd
+    state: restarted
+
+# Example action to reload service httpd, in all cases
+- community.general.simpleinit_msb:
+    name: httpd
+    state: reloaded
+
+# Example action to enable service httpd, and not touch the running state
+- community.general.simpleinit_msb:
+    name: httpd
+    enabled: yes
+'''
+
+import glob
+import os
+import platform
+import re
+import select
+import shlex
+import string
+import subprocess
+import tempfile
+import time
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.service import fail_if_missing
+
+
+class SimpleinitMSB(object):
+    """
+    Main simpleinit-msb service manipulation class
+    """
+
+    def __init__(self, module):
+        self.module         = module
+        self.name           = module.params['name']
+        self.state          = module.params['state']
+        self.enable         = module.params['enabled']
+        self.changed        = False
+        self.running        = None
+        self.action         = None
+        self.telinit_cmd    = None
+        self.svc_change     = False
+
+    def execute_command(self, cmd):
+        return self.module.run_command(cmd)
+
+    def check_service_changed(self):
+        if self.state and self.running is None:
+            self.module.fail_json(msg="failed determining service state, possible typo of service name?")
+        # Find out if state has changed
+        if not self.running and self.state in ["started", "running", "reloaded"]:
+            self.svc_change = True
+        elif self.running and self.state in ["stopped", "reloaded"]:
+            self.svc_change = True
+        elif self.state == "restarted":
+            self.svc_change = True
+        if self.module.check_mode and self.svc_change:
+            self.module.exit_json(changed=True, msg='service state changed')
+
+    def modify_service_state(self):
+        # Only do something if state will change
+        if self.svc_change:
+            # Control service
+            if self.state in ['started', 'running']:
+                self.action = "start"
+            elif not self.running and self.state == 'reloaded':
+                self.action = "start"
+            elif self.state == 'stopped':
+                self.action = "stop"
+            elif self.state == 'reloaded':
+                self.action = "reload"
+            elif self.state == 'restarted':
+                self.action = "restart"
+
+            if self.module.check_mode:
+                self.module.exit_json(changed=True, msg='changing service state')
+
+            return self.service_control()
+        else:
+            # If nothing needs to change just say all is well
+            rc = 0
+            err = ''
+            out = ''
+            return rc, out, err
+
+    def get_service_tools(self):
+        paths = ['/sbin', '/usr/sbin', '/bin', '/usr/bin']
+        binaries = ['telinit']
+        location = dict()
+
+        for binary in binaries:
+            location[binary] = self.module.get_bin_path(binary, opt_dirs=paths)
+
+        if location.get('telinit', False) and os.path.exists("/etc/init.d/smgl_init"):
+            self.telinit_cmd = location['telinit']
+
+        if self.telinit_cmd is None:
+            self.module.fail_json(msg='cannot find telinit script for simpleinit-msb, aborting...')
+
+    def get_service_status(self):
+        self.action = "status"
+        rc, status_stdout, status_stderr = self.service_control()
+
+        if self.running is None and status_stdout.count('\n') <= 1:
+            cleanout = status_stdout.lower().replace(self.name.lower(), '')
+
+            if "is not running" in cleanout:
+                self.running = False
+            elif "is running" in cleanout:
+                self.running = True
+
+        return self.running
+
+    def service_enable(self):
+        self.changed = True
+        action = None
+
+        self.service_exists()
+
+        action = "boot" + ("enable" if self.enable else "disable")
+
+        (rc, out, err) = self.execute_command("%s %s %s" % (self.telinit_cmd, action, self.name))
+
+        for line in err.splitlines():
+            if self.enable and line.find('already enabled') != -1:
+                self.changed = False
+                break
+            if not self.enable and line.find('already disabled') != -1:
+                self.changed = False
+                break
+
+        if not self.changed:
+            return
+
+        return (rc, out, err)
+
+        #
+        # If we've gotten to the end, the service needs to be updated
+        #
+        self.changed = True
+
+        args = (self.telinit_cmd, self.name, action)
+
+        if self.module.check_mode:
+            self.module.exit_json(changed=self.changed)
+
+        (rc, out, err) = self.execute_command("%s %s %s" % args)
+        if rc != 0:
+            if err:
+                self.module.fail_json(msg="Error when trying to %s %s: rc=%s %s" % (action, self.name, rc, err))
+            else:
+                self.module.fail_json(msg="Failure for %s %s: rc=%s %s" % (action, self.name, rc, out))
+
+        return (rc, out, err)
+
+    def service_exists(self):
+        (rc, out, err) = self.execute_command("%s list" % self.telinit_cmd)
+
+        service_exists = False
+
+        rex = re.compile('^\w+\s+%s$' % self.name)
+
+        for line in out.splitlines():
+            if rex.match(line):
+                service_exists = True
+                break
+
+        if not service_exists:
+            self.module.fail_json(msg='telinit could not find the requested service: %s' % self.name)
+
+    def service_control(self):
+        self.service_exists()
+
+        svc_cmd = "%s run %s" % (self.telinit_cmd, self.name)
+
+        rc_state, stdout, stderr = self.execute_command("%s %s" % (svc_cmd, self.action))
+
+        return(rc_state, stdout, stderr)
+
+# ===========================================
+# Main control flow
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True, aliases=['service']),
+            state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
+            enabled = dict(type='bool'),
+        ),
+        supports_check_mode=True,
+        required_one_of=[['state', 'enabled']],
+    )
+
+    service = SimpleinitMSB(module)
+
+    rc = 0
+    out = ''
+    err = ''
+    result = {}
+    result['name'] = service.name
+
+    # Find service management tools
+    service.get_service_tools()
+
+    # Enable/disable service startup at boot if requested
+    if service.module.params['enabled'] is not None:
+        # FIXME: ideally this should detect if we need to toggle the enablement state, though
+        # it's unlikely the changed handler would need to fire in this case so it's a minor thing.
+        service.service_enable()
+        result['enabled'] = service.enable
+
+    if module.params['state'] is None:
+        # Not changing the running state, so bail out now.
+        result['changed'] = service.changed
+        module.exit_json(**result)
+
+    result['state'] = service.state
+
+    service.get_service_status()
+
+    # Calculate if request will change service state
+    service.check_service_changed()
+
+    # Modify service state if necessary
+    (rc, out, err) = service.modify_service_state()
+
+    if rc != 0:
+        if err:
+            module.fail_json(msg=err)
+        else:
+            module.fail_json(msg=out)
+
+    result['changed'] = service.changed | service.svc_change
+    if service.module.params['enabled'] is not None:
+        result['enabled'] = service.module.params['enabled']
+
+    if not service.module.params['state']:
+        status = service.get_service_status()
+        if status is None:
+            result['state'] = 'absent'
+        elif status is False:
+            result['state'] = 'started'
+        else:
+            result['state'] = 'stopped'
+    else:
+        # as we may have just bounced the service the service command may not
+        # report accurate state at this moment so just show what we ran
+        if service.module.params['state'] in ['started', 'restarted', 'running', 'reloaded']:
+            result['state'] = 'started'
+        else:
+            result['state'] = 'stopped'
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -59,23 +59,23 @@ EXAMPLES = '''
     name: httpd
     state: started
 
-# Example action to stop service httpd, if running
-- community.general.simpleinit_msb:
+- name: Example action to stop service httpd, if running
+  community.general.simpleinit_msb:
     name: httpd
     state: stopped
 
-# Example action to restart service httpd, in all cases
-- community.general.simpleinit_msb:
+- name: Example action to restart service httpd, in all cases
+  community.general.simpleinit_msb:
     name: httpd
     state: restarted
 
-# Example action to reload service httpd, in all cases
-- community.general.simpleinit_msb:
+- name: Example action to reload service httpd, in all cases
+  community.general.simpleinit_msb:
     name: httpd
     state: reloaded
 
-# Example action to enable service httpd, and not touch the running state
-- community.general.simpleinit_msb:
+- name: Example action to enable service httpd, and not touch the running state
+  community.general.simpleinit_msb:
     name: httpd
     enabled: true
 '''

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -224,8 +224,8 @@ class SimpleinitMSB(object):
         return (rc_state, stdout, stderr)
 
 
-def main():
-    module = AnsibleModule(
+def build_module():
+    return AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, aliases=['service']),
             state=dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
@@ -234,6 +234,10 @@ def main():
         supports_check_mode=True,
         required_one_of=[['state', 'enabled']],
     )
+
+
+def main():
+    module = build_module()
 
     service = SimpleinitMSB(module)
 

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -49,8 +49,8 @@ options:
         type: bool
         required: false
         description:
-        - Whether the service should start on boot. B(At least one of state and
-          enabled are required.)
+        - Whether the service should start on boot.
+        - At least one of O(state) and O(enabled) are required.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -34,7 +34,7 @@ options:
         aliases: ['service']
     state:
         required: false
-        choices: [ started, stopped, restarted, reloaded ]
+        choices: [ running, started, stopped, restarted, reloaded ]
         description:
           - C(started)/C(stopped) are idempotent actions that will not run
             commands unless necessary.  C(restarted) will always bounce the
@@ -235,8 +235,6 @@ class SimpleinitMSB(object):
 
         return(rc_state, stdout, stderr)
 
-# ===========================================
-# Main control flow
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -43,7 +43,7 @@ options:
             service.  C(reloaded) will always reload. B(At least one of state
             and enabled are required.) Note that reloaded will start the
             service if it is not already started, even if your chosen init
-            system wouldn't normally.
+            system would not normally.
     enabled:
         type: bool
         required: false

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 # Example action to enable service httpd, and not touch the running state
 - community.general.simpleinit_msb:
     name: httpd
-    enabled: yes
+    enabled: true
 '''
 
 import os

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -15,9 +15,11 @@ DOCUMENTATION = '''
 ---
 module: simpleinit_msb
 short_description: Manage services on Source Mage GNU/Linux
-version_added: 7.3.0
+version_added: 7.5.0
 description:
   - Controls services on remote hosts using C(simpleinit-msb).
+requirements:
+  - ansible-core 2.15.5 or newer
 author: "Vlad Glagolev (@vaygr)"
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -18,8 +18,8 @@ short_description: Manage services on Source Mage GNU/Linux
 version_added: 7.5.0
 description:
   - Controls services on remote hosts using C(simpleinit-msb).
-requirements:
-  - ansible-core 2.15.5 or newer
+notes:
+  - This module needs ansible-core 2.15.5 or newer. Older versions have a broken and insufficient daemonize functionality.
 author: "Vlad Glagolev (@vaygr)"
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: simpleinit_msb
 short_description: Manage services on Source Mage GNU/Linux
-version_added: 7.1.0
+version_added: 7.3.0
 description:
   - Controls services on remote hosts using C(simpleinit-msb).
 author: "Vlad Glagolev (@vaygr)"

--- a/plugins/modules/simpleinit_msb.py
+++ b/plugins/modules/simpleinit_msb.py
@@ -17,40 +17,40 @@ module: simpleinit_msb
 short_description: Manage services on Source Mage GNU/Linux
 version_added: 7.1.0
 description:
-    - Controls services on remote hosts using C(simpleinit-msb).
+  - Controls services on remote hosts using C(simpleinit-msb).
 author: "Vlad Glagolev (@vaygr)"
 extends_documentation_fragment:
-    - community.general.attributes
+  - community.general.attributes
 attributes:
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
 options:
-    name:
-        type: str
-        description:
-            - Name of the service.
-        required: true
-        aliases: ['service']
-    state:
-        type: str
-        required: false
-        choices: [ running, started, stopped, restarted, reloaded ]
-        description:
-          - V(started)/V(stopped) are idempotent actions that will not run
-            commands unless necessary.  V(restarted) will always bounce the
-            service.  V(reloaded) will always reload.
-          - At least one of O(state) and O(enabled) are required.
-          - Note that V(reloaded) will start the
-            service if it is not already started, even if your chosen init
-            system would not normally.
-    enabled:
-        type: bool
-        required: false
-        description:
-        - Whether the service should start on boot.
-        - At least one of O(state) and O(enabled) are required.
+  name:
+    type: str
+    description:
+      - Name of the service.
+    required: true
+    aliases: ['service']
+  state:
+    type: str
+    required: false
+    choices: [ running, started, stopped, restarted, reloaded ]
+    description:
+      - V(started)/V(stopped) are idempotent actions that will not run
+        commands unless necessary.  V(restarted) will always bounce the
+        service.  V(reloaded) will always reload.
+      - At least one of O(state) and O(enabled) are required.
+      - Note that V(reloaded) will start the
+        service if it is not already started, even if your chosen init
+        system would not normally.
+  enabled:
+    type: bool
+    required: false
+    description:
+      - Whether the service should start on boot.
+      - At least one of O(state) and O(enabled) are required.
 '''
 
 EXAMPLES = '''

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -106,8 +106,10 @@ class TestSimpleinitMSB(ModuleTestCase):
 
         execute_command.return_value = (0, _TELINIT_LIST, "")
 
-        with self.assertRaises(AnsibleFailJson):
+        with self.assertRaises(AnsibleFailJson) as context:
             simpleinit_msb.service_exists()
+
+        self.assertEqual("telinit could not find the requested service: ntp", context.exception.args[0]["msg"])
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -37,11 +37,11 @@ S        smgl-metalog
 S        smgl-sysctl
 """
 
-_TELINIT_ENABLE = """
+_TELINIT_ENABLED = """
 Service smgl-suspend-single already enabled.
 """
 
-_TELINIT_DISABLE = """
+_TELINIT_DISABLED = """
 Service smgl-suspend-single already disabled.
 """
 
@@ -92,6 +92,46 @@ class TestSimpleinitMSB(ModuleTestCase):
 
         with self.assertRaises(AnsibleFailJson):
             simpleinit_msb.service_exists()
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
+    def test_check_service_enabled(self, execute_command, service_exists):
+        set_module_args({
+            'name': 'nscd',
+            'state': 'running',
+            'enabled': 'true',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        service_exists.return_value = True
+        execute_command.return_value = (0, "", _TELINIT_ENABLED)
+
+        simpleinit_msb.service_enable()
+
+        self.assertFalse(simpleinit_msb.changed)
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
+    def test_check_service_disabled(self, execute_command, service_exists):
+        set_module_args({
+            'name': 'nscd',
+            'state': 'stopped',
+            'enabled': 'false',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        service_exists.return_value = True
+        execute_command.return_value = (0, "", _TELINIT_DISABLED)
+
+        simpleinit_msb.service_enable()
+
+        self.assertFalse(simpleinit_msb.changed)
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
     def test_check_service_running(self, service_control):

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.module_utils import basic
 from ansible_collections.community.general.tests.unit.compat.mock import patch
 from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleFailJson, ModuleTestCase, set_module_args
 

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -62,6 +62,22 @@ class TestSimpleinitMSB(ModuleTestCase):
     def tearDown(self):
         super(TestSimpleinitMSB, self).tearDown()
 
+    @patch('os.path.exists', return_value=True)
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path', return_value="/sbin/telinit")
+    def test_get_service_tools(self, *args, **kwargs):
+        set_module_args({
+            'name': 'smgl-suspend-single',
+            'state': 'running',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        simpleinit_msb.get_service_tools()
+
+        self.assertEqual(simpleinit_msb.telinit_cmd, "/sbin/telinit")
+
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_service_exists(self, execute_command):
         set_module_args({

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023 Vlad Glagolev <scm@vaygr.net>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.module_utils import basic
+from ansible_collections.community.general.tests.unit.compat.mock import patch
+from ansible_collections.community.general.tests.unit.plugins.modules.utils import AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible_collections.community.general.plugins.modules.simpleinit_msb import SimpleinitMSB, build_module
+
+
+_TELINIT_LIST = """
+RUNLEVEL SCRIPT
+2        smgl-suspend-single
+3        crond
+3        fuse
+3        network
+3        nscd
+3        smgl-default-remote-fs
+3        smgl-misc
+3        sshd
+DEV        coldplug
+DEV        devices
+DEV        udevd
+S        hostname.sh
+S        hwclock.sh
+S        keymap.sh
+S        modutils
+S        mountall.sh
+S        mountroot.sh
+S        single
+S        smgl-default-crypt-fs
+S        smgl-metalog
+S        smgl-sysctl
+"""
+
+_TELINIT_ENABLE = """
+Service smgl-suspend-single already enabled.
+"""
+
+_TELINIT_DISABLE = """
+Service smgl-suspend-single already disabled.
+"""
+
+_TELINIT_STATUS_RUNNING = """
+sshd is running with Process ID(s) 8510 8508 2195
+"""
+
+_TELINIT_STATUS_RUNNING_NOT = """
+/sbin/metalog is not running
+"""
+
+
+class TestSimpleinitMSB(ModuleTestCase):
+
+    def setUp(self):
+        super(TestSimpleinitMSB, self).setUp()
+
+    def tearDown(self):
+        super(TestSimpleinitMSB, self).tearDown()
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
+    def test_service_exists(self, execute_command):
+        set_module_args({
+            'name': 'smgl-suspend-single',
+            'state': 'running',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        execute_command.return_value = (0, _TELINIT_LIST, "")
+
+        simpleinit_msb.service_exists()
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
+    def test_service_exists_not(self, execute_command):
+        set_module_args({
+            'name': 'ntp',
+            'state': 'running',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        execute_command.return_value = (0, _TELINIT_LIST, "")
+
+        with self.assertRaises(AnsibleFailJson):
+            simpleinit_msb.service_exists()
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
+    def test_check_service_running(self, service_control):
+        set_module_args({
+            'name': 'sshd',
+            'state': 'running',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        service_control.return_value = (0, _TELINIT_STATUS_RUNNING, "")
+
+        self.assertFalse(simpleinit_msb.get_service_status())
+
+    @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
+    def test_check_service_running_not(self, service_control):
+        set_module_args({
+            'name': 'smgl-metalog',
+            'state': 'running',
+        })
+
+        module = build_module()
+
+        simpleinit_msb = SimpleinitMSB(module)
+
+        service_control.return_value = (0, _TELINIT_STATUS_RUNNING_NOT, "")
+
+        self.assertFalse(simpleinit_msb.get_service_status())

--- a/tests/unit/plugins/modules/test_simpleinit_msb.py
+++ b/tests/unit/plugins/modules/test_simpleinit_msb.py
@@ -62,17 +62,18 @@ class TestSimpleinitMSB(ModuleTestCase):
     def tearDown(self):
         super(TestSimpleinitMSB, self).tearDown()
 
+    def init_module(self, args):
+        set_module_args(args)
+
+        return SimpleinitMSB(build_module())
+
     @patch('os.path.exists', return_value=True)
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path', return_value="/sbin/telinit")
     def test_get_service_tools(self, *args, **kwargs):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'smgl-suspend-single',
             'state': 'running',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         simpleinit_msb.get_service_tools()
 
@@ -80,14 +81,10 @@ class TestSimpleinitMSB(ModuleTestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_service_exists(self, execute_command):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'smgl-suspend-single',
             'state': 'running',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         execute_command.return_value = (0, _TELINIT_LIST, "")
 
@@ -95,14 +92,10 @@ class TestSimpleinitMSB(ModuleTestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_service_exists_not(self, execute_command):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'ntp',
             'state': 'running',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         execute_command.return_value = (0, _TELINIT_LIST, "")
 
@@ -114,15 +107,11 @@ class TestSimpleinitMSB(ModuleTestCase):
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_check_service_enabled(self, execute_command, service_exists):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'nscd',
             'state': 'running',
             'enabled': 'true',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         service_exists.return_value = True
         execute_command.return_value = (0, "", _TELINIT_ENABLED)
@@ -134,15 +123,11 @@ class TestSimpleinitMSB(ModuleTestCase):
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_exists')
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.execute_command')
     def test_check_service_disabled(self, execute_command, service_exists):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'nscd',
             'state': 'stopped',
             'enabled': 'false',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         service_exists.return_value = True
         execute_command.return_value = (0, "", _TELINIT_DISABLED)
@@ -153,14 +138,10 @@ class TestSimpleinitMSB(ModuleTestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
     def test_check_service_running(self, service_control):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'sshd',
             'state': 'running',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         service_control.return_value = (0, _TELINIT_STATUS_RUNNING, "")
 
@@ -168,14 +149,10 @@ class TestSimpleinitMSB(ModuleTestCase):
 
     @patch('ansible_collections.community.general.plugins.modules.simpleinit_msb.SimpleinitMSB.service_control')
     def test_check_service_running_not(self, service_control):
-        set_module_args({
+        simpleinit_msb = self.init_module({
             'name': 'smgl-metalog',
             'state': 'running',
         })
-
-        module = build_module()
-
-        simpleinit_msb = SimpleinitMSB(module)
 
         service_control.return_value = (0, _TELINIT_STATUS_RUNNING_NOT, "")
 


### PR DESCRIPTION
##### SUMMARY

This is a backport of https://github.com/ansible/ansible/pull/19231, support for `simpleinit-msb` -- an init system used in [Source Mage GNU/Linux](https://sourcemage.org/). GitHub mirror [here](https://github.com/sourcemage).

The fact part submitted in https://github.com/ansible/ansible/pull/80963.

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME

`community.general.simpleinit_msb`

##### ADDITIONAL INFORMATION

N/A