### PR TITLE
proxmox: default value when checking for dict key

### DIFF
--- a/changelogs/fragments/6838-proxmox-dict-template.yml
+++ b/changelogs/fragments/6838-proxmox-dict-template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox - fix error when a configuration had no ``template`` field (https://github.com/ansible-collections/community.general/pull/6838, https://github.com/ansible-collections/community.general/issues/5372).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -444,7 +444,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         """Check if the specified container is a template."""
         proxmox_node = self.proxmox_api.nodes(node)
         config = getattr(proxmox_node, VZ_TYPE)(vmid).config.get()
-        return config['template']
+        return config.get('template', False)
 
     def create_instance(self, vmid, node, disk, storage, cpus, memory, swap, timeout, clone, **kwargs):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use `dict.get()` to return default value if `template` does not exist.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #5372

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox