### PR TITLE
Fix multiple issues with the TSS lookup plugin when using fetch_attachments

### DIFF
--- a/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
+++ b/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - tss - fix multiple issues with the TSS lookup plugin when using ``fetch_attachments: True`` (https://github.com/ansible-collections/community.general/pull/6720).

--- a/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
+++ b/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "tss - fix multiple issues with the TSS lookup plugin when using ``fetch_attachments: True`` (https://github.com/ansible-collections/community.general/pull/6720)."
+  - "tss lookup plugin - fix multiple issues when using ``fetch_attachments=true`` (https://github.com/ansible-collections/community.general/pull/6720)."

--- a/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
+++ b/changelogs/fragments/6720-tss-fix-fetch-attachments.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - tss - fix multiple issues with the TSS lookup plugin when using ``fetch_attachments: True`` (https://github.com/ansible-collections/community.general/pull/6720).
+  - "tss - fix multiple issues with the TSS lookup plugin when using ``fetch_attachments: True`` (https://github.com/ansible-collections/community.general/pull/6720)."

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -289,8 +289,8 @@ class TSSClient(object):
                 if file_download_path and os.path.isdir(file_download_path):
                     if i['isFile']:
                         try:
-                            with open(os.path.join(file_download_path, str(obj['id']) + "_" + i['slug']), "w") as f:
-                                f.write(i['itemValue'].text)
+                            with open(os.path.join(file_download_path, str(obj['id']) + "_" + i['slug']), "wb") as f:
+                                f.write(i['itemValue'].content)
                             i['itemValue'] = "*** Not Valid For Display ***"
                         except ValueError:
                             raise AnsibleOptionsError("Failed to download {0}".format(str(i['slug'])))

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -292,11 +292,12 @@ class TSSClient(object):
                             file_content = i['itemValue'].content
                             with open(os.path.join(file_download_path, str(obj['id']) + "_" + i['slug']), "wb") as f:
                                 f.write(file_content)
-                            i['itemValue'] = "*** Not Valid For Display ***"
                         except ValueError:
                             raise AnsibleOptionsError("Failed to download {0}".format(str(i['slug'])))
                         except AttributeError:
                             display.warning("Could not read file content for {0}".format(str(i['slug'])))
+                        finally:
+                            i['itemValue'] = "*** Not Valid For Display ***"
                 else:
                     raise AnsibleOptionsError("File download path does not exist")
             return obj

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -289,11 +289,14 @@ class TSSClient(object):
                 if file_download_path and os.path.isdir(file_download_path):
                     if i['isFile']:
                         try:
+                            file_content = i['itemValue'].content
                             with open(os.path.join(file_download_path, str(obj['id']) + "_" + i['slug']), "wb") as f:
-                                f.write(i['itemValue'].content)
+                                f.write(file_content)
                             i['itemValue'] = "*** Not Valid For Display ***"
                         except ValueError:
                             raise AnsibleOptionsError("Failed to download {0}".format(str(i['slug'])))
+                        except AttributeError:
+                            display.warning("Could not read file content for {0}".format(str(i['slug'])))
                 else:
                     raise AnsibleOptionsError("File download path does not exist")
             return obj

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -300,8 +300,9 @@ class TSSClient(object):
                             i['itemValue'] = "*** Not Valid For Display ***"
                 else:
                     raise AnsibleOptionsError("File download path does not exist")
-
-        return self._client.get_secret_json(secret_id)
+            return obj
+        else:
+            return self._client.get_secret_json(secret_id)
 
     def get_secret_ids_by_folderid(self, term):
         display.debug("tss_lookup term: %s" % term)

--- a/plugins/lookup/tss.py
+++ b/plugins/lookup/tss.py
@@ -300,9 +300,8 @@ class TSSClient(object):
                             i['itemValue'] = "*** Not Valid For Display ***"
                 else:
                     raise AnsibleOptionsError("File download path does not exist")
-            return obj
-        else:
-            return self._client.get_secret_json(secret_id)
+
+        return self._client.get_secret_json(secret_id)
 
     def get_secret_ids_by_folderid(self, term):
         display.debug("tss_lookup term: %s" % term)


### PR DESCRIPTION
##### SUMMARY

There are multiple issues present in the TSS lookup plugin when the recently added `fetch_attachments` is set to `True`:
- All files are written as text with UTF-8 encoding - this does not work for PFX files which have to be written in binary format
- An `AttributeError` is raised (`'str' object has no attribute 'text'`) when some attachments are missing from a secret. This is an issue, as some attachments may be optional (e.g. a secret can hold both a PFX and PEM format certificate in separate fields)
- Empty files get created for missing attachments, so an empty certificate may be uploaded to a target server if we are only checking for the file being present

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tss

##### ADDITIONAL INFORMATION

1. An `AttributeError` is raised when attachments are missing:

   Before this PR (files get created for missing attachments and the whole task errors out):
   ```shell
   fatal: [localhost]: FAILED! => {
       "msg": "An unhandled exception occurred while templating '{{\n    lookup(\n        'community.general.tss',\n        1234,\n        fetch_attachments=True,\n        file_download_path='files/certs-test',\n    )\n}}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'community.general.tss'. Error was a <class 'AttributeError'>, original message: 'str' object has no attribute 'text'. 'str' object has no attribute 'text'"
   }
   ```

   After this PR (files won't be created for missing attachments and the task will raise warnings instead of erroring out):
   ```
   TASK [Test secret without all attachments] *************************************************************************
   [WARNING]: Could not read file content for certificate-file-pem
   [WARNING]: Could not read file content for key-file-pem
   [WARNING]: Could not read file content for full-chain-certificate-file-pem
   ```

2. Downloaded files are corrupted when using PFX attachments

   **Before this PR:** PFX files get corrupted when downloading them with the current lookup plugin, which uses the `text` field for loading the content of the attachment - i.e. they can't be read with `openssl pkcs12 -in my-cert.pfx -clcerts -nokeys -noout -text`.

   **After this PR:** Using the `content` field and writing the file as binary works for PFX files. It also works for PEM format certificates and RSA keys.

~3. The return values are different when using `fetch_attachments` and they cannot be printed~
I've reverted the relevant commit as this was an issue on our end, masked by the above the 2 issues. I was receiving errors as our secret template did not have a `private-key` field.