### PR TITLE
proxmox_disk: fix failure to create cdrom

### DIFF
--- a/changelogs/fragments/6770-proxmox_disk_create_cdrom.yml
+++ b/changelogs/fragments/6770-proxmox_disk_create_cdrom.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_disk - fix unable to create cdrom due to size always being appended (https://github.com/ansible-collections/community.general/pull/6770).
+  - proxmox_disk - fix unable to create ``cdrom`` media due to ``size`` always being appended (https://github.com/ansible-collections/community.general/pull/6770).

--- a/changelogs/fragments/6770-proxmox_disk_create_cdrom.yml
+++ b/changelogs/fragments/6770-proxmox_disk_create_cdrom.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_disk - fix unable to create cdrom due to size always being appended (https://github.com/ansible-collections/community.general/pull/6770).

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -505,7 +505,9 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
                 timeout_str = "Reached timeout while importing VM disk. Last line in task before timeout: %s"
                 ok_str = "Disk %s imported into VM %s"
             else:
-                config_str = "%s:%s" % (self.module.params["storage"], self.module.params["size"])
+                config_str = self.module.params["storage"]
+                if self.module.params.get("media") != "cdrom":
+                    config_str += ":%s" % (self.module.params["size"])
                 ok_str = "Disk %s created in VM %s"
                 timeout_str = "Reached timeout while creating VM disk. Last line in task before timeout: %s"
 


### PR DESCRIPTION
##### SUMMARY
proxmox_disk was always specifying the size when formatting the configuration string, which doesn't work when the `media` param is `cdrom`.

Fixes #6765.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_disk

##### ADDITIONAL INFORMATION
