### PR TITLE
rhsm_repository: update returned "repositories" when using "purge=true"

### DIFF
--- a/changelogs/fragments/6676-rhsm_repository-fix-returned-repositories-with-purge.yml
+++ b/changelogs/fragments/6676-rhsm_repository-fix-returned-repositories-with-purge.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - |
+    rhsm_repository - when using the ``purge`` option, the ``repositories``
+    dictionary element in the returned JSON is now properly updated according
+    to the pruning operation
+    (https://github.com/ansible-collections/community.general/pull/6676).

--- a/plugins/modules/rhsm_repository.py
+++ b/plugins/modules/rhsm_repository.py
@@ -226,6 +226,9 @@ def repository_modify(module, state, name, purge=False):
                 diff_after.join("Repository '{repoid}' is disabled for this system\n".format(repoid=repoid))
                 results.append("Repository '{repoid}' is disabled for this system".format(repoid=repoid))
                 rhsm_arguments.extend(['--disable', repoid])
+            for updated_repo in updated_repo_list:
+                if updated_repo['id'] in difference:
+                    updated_repo['enabled'] = False
 
     diff = {'before': diff_before,
             'after': diff_after,


### PR DESCRIPTION
##### SUMMARY

In case the `purge` option was enabled, the `repositories` element in the returned JSON was not updated with the repositories disabled by that option.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rhsm_repository