### PR TITLE
Add example for ECS Fargate/EFS Jenkins authentication

### DIFF
--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -194,6 +194,28 @@ EXAMPLES = '''
     url_username: admin
     url_password: p4ssw0rd
     url: http://localhost:8888
+#
+# Example of how to authenticate with serverless deployment
+#
+- name: Update plugins on ECS Fargate Jenkins instance
+  community.general.jenkins_plugin:
+    # plugin name and version
+    name: ws-cleanup
+    version: 0.45
+    # Jenkins home path mounted on ec2-helper VM (example)
+    jenkins_home: "/mnt/{{ jenkins_instance }}"
+    # default local EC2 user that owns the mount
+    owner: ubuntu
+    group: ubuntu
+    # Jenkins instance URL and admin credentials
+    url: "https://{{ jenkins_instance }}.com/"
+    url_username: admin
+    url_password: p4ssw0rd
+  # make module work from EC2 which has local access
+  # to EFS mount as well as Jenkins URL
+  delegate_to: ec2-helper
+  vars:
+    jenkins_instance: foobar
 
 #
 # Example of a Play which handles Jenkins restarts during the state changes

--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -202,7 +202,7 @@ EXAMPLES = '''
   community.general.jenkins_plugin:
     # plugin name and version
     name: ws-cleanup
-    version: 0.45
+    version: '0.45'
     # Jenkins home path mounted on ec2-helper VM (example)
     jenkins_home: "/mnt/{{ jenkins_instance }}"
     # default local EC2 user that owns the mount

--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -27,7 +27,7 @@ options:
   group:
     type: str
     description:
-      - Name of the Jenkins group on the OS.
+      - GID or name of the Jenkins group on the OS.
     default: jenkins
   jenkins_home:
     type: path
@@ -47,7 +47,7 @@ options:
   owner:
     type: str
     description:
-      - Name of the Jenkins user on the OS.
+      - UID or name of the Jenkins user on the OS.
     default: jenkins
   state:
     type: str
@@ -205,9 +205,9 @@ EXAMPLES = '''
     version: '0.45'
     # Jenkins home path mounted on ec2-helper VM (example)
     jenkins_home: "/mnt/{{ jenkins_instance }}"
-    # default local EC2 user that owns the mount
-    owner: ubuntu
-    group: ubuntu
+    # matching the UID/GID to one in official Jenkins image
+    owner: 1000
+    group: 1000
     # Jenkins instance URL and admin credentials
     url: "https://{{ jenkins_instance }}.com/"
     url_username: admin

--- a/plugins/modules/jenkins_plugin.py
+++ b/plugins/modules/jenkins_plugin.py
@@ -194,6 +194,7 @@ EXAMPLES = '''
     url_username: admin
     url_password: p4ssw0rd
     url: http://localhost:8888
+
 #
 # Example of how to authenticate with serverless deployment
 #


### PR DESCRIPTION
##### SUMMARY
Since ECS Fargate is serverless, one cannot access its jenkins_home other than from a machine (EC2 instance for example) that actually mounts and owns its EFS storage.

That way we can provide uid/gid 1000 (the same as for the default jenkins user inside the container) and authenticate at Jenkins URL.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
jenkins_plugin

##### ADDITIONAL INFORMATION
I feel this is not as straightforward from the docs and someone might benefit from such an example being present