### PR TITLE
plugins/inventory/cobbler: Collect IP addresses for hosts and add opt…

### DIFF
--- a/changelogs/fragments/6711-cobbler-ip-address.yml
+++ b/changelogs/fragments/6711-cobbler-ip-address.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - cobbler inventory plugin - add ``want_ip_addresses`` option to collect all interface DNS name to IP address mapping (https://github.com/ansible-collections/community.general/pull/6711).
+  - cobbler inventory plugin - add primary IP addess to ``cobbler_ipv4_address`` and IPv6 address to ``cobbler_ipv6_address`` host variable (https://github.com/ansible-collections/community.general/pull/6711).


### PR DESCRIPTION
…ion to collect all DNS name to IP address mappings

##### SUMMARY
It can be very helpful to have easy access to a host's primary IP address and various DNS name to IP address mappings defined in cobbler.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/cobbler.py

##### ADDITIONAL INFORMATION
```paste below
- debug:
    msg: "My IP address is {{ ip_address }}"
- debug:
    msg: "The IP address of server.example.com is {{ hostvars['server.example.com']['ip_address'] }}"
- debug:
    mesg "The IP address of server-interface.example.com is {{ cobbler_ip_addresses['server-interface.example.com'] }}"
```
