### PR TITLE
[datadog_downtime] - added 'type' to recurrence object when rrule param is present

### DIFF
--- a/changelogs/fragments/6811-datadog-downtime-rrule-type.yaml
+++ b/changelogs/fragments/6811-datadog-downtime-rrule-type.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - datadog_downtime - presence of ``rrule`` param lead to the Datadog API returning Bad Request due to a missing recurrence type. (https://github.com/ansible-collections/community.general/pull/6811).
+  - datadog_downtime - presence of ``rrule`` param lead to the Datadog API returning Bad Request due to a missing recurrence type (https://github.com/ansible-collections/community.general/pull/6811).

--- a/changelogs/fragments/6811-datadog-downtime-rrule-type.yaml
+++ b/changelogs/fragments/6811-datadog-downtime-rrule-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - datadog_downtime - presence of ``rrule`` param lead to the Datadog API returning Bad Request due to a missing recurrence type. (https://github.com/ansible-collections/community.general/pull/6811).

--- a/plugins/modules/datadog_downtime.py
+++ b/plugins/modules/datadog_downtime.py
@@ -249,7 +249,7 @@ def build_downtime(module):
     if module.params["rrule"]:
         downtime.recurrence = DowntimeRecurrence(
             rrule=module.params["rrule"],
-            type="rrule"
+            type="rrule",
         )
     return downtime
 

--- a/plugins/modules/datadog_downtime.py
+++ b/plugins/modules/datadog_downtime.py
@@ -248,7 +248,8 @@ def build_downtime(module):
         downtime.timezone = module.params["timezone"]
     if module.params["rrule"]:
         downtime.recurrence = DowntimeRecurrence(
-            rrule=module.params["rrule"]
+            rrule=module.params["rrule"],
+            type="rrule"
         )
     return downtime
 


### PR DESCRIPTION
##### SUMMARY

The `datadog_downtime` module includes the optional `rrule` parameter to provide the recurrence for a downtime in the [rrule-format](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html). The datadog api client that the module is based on [requires that the recurrence type is set as "rrule"](https://datadoghq.dev/datadog-api-client-python/datadog_api_client.v1.model.html#datadog_api_client.v1.model.downtime_recurrence.DowntimeRecurrence:~:text=The%20RRULE%20standard%20for%20defining%20recurring%20events%20(%20requires%20to%20set%20%E2%80%9Ctype%E2%80%9D%20to%20rrule%20)), which was not done in the module thus far. Whenever the `rrule` param was populated, the API would return a `Bad Request` with the response `{'errors': ['Invalid recurrence type']}`. 

This change simply fixes this by adding the type when the param is present. 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
datadog_downtime module
