### PR TITLE
Fixed gitlab_*_variable when using purge

### DIFF
--- a/changelogs/fragments/7251-gitlab-variables-deleteing-all-variables.yml
+++ b/changelogs/fragments/7251-gitlab-variables-deleteing-all-variables.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - gitlab_project_variable deletes all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).
-  - gitlab_group_variable deletes all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).
+  - gitlab_project_variable - deleted all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).
+  - gitlab_group_variable - deleted all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).

--- a/changelogs/fragments/7251-gitlab-variables-deleteing-all-variables.yml
+++ b/changelogs/fragments/7251-gitlab-variables-deleteing-all-variables.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - gitlab_project_variable deletes all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).
+  - gitlab_group_variable deletes all variables when used with ``purge=true`` due to missing ``raw`` property in KNOWN attributes (https://github.com/ansible-collections/community.general/issues/7250).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -116,7 +116,7 @@ def gitlab_authentication(module):
 def filter_returned_variables(gitlab_variables):
     # pop properties we don't know
     existing_variables = [dict(x.attributes) for x in gitlab_variables]
-    KNOWN = ['key', 'value', 'masked', 'protected', 'variable_type', 'environment_scope']
+    KNOWN = ['key', 'value', 'masked', 'protected', 'variable_type', 'environment_scope', 'raw']
     for item in existing_variables:
         for key in list(item.keys()):
             if key not in KNOWN:

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -381,6 +381,8 @@ def main():
         group=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
+        # please mind whenever changing the variables dict to also change module_utils/gitlab.py's
+        # KNOWN dict in filter_returned_variables or bad evil will happen
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
             value=dict(type='str', no_log=True),

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -404,6 +404,8 @@ def main():
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
         vars=dict(type='dict', required=False, default=dict(), no_log=True),
+        # please mind whenever changing the variables dict to also change module_utils/gitlab.py's
+        # KNOWN dict in filter_returned_variables or bad evil will happen
         variables=dict(type='list', elements='dict', required=False, default=list(), options=dict(
             name=dict(type='str', required=True),
             value=dict(type='str', no_log=True),


### PR DESCRIPTION
##### SUMMARY
Hotfix to 7.4 release deleting all GitLab variables

Fixes #7250 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
affected modules are:
- gitlab_group_variable
- gitlab_project_variable

##### ADDITIONAL INFORMATION
```paste below

```
