### PR TITLE
lvol: Fix pct of origin

### DIFF
--- a/changelogs/fragments/lvol-pct-of-origin.yml
+++ b/changelogs/fragments/lvol-pct-of-origin.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - lvol - add support for percentage of origin size specification when creating snapshot volumes (https://github.com/ansible-collections/community.general/issues/1630).
+  - lvol - add support for percentage of origin size specification when creating snapshot volumes (https://github.com/ansible-collections/community.general/issues/1630, https://github.com/ansible-collections/community.general/pull/7053).

--- a/changelogs/fragments/lvol-pct-of-origin.yml
+++ b/changelogs/fragments/lvol-pct-of-origin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - add support for percentage of origin size specification when creating snapshot volumes (https://github.com/ansible-collections/community.general/issues/1630).

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -41,13 +41,13 @@ options:
     description:
     - The size of the logical volume, according to lvcreate(8) --size, by
       default in megabytes or optionally with one of [bBsSkKmMgGtTpPeE] units; or
-      according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE];
+      according to lvcreate(8) --extents as a percentage of [VG|PVS|FREE|ORIGIN];
       Float values must begin with a digit.
     - When resizing, apart from specifying an absolute size you may, according to
       lvextend(8)|lvreduce(8) C(--size), specify the amount to extend the logical volume with
       the prefix V(+) or the amount to reduce the logical volume by with prefix V(-).
     - Resizing using V(+) or V(-) was not supported prior to community.general 3.0.0.
-    - Please note that when using V(+) or V(-), the module is B(not idempotent).
+    - Please note that when using V(+), V(-), or percentage of sizes, the module is B(not idempotent).
   state:
     type: str
     description:
@@ -73,7 +73,7 @@ options:
   snapshot:
     type: str
     description:
-    - The name of the snapshot volume
+    - The name of a snapshot volume to be configured. When creating a snapshot volume, the O(lv) parameter specifies the origin volume.
   pvs:
     type: str
     description:
@@ -368,10 +368,10 @@ def main():
             if size_percent > 100:
                 module.fail_json(msg="Size percentage cannot be larger than 100%")
             size_whole = size_parts[1]
-            if size_whole == 'ORIGIN':
-                module.fail_json(msg="Snapshot Volumes are not supported")
-            elif size_whole not in ['VG', 'PVS', 'FREE']:
-                module.fail_json(msg="Specify extents as a percentage of VG|PVS|FREE")
+            if size_whole == 'ORIGIN' and snapshot is None:
+                module.fail_json(msg="Percentage of ORIGIN supported only for snapshot volumes")
+            elif size_whole not in ['VG', 'PVS', 'FREE', 'ORIGIN']:
+                module.fail_json(msg="Specify extents as a percentage of VG|PVS|FREE|ORIGIN")
             size_opt = 'l'
             size_unit = ''
 

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -47,7 +47,7 @@ options:
       lvextend(8)|lvreduce(8) C(--size), specify the amount to extend the logical volume with
       the prefix V(+) or the amount to reduce the logical volume by with prefix V(-).
     - Resizing using V(+) or V(-) was not supported prior to community.general 3.0.0.
-    - Please note that when using V(+), V(-), or percentage of sizes, the module is B(not idempotent).
+    - Please note that when using V(+), V(-), or percentage of FREE, the module is B(not idempotent).
   state:
     type: str
     description:

--- a/tests/integration/targets/lvg/tasks/setup.yml
+++ b/tests/integration/targets/lvg/tasks/setup.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: "Create files to use as a disk devices"
-  command: "dd if=/dev/zero of={{ remote_tmp_dir }}/img{{ item }} bs=1M count=10"
+  command: "dd if=/dev/zero of={{ remote_tmp_dir }}/img{{ item }} bs=1M count=36"
   with_sequence: 'count=4'
 
 - name: "Show next free loop device"

--- a/tests/integration/targets/lvg/tasks/test_active_change.yml
+++ b/tests/integration/targets/lvg/tasks/test_active_change.yml
@@ -17,6 +17,16 @@
     lv: "{{ item }}"
     size: 2m
 
+- name: Create snapshot volumes of origin logical volumes
+  loop:
+    - lv1
+    - lv2
+  lvol:
+    vg: testvg
+    lv: "{{ item }}"
+    snapshot: "{{ item }}_snap"
+    size: 50%ORIGIN
+
 - name: Collect all lv active status in testvg
   shell: vgs -olv_active --noheadings testvg | xargs -n1
   register: initial_lv_status_result

--- a/tests/integration/targets/lvg/tasks/test_pvresize.yml
+++ b/tests/integration/targets/lvg/tasks/test_pvresize.yml
@@ -12,10 +12,10 @@
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
   register: cmd_result
 
-- name: Assert the testvg size is 8388608B
+- name: Assert the testvg size is 33554432B
   assert:
    that:
-    - "'8388608B' == cmd_result.stdout"
+    - "'33554432B' == cmd_result.stdout"
 
 - name: Increases size in file
   command: "dd if=/dev/zero bs=8MiB count=1 of={{ remote_tmp_dir }}/img1 conv=notrunc oflag=append"
@@ -38,10 +38,10 @@
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
   register: cmd_result
 
-- name: Assert the testvg size is still 8388608B
+- name: Assert the testvg size is still 33554432B
   assert:
    that:
-    - "'8388608B' == cmd_result.stdout"
+    - "'33554432B' == cmd_result.stdout"
 
 - name: "Reruns lvg with pvresize:yes and check_mode:yes"
   lvg:
@@ -60,10 +60,10 @@
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
   register: cmd_result
  
-- name: Assert the testvg size is still 8388608B
+- name: Assert the testvg size is still 33554432B
   assert:
    that:
-    - "'8388608B' == cmd_result.stdout"
+    - "'33554432B' == cmd_result.stdout"
 
 - name: "Reruns lvg with pvresize:yes"
   lvg:
@@ -75,7 +75,7 @@
   shell: vgs -v testvg -o pv_size --noheading --units b | xargs
   register: cmd_result
 
-- name: Assert the testvg size is now 16777216B
+- name: Assert the testvg size is now 41943040B
   assert:
    that:
-    - "'16777216B' == cmd_result.stdout"
+    - "'41943040B' == cmd_result.stdout"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `size` parameter of the `lvol` module did not support percentage of origin size specification when creating a snapshot volume. This is valid according to lvcreate(8). This PR addresses the issue. 

I increased the size of the loop devices in the test playbook to accommodate creating test snapshot LVs. The modified tests worked for me locally. Fingers crossed for the CI workflow. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1630 
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`lvol` module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
My first PR to the community.general collection. Kindly guide me if I've done anything wrong. Thanks! 