### PR TITLE
Use semantic markup (modules o-p)

### DIFF
--- a/plugins/modules/ocapi_command.py
+++ b/plugins/modules/ocapi_command.py
@@ -41,17 +41,17 @@ options:
       - Base URI of OOB controller.
     type: str
   proxy_slot_number:
-    description: For proxied inband requests, the slot number of the IOM.  Only applies if I(baseuri) is a proxy server.
+    description: For proxied inband requests, the slot number of the IOM.  Only applies if O(baseuri) is a proxy server.
     type: int
   update_image_path:
     required: false
     description:
-      - For C(FWUpload), the path on the local filesystem of the firmware update image.
+      - For O(command=FWUpload), the path on the local filesystem of the firmware update image.
     type: str
   job_name:
     required: false
     description:
-      - For C(DeleteJob) command, the name of the job to delete.
+      - For O(command=DeleteJob) command, the name of the job to delete.
     type: str
   username:
     required: true

--- a/plugins/modules/ocapi_info.py
+++ b/plugins/modules/ocapi_info.py
@@ -38,7 +38,7 @@ options:
       - Base URI of OOB controller.
     type: str
   proxy_slot_number:
-    description: For proxied inband requests, the slot number of the IOM.  Only applies if I(baseuri) is a proxy server.
+    description: For proxied inband requests, the slot number of the IOM.  Only applies if O(baseuri) is a proxy server.
     type: int
   username:
     required: true
@@ -83,45 +83,45 @@ msg:
     sample: "Action was successful"
 
 percentComplete:
-    description: Percent complete of the relevant operation.  Applies to C(JobStatus) command.
+    description: Percent complete of the relevant operation.  Applies to O(command=JobStatus).
     returned: when supported
     type: int
     sample: 99
 
 operationStatus:
-    description: Status of the relevant operation.  Applies to C(JobStatus) command.  See OCAPI documentation for details.
+    description: Status of the relevant operation.  Applies to O(command=JobStatus).  See OCAPI documentation for details.
     returned: when supported
     type: str
     sample: "Activate needed"
 
 operationStatusId:
-    description: Integer value of status (corresponds to operationStatus).  Applies to C(JobStatus) command.  See OCAPI documentation for details.
+    description: Integer value of status (corresponds to operationStatus).  Applies to O(command=JobStatus).  See OCAPI documentation for details.
     returned: when supported
     type: int
     sample: 65540
 
 operationHealth:
-    description: Health of the operation.  Applies to C(JobStatus) command.  See OCAPI documentation for details.
+    description: Health of the operation.  Applies to O(command=JobStatus).  See OCAPI documentation for details.
     returned: when supported
     type: str
     sample: "OK"
 
 operationHealthId:
     description: >
-     Integer value for health of the operation (corresponds to C(operationHealth)). Applies to C(JobStatus) command.
+     Integer value for health of the operation (corresponds to RV(operationHealth)). Applies to O(command=JobStatus).
      See OCAPI documentation for details.
     returned: when supported
     type: str
     sample: "OK"
 
 details:
-    description: Details of the relevant operation.  Applies to C(JobStatus) command.
+    description: Details of the relevant operation.  Applies to O(command=JobStatus).
     returned: when supported
     type: list
     elements: str
 
 status:
-    description: Dict containing status information.  See OCAPI documentation for details.
+    description: Dictionary containing status information.  See OCAPI documentation for details.
     returned: when supported
     type: dict
     sample: {

--- a/plugins/modules/oci_vcn.py
+++ b/plugins/modules/oci_vcn.py
@@ -23,12 +23,12 @@ attributes:
         support: none
 options:
     cidr_block:
-        description: The CIDR IP address block of the VCN. Required when creating a VCN with I(state=present).
+        description: The CIDR IP address block of the VCN. Required when creating a VCN with O(state=present).
         type: str
         required: false
     compartment_id:
-        description: The OCID of the compartment to contain the VCN. Required when creating a VCN with I(state=present).
-                     This option is mutually exclusive with I(vcn_id).
+        description: The OCID of the compartment to contain the VCN. Required when creating a VCN with O(state=present).
+                     This option is mutually exclusive with O(vcn_id).
         type: str
     display_name:
         description: A user-friendly name. Does not have to be unique, and it's changeable.
@@ -42,13 +42,13 @@ options:
                      with a letter. The value cannot be changed.
         type: str
     state:
-        description: Create or update a VCN with I(state=present). Use I(state=absent) to delete a VCN.
+        description: Create or update a VCN with O(state=present). Use O(state=absent) to delete a VCN.
         type: str
         default: present
         choices: ['present', 'absent']
     vcn_id:
-        description: The OCID of the VCN. Required when deleting a VCN with I(state=absent) or updating a VCN
-                     with I(state=present). This option is mutually exclusive with I(compartment_id).
+        description: The OCID of the VCN. Required when deleting a VCN with O(state=absent) or updating a VCN
+                     with O(state=present). This option is mutually exclusive with O(compartment_id).
         type: str
         aliases: [ 'id' ]
 author: "Rohit Chaware (@rohitChaware)"

--- a/plugins/modules/one_service.py
+++ b/plugins/modules/one_service.py
@@ -54,20 +54,20 @@ options:
     type: str
   unique:
     description:
-      - Setting I(unique=true) will make sure that there is only one service instance running with a name set with C(service_name) when
-        instantiating a service from a template specified with I(template_id) or I(template_name). Check examples below.
+      - Setting O(unique=true) will make sure that there is only one service instance running with a name set with O(service_name) when
+        instantiating a service from a template specified with O(template_id) or O(template_name). Check examples below.
     type: bool
     default: false
   state:
     description:
-      - C(present) - instantiate a service from a template specified with I(template_id) or I(template_name).
-      - C(absent) - terminate an instance of a service specified with I(template_id) or I(template_name).
+      - V(present) - instantiate a service from a template specified with O(template_id) or O(template_name).
+      - V(absent) - terminate an instance of a service specified with O(template_id) or O(template_name).
     choices: ["present", "absent"]
     default: present
     type: str
   mode:
     description:
-      - Set permission mode of a service instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+      - Set permission mode of a service instance in octet format, for example V(0600) to give owner C(use) and C(manage) and nothing to group and others.
     type: str
   owner_id:
     description:

--- a/plugins/modules/one_service.py
+++ b/plugins/modules/one_service.py
@@ -26,15 +26,15 @@ options:
     description:
       - URL of the OpenNebula OneFlow API server.
       - It is recommended to use HTTPS so that the username/password are not transferred over the network unencrypted.
-      - If not set then the value of the ONEFLOW_URL environment variable is used.
+      - If not set then the value of the E(ONEFLOW_URL) environment variable is used.
     type: str
   api_username:
     description:
-      - Name of the user to login into the OpenNebula OneFlow API server. If not set then the value of the C(ONEFLOW_USERNAME) environment variable is used.
+      - Name of the user to login into the OpenNebula OneFlow API server. If not set then the value of the E(ONEFLOW_USERNAME) environment variable is used.
     type: str
   api_password:
     description:
-      - Password of the user to login into OpenNebula OneFlow API server. If not set then the value of the C(ONEFLOW_PASSWORD) environment variable is used.
+      - Password of the user to login into OpenNebula OneFlow API server. If not set then the value of the E(ONEFLOW_PASSWORD) environment variable is used.
     type: str
   template_name:
     description:

--- a/plugins/modules/one_template.py
+++ b/plugins/modules/one_template.py
@@ -34,12 +34,12 @@ attributes:
 options:
   id:
     description:
-      - A I(id) of the template you would like to manage.  If not set then a
-      - new template will be created with the given I(name).
+      - A O(id) of the template you would like to manage.  If not set then a
+      - new template will be created with the given O(name).
     type: int
   name:
     description:
-      - A I(name) of the template you would like to manage.  If a template with
+      - A O(name) of the template you would like to manage.  If a template with
       - the given name does not exist it will be created, otherwise it will be
       - managed by this module.
     type: str
@@ -49,8 +49,8 @@ options:
     type: str
   state:
     description:
-      - C(present) - state that is used to manage the template.
-      - C(absent) - delete the template.
+      - V(present) - state that is used to manage the template.
+      - V(absent) - delete the template.
     choices: ["present", "absent"]
     default: present
     type: str
@@ -116,36 +116,36 @@ RETURN = '''
 id:
     description: template id
     type: int
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: 153
 name:
     description: template name
     type: str
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: app1
 template:
     description: the parsed template
     type: dict
-    returned: when I(state=present)
+    returned: when O(state=present)
 group_id:
     description: template's group id
     type: int
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: 1
 group_name:
     description: template's group name
     type: str
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: one-users
 owner_id:
     description: template's owner id
     type: int
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: 143
 owner_name:
     description: template's owner name
     type: str
-    returned: when I(state=present)
+    returned: when O(state=present)
     sample: ansible-test
 '''
 

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -30,20 +30,20 @@ options:
       - URL of the OpenNebula RPC server.
       - It is recommended to use HTTPS so that the username/password are not
         transferred over the network unencrypted.
-      - If not set then the value of the C(ONE_URL) environment variable is used.
+      - If not set then the value of the E(ONE_URL) environment variable is used.
     type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula RPC server. If not set
-        then the value of the C(ONE_USERNAME) environment variable is used.
+        then the value of the E(ONE_USERNAME) environment variable is used.
     type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula RPC server. If not set
-        then the value of the C(ONE_PASSWORD) environment variable is used.
+        then the value of the E(ONE_PASSWORD) environment variable is used.
         if both O(api_username) or O(api_password) are not set, then it will try
         authenticate with ONE auth file. Default path is "~/.one/one_auth".
-      - Set environment variable C(ONE_AUTH) to override this path.
+      - Set environment variable E(ONE_AUTH) to override this path.
     type: str
   template_name:
     description:

--- a/plugins/modules/one_vm.py
+++ b/plugins/modules/one_vm.py
@@ -29,20 +29,20 @@ options:
     description:
       - URL of the OpenNebula RPC server.
       - It is recommended to use HTTPS so that the username/password are not
-      - transferred over the network unencrypted.
+        transferred over the network unencrypted.
       - If not set then the value of the C(ONE_URL) environment variable is used.
     type: str
   api_username:
     description:
       - Name of the user to login into the OpenNebula RPC server. If not set
-      - then the value of the C(ONE_USERNAME) environment variable is used.
+        then the value of the C(ONE_USERNAME) environment variable is used.
     type: str
   api_password:
     description:
       - Password of the user to login into OpenNebula RPC server. If not set
-      - then the value of the C(ONE_PASSWORD) environment variable is used.
-      - if both I(api_username) or I(api_password) are not set, then it will try
-      - authenticate with ONE auth file. Default path is "~/.one/one_auth".
+        then the value of the C(ONE_PASSWORD) environment variable is used.
+        if both O(api_username) or O(api_password) are not set, then it will try
+        authenticate with ONE auth file. Default path is "~/.one/one_auth".
       - Set environment variable C(ONE_AUTH) to override this path.
     type: str
   template_name:
@@ -60,32 +60,32 @@ options:
     type: bool
   instance_ids:
     description:
-      - A list of instance ids used for states':' C(absent), C(running), C(rebooted), C(poweredoff)
+      - 'A list of instance ids used for states: V(absent), V(running), V(rebooted), V(poweredoff).'
     aliases: ['ids']
     type: list
     elements: int
   state:
     description:
-      - C(present) - create instances from a template specified with C(template_id)/C(template_name).
-      - C(running) - run instances
-      - C(poweredoff) - power-off instances
-      - C(rebooted) - reboot instances
-      - C(absent) - terminate instances
+      - V(present) - create instances from a template specified with C(template_id)/C(template_name).
+      - V(running) - run instances
+      - V(poweredoff) - power-off instances
+      - V(rebooted) - reboot instances
+      - V(absent) - terminate instances
     choices: ["present", "absent", "running", "rebooted", "poweredoff"]
     default: present
     type: str
   hard:
     description:
-      - Reboot, power-off or terminate instances C(hard)
+      - Reboot, power-off or terminate instances C(hard).
     default: false
     type: bool
   wait:
     description:
       - Wait for the instance to reach its desired state before returning. Keep
-      - in mind if you are waiting for instance to be in running state it
-      - doesn't mean that you will be able to SSH on that machine only that
-      - boot process have started on that instance, see 'wait_for' example for
-      - details.
+        in mind if you are waiting for instance to be in running state it
+        doesn't mean that you will be able to SSH on that machine only that
+        boot process have started on that instance, see 'wait_for' example for
+        details.
     default: true
     type: bool
   wait_timeout:
@@ -96,36 +96,36 @@ options:
   attributes:
     description:
       - A dictionary of key/value attributes to add to new instances, or for
-      - setting C(state) of instances with these attributes.
+        setting C(state) of instances with these attributes.
       - Keys are case insensitive and OpenNebula automatically converts them to upper case.
       - Be aware C(NAME) is a special attribute which sets the name of the VM when it's deployed.
       - C(#) character(s) can be appended to the C(NAME) and the module will automatically add
-      - indexes to the names of VMs.
+        indexes to the names of VMs.
       - For example':' C(NAME':' foo-###) would create VMs with names C(foo-000), C(foo-001),...
-      - When used with C(count_attributes) and C(exact_count) the module will
-      - match the base name without the index part.
+      - When used with O(count_attributes) and O(exact_count) the module will
+        match the base name without the index part.
     default: {}
     type: dict
   labels:
     description:
       - A list of labels to associate with new instances, or for setting
-      - C(state) of instances with these labels.
+        C(state) of instances with these labels.
     default: []
     type: list
     elements: str
   count_attributes:
     description:
       - A dictionary of key/value attributes that can only be used with
-      - C(exact_count) to determine how many nodes based on a specific
-      - attributes criteria should be deployed. This can be expressed in
-      - multiple ways and is shown in the EXAMPLES section.
+        O(exact_count) to determine how many nodes based on a specific
+        attributes criteria should be deployed. This can be expressed in
+        multiple ways and is shown in the EXAMPLES section.
     type: dict
   count_labels:
     description:
-      - A list of labels that can only be used with C(exact_count) to determine
-      - how many nodes based on a specific labels criteria should be deployed.
-      - This can be expressed in multiple ways and is shown in the EXAMPLES
-      - section.
+      - A list of labels that can only be used with O(exact_count) to determine
+        how many nodes based on a specific labels criteria should be deployed.
+        This can be expressed in multiple ways and is shown in the EXAMPLES
+        section.
     type: list
     elements: str
   count:
@@ -135,14 +135,14 @@ options:
     type: int
   exact_count:
     description:
-      - Indicates how many instances that match C(count_attributes) and
-      - C(count_labels) parameters should be deployed. Instances are either
-      - created or terminated based on this value.
-      - NOTE':' Instances with the least IDs will be terminated first.
+      - Indicates how many instances that match O(count_attributes) and
+        O(count_labels) parameters should be deployed. Instances are either
+        created or terminated based on this value.
+      - 'B(NOTE:) Instances with the least IDs will be terminated first.'
     type: int
   mode:
     description:
-      - Set permission mode of the instance in octet format, e.g. C(600) to give owner C(use) and C(manage) and nothing to group and others.
+      - Set permission mode of the instance in octet format, for example V(0600) to give owner C(use) and C(manage) and nothing to group and others.
     type: str
   owner_id:
     description:
@@ -159,14 +159,14 @@ options:
   disk_size:
     description:
       - The size of the disk created for new instances (in MB, GB, TB,...).
-      - NOTE':' If The Template hats Multiple Disks the Order of the Sizes is
-      - matched against the order specified in C(template_id)/C(template_name).
+      - 'B(NOTE:) If The Template hats Multiple Disks the Order of the Sizes is
+        matched against the order specified in O(template_id)/O(template_name).'
     type: list
     elements: str
   cpu:
     description:
       - Percentage of CPU divided by 100 required for the new instance. Half a
-      - processor is written 0.5.
+        processor is written 0.5.
     type: float
   vcpu:
     description:
@@ -183,8 +183,8 @@ options:
       - Creates an image from a VM disk.
       - It is a dictionary where you have to specify C(name) of the new image.
       - Optionally you can specify C(disk_id) of the disk you want to save. By default C(disk_id) is 0.
-      - I(NOTE)':' This operation will only be performed on the first VM (if more than one VM ID is passed)
-      - and the VM has to be in the C(poweredoff) state.
+      - 'B(NOTE:) This operation will only be performed on the first VM (if more than one VM ID is passed)
+        and the VM has to be in the C(poweredoff) state.'
       - Also this operation will fail if an image with specified C(name) already exists.
     type: dict
   persistent:
@@ -205,7 +205,7 @@ options:
     type: str
   updateconf:
     description:
-      - When I(instance_ids) is provided, updates running VMs with the C(updateconf) API call.
+      - When O(instance_ids) is provided, updates running VMs with the C(updateconf) API call.
       - When new VMs are being created, emulates the C(updateconf) API call via direct template merge.
       - Allows for complete modifications of the C(CONTEXT) attribute.
     type: dict
@@ -445,12 +445,12 @@ EXAMPLES = '''
 
 RETURN = '''
 instances_ids:
-    description: a list of instances ids whose state is changed or which are fetched with C(instance_ids) option.
+    description: a list of instances ids whose state is changed or which are fetched with O(instance_ids) option.
     type: list
     returned: success
     sample: [ 1234, 1235 ]
 instances:
-    description: a list of instances info whose state is changed or which are fetched with C(instance_ids) option.
+    description: a list of instances info whose state is changed or which are fetched with O(instance_ids) option.
     type: complex
     returned: success
     contains:
@@ -562,7 +562,7 @@ instances:
 tagged_instances:
     description:
         - A list of instances info based on a specific attributes and/or
-        - labels that are specified with C(count_attributes) and C(count_labels)
+        - labels that are specified with O(count_attributes) and O(count_labels)
         - options.
     type: complex
     returned: success

--- a/plugins/modules/oneandone_load_balancer.py
+++ b/plugins/modules/oneandone_load_balancer.py
@@ -83,7 +83,7 @@ options:
   datacenter:
     description:
       - ID or country code of the datacenter where the load balancer will be created.
-      - If not specified, it defaults to I(US).
+      - If not specified, it defaults to V(US).
     type: str
     choices: [ "US", "ES", "DE", "GB" ]
     required: false

--- a/plugins/modules/oneandone_load_balancer.py
+++ b/plugins/modules/oneandone_load_balancer.py
@@ -40,7 +40,7 @@ options:
   api_url:
     description:
       - Custom API URL. Overrides the
-        ONEANDONE_API_URL environment variable.
+        E(ONEANDONE_API_URL) environment variable.
     type: str
     required: false
   name:

--- a/plugins/modules/onepassword_info.py
+++ b/plugins/modules/onepassword_info.py
@@ -20,7 +20,7 @@ requirements:
     - C(op) 1Password command line utility. See U(https://support.1password.com/command-line/)
 notes:
     - Tested with C(op) version 0.5.5
-    - "Based on the C(onepassword) lookup plugin by Scott Buchanan <sbuchanan@ri.pn>."
+    - "Based on the P(community.general.onepassword#lookup) lookup plugin by Scott Buchanan <sbuchanan@ri.pn>."
 short_description: Gather items from 1Password
 description:
     - M(community.general.onepassword_info) wraps the C(op) command line utility to fetch data about one or more 1Password items.
@@ -28,7 +28,7 @@ description:
     - Recommend using with the C(no_log) option to avoid logging the values of the secrets being retrieved.
     - This module was called C(onepassword_facts) before Ansible 2.9, returning C(ansible_facts).
       Note that the M(community.general.onepassword_info) module no longer returns C(ansible_facts)!
-      You must now use the C(register) option to use the facts in other tasks.
+      You must now use the C(register) keyword to use the facts in other tasks.
 extends_documentation_fragment:
     - community.general.attributes
     - community.general.attributes.info_module
@@ -39,7 +39,7 @@ options:
         description:
             - A list of one or more search terms.
             - Each search term can either be a simple string or it can be a dictionary for more control.
-            - When passing a simple string, I(field) is assumed to be C(password).
+            - When passing a simple string, O(search_terms[].field) is assumed to be V(password).
             - When passing a dictionary, the following fields are available.
         suboptions:
             name:
@@ -82,7 +82,7 @@ options:
                 type: str
                 description:
                     - The master password for your subdomain.
-                    - This is always required when specifying C(auto_login).
+                    - This is always required when specifying O(auto_login).
                 required: true
             secret_key:
                 type: str

--- a/plugins/modules/open_iscsi.py
+++ b/plugins/modules/open_iscsi.py
@@ -85,7 +85,7 @@ options:
         - Whether the list of target nodes on the portal should be
           (re)discovered and added to the persistent iSCSI database.
         - Keep in mind that C(iscsiadm) discovery resets configuration, like C(node.startup)
-          to manual, hence combined with I(auto_node_startup=true) will always return
+          to manual, hence combined with O(auto_node_startup=true) will always return
           a changed state.
         type: bool
         default: false
@@ -97,7 +97,7 @@ options:
     rescan:
         description:
         - Rescan an established session for discovering new targets.
-        - When I(target) is omitted, will rescan all sessions.
+        - When O(target) is omitted, will rescan all sessions.
         type: bool
         default: false
         version_added: 4.1.0

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -34,9 +34,9 @@ options:
         elements: str
     state:
         description:
-          - C(present) will make sure the package is installed.
-            C(latest) will make sure the latest version of the package is installed.
-            C(absent) will make sure the specified package is not installed.
+          - V(present) will make sure the package is installed.
+          - V(latest) will make sure the latest version of the package is installed.
+          - V(absent) will make sure the specified package is not installed.
         choices: [ absent, latest, present, installed, removed ]
         default: present
         type: str
@@ -46,19 +46,19 @@ options:
             a binary. Requires that the port source tree is already installed.
             Automatically builds and installs the 'sqlports' package, if it is
             not already installed.
-          - Mutually exclusive with I(snapshot).
+          - Mutually exclusive with O(snapshot).
         type: bool
         default: false
     snapshot:
         description:
           - Force C(%c) and C(%m) to expand to C(snapshots), even on a release kernel.
-          - Mutually exclusive with I(build).
+          - Mutually exclusive with O(build).
         type: bool
         default: false
         version_added: 1.3.0
     ports_dir:
         description:
-          - When used in combination with the C(build) option, allows overriding
+          - When used in combination with the O(build) option, allows overriding
             the default ports source directory.
         default: /usr/ports
         type: path
@@ -77,7 +77,7 @@ options:
         default: false
 notes:
   - When used with a C(loop:) each package will be processed individually,
-    it is much more efficient to pass the list directly to the I(name) option.
+    it is much more efficient to pass the list directly to the O(name) option.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/openwrt_init.py
+++ b/plugins/modules/openwrt_init.py
@@ -32,8 +32,9 @@ options:
     state:
         type: str
         description:
-            - C(started)/C(stopped) are idempotent actions that will not run commands unless necessary.
-              C(restarted) will always bounce the service. C(reloaded) will always reload.
+            - V(started)/V(stopped) are idempotent actions that will not run commands unless necessary.
+            - V(restarted) will always bounce the service.
+            - V(reloaded) will always reload.
         choices: [ 'started', 'stopped', 'restarted', 'reloaded' ]
     enabled:
         description:
@@ -43,7 +44,7 @@ options:
         type: str
         description:
         - If the service does not respond to the 'running' command, name a
-          substring to look for as would be found in the output of the I(ps)
+          substring to look for as would be found in the output of the C(ps)
           command as a stand-in for a 'running' result.  If the string is found,
           the service will be assumed to be running.
 notes:

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -58,13 +58,13 @@ options:
   value:
     description:
       - The value to write.
-      - Only required when I(state=present).
+      - Only required when O(state=present).
     type: raw
   state:
     description:
       - The state of the user defaults.
-      - If set to C(list) will query the given parameter specified by C(key). Returns 'null' is nothing found or mis-spelled.
-      - C(list) added in version 2.8.
+      - If set to V(list) will query the given parameter specified by C(key). Returns 'null' is nothing found or mis-spelled.
+      - V(list) added in Ansible 2.8.
     type: str
     choices: [ absent, list, present ]
     default: present

--- a/plugins/modules/packet_device.py
+++ b/plugins/modules/packet_device.py
@@ -82,8 +82,8 @@ options:
   hostnames:
     description:
       - A hostname of a device, or a list of hostnames.
-      - If given string or one-item list, you can use the C("%d") Python string format to expand numbers from I(count).
-      - If only one hostname, it might be expanded to list if I(count)>1.
+      - If given string or one-item list, you can use the C("%d") Python string format to expand numbers from O(count).
+      - If only one hostname, it might be expanded to list if O(count)>1.
     aliases: [name]
     type: list
     elements: str
@@ -114,8 +114,8 @@ options:
   state:
     description:
       - Desired state of the device.
-      - If set to C(present) (the default), the module call will return immediately after the device-creating HTTP request successfully returns.
-      - If set to C(active), the module call will block until all the specified devices are in state active due to the Packet API, or until I(wait_timeout).
+      - If set to V(present) (the default), the module call will return immediately after the device-creating HTTP request successfully returns.
+      - If set to V(active), the module call will block until all the specified devices are in state active due to the Packet API, or until O(wait_timeout).
     choices: [present, absent, active, inactive, rebooted]
     default: present
     type: str
@@ -135,8 +135,8 @@ options:
 
   wait_timeout:
     description:
-      - How long (seconds) to wait either for automatic IP address assignment, or for the device to reach the C(active) I(state).
-      - If I(wait_for_public_IPv) is set and I(state) is C(active), the module will wait for both events consequently, applying the timeout twice.
+      - How long (seconds) to wait either for automatic IP address assignment, or for the device to reach the V(active) state.
+      - If O(wait_for_public_IPv) is set and O(state=active), the module will wait for both events consequently, applying the timeout twice.
     default: 900
     type: int
 

--- a/plugins/modules/packet_device.py
+++ b/plugins/modules/packet_device.py
@@ -40,7 +40,7 @@ attributes:
 options:
   auth_token:
     description:
-      - Packet API token. You can also supply it in env var C(PACKET_API_TOKEN).
+      - Packet API token. You can also supply it in environment variable E(PACKET_API_TOKEN).
     type: str
 
   count:
@@ -161,7 +161,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-# All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
+# All the examples assume that you have your Packet API token in environment variable PACKET_API_TOKEN.
 # You can also pass it to the auth_token parameter of the module instead.
 
 # Creating devices

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -34,17 +34,17 @@ options:
     name:
         description:
             - Name or list of names of the package(s) or file(s) to install, upgrade, or remove.
-              Can't be used in combination with C(upgrade).
+              Cannot be used in combination with O(upgrade).
         aliases: [ package, pkg ]
         type: list
         elements: str
 
     state:
         description:
-          - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed)) a package.
-          - C(present) and C(installed) will simply ensure that a desired package is installed.
-          - C(latest) will update the specified package if it is not of the latest available version.
-          - C(absent) and C(removed) will remove the specified package.
+          - Whether to install (V(present) or V(installed), V(latest)), or remove (V(absent) or V(removed)) a package.
+          - V(present) and V(installed) will simply ensure that a desired package is installed.
+          - V(latest) will update the specified package if it is not of the latest available version.
+          - V(absent) and V(removed) will remove the specified package.
         default: present
         choices: [ absent, installed, latest, present, removed ]
         type: str
@@ -52,9 +52,9 @@ options:
     force:
         description:
             - When removing packages, forcefully remove them, without any checks.
-              Same as I(extra_args="--nodeps --nodeps").
-              When combined with I(update_cache), force a refresh of all package databases.
-              Same as I(update_cache_extra_args="--refresh --refresh").
+              Same as O(extra_args="--nodeps --nodeps").
+            - When combined with O(update_cache), force a refresh of all package databases.
+              Same as O(update_cache_extra_args="--refresh --refresh").
         default: false
         type: bool
 
@@ -79,7 +79,7 @@ options:
 
     extra_args:
         description:
-            - Additional option to pass to pacman when enforcing C(state).
+            - Additional option to pass to pacman when enforcing O(state).
         default: ''
         type: str
 
@@ -87,28 +87,28 @@ options:
         description:
             - Whether or not to refresh the master package lists.
             - This can be run as part of a package installation or as a separate step.
-            - If not specified, it defaults to C(false).
+            - If not specified, it defaults to V(false).
             - Please note that this option only had an influence on the module's C(changed) state
-              if I(name) and I(upgrade) are not specified before community.general 5.0.0.
+              if O(name) and O(upgrade) are not specified before community.general 5.0.0.
               See the examples for how to keep the old behavior.
         type: bool
 
     update_cache_extra_args:
         description:
-            - Additional option to pass to pacman when enforcing C(update_cache).
+            - Additional option to pass to pacman when enforcing O(update_cache).
         default: ''
         type: str
 
     upgrade:
         description:
             - Whether or not to upgrade the whole system.
-              Can't be used in combination with C(name).
-            - If not specified, it defaults to C(false).
+              Cannot be used in combination with O(name).
+            - If not specified, it defaults to V(false).
         type: bool
 
     upgrade_extra_args:
         description:
-            - Additional option to pass to pacman when enforcing C(upgrade).
+            - Additional option to pass to pacman when enforcing O(upgrade).
         default: ''
         type: str
 
@@ -121,8 +121,8 @@ options:
 
     reason_for:
         description:
-            - Set the install reason for C(all) packages or only for C(new) packages.
-            - In case of I(state=latest) already installed packages which will be updated to a newer version are not counted as C(new).
+            - Set the install reason for V(all) packages or only for V(new) packages.
+            - In case of O(state=latest) already installed packages which will be updated to a newer version are not counted as V(new).
         default: new
         choices: [ all, new ]
         type: str
@@ -130,8 +130,8 @@ options:
 
 notes:
   - When used with a C(loop:) each package will be processed individually,
-    it is much more efficient to pass the list directly to the I(name) option.
-  - To use an AUR helper (I(executable) option), a few extra setup steps might be required beforehand.
+    it is much more efficient to pass the list directly to the O(name) option.
+  - To use an AUR helper (O(executable) option), a few extra setup steps might be required beforehand.
     For example, a dedicated build user with permissions to install packages could be necessary.
 """
 
@@ -139,11 +139,11 @@ RETURN = """
 packages:
     description:
         - A list of packages that have been changed.
-        - Before community.general 4.5.0 this was only returned when I(upgrade=true).
+        - Before community.general 4.5.0 this was only returned when O(upgrade=true).
           In community.general 4.5.0, it was sometimes omitted when the package list is empty,
-          but since community.general 4.6.0 it is always returned when I(name) is specified or
-          I(upgrade=true).
-    returned: success and I(name) is specified or I(upgrade=true)
+          but since community.general 4.6.0 it is always returned when O(name) is specified or
+          O(upgrade=true).
+    returned: success and O(name) is specified or O(upgrade=true)
     type: list
     elements: str
     sample: [ package, other-package ]
@@ -151,8 +151,8 @@ packages:
 cache_updated:
     description:
         - The changed status of C(pacman -Sy).
-        - Useful when I(name) or I(upgrade=true) are specified next to I(update_cache=true).
-    returned: success, when I(update_cache=true)
+        - Useful when O(name) or O(upgrade=true) are specified next to O(update_cache=true).
+    returned: success, when O(update_cache=true)
     type: bool
     sample: false
     version_added: 4.6.0

--- a/plugins/modules/pacman_key.py
+++ b/plugins/modules/pacman_key.py
@@ -19,10 +19,10 @@ description:
     - Add or remove gpg keys from the pacman keyring.
 notes:
     - Use full-length key ID (40 characters).
-    - Keys will be verified when using I(data), I(file), or I(url) unless I(verify) is overridden.
+    - Keys will be verified when using O(data), O(file), or O(url) unless O(verify) is overridden.
     - Keys will be locally signed after being imported into the keyring.
-    - If the key ID exists in the keyring, the key will not be added unless I(force_update) is specified.
-    - I(data), I(file), I(url), and I(keyserver) are mutually exclusive.
+    - If the key ID exists in the keyring, the key will not be added unless O(force_update) is specified.
+    - O(data), O(file), O(url), and O(keyserver) are mutually exclusive.
 requirements:
     - gpg
     - pacman-key
@@ -73,7 +73,7 @@ options:
     keyring:
         description:
             - The full path to the keyring folder on the remote server.
-            - If not specified, module will use pacman's default (C(/etc/pacman.d/gnupg)).
+            - If not specified, module will use pacman's default (V(/etc/pacman.d/gnupg)).
             - Useful if the remote system requires an alternative gnupg directory.
         type: path
         default: /etc/pacman.d/gnupg

--- a/plugins/modules/pagerduty.py
+++ b/plugins/modules/pagerduty.py
@@ -43,7 +43,7 @@ options:
     user:
         type: str
         description:
-            - PagerDuty user ID. Obsolete. Please, use I(token) for authorization.
+            - PagerDuty user ID. Obsolete. Please, use O(token) for authorization.
     token:
         type: str
         description:
@@ -80,7 +80,7 @@ options:
         default: Created by Ansible
     validate_certs:
         description:
-            - If C(false), SSL certificates will not be validated. This should only be used
+            - If V(false), SSL certificates will not be validated. This should only be used
               on personally controlled sites using self-signed certificates.
         type: bool
         default: true

--- a/plugins/modules/pagerduty_alert.py
+++ b/plugins/modules/pagerduty_alert.py
@@ -38,7 +38,7 @@ options:
     service_key:
         type: str
         description:
-            - The GUID of one of your "Generic API" services. Obsolete. Please use I(integration_key).
+            - The GUID of one of your "Generic API" services. Obsolete. Please use O(integration_key).
     integration_key:
         type: str
         description:
@@ -61,20 +61,20 @@ options:
     desc:
         type: str
         description:
-            - For C(triggered) I(state) - Required. Short description of the problem that led to this trigger. This field (or a truncated version)
+            - For O(state=triggered) - Required. Short description of the problem that led to this trigger. This field (or a truncated version)
               will be used when generating phone calls, SMS messages and alert emails. It will also appear on the incidents tables in the PagerDuty UI.
               The maximum length is 1024 characters.
-            - For C(acknowledged) or C(resolved) I(state) - Text that will appear in the incident's log associated with this event.
+            - For O(state=acknowledged) or O(state=resolved) - Text that will appear in the incident's log associated with this event.
         required: false
         default: Created via Ansible
     incident_key:
         type: str
         description:
-            - Identifies the incident to which this I(state) should be applied.
-            - For C(triggered) I(state) - If there's no open (i.e. unresolved) incident with this key, a new one will be created. If there's already an
+            - Identifies the incident to which this O(state) should be applied.
+            - For O(state=triggered) - If there's no open (i.e. unresolved) incident with this key, a new one will be created. If there's already an
               open incident with a matching key, this event will be appended to that incident's log. The event key provides an easy way to "de-dup"
               problem reports.
-            - For C(acknowledged) or C(resolved) I(state) - This should be the incident_key you received back when the incident was first opened by a
+            - For O(state=acknowledged) or O(state=resolved) - This should be the incident_key you received back when the incident was first opened by a
               trigger event. Acknowledge events referencing resolved or nonexistent incidents will be discarded.
         required: false
     client:

--- a/plugins/modules/pagerduty_change.py
+++ b/plugins/modules/pagerduty_change.py
@@ -25,7 +25,7 @@ attributes:
   check_mode:
     support: full
     details:
-      - Check mode simply does nothing except returning C(changed=true) in case the I(url) seems to be correct.
+      - Check mode simply does nothing except returning C(changed=true) in case the O(url) seems to be correct.
   diff_mode:
     support: none
 options:
@@ -61,7 +61,7 @@ options:
     type: str
   environment:
     description:
-      - The environment name, typically C(production), C(staging), etc.
+      - The environment name, typically V(production), V(staging), and so on.
     required: false
     type: str
   link_url:
@@ -82,7 +82,7 @@ options:
     type: str
   validate_certs:
     description:
-      - If C(false), SSL certificates for the target URL will not be validated.
+      - If V(false), SSL certificates for the target URL will not be validated.
         This should only be used on personally controlled sites using self-signed certificates.
     required: false
     default: true

--- a/plugins/modules/pagerduty_user.py
+++ b/plugins/modules/pagerduty_user.py
@@ -40,7 +40,7 @@ options:
     pd_email:
         description:
             - The user's email address.
-            - I(pd_email) is the unique identifier used and cannot be updated using this module.
+            - O(pd_email) is the unique identifier used and cannot be updated using this module.
         required: true
         type: str
     pd_role:
@@ -52,15 +52,15 @@ options:
     state:
         description:
             - State of the user.
-            - On C(present), it creates a user if the user doesn't exist.
-            - On C(absent), it removes a user if the account exists.
+            - On V(present), it creates a user if the user doesn't exist.
+            - On V(absent), it removes a user if the account exists.
         choices: ['present', 'absent']
         default: 'present'
         type: str
     pd_teams:
         description:
             - The teams to which the user belongs.
-            - Required if I(state=present).
+            - Required if O(state=present).
         type: list
         elements: str
 '''

--- a/plugins/modules/pam_limits.py
+++ b/plugins/modules/pam_limits.py
@@ -15,8 +15,8 @@ author:
 - "Sebastien Rohaut (@usawa)"
 short_description: Modify Linux PAM limits
 description:
-  - The C(pam_limits) module modifies PAM limits.
-  - The default file is C(/etc/security/limits.conf).
+  - The M(community.general.pam_limits) module modifies PAM limits.
+  - The default file is V(/etc/security/limits.conf).
   - For the full documentation, see C(man 5 limits.conf).
 extends_documentation_fragment:
   - community.general.attributes
@@ -68,8 +68,8 @@ options:
     type: str
     description:
       - The value of the limit.
-      - Value must either be C(unlimited), C(infinity) or C(-1), all of which indicate no limit, or a limit of 0 or larger.
-      - Value must be a number in the range -20 to 19 inclusive, if I(limit_item) is set to C(nice) or C(priority).
+      - Value must either be V(unlimited), V(infinity) or V(-1), all of which indicate no limit, or a limit of 0 or larger.
+      - Value must be a number in the range -20 to 19 inclusive, if O(limit_item) is set to V(nice) or V(priority).
       - Refer to the C(man 5 limits.conf) manual pages for more details.
     required: true
   backup:
@@ -81,7 +81,7 @@ options:
     default: false
   use_min:
     description:
-      - If set to C(true), the minimal value will be used or conserved.
+      - If set to V(true), the minimal value will be used or conserved.
       - If the specified value is inferior to the value in the file,
         file content is replaced with the new value, else content is not modified.
     required: false
@@ -89,7 +89,7 @@ options:
     default: false
   use_max:
     description:
-      - If set to C(true), the maximal value will be used or conserved.
+      - If set to V(true), the maximal value will be used or conserved.
       - If the specified value is superior to the value in the file,
         file content is replaced with the new value, else content is not modified.
     required: false
@@ -108,7 +108,7 @@ options:
     required: false
     default: ''
 notes:
-  - If I(dest) file does not exist, it is created.
+  - If O(dest) file does not exist, it is created.
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -21,10 +21,10 @@ description:
     check the GNU parted manual.
 requirements:
   - This module requires C(parted) version 1.8.3 and above.
-  - Option I(align) (except C(undefined)) requires C(parted) 2.1 or above.
+  - Option O(align) (except V(undefined)) requires C(parted) 2.1 or above.
   - If the version of C(parted) is below 3.1, it requires a Linux version running
     the C(sysfs) file system C(/sys/).
-  - Requires the C(resizepart) command when using the I(resize) parameter.
+  - Requires the C(resizepart) command when using the O(resize) parameter.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -42,7 +42,7 @@ options:
     required: true
   align:
     description:
-      - Set alignment for newly created partitions. Use C(undefined) for parted default aligment.
+      - Set alignment for newly created partitions. Use V(undefined) for parted default aligment.
     type: str
     choices: [ cylinder, minimal, none, optimal, undefined ]
     default: optimal
@@ -63,16 +63,16 @@ options:
   label:
     description:
       - Disk label type or partition table to use.
-      - If I(device) already contains a different label, it will be changed to I(label)
+      - If O(device) already contains a different label, it will be changed to O(label)
         and any previous partitions will be lost.
-      - A I(name) must be specified for a C(gpt) partition table.
+      - A O(name) must be specified for a V(gpt) partition table.
     type: str
     choices: [ aix, amiga, bsd, dvh, gpt, loop, mac, msdos, pc98, sun ]
     default: msdos
   part_type:
     description:
-      - May be specified only with I(label=msdos) or I(label=dvh).
-      - Neither I(part_type) nor I(name) may be used with I(label=sun).
+      - May be specified only with O(label=msdos) or O(label=dvh).
+      - Neither O(part_type) nor O(name) may be used with O(label=sun).
     type: str
     choices: [ extended, logical, primary ]
     default: primary
@@ -82,8 +82,8 @@ options:
         that is, the "distance" from the start of the disk. Negative numbers
         specify distance from the end of the disk.
       - The distance can be specified with all the units supported by parted
-        (except compat) and it is case sensitive, e.g. C(10GiB), C(15%).
-      - Using negative values may require setting of I(fs_type) (see notes).
+        (except compat) and it is case sensitive, for example V(10GiB), V(15%).
+      - Using negative values may require setting of O(fs_type) (see notes).
     type: str
     default: 0%
   part_end:
@@ -92,7 +92,7 @@ options:
         that is, the "distance" from the start of the disk. Negative numbers
         specify distance from the end of the disk.
       - The distance can be specified with all the units supported by parted
-        (except compat) and it is case sensitive, e.g. C(10GiB), C(15%).
+        (except compat) and it is case sensitive, for example V(10GiB), V(15%).
     type: str
     default: 100%
   name:
@@ -106,19 +106,19 @@ options:
   state:
     description:
       - Whether to create or delete a partition.
-      - If set to C(info) the module will only return the device information.
+      - If set to V(info) the module will only return the device information.
     type: str
     choices: [ absent, present, info ]
     default: info
   fs_type:
     description:
       - If specified and the partition does not exist, will set filesystem type to given partition.
-      - Parameter optional, but see notes below about negative I(part_start) values.
+      - Parameter optional, but see notes below about negative O(part_start) values.
     type: str
     version_added: '0.2.0'
   resize:
     description:
-      - Call C(resizepart) on existing partitions to match the size specified by I(part_end).
+      - Call C(resizepart) on existing partitions to match the size specified by O(part_end).
     type: bool
     default: false
     version_added: '1.3.0'
@@ -128,9 +128,9 @@ notes:
     installed on the system is before version 3.1, the module queries the kernel
     through C(/sys/) to obtain disk information. In this case the units CHS and
     CYL are not supported.
-  - Negative I(part_start) start values were rejected if I(fs_type) was not given.
-    This bug was fixed in parted 3.2.153. If you want to use negative I(part_start),
-    specify I(fs_type) as well or make sure your system contains newer parted.
+  - Negative O(part_start) start values were rejected if O(fs_type) was not given.
+    This bug was fixed in parted 3.2.153. If you want to use negative O(part_start),
+    specify O(fs_type) as well or make sure your system contains newer parted.
 '''
 
 RETURN = r'''

--- a/plugins/modules/pids.py
+++ b/plugins/modules/pids.py
@@ -31,7 +31,7 @@ options:
     type: str
     version_added: 3.0.0
   ignore_case:
-    description: Ignore case in pattern if using the I(pattern) option.
+    description: Ignore case in pattern if using the O(pattern) option.
     type: bool
     default: false
     version_added: 3.0.0

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -30,8 +30,8 @@ options:
         default: install
         description:
             - Desired state for the application.
-            - The states C(present) and C(absent) are aliases to C(install) and C(uninstall), respectively.
-            - The state C(latest) is equivalent to executing the task twice, with state C(install) and then C(upgrade).
+            - The states V(present) and V(absent) are aliases to V(install) and V(uninstall), respectively.
+            - The state V(latest) is equivalent to executing the task twice, with state V(install) and then V(upgrade).
               It was added in community.general 5.5.0.
     name:
         type: str
@@ -39,60 +39,60 @@ options:
             - >
               The name of the application to be installed. It must to be a simple package name.
               For passing package specifications or installing from URLs or directories,
-              please use the I(source) option.
+              please use the O(source) option.
     source:
         type: str
         description:
             - >
               If the application source, such as a package with version specifier, or an URL,
               directory or any other accepted specification. See C(pipx) documentation for more details.
-            - When specified, the C(pipx) command will use I(source) instead of I(name).
+            - When specified, the C(pipx) command will use O(source) instead of O(name).
     install_apps:
         description:
             - Add apps from the injected packages.
-            - Only used when I(state=inject).
+            - Only used when O(state=inject).
         type: bool
         default: false
         version_added: 6.5.0
     install_deps:
         description:
             - Include applications of dependent packages.
-            - Only used when I(state=install), I(state=latest), or I(state=inject).
+            - Only used when O(state=install), O(state=latest), or O(state=inject).
         type: bool
         default: false
     inject_packages:
         description:
             - Packages to be injected into an existing virtual environment.
-            - Only used when I(state=inject).
+            - Only used when O(state=inject).
         type: list
         elements: str
     force:
         description:
             - Force modification of the application's virtual environment. See C(pipx) for details.
-            - Only used when I(state=install), I(state=upgrade), I(state=upgrade_all), I(state=latest), or I(state=inject).
+            - Only used when O(state=install), O(state=upgrade), O(state=upgrade_all), O(state=latest), or O(state=inject).
         type: bool
         default: false
     include_injected:
         description:
             - Upgrade the injected packages along with the application.
-            - Only used when I(state=upgrade), I(state=upgrade_all), or I(state=latest).
-            - This is used with I(state=upgrade) and I(state=latest) since community.general 6.6.0.
+            - Only used when O(state=upgrade), O(state=upgrade_all), or O(state=latest).
+            - This is used with O(state=upgrade) and O(state=latest) since community.general 6.6.0.
         type: bool
         default: false
     index_url:
         description:
             - Base URL of Python Package Index.
-            - Only used when I(state=install), I(state=upgrade), I(state=latest), or I(state=inject).
+            - Only used when O(state=install), O(state=upgrade), O(state=latest), or O(state=inject).
         type: str
     python:
         description:
             - Python version to be used when creating the application virtual environment. Must be 3.6+.
-            - Only used when I(state=install), I(state=latest), I(state=reinstall), or I(state=reinstall_all).
+            - Only used when O(state=install), O(state=latest), O(state=reinstall), or O(state=reinstall_all).
         type: str
     system_site_packages:
         description:
             - Give application virtual environment access to the system site-packages directory.
-            - Only used when I(state=install) or I(state=latest).
+            - Only used when O(state=install) or O(state=latest).
         type: bool
         default: false
         version_added: 6.6.0

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -51,7 +51,7 @@ notes:
     - This module does not install the C(pipx) python package, however that can be easily done with the module M(ansible.builtin.pip).
     - This module does not require C(pipx) to be in the shell C(PATH), but it must be loadable by Python as a module.
     - >
-      This module will honor C(pipx) environment variables such as but not limited to C(PIPX_HOME) and C(PIPX_BIN_DIR)
+      This module will honor C(pipx) environment variables such as but not limited to E(PIPX_HOME) and E(PIPX_BIN_DIR)
       passed using the R(environment Ansible keyword, playbooks_environment).
     - This module requires C(pipx) version 0.16.2.1 or above.
     - Please note that C(pipx) requires Python 3.6 or above.

--- a/plugins/modules/pipx_info.py
+++ b/plugins/modules/pipx_info.py
@@ -37,7 +37,7 @@ options:
     include_raw:
         description:
             - Returns the raw output of C(pipx list --json).
-            - The raw output is not affected by I(include_deps) or I(include_injected).
+            - The raw output is not affected by O(include_deps) or O(include_injected).
         type: bool
         default: false
     executable:
@@ -98,20 +98,20 @@ application:
       type: str
       sample: "3.24.0"
     dependencies:
-      description: The dependencies of the installed application, when I(include_deps=true).
+      description: The dependencies of the installed application, when O(include_deps=true).
       returned: success
       type: list
       elements: str
       sample: ["virtualenv"]
     injected:
-      description: The injected packages for the installed application, when I(include_injected=true).
+      description: The injected packages for the installed application, when O(include_injected=true).
       returned: success
       type: dict
       sample:
         licenses: "0.6.1"
 
 raw_output:
-  description: The raw output of the C(pipx list) command, when I(include_raw=true). Used for debugging.
+  description: The raw output of the C(pipx list) command, when O(include_raw=true). Used for debugging.
   returned: success
   type: dict
 

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -29,13 +29,13 @@ options:
   name:
     description:
       - An FRMI of the package(s) to be installed/removed/updated.
-      - Multiple packages may be specified, separated by C(,).
+      - Multiple packages may be specified, separated by V(,).
     required: true
     type: list
     elements: str
   state:
     description:
-      - Whether to install (I(present), I(latest)), or remove (I(absent)) a package.
+      - Whether to install (V(present), V(latest)), or remove (V(absent)) a package.
     choices: [ absent, latest, present, installed, removed, uninstalled ]
     default: present
     type: str

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -31,10 +31,10 @@ options:
     name:
         description:
             - Name or list of names of packages to install/remove.
-            - "With I(name=*), I(state=latest) will operate, but I(state=present) and I(state=absent) will be noops."
+            - "With O(name=*), O(state=latest) will operate, but O(state=present) and O(state=absent) will be noops."
             - >
                 Warning: In Ansible 2.9 and earlier this module had a misfeature
-                where I(name=*) with I(state=latest) or I(state=present) would
+                where O(name=*) with O(state=latest) or O(state=present) would
                 install every package from every package repository, filling up
                 the machines disk. Avoid using them unless you are certain that
                 your role will only be used with newer versions.
@@ -45,7 +45,7 @@ options:
     state:
         description:
             - State of the package.
-            - 'Note: C(latest) added in 2.7.'
+            - 'Note: V(latest) added in Ansible 2.7.'
         choices: [ 'present', 'latest', 'absent' ]
         required: false
         default: present
@@ -59,8 +59,8 @@ options:
     annotation:
         description:
             - A list of keyvalue-pairs of the form
-              C(<+/-/:><key>[=<value>]). A C(+) denotes adding an annotation, a
-              C(-) denotes removing an annotation, and C(:) denotes modifying an
+              C(<+/-/:><key>[=<value>]). A V(+) denotes adding an annotation, a
+              V(-) denotes removing an annotation, and V(:) denotes modifying an
               annotation.
               If setting or modifying annotations, a value must be provided.
         required: false
@@ -79,19 +79,19 @@ options:
         description:
             - For pkgng versions 1.5 and later, pkg will install all packages
               within the specified root directory.
-            - Can not be used together with I(chroot) or I(jail) options.
+            - Can not be used together with O(chroot) or O(jail) options.
         required: false
         type: path
     chroot:
         description:
             - Pkg will chroot in the specified environment.
-            - Can not be used together with I(rootdir) or I(jail) options.
+            - Can not be used together with O(rootdir) or O(jail) options.
         required: false
         type: path
     jail:
         description:
             - Pkg will execute in the given jail name or id.
-            - Can not be used together with I(chroot) or I(rootdir) options.
+            - Can not be used together with O(chroot) or O(rootdir) options.
         type: str
     autoremove:
         description:
@@ -111,7 +111,7 @@ author: "bleader (@bleader)"
 notes:
   - When using pkgsite, be careful that already in cache packages won't be downloaded again.
   - When used with a C(loop:) each package will be processed individually,
-    it is much more efficient to pass the list directly to the I(name) option.
+    it is much more efficient to pass the list directly to the O(name) option.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -102,7 +102,7 @@ options:
     ignore_osver:
         description:
             - Ignore FreeBSD OS version check, useful on -STABLE and -CURRENT branches.
-            - Defines the C(IGNORE_OSVERSION) environment variable.
+            - Defines the E(IGNORE_OSVERSION) environment variable.
         required: false
         type: bool
         default: false

--- a/plugins/modules/pkgutil.py
+++ b/plugins/modules/pkgutil.py
@@ -36,7 +36,7 @@ options:
   name:
     description:
     - The name of the package.
-    - When using I(state=latest), this can be C('*'), which updates all installed packages managed by pkgutil.
+    - When using O(state=latest), this can be V('*'), which updates all installed packages managed by pkgutil.
     type: list
     required: true
     elements: str
@@ -49,19 +49,19 @@ options:
     type: str
   state:
     description:
-    - Whether to install (C(present)/C(installed)), or remove (C(absent)/C(removed)) packages.
-    - The upgrade (C(latest)) operation will update/install the packages to the latest version available.
+    - Whether to install (V(present)/V(installed)), or remove (V(absent)/V(removed)) packages.
+    - The upgrade (V(latest)) operation will update/install the packages to the latest version available.
     type: str
     required: true
     choices: [ absent, installed, latest, present, removed ]
   update_catalog:
     description:
-    - If you always want to refresh your catalog from the mirror, even when it's not stale, set this to C(true).
+    - If you always want to refresh your catalog from the mirror, even when it's not stale, set this to V(true).
     type: bool
     default: false
   force:
     description:
-    - To allow the update process to downgrade packages to match what is present in the repository, set this to C(true).
+    - To allow the update process to downgrade packages to match what is present in the repository, set this to V(true).
     - This is useful for rolling back to stable from testing, or similar operations.
     type: bool
     default: false

--- a/plugins/modules/pmem.py
+++ b/plugins/modules/pmem.py
@@ -30,10 +30,10 @@ attributes:
 options:
   appdirect:
     description:
-     - Percentage of the total capacity to use in AppDirect Mode (C(0)-C(100)).
+     - Percentage of the total capacity to use in AppDirect Mode (V(0)-V(100)).
      - Create AppDirect capacity utilizing hardware interleaving across the
        requested PMem modules if applicable given the specified target.
-     - Total of I(appdirect), I(memorymode) and I(reserved) must be C(100)
+     - Total of O(appdirect), O(memorymode) and O(reserved) must be V(100)
     type: int
   appdirect_interleaved:
     description:
@@ -43,20 +43,20 @@ options:
     default: true
   memorymode:
     description:
-     - Percentage of the total capacity to use in Memory Mode (C(0)-C(100)).
+     - Percentage of the total capacity to use in Memory Mode (V(0)-V(100)).
     type: int
   reserved:
     description:
-     - Percentage of the capacity to reserve (C(0)-C(100)). I(reserved) will not be mapped
+     - Percentage of the capacity to reserve (V(0)-V(100)). O(reserved) will not be mapped
        into the system physical address space and will be presented as reserved
        capacity with Show Device and Show Memory Resources Commands.
-     - I(reserved) will be set automatically if this is not configured.
+     - O(reserved) will be set automatically if this is not configured.
     type: int
     required: false
   socket:
     description:
      - This enables to set the configuration for each socket by using the socket ID.
-     - Total of I(appdirect), I(memorymode) and I(reserved) must be C(100) within one socket.
+     - Total of O(appdirect), O(memorymode) and O(reserved) must be V(100) within one socket.
     type: list
     elements: dict
     suboptions:
@@ -66,7 +66,7 @@ options:
         required: true
       appdirect:
         description:
-         - Percentage of the total capacity to use in AppDirect Mode (C(0)-C(100)) within the socket ID.
+         - Percentage of the total capacity to use in AppDirect Mode (V(0)-V(100)) within the socket ID.
         type: int
         required: true
       appdirect_interleaved:
@@ -77,12 +77,12 @@ options:
         default: true
       memorymode:
         description:
-         - Percentage of the total capacity to use in Memory Mode (C(0)-C(100)) within the socket ID.
+         - Percentage of the total capacity to use in Memory Mode (V(0)-V(100)) within the socket ID.
         type: int
         required: true
       reserved:
         description:
-          - Percentage of the capacity to reserve (C(0)-C(100)) within the socket ID.
+          - Percentage of the capacity to reserve (V(0)-V(100)) within the socket ID.
         type: int
   namespace:
     description:
@@ -104,8 +104,8 @@ options:
         choices: ['pmem', 'blk']
       size:
         description:
-          - The size of namespace. This option supports the suffixes C(k) or C(K) or C(KB) for KiB,
-            C(m) or C(M) or C(MB) for MiB, C(g) or C(G) or C(GB) for GiB and C(t) or C(T) or C(TB) for TiB.
+          - The size of namespace. This option supports the suffixes V(k) or V(K) or V(KB) for KiB,
+            V(m) or V(M) or V(MB) for MiB, V(g) or V(G) or V(GB) for GiB and V(t) or V(T) or V(TB) for TiB.
           - This option is required if multiple namespaces are configured.
           - If this option is not set, all of the available space of a region is configured.
         type: str
@@ -113,7 +113,7 @@ options:
   namespace_append:
     description:
      - Enable to append the new namespaces to the system.
-     - The default is C(false) so the all existing namespaces not listed in I(namespace) are removed.
+     - The default is V(false) so the all existing namespaces not listed in O(namespace) are removed.
     type: bool
     default: false
     required: false
@@ -128,8 +128,8 @@ reboot_required:
 result:
     description:
      - Shows the value of AppDirect, Memory Mode and Reserved size in bytes.
-     - If I(socket) argument is provided, shows the values in each socket with C(socket) which contains the socket ID.
-     - If I(namespace) argument is provided, shows the detail of each namespace.
+     - If O(socket) argument is provided, shows the values in each socket with C(socket) which contains the socket ID.
+     - If O(namespace) argument is provided, shows the detail of each namespace.
     returned: success
     type: list
     elements: dict

--- a/plugins/modules/pritunl_org.py
+++ b/plugins/modules/pritunl_org.py
@@ -37,9 +37,9 @@ options:
         type: bool
         default: false
         description:
-            - If I(force) is C(true) and I(state) is C(absent), the module
+            - If O(force) is V(true) and O(state) is V(absent), the module
               will delete the organization, no matter if it contains users
-              or not. By default I(force) is C(false), which will cause the
+              or not. By default O(force) is V(false), which will cause the
               module to fail the deletion of the organization when it contains
               users.
 
@@ -50,9 +50,9 @@ options:
             - present
             - absent
         description:
-            - If C(present), the module adds organization I(name) to
-              Pritunl. If C(absent), attempt to delete the organization
-              from Pritunl (please read about I(force) usage).
+            - If V(present), the module adds organization O(name) to
+              Pritunl. If V(absent), attempt to delete the organization
+              from Pritunl (please read about O(force) usage).
 """
 
 EXAMPLES = """

--- a/plugins/modules/pritunl_user.py
+++ b/plugins/modules/pritunl_user.py
@@ -40,9 +40,9 @@ options:
             - present
             - absent
         description:
-            - If C(present), the module adds user I(user_name) to
-              the Pritunl I(organization). If C(absent), removes the user
-              I(user_name) from the Pritunl I(organization).
+            - If V(present), the module adds user O(user_name) to
+              the Pritunl O(organization). If V(absent), removes the user
+              O(user_name) from the Pritunl O(organization).
 
     user_name:
         type: str
@@ -56,7 +56,7 @@ options:
         required: false
         default: null
         description:
-            - Email address associated with the user I(user_name).
+            - Email address associated with the user O(user_name).
 
     user_type:
         type: str
@@ -66,7 +66,7 @@ options:
             - client
             - server
         description:
-            - Type of the user I(user_name).
+            - Type of the user O(user_name).
 
     user_groups:
         type: list
@@ -74,27 +74,27 @@ options:
         required: false
         default: null
         description:
-            - List of groups associated with the user I(user_name).
+            - List of groups associated with the user O(user_name).
 
     user_disabled:
         type: bool
         required: false
         default: null
         description:
-            - Enable/Disable the user I(user_name).
+            - Enable/Disable the user O(user_name).
 
     user_gravatar:
         type: bool
         required: false
         default: null
         description:
-            - Enable/Disable Gravatar usage for the user I(user_name).
+            - Enable/Disable Gravatar usage for the user O(user_name).
 
     user_mac_addresses:
         type: list
         elements: str
         description:
-            - Allowed MAC addresses for the user I(user_name).
+            - Allowed MAC addresses for the user O(user_name).
         version_added: 5.0.0
 """
 

--- a/plugins/modules/pritunl_user_info.py
+++ b/plugins/modules/pritunl_user_info.py
@@ -43,7 +43,7 @@ options:
             - client
             - server
         description:
-            - Type of the user I(user_name).
+            - Type of the user O(user_name).
 """
 
 EXAMPLES = """

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -15,7 +15,7 @@ short_description: Management of instances in Proxmox VE cluster
 description:
   - allows you to create/delete/stop instances in Proxmox VE cluster
   - Starting in Ansible 2.1, it automatically detects containerization type (lxc for PVE 4, openvz for older)
-  - Since community.general 4.0.0 on, there are no more default values, see I(proxmox_default_behavior).
+  - Since community.general 4.0.0 on, there are no more default values, see O(proxmox_default_behavior).
 attributes:
   check_mode:
     support: none
@@ -29,45 +29,45 @@ options:
   hostname:
     description:
       - the instance hostname
-      - required only for C(state=present)
+      - required only for O(state=present)
       - must be unique if vmid is not passed
     type: str
   ostemplate:
     description:
       - the template for VM creating
-      - required only for C(state=present)
+      - required only for O(state=present)
     type: str
   disk:
     description:
       - This option was previously described as "hard disk size in GB for instance" however several formats describing
         a lxc mount are permitted.
-      - Older versions of Proxmox will accept a numeric value for size using the I(storage) parameter to automatically
+      - Older versions of Proxmox will accept a numeric value for size using the O(storage) parameter to automatically
         choose which storage to allocate from, however new versions enforce the C(<STORAGE>:<SIZE>) syntax.
       - "Additional options are available by using some combination of the following key-value pairs as a
         comma-delimited list C([volume=]<volume> [,acl=<1|0>] [,mountoptions=<opt[;opt...]>] [,quota=<1|0>]
         [,replicate=<1|0>] [,ro=<1|0>] [,shared=<1|0>] [,size=<DiskSize>])."
       - See U(https://pve.proxmox.com/wiki/Linux_Container) for a full description.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(3).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(3).
     type: str
   cores:
     description:
       - Specify number of cores per socket.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1).
     type: int
   cpus:
     description:
       - numbers of allocated cpus for instance
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1).
     type: int
   memory:
     description:
       - memory size in MB for instance
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(512).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(512).
     type: int
   swap:
     description:
       - swap memory size in MB for instance
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(0).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(0).
     type: int
   netif:
     description:
@@ -91,7 +91,7 @@ options:
   onboot:
     description:
       - specifies whether a VM will be started during system bootup
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(false).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(false).
     type: bool
   storage:
     description:
@@ -101,7 +101,7 @@ options:
   cpuunits:
     description:
       - CPU weight for a VM
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1000).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1000).
     type: int
   nameserver:
     description:
@@ -114,7 +114,7 @@ options:
   tags:
     description:
       - List of tags to apply to the container.
-      - Tags must start with C([a-z0-9_]) followed by zero or more of the following characters C([a-z0-9_-+.]).
+      - Tags must start with V([a-z0-9_]) followed by zero or more of the following characters V([a-z0-9_-+.]).
       - Tags are only available in Proxmox 7+.
     type: list
     elements: str
@@ -126,10 +126,10 @@ options:
     default: 30
   force:
     description:
-      - forcing operations
-      - can be used only with states C(present), C(stopped), C(restarted)
-      - with C(state=present) force option allow to overwrite existing container
-      - with states C(stopped) , C(restarted) allow to force stop instance
+      - Forcing operations.
+      - Can be used only with states V(present), V(stopped), V(restarted).
+      - with O(state=present) force option allow to overwrite existing container.
+      - with states V(stopped), V(restarted) allow to force stop instance.
     type: bool
     default: false
   purge:
@@ -137,7 +137,7 @@ options:
       - Remove container from all related configurations.
       - For example backup jobs, replication jobs, or HA.
       - Related ACLs and Firewall entries will always be removed.
-      - Used with state C(absent).
+      - Used with O(state=absent).
     type: bool
     default: false
     version_added: 2.3.0
@@ -154,7 +154,7 @@ options:
   unprivileged:
     description:
       - Indicate if the container should be unprivileged.
-      - The default change to C(true) in community.general 7.0.0. It used to be C(false) before.
+      - The default change to V(true) in community.general 7.0.0. It used to be V(false) before.
     type: bool
     default: true
   description:
@@ -170,8 +170,8 @@ options:
     version_added: '0.2.0'
   timezone:
     description:
-      - Timezone used by the container, accepts values like C(Europe/Paris).
-      - The special value C(host) configures the same timezone used by Proxmox host.
+      - Timezone used by the container, accepts values like V(Europe/Paris).
+      - The special value V(host) configures the same timezone used by Proxmox host.
     type: str
     version_added: '7.1.0'
   proxmox_default_behavior:
@@ -179,10 +179,10 @@ options:
       - As of community.general 4.0.0, various options no longer have default values.
         These default values caused problems when users expected different behavior from Proxmox
         by default or filled options which caused problems when set.
-      - The value C(compatibility) (default before community.general 4.0.0) will ensure that the default values
-        are used when the values are not explicitly specified by the user. The new default is C(no_defaults),
+      - The value V(compatibility) (default before community.general 4.0.0) will ensure that the default values
+        are used when the values are not explicitly specified by the user. The new default is V(no_defaults),
         which makes sure these options have no defaults.
-      - This affects the I(disk), I(cores), I(cpus), I(memory), I(onboot), I(swap), I(cpuunits) options.
+      - This affects the O(disk), O(cores), O(cpus), O(memory), O(onboot), O(swap), and O(cpuunits) options.
     type: str
     default: no_defaults
     choices:
@@ -192,18 +192,18 @@ options:
   clone:
     description:
       - ID of the container to be cloned.
-      - I(description), I(hostname), and I(pool) will be copied from the cloned container if not specified.
-      - The type of clone created is defined by the I(clone_type) parameter.
+      - O(description), O(hostname), and O(pool) will be copied from the cloned container if not specified.
+      - The type of clone created is defined by the O(clone_type) parameter.
       - This operator is only supported for Proxmox clusters that use LXC containerization (PVE version >= 4).
     type: int
     version_added: 4.3.0
   clone_type:
     description:
       - Type of the clone created.
-      - C(full) creates a full clone, and I(storage) must be specified.
-      - C(linked) creates a linked clone, and the cloned container must be a template container.
-      - C(opportunistic) creates a linked clone if the cloned container is a template container, and a full clone if not.
-        I(storage) may be specified, if not it will fall back to the default.
+      - V(full) creates a full clone, and O(storage) must be specified.
+      - V(linked) creates a linked clone, and the cloned container must be a template container.
+      - V(opportunistic) creates a linked clone if the cloned container is a template container, and a full clone if not.
+        O(storage) may be specified, if not it will fall back to the default.
     type: str
     choices: ['full', 'linked', 'opportunistic']
     default: opportunistic

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -25,17 +25,17 @@ options:
   name:
     description:
       - The unique name of the VM.
-      - You can specify either I(name) or I(vmid) or both of them.
+      - You can specify either O(name) or O(vmid) or both of them.
     type: str
   vmid:
     description:
       - The unique ID of the VM.
-      - You can specify either I(vmid) or I(name) or both of them.
+      - You can specify either O(vmid) or O(name) or both of them.
     type: int
   disk:
     description:
-      - The disk key (C(unused[n]), C(ide[n]), C(sata[n]), C(scsi[n]) or C(virtio[n])) you want to operate on.
-      - Disk buses (IDE, SATA and so on) have fixed ranges of C(n) that accepted by Proxmox API.
+      - The disk key (V(unused[n]), V(ide[n]), V(sata[n]), V(scsi[n]) or V(virtio[n])) you want to operate on.
+      - Disk buses (IDE, SATA and so on) have fixed ranges of V(n) that accepted by Proxmox API.
       - >
         For IDE: 0-3;
         for SCSI: 0-30;
@@ -48,79 +48,79 @@ options:
     description:
       - Indicates desired state of the disk.
       - >
-        I(state=present) can be used to create, replace disk or update options in existing disk. It will create missing
-        disk or update options in existing one by default. See the I(create) parameter description to control behavior
+        O(state=present) can be used to create, replace disk or update options in existing disk. It will create missing
+        disk or update options in existing one by default. See the O(create) parameter description to control behavior
         of this option.
-      - Some updates on options (like I(cache)) are not being applied instantly and require VM restart.
+      - Some updates on options (like O(cache)) are not being applied instantly and require VM restart.
       - >
-        Use I(state=detached) to detach existing disk from VM but do not remove it entirely.
-        When I(state=detached) and disk is C(unused[n]) it will be left in same state (not removed).
+        Use O(state=detached) to detach existing disk from VM but do not remove it entirely.
+        When O(state=detached) and disk is V(unused[n]) it will be left in same state (not removed).
       - >
-        I(state=moved) may be used to change backing storage for the disk in bounds of the same VM
+        O(state=moved) may be used to change backing storage for the disk in bounds of the same VM
         or to send the disk to another VM (using the same backing storage).
       - >
-        I(state=resized) intended to change the disk size. As of Proxmox 7.2 you can only increase the disk size
+        O(state=resized) intended to change the disk size. As of Proxmox 7.2 you can only increase the disk size
         because shrinking disks is not supported by the PVE API and has to be done manually.
-      - To entirely remove the disk from backing storage use I(state=absent).
+      - To entirely remove the disk from backing storage use O(state=absent).
     type: str
     choices: ['present', 'resized', 'detached', 'moved', 'absent']
     default: present
   create:
     description:
-      - With I(create) flag you can control behavior of I(state=present).
-      - When I(create=disabled) it will not create new disk (if not exists) but will update options in existing disk.
-      - When I(create=regular) it will either create new disk (if not exists) or update options in existing disk.
-      - When I(create=forced) it will always create new disk (if disk exists it will be detached and left unused).
+      - With O(create) flag you can control behavior of O(state=present).
+      - When O(create=disabled) it will not create new disk (if not exists) but will update options in existing disk.
+      - When O(create=regular) it will either create new disk (if not exists) or update options in existing disk.
+      - When O(create=forced) it will always create new disk (if disk exists it will be detached and left unused).
     type: str
     choices: ['disabled', 'regular', 'forced']
     default: regular
   storage:
     description:
       - The drive's backing storage.
-      - Used only when I(state) is C(present).
+      - Used only when O(state) is V(present).
     type: str
   size:
     description:
-      - Desired volume size in GB to allocate when I(state=present) (specify I(size) without suffix).
+      - Desired volume size in GB to allocate when O(state=present) (specify O(size) without suffix).
       - >
-        New (or additional) size of volume when I(state=resized). With the C(+) sign
+        New (or additional) size of volume when O(state=resized). With the V(+) sign
         the value is added to the actual size of the volume
         and without it, the value is taken as an absolute one.
     type: str
   bwlimit:
     description:
       - Override I/O bandwidth limit (in KB/s).
-      - Used only when I(state=moved).
+      - Used only when O(state=moved).
     type: int
   delete_moved:
     description:
       - Delete the original disk after successful copy.
       - By default the original disk is kept as unused disk.
-      - Used only when I(state=moved).
+      - Used only when O(state=moved).
     type: bool
   target_disk:
     description:
-      - The config key the disk will be moved to on the target VM (for example, C(ide0) or C(scsi1)).
+      - The config key the disk will be moved to on the target VM (for example, V(ide0) or V(scsi1)).
       - Default is the source disk key.
-      - Used only when I(state=moved).
+      - Used only when O(state=moved).
     type: str
   target_storage:
     description:
-      - Move the disk to this storage when I(state=moved).
+      - Move the disk to this storage when O(state=moved).
       - You can move between storages only in scope of one VM.
-      - Mutually exclusive with I(target_vmid).
-      - Consider increasing I(timeout) in case of large disk images or slow storage backend.
+      - Mutually exclusive with O(target_vmid).
+      - Consider increasing O(timeout) in case of large disk images or slow storage backend.
     type: str
   target_vmid:
     description:
-      - The (unique) ID of the VM where disk will be placed when I(state=moved).
+      - The (unique) ID of the VM where disk will be placed when O(state=moved).
       - You can move disk between VMs only when the same storage is used.
-      - Mutually exclusive with I(target_vmid).
+      - Mutually exclusive with O(target_vmid).
     type: int
   timeout:
     description:
       - Timeout in seconds to wait for slow operations such as importing disk or moving disk between storages.
-      - Used only when I(state) is C(present) or C(moved).
+      - Used only when O(state) is V(present) or V(moved).
     type: int
     default: 600
   aio:
@@ -177,13 +177,13 @@ options:
       - Volume string format
       - C(<STORAGE>:<VMID>/<FULL_NAME>) or C(<ABSOLUTE_PATH>/<FULL_NAME>)
       - Attention! Only root can use absolute paths.
-      - This parameter is mutually exclusive with I(size).
-      - Increase I(timeout) parameter when importing large disk images or using slow storage.
+      - This parameter is mutually exclusive with O(size).
+      - Increase O(timeout) parameter when importing large disk images or using slow storage.
     type: str
   iops:
     description:
       - Maximum total r/w I/O in operations per second.
-      - You can specify either total limit or per operation (mutually exclusive with I(iops_rd) and I(iops_wr)).
+      - You can specify either total limit or per operation (mutually exclusive with O(iops_rd) and O(iops_wr)).
     type: int
   iops_max:
     description:
@@ -196,7 +196,7 @@ options:
   iops_rd:
     description:
       - Maximum read I/O in operations per second.
-      - You can specify either read or total limit (mutually exclusive with I(iops)).
+      - You can specify either read or total limit (mutually exclusive with O(iops)).
     type: int
   iops_rd_max:
     description:
@@ -209,7 +209,7 @@ options:
   iops_wr:
     description:
       - Maximum write I/O in operations per second.
-      - You can specify either write or total limit (mutually exclusive with I(iops)).
+      - You can specify either write or total limit (mutually exclusive with O(iops)).
     type: int
   iops_wr_max:
     description:
@@ -227,7 +227,7 @@ options:
     description:
       - Maximum total r/w speed in megabytes per second.
       - Can be fractional but use with caution - fractionals less than 1 are not supported officially.
-      - You can specify either total limit or per operation (mutually exclusive with I(mbps_rd) and I(mbps_wr)).
+      - You can specify either total limit or per operation (mutually exclusive with O(mbps_rd) and O(mbps_wr)).
     type: float
   mbps_max:
     description:
@@ -236,7 +236,7 @@ options:
   mbps_rd:
     description:
       - Maximum read speed in megabytes per second.
-      - You can specify either read or total limit (mutually exclusive with I(mbps)).
+      - You can specify either read or total limit (mutually exclusive with O(mbps)).
     type: float
   mbps_rd_max:
     description:
@@ -245,7 +245,7 @@ options:
   mbps_wr:
     description:
       - Maximum write speed in megabytes per second.
-      - You can specify either write or total limit (mutually exclusive with I(mbps)).
+      - You can specify either write or total limit (mutually exclusive with O(mbps)).
     type: float
   mbps_wr_max:
     description:
@@ -312,7 +312,7 @@ options:
     choices: ['enospc', 'ignore', 'report', 'stop']
   wwn:
     description:
-      - The drive's worldwide name, encoded as 16 bytes hex string, prefixed by C(0x).
+      - The drive's worldwide name, encoded as 16 bytes hex string, prefixed by V(0x).
     type: str
 extends_documentation_fragment:
   - community.general.proxmox.documentation

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -14,7 +14,7 @@ module: proxmox_kvm
 short_description: Management of Qemu(KVM) Virtual Machines in Proxmox VE cluster
 description:
   - Allows you to create/delete/stop Qemu(KVM) Virtual Machines in Proxmox VE cluster.
-  - Since community.general 4.0.0 on, there are no more default values, see I(proxmox_default_behavior).
+  - Since community.general 4.0.0 on, there are no more default values, see O(proxmox_default_behavior).
 author: "Abdoul Bah (@helldorado) <bahabdoul at gmail.com>"
 attributes:
   check_mode:
@@ -30,31 +30,31 @@ options:
   acpi:
     description:
       - Specify if ACPI should be enabled/disabled.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(true).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(true).
     type: bool
   agent:
     description:
       - Specify if the QEMU Guest Agent should be enabled/disabled.
       - Since community.general 5.5.0, this can also be a string instead of a boolean.
-        This allows to specify values such as C(enabled=1,fstrim_cloned_disks=1).
+        This allows to specify values such as V(enabled=1,fstrim_cloned_disks=1).
     type: str
   args:
     description:
       - Pass arbitrary arguments to kvm.
       - This option is for experts only!
-      - If I(proxmox_default_behavior) is set to C(compatiblity), this option has a default of
-        C(-serial unix:/var/run/qemu-server/<vmid>.serial,server,nowait).
+      - If O(proxmox_default_behavior) is set to V(compatiblity), this option has a default of
+        V(-serial unix:/var/run/qemu-server/<vmid>.serial,server,nowait).
     type: str
   autostart:
     description:
       - Specify if the VM should be automatically restarted after crash (currently ignored in PVE API).
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(false).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(false).
     type: bool
   balloon:
     description:
       - Specify the amount of RAM for the VM in MB.
       - Using zero disables the balloon driver.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(0).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(0).
     type: int
   bios:
     description:
@@ -63,13 +63,13 @@ options:
     choices: ['seabios', 'ovmf']
   boot:
     description:
-      - Specify the boot order -> boot on floppy C(a), hard disk C(c), CD-ROM C(d), or network C(n).
+      - Specify the boot order -> boot on floppy V(a), hard disk V(c), CD-ROM V(d), or network V(n).
       - You can combine to set order.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(cnd).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(cnd).
     type: str
   bootdisk:
     description:
-      - Enable booting from specified disk. C((ide|sata|scsi|virtio)\d+)
+      - 'Enable booting from specified disk. Format V((ide|sata|scsi|virtio\)\\d+).'
     type: str
   cicustom:
     description:
@@ -84,8 +84,8 @@ options:
   citype:
     description:
       - 'cloud-init: Specifies the cloud-init configuration format.'
-      - The default depends on the configured operating system type (C(ostype)).
-      - We use the C(nocloud) format for Linux, and C(configdrive2) for Windows.
+      - The default depends on the configured operating system type (V(ostype)).
+      - We use the V(nocloud) format for Linux, and V(configdrive2) for Windows.
     type: str
     choices: ['nocloud', 'configdrive2']
     version_added: 1.3.0
@@ -96,17 +96,17 @@ options:
     version_added: 1.3.0
   clone:
     description:
-      - Name of VM to be cloned. If I(vmid) is set, I(clone) can take an arbitrary value but is required for initiating the clone.
+      - Name of VM to be cloned. If O(vmid) is set, O(clone) can take an arbitrary value but is required for initiating the clone.
     type: str
   cores:
     description:
       - Specify number of cores per socket.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1).
     type: int
   cpu:
     description:
       - Specify emulated CPU type.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(kvm64).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(kvm64).
     type: str
   cpulimit:
     description:
@@ -117,7 +117,7 @@ options:
     description:
       - Specify CPU weight for a VM.
       - You can disable fair-scheduler configuration by setting this to 0
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1000).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1000).
     type: int
   delete:
     description:
@@ -136,24 +136,24 @@ options:
   efidisk0:
     description:
       - Specify a hash/dictionary of EFI disk options.
-      - Requires I(bios=ovmf) to be set to be able to use it.
+      - Requires O(bios=ovmf) to be set to be able to use it.
     type: dict
     suboptions:
       storage:
         description:
-          - C(storage) is the storage identifier where to create the disk.
+          - V(storage) is the storage identifier where to create the disk.
         type: str
       format:
         description:
-          - C(format) is the drive's backing file's data format. Please refer to the Proxmox VE Administrator Guide,
+          - V(format) is the drive's backing file's data format. Please refer to the Proxmox VE Administrator Guide,
            section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest
            version, tables 3 to 14) to find out format supported by the provided storage backend.
         type: str
       efitype:
         description:
-          - C(efitype) indicates the size of the EFI disk.
-          - C(2m) will allow for a 2MB EFI disk, which will be enough to persist boot order and new boot entries.
-          - C(4m) will allow for a 4MB EFI disk, which will additionally allow to store EFI keys in order to enable
+          - V(efitype) indicates the size of the EFI disk.
+          - V(2m) will allow for a 2MB EFI disk, which will be enough to persist boot order and new boot entries.
+          - V(4m) will allow for a 4MB EFI disk, which will additionally allow to store EFI keys in order to enable
            Secure Boot
         type: str
         choices:
@@ -161,27 +161,27 @@ options:
           - 4m
       pre_enrolled_keys:
         description:
-          - C(pre_enrolled_keys) indicates whether EFI keys for Secure Boot should be enrolled C(1) in the VM firmware
+          - V(pre_enrolled_keys) indicates whether EFI keys for Secure Boot should be enrolled V(1) in the VM firmware
            upon creation or not (0).
-          - If set to C(1), Secure Boot will also be enabled by default when the VM is created.
+          - If set to V(1), Secure Boot will also be enabled by default when the VM is created.
         type: bool
     version_added: 4.5.0
   force:
     description:
       - Allow to force stop VM.
-      - Can be used with states C(stopped), C(restarted) and C(absent).
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(false).
+      - Can be used with states V(stopped), V(restarted), and V(absent).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(false).
     type: bool
   format:
     description:
       - Target drive's backing file's data format.
       - Used only with clone
-      - Use I(format=unspecified) and I(full=false) for a linked clone.
+      - Use O(format=unspecified) and O(full=false) for a linked clone.
       - Please refer to the Proxmox VE Administrator Guide, section Proxmox VE Storage (see
         U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest version, tables 3 to 14) to find out format
         supported by the provided storage backend.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(qcow2).
-        If I(proxmox_default_behavior) is set to C(no_defaults), not specifying this option is equivalent to setting it to C(unspecified).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(qcow2).
+        If O(proxmox_default_behavior) is set to V(no_defaults), not specifying this option is equivalent to setting it to V(unspecified).
     type: str
     choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk", "unspecified" ]
   freeze:
@@ -197,20 +197,20 @@ options:
     default: true
   hostpci:
     description:
-      - Specify a hash/dictionary of map host pci devices into guest. C(hostpci='{"key":"value", "key":"value"}').
+      - Specify a hash/dictionary of map host pci devices into guest. O(hostpci='{"key":"value", "key":"value"}').
       - Keys allowed are - C(hostpci[n]) where 0 ≤ n ≤ N.
       - Values allowed are -  C("host="HOSTPCIID[;HOSTPCIID2...]",pcie="1|0",rombar="1|0",x-vga="1|0"").
       - The C(host) parameter is Host PCI device pass through. HOSTPCIID syntax is C(bus:dev.func) (hexadecimal numbers).
-      - C(pcie=boolean) I(default=0) Choose the PCI-express bus (needs the q35 machine model).
-      - C(rombar=boolean) I(default=1) Specify whether or not the device's ROM will be visible in the guest's memory map.
-      - C(x-vga=boolean) I(default=0) Enable vfio-vga device support.
+      - C(pcie=boolean) C(default=0) Choose the PCI-express bus (needs the q35 machine model).
+      - C(rombar=boolean) C(default=1) Specify whether or not the device's ROM will be visible in the guest's memory map.
+      - C(x-vga=boolean) C(default=0) Enable vfio-vga device support.
       - /!\ This option allows direct access to host hardware. So it is no longer possible to migrate such machines - use with special care.
     type: dict
   hotplug:
     description:
       - Selectively enable hotplug features.
-      - This is a comma separated list of hotplug features C('network', 'disk', 'cpu', 'memory' and 'usb').
-      - Value 0 disables hotplug completely and value 1 is an alias for the default C('network,disk,usb').
+      - This is a comma separated list of hotplug features V(network), V(disk), V(cpu), V(memory), and V(usb).
+      - Value 0 disables hotplug completely and value 1 is an alias for the default V(network,disk,usb).
     type: str
   hugepages:
     description:
@@ -219,7 +219,7 @@ options:
     choices: ['any', '2', '1024']
   ide:
     description:
-      - A hash/dictionary of volume used as IDE hard disk or CD-ROM. C(ide='{"key":"value", "key":"value"}').
+      - A hash/dictionary of volume used as IDE hard disk or CD-ROM. O(ide='{"key":"value", "key":"value"}').
       - Keys allowed are - C(ide[n]) where 0 ≤ n ≤ 3.
       - Values allowed are - C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
@@ -231,7 +231,7 @@ options:
   ipconfig:
     description:
       - 'cloud-init: Set the IP configuration.'
-      - A hash/dictionary of network ip configurations. C(ipconfig='{"key":"value", "key":"value"}').
+      - A hash/dictionary of network ip configurations. O(ipconfig='{"key":"value", "key":"value"}').
       - Keys allowed are - C(ipconfig[n]) where 0 ≤ n ≤ network interfaces.
       - Values allowed are -  C("[gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]").
       - 'cloud-init: Specify IP addresses and gateways for the corresponding interface.'
@@ -248,7 +248,7 @@ options:
   kvm:
     description:
       - Enable/disable KVM hardware virtualization.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(true).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(true).
     type: bool
   localtime:
     description:
@@ -263,16 +263,16 @@ options:
   machine:
     description:
       - Specifies the Qemu machine type.
-      - type => C((pc|pc(-i440fx)?-\d+\.\d+(\.pxe)?|q35|pc-q35-\d+\.\d+(\.pxe)?))
+      - 'Type => V((pc|pc(-i440fx\)?-\\d+\\.\\d+(\\.pxe\)?|q35|pc-q35-\\d+\\.\\d+(\\.pxe\)?\)).'
     type: str
   memory:
     description:
       - Memory size in MB for instance.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(512).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(512).
     type: int
   migrate:
     description:
-      - Migrate the VM to I(node) if it is on another node.
+      - Migrate the VM to O(node) if it is on another node.
     type: bool
     default: false
     version_added: 7.0.0
@@ -288,7 +288,7 @@ options:
   name:
     description:
       - Specifies the VM name. Only used on the configuration web interface.
-      - Required only for C(state=present).
+      - Required only for O(state=present).
     type: str
   nameservers:
     description:
@@ -299,7 +299,7 @@ options:
     version_added: 1.3.0
   net:
     description:
-      - A hash/dictionary of network interfaces for the VM. C(net='{"key":"value", "key":"value"}').
+      - A hash/dictionary of network interfaces for the VM. O(net='{"key":"value", "key":"value"}').
       - Keys allowed are - C(net[n]) where 0 ≤ n ≤ N.
       - Values allowed are - C("model="XX:XX:XX:XX:XX:XX",bridge="value",rate="value",tag="value",firewall="1|0",trunks="vlanid"").
       - Model is one of C(e1000 e1000-82540em e1000-82544gc e1000-82545em i82551 i82557b i82559er ne2k_isa ne2k_pci pcnet rtl8139 virtio vmxnet3).
@@ -315,7 +315,7 @@ options:
     type: int
   numa:
     description:
-      - A hash/dictionaries of NUMA topology. C(numa='{"key":"value", "key":"value"}').
+      - A hash/dictionaries of NUMA topology. O(numa='{"key":"value", "key":"value"}').
       - Keys allowed are - C(numa[n]) where 0 ≤ n ≤ N.
       - Values allowed are - C("cpu="<id[-id];...>",hostnodes="<id[-id];...>",memory="number",policy="(bind|interleave|preferred)"").
       - C(cpus) CPUs accessing this NUMA node.
@@ -330,18 +330,18 @@ options:
   onboot:
     description:
       - Specifies whether a VM will be started during system bootup.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(true).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(true).
     type: bool
   ostype:
     description:
       - Specifies guest operating system. This is used to enable special optimization/features for specific operating systems.
       - The l26 is Linux 2.6/3.X Kernel.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(l26).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(l26).
     type: str
     choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'win11', 'l24', 'l26', 'solaris']
   parallel:
     description:
-      - A hash/dictionary of map host parallel devices. C(parallel='{"key":"value", "key":"value"}').
+      - A hash/dictionary of map host parallel devices. O(parallel='{"key":"value", "key":"value"}').
       - Keys allowed are - (parallel[n]) where 0 ≤ n ≤ 2.
       - Values allowed are - C("/dev/parport\d+|/dev/usb/lp\d+").
     type: dict
@@ -351,7 +351,7 @@ options:
     type: bool
   reboot:
     description:
-      - Allow reboot. If set to C(true), the VM exit on reboot.
+      - Allow reboot. If set to V(true), the VM exit on reboot.
     type: bool
   revert:
     description:
@@ -359,7 +359,7 @@ options:
     type: str
   sata:
     description:
-      - A hash/dictionary of volume used as sata hard disk or CD-ROM. C(sata='{"key":"value", "key":"value"}').
+      - A hash/dictionary of volume used as sata hard disk or CD-ROM. O(sata='{"key":"value", "key":"value"}').
       - Keys allowed are - C(sata[n]) where 0 ≤ n ≤ 5.
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
@@ -370,7 +370,7 @@ options:
     type: dict
   scsi:
     description:
-      - A hash/dictionary of volume used as SCSI hard disk or CD-ROM. C(scsi='{"key":"value", "key":"value"}').
+      - A hash/dictionary of volume used as SCSI hard disk or CD-ROM. O(scsi='{"key":"value", "key":"value"}').
       - Keys allowed are - C(sata[n]) where 0 ≤ n ≤ 13.
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
@@ -393,9 +393,9 @@ options:
     version_added: 1.3.0
   serial:
     description:
-      - A hash/dictionary of serial device to create inside the VM. C('{"key":"value", "key":"value"}').
+      - A hash/dictionary of serial device to create inside the VM. V('{"key":"value", "key":"value"}').
       - Keys allowed are - serial[n](str; required) where 0 ≤ n ≤ 3.
-      - Values allowed are - C((/dev/.+|socket)).
+      - Values allowed are - V((/dev/.+|socket\)).
       - /!\ If you pass through a host serial device, it is no longer possible to migrate such machines - use with special care.
     type: dict
   shares:
@@ -421,7 +421,7 @@ options:
   sockets:
     description:
       - Sets the number of CPU sockets. (1 - N).
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(1).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(1).
     type: int
   sshkeys:
     description:
@@ -431,18 +431,18 @@ options:
   startdate:
     description:
       - Sets the initial date of the real time clock.
-      - Valid format for date are C('now') or C('2016-09-25T16:01:21') or C('2016-09-25').
+      - Valid format for date are V('now') or V('2016-09-25T16:01:21') or V('2016-09-25').
     type: str
   startup:
     description:
-      - Startup and shutdown behavior. C([[order=]\d+] [,up=\d+] [,down=\d+]).
+      - Startup and shutdown behavior. V([[order=]\\d+] [,up=\\d+] [,down=\\d+]).
       - Order is a non-negative number defining the general startup order.
       - Shutdown in done with reverse ordering.
     type: str
   state:
     description:
       - Indicates desired state of the instance.
-      - If C(current), the current state of the VM will be fetched. You can access it with C(results.status)
+      - If V(current), the current state of the VM will be fetched. You can access it with C(results.status)
     type: str
     choices: ['present', 'started', 'absent', 'stopped', 'restarted', 'current']
     default: present
@@ -453,12 +453,12 @@ options:
   tablet:
     description:
       - Enables/disables the USB tablet device.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(false).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(false).
     type: bool
   tags:
     description:
       - List of tags to apply to the VM instance.
-      - Tags must start with C([a-z0-9_]) followed by zero or more of the following characters C([a-z0-9_-+.]).
+      - Tags must start with V([a-z0-9_]) followed by zero or more of the following characters V([a-z0-9_-+.]).
       - Tags are only available in Proxmox 6+.
     type: list
     elements: str
@@ -475,12 +475,12 @@ options:
   template:
     description:
       - Enables/disables the template.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(false).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(false).
     type: bool
   timeout:
     description:
       - Timeout for operations.
-      - When used with I(state=stopped) the option sets a graceful timeout for VM stop after which a VM will be forcefully stopped.
+      - When used with O(state=stopped) the option sets a graceful timeout for VM stop after which a VM will be forcefully stopped.
     type: int
     default: 30
   tpmstate0:
@@ -503,10 +503,10 @@ options:
     version_added: 7.1.0
   update:
     description:
-      - If C(true), the VM will be updated with new value.
-      - Cause of the operations of the API and security reasons, I have disabled the update of the following parameters
-      - C(net, virtio, ide, sata, scsi). Per example updating C(net) update the MAC address and C(virtio) create always new disk...
-      - Update of C(pool) is disabled. It needs an additional API endpoint not covered by this module.
+      - If V(true), the VM will be updated with new value.
+      - Because of the operations of the API and security reasons, I have disabled the update of the following parameters
+        O(net), O(virtio), O(ide), O(sata), O(scsi). Per example updating O(net) update the MAC address and C(virtio) create always new disk...
+      - Update of O(pool) is disabled. It needs an additional API endpoint not covered by this module.
     type: bool
     default: false
   vcpus:
@@ -516,12 +516,12 @@ options:
   vga:
     description:
       - Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
-      - This option has no default unless I(proxmox_default_behavior) is set to C(compatiblity); then the default is C(std).
+      - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(std).
     type: str
     choices: ['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']
   virtio:
     description:
-      - A hash/dictionary of volume used as VIRTIO hard disk. C(virtio='{"key":"value", "key":"value"}').
+      - A hash/dictionary of volume used as VIRTIO hard disk. O(virtio='{"key":"value", "key":"value"}').
       - Keys allowed are - C(virto[n]) where 0 ≤ n ≤ 15.
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
@@ -539,12 +539,12 @@ options:
      - As of community.general 4.0.0, various options no longer have default values.
         These default values caused problems when users expected different behavior from Proxmox
         by default or filled options which caused problems when set.
-      - The value C(compatibility) (default before community.general 4.0.0) will ensure that the default values
-        are used when the values are not explicitly specified by the user. The new default is C(no_defaults),
+      - The value V(compatibility) (default before community.general 4.0.0) will ensure that the default values
+        are used when the values are not explicitly specified by the user. The new default is V(no_defaults),
         which makes sure these options have no defaults.
-      - This affects the I(acpi), I(autostart), I(balloon), I(boot), I(cores), I(cpu),
-        I(cpuunits), I(force), I(format), I(kvm), I(memory), I(onboot), I(ostype), I(sockets),
-        I(tablet), I(template), I(vga), options.
+      - This affects the O(acpi), O(autostart), O(balloon), O(boot), O(cores), O(cpu),
+        O(cpuunits), O(force), O(format), O(kvm), O(memory), O(onboot), O(ostype), O(sockets),
+        O(tablet), O(template), and O(vga) options.
     type: str
     default: no_defaults
     choices:

--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -24,7 +24,7 @@ attributes:
 options:
   bridge:
     description:
-      - Add this interface to the specified bridge device. The Proxmox VE default bridge is called C(vmbr0).
+      - Add this interface to the specified bridge device. The Proxmox VE default bridge is called V(vmbr0).
     type: str
   firewall:
     description:
@@ -33,7 +33,7 @@ options:
     default: false
   interface:
     description:
-      - Name of the interface, should be C(net[n]) where C(1 ≤ n ≤ 31).
+      - Name of the interface, should be V(net[n]) where C(1 ≤ n ≤ 31).
     type: str
     required: true
   link_down:
@@ -43,7 +43,7 @@ options:
     default: false
   mac:
     description:
-      - C(XX:XX:XX:XX:XX:XX) should be a unique MAC address. This is automatically generated if not specified.
+      - V(XX:XX:XX:XX:XX:XX) should be a unique MAC address. This is automatically generated if not specified.
       - When not specified this module will keep the MAC address the same when changing an existing interface.
     type: str
   model:
@@ -56,13 +56,13 @@ options:
   mtu:
     description:
       - Force MTU, for C(virtio) model only, setting will be ignored otherwise.
-      - Set to C(1) to use the bridge MTU.
+      - Set to V(1) to use the bridge MTU.
       - Value should be C(1 ≤ n ≤ 65520).
     type: int
   name:
     description:
       - Specifies the VM name. Only used on the configuration web interface.
-      - Required only for I(state=present).
+      - Required only for O(state=present).
     type: str
   queues:
     description:

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -34,7 +34,7 @@ options:
   state:
     description:
      - Indicate desired state of the instance snapshot.
-     - The C(rollback) value was added in community.general 4.8.0.
+     - The V(rollback) value was added in community.general 4.8.0.
     choices: ['present', 'absent', 'rollback']
     default: present
     type: str
@@ -49,7 +49,7 @@ options:
       - Allows to snapshot a container even if it has configured mountpoints.
       - Temporarily disables all configured mountpoints, takes snapshot, and finally restores original configuration.
       - If running, the container will be stopped and restarted to apply config changes.
-      - Due to restrictions in the Proxmox API this option can only be used authenticating as C(root@pam) with I(api_password), API tokens do not work either.
+      - Due to restrictions in the Proxmox API this option can only be used authenticating as V(root@pam) with O(api_password), API tokens do not work either.
       - See U(https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/config) (PUT tab) for more details.
     default: false
     type: bool

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -28,18 +28,18 @@ options:
   src:
     description:
       - Path to uploaded file.
-      - Required only for I(state=present).
+      - Required only for O(state=present).
     type: path
   template:
     description:
       - The template name.
-      - Required for I(state=absent) to delete a template.
-      - Required for I(state=present) to download an appliance container template (pveam).
+      - Required for O(state=absent) to delete a template.
+      - Required for O(state=present) to download an appliance container template (pveam).
     type: str
   content_type:
     description:
       - Content type.
-      - Required only for I(state=present).
+      - Required only for O(state=present).
     type: str
     default: 'vztmpl'
     choices: ['vztmpl', 'iso']
@@ -55,7 +55,7 @@ options:
     default: 30
   force:
     description:
-      - It can only be used with I(state=present), existing template will be overwritten.
+      - It can only be used with O(state=present), existing template will be overwritten.
     type: bool
     default: false
   state:

--- a/plugins/modules/pubnub_blocks.py
+++ b/plugins/modules/pubnub_blocks.py
@@ -40,15 +40,15 @@ options:
   email:
     description:
       - Email from account for which new session should be started.
-      - "Not required if C(cache) contains result of previous module call (in
+      - "Not required if O(cache) contains result of previous module call (in
         same play)."
     required: false
     type: str
     default: ''
   password:
     description:
-      - Password which match to account to which specified C(email) belong.
-      - "Not required if C(cache) contains result of previous module call (in
+      - Password which match to account to which specified O(email) belong.
+      - "Not required if O(cache) contains result of previous module call (in
         same play)."
     required: false
     type: str
@@ -63,7 +63,7 @@ options:
     default: {}
   account:
     description:
-      - "Name of PubNub account for from which C(application) will be used to
+      - "Name of PubNub account for from which O(application) will be used to
         manage blocks."
       - "User's account will be used if value not set or empty."
     type: str
@@ -71,7 +71,7 @@ options:
   application:
     description:
       - "Name of target PubNub application for which blocks configuration on
-        specific C(keyset) will be done."
+        specific O(keyset) will be done."
     type: str
     required: true
   keyset:
@@ -102,7 +102,7 @@ options:
   event_handlers:
     description:
       - "List of event handlers which should be updated for specified block
-        C(name)."
+        O(name)."
       - "Each entry for new event handler should contain: C(name), C(src),
         C(channels), C(event). C(name) used as event handler name which can be
         used later to make changes to it."
@@ -110,7 +110,7 @@ options:
       - "C(channels) is name of channel from which event handler is waiting
         for events."
       - "C(event) is type of event which is able to trigger event handler:
-        I(js-before-publish), I(js-after-publish), I(js-after-presence)."
+        C(js-before-publish), C(js-after-publish), C(js-after-presence)."
       - "Each entry for existing handlers should contain C(name) (so target
         handler can be identified). Rest parameters (C(src), C(channels) and
         C(event)) can be added if changes required for them."
@@ -127,7 +127,7 @@ options:
     description:
       - "List of fields which should be changed by block itself (doesn't
         affect any event handlers)."
-      - "Possible options for change is: C(name)."
+      - "Possible options for change is: O(name)."
     required: false
     default: {}
     type: dict
@@ -136,7 +136,7 @@ options:
       - "This key allow to try skip certificates check when performing REST API
         calls. Sometimes host may have issues with certificates on it and this
         will cause problems to call PubNub REST API."
-      - If check should be ignored C(False) should be passed to this parameter.
+      - If check should be ignored V(false) should be passed to this parameter.
     required: false
     default: true
     type: bool

--- a/plugins/modules/pulp_repo.py
+++ b/plugins/modules/pulp_repo.py
@@ -67,7 +67,7 @@ options:
     aliases: [ importer_ssl_client_cert ]
   feed_client_key:
     description:
-      - Private key to the certificate specified in I(importer_ssl_client_cert),
+      - Private key to the certificate specified in O(importer_ssl_client_cert),
         assuming it is not included in the certificate file itself. This can be
         the file content or the path to the file.
     type: str
@@ -105,7 +105,7 @@ options:
     type: str
   publish_distributor:
     description:
-      - Distributor to use when state is C(publish). The default is to
+      - Distributor to use when O(state=publish). The default is to
         publish all distributors.
     type: str
   pulp_host:
@@ -119,13 +119,13 @@ options:
     type: str
   repo_type:
     description:
-      - Repo plugin type to use (i.e. C(rpm), C(docker)).
+      - Repo plugin type to use (that is, V(rpm), V(docker)).
     default: rpm
     type: str
   repoview:
     description:
       - Whether to generate repoview files for a published repository. Setting
-        this to C(true) automatically activates C(generate_sqlite).
+        this to V(true) automatically activates O(generate_sqlite).
     required: false
     type: bool
     default: false
@@ -141,23 +141,23 @@ options:
     default: true
   state:
     description:
-      - The repo state. A state of C(sync) will queue a sync of the repo.
+      - The repo state. A state of V(sync) will queue a sync of the repo.
         This is asynchronous but not delayed like a scheduled sync. A state of
-        C(publish) will use the repository's distributor to publish the content.
+        V(publish) will use the repository's distributor to publish the content.
     default: present
     choices: [ "present", "absent", "sync", "publish" ]
     type: str
   url_password:
     description:
       - The password for use in HTTP basic authentication to the pulp API.
-        If the I(url_username) parameter is not specified, the I(url_password)
+        If the O(url_username) parameter is not specified, the O(url_password)
         parameter will not be used.
   url_username:
     description:
       - The username for use in HTTP basic authentication to the pulp API.
   validate_certs:
     description:
-      - If C(false), SSL certificates will not be validated. This should only be
+      - If V(false), SSL certificates will not be validated. This should only be
         used on personally controlled sites using self-signed certificates.
     type: bool
     default: true

--- a/plugins/modules/pulp_repo.py
+++ b/plugins/modules/pulp_repo.py
@@ -67,7 +67,7 @@ options:
     aliases: [ importer_ssl_client_cert ]
   feed_client_key:
     description:
-      - Private key to the certificate specified in O(importer_ssl_client_cert),
+      - Private key to the certificate specified in O(feed_client_cert),
         assuming it is not included in the certificate file itself. This can be
         the file content or the path to the file.
     type: str

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: puppet
 short_description: Runs puppet
 description:
-  - Runs I(puppet) agent or apply in a reliable manner.
+  - Runs C(puppet) agent or apply in a reliable manner.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:
@@ -24,7 +24,7 @@ attributes:
 options:
   timeout:
     description:
-      - How long to wait for I(puppet) to finish.
+      - How long to wait for C(puppet) to finish.
     type: str
     default: 30m
   puppetmaster:
@@ -42,8 +42,8 @@ options:
   noop:
     description:
       - Override puppet.conf noop mode.
-      - When C(true), run Puppet agent with C(--noop) switch set.
-      - When C(false), run Puppet agent with C(--no-noop) switch set.
+      - When V(true), run Puppet agent with C(--noop) switch set.
+      - When V(false), run Puppet agent with C(--no-noop) switch set.
       - When unset (default), use default or puppet.conf value if defined.
     type: bool
   facts:
@@ -67,8 +67,8 @@ options:
   logdest:
     description:
     - Where the puppet logs should go, if puppet apply is being used.
-    - C(all) will go to both C(console) and C(syslog).
-    - C(stdout) will be deprecated and replaced by C(console).
+    - V(all) will go to both C(console) and C(syslog).
+    - V(stdout) will be deprecated and replaced by C(console).
     type: str
     choices: [ all, stdout, syslog ]
     default: stdout

--- a/plugins/modules/pushbullet.py
+++ b/plugins/modules/pushbullet.py
@@ -59,7 +59,7 @@ options:
     url:
         type: str
         description:
-          - URL field, used when I(push_type) is C(link).
+          - URL field, used when O(push_type=link).
 
 notes:
    - Requires pushbullet.py Python package on the remote host.

--- a/plugins/modules/python_requirements_info.py
+++ b/plugins/modules/python_requirements_info.py
@@ -23,8 +23,8 @@ options:
     description: >
       A list of version-likes or module names to check for installation.
       Supported operators: <, >, <=, >=, or ==. The bare module name like
-      I(ansible), the module with a specific version like I(boto3==1.6.1), or a
-      partial version like I(requests>2) are all valid specifications.
+      C(ansible), the module with a specific version like C(boto3==1.6.1), or a
+      partial version like C(requests>2) are all valid specifications.
     default: []
 author:
   - Will Thames (@willthames)
@@ -92,7 +92,7 @@ python_system_path:
     - /usr/local/opt/python@2/site-packages/
     - /usr/lib/python/site-packages/
 valid:
-  description: A dictionary of dependencies that matched their desired versions. If no version was specified, then I(desired) will be null
+  description: A dictionary of dependencies that matched their desired versions. If no version was specified, then RV(ignore:desired) will be null
   returned: always
   type: dict
   sample:


### PR DESCRIPTION
##### SUMMARY
For information on semantic markup, see https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#semantic-markup-within-module-documentation.

Ref: #6627

(Note: I'm only considering modules containing `I(` for now.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
modules starting with o-p
