### PR TITLE
crypt is still deprecated in Python 3.12

### DIFF
--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -3,6 +3,7 @@ plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/gconftool2.py validate-modules:parameter-state-invalid-choice         # state=get - removed in 8.0.0
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
 plugins/modules/manageiq_policies.py validate-modules:parameter-state-invalid-choice  # state=list - removed in 8.0.0
@@ -18,4 +19,5 @@ plugins/modules/rax_files.py validate-modules:parameter-state-invalid-choice    
 plugins/modules/rax.py use-argspec-type-path                                          # module deprecated - removed in 9.0.0
 plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
 plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/xfconf.py validate-modules:return-syntax-error


### PR DESCRIPTION
##### SUMMARY
Ref: #4690
Ref: #4691
Ref: https://docs.python.org/3.12/library/crypt.html#module-crypt

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity tests
