### PR TITLE
Update Datadog downtime URL

### DIFF
--- a/plugins/modules/datadog_downtime.py
+++ b/plugins/modules/datadog_downtime.py
@@ -16,7 +16,7 @@ short_description: Manages Datadog downtimes
 version_added: 2.0.0
 description:
   - Manages downtimes within Datadog.
-  - Options as described on U(https://docs.datadoghq.com/api/v1/downtimes/s).
+  - Options as described on U(https://docs.datadoghq.com/api/v1/downtimes/).
 author:
   - Datadog (@Datadog)
 requirements:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Datadog URL downtime api is invalid due to an extra 's' at the end. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
community.general.datadog_downtime module
