### PR TITLE
xfconf*: using yaml-specified unit tests

### DIFF
--- a/tests/unit/plugins/modules/test_opkg.py
+++ b/tests/unit/plugins/modules/test_opkg.py
@@ -24,7 +24,7 @@ with open("tests/unit/plugins/modules/test_opkg.yaml", "r") as TEST_CASES:
                          helper.testcases_params, ids=helper.testcases_ids,
                          indirect=['patch_ansible_module'])
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_opkg(mocker, capfd, patch_bin, testcase):
+def test_module(mocker, capfd, patch_bin, testcase):
     """
     Run unit tests for test cases listed in TEST_CASES
     """

--- a/tests/unit/plugins/modules/test_xfconf.py
+++ b/tests/unit/plugins/modules/test_xfconf.py
@@ -13,300 +13,34 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-
-from ansible_collections.community.general.plugins.modules import xfconf
+from ansible_collections.community.general.plugins.modules import xfconf as module
 
 import pytest
 
-TESTED_MODULE = xfconf.__name__
+from .cmd_runner_test_utils import CmdRunnerTestHelper
 
 
-@pytest.fixture
-def patch_xfconf(mocker):
-    """
-    Function used for mocking some parts of redhat_subscription module
-    """
-    mocker.patch('ansible_collections.community.general.plugins.module_utils.mh.module_helper.AnsibleModule.get_bin_path',
-                 return_value='/testbin/xfconf-query')
-
-
-@pytest.mark.parametrize('patch_ansible_module', [{}], indirect=['patch_ansible_module'])
-@pytest.mark.usefixtures('patch_ansible_module')
-def test_without_required_parameters(capfd, patch_xfconf):
-    """
-    Failure must occurs when all parameters are missing
-    """
-    with pytest.raises(SystemExit):
-        xfconf.main()
-    out, err = capfd.readouterr()
-    results = json.loads(out)
-    assert results['failed']
-    assert 'missing required arguments' in results['msg']
-
-
-TEST_CASES = [
-    [
-        {
-            'channel': 'xfwm4',
-            'property': '/general/inactive_opacity',
-            'state': 'present',
-            'value_type': 'int',
-            'value': 90,
-        },
-        {
-            'id': 'test_property_set_property',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '100\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
-                     '--create', '--type', 'int', '--set', '90'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '', '',),
-                ),
-            ],
-            'changed': True,
-            'previous_value': '100',
-            'value_type': 'int',
-            'value': '90',
-        },
-    ],
-    [
-        {
-            'channel': 'xfwm4',
-            'property': '/general/inactive_opacity',
-            'state': 'present',
-            'value_type': 'int',
-            'value': 90,
-        },
-        {
-            'id': 'test_property_set_property_same_value',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '90\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity',
-                     '--create', '--type', 'int', '--set', '90'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '', '',),
-                ),
-            ],
-            'changed': False,
-            'previous_value': '90',
-            'value_type': 'int',
-            'value': '90',
-        },
-    ],
-    [
-        {
-            'channel': 'xfce4-session',
-            'property': '/general/SaveOnExit',
-            'state': 'present',
-            'value_type': 'bool',
-            'value': False,
-        },
-        {
-            'id': 'test_property_set_property_bool_false',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfce4-session', '--property', '/general/SaveOnExit'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'true\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfce4-session', '--property', '/general/SaveOnExit',
-                     '--create', '--type', 'bool', '--set', 'false'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'false\n', '',),
-                ),
-            ],
-            'changed': True,
-            'previous_value': 'true',
-            'value_type': 'bool',
-            'value': 'False',
-        },
-    ],
-    [
-        {
-            'channel': 'xfwm4',
-            'property': '/general/workspace_names',
-            'state': 'present',
-            'value_type': 'string',
-            'value': ['A', 'B', 'C'],
-        },
-        {
-            'id': 'test_property_set_array',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
-                     '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
-                     '--type', 'string', '--set', 'C'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '', '',),
-                ),
-            ],
-            'changed': True,
-            'previous_value': ['Main', 'Work', 'Tmp'],
-            'value_type': ['str', 'str', 'str'],
-            'value': ['A', 'B', 'C'],
-        },
-    ],
-    [
-        {
-            'channel': 'xfwm4',
-            'property': '/general/workspace_names',
-            'state': 'present',
-            'value_type': 'string',
-            'value': ['A', 'B', 'C'],
-        },
-        {
-            'id': 'test_property_set_array_to_same_value',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
-                     '--create', '--force-array', '--type', 'string', '--set', 'A', '--type', 'string', '--set', 'B',
-                     '--type', 'string', '--set', 'C'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '', '',),
-                ),
-            ],
-            'changed': False,
-            'previous_value': ['A', 'B', 'C'],
-            'value_type': ['str', 'str', 'str'],
-            'value': ['A', 'B', 'C'],
-        },
-    ],
-    [
-        {
-            'channel': 'xfwm4',
-            'property': '/general/workspace_names',
-            'state': 'absent',
-        },
-        {
-            'id': 'test_property_reset_value',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'Value is an array with 3 items:\n\nA\nB\nC\n', '',),
-                ),
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names',
-                     '--reset'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': False},
-                    # Mock of returned code, stdout and stderr
-                    (0, '', '',),
-                ),
-            ],
-            'changed': True,
-            'previous_value': ['A', 'B', 'C'],
-            'value_type': None,
-            'value': None,
-        },
-    ],
-]
-TEST_CASES_IDS = [item[1]['id'] for item in TEST_CASES]
+TESTED_MODULE = module.__name__
+with open("tests/unit/plugins/modules/test_xfconf.yaml", "r") as TEST_CASES:
+    helper = CmdRunnerTestHelper(command="xfconf-query", test_cases=TEST_CASES)
+    patch_bin = helper.cmd_fixture
 
 
 @pytest.mark.parametrize('patch_ansible_module, testcase',
-                         TEST_CASES,
-                         ids=TEST_CASES_IDS,
+                         helper.testcases_params, ids=helper.testcases_ids,
                          indirect=['patch_ansible_module'])
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_xfconf(mocker, capfd, patch_xfconf, testcase):
+def test_module(mocker, capfd, patch_bin, testcase):
     """
-    Run unit tests for test cases listen in TEST_CASES
+    Run unit tests for test cases listed in TEST_CASES
     """
 
-    # Mock function used for running commands first
-    call_results = [item[2] for item in testcase['run_command.calls']]
-    mock_run_command = mocker.patch(
-        'ansible.module_utils.basic.AnsibleModule.run_command',
-        side_effect=call_results)
+    with helper(testcase, mocker) as ctx:
+        # Try to run test case
+        with pytest.raises(SystemExit):
+            module.main()
 
-    # Try to run test case
-    with pytest.raises(SystemExit):
-        xfconf.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
 
-    out, err = capfd.readouterr()
-    results = json.loads(out)
-    print("testcase =\n%s" % testcase)
-    print("results =\n%s" % results)
-
-    assert 'changed' in results
-    assert results['changed'] == testcase['changed']
-
-    for test_result in ('channel', 'property'):
-        assert test_result in results, "'{0}' not found in {1}".format(test_result, results)
-        assert results[test_result] == results['invocation']['module_args'][test_result], \
-            "'{0}': '{1}' != '{2}'".format(test_result, results[test_result], results['invocation']['module_args'][test_result])
-
-    assert mock_run_command.call_count == len(testcase['run_command.calls'])
-    if mock_run_command.call_count:
-        call_args_list = [(item[0][0], item[1]) for item in mock_run_command.call_args_list]
-        expected_call_args_list = [(item[0], item[1]) for item in testcase['run_command.calls']]
-        print("call args list =\n%s" % call_args_list)
-        print("expected args list =\n%s" % expected_call_args_list)
-        assert call_args_list == expected_call_args_list
-
-        expected_cmd, dummy, expected_res = testcase['run_command.calls'][-1]
-        assert results['cmd'] == expected_cmd
-        assert results['stdout'] == expected_res[1]
-        assert results['stderr'] == expected_res[2]
-
-    for conditional_test_result in ('msg', 'value', 'previous_value'):
-        if conditional_test_result in testcase:
-            assert conditional_test_result in results, "'{0}' not found in {1}".format(conditional_test_result, results)
-            assert results[conditional_test_result] == testcase[conditional_test_result], \
-                "'{0}': '{1}' != '{2}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
+        ctx.check_results(results)

--- a/tests/unit/plugins/modules/test_xfconf.yaml
+++ b/tests/unit/plugins/modules/test_xfconf.yaml
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Alexei Znamensky (russoz@gmail.com)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+---
+- id: test_missing_input
+  input: {}
+  output:
+    failed: true
+    msg: "missing required arguments: channel, property"
+- id: test_property_set_property
+  input:
+    channel: xfwm4
+    property: /general/inactive_opacity
+    state: present
+    value_type: int
+    value: 90
+  output:
+    changed: true
+    previous_value: '100'
+    type: int
+    value: '90'
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/inactive_opacity]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "100\n"
+      err: ""
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/inactive_opacity, --create, --type, int, --set, '90']
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: ""
+      err: ""
+- id: test_property_set_property_same_value
+  input:
+    channel: xfwm4
+    property: /general/inactive_opacity
+    state: present
+    value_type: int
+    value: 90
+  output:
+    changed: false
+    previous_value: '90'
+    type: int
+    value: '90'
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/inactive_opacity]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "90\n"
+      err: ""
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/inactive_opacity, --create, --type, int, --set, '90']
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: ""
+      err: ""
+- id: test_property_set_property_bool_false
+  input:
+    channel: xfce4-session
+    property: /general/SaveOnExit
+    state: present
+    value_type: bool
+    value: False
+  output:
+    changed: true
+    previous_value: 'true'
+    type: bool
+    value: 'False'
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfce4-session, --property, /general/SaveOnExit]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "true\n"
+      err: ""
+    - command: [/testbin/xfconf-query, --channel, xfce4-session, --property, /general/SaveOnExit, --create, --type, bool, --set, 'false']
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "false\n"
+      err: ""
+- id: test_property_set_array
+  input:
+    channel: xfwm4
+    property: /general/workspace_names
+    state: present
+    value_type: string
+    value: [A, B, C]
+  output:
+    changed: true
+    previous_value: [Main, Work, Tmp]
+    type: [string, string, string]
+    value: [A, B, C]
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/workspace_names]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "Value is an array with 3 items:\n\nMain\nWork\nTmp\n"
+      err: ""
+    - command:
+        - /testbin/xfconf-query
+        - --channel
+        - xfwm4
+        - --property
+        - /general/workspace_names
+        - --create
+        - --force-array
+        - --type
+        - string
+        - --set
+        - A
+        - --type
+        - string
+        - --set
+        - B
+        - --type
+        - string
+        - --set
+        - C
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: ""
+      err: ""
+- id: test_property_set_array_to_same_value
+  input:
+    channel: xfwm4
+    property: /general/workspace_names
+    state: present
+    value_type: string
+    value: [A, B, C]
+  output:
+    changed: false
+    previous_value: [A, B, C]
+    type: [string, string, string]
+    value: [A, B, C]
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/workspace_names]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "Value is an array with 3 items:\n\nA\nB\nC\n"
+      err: ""
+    - command:
+        - /testbin/xfconf-query
+        - --channel
+        - xfwm4
+        - --property
+        - /general/workspace_names
+        - --create
+        - --force-array
+        - --type
+        - string
+        - --set
+        - A
+        - --type
+        - string
+        - --set
+        - B
+        - --type
+        - string
+        - --set
+        - C
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: ""
+      err: ""
+- id: test_property_reset_value
+  input:
+    channel: xfwm4
+    property: /general/workspace_names
+    state: absent
+  output:
+    changed: true
+    previous_value: [A, B, C]
+    type: null
+    value: null
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/workspace_names]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: "Value is an array with 3 items:\n\nA\nB\nC\n"
+      err: ""
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/workspace_names, --reset]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: false}
+      rc: 0
+      out: ""
+      err: ""

--- a/tests/unit/plugins/modules/test_xfconf_info.py
+++ b/tests/unit/plugins/modules/test_xfconf_info.py
@@ -6,167 +6,34 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-
-from ansible_collections.community.general.plugins.modules import xfconf_info
+from ansible_collections.community.general.plugins.modules import xfconf_info as module
 
 import pytest
 
-TESTED_MODULE = xfconf_info.__name__
+from .cmd_runner_test_utils import CmdRunnerTestHelper
 
 
-@pytest.fixture
-def patch_xfconf_info(mocker):
-    """
-    Function used for mocking some parts of redhat_subscription module
-    """
-    mocker.patch('ansible_collections.community.general.plugins.module_utils.mh.module_helper.AnsibleModule.get_bin_path',
-                 return_value='/testbin/xfconf-query')
-
-
-TEST_CASES = [
-    [
-        {'channel': 'xfwm4', 'property': '/general/inactive_opacity'},
-        {
-            'id': 'test_simple_property_get',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/inactive_opacity'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
-                    # Mock of returned code, stdout and stderr
-                    (0, '100\n', '',),
-                ),
-            ],
-            'is_array': False,
-            'value': '100',
-        }
-    ],
-    [
-        {'channel': 'xfwm4', 'property': '/general/i_dont_exist'},
-        {
-            'id': 'test_simple_property_get_nonexistent',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/i_dont_exist'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
-                    # Mock of returned code, stdout and stderr
-                    (1, '', 'Property "/general/i_dont_exist" does not exist on channel "xfwm4".\n',),
-                ),
-            ],
-            'is_array': False,
-        }
-    ],
-    [
-        {'property': '/general/i_dont_exist'},
-        {
-            'id': 'test_property_no_channel',
-            'run_command.calls': [],
-        }
-    ],
-    [
-        {'channel': 'xfwm4', 'property': '/general/workspace_names'},
-        {
-            'id': 'test_property_get_array',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--channel', 'xfwm4', '--property', '/general/workspace_names'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'Value is an array with 3 items:\n\nMain\nWork\nTmp\n', '',),
-                ),
-            ],
-            'is_array': True,
-            'value_array': ['Main', 'Work', 'Tmp'],
-        },
-    ],
-    [
-        {},
-        {
-            'id': 'get_channels',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--list'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
-                    # Mock of returned code, stdout and stderr
-                    (0, 'Channels:\n  a\n  b\n  c\n', '',),
-                ),
-            ],
-            'is_array': False,
-            'channels': ['a', 'b', 'c'],
-        },
-    ],
-    [
-        {'channel': 'xfwm4'},
-        {
-            'id': 'get_properties',
-            'run_command.calls': [
-                (
-                    # Calling of following command will be asserted
-                    ['/testbin/xfconf-query', '--list', '--channel', 'xfwm4'],
-                    # Was return code checked?
-                    {'environ_update': {'LANGUAGE': 'C', 'LC_ALL': 'C'}, 'check_rc': True},
-                    # Mock of returned code, stdout and stderr
-                    (0, '/general/wrap_cycle\n/general/wrap_layout\n/general/wrap_resistance\n/general/wrap_windows\n'
-                        '/general/wrap_workspaces\n/general/zoom_desktop\n', '',),
-                ),
-            ],
-            'is_array': False,
-            'properties': [
-                '/general/wrap_cycle',
-                '/general/wrap_layout',
-                '/general/wrap_resistance',
-                '/general/wrap_windows',
-                '/general/wrap_workspaces',
-                '/general/zoom_desktop',
-            ],
-        },
-    ],
-]
-TEST_CASES_IDS = [item[1]['id'] for item in TEST_CASES]
+TESTED_MODULE = module.__name__
+with open("tests/unit/plugins/modules/test_xfconf_info.yaml", "r") as TEST_CASES:
+    helper = CmdRunnerTestHelper(command="xfconf-query", test_cases=TEST_CASES)
+    patch_bin = helper.cmd_fixture
 
 
 @pytest.mark.parametrize('patch_ansible_module, testcase',
-                         TEST_CASES,
-                         ids=TEST_CASES_IDS,
+                         helper.testcases_params, ids=helper.testcases_ids,
                          indirect=['patch_ansible_module'])
 @pytest.mark.usefixtures('patch_ansible_module')
-def test_xfconf_info(mocker, capfd, patch_xfconf_info, testcase):
+def test_module(mocker, capfd, patch_bin, testcase):
     """
-    Run unit tests for test cases listen in TEST_CASES
+    Run unit tests for test cases listed in TEST_CASES
     """
 
-    # Mock function used for running commands first
-    call_results = [item[2] for item in testcase['run_command.calls']]
-    mock_run_command = mocker.patch(
-        'ansible_collections.community.general.plugins.module_utils.mh.module_helper.AnsibleModule.run_command',
-        side_effect=call_results)
+    with helper(testcase, mocker) as ctx:
+        # Try to run test case
+        with pytest.raises(SystemExit):
+            module.main()
 
-    # Try to run test case
-    with pytest.raises(SystemExit):
-        xfconf_info.main()
+        out, err = capfd.readouterr()
+        results = json.loads(out)
 
-    out, err = capfd.readouterr()
-    results = json.loads(out)
-    print("testcase =\n%s" % testcase)
-    print("results =\n%s" % results)
-
-    for conditional_test_result in ('value_array', 'value', 'is_array', 'properties', 'channels'):
-        if conditional_test_result in testcase:
-            assert conditional_test_result in results, "'{0}' not found in {1}".format(conditional_test_result, results)
-            assert results[conditional_test_result] == testcase[conditional_test_result], \
-                "'{0}': '{1}' != '{2}'".format(conditional_test_result, results[conditional_test_result], testcase[conditional_test_result])
-
-    assert mock_run_command.call_count == len(testcase['run_command.calls'])
-    if mock_run_command.call_count:
-        call_args_list = [(item[0][0], item[1]) for item in mock_run_command.call_args_list]
-        expected_call_args_list = [(item[0], item[1]) for item in testcase['run_command.calls']]
-        print("call args list =\n%s" % call_args_list)
-        print("expected args list =\n%s" % expected_call_args_list)
-        assert call_args_list == expected_call_args_list
+        ctx.check_results(results)

--- a/tests/unit/plugins/modules/test_xfconf_info.yaml
+++ b/tests/unit/plugins/modules/test_xfconf_info.yaml
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Alexei Znamensky (russoz@gmail.com)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+---
+- id: test_simple_property_get
+  input:
+    channel: xfwm4
+    property: /general/inactive_opacity
+  output:
+    value: '100'
+    is_array: false
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/inactive_opacity]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: true}
+      rc: 0
+      out: "100\n"
+      err: ""
+- id: test_simple_property_get_nonexistent
+  input:
+    channel: xfwm4
+    property: /general/i_dont_exist
+  output: {}
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/i_dont_exist]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: true}
+      rc: 1
+      out: ""
+      err: 'Property "/general/i_dont_exist" does not exist on channel "xfwm4".\n'
+- id: test_property_no_channel
+  input:
+    property: /general/i_dont_exist
+  output:
+    failed: true
+    msg: "missing parameter(s) required by 'property': channel"
+  run_command_calls: []
+- id: test_property_get_array
+  input:
+    channel: xfwm4
+    property: /general/workspace_names
+  output:
+    is_array: true
+    value_array: [Main, Work, Tmp]
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --channel, xfwm4, --property, /general/workspace_names]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: true}
+      rc: 0
+      out: "Value is an array with 3 items:\n\nMain\nWork\nTmp\n"
+      err: ""
+- id: get_channels
+  input: {}
+  output:
+    channels: [a, b, c]
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --list]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: true}
+      rc: 0
+      out: "Channels:\n  a\n  b\n  c\n"
+      err: ""
+- id: get_properties
+  input:
+    channel: xfwm4
+  output:
+    properties:
+      - /general/wrap_cycle
+      - /general/wrap_layout
+      - /general/wrap_resistance
+      - /general/wrap_windows
+      - /general/wrap_workspaces
+      - /general/zoom_desktop
+  run_command_calls:
+    - command: [/testbin/xfconf-query, --list, --channel, xfwm4]
+      environ: {environ_update: {LANGUAGE: C, LC_ALL: C}, check_rc: true}
+      rc: 0
+      out: |
+        /general/wrap_cycle
+        /general/wrap_layout
+        /general/wrap_resistance
+        /general/wrap_windows
+        /general/wrap_workspaces
+        /general/zoom_desktop
+      err: ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using the new YAML-spec for CmdRunner tests from #7154 for unit tests of `xfconf` and `xfconf_info`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
xfconf
xfconf_info
