### PR TITLE
ejabberd_user: deprecate parameter logging

### DIFF
--- a/plugins/modules/ejabberd_user.py
+++ b/plugins/modules/ejabberd_user.py
@@ -150,7 +150,7 @@ def main():
             username=dict(required=True, type='str'),
             password=dict(type='str', no_log=True),
             state=dict(default='present', choices=['present', 'absent']),
-            logging=dict(default=False, type='bool')  # deprecate in favour of c.g.syslogger?
+            logging=dict(default=False, type='bool', removed_in_version='9.0.0', removed_from_collection='community.general'),
         ),
         required_if=[
             ('state', 'present', ['password']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Parameter `logging` is used to log messages from the module straight into `syslog`. This seems to be a little bit off the responsibility of the module, and `syslog` is far from being the only way of registering log messages these days.

Deprecating the option, and will work on the module to provide meaningful information in its output when needed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
ejabberd
