### PR TITLE
CI: ansible-core devel only supports Alpine 3.18 VMs, no longer Alpine 3.17 VMs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -171,8 +171,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: Alpine 3.17
-              test: alpine/3.17
+            - name: Alpine 3.18
+              test: alpine/3.18
             # - name: Fedora 38
             #   test: fedora/38
             - name: Ubuntu 22.04


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible/ansible/commit/6d1f85bbe937d671f6bef06837e3be428c692d41.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
