### PR TITLE
setup_docker: handlers to stop service and remove requests

### DIFF
--- a/tests/integration/targets/setup_docker/handlers/main.yml
+++ b/tests/integration/targets/setup_docker/handlers/main.yml
@@ -3,17 +3,29 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Remove python requests
+  ansible.builtin.pip:
+    name:
+      - requests
+    state: absent
+
+- name: Stop docker service
+  become: true
+  ansible.builtin.service:
+    name: docker
+    state: stopped
+
 - name: Remove Docker packages
-  package:
+  ansible.builtin.package:
     name: "{{ docker_packages }}"
     state: absent
 
 - name: "D-Fedora : Remove repository"
-  file:
+  ansible.builtin.file:
     path: /etc/yum.repos.d/docker-ce.repo
     state: absent
 
 - name: "D-Fedora : Remove dnf-plugins-core"
-  package:
+  ansible.builtin.package:
     name: dnf-plugins-core
     state: absent

--- a/tests/integration/targets/setup_docker/tasks/main.yml
+++ b/tests/integration/targets/setup_docker/tasks/main.yml
@@ -41,6 +41,7 @@
   ansible.builtin.service:
     name: docker
     state: started
+  notify: Stop docker service
 
 - name: Cheat on the docker socket permissions
   become: true
@@ -53,3 +54,4 @@
     name:
       - requests
     state: present
+  notify: Remove python requests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add handlers to stop the docker service and remove the `requests` Python package.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/integration/targets/setup_docker/

