### PR TITLE
filesystem: add UUID change feature

### DIFF
--- a/changelogs/fragments/6680-filesystem-uuid-change.yml
+++ b/changelogs/fragments/6680-filesystem-uuid-change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - filesystem - add ``uuid`` parameter for UUID change feature (https://github.com/ansible-collections/community.general/pull/6680).

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -650,6 +650,9 @@ def main():
 
         filesystem = klass(module)
 
+        if uuid and not (filesystem.CHANGE_UUID or filesystem.MKFS_SET_UUID_OPTIONS):
+            module.fail_json(changed=False, msg="module does not support UUID option for this filesystem (%s) yet." % fstype)
+
         same_fs = fs and FILESYSTEMS.get(fs) == FILESYSTEMS[fstype]
         if same_fs and not resizefs and not uuid and not force:
             module.exit_json(changed=False)

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -605,7 +605,7 @@ def main():
             ('state', 'present', ['fstype'])
         ],
         mutually_exclusive=[
-            ('resizefs', 'uuid')
+            ('resizefs', 'uuid'),
         ],
         supports_check_mode=True,
     )
@@ -670,8 +670,6 @@ def main():
 
                 module.exit_json(changed=True, msg=out)
             elif uuid:
-                if not filesystem.CHANGE_UUID:
-                    module.fail_json(changed=False, msg="module does not support UUID change for %s filesystem yet." % fstype)
 
                 out = filesystem.change_uuid(new_uuid=uuid, dev=dev)
 

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -83,10 +83,11 @@ options:
     description:
       - Set existing filesystem's UUID to the given value.
       - See xfs_admin(8) (C(xfs)), tune2fs(8) (C(ext2), C(ext3), C(ext4), C(ext4dev)) for possible values.
-      - For C(lvm) the value is ignored, it resets the pv UUID if set.
-      - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(lvm), C(xfs) filesystems.
-      - B(Not idempotent)
+      - For O(fstype=lvm) the value is ignored, it resets the PV UUID if set.
+      - Supported for O(fstype) being one of C(ext2), C(ext3), C(ext4), C(ext4dev), C(lvm), or C(xfs).
+      - This is B(not idempotent). Specifying this option will always result in a change.
     type: str
+    version_added: 7.1.0
 requirements:
   - Uses specific tools related to the I(fstype) for creating or resizing a
     filesystem (from packages e2fsprogs, xfsprogs, dosfstools, and so on).
@@ -147,7 +148,7 @@ EXAMPLES = '''
     dev: /dev/sdb1
     uuid: random
 
-- name: Reset an LVM filesystem (pv) UUID on /dev/sdc
+- name: Reset an LVM filesystem (PV) UUID on /dev/sdc
   community.general.filesystem:
     fstype: lvm
     dev: /dev/sdc
@@ -653,7 +654,7 @@ def main():
 
             out = filesystem.change_uuid(new_uuid=uuid, dev=dev)
 
-            module.exit_json(changed=True, msgout=out)
+            module.exit_json(changed=True, msg=out)
         elif fs and not force:
             module.fail_json(msg="'%s' is already used as %s, use force=true to overwrite" % (dev, fs), rc=rc, err=err)
 

--- a/tests/integration/targets/filesystem/defaults/main.yml
+++ b/tests/integration/targets/filesystem/defaults/main.yml
@@ -15,19 +15,19 @@ tested_filesystems:
   #     - 1.7.0 requires at least 30Mo
   #     - 1.10.0 requires at least 38Mo
   #     - resizefs asserts when initial fs is smaller than 60Mo and seems to require 1.10.0
-  ext4: {fssize: 10, grow: true}
-  ext4dev: {fssize: 10, grow: true}
-  ext3: {fssize: 10, grow: true}
-  ext2: {fssize: 10, grow: true}
-  xfs: {fssize: 300, grow: false}  # grow requires a mounted filesystem
-  btrfs: {fssize: 150, grow: false}  # grow requires a mounted filesystem
-  reiserfs: {fssize: 33, grow: false}  # grow not implemented
-  vfat: {fssize: 20, grow: true}
-  ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: false}  # grow not implemented
-  f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")'}
-  lvm: {fssize: 20, grow: true}
-  swap: {fssize: 10, grow: false}  # grow not implemented
-  ufs: {fssize: 10, grow: true}
+  ext4: {fssize: 10, grow: true, new_uuid: 'random'}
+  ext4dev: {fssize: 10, grow: true, new_uuid: 'random'}
+  ext3: {fssize: 10, grow: true, new_uuid: 'random'}
+  ext2: {fssize: 10, grow: true, new_uuid: 'random'}
+  xfs: {fssize: 300, grow: false, new_uuid: 'generate'}  # grow requires a mounted filesystem
+  btrfs: {fssize: 150, grow: false, new_uuid: null}  # grow requires a mounted filesystem
+  reiserfs: {fssize: 33, grow: false, new_uuid: null}  # grow not implemented
+  vfat: {fssize: 20, grow: true, new_uuid: null}
+  ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: false, new_uuid: null}  # grow not implemented
+  f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")', new_uuid: null}
+  lvm: {fssize: 20, grow: true, new_uuid: 'something'}
+  swap: {fssize: 10, grow: false, new_uuid: null}  # grow not implemented
+  ufs: {fssize: 10, grow: true, new_uuid: null}
 
 
 get_uuid_any: "blkid -c /dev/null -o value -s UUID {{ dev }}"

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -84,7 +84,7 @@
     # TODO: something seems to be broken on Alpine
     - 'not (ansible_distribution == "Alpine")'
 
-  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'reset_fs_uuid', 'overwrite_another_fs', 'remove_fs'])|list }}"
+  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'reset_fs_uuid', 'overwrite_another_fs', 'remove_fs', 'set_fs_uuid_on_creation'])|list }}"
 
 
 # With FreeBSD extended support (util-linux is not available before 12.2)

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -29,6 +29,7 @@
     fstype: '{{ item.0.key }}'
     fssize: '{{ item.0.value.fssize }}'
     grow: '{{ item.0.value.grow }}'
+    new_uuid: '{{ item.0.value.new_uuid }}'
     action: '{{ item.1 }}'
   when:
     # FreeBSD limited support
@@ -83,7 +84,7 @@
     # TODO: something seems to be broken on Alpine
     - 'not (ansible_distribution == "Alpine")'
 
-  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs', 'remove_fs'])|list }}"
+  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'reset_fs_uuid', 'overwrite_another_fs', 'remove_fs'])|list }}"
 
 
 # With FreeBSD extended support (util-linux is not available before 12.2)

--- a/tests/integration/targets/filesystem/tasks/main.yml
+++ b/tests/integration/targets/filesystem/tasks/main.yml
@@ -84,7 +84,7 @@
     # TODO: something seems to be broken on Alpine
     - 'not (ansible_distribution == "Alpine")'
 
-  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'reset_fs_uuid', 'overwrite_another_fs', 'remove_fs', 'set_fs_uuid_on_creation'])|list }}"
+  loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'reset_fs_uuid', 'overwrite_another_fs', 'remove_fs', 'set_fs_uuid_on_creation', 'set_fs_uuid_on_creation_with_opts'])|list }}"
 
 
 # With FreeBSD extended support (util-linux is not available before 12.2)

--- a/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
+++ b/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
@@ -1,0 +1,39 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+- when: new_uuid | default(False)
+  block:
+  - name: "Create filesystem ({{ fstype }})"
+    community.general.filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+    register: fs_result
+
+  - name: "Get UUID of created filesystem"
+    ansible.builtin.shell:
+      cmd: "{{ get_uuid_cmd }}"
+    changed_when: false
+    register: uuid
+
+  - name: "Reset filesystem ({{ fstype }}) UUID"
+    community.general.filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+      uuid: "{{ new_uuid }}"
+    register: fs_resetuuid_result
+
+  - name: "Get UUID of the filesystem"
+    ansible.builtin.shell:
+      cmd: "{{ get_uuid_cmd }}"
+    changed_when: false
+    register: uuid2
+
+  - name: "Assert that filesystem UUID is changed"
+    ansible.builtin.assert:
+      that:
+        - 'fs_resetuuid_result is changed'
+        - 'fs_resetuuid_result is success'
+        - 'uuid.stdout != uuid2.stdout'

--- a/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
+++ b/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
@@ -3,8 +3,10 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-
-- when: new_uuid | default(False)
+# Skip UUID reset tests for FreeBSD due to "xfs_admin: only 'rewrite' supported on V5 fs"
+- when: 
+    - new_uuid | default(False)
+    - not (ansible_system == "FreeBSD" and fstype == "xfs")
   block:
   - name: "Create filesystem ({{ fstype }})"
     community.general.filesystem:

--- a/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
+++ b/tests/integration/targets/filesystem/tasks/reset_fs_uuid.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Skip UUID reset tests for FreeBSD due to "xfs_admin: only 'rewrite' supported on V5 fs"
-- when: 
+- when:
     - new_uuid | default(False)
     - not (ansible_system == "FreeBSD" and fstype == "xfs")
   block:
@@ -39,3 +39,21 @@
         - 'fs_resetuuid_result is changed'
         - 'fs_resetuuid_result is success'
         - 'uuid.stdout != uuid2.stdout'
+
+  - when:
+    - (grow | bool and (fstype != "vfat" or resize_vfat)) or
+      (fstype == "xfs" and ansible_system == "Linux" and
+      ansible_distribution not in ["CentOS", "Ubuntu"])
+    block:
+    - name: "Reset filesystem ({{ fstype }}) UUID and resizefs"
+      ignore_errors: true
+      community.general.filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        uuid: "{{ new_uuid }}"
+        resizefs: true
+      register: fs_resetuuid_and_resizefs_result
+
+    - name: "Assert that filesystem UUID reset and resizefs failed"
+      ansible.builtin.assert:
+        that: fs_resetuuid_and_resizefs_result is failed

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
@@ -1,0 +1,67 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Skip UUID set at creation tests for FreeBSD due to "xfs_admin: only 'rewrite' supported on V5 fs"
+- when: 
+    - new_uuid | default(False)
+    - not (ansible_system == "FreeBSD" and fstype == "xfs")
+  block:
+
+  - name: "Generate a random UUID"
+    ansible.builtin.command:
+      cmd: "uuidgen -r"
+    register: random_uuid
+
+  - name: "Create filesystem ({{ fstype }}) with UUID"
+    community.general.filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+      uuid: '{{ random_uuid.stdout }}'
+    register: fs_result
+
+  - name: "Get UUID of the created filesystem"
+    ansible.builtin.shell:
+      cmd: "{{ get_uuid_cmd }}"
+    changed_when: false
+    register: uuid
+
+  - name: "Assert that filesystem UUID is the random UUID set on creation"
+    ansible.builtin.assert:
+      that: (random_uuid.stdout | replace('-','')) == ( uuid.stdout | replace('-',''))
+
+  - name: "Remove filesystem"
+    community.general.filesystem:
+      dev: '{{ dev }}'
+      state: absent
+
+  - name: "Generate a second random UUID"
+    ansible.builtin.command:
+      cmd: "uuidgen -r"
+    register: random_uuid2
+
+  - when: fstype in ["ext2", "ext3", "ext4", "ext4dev", "lvm"]
+    block:
+    - name: "Create filesystem ({{ fstype }}) with fix UUID as opt"
+      community.general.filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        opts: "{{ ((fstype == 'lvm') | ansible.builtin.ternary('--norestorefile --uuid', '-U')) + ' ' + random_uuid2.stdout }}"
+        uuid: '{{ random_uuid.stdout }}'
+      register: fs_result2
+
+    - name: "Get UUID of the created filesystem"
+      ansible.builtin.shell:
+        cmd: "{{ get_uuid_cmd }}"
+      changed_when: false
+      register: uuid2
+
+    - name: "Assert that filesystem UUID is the random UUID set on creation with opt"
+      ansible.builtin.assert:
+        that: (random_uuid.stdout | replace('-','')) == ( uuid.stdout | replace('-',''))
+
+    - name: "Remove filesystem"
+      community.general.filesystem:
+        dev: '{{ dev }}'
+        state: absent

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
@@ -10,15 +10,14 @@
   block:
 
   - name: "Generate a random UUID"
-    ansible.builtin.command:
-      cmd: "uuidgen -r"
-    register: random_uuid
+    ansible.builtin.set_fact:
+      random_uuid: '{{ "first_random_uuid" | ansible.builtin.to_uuid }}'
 
   - name: "Create filesystem ({{ fstype }}) with UUID"
     community.general.filesystem:
       dev: '{{ dev }}'
       fstype: '{{ fstype }}'
-      uuid: '{{ random_uuid.stdout }}'
+      uuid: '{{ random_uuid }}'
     register: fs_result
 
   - name: "Get UUID of the created filesystem"
@@ -29,26 +28,25 @@
 
   - name: "Assert that filesystem UUID is the random UUID set on creation"
     ansible.builtin.assert:
-      that: (random_uuid.stdout | replace('-','')) == ( uuid.stdout | replace('-',''))
+      that: (random_uuid | replace('-','')) == ( uuid.stdout | replace('-',''))
 
   - name: "Remove filesystem"
     community.general.filesystem:
       dev: '{{ dev }}'
       state: absent
 
-  - name: "Generate a second random UUID"
-    ansible.builtin.command:
-      cmd: "uuidgen -r"
-    register: random_uuid2
-
   - when: fstype in ["ext2", "ext3", "ext4", "ext4dev", "lvm"]
     block:
+    - name: "Generate a second random UUID"
+      ansible.builtin.set_fact:
+        random_uuid2: '{{ "second_random_uuid" | ansible.builtin.to_uuid }}'
+
     - name: "Create filesystem ({{ fstype }}) with fix UUID as opt"
       community.general.filesystem:
         dev: '{{ dev }}'
         fstype: '{{ fstype }}'
-        opts: "{{ ((fstype == 'lvm') | ansible.builtin.ternary('--norestorefile --uuid', '-U')) + ' ' + random_uuid2.stdout }}"
-        uuid: '{{ random_uuid.stdout }}'
+        opts: "{{ ((fstype == 'lvm') | ansible.builtin.ternary('--norestorefile --uuid ', '-U ')) + random_uuid2 }}"
+        uuid: '{{ random_uuid }}'
       register: fs_result2
 
     - name: "Get UUID of the created filesystem"
@@ -59,7 +57,7 @@
 
     - name: "Assert that filesystem UUID is the random UUID set on creation with opt"
       ansible.builtin.assert:
-        that: (random_uuid.stdout | replace('-','')) == ( uuid.stdout | replace('-',''))
+        that: (random_uuid2 | replace('-','')) == ( uuid2.stdout | replace('-',''))
 
     - name: "Remove filesystem"
       community.general.filesystem:

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation.yml
@@ -3,16 +3,15 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: "Generate a random UUID"
+  ansible.builtin.set_fact:
+    random_uuid: '{{ "first_random_uuid" | ansible.builtin.to_uuid }}'
+
 # Skip UUID set at creation tests for FreeBSD due to "xfs_admin: only 'rewrite' supported on V5 fs"
 - when:
     - new_uuid | default(False)
     - not (ansible_system == "FreeBSD" and fstype == "xfs")
   block:
-
-  - name: "Generate a random UUID"
-    ansible.builtin.set_fact:
-      random_uuid: '{{ "first_random_uuid" | ansible.builtin.to_uuid }}'
-
   - name: "Create filesystem ({{ fstype }}) with UUID"
     community.general.filesystem:
       dev: '{{ dev }}'
@@ -29,3 +28,17 @@
   - name: "Assert that filesystem UUID is the random UUID set on creation"
     ansible.builtin.assert:
       that: (random_uuid | replace('-','')) == ( uuid.stdout | replace('-',''))
+
+- when: not (new_uuid | default(False))
+  block:
+  - name: "Create filesystem ({{ fstype }}) without UUID support"
+    ignore_errors: true
+    community.general.filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+      uuid: '{{ random_uuid }}'
+    register: fs_result
+
+  - name: "Assert that filesystem creation failed"
+    ansible.builtin.assert:
+      that: fs_result is failed

--- a/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation_with_opts.yml
+++ b/tests/integration/targets/filesystem/tasks/set_fs_uuid_on_creation_with_opts.yml
@@ -3,29 +3,31 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Skip UUID set at creation tests for FreeBSD due to "xfs_admin: only 'rewrite' supported on V5 fs"
+# UUID set at creation with opts for XFS is not supported
 - when:
     - new_uuid | default(False)
-    - not (ansible_system == "FreeBSD" and fstype == "xfs")
+    - fstype != "xfs"
   block:
 
-  - name: "Generate a random UUID"
+  - name: "Generate random UUIDs"
     ansible.builtin.set_fact:
       random_uuid: '{{ "first_random_uuid" | ansible.builtin.to_uuid }}'
+      random_uuid2: '{{ "second_random_uuid" | ansible.builtin.to_uuid }}'
 
-  - name: "Create filesystem ({{ fstype }}) with UUID"
+  - name: "Create filesystem ({{ fstype }}) with fix UUID as opt"
     community.general.filesystem:
       dev: '{{ dev }}'
       fstype: '{{ fstype }}'
+      opts: "{{ ((fstype == 'lvm') | ansible.builtin.ternary('--norestorefile --uuid ', '-U ')) + random_uuid2 }}"
       uuid: '{{ random_uuid }}'
-    register: fs_result
+    register: fs_result2
 
   - name: "Get UUID of the created filesystem"
     ansible.builtin.shell:
       cmd: "{{ get_uuid_cmd }}"
     changed_when: false
-    register: uuid
+    register: uuid2
 
-  - name: "Assert that filesystem UUID is the random UUID set on creation"
+  - name: "Assert that filesystem UUID is the one set on creation with opt"
     ansible.builtin.assert:
-      that: (random_uuid | replace('-','')) == ( uuid.stdout | replace('-',''))
+      that: (random_uuid2 | replace('-','')) == ( uuid2.stdout | replace('-',''))


### PR DESCRIPTION
##### SUMMARY
Add a new feature to the filesystem module for managing UUID.
The feature does not break backward compatibility. It introduces an optional ``uuid`` parameter.

Rationale:
During disk cloning / lvm snapshot creation, the filesystem uuid remains the same. This new feature manages the filesystem UUID in an automated fashion.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
filesystem

##### ADDITIONAL INFORMATION
The ``version_added`` entry in the ``uuid`` parameter's documentation needs to be set.
