### PR TITLE
feat(gitlab_runner module): Add support for the new runner creation workflow

### DIFF
--- a/changelogs/fragments/7199-gitlab-runner-new-creation-workflow.yml
+++ b/changelogs/fragments/7199-gitlab-runner-new-creation-workflow.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_runner - add support for new runner creation workflow (https://github.com/ansible-collections/community.general/pull/7199).


### PR DESCRIPTION
##### SUMMARY
This PR adds support  for the new GitLab Runner creation workflow.

See docs here : https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_runner module

##### ADDITIONAL INFORMATION
In GitLab's new API endpoint, `active` option is not supported any more (deprecated since 14.8, latest version is 16.4), and replaced with `paused`.

Both options are here handled (mutually exclusive) to keep backward compatibility. Another PR will be necessary to deprecate `active` option following GitLab evolution.

Fixes #3742

**NB :** This PR will keep Draft status until `python-gitlab` next release including the new API endpoint.
