### PR TITLE
gitlab_project_variable/gitlab_group_variable: Add support for 'raw' option

### DIFF
--- a/changelogs/fragments/7132-gitlab-raw-variables.yml
+++ b/changelogs/fragments/7132-gitlab-raw-variables.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - gitlab_project_variable - add support for ``raw`` variables suboption (https://github.com/ansible-collections/community.general/pull/7132).
+  - gitlab_group_variable - add support for ``raw`` variables suboption (https://github.com/ansible-collections/community.general/pull/7132).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -135,6 +135,7 @@ def vars_to_variables(vars, module):
                     "value": str(value),
                     "masked": False,
                     "protected": False,
+                    "raw": False,
                     "variable_type": "env_var",
                 }
             )
@@ -145,6 +146,7 @@ def vars_to_variables(vars, module):
                 "value": value.get('value'),
                 "masked": value.get('masked'),
                 "protected": value.get('protected'),
+                "raw": value.get('raw'),
                 "variable_type": value.get('variable_type'),
             }
 

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -53,13 +53,14 @@ options:
     type: bool
   vars:
     description:
-      - When the list element is a simple key-value pair, set masked and protected to false.
-      - When the list element is a dict with the keys C(value), C(masked) and C(protected), the user can
-        have full control about whether a value should be masked, protected or both.
+      - When the list element is a simple key-value pair, masked, raw and protected will be set to false.
+      - When the list element is a dict with the keys C(value), C(masked), C(raw) and C(protected), the user can
+        have full control about whether a value should be masked, raw, protected or both.
       - Support for group variables requires GitLab >= 9.5.
       - Support for environment_scope requires GitLab Premium >= 13.11.
       - Support for protected values requires GitLab >= 9.3.
       - Support for masked values requires GitLab >= 11.10.
+      - Support for raw values requires GitLab >= 15.7.
       - A C(value) must be a string or a number.
       - Field C(variable_type) must be a string with either V(env_var), which is the default, or V(file).
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
@@ -95,6 +96,13 @@ options:
           - Wether variable value is protected or not.
         type: bool
         default: false
+      raw:
+        description:
+          - Wether variable value is raw or not.
+          - Support for raw values requires GitLab >= 15.7.
+        type: bool
+        default: false
+        version_added: '7.4.0'
       variable_type:
         description:
           - Wether a variable is an environment variable (V(env_var)) or a file (V(file)).
@@ -125,6 +133,38 @@ EXAMPLES = r'''
         protected: true
         variable_type: env_var
         environment_scope: production
+
+- name: Set or update some CI/CD variables with raw value
+  community.general.gitlab_group_variable:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    group: scodeman/testgroup/
+    purge: false
+    vars:
+      ACCESS_KEY_ID: abc123
+      SECRET_ACCESS_KEY:
+        value: 3214cbad
+        masked: true
+        protected: true
+        raw: true
+        variable_type: env_var
+        environment_scope: '*'
+
+- name: Set or update some CI/CD variables with expandable value
+  community.general.gitlab_group_variable:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    group: scodeman/testgroup/
+    purge: false
+    vars:
+      ACCESS_KEY_ID: abc123
+      SECRET_ACCESS_KEY:
+        value: '$MY_OTHER_VARIABLE'
+        masked: true
+        protected: true
+        raw: false
+        variable_type: env_var
+        environment_scope: '*'
 
 - name: Delete one variable
   community.general.gitlab_group_variable:
@@ -199,6 +239,7 @@ class GitlabGroupVariables(object):
             "value": var_obj.get('value'),
             "masked": var_obj.get('masked'),
             "protected": var_obj.get('protected'),
+            "raw": var_obj.get('raw'),
             "variable_type": var_obj.get('variable_type'),
         }
         if var_obj.get('environment_scope') is not None:
@@ -267,6 +308,8 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
             item['protected'] = False
+        if item.get('raw') is None:
+            item['raw'] = False
         if item.get('masked') is None:
             item['masked'] = False
         if item.get('environment_scope') is None:
@@ -343,6 +386,7 @@ def main():
             value=dict(type='str', no_log=True),
             masked=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),
+            raw=dict(type='bool', default=False),
             environment_scope=dict(type='str', default='*'),
             variable_type=dict(type='str', default='env_var', choices=["env_var", "file"])
         )),

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -51,11 +51,12 @@ options:
     type: bool
   vars:
     description:
-      - When the list element is a simple key-value pair, masked and protected will be set to false.
-      - When the list element is a dict with the keys C(value), C(masked) and C(protected), the user can
-        have full control about whether a value should be masked, protected or both.
+      - When the list element is a simple key-value pair, masked, raw and protected will be set to false.
+      - When the list element is a dict with the keys C(value), C(masked), C(raw) and C(protected), the user can
+        have full control about whether a value should be masked, raw, protected or both.
       - Support for protected values requires GitLab >= 9.3.
       - Support for masked values requires GitLab >= 11.10.
+      - Support for raw values requires GitLab >= 15.7.
       - Support for environment_scope requires GitLab Premium >= 13.11.
       - Support for variable_type requires GitLab >= 11.11.
       - A C(value) must be a string or a number.
@@ -96,6 +97,13 @@ options:
           - Support for protected values requires GitLab >= 9.3.
         type: bool
         default: false
+      raw:
+        description:
+          - Wether variable value is raw or not.
+          - Support for raw values requires GitLab >= 15.7.
+        type: bool
+        default: false
+        version_added: '7.4.0'
       variable_type:
         description:
           - Wether a variable is an environment variable (V(env_var)) or a file (V(file)).
@@ -140,6 +148,38 @@ EXAMPLES = '''
         value: 3214cbad
         masked: true
         protected: true
+        variable_type: env_var
+        environment_scope: '*'
+
+- name: Set or update some CI/CD variables with raw value
+  community.general.gitlab_project_variable:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    project: markuman/dotfiles
+    purge: false
+    vars:
+      ACCESS_KEY_ID: abc123
+      SECRET_ACCESS_KEY:
+        value: 3214cbad
+        masked: true
+        protected: true
+        raw: true
+        variable_type: env_var
+        environment_scope: '*'
+
+- name: Set or update some CI/CD variables with expandable value
+  community.general.gitlab_project_variable:
+    api_url: https://gitlab.com
+    api_token: secret_access_token
+    project: markuman/dotfiles
+    purge: false
+    vars:
+      ACCESS_KEY_ID: abc123
+      SECRET_ACCESS_KEY:
+        value: '$MY_OTHER_VARIABLE'
+        masked: true
+        protected: true
+        raw: false
         variable_type: env_var
         environment_scope: '*'
 
@@ -220,6 +260,7 @@ class GitlabProjectVariables(object):
             "value": var_obj.get('value'),
             "masked": var_obj.get('masked'),
             "protected": var_obj.get('protected'),
+            "raw": var_obj.get('raw'),
             "variable_type": var_obj.get('variable_type'),
         }
 
@@ -290,6 +331,8 @@ def native_python_main(this_gitlab, purge, requested_variables, state, module):
         item['value'] = str(item.get('value'))
         if item.get('protected') is None:
             item['protected'] = False
+        if item.get('raw') is None:
+            item['raw'] = False
         if item.get('masked') is None:
             item['masked'] = False
         if item.get('environment_scope') is None:
@@ -366,6 +409,7 @@ def main():
             value=dict(type='str', no_log=True),
             masked=dict(type='bool', default=False),
             protected=dict(type='bool', default=False),
+            raw=dict(type='bool', default=False),
             environment_scope=dict(type='str', default='*'),
             variable_type=dict(type='str', default='env_var', choices=["env_var", "file"]),
         )),


### PR DESCRIPTION
##### SUMMARY
This PR adds support for `raw` suboption in `gitlab_group_variable` and `gitlab_project_variable` modules.

Fixes #5685 

##### ISSUE TYPE
- New option for existing modules

##### COMPONENT NAME
- gitlab_group_variable
- gitlab_project_variable

##### ADDITIONAL INFORMATION
This PR includes 2 modules changes since the added feature is exactly the same.