### PR TITLE
pacman: support yay as root

### DIFF
--- a/changelogs/fragments/6713-yay-become.yml
+++ b/changelogs/fragments/6713-yay-become.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacman - module recognizes the output of ``yay`` running as ``root`` (https://github.com/ansible-collections/community.general/pull/6713).

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -133,7 +133,8 @@ notes:
     it is much more efficient to pass the list directly to the O(name) option.
   - To use an AUR helper (O(executable) option), a few extra setup steps might be required beforehand.
     For example, a dedicated build user with permissions to install packages could be necessary.
-  - In the tests, while using C(yay) as the O(executable) option, the module failed to install AUR packages
+  - >
+    In the tests, while using C(yay) as the O(executable) option, the module failed to install AUR packages
     with the error: C(error: target not found: <pkg>).
 """
 

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -133,6 +133,8 @@ notes:
     it is much more efficient to pass the list directly to the O(name) option.
   - To use an AUR helper (O(executable) option), a few extra setup steps might be required beforehand.
     For example, a dedicated build user with permissions to install packages could be necessary.
+  - In the tests, while using C(yay) as the O(executable) option, the module failed to install AUR packages
+    with the error: C(error: target not found: <pkg>).
 """
 
 RETURN = """

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -263,7 +263,8 @@ EXAMPLES = """
     reason_for: all
 """
 
-import re, shlex
+import re
+import shlex
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict, namedtuple
 

--- a/plugins/modules/pacman.py
+++ b/plugins/modules/pacman.py
@@ -707,7 +707,7 @@ class Pacman(object):
         installed_pkgs = {}
         dummy, stdout, dummy = self.m.run_command([self.pacman_path, "--query"], check_rc=True)
         # Format of a line: "pacman 6.0.1-2"
-        query_re = re.compile(r'^(?P<pkg>\S+)\s+(?P<ver>\S+)\s*$')
+        query_re = re.compile(r'^\s*(?P<pkg>\S+)\s+(?P<ver>\S+)\s*$')
         for l in stdout.splitlines():
             query_match = query_re.match(l)
             if not query_match:
@@ -723,7 +723,7 @@ class Pacman(object):
         #     base-devel file
         #     base-devel findutils
         #     ...
-        query_groups_re = re.compile(r'^(?P<group>\S+)\s+(?P<pkg>\S+)\s*$')
+        query_groups_re = re.compile(r'^\s*(?P<group>\S+)\s+(?P<pkg>\S+)\s*$')
         for l in stdout.splitlines():
             query_groups_match = query_groups_re.match(l)
             if not query_groups_match:
@@ -750,7 +750,7 @@ class Pacman(object):
         #     vim-plugins vim-airline-themes
         #     vim-plugins vim-ale
         #     ...
-        sync_groups_re = re.compile(r'^(?P<group>\S+)\s+(?P<pkg>\S+)\s*$')
+        sync_groups_re = re.compile(r'^\s*(?P<group>\S+)\s+(?P<pkg>\S+)\s*$')
         for l in stdout.splitlines():
             sync_groups_match = sync_groups_re.match(l)
             if not sync_groups_match:
@@ -766,6 +766,7 @@ class Pacman(object):
         stdout = stdout.splitlines()
         if stdout and "Avoid running" in stdout[0]:
             stdout = stdout[1:]
+        stdout = "\n".join(stdout)
 
         # non-zero exit with nothing in stdout -> nothing to upgrade, all good
         # stderr can have warnings, so not checked here
@@ -775,7 +776,7 @@ class Pacman(object):
             # Format of lines:
             #     strace 5.14-1 -> 5.15-1
             #     systemd 249.7-1 -> 249.7-2 [ignored]
-            for l in stdout:
+            for l in stdout.splitlines():
                 l = l.strip()
                 if not l:
                     continue

--- a/tests/integration/targets/pacman/handlers/main.yml
+++ b/tests/integration/targets/pacman/handlers/main.yml
@@ -15,10 +15,9 @@
 
 - name: Remove packages for yay-become
   ansible.builtin.package:
-    name: "{{ item }}"
+    name:
+      - base-devel
+      - yay
+      - git
+      - nmap
     state: absent
-  loop:
-    - base-devel
-    - yay
-    - git
-    - nmap

--- a/tests/integration/targets/pacman/handlers/main.yml
+++ b/tests/integration/targets/pacman/handlers/main.yml
@@ -1,0 +1,24 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Remove user yaybuilder
+  ansible.builtin.user:
+    name: yaybuilder
+    state: absent
+
+- name: Remove yay
+  ansible.builtin.package:
+    name: yay
+    state: absent
+
+- name: Remove packages for yay-become
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - base-devel
+    - yay
+    - git
+    - nmap

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -11,9 +11,10 @@
 - when: ansible_os_family == 'Archlinux'
   block:
     # Add more tests here by including more task files:
-    - include_tasks: 'basic.yml'
-    - include_tasks: 'package_urls.yml'
-    - include_tasks: 'remove_nosave.yml'
-    - include_tasks: 'update_cache.yml'
-    - include_tasks: 'locally_installed_package.yml'
-    - include_tasks: 'reason.yml'
+    # - include_tasks: 'basic.yml'
+    # - include_tasks: 'package_urls.yml'
+    # - include_tasks: 'remove_nosave.yml'
+    # - include_tasks: 'update_cache.yml'
+    # - include_tasks: 'locally_installed_package.yml'
+    # - include_tasks: 'reason.yml'
+    - include_tasks: 'yay-become.yml'

--- a/tests/integration/targets/pacman/tasks/main.yml
+++ b/tests/integration/targets/pacman/tasks/main.yml
@@ -11,10 +11,10 @@
 - when: ansible_os_family == 'Archlinux'
   block:
     # Add more tests here by including more task files:
-    # - include_tasks: 'basic.yml'
-    # - include_tasks: 'package_urls.yml'
-    # - include_tasks: 'remove_nosave.yml'
-    # - include_tasks: 'update_cache.yml'
-    # - include_tasks: 'locally_installed_package.yml'
-    # - include_tasks: 'reason.yml'
+    - include_tasks: 'basic.yml'
+    - include_tasks: 'package_urls.yml'
+    - include_tasks: 'remove_nosave.yml'
+    - include_tasks: 'update_cache.yml'
+    - include_tasks: 'locally_installed_package.yml'
+    - include_tasks: 'reason.yml'
     - include_tasks: 'yay-become.yml'

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -23,12 +23,11 @@
 
 - name: Install base packages
   ansible.builtin.package:
-    name: "{{ item }}"
+    name:
+      - base-devel
+      - git
+      - go
     state: present
-  with_items:
-    - base-devel
-    - git
-    - go
   notify: Remove packages for yay-become
 
 - name: Hack permssions for the remote_tmp_dir

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -10,13 +10,14 @@
 
 - name: create user
   ansible.builtin.user:
-    name: builder
+    name: yaybuilder
     state: present
+  notify: Remove user yaybuilder
 
 - name: grant sudo powers to builder
   community.general.sudoers:
-    name: builder
-    user: builder
+    name: yaybuilder
+    user: yaybuilder
     commands: ALL
     nopassword: true
 
@@ -28,6 +29,7 @@
     - base-devel
     - git
     - go
+  notify: Remove packages for yay-become
 
 - name: Hack permssions for the remote_tmp_dir
   ansible.builtin.file:
@@ -37,13 +39,13 @@
 - name: Create temp directory for builder
   ansible.builtin.file:
     path: "{{ remote_tmp_dir }}/builder"
-    owner: builder
+    owner: yaybuilder
     state: directory
     mode: '755'
 
 - name: clone yay git repo
   become: true
-  become_user: builder
+  become_user: yaybuilder
   ansible.builtin.git:
     repo: https://aur.archlinux.org/yay.git
     dest: "{{ remote_tmp_dir  }}/builder/yay"
@@ -51,10 +53,11 @@
 
 - name: make package
   become: true
-  become_user: builder
+  become_user: yaybuilder
   ansible.builtin.command:
     chdir: "{{ remote_tmp_dir  }}/builder/yay"
     cmd: makepkg -si --noconfirm
+  notify: Remove yay
 
 - name: Install nmap
   community.general.pacman:
@@ -62,18 +65,3 @@
     state: present
     executable: yay
     extra_args: --builddir /var/cache/yay
-
-- name: Remove packages
-  ansible.builtin.package:
-    name: "{{ item }}"
-    state: absent
-  loop:
-    - base-devel
-    - yay
-    - git
-    - nmap
-
-- name: Remove user
-  ansible.builtin.user:
-    name: builder
-    state: absent

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -41,7 +41,7 @@
     path: "{{ remote_tmp_dir }}/builder"
     owner: yaybuilder
     state: directory
-    mode: '755'
+    mode: '0755'
 
 - name: clone yay git repo
   become: true

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -1,0 +1,88 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# This is more convoluted that one might expect, because:
+#   - yay is not available or installation in ArchLinux (as it is in Manjaro - issue 6184 reports using it)
+#   - to install yay in ArchLinux requires building the package
+#   - makepkg cannot be run as root, but the user running it must have sudo to install the resulting package
+
+- name: create user
+  ansible.builtin.user:
+    name: builder
+    state: present
+
+- name: grant sudo powers to builder
+  community.general.sudoers:
+    name: builder
+    user: builder
+    commands: ALL
+    nopassword: true
+
+- name: Install base packages
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - base-devel
+    - git
+    - go
+
+- name: Hack permssions for the remote_tmp_dir
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}"
+    mode: 777
+
+- name: Create temp directory for builder
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}/builder"
+    owner: builder
+    state: directory
+    mode: '755'
+
+- name: clone yay git repo
+  become: true
+  become_user: builder
+  ansible.builtin.git:
+    repo: https://aur.archlinux.org/yay.git
+    dest: "{{ remote_tmp_dir  }}/builder/yay"
+    depth: 1
+
+- name: make package
+  become: true
+  become_user: builder
+  ansible.builtin.command:
+    chdir: "{{ remote_tmp_dir  }}/builder/yay"
+    cmd: makepkg -si --noconfirm
+
+- name: Install nmap
+  community.general.pacman:
+    name: nmap
+    state: present
+    executable: yay
+    extra_args: --builddir /var/cache/yay
+
+- name: Install XRDP
+  become: true
+  become_user: builder
+  community.general.pacman:
+    name: xrdp
+    state: present
+    executable: yay
+    extra_args: --builddir /var/cache/yay
+
+- name: Remove packages
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - base-devel
+    - yay
+    - git
+    - nmap
+
+- name: Remove user
+  ansible.builtin.user:
+    name: builder
+    state: absent

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -63,15 +63,6 @@
     executable: yay
     extra_args: --builddir /var/cache/yay
 
-- name: Install XRDP
-  become: true
-  become_user: builder
-  community.general.pacman:
-    name: xrdp
-    state: present
-    executable: yay
-    extra_args: --builddir /var/cache/yay
-
 - name: Remove packages
   ansible.builtin.package:
     name: "{{ item }}"

--- a/tests/integration/targets/pacman/tasks/yay-become.yml
+++ b/tests/integration/targets/pacman/tasks/yay-become.yml
@@ -34,7 +34,7 @@
 - name: Hack permssions for the remote_tmp_dir
   ansible.builtin.file:
     path: "{{ remote_tmp_dir }}"
-    mode: 777
+    mode: '0777'
 
 - name: Create temp directory for builder
   ansible.builtin.file:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add additional parsing to support `yay` running as root, as the tool will **always** print a warning about the fact.

It must be noted, however, that for some reason I haven't identified (nor planning to invest so much time to do that), whenever `yay` is executed on a remote node (tested on a local VM with vagrant), it will not install AUR packages, only stable repositories are read.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6184 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
pacman
