### PR TITLE
Handle pkg_info(1) error message "Can't find"

### DIFF
--- a/changelogs/fragments/6785-openbsd_pkg_pkg_info_handling.yml
+++ b/changelogs/fragments/6785-openbsd_pkg_pkg_info_handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openbsd_pkg - the pkg_info(1) behavior has changed in OpenBSD >7.3. The error message ``Can't find`` should not lead to an error case (https://github.com/ansible-collections/community.general/pull/6785).

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -169,7 +169,7 @@ def get_package_state(names, pkg_spec, module):
         rc, stdout, stderr = execute_command(command, module)
 
         if stderr:
-            match = re.search(r"^Can't find inst:%s$" % name, stderr)
+            match = re.search(r"^Can't find inst:%s$" % re.escape(name), stderr)
             if match:
                 pkg_spec[name]['installed_state'] = False
             else:

--- a/plugins/modules/openbsd_pkg.py
+++ b/plugins/modules/openbsd_pkg.py
@@ -169,7 +169,11 @@ def get_package_state(names, pkg_spec, module):
         rc, stdout, stderr = execute_command(command, module)
 
         if stderr:
-            module.fail_json(msg="failed in get_package_state(): " + stderr)
+            match = re.search(r"^Can't find inst:%s$" % name, stderr)
+            if match:
+                pkg_spec[name]['installed_state'] = False
+            else:
+                module.fail_json(msg="failed in get_package_state(): " + stderr)
 
         if stdout:
             # If the requested package name is just a stem, like "python", we may


### PR DESCRIPTION
##### SUMMARY
**OpenBSD pkg_info(1) behavior change.**

As we can see pkg_info behaves different between OpenBSD -current (>7.3) and OpenBSD <= 7.3.
It prints "Can't find inst:PKGNAME" if the package is not present. This has to be handled in the module otherwise we see

```
failed: [dev] (item=ranger) => {"ansible_loop_var": "item", "changed": false, "item": "ranger", "msg": "failed in get_package_state(): Can't find inst:ranger\n"}
```
 
**Example pkg_info(1) call on OpenBSD 7.3 -stable**
```
$ dmesg | head
OpenBSD 7.3 (RAMDISK_CD) #1063: Sat Mar 25 10:41:49 MDT 2023
    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/RAMDISK_CD
$ pkg_info -Iq inst:abook
abook-0.6.1p3
triangle$ echo $?
0
$ pkg_info -Iq inst:NOTINSTALLED
$ echo $?
1
```
**Example pkg_info(1) call on OpenBSD -current**
```
$ dmesg | head
OpenBSD 7.3-current (GENERIC.MP) #1247: Sun Jun 18 09:42:58 MDT 2023
    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC.MP
$ pkg_info -Iq inst:abook
abook-0.6.1p3
$ echo $?
0
$ pkg_info -Iq inst:NOTINSTALLED
Can't find inst:NOTINSTALLED
$ echo $?
1
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
openbsd_pkg
