### PR TITLE
Improve performance of the bitwarden lookup plugin

### DIFF
--- a/changelogs/fragments/bitwarden-lookup-performance.yaml
+++ b/changelogs/fragments/bitwarden-lookup-performance.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - bitwarden lookup plugin: When looking for items using an item id, the item is now accessed directly with bw get item instead of searching through all items. 
+This doubles the lookup speed.

--- a/changelogs/fragments/bitwarden-lookup-performance.yaml
+++ b/changelogs/fragments/bitwarden-lookup-performance.yaml
@@ -1,3 +1,2 @@
 minor_changes:
-  - bitwarden lookup plugin: When looking for items using an item id, the item is now accessed directly with bw get item instead of searching through all items. 
-This doubles the lookup speed.
+  - "bitwarden lookup plugin - when looking for items using an item ID, the item is now accessed directly with ``bw get item`` instead of searching through all items. This doubles the lookup speed (https://github.com/ansible-collections/community.general/pull/6619)."

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -110,7 +110,10 @@ class Bitwarden(object):
         """
 
         # Prepare set of params for Bitwarden CLI
-        params = ['list', 'items', '--search', search_value]
+        if search_field == 'id':
+          params = ['get', 'item', search_value]
+        else:
+          params = ['list', 'items', '--search', search_value]
 
         if collection_id:
             params.extend(['--collectionid', collection_id])
@@ -119,7 +122,8 @@ class Bitwarden(object):
 
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
-
+        if search_field == 'id':
+          initial_matches = [initial_matches]
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -111,9 +111,9 @@ class Bitwarden(object):
 
         # Prepare set of params for Bitwarden CLI
         if search_field == 'id':
-          params = ['get', 'item', search_value]
+            params = ['get', 'item', search_value]
         else:
-          params = ['list', 'items', '--search', search_value]
+            params = ['list', 'items', '--search', search_value]
 
         if collection_id:
             params.extend(['--collectionid', collection_id])
@@ -123,7 +123,7 @@ class Bitwarden(object):
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
         if search_field == 'id':
-          initial_matches = [initial_matches]
+            initial_matches = [initial_matches]
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 


### PR DESCRIPTION
When looking for items using an item id, we can access the item directly with bw get item instead of searching through all items. This doubles the lookup speed.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
The bitwarden lookup plugin searches through all items using `bw list items --search`, which takes a lot of time. However, when looking for an item using the item id, there is a much faster way: `bw get item  <itemid>`. This PR introduces this method for every lookup that uses the item's id.

Some comparisons:
```
bw list items --search 52c0e9ce***  1,31s user 0,14s system 126% cpu 1,150 total
bw get item 52c0e9ce***  0,59s user 0,10s system 105% cpu 0,655 total
```

Or using a task that runs twelve lookups against a single host:
Before this change: 46.52s
After this change: 25.65s

This is close to double speed.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature/Performance Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
bitwarden
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As `bw list` returns a list, but `bw get` a single item, I choose to put it back into a list to not introduce any breaking changes here.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
