### PR TITLE
lxc: fix remote_addr default to inventory_hostname

### DIFF
--- a/changelogs/fragments/7104_fix_lxc_remoteaddr_default.yml
+++ b/changelogs/fragments/7104_fix_lxc_remoteaddr_default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "lxc connection now handles remote_addr defaulting to inventory_hostname correctly. (https://github.com/ansible-collections/community.general/pull/7104)"

--- a/changelogs/fragments/7104_fix_lxc_remoteaddr_default.yml
+++ b/changelogs/fragments/7104_fix_lxc_remoteaddr_default.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "lxc connection now handles remote_addr defaulting to inventory_hostname correctly. (https://github.com/ansible-collections/community.general/pull/7104)"
+  - "lxc connection plugin - now handles ``remote_addr`` defaulting to ``inventory_hostname`` correctly (https://github.com/ansible-collections/community.general/pull/7104)."

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -19,6 +19,7 @@ DOCUMENTATION = '''
             - Container identifier
         default: inventory_hostname
         vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: ansible_lxc_host
       executable:


### PR DESCRIPTION
##### SUMMARY
Ansible currently prints a warning when not explicitly defining one of the lxc `remote_addr` parameter variables and the fallback to `inventory_hostname` is used.

```
[WARNING]: The "lxc" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string
```

This PR implements the same solution as ansible/ansible#77844, defining `inventory_hostname` as the lowest-priority variable for the `remote_addr` parameter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc

##### ADDITIONAL INFORMATION
Encountered, fixed and tested with:
```
$ ansible --version
ansible [core 2.14.3]
  config file = None
  configured module search path = ['/home/corubba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/corubba/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```
