### PR TITLE
community.general.make:

### DIFF
--- a/changelogs/fragments/7180-make_params_without_value.yml
+++ b/changelogs/fragments/7180-make_params_without_value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - make module - allows params to be used without value

--- a/changelogs/fragments/7180-make_params_without_value.yml
+++ b/changelogs/fragments/7180-make_params_without_value.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - make module - allows params to be used without value
+  - make - allows ``params`` to be used without value (https://github.com/ansible-collections/community.general/pull/7180).

--- a/plugins/modules/make.py
+++ b/plugins/modules/make.py
@@ -49,6 +49,7 @@ options:
   params:
     description:
       - Any extra parameters to pass to make.
+      - If the value is empty, only the key will be used. For example, V(FOO:) will produce V(FOO), not V(FOO=).
     type: dict
   target:
     description:

--- a/plugins/modules/make.py
+++ b/plugins/modules/make.py
@@ -90,6 +90,16 @@ EXAMPLES = r'''
     chdir: /home/ubuntu/cool-project
     target: all
     file: /some-project/Makefile
+
+- name: build arm64 kernel on FreeBSD, with 16 parallel jobs
+  community.general.make:
+    chdir: /usr/src
+    jobs: 16
+    target: buildkernel
+    params:
+      -DWITH_FDT:
+      TARGET_ARCH: aarch64
+      TARGET: arm64
 '''
 
 RETURN = r'''

--- a/plugins/modules/make.py
+++ b/plugins/modules/make.py
@@ -98,9 +98,11 @@ EXAMPLES = r'''
     jobs: 16
     target: buildkernel
     params:
+      # This adds -DWITH_FDT to the command line:
       -DWITH_FDT:
-      TARGET_ARCH: aarch64
+      # The following adds TARGET=arm64 TARGET_ARCH=aarch64 to the command line:
       TARGET: arm64
+      TARGET_ARCH: aarch64
 '''
 
 RETURN = r'''

--- a/plugins/modules/make.py
+++ b/plugins/modules/make.py
@@ -190,7 +190,7 @@ def main():
             # Fall back to system make
             make_path = module.get_bin_path('make', required=True)
     if module.params['params'] is not None:
-        make_parameters = [k + (('=' + str(v)) if v != None else '') for k, v in iteritems(module.params['params'])]
+        make_parameters = [k + (('=' + str(v)) if v is not None else '') for k, v in iteritems(module.params['params'])]
     else:
         make_parameters = []
 

--- a/plugins/modules/make.py
+++ b/plugins/modules/make.py
@@ -190,7 +190,7 @@ def main():
             # Fall back to system make
             make_path = module.get_bin_path('make', required=True)
     if module.params['params'] is not None:
-        make_parameters = [k + '=' + str(v) for k, v in iteritems(module.params['params'])]
+        make_parameters = [k + (('=' + str(v)) if v != None else '') for k, v in iteritems(module.params['params'])]
     else:
         make_parameters = []
 


### PR DESCRIPTION
allows to use parameters with empty value in community.general.make.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, params with empty value get set as None, which is not useful and can lead to unexpected behavior.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #7178
<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
make
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Currently this code, used to build freebsd from sources:
```
community.general.make:
  target: buildworld
  chdir: "{{ freebsd_src_dir }}"
  params:
    -DWITH_FDT:
    TARGET: arm64
```
produces `make -DWITH_FDT=None TARGET=arm64`  while `make -DWITH_FDT TARGET=arm64` is expected. 
Note the absence of "=None" for -DWITH_FDT.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
