### PR TITLE
🔎 Speed up the CLI version lookup

### DIFF
--- a/changelogs/fragments/7230-manual-cli-version-support.yaml
+++ b/changelogs/fragments/7230-manual-cli-version-support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - onepassword lookup plugin - add CLI version lookup support to speed up auto-detection support (https://github.com/ansible-collections/community.general/pull/7230).
+  - onepassword_raw lookup plugin - add CLI version lookup to speed up auto-detection support (https://github.com/ansible-collections/community.general/pull/7230).

--- a/changelogs/fragments/7230-manual-cli-version-support.yaml
+++ b/changelogs/fragments/7230-manual-cli-version-support.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - onepassword lookup plugin - add CLI version lookup support to speed up auto-detection support (https://github.com/ansible-collections/community.general/pull/7230).
+  - onepassword lookup plugin - allow to specify CLI major version as ``major_version`` to skip version auto-detection, which speeds up the plugin execution (https://github.com/ansible-collections/community.general/pull/7230).
   - onepassword_raw lookup plugin - add CLI version lookup to speed up auto-detection support (https://github.com/ansible-collections/community.general/pull/7230).

--- a/changelogs/fragments/7230-manual-cli-version-support.yaml
+++ b/changelogs/fragments/7230-manual-cli-version-support.yaml
@@ -1,3 +1,3 @@
 minor_changes:
   - onepassword lookup plugin - allow to specify CLI major version as ``major_version`` to skip version auto-detection, which speeds up the plugin execution (https://github.com/ansible-collections/community.general/pull/7230).
-  - onepassword_raw lookup plugin - add CLI version lookup to speed up auto-detection support (https://github.com/ansible-collections/community.general/pull/7230).
+  - onepassword_raw lookup plugin - allow to specify CLI major version as ``major_version`` to skip version auto-detection, which speeds up the plugin execution (https://github.com/ansible-collections/community.general/pull/7230).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -52,6 +52,8 @@ DOCUMENTATION = '''
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
       major_version:
         description: The op CLI major version. If absent will attempt to auto-detect the version.
+        type: str
+        version_added: 7.4.0
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config), C(~/.config/op/config) or C(~/.config/.op/config) exists), then only the
@@ -581,7 +583,7 @@ class OnePass(object):
 
         if not major_version:
             version = OnePassCLIBase.get_current_version()
-            major_version = version.split(".")[0]
+            major_version = version.split(".", 1)[0]
 
         for cls in OnePassCLIBase.__subclasses__():
             if cls.supports_version == major_version:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -54,6 +54,9 @@ DOCUMENTATION = '''
         description: The op CLI major version. If absent will attempt to auto-detect the version.
         type: str
         version_added: 7.4.0
+        choices:
+          - "1"
+          - "2"
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config), C(~/.config/op/config) or C(~/.config/.op/config) exists), then only the

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -49,6 +49,8 @@ DOCUMENTATION = '''
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
       major_version:
         description: The op CLI major version. If absent will attempt to auto-detect the version.
+        type: str
+        version_added: 7.4.0
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config exists)), then only the O(master_password) is required.

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -53,7 +53,7 @@ DOCUMENTATION = '''
         version_added: 7.4.0
         choices:
           - "1"
-	  - "2"
+          - "2"
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config exists)), then only the O(master_password) is required.

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -47,6 +47,8 @@ DOCUMENTATION = '''
         version_added: 7.1.0
       vault:
         description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
+      major_version:
+        description: The op CLI major version. If absent will attempt to auto-detect the version.
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config exists)), then only the O(master_password) is required.
@@ -96,8 +98,9 @@ class LookupModule(LookupBase):
         secret_key = self.get_option("secret_key")
         master_password = self.get_option("master_password")
         service_account_token = self.get_option("service_account_token")
+        major_version = self.get_option("major_version")
 
-        op = OnePass(subdomain, domain, username, secret_key, master_password, service_account_token)
+        op = OnePass(subdomain, domain, username, secret_key, master_password, service_account_token, major_version)
         op.assert_logged_in()
 
         values = []

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -51,6 +51,9 @@ DOCUMENTATION = '''
         description: The op CLI major version. If absent will attempt to auto-detect the version.
         type: str
         version_added: 7.4.0
+        choices:
+          - "1"
+	  - "2"
     notes:
       - This lookup will use an existing 1Password session if one exists. If not, and you have already
         performed an initial sign in (meaning C(~/.op/config exists)), then only the O(master_password) is required.


### PR DESCRIPTION
##### SUMMARY

Speed-up the `op` CLI version detection by manually providing the major version.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`community.general.onepassword`
