### PR TITLE
redhat_subscription: refactor of internal Rhsm class

### DIFF
--- a/changelogs/fragments/6658-redhat_subscription-internal-rhsm-refactor.yml
+++ b/changelogs/fragments/6658-redhat_subscription-internal-rhsm-refactor.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - |
+    redhat_subscription - the internal ``RegistrationBase`` class was folded
+    into the other internal ``Rhsm`` class, as the separation had no purpose
+    anymore
+    (https://github.com/ansible-collections/community.general/pull/6658).

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -22,7 +22,7 @@ def patch_redhat_subscription(mocker):
     """
     Function used for mocking some parts of redhat_subscription module
     """
-    mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.RegistrationBase.REDHAT_REPO')
+    mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.Rhsm.REDHAT_REPO')
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.isfile', return_value=False)
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.unlink', return_value=True)
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.AnsibleModule.get_bin_path',


### PR DESCRIPTION
##### SUMMARY

The two `RegistrationBase` & `Rhsm` classes were copied from the ones in the shared `module_utils.redhat` module; that said:
- the versions here got improvements over the years
- the `RegistrationBase` in `module_utils.redhat` is used only by the RHN modules, which are deprecated and slated for removal

Hence, the classes here can be kept and simplified a bit:
- fold the non-dummy content of `RegistrationBase` into `Rhsm`: there is no more need for the separate `RegistrationBase` base class
- drop the init arguments `username`, `password`, and `token`: the instance variables of them are not used anywhere, as the needed credentials (together with other variables) are passed to the `register()` method
- create the `Rhsm` object later in `main()`, after the `AnsibleModule` creation and the uid check: this avoids the creation of `Rhsm` with a null module variable, changing it later

There should be no behaviour change.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

redhat_subscription
