### PR TITLE
snap: Only treat `---` as an info separator when it's preceded by newline

### DIFF
--- a/changelogs/fragments/7046-snap-newline-before-separator.yml
+++ b/changelogs/fragments/7046-snap-newline-before-separator.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - snap - fix crash when multiple snaps specified and one has ``---`` in its description (https://github.com/ansible-collections/community.general/pull/7046).
+  - snap - fix crash when multiple snaps are specified and one has ``---`` in its description (https://github.com/ansible-collections/community.general/pull/7046).

--- a/changelogs/fragments/7046-snap-newline-before-separator.yml
+++ b/changelogs/fragments/7046-snap-newline-before-separator.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - snap - fix crash when multiple snaps specified and one has ``---`` in its description (https://github.com/ansible-collections/community.general/pull/7046).

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -303,6 +303,9 @@ class Snap(StateModuleHelper):
             return [name]
 
         def process_many(rc, out, err):
+            # This needs to be "\n---" instead of just "---" because otherwise
+            # if a snap uses "---" in its description then that will incorrectly
+            # be interpreted as a separator between snaps in the output.
             outputs = out.split("\n---")
             res = []
             for sout in outputs:

--- a/plugins/modules/snap.py
+++ b/plugins/modules/snap.py
@@ -303,7 +303,7 @@ class Snap(StateModuleHelper):
             return [name]
 
         def process_many(rc, out, err):
-            outputs = out.split("---")
+            outputs = out.split("\n---")
             res = []
             for sout in outputs:
                 res.extend(process_one(rc, sout, ""))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

The code for splitting the output of `snap info` for multiple snaps can't assume that `---` separates snaps any time it appears in the output; it needs to treat that as the separator only when it's at the start of a line. Otherwise it breaks if any snap uses `---` in its description text, which, e.g., the `bw` snap does as of the date of this commit.

Fixes #7045.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
snap

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
