### PR TITLE
proxmox module utils: better error msg when token fails with old proxmoxer

### DIFF
--- a/changelogs/fragments/6839-promoxer-tokens.yml
+++ b/changelogs/fragments/6839-promoxer-tokens.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox module utils - add logic to detect whether an old Promoxer complains about the ``token_name`` and ``token_value`` parameters and provide a better error message when that happens (https://github.com/ansible-collections/community.general/pull/6839, https://github.com/ansible-collections/community.general/issues/5371).

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -29,11 +29,13 @@ options:
   api_token_id:
     description:
       - Specify the token ID.
+      - Requires C(proxmoxer>=1.1.0) to work.
     type: str
     version_added: 1.3.0
   api_token_secret:
     description:
       - Specify the token secret.
+      - Requires C(proxmoxer>=1.1.0) to work.
     type: str
     version_added: 1.3.0
   validate_certs:

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -100,17 +100,13 @@ class ProxmoxAnsible(object):
         if api_password:
             auth_args['password'] = api_password
         else:
+            if self.version() < LooseVersion('1.1.0'):
+                self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
             auth_args['token_name'] = api_token_id
             auth_args['token_value'] = api_token_secret
 
         try:
             return ProxmoxAPI(api_host, verify_ssl=validate_certs, **auth_args)
-        except TypeError as e:
-            msg = str(e)
-            if 'token_name' in msg or 'token_value' in msg:
-                self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
-            else:
-                self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
         except Exception as e:
             self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
 

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -105,6 +105,12 @@ class ProxmoxAnsible(object):
 
         try:
             return ProxmoxAPI(api_host, verify_ssl=validate_certs, **auth_args)
+        except TypeError as e:
+            msg = str(e)
+            if 'token_name' in msg or 'token_value' in msg:
+                self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
+            else:
+                self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
         except Exception as e:
             self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add logic to detect whether an old Promoxer complains about the `token_name` and `token_value` parameters and provide a better error message when that happens.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #5371

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/proxmox.py