### PR TITLE
Onepassword lookup add service accounts

### DIFF
--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -554,7 +554,7 @@ class OnePass(object):
         for cls in OnePassCLIBase.__subclasses__():
             if cls.supports_version == version.split(".")[0]:
                 try:
-                    return cls(self.subdomain, self.domain, self.username, self.secret_key, self.master_password)
+                    return cls(self.subdomain, self.domain, self.username, self.secret_key, self.master_password, self.service_account_token)
                 except TypeError as e:
                     raise AnsibleLookupError(e)
 

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -42,6 +42,8 @@ DOCUMENTATION = '''
         description: The username used to sign in.
       secret_key:
         description: The secret key used when performing an initial sign in.
+      service_account_token:
+        description: The access key for a service account.
       vault:
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
     notes:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -128,17 +128,17 @@ class OnePassCLIBase(with_metaclass(abc.ABCMeta, object)):
 
     def _check_required_params(self, required_params):
         if not self.service_account_token:
-          non_empty_attrs = dict((param, getattr(self, param, None)) for param in required_params if getattr(self, param, None))
-          missing = set(required_params).difference(non_empty_attrs)
-          if missing:
-              prefix = "Unable to sign in to 1Password. Missing required parameter"
-              plural = ""
-              suffix = ": {params}. Or use a service_account_token.".format(params=", ".join(missing))
-              if len(missing) > 1:
-                  plural = "s"
+            non_empty_attrs = dict((param, getattr(self, param, None)) for param in required_params if getattr(self, param, None))
+            missing = set(required_params).difference(non_empty_attrs)
+            if missing:
+                prefix = "Unable to sign in to 1Password. Missing required parameter"
+                plural = ""
+                suffix = ": {params}. Or use a service_account_token.".format(params=", ".join(missing))
+                if len(missing) > 1:
+                    plural = "s"
 
-              msg = "{prefix}{plural}{suffix}".format(prefix=prefix, plural=plural, suffix=suffix)
-              raise AnsibleLookupError(msg)
+                msg = "{prefix}{plural}{suffix}".format(prefix=prefix, plural=plural, suffix=suffix)
+                raise AnsibleLookupError(msg)
 
     @abc.abstractmethod
     def _parse_field(self, data_json, field_name, section_title):

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -89,8 +89,9 @@ class LookupModule(LookupBase):
         username = self.get_option("username")
         secret_key = self.get_option("secret_key")
         master_password = self.get_option("master_password")
+        service_account_token = self.get_option("service_account_token")
 
-        op = OnePass(subdomain, domain, username, secret_key, master_password)
+        op = OnePass(subdomain, domain, username, secret_key, master_password, service_account_token)
         op.assert_logged_in()
 
         values = []

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -39,6 +39,8 @@ DOCUMENTATION = '''
         description: The username used to sign in.
       secret_key:
         description: The secret key used when performing an initial sign in.
+      service_account_token:
+        description: The access key for a service account.
       vault:
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
     notes:

--- a/plugins/modules/onepassword_info.py
+++ b/plugins/modules/onepassword_info.py
@@ -78,6 +78,11 @@ options:
                 description:
                     - 1Password username.
                     - Only required for initial sign in.
+            service_account_token:
+                type: str
+                description:
+                    - 1Password service account token.
+                    - Only required for initial sign in.
             master_password:
                 type: str
                 description:

--- a/plugins/modules/onepassword_info.py
+++ b/plugins/modules/onepassword_info.py
@@ -380,6 +380,7 @@ def main():
                 username=dict(type='str'),
                 master_password=dict(required=True, type='str', no_log=True),
                 secret_key=dict(type='str', no_log=True),
+                service_account_token=dict(type='str', no_log=True),
             ), default=None),
             search_terms=dict(required=True, type='list', elements='dict'),
         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

add new service_account_token for onepassword lookup

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #6635

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

minor_changes:
  - onepassword lookup - adds ``service_account_token`` parameters for supporting 1password service accounts

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

onepassword

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
lookup('community.general.onepassword', 'KITT', vault='Servers', service_account_token='ops_foobar....')
```
