### PR TITLE
rhsm_repository: refactor handling of subscription-manager

### DIFF
--- a/changelogs/fragments/6783-rhsm_repository-internal-refactor.yml
+++ b/changelogs/fragments/6783-rhsm_repository-internal-refactor.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - |
+    rhsm_repository - the interaction with ``subscription-manager`` was
+    refactored by grouping things together, removing unused bits, and hardening
+    the way it is run; no behaviour change is expected
+    (https://github.com/ansible-collections/community.general/pull/6783).

--- a/plugins/modules/rhsm_repository.py
+++ b/plugins/modules/rhsm_repository.py
@@ -97,86 +97,91 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 
 
-def run_subscription_manager(module, arguments):
-    # Execute subscription-manager with arguments and manage common errors
-    rhsm_bin = module.get_bin_path('subscription-manager')
-    if not rhsm_bin:
-        module.fail_json(msg='The executable file subscription-manager was not found in PATH')
+class Rhsm(object):
+    def __init__(self, module):
+        self.module = module
+        self.rhsm_bin = self.module.get_bin_path('subscription-manager', required=True)
+        self.rhsm_kwargs = {
+            'environ_update': dict(LANG='C', LC_ALL='C', LC_MESSAGES='C'),
+            'expand_user_and_vars': False,
+            'use_unsafe_shell': False,
+        }
 
-    lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
-    rc, out, err = module.run_command("%s %s" % (rhsm_bin, " ".join(arguments)), environ_update=lang_env)
+    def run_repos(self, arguments):
+        """
+        Execute `subscription-manager repos` with arguments and manage common errors
+        """
+        rc, out, err = self.module.run_command(
+            [self.rhsm_bin, 'repos'] + arguments,
+            **self.rhsm_kwargs
+        )
 
-    if rc == 0 and out == 'This system has no repositories available through subscriptions.\n':
-        module.fail_json(msg='This system has no repositories available through subscriptions')
-    elif rc == 1:
-        module.fail_json(msg='subscription-manager failed with the following error: %s' % err)
-    else:
-        return rc, out, err
+        if rc == 0 and out == 'This system has no repositories available through subscriptions.\n':
+            self.module.fail_json(msg='This system has no repositories available through subscriptions')
+        elif rc == 1:
+            self.module.fail_json(msg='subscription-manager failed with the following error: %s' % err)
+        else:
+            return rc, out, err
+
+    def list_repositories(self):
+        """
+        Generate RHSM repository list and return a list of dict
+        """
+        rc, out, err = self.run_repos(['--list'])
+
+        skip_lines = [
+            '+----------------------------------------------------------+',
+            '    Available Repositories in /etc/yum.repos.d/redhat.repo'
+        ]
+        repo_id_re = re.compile(r'Repo ID:\s+(.*)')
+        repo_name_re = re.compile(r'Repo Name:\s+(.*)')
+        repo_url_re = re.compile(r'Repo URL:\s+(.*)')
+        repo_enabled_re = re.compile(r'Enabled:\s+(.*)')
+
+        repo_id = ''
+        repo_name = ''
+        repo_url = ''
+        repo_enabled = ''
+
+        repo_result = []
+        for line in out.splitlines():
+            if line == '' or line in skip_lines:
+                continue
+
+            repo_id_match = repo_id_re.match(line)
+            if repo_id_match:
+                repo_id = repo_id_match.group(1)
+                continue
+
+            repo_name_match = repo_name_re.match(line)
+            if repo_name_match:
+                repo_name = repo_name_match.group(1)
+                continue
+
+            repo_url_match = repo_url_re.match(line)
+            if repo_url_match:
+                repo_url = repo_url_match.group(1)
+                continue
+
+            repo_enabled_match = repo_enabled_re.match(line)
+            if repo_enabled_match:
+                repo_enabled = repo_enabled_match.group(1)
+
+                repo = {
+                    "id": repo_id,
+                    "name": repo_name,
+                    "url": repo_url,
+                    "enabled": True if repo_enabled == '1' else False
+                }
+
+                repo_result.append(repo)
+
+        return repo_result
 
 
-def get_repository_list(module, list_parameter):
-    # Generate RHSM repository list and return a list of dict
-    if list_parameter == 'list_enabled':
-        rhsm_arguments = ['repos', '--list-enabled']
-    elif list_parameter == 'list_disabled':
-        rhsm_arguments = ['repos', '--list-disabled']
-    elif list_parameter == 'list':
-        rhsm_arguments = ['repos', '--list']
-    rc, out, err = run_subscription_manager(module, rhsm_arguments)
-
-    skip_lines = [
-        '+----------------------------------------------------------+',
-        '    Available Repositories in /etc/yum.repos.d/redhat.repo'
-    ]
-    repo_id_re = re.compile(r'Repo ID:\s+(.*)')
-    repo_name_re = re.compile(r'Repo Name:\s+(.*)')
-    repo_url_re = re.compile(r'Repo URL:\s+(.*)')
-    repo_enabled_re = re.compile(r'Enabled:\s+(.*)')
-
-    repo_id = ''
-    repo_name = ''
-    repo_url = ''
-    repo_enabled = ''
-
-    repo_result = []
-    for line in out.splitlines():
-        if line == '' or line in skip_lines:
-            continue
-
-        repo_id_match = repo_id_re.match(line)
-        if repo_id_match:
-            repo_id = repo_id_match.group(1)
-            continue
-
-        repo_name_match = repo_name_re.match(line)
-        if repo_name_match:
-            repo_name = repo_name_match.group(1)
-            continue
-
-        repo_url_match = repo_url_re.match(line)
-        if repo_url_match:
-            repo_url = repo_url_match.group(1)
-            continue
-
-        repo_enabled_match = repo_enabled_re.match(line)
-        if repo_enabled_match:
-            repo_enabled = repo_enabled_match.group(1)
-
-            repo = {
-                "id": repo_id,
-                "name": repo_name,
-                "url": repo_url,
-                "enabled": True if repo_enabled == '1' else False
-            }
-
-            repo_result.append(repo)
-
-    return repo_result
-
-
-def repository_modify(module, state, name, purge=False):
+def repository_modify(module, rhsm, state, name, purge=False):
     name = set(name)
-    current_repo_list = get_repository_list(module, 'list')
+    current_repo_list = rhsm.list_repositories()
     updated_repo_list = deepcopy(current_repo_list)
     matched_existing_repo = {}
     for repoid in name:
@@ -191,7 +196,7 @@ def repository_modify(module, state, name, purge=False):
     results = []
     diff_before = ""
     diff_after = ""
-    rhsm_arguments = ['repos']
+    rhsm_arguments = []
 
     for repoid in matched_existing_repo:
         if len(matched_existing_repo[repoid]) == 0:
@@ -236,7 +241,7 @@ def repository_modify(module, state, name, purge=False):
             'after_header': "RHSM repositories"}
 
     if not module.check_mode and changed:
-        rc, out, err = run_subscription_manager(module, rhsm_arguments)
+        rc, out, err = rhsm.run_repos(rhsm_arguments)
         results = out.splitlines()
     module.exit_json(results=results, changed=changed, repositories=updated_repo_list, diff=diff)
 
@@ -256,6 +261,8 @@ def main():
             msg="Interacting with subscription-manager requires root permissions ('become: true')"
         )
 
+    rhsm = Rhsm(module)
+
     name = module.params['name']
     state = module.params['state']
     purge = module.params['purge']
@@ -268,7 +275,7 @@ def main():
             collection_name='community.general',
         )
 
-    repository_modify(module, state, name, purge)
+    repository_modify(module, rhsm, state, name, purge)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY

Create a small helper class `Rhsm`, so all the logic related to the interaction with subscription-manager is grouped there:
- create the `Rhsm` object in `main()`, once the initial checks are done
- search `subscription-manager` as required (so there is no need to manually check it), and store its path for reuse
- store the common arguments for running `subscription-manager`
- move `run_subscription_manager()` to `Rhsm` as `run_repos()`
- get rid of the different list parameters: we list only all the repositories, so the other cases are not needed (and can be added easily, if needed)
- move `get_repository_list()` to `Rhsm` as `list_repositories()`

The execution of `subscription-manager` is improved as well:
- pass the arguments to `run_command()` directly as list, rather than joining the arguments to string, which `run_command()` will need to split again
- move the `repos` parameter directly in `run_repos()`
- explicitly disable the shell, already off by default
- disable the expansions of variables, as there are none

Adapt the unit test to the different way `run_command()` is called.

There should be no behaviour changes.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

rhsm_repository