### PR TITLE
feature(yum_versionlock): add support to pin specific package versions

### DIFF
--- a/changelogs/fragments/6861-yum_versionlock_minor_change_add-pinning-specific-versions.yml
+++ b/changelogs/fragments/6861-yum_versionlock_minor_change_add-pinning-specific-versions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - yum_versionlock - add support to pin specific package versions instead of only the package itself (https://github.com/ansible-collections/community.general/pull/6861, https://github.com/ansible-collections/community.general/issues/4470).

--- a/plugins/modules/yum_versionlock.py
+++ b/plugins/modules/yum_versionlock.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018, Florian Paul Azim Hoberg <florian.hoberg@credativ.de>
+# Copyright (c) 2018, Florian Paul Azim Hoberg (@gyptazy) <gyptazy@gyptazy.ch>
 #
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -25,7 +25,8 @@ attributes:
 options:
   name:
     description:
-      - Package name or a list of package names with optional wildcards.
+      - Package name or a list of package names with optional version or wildcards.
+      - Specifying versions is supported since community.general 7.2.0.
     type: list
     required: true
     elements: str
@@ -50,7 +51,14 @@ EXAMPLES = r'''
 - name: Prevent Apache / httpd from being updated
   community.general.yum_versionlock:
     state: present
-    name: httpd
+    name:
+    - httpd
+
+- name: Prevent Apache / httpd version 2.4.57-2 from being updated
+  community.general.yum_versionlock:
+    state: present
+    name:
+    - httpd-0:2.4.57-2.el9
 
 - name: Prevent multiple packages from being updated
   community.general.yum_versionlock:
@@ -111,22 +119,30 @@ class YumVersionLock:
     def ensure_state(self, packages, command):
         """ Ensure packages state """
         rc, out, err = self.module.run_command([self.yum_bin, "-q", "versionlock", command] + packages)
+        # If no package can be found this will be written on stdout with rc 0
+        if 'No package found for' in out:
+            self.module.fail_json(msg=out)
         if rc == 0:
             return True
         self.module.fail_json(msg="Error: " + to_native(err) + to_native(out))
 
 
 def match(entry, name):
+    match = False
     m = NEVRA_RE_YUM.match(entry)
     if not m:
         m = NEVRA_RE_DNF.match(entry)
     if not m:
         return False
-    return fnmatch(m.group("name"), name)
+    if fnmatch(m.group("name"), name):
+        match = True
+    if entry.rstrip('.*') == name:
+        match = True
+    return match
 
 
 def main():
-    """ start main program to add/remove a package to yum versionlock"""
+    """ start main program to add/delete a package to yum versionlock """
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
feature(yum_versionlock): add support to pin specific package versions

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adjusted `yum_versionlock` (as requested in #4470) to handle version suffixes in a correct way to avoid wrong change results. This will validate and handle the following cases:
  - package name like:             httpd
  - package name and version like: httpd-0:2.4.57-3.el9

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #4470
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
yum_versionlock

##### ADDITIONAL INFORMATION
@tedgin & @matt-horwood-mayden as you requested this change, please feel free to test.



<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
[gyptazy@localhost ansible]# ansible-playbook playbooks/yum_versionlock.yml 

PLAY [yum versionlock] ***************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [lock iCommands to version 4.2.8] ***********************************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

After:
```
[gyptazy@localhost ansible]# ansible-playbook playbooks/yum_versionlock.yml 

PLAY [yum versionlock] ***************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [lock iCommands to version 4.2.8] ***********************************************************************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```