### PR TITLE
MH mh/mixins/deps.py: prevent deprecation warning when no deps are specified

### DIFF
--- a/changelogs/fragments/6644-dependencymixin-fix.yml
+++ b/changelogs/fragments/6644-dependencymixin-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - MH DependencyMixin module utils - deprecation notice was popping up for modules not using dependencies (https://github.com/ansible-collections/community.general/pull/6644, https://github.com/ansible-collections/community.general/issues/6639).

--- a/plugins/module_utils/mh/mixins/deps.py
+++ b/plugins/module_utils/mh/mixins/deps.py
@@ -52,6 +52,8 @@ class DependencyMixin(ModuleHelperBase):
         return cls._dependencies[-1]
 
     def fail_on_missing_deps(self):
+        if not self._dependencies:
+            return
         self.module.deprecate(
             'The DependencyMixin is being deprecated. '
             'Modules should use community.general.plugins.module_utils.deps instead.',

--- a/tests/integration/targets/kernel_blacklist/tasks/main.yml
+++ b/tests/integration/targets/kernel_blacklist/tasks/main.yml
@@ -50,7 +50,7 @@
     expected_content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-License-Identifier: GPL-3.0-or-later
+      # SPDX{{ '' }}-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist bbbb
@@ -77,7 +77,7 @@
     content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-License-Identifier: GPL-3.0-or-later
+      # SPDX{{ '' }}-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist bbbb
@@ -105,7 +105,7 @@
     content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-License-Identifier: GPL-3.0-or-later
+      # SPDX{{ '' }}-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist cccc

--- a/tests/integration/targets/kernel_blacklist/tasks/main.yml
+++ b/tests/integration/targets/kernel_blacklist/tasks/main.yml
@@ -40,6 +40,7 @@
   assert:
     that:
     - bl_test_1 is not changed
+    - "'deprecations' not in bl_test_1"
     - bl_test_1a is not changed
     - orig_stat.stat.size == stat_test_1.stat.size
     - orig_stat.stat.checksum == stat_test_1.stat.checksum
@@ -49,7 +50,7 @@
     expected_content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-{{ '' }}License-Identifier: GPL-3.0-or-later
+      # SPDX-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist bbbb
@@ -76,7 +77,7 @@
     content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-{{ '' }}License-Identifier: GPL-3.0-or-later
+      # SPDX-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist bbbb
@@ -104,7 +105,7 @@
     content: |
       # Copyright (c) Ansible Project
       # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-      # SPDX-{{ '' }}License-Identifier: GPL-3.0-or-later
+      # SPDX-License-Identifier: GPL-3.0-or-later
 
       blacklist aaaa
       blacklist cccc

--- a/tests/integration/targets/kernel_blacklist/tasks/main.yml
+++ b/tests/integration/targets/kernel_blacklist/tasks/main.yml
@@ -36,11 +36,17 @@
     path: '{{ bl_file }}'
   register: stat_test_1
 
+- name: show bl_test_1
+  ansible.builtin.debug:
+    var: bl_test_1_depr_msgs
+  vars:
+    bl_test_1_depr_msgs: "{{ (bl_test_1.deprecations | default([])) | map(attribute='msg') }}"
+    # q('ansible.builtin.subelements', bl_test_1, 'deprecations', {'skip_missing': True}) }}"
+
 - name: assert file is unchanged
   assert:
     that:
     - bl_test_1 is not changed
-    - "'deprecations' not in bl_test_1"
     - bl_test_1a is not changed
     - orig_stat.stat.size == stat_test_1.stat.size
     - orig_stat.stat.checksum == stat_test_1.stat.checksum
@@ -55,6 +61,11 @@
       blacklist aaaa
       blacklist bbbb
       blacklist cccc
+
+- name: test deprecation
+  assert:
+    that:
+    - "'deprecations' not in bl_test_1 or (ansible_version.major == 2 and ansible_version.minor == 12)"
 
 - name: add new item to list
   community.general.kernel_blacklist:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add test to deprecated `DependencyMixin` so that the deprecation warning only pops up when dependencies are actually specified.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6639 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/mh/mixins/deps.py
