### PR TITLE
Follow DMTF redfish deprecation on StorageControllers

### DIFF
--- a/changelogs/fragments/7081-redfish-utils-fix-for-storagecontrollers-deprecated-key.yaml
+++ b/changelogs/fragments/7081-redfish-utils-fix-for-storagecontrollers-deprecated-key.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_utils - use Controllers key in redfish data to obtain Storage controllers properties (https://github.com/ansible-collections/community.general/pull/7081).
+  - redfish_utils - use ``Controllers`` key in redfish data to obtain Storage controllers properties (https://github.com/ansible-collections/community.general/pull/7081).

--- a/changelogs/fragments/7081-redfish-utils-fix-for-storagecontrollers-deprecated-key.yaml
+++ b/changelogs/fragments/7081-redfish-utils-fix-for-storagecontrollers-deprecated-key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils - use Controllers key in redfish data to obtain Storage controllers properties (https://github.com/ansible-collections/community.general/pull/7081).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -746,9 +746,9 @@ class RedfishUtils(object):
                 data = response['data']
 
                 if key in data:
-                    controller_uri = data[key][u'@odata.id']
+                    controllers_uri = data[key][u'@odata.id']
 
-                    response = self.get_request(self.root_uri + controller_uri)
+                    response = self.get_request(self.root_uri + controllers_uri)
                     if response['ret'] is False:
                         return response
                     result['ret'] = True
@@ -824,7 +824,25 @@ class RedfishUtils(object):
                         return response
                     data = response['data']
                     controller_name = 'Controller 1'
-                    if 'StorageControllers' in data:
+                    if 'Controllers' in data:
+                        controllers_uri = data['Controllers'][u'@odata.id']
+
+                        response = self.get_request(self.root_uri + controllers_uri)
+                        if response['ret'] is False:
+                            return response
+                        result['ret'] = True
+                        cdata = response['data']
+
+                        if cdata[u'Members']:
+                            controller_member_uri = cdata[u'Members'][0][u'@odata.id']
+
+                            response = self.get_request(self.root_uri + controller_member_uri)
+                            if response['ret'] is False:
+                                return response
+                            result['ret'] = True
+                            cdata = response['data']
+                            controller_name = cdata['Name']
+                    elif 'StorageControllers' in data:
                         sc = data['StorageControllers']
                         if sc:
                             if 'Name' in sc[0]:
@@ -928,15 +946,7 @@ class RedfishUtils(object):
                         return response
                     data = response['data']
                     controller_name = 'Controller %s' % str(idx)
-                    if 'StorageControllers' in data:
-                        sc = data['StorageControllers']
-                        if sc:
-                            if 'Name' in sc[0]:
-                                controller_name = sc[0]['Name']
-                            else:
-                                sc_id = sc[0].get('Id', '1')
-                                controller_name = 'Controller %s' % sc_id
-                    elif 'Controllers' in data:
+                    if 'Controllers' in data:
                         response = self.get_request(self.root_uri + data['Controllers'][u'@odata.id'])
                         if response['ret'] is False:
                             return response
@@ -954,6 +964,14 @@ class RedfishUtils(object):
                                 else:
                                     controller_id = member_data.get('Id', '1')
                                     controller_name = 'Controller %s' % controller_id
+                    elif 'StorageControllers' in data:
+                        sc = data['StorageControllers']
+                        if sc:
+                            if 'Name' in sc[0]:
+                                controller_name = sc[0]['Name']
+                            else:
+                                sc_id = sc[0].get('Id', '1')
+                                controller_name = 'Controller %s' % sc_id
                     volume_results = []
                     volume_list = []
                     if 'Volumes' in data:


### PR DESCRIPTION
Get controller information from "Controllers" field instead of "StorageControllers" which is deprecated

cf. page 9 of  https://www.dmtf.org/sites/default/files/Redfish_Release_2022.1_Overview.pdf

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
get_storage_controller_inventory now use _Controllers_ field as main key to obtain storage controllers properties. And if _Controllers_ is not available , get_storage_controller_inventory will use the deprecated key _StorageControllers_

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #7080 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
On the same HPe server, i had empty array:
```
TASK [ansible.builtin.debug] ***********************************************************************************************************************************
ok: [localhost] => {                                                            
    "controllers_inventory": {                                                  
        "ansible_facts": {           
            "discovered_interpreter_python": "/usr/bin/python3"
        },                                                                      
        "changed": false,                                                       
        "failed": false,                                                        
        "redfish_facts": {                                                      
            "storage_controller": {                                             
                "entries": [                                                    
                    [                                                           
                        {                                                       
                            "system_uri": "/redfish/v1/Systems/1/"
                        },       
                        [     
                            {
                                "CacheSummary": {
                                    "PersistentCacheSizeMiB": 3856,
                                    "Status": {
                                        "Health": "OK",
                                        "State": "Disabled"
                                    },
                                    "TotalCacheSizeMiB": 4096
                                },
                                "FirmwareVersion": "5.32",                                                                                                      
                                "Id": "0",                                                                                                                      
                                "Identifiers": [
                                    {                                           
                                        "DurableName": "51402EC019A26FC0",
                                        "DurableNameFormat": "NAA"
                                    }
                                ],
                                "Location": {
                                    "PartLocation": {
                                        "LocationOrdinalValue": 0,
                                        "LocationType": "Slot",
                                        "ServiceLabel": "Slot=0"
                                    }
                                },
                                "Manufacturer": "HPE",
                                "Model": "HPE Smart Array P816i-a SR Gen10",
                                "Name": "HPE Smart Array P816i-a SR Gen10",
                                "PartNumber": "869085-004",
                                "SerialNumber": "PZXNU0BRHH501M ",
                                "SpeedGbps": 12.0,
                                "Status": {
                                    "Health": "OK",
                                    "State": "Enabled"
                                }
                            },
                            {
                                "CacheSummary": {
                                    "PersistentCacheSizeMiB": 0,
                                    "Status": {
                                        "Health": "OK",
                                        "State": "Disabled"
                                    },
                                    "TotalCacheSizeMiB": 128
                                },
                                "FirmwareVersion": "5.32",
                                "Id": "0",
                                "Identifiers": [
                                    {
                                        "DurableName": "51402EC015A28DC0",
                                        "DurableNameFormat": "NAA"
                                    }
                                ],
                                "Location": {
                                    "PartLocation": {
                                        "LocationOrdinalValue": 4,
                                        "LocationType": "Slot",
                                        "ServiceLabel": "Slot=4"
                                    }
                                },
                                "Manufacturer": "HPE",
                                "Model": "HPE Smart Array E208i-p SR Gen10",
                                "Name": "HPE Smart Array E208i-p SR Gen10",
                                "PartNumber": "804397-001",
                                "SerialNumber": "PEYHL0B52GX0QG ",
                                "SpeedGbps": 12.0,
                                "Status": {
                                    "Health": "OK",
                                    "State": "Enabled"
                                }
                            }
                        ]
                    ]
                ],
                "ret": true
            }
        }
    }
}
```
