### PR TITLE
rhsm_repository: deprecate "state=present" and "state=absent"

### DIFF
--- a/changelogs/fragments/6673-rhsm_repository-deprecate-present-absent.yml
+++ b/changelogs/fragments/6673-rhsm_repository-deprecate-present-absent.yml
@@ -1,0 +1,8 @@
+deprecated_features:
+- |
+  rhsm_repository - ``state=present`` has not been working as expected for many years,
+  and it seems it was not noticed so far; also, "presence" is not really a valid concept
+  for subscription repositories, which can only be enabled or disabled. Hence, mark the
+  ``present`` and ``absent`` values of the ``state`` option as deprecated, slating them
+  for removal in community.general 10.0.0
+  (https://github.com/ansible-collections/community.general/pull/6673).

--- a/plugins/modules/rhsm_repository.py
+++ b/plugins/modules/rhsm_repository.py
@@ -36,6 +36,10 @@ options:
     description:
       - If state is equal to present or disabled, indicates the desired
         repository state.
+      - |
+        Please note that V(present) and V(absent) are deprecated, and will be
+        removed in community.general 10.0.0; please use V(enabled) and
+        V(disabled) instead.
     choices: [present, enabled, absent, disabled]
     default: "enabled"
     type: str
@@ -252,6 +256,14 @@ def main():
     name = module.params['name']
     state = module.params['state']
     purge = module.params['purge']
+
+    if state in ['present', 'absent']:
+        replacement = 'enabled' if state == 'present' else 'disabled'
+        module.deprecate(
+            'state=%s is deprecated; please use state=%s instead' % (state, replacement),
+            version='10.0.0',
+            collection_name='community.general',
+        )
 
     repository_modify(module, state, name, purge)
 


### PR DESCRIPTION
##### SUMMARY

`state=present` is broken, and acts like `disabled`; also, the subscription repositories cannot be really "added" or "removed", which is what `present` and `absent` would imply, but only enabled or disabled. Hence, deprecate both these states, slating them for removal in community.general 10.0.0.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

rhsm_repository