### PR TITLE
Rundeck - fix TypeError on 404 api response

### DIFF
--- a/changelogs/fragments/6983-rundeck-fix-typerrror-on-404-api-response.yml
+++ b/changelogs/fragments/6983-rundeck-fix-typerrror-on-404-api-response.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - rundeck - fix TypeError on 404 api response.
+  - rundeck - fix ``TypeError`` on 404 API response (https://github.com/ansible-collections/community.general/pull/6983).

--- a/changelogs/fragments/6983-rundeck-fix-typerrror-on-404-api-response.yml
+++ b/changelogs/fragments/6983-rundeck-fix-typerrror-on-404-api-response.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rundeck - fix TypeError on 404 api response.

--- a/plugins/module_utils/rundeck.py
+++ b/plugins/module_utils/rundeck.py
@@ -72,7 +72,9 @@ def api_request(module, endpoint, data=None, method="GET"):
     if info["status"] == 403:
         module.fail_json(msg="Token authorization failed",
                          execution_info=json.loads(info["body"]))
-    if info["status"] == 409:
+    elif info["status"] == 404:
+        return None, info
+    elif info["status"] == 409:
         module.fail_json(msg="Job executions limit reached",
                          execution_info=json.loads(info["body"]))
     elif info["status"] >= 500:


### PR DESCRIPTION
Hello dear Ansible community :)

This is my first contribution, feel free to express any kind of criticism, be it on the content or the format.

##### SUMMARY
I found a bug when using `community.general.rundeck_acl_policy`.

While creating a new ACL, I was greeted by the following trace:
```
  File "/.../community/general/plugins/modules/rundeck_acl_policy.py", line 239, in <module>
  File "/.../community/general/plugins/modules/rundeck_acl_policy.py", line 233, in main
  File "/.../community/general/plugins/modules/rundeck_acl_policy.py", line 143, in create_or_update_acl
  File "/.../community/general/plugins/modules/rundeck_acl_policy.py", line 137, in get_acl
  File "/.../community/general/plugins/module_utils/rundeck.py", line 83, in api_request
TypeError: 'NoneType' object is not callable
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- plugins/module_utils/rundeck.py

##### ADDITIONAL INFORMATION
On success, the `fetch_url` function returns something like:
`<addinfourl at 139713744344848 whose fp = <socket._fileobject object at 0x7f11a69761d0>>`

However, when the api returns a 404, the return value is:
`HTTP Error 404: Not Found`
In such a case, `response.read()` fails with the aforementionned TypeError.

The error ***could*** be specific to sundeck's API version. I did my testing with api version 40, which is not too far behind latest (v45), and way ahead of the current depreciation threshold (v14). [source](https://docs.rundeck.com/docs/api/rundeck-api-versions.html)

Let me know if I am missing anything!

Have a great day :)


