### PR TITLE
redfish_utils: Add support for "nextLink" property tag pagination

### DIFF
--- a/changelogs/fragments/7020-redfish-utils-pagination.yml
+++ b/changelogs/fragments/7020-redfish-utils-pagination.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - redfish_utils - add support for following ``@odata.nextLink`` pagination in software_inventory responses feature (https://github.com/ansible-collections/community.general/pull/7020).
+ - redfish_utils module utils - add support for following ``@odata.nextLink`` pagination in ``software_inventory`` responses feature (https://github.com/ansible-collections/community.general/pull/7020).

--- a/changelogs/fragments/7020-redfish-utils-pagination.yml
+++ b/changelogs/fragments/7020-redfish-utils-pagination.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - redfish_utils - add support for following ``@odata.nextLink`` pagination in software_inventory responses feature (https://github.com/ansible-collections/community.general/pull/7020).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1524,8 +1524,8 @@ class RedfishUtils(object):
                 software = {}
                 # Get these standard properties if present
                 for key in ['Name', 'Id', 'Status', 'Version', 'Updateable',
-                           'SoftwareId', 'LowestSupportedVersion', 'Manufacturer',
-                           'ReleaseDate']:
+                            'SoftwareId', 'LowestSupportedVersion', 'Manufacturer',
+                            'ReleaseDate']:
                     if key in data:
                         software[key] = data.get(key)
                 result['entries'].append(software)

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1499,29 +1499,37 @@ class RedfishUtils(object):
 
     def _software_inventory(self, uri):
         result = {}
-        response = self.get_request(self.root_uri + uri)
-        if response['ret'] is False:
-            return response
-        result['ret'] = True
-        data = response['data']
-
         result['entries'] = []
-        for member in data[u'Members']:
-            uri = self.root_uri + member[u'@odata.id']
-            # Get details for each software or firmware member
-            response = self.get_request(uri)
+
+        while uri:
+            response = self.get_request(self.root_uri + uri)
             if response['ret'] is False:
                 return response
             result['ret'] = True
+
             data = response['data']
-            software = {}
-            # Get these standard properties if present
-            for key in ['Name', 'Id', 'Status', 'Version', 'Updateable',
-                        'SoftwareId', 'LowestSupportedVersion', 'Manufacturer',
-                        'ReleaseDate']:
-                if key in data:
-                    software[key] = data.get(key)
-            result['entries'].append(software)
+            if data.get('Members@odata.nextLink'):
+                uri = data.get('Members@odata.nextLink')
+            else:
+                uri = None
+
+            for member in data[u'Members']:
+                fw_uri = self.root_uri + member[u'@odata.id']
+                # Get details for each software or firmware member
+                response = self.get_request(fw_uri)
+                if response['ret'] is False:
+                    return response
+                result['ret'] = True
+                data = response['data']
+                software = {}
+                # Get these standard properties if present
+                for key in ['Name', 'Id', 'Status', 'Version', 'Updateable',
+                           'SoftwareId', 'LowestSupportedVersion', 'Manufacturer',
+                           'ReleaseDate']:
+                    if key in data:
+                        software[key] = data.get(key)
+                result['entries'].append(software)
+
         return result
 
     def get_firmware_inventory(self):


### PR DESCRIPTION
##### SUMMARY

Add support for paginated responses in the _software_inventory method

Fixes https://github.com/ansible-collections/community.general/issues/7011

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION
Redfish supports a property in responses `@odata.nextLink` which indicates a partial set of data is returned (paginated response). The existing method would truncate the returned data with no indication items were missing from the response.

Running a normal firmware inventory task:
```
  - name: Collect Firmware Inventory
    community.general.redfish_info:
      category: Update
      command: GetFirmwareInventory
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
    register: redfish_fw_inventory
    delegate_to: localhost

  - debug:
      msg: "{{ redfish_fw_inventory.redfish_facts.firmware.entries | length }}"
```

Would return:
```
TASK [debug] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/sseekamp/Github/ansible-test/fi.yaml:20
ok: [x.x.x.x] => {
    "msg": "50"
}
```

which corresponded with the first page of response from a raw curl request:
```
...
  "Members@odata.count": 65,
  "Members@odata.nextLink": "/redfish/v1/UpdateService/FirmwareInventory?$skip=50",
  "Name": "Firmware Inventory Collection"
...
```

After the change:
```
TASK [debug] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/sseekamp/Github/ansible-test/fi.yaml:20
ok: [x.x.x.x] => {
    "msg": "98"
}
```

which is the expected full collection of firmware inventory items.