### PR TITLE
MH VarsMixin deprecation

### DIFF
--- a/changelogs/fragments/6649-varsmixin-deprecation.yml
+++ b/changelogs/fragments/6649-varsmixin-deprecation.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - MH VarsMixin module utils - deprecates ``VarsMixin`` and supporting classes in favor of plain ``vardict`` module util (https://github.com/ansible-collections/community.general/pull/6649).

--- a/plugins/module_utils/mh/mixins/vars.py
+++ b/plugins/module_utils/mh/mixins/vars.py
@@ -11,6 +11,13 @@ import copy
 
 
 class VarMeta(object):
+    """
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 10.0.0
+    Modules should use the VarDict from plugins/module_utils/vardict.py instead.
+    """
+
     NOTHING = object()
 
     def __init__(self, diff=False, output=True, change=None, fact=False):
@@ -60,6 +67,12 @@ class VarMeta(object):
 
 
 class VarDict(object):
+    """
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 10.0.0
+    Modules should use the VarDict from plugins/module_utils/vardict.py instead.
+    """
     def __init__(self):
         self._data = dict()
         self._meta = dict()
@@ -123,7 +136,12 @@ class VarDict(object):
 
 
 class VarsMixin(object):
+    """
+    DEPRECATION WARNING
 
+    This class is deprecated and will be removed in community.general 10.0.0
+    Modules should use the VarDict from plugins/module_utils/vardict.py instead.
+    """
     def __init__(self, module=None):
         self.vars = VarDict()
         super(VarsMixin, self).__init__(module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deprecate the classes `VarsMixin`, `VarDict` and `VarMeta` from the file `plugins/module_utils/mh/mixins/vars.py`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/mh/mixins/vars.py
