### PR TITLE
Documentation to reflect newer Proxmox VE boot string format

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -64,6 +64,7 @@ options:
   boot:
     description:
       - Specify the boot order -> boot on floppy V(a), hard disk V(c), CD-ROM V(d), or network V(n).
+      - For newer versions of Proxmox VE, use a boot order like V(order=scsi0;net0;hostpci0).
       - You can combine to set order.
       - This option has no default unless O(proxmox_default_behavior) is set to V(compatiblity); then the default is V(cnd).
     type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a line of documentation to reflect boot order string format for Proxmox.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #7035

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
proxmox_kvm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The new documentation reflects the boot order string from the [official Proxmox VE documentation](https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines). I am unsure if the old documentation reflected an older version of Proxmox, so I phrased the documentation to indicate that newer Proxmox VE versions would require the string as described in the official documentation.