### PR TITLE
rhsm_repository: refactor parsing of "subscription-manager repos" output

### DIFF
--- a/changelogs/fragments/6783-6837-rhsm_repository-internal-refactor.yml
+++ b/changelogs/fragments/6783-6837-rhsm_repository-internal-refactor.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - |
+    rhsm_repository - the interaction with ``subscription-manager`` was
+    refactored by grouping things together, removing unused bits, and hardening
+    the way it is run; also, the parsing of ``subscription-manager repos --list``
+    was improved and made slightly faster; no behaviour change is expected
+    (https://github.com/ansible-collections/community.general/pull/6783,
+    https://github.com/ansible-collections/community.general/pull/6837).

--- a/changelogs/fragments/6783-rhsm_repository-internal-refactor.yml
+++ b/changelogs/fragments/6783-rhsm_repository-internal-refactor.yml
@@ -1,6 +1,0 @@
-minor_changes:
-  - |
-    rhsm_repository - the interaction with ``subscription-manager`` was
-    refactored by grouping things together, removing unused bits, and hardening
-    the way it is run; no behaviour change is expected
-    (https://github.com/ansible-collections/community.general/pull/6783).


### PR DESCRIPTION
##### SUMMARY

Simplify a bit (and possibly speed it up a little) the parsing of the output of `subscription-manager repos --list`:
- simplify skipping the lines that are not interesting: check the first character only, as it is enough to determine whether it contains repository data or not
- check the start of each line manually, rather than with regexp: a simple slice + `lstrip()` gives the same result

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

rhsm_repository