### PR TITLE
Keycloak authentication provider ID choices

### DIFF
--- a/changelogs/fragments/6763-keycloak-auth-provider-choices.yml
+++ b/changelogs/fragments/6763-keycloak-auth-provider-choices.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Added provider ID choices, since Keycloak supports only those two specific ones (https://github.com/ansible-collections/community.general/pull/6763).
+  - keycloak_authentication - added provider ID choices, since Keycloak supports only those two specific ones (https://github.com/ansible-collections/community.general/pull/6763).

--- a/changelogs/fragments/6763-keycloak-auth-provider-choices.yml
+++ b/changelogs/fragments/6763-keycloak-auth-provider-choices.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added provider ID choices, since Keycloak supports only those two specific ones (https://github.com/ansible-collections/community.general/pull/6763).

--- a/plugins/modules/keycloak_authentication.py
+++ b/plugins/modules/keycloak_authentication.py
@@ -43,6 +43,7 @@ options:
     providerId:
         description:
             - C(providerId) for the new flow when not copied from an existing flow.
+        choices: [ "basic-flow", "client-flow" ]
         type: str
     copyFrom:
         description:
@@ -331,7 +332,7 @@ def main():
     meta_args = dict(
         realm=dict(type='str', required=True),
         alias=dict(type='str', required=True),
-        providerId=dict(type='str'),
+        providerId=dict(type='str', choices=["basic-flow", "client-flow"]),
         description=dict(type='str'),
         copyFrom=dict(type='str'),
         authenticationExecutions=dict(type='list', elements='dict',


### PR DESCRIPTION
##### SUMMARY
The provider ID according to Keycloak can only be basic-flow or client-flow, so I introduced choices for it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
keycloak_authentication

##### ADDITIONAL INFORMATION
This is a separate PR for minor changes I introduced in #6734. I did so, in order to have the bugfix backported.
