### PR TITLE
proxmox_kvm: Add required timeout arg when force deleting

### DIFF
--- a/changelogs/fragments/6827-proxmox_kvm-force-delete-bug-fix.yaml
+++ b/changelogs/fragments/6827-proxmox_kvm-force-delete-bug-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - proxmox_kvm - ``absent`` state with ``force`` specified failed to stop the VM due to the ``timeout`` value not being passed to ``stop_vm``. (https://github.com/ansible-collections/community.general/pull/6827).
+  - proxmox_kvm - ``absent`` state with ``force`` specified failed to stop the VM due to the ``timeout`` value not being passed to ``stop_vm`` (https://github.com/ansible-collections/community.general/pull/6827).

--- a/changelogs/fragments/6827-proxmox_kvm-force-delete-bug-fix.yaml
+++ b/changelogs/fragments/6827-proxmox_kvm-force-delete-bug-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - ``absent`` state with ``force`` specified failed to stop the VM due to the ``timeout`` value not being passed to ``stop_vm``. (https://github.com/ansible-collections/community.general/pull/6827).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1494,7 +1494,7 @@ def main():
             status['status'] = vm['status']
             if vm['status'] == 'running':
                 if module.params['force']:
-                    proxmox.stop_vm(vm, True)
+                    proxmox.stop_vm(vm, True, timeout=module.params['timeout'])
                 else:
                     module.exit_json(changed=False, vmid=vmid, msg="VM %s is running. Stop it before deletion or use force=true." % vmid)
             taskid = proxmox_node.qemu.delete(vmid)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

When attempting to force delete a VM, the module fails with the following error:
`fatal: [localhost]: FAILED! => {"changed": false, "msg": "deletion of VM 102 failed with exception: ProxmoxKvmAnsible.stop_vm() missing 1 required positional argument: 'timeout'"}`

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This is caused by `proxmox_kvm` not passing the module's timeout argument to the `stop_vm()` method. This PR adds the passing of said timeout value.

Example task:

```yaml
- name: Force delete VM
  community.general.proxmox_kvm:
    name: "{{ vm_name }}"
    state: absent
    force: true
    timeout: 60
```
