### PR TITLE
Deprecate module_utils.redhat

### DIFF
--- a/changelogs/fragments/6663-deprecate-module_utils-redhat.yml
+++ b/changelogs/fragments/6663-deprecate-module_utils-redhat.yml
@@ -1,0 +1,11 @@
+deprecated_features:
+  - |
+    redhat module utils - the ``module_utils.redhat`` module is deprecated, as
+    effectively unused: the ``Rhsm``, ``RhsmPool``, and ``RhsmPools`` classes
+    will be removed in community.general 9.0.0; the ``RegistrationBase`` class
+    will be removed in community.general 10.0.0 together with the
+    ``rhn_register`` module, as it is the only user of this class; this means
+    that the whole ``module_utils.redhat`` module will be dropped in
+    community.general 10.0.0, so importing it without even using anything of it
+    will fail
+    (https://github.com/ansible-collections/community.general/pull/6663).

--- a/plugins/module_utils/redhat.py
+++ b/plugins/module_utils/redhat.py
@@ -24,6 +24,14 @@ from ansible.module_utils.six.moves import configparser
 
 
 class RegistrationBase(object):
+    """
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 10.0.0.
+    There is no replacement for it; please contact the community.general
+    maintainers in case you are using it.
+    """
+
     def __init__(self, module, username=None, password=None):
         self.module = module
         self.username = username
@@ -71,10 +79,23 @@ class RegistrationBase(object):
 
 
 class Rhsm(RegistrationBase):
+    """
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 9.0.0.
+    There is no replacement for it; please contact the community.general
+    maintainers in case you are using it.
+    """
+
     def __init__(self, module, username=None, password=None):
         RegistrationBase.__init__(self, module, username, password)
         self.config = self._read_config()
         self.module = module
+        self.module.deprecate(
+            'The Rhsm class is deprecated with no replacement.',
+            version='9.0.0',
+            collection_name='community.general',
+        )
 
     def _read_config(self, rhsm_conf='/etc/rhsm/rhsm.conf'):
         '''
@@ -200,14 +221,25 @@ class Rhsm(RegistrationBase):
 
 
 class RhsmPool(object):
-    '''
-        Convenience class for housing subscription information
-    '''
+    """
+    Convenience class for housing subscription information
+
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 9.0.0.
+    There is no replacement for it; please contact the community.general
+    maintainers in case you are using it.
+    """
 
     def __init__(self, module, **kwargs):
         self.module = module
         for k, v in kwargs.items():
             setattr(self, k, v)
+        self.module.deprecate(
+            'The RhsmPool class is deprecated with no replacement.',
+            version='9.0.0',
+            collection_name='community.general',
+        )
 
     def __str__(self):
         return str(self.__getattribute__('_name'))
@@ -223,11 +255,23 @@ class RhsmPool(object):
 
 class RhsmPools(object):
     """
-        This class is used for manipulating pools subscriptions with RHSM
+    This class is used for manipulating pools subscriptions with RHSM
+
+    DEPRECATION WARNING
+
+    This class is deprecated and will be removed in community.general 9.0.0.
+    There is no replacement for it; please contact the community.general
+    maintainers in case you are using it.
     """
+
     def __init__(self, module):
         self.module = module
         self.products = self._load_product_list()
+        self.module.deprecate(
+            'The RhsmPools class is deprecated with no replacement.',
+            version='9.0.0',
+            collection_name='community.general',
+        )
 
     def __iter__(self):
         return self.products.__iter__()


### PR DESCRIPTION
##### SUMMARY

This module contains bits that are either unused (the `Rhsm*` classes), or used only by deprecated modules (the `RegistrationBase` class). Considering that the bits here have not seen updates in years, it is unlikely that anyone is actually using them as "library".

Hence, deprecate the whole module altogether:
- the `Rhsm*` classes, as not used by anything, are slated for removal in 9.0.0
- the `RegistrationBase` class is slated for removal in 10.0.0, together with its only user (i.e. the `rhn_register` module)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/module_utils/redhat.py