### PR TITLE
redhat_subscription: officially deprecate "autosubscribe"

### DIFF
--- a/changelogs/fragments/6646-redhat_subscription-deprecate-autosubscribe.yml
+++ b/changelogs/fragments/6646-redhat_subscription-deprecate-autosubscribe.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+- |
+  redhat_subscription - the ``autosubscribe`` alias for the ``auto_attach`` option has been
+  deprecated for many years, although only in the documentation. Officially mark this alias
+  as deprecated, and it will be removed in community.general 9.0.0
+  (https://github.com/ansible-collections/community.general/pull/6646).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -122,7 +122,10 @@ options:
     auto_attach:
         description:
             - Upon successful registration, auto-consume available subscriptions
-            - Added in favor of deprecated autosubscribe in 2.5.
+            - |
+              Added in favor of the deprecated I(autosubscribe) option in
+              Ansible 2.5; please note that I(autosubscribe) will be removed in
+              community.general 9.0.0.
         type: bool
         aliases: [autosubscribe]
     activationkey:
@@ -1074,7 +1077,17 @@ def main():
             'server_port': {},
             'rhsm_baseurl': {},
             'rhsm_repo_ca_cert': {},
-            'auto_attach': {'aliases': ['autosubscribe'], 'type': 'bool'},
+            'auto_attach': {
+                'type': 'bool',
+                'aliases': ['autosubscribe'],
+                'deprecated_aliases': [
+                    {
+                        'name': 'autosubscribe',
+                        'version': '9.0.0',
+                        'collection_name': 'community.general',
+                    },
+                ],
+            },
             'activationkey': {'no_log': True},
             'org_id': {},
             'environment': {},


### PR DESCRIPTION
##### SUMMARY

The `autosubscribe` alias for the `auto_attach` option has been deprecated for many years, although only in the documentation. Officially mark it as deprecated also in the module parameters spec, slating it for removal in 9.0.0.

The short deprecation time is because of the following reasons:
- `auto_attach` was introduced many years ago, so even if you rely on e.g. Ansible 2.9, that option is there already
- migrating from `autosubscribe` to `auto_attach` is very easy 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

redhat_subscription