### PR TITLE
CI: remove no longer needed ignore

### DIFF
--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,3 @@
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/modules/consul.py validate-modules:doc-missing-type
 plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
Nightly CI fails because ansible-core devel's ansible-test no longer requires a `replace-urlopen` ignore for `.azure-pipelines/scripts/publish-codecov.py`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity test ignores
