### PR TITLE
remove extraneous unused constant

### DIFF
--- a/tests/unit/plugins/modules/test_cpanm.py
+++ b/tests/unit/plugins/modules/test_cpanm.py
@@ -18,8 +18,6 @@ from ansible_collections.community.general.plugins.modules import cpanm
 
 import pytest
 
-TESTED_MODULE = cpanm.__name__
-
 
 @pytest.fixture
 def patch_cpanm(mocker):

--- a/tests/unit/plugins/modules/test_gconftool2.py
+++ b/tests/unit/plugins/modules/test_gconftool2.py
@@ -12,8 +12,6 @@ from ansible_collections.community.general.plugins.modules import gconftool2
 
 import pytest
 
-TESTED_MODULE = gconftool2.__name__
-
 
 @pytest.fixture
 def patch_gconftool2(mocker):

--- a/tests/unit/plugins/modules/test_gconftool2_info.py
+++ b/tests/unit/plugins/modules/test_gconftool2_info.py
@@ -12,8 +12,6 @@ from ansible_collections.community.general.plugins.modules import gconftool2_inf
 
 import pytest
 
-TESTED_MODULE = gconftool2_info.__name__
-
 
 @pytest.fixture
 def patch_gconftool2_info(mocker):

--- a/tests/unit/plugins/modules/test_opkg.py
+++ b/tests/unit/plugins/modules/test_opkg.py
@@ -14,7 +14,6 @@ import pytest
 from .cmd_runner_test_utils import CmdRunnerTestHelper
 
 
-TESTED_MODULE = module.__name__
 with open("tests/unit/plugins/modules/test_opkg.yaml", "r") as TEST_CASES:
     helper = CmdRunnerTestHelper(command="opkg", test_cases=TEST_CASES)
     patch_bin = helper.cmd_fixture

--- a/tests/unit/plugins/modules/test_puppet.py
+++ b/tests/unit/plugins/modules/test_puppet.py
@@ -19,8 +19,6 @@ from ansible_collections.community.general.plugins.modules import puppet
 
 import pytest
 
-TESTED_MODULE = puppet.__name__
-
 
 ModuleTestCase = namedtuple("ModuleTestCase", ["id", "input", "output", "run_command_calls"])
 RunCmdCall = namedtuple("RunCmdCall", ["command", "environ", "rc", "out", "err"])

--- a/tests/unit/plugins/modules/test_snap.py
+++ b/tests/unit/plugins/modules/test_snap.py
@@ -13,8 +13,6 @@ from ansible_collections.community.general.plugins.modules import snap
 
 import pytest
 
-TESTED_MODULE = snap.__name__
-
 
 ModuleTestCase = namedtuple("ModuleTestCase", ["id", "input", "output", "run_command_calls"])
 RunCmdCall = namedtuple("RunCmdCall", ["command", "environ", "rc", "out", "err"])

--- a/tests/unit/plugins/modules/test_xfconf.py
+++ b/tests/unit/plugins/modules/test_xfconf.py
@@ -20,7 +20,6 @@ import pytest
 from .cmd_runner_test_utils import CmdRunnerTestHelper
 
 
-TESTED_MODULE = module.__name__
 with open("tests/unit/plugins/modules/test_xfconf.yaml", "r") as TEST_CASES:
     helper = CmdRunnerTestHelper(command="xfconf-query", test_cases=TEST_CASES)
     patch_bin = helper.cmd_fixture

--- a/tests/unit/plugins/modules/test_xfconf_info.py
+++ b/tests/unit/plugins/modules/test_xfconf_info.py
@@ -13,7 +13,6 @@ import pytest
 from .cmd_runner_test_utils import CmdRunnerTestHelper
 
 
-TESTED_MODULE = module.__name__
 with open("tests/unit/plugins/modules/test_xfconf_info.yaml", "r") as TEST_CASES:
     helper = CmdRunnerTestHelper(command="xfconf-query", test_cases=TEST_CASES)
     patch_bin = helper.cmd_fixture


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The constant `TESTED_MODULE` was copied from a previously existing test module, and it has been replicated over and over in these other tests. however, it is apparently not really used, so this PR trims the extra baggage.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
tests/unit/plugins/modules/test_cpanm.py
tests/unit/plugins/modules/test_gconftool2.py
tests/unit/plugins/modules/test_gconftool2_info.py
tests/unit/plugins/modules/test_opkg.py
tests/unit/plugins/modules/test_puppet.py
tests/unit/plugins/modules/test_snap.py
tests/unit/plugins/modules/test_xfconf.py
tests/unit/plugins/modules/test_xfconf_info.py
