### PR TITLE
[WIP] proxmox module utils: pass timeout parameter to ProxmoxAPI

### DIFF
--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -96,17 +96,22 @@ class ProxmoxAnsible(object):
         api_token_secret = self.module.params['api_token_secret']
         validate_certs = self.module.params['validate_certs']
 
-        auth_args = {'user': api_user}
+        args = {'user': api_user}
         if api_password:
-            auth_args['password'] = api_password
+            args['password'] = api_password
         else:
             if self.version() < LooseVersion('1.1.0'):
                 self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
-            auth_args['token_name'] = api_token_id
-            auth_args['token_value'] = api_token_secret
+            args['token_name'] = api_token_id
+            args['token_value'] = api_token_secret
 
         try:
-            return ProxmoxAPI(api_host, verify_ssl=validate_certs, **auth_args)
+            args['timeout'] = self.module.params['timeout']
+        except KeyError:
+            pass
+
+        try:
+            return ProxmoxAPI(api_host, verify_ssl=validate_certs, **args)
         except Exception as e:
             self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For the `proxmox*` modules that have a `timeout` parameter, pass its value to the underlying `ProxmoxAPI` object.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6843 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/proxmox.py
