### PR TITLE
redfish_info: Report Id in GetManagerInventory output

### DIFF
--- a/changelogs/fragments/7140-id-getmanagerinv-output.yml
+++ b/changelogs/fragments/7140-id-getmanagerinv-output.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_info - report ``Id`` in the output of ``GetManagerInventory`` (https://github.com/ansible-collections/community.general/pull/7140).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -3344,7 +3344,7 @@ class RedfishUtils(object):
         result = {}
         inventory = {}
         # Get these entries, but does not fail if not found
-        properties = ['FirmwareVersion', 'ManagerType', 'Manufacturer', 'Model',
+        properties = ['Id', 'FirmwareVersion', 'ManagerType', 'Manufacturer', 'Model',
                       'PartNumber', 'PowerState', 'SerialNumber', 'Status', 'UUID']
 
         response = self.get_request(self.root_uri + manager_uri)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add Id to the output of GetManagerInventory. This is to make it easier to filter down the list of results for servers with multiple managers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

redfish_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Prior to this change, it was not have been possible to filter down a list of multiple managers in the way shown below (by id).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

  - name: Get BMC info
    community.general.redfish_info:
      category: Manager
      command: GetManagerInventory
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
    register: redfish_bmc_info

  - debug:
      var: redfish_bmc_info.redfish_facts.manager.entries | map('last') | selectattr('Id', '==', '$ID_MANAGER_OF_INTEREST')


```
