### PR TITLE
Skip java_cert and java_keystore tests on RHEL

### DIFF
--- a/tests/integration/targets/java_cert/aliases
+++ b/tests/integration/targets/java_cert/aliases
@@ -9,3 +9,4 @@ skip/osx
 skip/macos
 skip/freebsd
 needs/root
+skip/rhel  # FIXME: keytool seems to be broken on newer RHELs

--- a/tests/integration/targets/java_keystore/aliases
+++ b/tests/integration/targets/java_keystore/aliases
@@ -9,3 +9,4 @@ skip/osx
 skip/macos
 skip/freebsd
 needs/root
+skip/rhel  # FIXME: keytool seems to be broken on newer RHELs


### PR DESCRIPTION
##### SUMMARY
For some reason keytool seems to be broken on newer RHELs (the timezone database for Java is not available). Disable the tests on RHEL for now.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
java_cert
java_keystore
