### PR TITLE
[proxmox_vm_info] Return empty list when requested VM doesn't exist

### DIFF
--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -223,10 +223,12 @@ def main():
         module.fail_json(msg="Node %s doesn't exist in PVE cluster" % node)
 
     if not vmid and name:
-        vmid = int(proxmox.get_vmid(name, ignore_missing=False))
+        vmid = proxmox.get_vmid(name, ignore_missing=True)
+        if vmid is not None:
+            vmid = int(vmid)
 
     vms_cluster_resources = proxmox.get_vms_from_cluster_resources()
-    vms = None
+    vms = []
 
     if type == "lxc":
         vms = proxmox.get_lxc_vms(vms_cluster_resources, vmid, node)
@@ -237,15 +239,8 @@ def main():
             vms_cluster_resources, vmid, node
         ) + proxmox.get_lxc_vms(vms_cluster_resources, vmid, node)
 
-    if vms or vmid is None:
-        result["proxmox_vms"] = vms
-        module.exit_json(**result)
-    else:
-        if node is None:
-            result["msg"] = "VM with vmid %s doesn't exist in cluster" % (vmid)
-        else:
-            result["msg"] = "VM with vmid %s doesn't exist on node %s" % (vmid, node)
-        module.fail_json(**result)
+    result["proxmox_vms"] = vms
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -464,23 +464,14 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
         assert result["proxmox_vms"] == expected_output
         assert len(result["proxmox_vms"]) == 2
 
-    def test_module_fail_when_vm_does_not_exist_on_node(self):
-        with pytest.raises(AnsibleFailJson) as exc_info:
-            vmid = 200
-            set_module_args(get_module_args(type="all", vmid=vmid, node=NODE1))
-            self.module.main()
-
-        result = exc_info.value.args[0]
-        assert result["msg"] == "VM with vmid 200 doesn't exist on node pve"
-
-    def test_module_fail_when_vm_does_not_exist_in_cluster(self):
-        with pytest.raises(AnsibleFailJson) as exc_info:
+    def test_module_returns_empty_list_when_vm_does_not_exist(self):
+        with pytest.raises(AnsibleExitJson) as exc_info:
             vmid = 200
             set_module_args(get_module_args(type="all", vmid=vmid))
             self.module.main()
 
         result = exc_info.value.args[0]
-        assert result["msg"] == "VM with vmid 200 doesn't exist in cluster"
+        assert result["proxmox_vms"] == []
 
     def test_module_fail_when_qemu_request_fails(self):
         self.connect_mock.return_value.nodes.return_value.qemu.return_value.get.side_effect = IOError(


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Instead of failing when VM with provided name/vmid doesn't exist the module should have empty response. Than allows the workflows with checking VM existence.

##### ISSUE TYPE

<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Feature Pull Request

##### COMPONENT NAME

<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

proxmox_vm_info

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
