### PR TITLE
ipify_facts: skip tests on Python 2.6

### DIFF
--- a/tests/integration/targets/ipify_facts/aliases
+++ b/tests/integration/targets/ipify_facts/aliases
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
+skip/python2.6


### PR DESCRIPTION
##### SUMMARY
Needs some special requirements on Python 2.6 so that it can contact the server.

These seem to be installed when running all tests. I don't want to figure out what exactly is missing, so let's just skip the tests on Python 2.6 for now.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ipify_facts integration tests
