### PR TITLE
htpasswd: deprecate crypt_scheme

### DIFF
--- a/changelogs/fragments/6841-htpasswd-crypt-scheme.yml
+++ b/changelogs/fragments/6841-htpasswd-crypt-scheme.yml
@@ -1,4 +1,2 @@
 minor_changes:
   - htpasswd - the parameter ``crypt_scheme`` is being renamed as ``hash_scheme`` and added as an alias to it (https://github.com/ansible-collections/community.general/pull/6841).
-deprecated_features:
-  - htpasswd - the alias ``crypt_scheme`` is being deprecated and it shoudl  be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6841).

--- a/changelogs/fragments/6841-htpasswd-crypt-scheme.yml
+++ b/changelogs/fragments/6841-htpasswd-crypt-scheme.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - htpasswd - the parameter ``crypt_scheme`` is being renamed as ``hash_scheme`` and added as an alias to it (https://github.com/ansible-collections/community.general/pull/6841).
+deprecated_features:
+  - htpasswd - the alias ``crypt_scheme`` is being deprecated and it shoudl  be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6841).

--- a/plugins/modules/htpasswd.py
+++ b/plugins/modules/htpasswd.py
@@ -39,12 +39,12 @@ options:
     description:
       - Password associated with user.
       - Must be specified if user does not exist yet.
-  crypt_scheme:
+  hash_scheme:
     type: str
     required: false
     default: "apr_md5_crypt"
     description:
-      - Encryption scheme to be used. As well as the four choices listed
+      - Hashing scheme to be used. As well as the four choices listed
         here, you can also use any other hash supported by passlib, such as
         V(portable_apache22) and V(host_apache24); or V(md5_crypt) and V(sha256_crypt),
         which are Linux passwd hashes. Only some schemes in addition to
@@ -52,6 +52,7 @@ options:
         supported schemes depend on passlib version and its dependencies.
       - See U(https://passlib.readthedocs.io/en/stable/lib/passlib.apache.html#passlib.apache.HtpasswdFile) parameter C(default_scheme).
       - 'Some of the available choices might be: V(apr_md5_crypt), V(des_crypt), V(ldap_sha1), V(plaintext).'
+    aliases: [crypt_scheme]
   state:
     type: str
     required: false
@@ -215,7 +216,7 @@ def main():
         path=dict(type='path', required=True, aliases=["dest", "destfile"]),
         name=dict(type='str', required=True, aliases=["username"]),
         password=dict(type='str', required=False, default=None, no_log=True),
-        crypt_scheme=dict(type='str', required=False, default="apr_md5_crypt"),
+        hash_scheme=dict(type='str', required=False, default="apr_md5_crypt", aliases=["crypt_scheme"]),
         state=dict(type='str', required=False, default="present", choices=["present", "absent"]),
         create=dict(type='bool', default=True),
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Technical nit-picking. What `htpasswd` does with the `.htpasswd` fiels used by Apache httpd is _hashing_, not _encrypting_. This PR renames the parameter `crypt_scheme` to `hash_scheme`, and add `crypt_scheme` as a deprecated alias of that option. It also updates the docs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
htpasswd
