### PR TITLE
CI: Stop restricting idna

### DIFF
--- a/tests/utils/constraints.txt
+++ b/tests/utils/constraints.txt
@@ -19,7 +19,7 @@ wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 
 yamllint != 1.8.0, < 1.14.0 ; python_version < '2.7' # yamllint 1.8.0 and 1.14.0+ require python 2.7+
 pycrypto >= 2.6 # Need features found in 2.6 and greater
 ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
-idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
+# idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 python-nomad < 2.0.0 ; python_version <= '3.7'  # python-nomad 2.0.0 needs Python 3.7+
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6


### PR DESCRIPTION
##### SUMMARY
This breaks CI for latest dnspython. (https://dev.azure.com/ansible/community.general/_build/results?buildId=83843&view=logs&j=89290267-74d5-5b3e-330d-ba0f2945add4&t=0ecc9edb-08fd-5c6e-50b9-4c9e0e2c0b70&l=6613)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
constraints file
