### PR TITLE
webfaction modules: deprecation

### DIFF
--- a/changelogs/fragments/6909-deprecate-webfaction.yml
+++ b/changelogs/fragments/6909-deprecate-webfaction.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+  - webfaction_app - module relies entirely on no longer existent API endpoints, and it will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6909).
+  - webfaction_db - module relies entirely on no longer existent API endpoints, and it will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6909).
+  - webfaction_domain - module relies entirely on no longer existent API endpoints, and it will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6909).
+  - webfaction_mailbox - module relies entirely on no longer existent API endpoints, and it will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6909).
+  - webfaction_site - module relies entirely on no longer existent API endpoints, and it will be removed in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/6909).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4433,6 +4433,10 @@ plugin_routing:
         warning_text: You are using an internal name to access the community.general.wdc_redfish_info
           modules. This has never been supported or documented, and will stop working
           in community.general 9.0.0.
+    webfaction_app:
+      deprecation:
+        removal_version: 9.0.0
+        warning_text: This module relies on HTTPS APIs that do not exist anymore and there is no clear path to update.
     cloud.webfaction.webfaction_app:
       redirect: community.general.webfaction_app
       deprecation:
@@ -4440,6 +4444,10 @@ plugin_routing:
         warning_text: You are using an internal name to access the community.general.webfaction_app
           modules. This has never been supported or documented, and will stop working
           in community.general 9.0.0.
+    webfaction_db:
+      deprecation:
+        removal_version: 9.0.0
+        warning_text: This module relies on HTTPS APIs that do not exist anymore and there is no clear path to update.
     cloud.webfaction.webfaction_db:
       redirect: community.general.webfaction_db
       deprecation:
@@ -4447,6 +4455,10 @@ plugin_routing:
         warning_text: You are using an internal name to access the community.general.webfaction_db
           modules. This has never been supported or documented, and will stop working
           in community.general 9.0.0.
+    webfaction_domain:
+      deprecation:
+        removal_version: 9.0.0
+        warning_text: This module relies on HTTPS APIs that do not exist anymore and there is no clear path to update.
     cloud.webfaction.webfaction_domain:
       redirect: community.general.webfaction_domain
       deprecation:
@@ -4454,6 +4466,10 @@ plugin_routing:
         warning_text: You are using an internal name to access the community.general.webfaction_domain
           modules. This has never been supported or documented, and will stop working
           in community.general 9.0.0.
+    webfaction_mailbox:
+      deprecation:
+        removal_version: 9.0.0
+        warning_text: This module relies on HTTPS APIs that do not exist anymore and there is no clear path to update.
     cloud.webfaction.webfaction_mailbox:
       redirect: community.general.webfaction_mailbox
       deprecation:
@@ -4461,6 +4477,10 @@ plugin_routing:
         warning_text: You are using an internal name to access the community.general.webfaction_mailbox
           modules. This has never been supported or documented, and will stop working
           in community.general 9.0.0.
+    webfaction_site:
+      deprecation:
+        removal_version: 9.0.0
+        warning_text: This module relies on HTTPS APIs that do not exist anymore and there is no clear path to update.
     cloud.webfaction.webfaction_site:
       redirect: community.general.webfaction_site
       deprecation:

--- a/plugins/modules/webfaction_app.py
+++ b/plugins/modules/webfaction_app.py
@@ -19,6 +19,12 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
+
+deprecated:
+  removed_in: 9.0.0
+  why: the endpoints this module relies on do not exist any more and do not resolve to IPs in DNS.
+  alternative: no known alternative at this point
+
 module: webfaction_app
 short_description: Add or remove applications on a Webfaction host
 description:

--- a/plugins/modules/webfaction_db.py
+++ b/plugins/modules/webfaction_db.py
@@ -16,6 +16,12 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
+
+deprecated:
+  removed_in: 9.0.0
+  why: the endpoints this module relies on do not exist any more and do not resolve to IPs in DNS.
+  alternative: no known alternative at this point
+
 module: webfaction_db
 short_description: Add or remove a database on Webfaction
 description:

--- a/plugins/modules/webfaction_domain.py
+++ b/plugins/modules/webfaction_domain.py
@@ -13,6 +13,12 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
+
+deprecated:
+  removed_in: 9.0.0
+  why: the endpoints this module relies on do not exist any more and do not resolve to IPs in DNS.
+  alternative: no known alternative at this point
+
 module: webfaction_domain
 short_description: Add or remove domains and subdomains on Webfaction
 description:

--- a/plugins/modules/webfaction_mailbox.py
+++ b/plugins/modules/webfaction_mailbox.py
@@ -13,6 +13,12 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
+
+deprecated:
+  removed_in: 9.0.0
+  why: the endpoints this module relies on do not exist any more and do not resolve to IPs in DNS.
+  alternative: no known alternative at this point
+
 module: webfaction_mailbox
 short_description: Add or remove mailboxes on Webfaction
 description:

--- a/plugins/modules/webfaction_site.py
+++ b/plugins/modules/webfaction_site.py
@@ -13,6 +13,12 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
+
+deprecated:
+  removed_in: 9.0.0
+  why: the endpoints this module relies on do not exist any more and do not resolve to IPs in DNS.
+  alternative: no known alternative at this point
+
 module: webfaction_site
 short_description: Add or remove a website on a Webfaction host
 description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The URLs used by the webfaction modules do not resolve DNS anymore. It seems that webfaction.com has been swallowed by  tsohost.com in 2020, but there is no clear indication of any API compatibility.

Ref: https://www.sebomarketing.com/webfaction-migrates-to-tsohost/

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/webfaction_app.py
plugins/modules/webfaction_db.py
plugins/modules/webfaction_domain.py
plugins/modules/webfaction_mailbox.py
plugins/modules/webfaction_site.py
