### PR TITLE
cmd_runner module utils: fix bug when argument spec has implicit type

### DIFF
--- a/changelogs/fragments/6968-cmdrunner-implicit-type.yml
+++ b/changelogs/fragments/6968-cmdrunner-implicit-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cmd_runner module utils - when a parameter in ``argument_spec`` has no type, meaning it is implicitly a ``str``, ``CmdRunner`` would fail trying to find the ``type`` key in that dictionary (https://github.com/ansible-collections/community.general/pull/6968).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -208,7 +208,7 @@ class CmdRunner(object):
 
         for mod_param_name, spec in iteritems(module.argument_spec):
             if mod_param_name not in self.arg_formats:
-                self.arg_formats[mod_param_name] = _Format.as_default_type(spec['type'], mod_param_name)
+                self.arg_formats[mod_param_name] = _Format.as_default_type(spec.get('type', 'str'), mod_param_name)
 
     def __call__(self, args_order=None, output_process=None, ignore_value_none=True, check_mode_skip=False, check_mode_return=None, **kwargs):
         if output_process is None:

--- a/tests/integration/targets/cmd_runner/library/cmd_echo.py
+++ b/tests/integration/targets/cmd_runner/library/cmd_echo.py
@@ -26,6 +26,7 @@ def main():
             arg_values=dict(type="dict", default={}),
             check_mode_skip=dict(type="bool", default=False),
             aa=dict(type="raw"),
+            tt=dict(),
         ),
         supports_check_mode=True,
     )

--- a/tests/integration/targets/cmd_runner/vars/main.yml
+++ b/tests/integration/targets/cmd_runner/vars/main.yml
@@ -121,3 +121,20 @@ cmd_echo_tests:
       - test_result.rc == None
       - test_result.out == None
       - test_result.err == None
+
+  - name: set aa and tt value
+    arg_formats:
+      aa:
+        func: as_opt_eq_val
+        args: [--answer]
+      tt:
+        func: as_opt_val
+        args: [--tt-arg]
+    arg_order: 'aa tt'
+    arg_values:
+      tt: potatoes
+    aa: 11
+    assertions:
+      - test_result.rc == 0
+      - test_result.out == "-- --answer=11 --tt-arg potatoes\n"
+      - test_result.err == ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a parameter in `argument_spec` has no type, meaning it is implicitly a `str`, `CmdRunner` would fail trying to find the `type` key in that dictionary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/cmd_runner.py
