### PR TITLE
bitwarden lookup fix `get_field`

### DIFF
--- a/changelogs/fragments/7061-fix-bitwarden-get_field.yml
+++ b/changelogs/fragments/7061-fix-bitwarden-get_field.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - bitwarden lookup makes assumptions about the structure of a bitwarden JSON object which may have been broken by an update in the bitwarden API. Remove assumptions, and allow queries for general fields such as 'notes'.

--- a/changelogs/fragments/7061-fix-bitwarden-get_field.yml
+++ b/changelogs/fragments/7061-fix-bitwarden-get_field.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - bitwarden lookup makes assumptions about the structure of a bitwarden JSON object which may have been broken by an update in the bitwarden API. Remove assumptions, and allow queries for general fields such as 'notes'.
+  - bitwarden lookup plugin - the plugin made assumptions about the structure of a Bitwarden JSON object which may have been broken by an update in the Bitwarden API. Remove assumptions, and allow queries for general fields such as ``notes`` (https://github.com/ansible-collections/community.general/pull/7061).

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -149,7 +149,7 @@ class Bitwarden(object):
             if 'login' in match and field in match['login']:
                 field_matches.append(match['login'][field])
                 continue
-            if field in match.keys():
+            if field in match:
                 field_matches.append(match[field])
                 continue
         if matches and not field_matches:

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -137,7 +137,7 @@ class Bitwarden(object):
         field_matches = []
         for match in matches:
             # if there are no custom fields, then `match` has no key 'fields'
-            if 'fields' in match.keys():
+            if 'fields' in match:
                 custom_field_found = False
                 for custom_field in match['fields']:
                     if field == custom_field['name']:

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -146,7 +146,7 @@ class Bitwarden(object):
                         break
                 if custom_field_found:
                     continue
-            if 'login' in match.keys() and field in match['login'].keys():
+            if 'login' in match and field in match['login']:
                 field_matches.append(match['login'][field])
                 continue
             if field in match.keys():

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -156,6 +156,7 @@ class Bitwarden(object):
             raise AnsibleError("field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
         return field_matches
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -132,21 +132,29 @@ class Bitwarden(object):
         If field is None, return the whole record for each match.
         """
         matches = self._get_matches(search_value, search_field, collection_id)
-
-        if field in ['autofillOnPageLoad', 'password', 'passwordRevisionDate', 'totp', 'uris', 'username']:
-            return [match['login'][field] for match in matches]
-        elif not field:
+        if not field:
             return matches
-        else:
-            custom_field_matches = []
-            for match in matches:
+        field_matches = []
+        for match in matches:
+            # if there are no custom fields, then `match` has no key 'fields'
+            if 'fields' in match.keys():
+                custom_field_found = False
                 for custom_field in match['fields']:
-                    if custom_field['name'] == field:
-                        custom_field_matches.append(custom_field['value'])
-            if matches and not custom_field_matches:
-                raise AnsibleError("Custom field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
-            return custom_field_matches
-
+                    if field == custom_field['name']:
+                        field_matches.append(custom_field['value'])
+                        custom_field_found = True
+                        break
+                if custom_field_found:
+                    continue
+            if 'login' in match.keys() and field in match['login'].keys():
+                field_matches.append(match['login'][field])
+                continue
+            if field in match.keys():
+                field_matches.append(match[field])
+                continue
+        if matches and not field_matches:
+            raise AnsibleError("field {field} does not exist in {search_value}".format(field=field, search_value=search_value))
+        return field_matches
 
 class LookupModule(LookupBase):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A bitwarden record without any custom fields will throw a `KeyError` when you try to search with `field='notes'`. The code here tries to open `match['fields']` without first checking if the key `fields` exists in `match`.
It turns out that with the current logic you can't get the `notes` field. It's either the login fields or custom fields. The new logic looks for your key in custom fields, then in login fields, then in the general fields for that record.

Fixes #6617

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bitwarden

##### ADDITIONAL INFORMATION
Here's the structure of a bitwarden record json object:
```
{
    "collectionIds": null,
    "creationDate": null,
    "deletedDate": null,
    "favorite": false,
    "fields": [
        {
            "linkedId": null,
            "name": "custom-field1",
            "type": null,
            "value": null
        }
        {
            "linkedId": null,
            "name": "custom-field2",
            "type": null,
            "value": null
        }
    ],
    "folderId": null,
    "id": null,
    "login": {
        "password": null,
        "passwordRevisionDate": null,
        "totp": null,
        "username": null
    },
    "name": null,
    "notes": null,
    "object": null,
    "organizationId": null,
    "passwordHistory": null,
    "reprompt": null,
    "revisionDate": null,
    "type": null,
}
```

##### BEFORE AND AFTER

```
- name: print bitwarden value
  debug:
    msg: "{{ lookup('community.general.bitwarden', 'record-name', field='notes') }}"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
TASK [hostname : print bitwarden value] ******************************************************************************
fatal: [hostname]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'community.general.bitwarden'. Error was a <class 'KeyError'>, original message: 'fields'. 'fields'"}
```
after:
```
ok: [hostname] => {
    "msg": [
        "these are notes"
    ]
}
```
