### PR TITLE
gitlab_user: fix, ssh keys in gitlab are identified by their id

### DIFF
--- a/changelogs/fragments/7220-gitlab-user-ssh-key.yml
+++ b/changelogs/fragments/7220-gitlab-user-ssh-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_user - the module correctly identifies existing keys by their public key value now (https://github.com/ansible-collections/community.general/pull/7220).

--- a/plugins/modules/gitlab_user.py
+++ b/plugins/modules/gitlab_user.py
@@ -346,19 +346,19 @@ class GitLabUser(object):
 
     '''
     @param user User object
-    @param sshkey_name Name of the ssh key
+    @param sshkey_key Public key of the ssh key
     '''
-    def ssh_key_exists(self, user, sshkey_name):
-        keyList = map(lambda k: k.title, user.keys.list(all=True))
+    def ssh_key_exists(self, user, sshkey_key):
+        keySet = set(ssh_key_value(k.key) for k in user.keys.list(all=True))
 
-        return sshkey_name in keyList
+        return ssh_key_value(sshkey_key) in keySet
 
     '''
     @param user User object
     @param sshkey Dict containing sshkey infos {"name": "", "file": "", "expires_at": ""}
     '''
     def add_ssh_key_to_user(self, user, sshkey):
-        if not self.ssh_key_exists(user, sshkey['name']):
+        if not self.ssh_key_exists(user, sshkey['file']):
             if self._module.check_mode:
                 return True
 
@@ -572,6 +572,17 @@ def sanitize_arguments(arguments):
         if value is None:
             del arguments[key]
     return arguments
+
+
+def ssh_key_value(public_key):
+    '''
+    strip comment from public key
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAA.... this is the comment to be stripped"
+    =>
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAA...."
+    @param public_key The public key value of an ssh key
+    '''
+    return ' '.join(public_key.split()[0:2])
 
 
 def main():

--- a/tests/unit/plugins/modules/test_gitlab_user.py
+++ b/tests/unit/plugins/modules/test_gitlab_user.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.community.general.plugins.modules.gitlab_user import GitLabUser
+from ansible_collections.community.general.plugins.modules.gitlab_user import GitLabUser, ssh_key_value
 
 
 def _dummy(x):
@@ -129,10 +129,20 @@ class TestGitlabUser(GitlabModuleTestCase):
     def test_sshkey_exist(self):
         user = self.gitlab_instance.users.get(1)
 
-        exist = self.moduleUtil.ssh_key_exists(user, "Public key")
+        exist = self.moduleUtil.ssh_key_exists(
+            user,
+            "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k"
+            "6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H"
+            "5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0= test_gitlab_user.py")
         self.assertEqual(exist, True)
 
-        notExist = self.moduleUtil.ssh_key_exists(user, "Private key")
+        notExist = self.moduleUtil.ssh_key_exists(
+            user,
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA1YotVDm2mAyk2tPt4E7AHm01sS6JZmcUdRuSuA5z"
+            "szUJzYPPUSRAX3BCgTqLqYx//UuVncK7YqLVSbbwjKR2Ez5lISgCnVfLVEXzwhv+xawxKWmI7hJ5S0tO"
+            "v6MJ+IxyTa4xcKwJTwB86z22n9fVOQeJTR2dSOH1WJrf0PvRk+KVNY2jTiGHTi9AIjLnyD/jWRpOgtdf"
+            "kLRc8EzAWrWlgNmH2WOKBw6za0az6XoG75obUdFVdW3qcD0xc809OHLi7FDf+E7U4wiZJCFuUizMeXyu"
+            "K/SkaE1aee4Qp5R4dxTR4TP9M1XAYkf+kF0W9srZ+mhF069XD/zhUPJsvwEF")
         self.assertEqual(notExist, False)
 
     @with_httmock(resp_get_user)
@@ -150,12 +160,13 @@ class TestGitlabUser(GitlabModuleTestCase):
         self.assertEqual(rvalue, False)
 
         rvalue = self.moduleUtil.add_ssh_key_to_user(user, {
-            'name': "Private key",
+            'name': "Not a private key",
             'file': "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA1YotVDm2mAyk2tPt4E7AHm01sS6JZmcU"
                     "dRuSuA5zszUJzYPPUSRAX3BCgTqLqYx//UuVncK7YqLVSbbwjKR2Ez5lISgCnVfLVEXzwhv+"
                     "xawxKWmI7hJ5S0tOv6MJ+IxyTa4xcKwJTwB86z22n9fVOQeJTR2dSOH1WJrf0PvRk+KVNY2j"
                     "TiGHTi9AIjLnyD/jWRpOgtdfkLRc8EzAWrWlgNmH2WOKBw6za0az6XoG75obUdFVdW3qcD0x"
-                    "c809OHLi7FDf+E7U4wiZJCFuUizMeXyuK/SkaE1aee4Qp5R4dxTR4TP9M1XAYkf+kF0W9srZ+mhF069XD/zhUPJsvwEF",
+                    "c809OHLi7FDf+E7U4wiZJCFuUizMeXyuK/SkaE1aee4Qp5R4dxTR4TP9M1XAYkf+kF0W9srZ"
+                    "+mhF069XD/zhUPJsvwEF",
             'expires_at': "2027-01-01"})
         self.assertEqual(rvalue, True)
 
@@ -182,3 +193,18 @@ class TestGitlabUser(GitlabModuleTestCase):
 
         rvalue = self.moduleUtil.assign_user_to_group(user, group.id, "guest")
         self.assertEqual(rvalue, True)
+
+    def test_ssh_key_value(self):
+        ssh_public_key = (
+            "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCVA7p3quYXJfihdZIrHb/miia7DPL14mQ6wMp2LnJm"
+            "BW8QqrFZ0xZDxEIbSZ+cnBhL76+xWi83eBeedeTBHsCUY2teqG8FFIJhB0YwjtSXQqRefgH3x6bincx4"
+            "b3Hv8rRTwpKuGw6Q1sHbvzTSL9w5hhAm0iU7wSq67jBTFGvhXmFzcHwRZEh2yI0qIrp79mXF8pVsdUhU"
+            "Uzg/pstNUHXQhwMo5ur1yQVZsFPnrwvybzkfZ1rp9UqnJQC7695ILxT+pCOn7vL5PHiRCTw6l37uo/K4"
+            "i8JlUf/+Pmc/xnqLBPe5yzTdcJth/lXvP5M0vwjnYK9SaUDIzfpCnMmFGt/Rfa9tOXqhE7c3U6E1Iv7C"
+            "ifktSsnYS+87Eif7xkC5Mpk7aBD+b4RjOJ1tNFNcl7xAa0mE6g/qOHbRK1ZNEVtw9ofqe7ycqdg3ojpm"
+            "vS9XFmROcikAyOt+f02gyiv07LC0tlBVCKU7QawH+UoN0rKYNDEjq2mLrqMcAH0hmSMM26E="
+        )
+        self.assertEqual(ssh_public_key, ssh_key_value(ssh_public_key + " test_gitlab_user.py"))
+        self.assertEqual(ssh_public_key, ssh_key_value(ssh_public_key + " some comment with more spaces"))
+        self.assertEqual(ssh_public_key, ssh_key_value(ssh_public_key))
+        self.assertEqual("garbage", ssh_key_value("garbage"))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Gitlab ssh keys are identified by their public key value (excluding the comment). One cannot add the same key twice. So when adding an ssh key with `gitlab_user` with the same value but a different name, `gitlab_user` tried to add the key to the user but failed with http status code 400. Also when adding a different key with the same name, `gitlab_user` assumed the key already exists and did not update the Gitlab users keys.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #6516

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
gitlab_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [redacted : redacted] *****************************************************************************************
Donnerstag 07 September 2023  15:09:23 +0200 (0:00:00.102)       0:00:13.898 *** 
Donnerstag 07 September 2023  15:09:23 +0200 (0:00:00.102)       0:00:13.897 *** 
fatal: [test_build_server]: FAILED! => changed=false 
  msg: 'Failed to assign sshkey to user: 400: {''fingerprint_sha256'': [''has already been taken'']}'
```

Info @wt-io-it
