### PR TITLE
freebsd: shutdown -p ... on freebsd to power off machine

### DIFF
--- a/changelogs/fragments/7102-freebsd-shutdown-p.yml
+++ b/changelogs/fragments/7102-freebsd-shutdown-p.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Use shutdown -p ... with FreeBSD to half and power off machien with community.general.shutdown
+  - shutdown - use ``shutdown -p ...`` with FreeBSD to halt and power off machine (https://github.com/ansible-collections/community.general/pull/7102).

--- a/changelogs/fragments/7102-freebsd-shutdown-p.yml
+++ b/changelogs/fragments/7102-freebsd-shutdown-p.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use shutdown -p ... with FreeBSD to half and power off machien with community.general.shutdown

--- a/plugins/action/shutdown.py
+++ b/plugins/action/shutdown.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
     SHUTDOWN_COMMAND_ARGS = {
         'alpine': '',
         'void': '-h +{delay_min} "{message}"',
-        'freebsd': '-h +{delay_sec}s "{message}"',
+        'freebsd': '-p +{delay_sec}s "{message}"',
         'linux': DEFAULT_SHUTDOWN_COMMAND_ARGS,
         'macosx': '-h +{delay_min} "{message}"',
         'openbsd': '-h +{delay_min} "{message}"',

--- a/tests/integration/targets/shutdown/tasks/main.yml
+++ b/tests/integration/targets/shutdown/tasks/main.yml
@@ -77,8 +77,8 @@
 - name: Verify shutdown delay is present in seconds in FreeBSD
   assert:
     that:
-      - '"-h +100s" in shutdown_result["shutdown_command"]'
-      - '"-h +0s" in shutdown_result_minus["shutdown_command"]'
+      - '"-p +100s" in shutdown_result["shutdown_command"]'
+      - '"-p +0s" in shutdown_result_minus["shutdown_command"]'
   when: ansible_system == 'FreeBSD'
 
 - name: Verify shutdown delay is present in seconds in Solaris, SunOS


### PR DESCRIPTION
* Use shutdown -p ... on FreeBSD such that the machine is halted and
  powered off (-p) otherwise the machine is halted (-h) but remains on.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
To follow suit with the other shutdown commands that also power off the machine freebsd shutdown should also power off the machine.  In that case -p should be used that will halt and power off vs -h that will just halt the machine leave it powered on with a prompt to power off and/or any key to reboot.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.shutdown

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
