### PR TITLE
Module `proxmox_kvm` `restarted` state bug fix

### DIFF
--- a/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
+++ b/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
@@ -1,2 +1,3 @@
 bugfixes:
-  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions. (https://github.com/ansible-collections/community.general/pull/6773)
+  - proxmox_kvm - ``restarted`` state did not actually restart a VM in some VM configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions (https://github.com/ansible-collections/community.general/pull/6773).
+

--- a/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
+++ b/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Promox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions.

--- a/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
+++ b/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions.
+  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions. (https://github.com/ansible-collections/community.general/pull/6773)

--- a/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
+++ b/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
@@ -1,3 +1,2 @@
 bugfixes:
   - proxmox_kvm - ``restarted`` state did not actually restart a VM in some VM configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions (https://github.com/ansible-collections/community.general/pull/6773).
-

--- a/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
+++ b/changelogs/fragments/6773-proxmox_kvm-restarted-state-bug-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Promox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions.
+  - proxmox_kvm - ``restarted`` state did not actually restart a vm in some vm configurations. The state now uses the Proxmox reboot endpoint instead of calling the ``stop_vm`` and ``start_vm`` functions.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1099,15 +1099,19 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             return False
         return True
 
-    def restart_vm(self, vm):
+    def restart_vm(self, vm, **status):
         vmid = vm['vmid']
-        proxmox_node = self.proxmox_api.nodes(vm['node'])
-        taskid = proxmox_node.qemu(vmid).status.reboot.post()
-        if not self.wait_for_task(vm['node'], taskid):
-            self.module.fail_json(msg='Reached timeout while waiting for rebooting VM. Last line in task before timeout: %s' %
-                                      proxmox_node.tasks(taskid).log.get()[:1])
+        try:
+            proxmox_node = self.proxmox_api.nodes(vm['node'])
+            taskid = proxmox_node.qemu(vmid).status.reboot.post()
+            if not self.wait_for_task(vm['node'], taskid):
+                self.module.fail_json(msg='Reached timeout while waiting for rebooting VM. Last line in task before timeout: %s' %
+                                          proxmox_node.tasks(taskid).log.get()[:1])
+                return False
+            return True
+        except Exception as e:
+            self.module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e))
             return False
-        return True
 
     def migrate_vm(self, vm, target_node):
         vmid = vm['vmid']
@@ -1468,16 +1472,13 @@ def main():
             module.fail_json(msg='VM with name = %s does not exist in cluster' % name)
 
         status = {}
-        try:
-            vm = proxmox.get_vm(vmid)
-            status['status'] = vm['status']
-            if vm['status'] == 'stopped':
-                module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid, **status)
+        vm = proxmox.get_vm(vmid)
+        status['status'] = vm['status']
+        if vm['status'] == 'stopped':
+            module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid, **status)
 
-            if proxmox.restart_vm(vm):
-                module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid, **status)
-        except Exception as e:
-            module.fail_json(vmid=vmid, msg="restarting of VM %s failed with exception: %s" % (vmid, e), **status)
+        if proxmox.restart_vm(vm):
+            module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid, **status)
 
     elif state == 'absent':
         status = {}


### PR DESCRIPTION
##### SUMMARY

Previously, the `restarted` state used both stop and start vm functions to restart a vm. In some cases, the start_vm function starts before the vm on Proxmox finishes shutting down. This causes the start_vm function to return saying that the vm is already running. The vm ends up in the `stopped` state and the output will wrongly display that the restart was successful. 
This change introduces the a new function that utilizes the Proxmox reboot endpoint instead for a more reliable method of restarting a vm.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_kvm

##### ADDITIONAL INFORMATION

To reproduce this bug, have a running vm on Proxmox with these parameters set for High Availability:
![Proxmox-HA-UI](https://github.com/ansible-collections/community.general/assets/65736594/cd05ca1a-8216-47f4-ae3f-c844f5565022)
Then run an Ansible playbook with the state set to `restarted`.
There may be other vm configurations in which the restart fails but this is the one I have found to fail often. 


This change does not produce a different output.
