### PR TITLE
ejabberd_user: better error when command not installed

### DIFF
--- a/changelogs/fragments/6949-ejabberdctl-error.yml
+++ b/changelogs/fragments/6949-ejabberdctl-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ejabberd_user - provide meaningful error message when the ``ejabberdctl`` command is not found (https://github.com/ansible-collections/community.general/pull/7028, https://github.com/ansible-collections/community.general/issues/6949).

--- a/plugins/modules/ejabberd_user.py
+++ b/plugins/modules/ejabberd_user.py
@@ -122,7 +122,7 @@ class EjabberdUser(object):
         """ This method will run the any command specified and return the
         returns using the Ansible common module
         """
-        cmd = [self.module.get_bin_path('ejabberdctl'), cmd] + options
+        cmd = [self.module.get_bin_path('ejabberdctl', required=True), cmd] + options
         self.log('command: %s' % " ".join(cmd))
         return self.module.run_command(cmd)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the `ejabberdctl` command is not found, throws a more meaningful error message indicating so. Previously the message made no mention to the root of the problem.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6949 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/modules/ejabberd_user.py
