### PR TITLE
Update incorrect path for pritunl organization post

### DIFF
--- a/changelogs/fragments/7161-fix-incorrect-post-parameter.yml
+++ b/changelogs/fragments/7161-fix-incorrect-post-parameter.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- pritunl module utils - fix incorrect url parameter for orgnization add method. (https://github.com/ansible-collections/community.general/pull/7161).

--- a/changelogs/fragments/7161-fix-incorrect-post-parameter.yml
+++ b/changelogs/fragments/7161-fix-incorrect-post-parameter.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- pritunl module utils - fix incorrect url parameter for orgnization add method. (https://github.com/ansible-collections/community.general/pull/7161).
+- pritunl module utils - fix incorrect URL parameter for orgnization add method (https://github.com/ansible-collections/community.general/pull/7161).

--- a/plugins/module_utils/net_tools/pritunl/api.py
+++ b/plugins/module_utils/net_tools/pritunl/api.py
@@ -79,7 +79,7 @@ def _post_pritunl_organization(
         api_secret=api_secret,
         base_url=base_url,
         method="POST",
-        path="/organization/%s",
+        path="/organization",
         headers={"Content-Type": "application/json"},
         data=json.dumps(organization_data),
         validate_certs=validate_certs,


### PR DESCRIPTION
##### SUMMARY
Fix Pritunl API incorrect URL parameters.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.general.pritunl_org

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE
```console
TASK [pritunl-server-ubuntu : Install Pritunl | Create Organisation]
fatal: [server01-vm_8aac]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "force": false,
            "name": "orgName",
            "pritunl_api_secret": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "pritunl_api_token": "HIDDEN",
            "pritunl_url": "https://HIDDEN",
            "state": "present",
            "validate_certs": false
        }
    },
    "msg": "HTTP Error 307: Temporary Redirect"
}

```

AFTER
```console
TASK [pritunl-server-ubuntu : Install Pritunl | Create Organisation]
ok: [server01-vm_8aac]
```

