### PR TITLE
[PR #6981/f9448574 backport][stable-6] [proxmox_kvm] Don't create VM if name is used without vmid

### DIFF
--- a/changelogs/fragments/6981-proxmox-fix-vm-creation-when-only-name-provided.yml
+++ b/changelogs/fragments/6981-proxmox-fix-vm-creation-when-only-name-provided.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - when ``name`` option is provided without ``vmid`` and VM with that name already exists then no new VM will be created (https://github.com/ansible-collections/community.general/issues/6911, https://github.com/ansible-collections/community.general/pull/6981).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -281,8 +281,9 @@ options:
     type: int
   name:
     description:
-      - Specifies the VM name. Only used on the configuration web interface.
-      - Required only for C(state=present).
+      - Specifies the VM name. Name could be non-unique across the cluster.
+      - Required only for O(state=present).
+      - With O(state=present) if O(vmid) not provided and VM with name exists in the cluster then no changes will be made.
     type: str
   nameservers:
     description:
@@ -1210,10 +1211,14 @@ def main():
     # the cloned vm name or retrieve the next free VM id from ProxmoxAPI.
     if not vmid:
         if state == 'present' and not update and not clone and not delete and not revert:
-            try:
-                vmid = proxmox.get_nextvmid()
-            except Exception:
-                module.fail_json(msg="Can't get the next vmid for VM {0} automatically. Ensure your cluster state is good".format(name))
+            existing_vmid = proxmox.get_vmid(name, ignore_missing=True)
+            if existing_vmid:
+                vmid = existing_vmid
+            else:
+                try:
+                    vmid = proxmox.get_nextvmid()
+                except Exception:
+                    module.fail_json(msg="Can't get the next vmid for VM {0} automatically. Ensure your cluster state is good".format(name))
         else:
             clone_target = clone or name
             vmid = proxmox.get_vmid(clone_target, ignore_missing=True)

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -282,8 +282,8 @@ options:
   name:
     description:
       - Specifies the VM name. Name could be non-unique across the cluster.
-      - Required only for O(state=present).
-      - With O(state=present) if O(vmid) not provided and VM with name exists in the cluster then no changes will be made.
+      - Required only for I(state=present).
+      - With I(state=present) if I(vmid) not provided and VM with name exists in the cluster then no changes will be made.
     type: str
   nameservers:
     description:


### PR DESCRIPTION
This is a backport of PR #6981 as merged into main.

(cherry picked from commit f9448574bd43611d71932f0d88bc67585d528f2f)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Fixes #6911

While creating VM by using name only we check if VM with that name already exist and cluster and do nothing in that case.

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_kvm

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
