### PR TITLE
chroot: add `disable_root_check` option

### DIFF
--- a/changelogs/fragments/7099-chroot-disable-root-check-option.yml
+++ b/changelogs/fragments/7099-chroot-disable-root-check-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "chroot - add ``disable_root_check`` option (https://github.com/ansible-collections/community.general/pull/7099)."
+  - "chroot connection plugin - add ``disable_root_check`` option (https://github.com/ansible-collections/community.general/pull/7099)."

--- a/changelogs/fragments/7099-chroot-disable-root-check-option.yml
+++ b/changelogs/fragments/7099-chroot-disable-root-check-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "chroot - add ``disable_root_check`` option (https://github.com/ansible-collections/community.general/pull/7099)."

--- a/plugins/connection/chroot.py
+++ b/plugins/connection/chroot.py
@@ -57,6 +57,8 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_chroot_disable_root_check
         default: false
+        type: bool
+        version_added: 7.3.0
 '''
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
Some chroot executables, like `arch-chroot`, support unshare mode (-N), which does not require root. This PR adds an option to disable the root check in the chroot connection plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`plugins/connection/chroot.py`

##### ADDITIONAL INFORMATION
