### PR TITLE
[PR #6980/796ad356 backport][stable-6] [proxmox] Use proxmoxer_version instead of server API version

### DIFF
--- a/changelogs/fragments/6980-proxmox-fix-token-auth.yml
+++ b/changelogs/fragments/6980-proxmox-fix-token-auth.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox module utils - fix proxmoxer library version check (https://github.com/ansible-collections/community.general/issues/6974, https://github.com/ansible-collections/community.general/issues/6975, https://github.com/ansible-collections/community.general/pull/6980).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -18,6 +18,7 @@ import traceback
 PROXMOXER_IMP_ERR = None
 try:
     from proxmoxer import ProxmoxAPI
+    from proxmoxer import __version__ as proxmoxer_version
     HAS_PROXMOXER = True
 except ImportError:
     HAS_PROXMOXER = False
@@ -79,6 +80,7 @@ class ProxmoxAnsible(object):
             module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
 
         self.module = module
+        self.proxmoxer_version = proxmoxer_version
         self.proxmox_api = self._connect()
         # Test token validity
         try:
@@ -98,7 +100,7 @@ class ProxmoxAnsible(object):
         if api_password:
             auth_args['password'] = api_password
         else:
-            if self.version() < LooseVersion('1.1.0'):
+            if self.proxmoxer_version < LooseVersion('1.1.0'):
                 self.module.fail_json('Using "token_name" and "token_value" require proxmoxer>=1.1.0')
             auth_args['token_name'] = api_token_id
             auth_args['token_value'] = api_token_secret

--- a/tests/unit/plugins/modules/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap.py
@@ -8,6 +8,13 @@ __metaclass__ = type
 
 import json
 import pytest
+import sys
+
+proxmoxer = pytest.importorskip('proxmoxer')
+mandatory_py_version = pytest.mark.skipif(
+    sys.version_info < (2, 7),
+    reason='The proxmoxer dependency requires python2.7 or higher'
+)
 
 from ansible_collections.community.general.tests.unit.compat.mock import MagicMock, patch
 from ansible_collections.community.general.plugins.modules import proxmox_snap

--- a/tests/unit/plugins/modules/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_tasks_info.py
@@ -12,6 +12,13 @@ __metaclass__ = type
 
 import pytest
 import json
+import sys
+
+proxmoxer = pytest.importorskip('proxmoxer')
+mandatory_py_version = pytest.mark.skipif(
+    sys.version_info < (2, 7),
+    reason='The proxmoxer dependency requires python2.7 or higher'
+)
 
 from ansible_collections.community.general.plugins.modules import proxmox_tasks_info
 import ansible_collections.community.general.plugins.module_utils.proxmox as proxmox_utils

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -44,3 +44,7 @@ elastic-apm ; python_version >= '3.6'
 
 # requirements for scaleway modules
 passlib[argon2]
+
+# requirements for the proxmox modules
+proxmoxer < 2.0.0 ; python_version >= '2.7' and python_version <= '3.6'
+proxmoxer ; python_version > '3.6'


### PR DESCRIPTION
This is a backport of PR #6980 as merged into main.

- Use proxmoxer_version instead of server API version

- Add changelog fragment

(cherry picked from commit 796ad3565eab36a0146c3f3d084306969a5e51ee)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Fixes authorization via tokens. Check for the version is done against proxmoxer, not the API itself.
Fixes #6975, #6974.

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
