### PR TITLE
CI: make sure EXTERNALLY-MANAGED is absent on Arch Linux

### DIFF
--- a/tests/integration/targets/setup_pkg_mgr/tasks/archlinux.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/archlinux.yml
@@ -21,3 +21,8 @@
     update_cache: true
     upgrade: true
   when: archlinux_upgrade_tag is changed
+
+- name: Remove EXTERNALLY-MANAGED file
+  file:
+    path: /usr/lib/python{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}/EXTERNALLY-MANAGED
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Arch Linux tests are currently failing in CI once they try to install something with `pip`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
