### PR TITLE
proxmox: deprecate old compatibility feature flag

### DIFF
--- a/changelogs/fragments/6836-proxmox-deprecate-compatibility.yml
+++ b/changelogs/fragments/6836-proxmox-deprecate-compatibility.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - proxmox - old feature flag ``proxmox_default_behavior`` will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6836).

--- a/changelogs/fragments/6836-proxmox-deprecate-compatibility.yml
+++ b/changelogs/fragments/6836-proxmox-deprecate-compatibility.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - proxmox - old feature flag ``proxmox_default_behavior`` will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6836).
+  - proxmox - old feature flag ``proxmox_default_behavior`` will be removed in community.general 10.0.0 (https://github.com/ansible-collections/community.general/pull/6836).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -183,6 +183,10 @@ options:
         are used when the values are not explicitly specified by the user. The new default is V(no_defaults),
         which makes sure these options have no defaults.
       - This affects the O(disk), O(cores), O(cpus), O(memory), O(onboot), O(swap), and O(cpuunits) options.
+      - >
+        This parameter is now B(deprecated) and it will be removed in community.general 9.0.0.
+        By then, the module's behavior should be to not set default values, equivalent to V(no_defaults).
+        If a consistent set of defaults is needed, the playbook or role should be responsible for setting it.
     type: str
     default: no_defaults
     choices:
@@ -621,7 +625,8 @@ def main():
         description=dict(type='str'),
         hookscript=dict(type='str'),
         timezone=dict(type='str'),
-        proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults']),
+        proxmox_default_behavior=dict(type='str', default='no_defaults', choices=['compatibility', 'no_defaults'],
+                                      removed_in_version='9.0.0', removed_from_collection='community.general'),
         clone=dict(type='int'),
         clone_type=dict(default='opportunistic', choices=['full', 'linked', 'opportunistic']),
         tags=dict(type='list', elements='str')

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -184,7 +184,7 @@ options:
         which makes sure these options have no defaults.
       - This affects the O(disk), O(cores), O(cpus), O(memory), O(onboot), O(swap), and O(cpuunits) options.
       - >
-        This parameter is now B(deprecated) and it will be removed in community.general 9.0.0.
+        This parameter is now B(deprecated) and it will be removed in community.general 10.0.0.
         By then, the module's behavior should be to not set default values, equivalent to V(no_defaults).
         If a consistent set of defaults is needed, the playbook or role should be responsible for setting it.
     type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deprecate parameter `proxmox_default_behavior` added in version 1.3.0.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/proxmox.py
