### PR TITLE
Semantic markup: use E() in more places

### DIFF
--- a/plugins/doc_fragments/alicloud.py
+++ b/plugins/doc_fragments/alicloud.py
@@ -15,27 +15,27 @@ class ModuleDocFragment(object):
 options:
   alicloud_access_key:
     description:
-      - Alibaba Cloud access key. If not set then the value of environment variable C(ALICLOUD_ACCESS_KEY),
-        C(ALICLOUD_ACCESS_KEY_ID) will be used instead.
+      - Alibaba Cloud access key. If not set then the value of environment variable E(ALICLOUD_ACCESS_KEY),
+        E(ALICLOUD_ACCESS_KEY_ID) will be used instead.
     aliases: ['access_key_id', 'access_key']
     type: str
   alicloud_secret_key:
     description:
-      - Alibaba Cloud secret key. If not set then the value of environment variable C(ALICLOUD_SECRET_KEY),
-        C(ALICLOUD_SECRET_ACCESS_KEY) will be used instead.
+      - Alibaba Cloud secret key. If not set then the value of environment variable E(ALICLOUD_SECRET_KEY),
+        E(ALICLOUD_SECRET_ACCESS_KEY) will be used instead.
     aliases: ['secret_access_key', 'secret_key']
     type: str
   alicloud_region:
     description:
       - The Alibaba Cloud region to use. If not specified then the value of environment variable
-        C(ALICLOUD_REGION), C(ALICLOUD_REGION_ID) will be used instead.
+        E(ALICLOUD_REGION), E(ALICLOUD_REGION_ID) will be used instead.
     aliases: ['region', 'region_id']
     required: true
     type: str
   alicloud_security_token:
     description:
       - The Alibaba Cloud security token. If not specified then the value of environment variable
-        C(ALICLOUD_SECURITY_TOKEN) will be used instead.
+        E(ALICLOUD_SECURITY_TOKEN) will be used instead.
     aliases: ['security_token']
     type: str
   alicloud_assume_role:
@@ -48,7 +48,7 @@ options:
   alicloud_assume_role_arn:
     description:
       - The Alibaba Cloud role_arn. The ARN of the role to assume. If ARN is set to an empty string,
-        it does not perform role switching. It supports environment variable ALICLOUD_ASSUME_ROLE_ARN.
+        it does not perform role switching. It supports environment variable E(ALICLOUD_ASSUME_ROLE_ARN).
         ansible will execute with provided credentials.
     aliases: ['assume_role_arn']
     type: str
@@ -56,14 +56,14 @@ options:
     description:
       - The Alibaba Cloud session_name. The session name to use when assuming the role. If omitted,
         'ansible' is passed to the AssumeRole call as session name. It supports environment variable
-        ALICLOUD_ASSUME_ROLE_SESSION_NAME
+        E(ALICLOUD_ASSUME_ROLE_SESSION_NAME).
     aliases: ['assume_role_session_name']
     type: str
   alicloud_assume_role_session_expiration:
     description:
       - The Alibaba Cloud session_expiration. The time after which the established session for assuming
         role expires. Valid value range 900-3600 seconds. Default to 3600 (in this case Alicloud use own default
-        value). It supports environment variable ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION
+        value). It supports environment variable E(ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION).
     aliases: ['assume_role_session_expiration']
     type: int
   ecs_role_name:
@@ -79,11 +79,11 @@ options:
   profile:
     description:
       - This is the Alicloud profile name as set in the shared credentials file. It can also be sourced from the
-        ALICLOUD_PROFILE environment variable.
+        E(ALICLOUD_PROFILE) environment variable.
     type: str
   shared_credentials_file:
     description:
-      - This is the path to the shared credentials file. It can also be sourced from the ALICLOUD_SHARED_CREDENTIALS_FILE
+      - This is the path to the shared credentials file. It can also be sourced from the E(ALICLOUD_SHARED_CREDENTIALS_FILE)
         environment variable.
       - If this is not set and a profile is specified,  ~/.aliyun/config.json will be used.
     type: str
@@ -94,16 +94,16 @@ requirements:
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence
-    C(ALICLOUD_ACCESS_KEY) or C(ALICLOUD_ACCESS_KEY_ID),
-    C(ALICLOUD_SECRET_KEY) or C(ALICLOUD_SECRET_ACCESS_KEY),
-    C(ALICLOUD_REGION) or C(ALICLOUD_REGION_ID),
-    C(ALICLOUD_SECURITY_TOKEN),
-    C(ALICLOUD_ECS_ROLE_NAME),
-    C(ALICLOUD_SHARED_CREDENTIALS_FILE),
-    C(ALICLOUD_PROFILE),
-    C(ALICLOUD_ASSUME_ROLE_ARN),
-    C(ALICLOUD_ASSUME_ROLE_SESSION_NAME),
-    C(ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION),
-  - C(ALICLOUD_REGION) or C(ALICLOUD_REGION_ID) can be typically be used to specify the
+    E(ALICLOUD_ACCESS_KEY) or E(ALICLOUD_ACCESS_KEY_ID),
+    E(ALICLOUD_SECRET_KEY) or E(ALICLOUD_SECRET_ACCESS_KEY),
+    E(ALICLOUD_REGION) or E(ALICLOUD_REGION_ID),
+    E(ALICLOUD_SECURITY_TOKEN),
+    E(ALICLOUD_ECS_ROLE_NAME),
+    E(ALICLOUD_SHARED_CREDENTIALS_FILE),
+    E(ALICLOUD_PROFILE),
+    E(ALICLOUD_ASSUME_ROLE_ARN),
+    E(ALICLOUD_ASSUME_ROLE_SESSION_NAME),
+    E(ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION),
+  - E(ALICLOUD_REGION) or E(ALICLOUD_REGION_ID) can be typically be used to specify the
     ALICLOUD region, when required, but this can also be configured in the footmark config file
 '''

--- a/plugins/doc_fragments/bitbucket.py
+++ b/plugins/doc_fragments/bitbucket.py
@@ -16,17 +16,17 @@ options:
   client_id:
     description:
       - The OAuth consumer key.
-      - If not set the environment variable C(BITBUCKET_CLIENT_ID) will be used.
+      - If not set the environment variable E(BITBUCKET_CLIENT_ID) will be used.
     type: str
   client_secret:
     description:
       - The OAuth consumer secret.
-      - If not set the environment variable C(BITBUCKET_CLIENT_SECRET) will be used.
+      - If not set the environment variable E(BITBUCKET_CLIENT_SECRET) will be used.
     type: str
   user:
     description:
       - The username.
-      - If not set the environment variable C(BITBUCKET_USERNAME) will be used.
+      - If not set the environment variable E(BITBUCKET_USERNAME) will be used.
       - O(ignore:username) is an alias of O(user) since community.general 6.0.0. It was an alias of O(workspace) before.
     type: str
     version_added: 4.0.0
@@ -34,7 +34,7 @@ options:
   password:
     description:
       - The App password.
-      - If not set the environment variable C(BITBUCKET_PASSWORD) will be used.
+      - If not set the environment variable E(BITBUCKET_PASSWORD) will be used.
     type: str
     version_added: 4.0.0
 notes:

--- a/plugins/doc_fragments/dimensiondata.py
+++ b/plugins/doc_fragments/dimensiondata.py
@@ -29,12 +29,12 @@ options:
   mcp_user:
     description:
       - The username used to authenticate to the CloudControl API.
-      - If not specified, will fall back to C(MCP_USER) from environment variable or C(~/.dimensiondata).
+      - If not specified, will fall back to E(MCP_USER) from environment variable or C(~/.dimensiondata).
     type: str
   mcp_password:
     description:
       - The password used to authenticate to the CloudControl API.
-      - If not specified, will fall back to C(MCP_PASSWORD) from environment variable or C(~/.dimensiondata).
+      - If not specified, will fall back to E(MCP_PASSWORD) from environment variable or C(~/.dimensiondata).
       - Required if O(mcp_user) is specified.
     type: str
   location:

--- a/plugins/doc_fragments/hwc.py
+++ b/plugins/doc_fragments/hwc.py
@@ -51,16 +51,16 @@ options:
         type: str
 notes:
   - For authentication, you can set identity_endpoint using the
-    C(ANSIBLE_HWC_IDENTITY_ENDPOINT) env variable.
+    E(ANSIBLE_HWC_IDENTITY_ENDPOINT) env variable.
   - For authentication, you can set user using the
-    C(ANSIBLE_HWC_USER) env variable.
-  - For authentication, you can set password using the C(ANSIBLE_HWC_PASSWORD) env
+    E(ANSIBLE_HWC_USER) env variable.
+  - For authentication, you can set password using the E(ANSIBLE_HWC_PASSWORD) env
     variable.
-  - For authentication, you can set domain using the C(ANSIBLE_HWC_DOMAIN) env
+  - For authentication, you can set domain using the E(ANSIBLE_HWC_DOMAIN) env
     variable.
-  - For authentication, you can set project using the C(ANSIBLE_HWC_PROJECT) env
+  - For authentication, you can set project using the E(ANSIBLE_HWC_PROJECT) env
     variable.
-  - For authentication, you can set region using the C(ANSIBLE_HWC_REGION) env variable.
+  - For authentication, you can set region using the E(ANSIBLE_HWC_REGION) env variable.
   - Environment variables values will only be used if the playbook values are
     not set.
 '''

--- a/plugins/doc_fragments/influxdb.py
+++ b/plugins/doc_fragments/influxdb.py
@@ -22,14 +22,14 @@ options:
   username:
     description:
     - Username that will be used to authenticate against InfluxDB server.
-    - Alias O(ignore:login_username) added in Ansible 2.5.
+    - Alias O(login_username) added in Ansible 2.5.
     type: str
     default: root
     aliases: [ login_username ]
   password:
     description:
     - Password that will be used to authenticate against InfluxDB server.
-    - Alias O(ignore:login_password) added in Ansible 2.5.
+    - Alias O(login_password) added in Ansible 2.5.
     type: str
     default: root
     aliases: [ login_password ]

--- a/plugins/doc_fragments/ipa.py
+++ b/plugins/doc_fragments/ipa.py
@@ -16,44 +16,44 @@ options:
   ipa_port:
     description:
     - Port of FreeIPA / IPA server.
-    - If the value is not specified in the task, the value of environment variable C(IPA_PORT) will be used instead.
-    - If both the environment variable C(IPA_PORT) and the value are not specified in the task, then default value is set.
+    - If the value is not specified in the task, the value of environment variable E(IPA_PORT) will be used instead.
+    - If both the environment variable E(IPA_PORT) and the value are not specified in the task, then default value is set.
     - Environment variable fallback mechanism is added in Ansible 2.5.
     type: int
     default: 443
   ipa_host:
     description:
     - IP or hostname of IPA server.
-    - If the value is not specified in the task, the value of environment variable C(IPA_HOST) will be used instead.
-    - If both the environment variable C(IPA_HOST) and the value are not specified in the task, then DNS will be used to try to discover the FreeIPA server.
+    - If the value is not specified in the task, the value of environment variable E(IPA_HOST) will be used instead.
+    - If both the environment variable E(IPA_HOST) and the value are not specified in the task, then DNS will be used to try to discover the FreeIPA server.
     - The relevant entry needed in FreeIPA is the 'ipa-ca' entry.
-    - If neither the DNS entry, nor the environment C(IPA_HOST), nor the value are available in the task, then the default value will be used.
+    - If neither the DNS entry, nor the environment E(IPA_HOST), nor the value are available in the task, then the default value will be used.
     - Environment variable fallback mechanism is added in Ansible 2.5.
     type: str
     default: ipa.example.com
   ipa_user:
     description:
     - Administrative account used on IPA server.
-    - If the value is not specified in the task, the value of environment variable C(IPA_USER) will be used instead.
-    - If both the environment variable C(IPA_USER) and the value are not specified in the task, then default value is set.
+    - If the value is not specified in the task, the value of environment variable E(IPA_USER) will be used instead.
+    - If both the environment variable E(IPA_USER) and the value are not specified in the task, then default value is set.
     - Environment variable fallback mechanism is added in Ansible 2.5.
     type: str
     default: admin
   ipa_pass:
     description:
     - Password of administrative user.
-    - If the value is not specified in the task, the value of environment variable C(IPA_PASS) will be used instead.
-    - Note that if the 'urllib_gssapi' library is available, it is possible to use GSSAPI to authenticate to FreeIPA.
-    - If the environment variable C(KRB5CCNAME) is available, the module will use this kerberos credentials cache to authenticate to the FreeIPA server.
-    - If the environment variable C(KRB5_CLIENT_KTNAME) is available, and C(KRB5CCNAME) is not; the module will use this kerberos keytab to authenticate.
-    - If GSSAPI is not available, the usage of 'ipa_pass' is required.
+    - If the value is not specified in the task, the value of environment variable E(IPA_PASS) will be used instead.
+    - Note that if the C(urllib_gssapi) library is available, it is possible to use GSSAPI to authenticate to FreeIPA.
+    - If the environment variable E(KRB5CCNAME) is available, the module will use this kerberos credentials cache to authenticate to the FreeIPA server.
+    - If the environment variable E(KRB5_CLIENT_KTNAME) is available, and E(KRB5CCNAME) is not; the module will use this kerberos keytab to authenticate.
+    - If GSSAPI is not available, the usage of O(ipa_pass) is required.
     - Environment variable fallback mechanism is added in Ansible 2.5.
     type: str
   ipa_prot:
     description:
     - Protocol used by IPA server.
-    - If the value is not specified in the task, the value of environment variable C(IPA_PROT) will be used instead.
-    - If both the environment variable C(IPA_PROT) and the value are not specified in the task, then default value is set.
+    - If the value is not specified in the task, the value of environment variable E(IPA_PROT) will be used instead.
+    - If both the environment variable E(IPA_PROT) and the value are not specified in the task, then default value is set.
     - Environment variable fallback mechanism is added in Ansible 2.5.
     type: str
     choices: [ http, https ]
@@ -69,8 +69,8 @@ options:
     description:
     - Specifies idle timeout (in seconds) for the connection.
     - For bulk operations, you may want to increase this in order to avoid timeout from IPA server.
-    - If the value is not specified in the task, the value of environment variable C(IPA_TIMEOUT) will be used instead.
-    - If both the environment variable C(IPA_TIMEOUT) and the value are not specified in the task, then default value is set.
+    - If the value is not specified in the task, the value of environment variable E(IPA_TIMEOUT) will be used instead.
+    - If both the environment variable E(IPA_TIMEOUT) and the value are not specified in the task, then default value is set.
     type: int
     default: 10
 '''

--- a/plugins/doc_fragments/manageiq.py
+++ b/plugins/doc_fragments/manageiq.py
@@ -21,30 +21,30 @@ options:
     suboptions:
       url:
         description:
-          - ManageIQ environment URL. C(MIQ_URL) environment variable if set. otherwise, it is required to pass it.
+          - ManageIQ environment URL. E(MIQ_URL) environment variable if set. Otherwise, it is required to pass it.
         type: str
         required: false
       username:
         description:
-          - ManageIQ username. C(MIQ_USERNAME) environment variable if set. otherwise, required if no token is passed in.
+          - ManageIQ username. E(MIQ_USERNAME) environment variable if set. Otherwise, required if no token is passed in.
         type: str
       password:
         description:
-          - ManageIQ password. C(MIQ_PASSWORD) environment variable if set. otherwise, required if no token is passed in.
+          - ManageIQ password. E(MIQ_PASSWORD) environment variable if set. Otherwise, required if no token is passed in.
         type: str
       token:
         description:
-          - ManageIQ token. C(MIQ_TOKEN) environment variable if set. otherwise, required if no username or password is passed in.
+          - ManageIQ token. E(MIQ_TOKEN) environment variable if set. Otherwise, required if no username or password is passed in.
         type: str
       validate_certs:
         description:
-          - Whether SSL certificates should be verified for HTTPS requests. defaults to True.
+          - Whether SSL certificates should be verified for HTTPS requests.
         type: bool
         default: true
         aliases: [ verify_ssl ]
       ca_cert:
         description:
-          - The path to a CA bundle file or directory with certificates. defaults to None.
+          - The path to a CA bundle file or directory with certificates.
         type: str
         aliases: [ ca_bundle_path ]
 

--- a/plugins/doc_fragments/online.py
+++ b/plugins/doc_fragments/online.py
@@ -39,7 +39,7 @@ notes:
   - Also see the API documentation on U(https://console.online.net/en/api/)
   - If O(api_token) is not set within the module, the following
     environment variables can be used in decreasing order of precedence
-    C(ONLINE_TOKEN), C(ONLINE_API_KEY), C(ONLINE_OAUTH_TOKEN), C(ONLINE_API_TOKEN)
-  - If one wants to use a different O(api_url) one can also set the C(ONLINE_API_URL)
+    E(ONLINE_TOKEN), E(ONLINE_API_KEY), E(ONLINE_OAUTH_TOKEN), E(ONLINE_API_TOKEN).
+  - If one wants to use a different O(api_url) one can also set the E(ONLINE_API_URL)
     environment variable.
 '''

--- a/plugins/doc_fragments/opennebula.py
+++ b/plugins/doc_fragments/opennebula.py
@@ -15,26 +15,26 @@ options:
     api_url:
         description:
             - The ENDPOINT URL of the XMLRPC server.
-            - If not specified then the value of the C(ONE_URL) environment variable, if any, is used.
+            - If not specified then the value of the E(ONE_URL) environment variable, if any, is used.
         type: str
         aliases:
             - api_endpoint
     api_username:
         description:
             - The name of the user for XMLRPC authentication.
-            - If not specified then the value of the C(ONE_USERNAME) environment variable, if any, is used.
+            - If not specified then the value of the E(ONE_USERNAME) environment variable, if any, is used.
         type: str
     api_password:
         description:
             - The password or token for XMLRPC authentication.
-            - If not specified then the value of the C(ONE_PASSWORD) environment variable, if any, is used.
+            - If not specified then the value of the E(ONE_PASSWORD) environment variable, if any, is used.
         type: str
         aliases:
             - api_token
     validate_certs:
         description:
             - Whether to validate the TLS/SSL certificates or not.
-            - This parameter is ignored if C(PYTHONHTTPSVERIFY) environment variable is used.
+            - This parameter is ignored if E(PYTHONHTTPSVERIFY) environment variable is used.
         type: bool
         default: true
     wait_timeout:

--- a/plugins/doc_fragments/openswitch.py
+++ b/plugins/doc_fragments/openswitch.py
@@ -36,7 +36,7 @@ options:
         either the CLI login or the eAPI authentication depending on which
         transport is used. Note this argument does not affect the SSH
         transport. If the value is not specified in the task, the value of
-        environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
+        environment variable E(ANSIBLE_NET_USERNAME) will be used instead.
     type: str
   password:
     description:
@@ -44,7 +44,7 @@ options:
         the remote device.  This is a common argument used for either O(transport=cli)
         or O(transport=rest).  Note this argument does not affect the SSH
         transport. If the value is not specified in the task, the value of
-        environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+        environment variable E(ANSIBLE_NET_PASSWORD) will be used instead.
     type: str
   timeout:
     description:
@@ -58,7 +58,7 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.  This argument is only used for O(transport=cli).
         If the value is not specified in the task, the value of
-        environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
+        environment variable E(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     type: path
   transport:
     description:

--- a/plugins/doc_fragments/oracle.py
+++ b/plugins/doc_fragments/oracle.py
@@ -18,26 +18,26 @@ class ModuleDocFragment(object):
     options:
         config_file_location:
             description:
-                - Path to configuration file. If not set then the value of the OCI_CONFIG_FILE environment variable,
+                - Path to configuration file. If not set then the value of the E(OCI_CONFIG_FILE) environment variable,
                   if any, is used. Otherwise, defaults to ~/.oci/config.
             type: str
         config_profile_name:
             description:
                 - The profile to load from the config file referenced by O(config_file_location). If not set, then the
-                  value of the OCI_CONFIG_PROFILE environment variable, if any, is used. Otherwise, defaults to the
+                  value of the E(OCI_CONFIG_PROFILE) environment variable, if any, is used. Otherwise, defaults to the
                   "DEFAULT" profile in O(config_file_location).
             default: "DEFAULT"
             type: str
         api_user:
             description:
                 - The OCID of the user, on whose behalf, OCI APIs are invoked. If not set, then the
-                  value of the OCI_USER_OCID environment variable, if any, is used. This option is required if the user
+                  value of the E(OCI_USER_OCID) environment variable, if any, is used. This option is required if the user
                   is not specified through a configuration file (See O(config_file_location)). To get the user's OCID,
                   please refer U(https://docs.us-phoenix-1.oraclecloud.com/Content/API/Concepts/apisigningkey.htm).
             type: str
         api_user_fingerprint:
             description:
-                - Fingerprint for the key pair being used. If not set, then the value of the OCI_USER_FINGERPRINT
+                - Fingerprint for the key pair being used. If not set, then the value of the E(OCI_USER_FINGERPRINT)
                   environment variable, if any, is used. This option is required if the key fingerprint is not
                   specified through a configuration file (See O(config_file_location)). To get the key pair's
                   fingerprint value please refer

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -24,7 +24,7 @@ options:
   api_password:
     description:
       - Specify the password to authenticate with.
-      - You can use C(PROXMOX_PASSWORD) environment variable.
+      - You can use E(PROXMOX_PASSWORD) environment variable.
     type: str
   api_token_id:
     description:

--- a/plugins/doc_fragments/purestorage.py
+++ b/plugins/doc_fragments/purestorage.py
@@ -33,7 +33,7 @@ options:
     type: str
 notes:
   - This module requires the C(purity_fb) Python library
-  - You must set C(PUREFB_URL) and C(PUREFB_API) environment variables
+  - You must set E(PUREFB_URL) and E(PUREFB_API) environment variables
     if O(fb_url) and O(api_token) arguments are not passed to the module directly
 requirements:
   - python >= 2.7
@@ -55,7 +55,7 @@ options:
     required: true
 notes:
   - This module requires the C(purestorage) Python library
-  - You must set C(PUREFA_URL) and C(PUREFA_API) environment variables
+  - You must set E(PUREFA_URL) and E(PUREFA_API) environment variables
     if O(fa_url) and O(api_token) arguments are not passed to the module directly
 requirements:
   - python >= 2.7

--- a/plugins/doc_fragments/rackspace.py
+++ b/plugins/doc_fragments/rackspace.py
@@ -46,12 +46,12 @@ requirements:
   - python >= 2.6
   - pyrax
 notes:
-  - The following environment variables can be used, C(RAX_USERNAME),
-    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
-  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+  - The following environment variables can be used, E(RAX_USERNAME),
+    E(RAX_API_KEY), E(RAX_CREDS_FILE), E(RAX_CREDENTIALS), E(RAX_REGION).
+  - E(RAX_CREDENTIALS) and E(RAX_CREDS_FILE) point to a credentials file
     appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
-  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
-  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+  - E(RAX_USERNAME) and E(RAX_API_KEY) obviate the use of a credentials file
+  - E(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
 '''
 
     # Documentation fragment including attributes to enable communication
@@ -113,10 +113,10 @@ requirements:
   - python >= 2.6
   - pyrax
 notes:
-  - The following environment variables can be used, C(RAX_USERNAME),
-    C(RAX_API_KEY), C(RAX_CREDS_FILE), C(RAX_CREDENTIALS), C(RAX_REGION).
-  - C(RAX_CREDENTIALS) and C(RAX_CREDS_FILE) points to a credentials file
+  - The following environment variables can be used, E(RAX_USERNAME),
+    E(RAX_API_KEY), E(RAX_CREDS_FILE), E(RAX_CREDENTIALS), E(RAX_REGION).
+  - E(RAX_CREDENTIALS) and E(RAX_CREDS_FILE) points to a credentials file
     appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
-  - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
-  - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+  - E(RAX_USERNAME) and E(RAX_API_KEY) obviate the use of a credentials file
+  - E(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
 '''

--- a/plugins/doc_fragments/scaleway.py
+++ b/plugins/doc_fragments/scaleway.py
@@ -45,7 +45,7 @@ notes:
   - Also see the API documentation on U(https://developer.scaleway.com/)
   - If O(api_token) is not set within the module, the following
     environment variables can be used in decreasing order of precedence
-    C(SCW_TOKEN), C(SCW_API_KEY), C(SCW_OAUTH_TOKEN) or C(SCW_API_TOKEN).
-  - If one wants to use a different O(api_url) one can also set the C(SCW_API_URL)
+    E(SCW_TOKEN), E(SCW_API_KEY), E(SCW_OAUTH_TOKEN) or E(SCW_API_TOKEN).
+  - If one wants to use a different O(api_url) one can also set the E(SCW_API_URL)
     environment variable.
 '''

--- a/plugins/doc_fragments/xenserver.py
+++ b/plugins/doc_fragments/xenserver.py
@@ -15,27 +15,27 @@ options:
   hostname:
     description:
     - The hostname or IP address of the XenServer host or XenServer pool master.
-    - If the value is not specified in the task, the value of environment variable C(XENSERVER_HOST) will be used instead.
+    - If the value is not specified in the task, the value of environment variable E(XENSERVER_HOST) will be used instead.
     type: str
     default: localhost
     aliases: [ host, pool ]
   username:
     description:
     - The username to use for connecting to XenServer.
-    - If the value is not specified in the task, the value of environment variable C(XENSERVER_USER) will be used instead.
+    - If the value is not specified in the task, the value of environment variable E(XENSERVER_USER) will be used instead.
     type: str
     default: root
     aliases: [ admin, user ]
   password:
     description:
     - The password to use for connecting to XenServer.
-    - If the value is not specified in the task, the value of environment variable C(XENSERVER_PASSWORD) will be used instead.
+    - If the value is not specified in the task, the value of environment variable E(XENSERVER_PASSWORD) will be used instead.
     type: str
     aliases: [ pass, pwd ]
   validate_certs:
     description:
     - Allows connection when SSL certificates are not valid. Set to V(false) when certificates are not trusted.
-    - If the value is not specified in the task, the value of environment variable C(XENSERVER_VALIDATE_CERTS) will be used instead.
+    - If the value is not specified in the task, the value of environment variable E(XENSERVER_VALIDATE_CERTS) will be used instead.
     type: bool
     default: true
 '''

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -72,7 +72,7 @@ DOCUMENTATION = r'''
             description:
             - If an instance has multiple network interfaces, select which one is the prefered as pattern.
             - Combined with the first number that can be found e.g. 'eth' + 0.
-            - The option has been renamed from O(ignore:prefered_container_network_interface) to O(prefered_instance_network_interface)
+            - The option has been renamed from O(prefered_container_network_interface) to O(prefered_instance_network_interface)
               in community.general 3.8.0. The old name still works as an alias.
             type: str
             default: eth

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -13,7 +13,7 @@ DOCUMENTATION = """
       - bw (command line utility)
       - be logged into bitwarden
       - bitwarden vault unlocked
-      - C(BW_SESSION) environment variable set
+      - E(BW_SESSION) environment variable set
     short_description: Retrieve secrets from Bitwarden
     version_added: 5.4.0
     description:

--- a/plugins/lookup/etcd.py
+++ b/plugins/lookup/etcd.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
             required: true
         url:
             description:
-                - Environment variable with the url for the etcd server
+                - Environment variable with the URL for the etcd server
             default: 'http://127.0.0.1:4001'
             env:
               - name: ANSIBLE_ETCD_URL


### PR DESCRIPTION
##### SUMMARY
With antsibull-docs 2.1.0 we can finally use `E(...)` as intended.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various
