### PR TITLE
Fix key error for reverse zone (#6905)

### DIFF
--- a/changelogs/fragments/6905-ipa_dnszone-key-error-fix.yml
+++ b/changelogs/fragments/6905-ipa_dnszone-key-error-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_dnszone module - fix 'idnsallowsyncptr' key error for reverse zone (https://github.com/ansible-collections/community.general/pull/6906, https://github.com/ansible-collections/community.general/issues/6905).
+  - ipa_dnszone - fix 'idnsallowsyncptr' key error for reverse zone (https://github.com/ansible-collections/community.general/pull/6906, https://github.com/ansible-collections/community.general/issues/6905).

--- a/changelogs/fragments/6905-ipa_dnszone-key-error-fix.yml
+++ b/changelogs/fragments/6905-ipa_dnszone-key-error-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_dnszone module - fix 'idnsallowsyncptr' key error for reverse zone (https://github.com/ansible-collections/community.general/pull/6906, https://github.com/ansible-collections/community.general/issues/6905).

--- a/plugins/modules/ipa_dnszone.py
+++ b/plugins/modules/ipa_dnszone.py
@@ -152,7 +152,8 @@ def ensure(module, client):
             changed = True
             if not module.check_mode:
                 client.dnszone_add(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})
-        elif ipa_dnszone['idnsallowdynupdate'][0] != str(dynamicupdate).upper() or ipa_dnszone['idnsallowsyncptr'][0] != str(allowsyncptr).upper():
+        elif ipa_dnszone['idnsallowdynupdate'][0] != str(dynamicupdate).upper() or \
+                ipa_dnszone.get('idnsallowsyncptr') and ipa_dnszone['idnsallowsyncptr'][0] != str(allowsyncptr).upper():
             changed = True
             if not module.check_mode:
                 client.dnszone_mod(zone_name=zone_name, details={'idnsallowdynupdate': dynamicupdate, 'idnsallowsyncptr': allowsyncptr})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Checking if 'idnsallowsyncptr' key exists in Freeipa response, before using this key 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #6905 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

bugfixes:
  - ipa_dnszone - fix 'idnsallowsyncptr' key error for reverse zone (https://github.com/ansible-collections/community.general/issues/6905).

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ipa_dnszone
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```