### PR TITLE
passwordstore: allow to use directory with gopass

### DIFF
--- a/changelogs/fragments/6717-password-store_fix-directory-for-gopass.yml
+++ b/changelogs/fragments/6717-password-store_fix-directory-for-gopass.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - passwordstore lookup plugin - allow to use the `directory` with gopass
+  - passwordstore lookup plugin - allow to set directory in ansible.cfg

--- a/changelogs/fragments/6717-password-store_fix-directory-for-gopass.yml
+++ b/changelogs/fragments/6717-password-store_fix-directory-for-gopass.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - passwordstore lookup plugin - allow to use the `directory` with gopass

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -320,7 +320,8 @@ class LookupModule(LookupBase):
 
             if self.backend == 'gopass':
                 self.env['GOPASS_NO_REMINDER'] = "YES"
-            elif os.path.isdir(self.paramvals['directory']):
+
+            if os.path.isdir(self.paramvals['directory']):
                 # Set PASSWORD_STORE_DIR
                 self.env['PASSWORD_STORE_DIR'] = self.paramvals['directory']
             elif self.is_real_pass():

--- a/plugins/lookup/passwordstore.py
+++ b/plugins/lookup/passwordstore.py
@@ -32,6 +32,9 @@ DOCUMENTATION = '''
           - name: passwordstore
         env:
           - name: PASSWORD_STORE_DIR
+        ini:
+          - section: passwordstore_lookup
+            key: directory
       create:
         description: Create the password if it does not already exist. Takes precedence over O(missing).
         type: bool


### PR DESCRIPTION
##### SUMMARY
passwordstore allows multiple backend. With the gopass backend the directory option got ignored.
Since gopass 1.14.4 it support the environment variable PASSWORD_STORE_DIR.
Set the environment when the directory is set.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
- passwordstore_lookup

##### ADDITIONAL INFORMATION
Set the ansible.cfg configuration

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

initialize the password store
```paste below
# init pass
mkdir -p credentials/
export PASSWORD_STORE_DIR=$(pwd)/credentials/
pass init lynxis@fe80.eu
pass generate foobar

```

example playbook
```
---
- hosts: localhost
  tasks:
    - name: Print password (pass)
      ansible.builtin.debug:
        msg: "{{ lookup('community.general.passwordstore', 'foobar', backend='pass', directory='credentials') }}"
      ignore_errors: True
    - name: Print password (gopass)
      ansible.builtin.debug:
        msg: "{{ lookup('community.general.passwordstore', 'foobar', backend='gopass', directory='credentials') }}"
      ignore_errors: True
```

error output
```

PLAY [localhost] *****************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [localhost]

TASK [Print password (pass)] *****************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "g:-WrC2+it:vG\"6K4t%S&E<o,"
}

TASK [Print password (gopass)] *****************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'community.general.passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: passwordstore: passname foobar not found and missing=error is set. passwordstore: passname foobar not found and missing=error is set"}
...ignoring

PLAY RECAP ***********************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   


```

expected output
```
PLAY [localhost] *****************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [localhost]

TASK [Print password (pass)] *****************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "g:-WrC2+it:vG\"6K4t%S&E<o,"
}

TASK [Print password (gopass)] *****************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "g:-WrC2+it:vG\"6K4t%S&E<o,"
}

PLAY RECAP ***********************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```