### PR TITLE
rhsm_repository: make state=present work

### DIFF
--- a/changelogs/fragments/6665-rhsm_repository-fix-state-present.yml
+++ b/changelogs/fragments/6665-rhsm_repository-fix-state-present.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rhsm_repository - make ``state=present`` work again
+    (https://github.com/ansible-collections/community.general/pull/6665).

--- a/plugins/modules/rhsm_repository.py
+++ b/plugins/modules/rhsm_repository.py
@@ -181,7 +181,7 @@ def repository_modify(module, state, name, purge=False):
             if fnmatch(repo['id'], repoid):
                 matched_existing_repo[repoid].append(repo)
                 # Update current_repo_list to return it as result variable
-                updated_repo_list[idx]['enabled'] = True if state == 'enabled' else False
+                updated_repo_list[idx]['enabled'] = True if state in ['enabled', 'present'] else False
 
     changed = False
     results = []


### PR DESCRIPTION
##### SUMMARY

There was one place that only checked for `state=enabled`; since `present` is an allowed and documented state, check for it as well so it works (again, or ever).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rhsm_repository

##### ADDITIONAL INFORMATION

Easy to reproduce:
```yaml
- rhsm_repository:
    name: some-repo-not-already-enabled
    state: present
  register: repo_changes

- assert:
    that: repo_changes.changed
```
