### PR TITLE
proxmox_kvm: Current verbosity

### DIFF
--- a/changelogs/fragments/6828-proxmox_kvm-state-current-verbosity.yaml
+++ b/changelogs/fragments/6828-proxmox_kvm-state-current-verbosity.yaml
@@ -1,3 +1,5 @@
 minor_changes:
-  - proxmox_kvm - ``current`` state now includes the full resource object under the `data` key. (https://github.com/ansible-collections/community.general/pull/6828).
-  - proxmox_kvm - Removed redundant API call when fetching ``current`` state. This call provided the VM power state. (https://github.com/ansible-collections/community.general/pull/6828).
+  - proxmox_kvm - ``current`` state now includes the full resource object under the ``data`` key (https://github.com/ansible-collections/community.general/pull/6828).
+
+  - proxmox_kvm - removed redundant API call when fetching ``current`` state. This call provided the VM power state (https://github.com/ansible-collections/community.general/pull/6828).
+

--- a/changelogs/fragments/6828-proxmox_kvm-state-current-verbosity.yaml
+++ b/changelogs/fragments/6828-proxmox_kvm-state-current-verbosity.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - proxmox_kvm - ``current`` state now includes the full resource object under the `data` key. (https://github.com/ansible-collections/community.general/pull/6828).
+  - proxmox_kvm - Removed redundant API call when fetching ``current`` state. This call provided the VM power state. (https://github.com/ansible-collections/community.general/pull/6828).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1516,7 +1516,7 @@ def main():
         current = proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).status.current.get()['status']
         status['status'] = current
         if status:
-            module.exit_json(changed=False, vmid=vmid, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
+            module.exit_json(changed=False, vmid=vmid, data=vm, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1513,7 +1513,7 @@ def main():
         vm = proxmox.get_vm(vmid)
         if not name:
             name = vm.get('name', '(unnamed)')
-        current = proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).status.current.get()['status']
+        current = vm.get('status')
         status['status'] = current
         if status:
             module.exit_json(changed=False, vmid=vmid, data=vm, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Adds exposing the full VM resource object when `state: current`

Provides a workaround for #1987

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

When getting the current state of a VM, only a few fields are exposed by the module, while Proxmox provides many fields that are particularly useful. For example, the node name and resource allocation values. This PR fully exposes the VM resource object provided by `/api2/json/cluster/resources` under the `data` key. This was done to avoid breaking any existing playbooks while extending existing functionality. The name `data` was used as this is the name of the key that Proxmox exposes this exact object under.

I also noticed this particular process had a redundant API call, which was used to fetch the named status of the VM (running/stopped/etc). This value is identically exposed through existing data, so it was removed. 

I used the following tasks to test this change, against a PVE 8.0.3 cluster: 

```yaml
- name: Get VM state
  community.general.proxmox_kvm:
    name: "drewburrs-vm"
    state: current
  register: vm_state

- ansible.builtin.debug:
    var: vm_state
```

Before this change:

```
TASK [ansible.builtin.debug]
ok: [localhost] => {
    "vm_state": {
        "changed": false,
        "failed": false,
        "msg": "VM drewburrs-vm with vmid = 104 is stopped",
        "status": "stopped",
        "vmid": 104
    }
}
```

After this change: 

```
TASK [ansible.builtin.debug]
ok: [localhost] => {
    "vm_state": {
        "changed": false,
        "data": {
            "cpu": 0,
            "disk": 0,
            "diskread": 0,
            "diskwrite": 0,
            "id": "qemu/104",
            "maxcpu": 4,
            "maxdisk": 0,
            "maxmem": 6442450944,
            "mem": 0,
            "name": "drewburrs-vm",
            "netin": 0,
            "netout": 0,
            "node": "pve04",
            "status": "stopped",
            "template": 0,
            "type": "qemu",
            "uptime": 0,
            "vmid": 104
        },
        "failed": false,
        "msg": "VM drewburrs-vm with vmid = 104 is stopped",
        "status": "stopped",
        "vmid": 104
    }
}
```

