### PR TITLE
Add support for Redfish PowerCycle reset type

### DIFF
--- a/changelogs/fragments/7113-redfish-utils-power-cycle.yml
+++ b/changelogs/fragments/7113-redfish-utils-power-cycle.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils module utils - add support for ``PowerCycle`` reset type for ``redfish_command`` responses feature (https://github.com/ansible-collections/community.general/issues/7083).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1074,7 +1074,12 @@ class RedfishUtils(object):
         # command should be PowerOn, PowerForceOff, etc.
         if not command.startswith('Power'):
             return {'ret': False, 'msg': 'Invalid Command (%s)' % command}
-        reset_type = command[5:]
+
+        # Commands (except PowerCycle) will be stripped of the 'Power' prefix
+        if command == 'PowerCycle':
+            reset_type = command
+        else:
+            reset_type = command[5:]
 
         # map Reboot to a ResetType that does a reboot
         if reset_type == 'Reboot':

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -747,7 +747,7 @@ from ansible.module_utils.common.text.converters import to_native
 # More will be added as module features are expanded
 CATEGORY_COMMANDS_ALL = {
     "Systems": ["PowerOn", "PowerForceOff", "PowerForceRestart", "PowerGracefulRestart",
-                "PowerGracefulShutdown", "PowerReboot", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
+                "PowerGracefulShutdown", "PowerReboot", "PowerCycle", "SetOneTimeBoot", "EnableContinuousBootOverride", "DisableBootOverride",
                 "IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink", "VirtualMediaInsert", "VirtualMediaEject", "VerifyBiosAttributes"],
     "Chassis": ["IndicatorLedOn", "IndicatorLedOff", "IndicatorLedBlink"],
     "Accounts": ["AddUser", "EnableUser", "DeleteUser", "DisableUser",


### PR DESCRIPTION
##### SUMMARY
Adds support for the `PowerCycle` Redfish reset type

Fixes #7083

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_utils
redfish_command

##### ADDITIONAL INFORMATION
Used like the other Redfish power command options:

```
  tasks:
  - name: Power Cycle System
    community.general.redfish_command:
      category: Systems
      command: PowerCycle
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
    delegate_to: 127.0.0.1
    register: power

  - debug:
      var: power

  - name: Wait for node to reboot
    ansible.builtin.wait_for_connection:
      delay: 300
      sleep: 10
      timeout: 8000
```

Which results in a system power cycle as expected:
```
PLAY [test power cycle] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Power Cycle System] ************************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [x.x.x.x -> 127.0.0.1] => {"changed": true, "msg": "Action was successful", "return_values": {}, "session": {}}

TASK [debug] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [x.x.x.x] => {
    "power": {
        "changed": true,
        "failed": false,
        "msg": "Action was successful",
        "return_values": {},
        "session": {}
    }
}

TASK [Wait for node to reboot] **********************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [x.x.x.x] => {"changed": false, "elapsed": 300}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************************************************************************************************
10.161.139.4               : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```