### PR TITLE
nsupdate: fix 'index out of range' error when no TTL answer is given

### DIFF
--- a/changelogs/fragments/7219-fix-nsupdate-cname.yaml
+++ b/changelogs/fragments/7219-fix-nsupdate-cname.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - fix a possible `list index out of range` exception (https://github.com/ansible-collections/community.general/issues/836).

--- a/changelogs/fragments/7219-fix-nsupdate-cname.yaml
+++ b/changelogs/fragments/7219-fix-nsupdate-cname.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nsupdate - fix a possible `list index out of range` exception (https://github.com/ansible-collections/community.general/issues/836).
+  - nsupdate - fix a possible ``list index out of range`` exception (https://github.com/ansible-collections/community.general/issues/836).

--- a/plugins/modules/nsupdate.py
+++ b/plugins/modules/nsupdate.py
@@ -467,10 +467,8 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
-        if self.module.params['type'] == 'NS':
-            current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
-        else:
-            current_ttl = lookup.answer[0].ttl
+        current_ttl = lookup.answer[0].ttl if lookup.answer else lookup.authority[0].ttl
+
         return current_ttl != self.module.params['ttl']
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Fix a possible `list index out of range` when no answer is returned in the `ttl_changed` method by applying the existing workaround for NS records to all record types.

Resolves #836

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

nsupdate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #836

<!--- Paste verbatim command output below, e.g. before and after your change -->

