### PR TITLE
[stable-5] CI: Remove ansible-core devel tests; should have stopped with stable-2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -154,8 +154,6 @@ stages:
               test: rhel/9.1
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
             - name: FreeBSD 13.1
               test: freebsd/13.1
             - name: FreeBSD 12.4

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -59,20 +59,6 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
-            - test: extra
   - stage: Sanity_2_15
     displayName: Sanity 2.15
     dependsOn: []
@@ -86,6 +72,7 @@ stages:
             - test: 2
             - test: 3
             - test: 4
+            - test: extra
   - stage: Sanity_2_14
     displayName: Sanity 2.14
     dependsOn: []
@@ -113,22 +100,6 @@ stages:
             - test: 3
             - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
-          targets:
-            - test: 2.7
-            - test: 3.6
-            - test: 3.7
-            - test: 3.8
-            - test: 3.9
-            - test: '3.10'
-            - test: '3.11'
   - stage: Units_2_15
     displayName: Units 2.15
     dependsOn: []
@@ -138,8 +109,14 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.15/units/{0}/1
           targets:
+            - test: 2.7
             - test: 3.5
-            - test: "3.10"
+            - test: 3.6
+            - test: 3.7
+            - test: 3.8
+            - test: 3.9
+            - test: '3.10'
+            - test: '3.11'
   - stage: Units_2_14
     displayName: Units 2.14
     dependsOn: []
@@ -163,26 +140,6 @@ stages:
             - test: 3.8
 
 ## Remote
-  - stage: Remote_devel
-    displayName: Remote devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/{0}
-          targets:
-            - name: macOS 13.2
-              test: macos/13.2
-            - name: RHEL 9.1
-              test: rhel/9.1
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
-          groups:
-            - 1
-            - 2
-            - 3
   - stage: Remote_2_15
     displayName: Remote 2.15
     dependsOn: []
@@ -191,10 +148,18 @@ stages:
         parameters:
           testFormat: 2.15/{0}
           targets:
+            - name: macOS 13.2
+              test: macos/13.2
+            - name: RHEL 9.1
+              test: rhel/9.1
             - name: RHEL 7.9
               test: rhel/7.9
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
             - name: FreeBSD 13.1
               test: freebsd/13.1
+            - name: FreeBSD 12.4
+              test: freebsd/12.4
           groups:
             - 1
             - 2
@@ -235,13 +200,13 @@ stages:
             - 3
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_15
+    displayName: Docker 2.15
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.15/linux/{0}
           targets:
             - name: Fedora 37
               test: fedora37
@@ -253,18 +218,6 @@ stages:
               test: ubuntu2204
             - name: Alpine 3
               test: alpine3
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_15
-    displayName: Docker 2.15
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.15/linux/{0}
-          targets:
             - name: CentOS 7
               test: centos7
           groups:
@@ -305,13 +258,13 @@ stages:
             - 3
 
 ### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: Docker_community_2_15
+    displayName: Docker (community images) 2.15
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
+          testFormat: 2.15/linux-community/{0}
           targets:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
@@ -325,17 +278,6 @@ stages:
             - 3
 
 ### Generic
-  - stage: Generic_devel
-    displayName: Generic devel
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: devel/generic/{0}/1
-          targets:
-            - test: 2.7
-            - test: '3.11'
   - stage: Generic_2_15
     displayName: Generic 2.15
     dependsOn: []
@@ -345,7 +287,9 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.15/generic/{0}/1
           targets:
+            - test: 2.7
             - test: 3.9
+            - test: '3.11'
   - stage: Generic_2_14
     displayName: Generic 2.14
     dependsOn: []
@@ -370,25 +314,20 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
       - Sanity_2_13
       - Sanity_2_14
       - Sanity_2_15
-      - Units_devel
       - Units_2_13
       - Units_2_14
       - Units_2_15
-      - Remote_devel
       - Remote_2_13
       - Remote_2_14
       - Remote_2_15
-      - Docker_devel
       - Docker_2_13
       - Docker_2_14
       - Docker_2_15
-      - Docker_community_devel
+      - Docker_community_2_15
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-#      - Generic_devel
 #      - Generic_2_13
 #      - Generic_2_14
 #      - Generic_2_15

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14 releases and the current development version of ansible-core. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, and ansible-core 2.15 releases. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 Parts of this collection will not work with ansible-core 2.11 on Python 3.12+.
 


### PR DESCRIPTION
##### SUMMARY
The stable-5 branch should have been changed from devel to stable-2.15, instead of adding stable-2.15.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
