### PR TITLE
proxmox_kvm: enable 'force' restart of vm (as documented)

### DIFF
--- a/changelogs/fragments/6914-proxmox_kvm-enable-force-restart.yml
+++ b/changelogs/fragments/6914-proxmox_kvm-enable-force-restart.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - enabled force restart of VM, bringing the 'force' parameter functionality in line with what is described in the docs (https://github.com/ansible-collections/community.general/pull/6914).

--- a/changelogs/fragments/6914-proxmox_kvm-enable-force-restart.yml
+++ b/changelogs/fragments/6914-proxmox_kvm-enable-force-restart.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - enabled force restart of VM, bringing the 'force' parameter functionality in line with what is described in the docs (https://github.com/ansible-collections/community.general/pull/6914).
+  - proxmox_kvm - enabled force restart of VM, bringing the ``force`` parameter functionality in line with what is described in the docs (https://github.com/ansible-collections/community.general/pull/6914).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1110,11 +1110,11 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             return False
         return True
 
-    def restart_vm(self, vm, **status):
+    def restart_vm(self, vm, force, **status):
         vmid = vm['vmid']
         try:
             proxmox_node = self.proxmox_api.nodes(vm['node'])
-            taskid = proxmox_node.qemu(vmid).status.reboot.post()
+            taskid = proxmox_node.qemu(vmid).status.reset.post() if force else proxmox_node.qemu(vmid).status.reboot.post()
             if not self.wait_for_task(vm['node'], taskid):
                 self.module.fail_json(msg='Reached timeout while waiting for rebooting VM. Last line in task before timeout: %s' %
                                           proxmox_node.tasks(taskid).log.get()[:1])
@@ -1488,7 +1488,7 @@ def main():
         if vm['status'] == 'stopped':
             module.exit_json(changed=False, vmid=vmid, msg="VM %s is not running" % vmid, **status)
 
-        if proxmox.restart_vm(vm):
+        if proxmox.restart_vm(vm, force=module.params['force']):
             module.exit_json(changed=True, vmid=vmid, msg="VM %s is restarted" % vmid, **status)
 
     elif state == 'absent':


### PR DESCRIPTION
##### SUMMARY
The documentation states the follow for the the `force` parameter:

> Can be used with states stopped, restarted, and absent.

Despite that, `force` is not actually used when `state=restarted`, this PR aims to fix that by executing a VM "reset" when force is `True`, and a "restart" otherwise.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
N/A
