### PR TITLE
[proxmox] Use proxmoxer_version instead of server API version

### DIFF
--- a/changelogs/fragments/6980-proxmox-fix-token-auth.yml
+++ b/changelogs/fragments/6980-proxmox-fix-token-auth.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox module utils - fix proxmoxer library version check (https://github.com/ansible-collections/community.general/issues/6974, https://github.com/ansible-collections/community.general/issues/6975, https://github.com/ansible-collections/community.general/pull/6980).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -72,8 +72,8 @@ class ProxmoxAnsible(object):
             module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
         self.module = module
-        self.proxmox_api = self._connect()
         self.proxmoxer_version = proxmoxer_version
+        self.proxmox_api = self._connect()
         # Test token validity
         try:
             self.proxmox_api.version.get()
@@ -92,7 +92,7 @@ class ProxmoxAnsible(object):
         if api_password:
             auth_args['password'] = api_password
         else:
-            if self.version() < LooseVersion('1.1.0'):
+            if self.proxmoxer_version < LooseVersion('1.1.0'):
                 self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
             auth_args['token_name'] = api_token_id
             auth_args['token_value'] = api_token_secret


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Fixes authorization via tokens. Check for the version is done against `proxmoxer`, not the API itself.
Fixes https://github.com/ansible-collections/community.general/issues/6975, https://github.com/ansible-collections/community.general/issues/6974.

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

module_utils/proxmox

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
