### PR TITLE
Update my maintainer status for 1PW plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -250,10 +250,10 @@ files:
     maintainers: samdoran
   $lookups/onepassword.py:
     ignore: scottsb
-    maintainers: azenk scottsb
+    maintainers: azenk
   $lookups/onepassword_raw.py:
     ignore: scottsb
-    maintainers: azenk scottsb
+    maintainers: azenk
   $lookups/passwordstore.py: {}
   $lookups/random_pet.py:
     maintainers: Akasurde

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -249,8 +249,10 @@ files:
     labels: onepassword
     maintainers: samdoran
   $lookups/onepassword.py:
+    ignore: scottsb
     maintainers: azenk scottsb
   $lookups/onepassword_raw.py:
+    ignore: scottsb
     maintainers: azenk scottsb
   $lookups/passwordstore.py: {}
   $lookups/random_pet.py:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018, Scott Buchanan <sbuchanan@ri.pn>
+# Copyright (c) 2018, Scott Buchanan <scott@buchanan.works>
 # Copyright (c) 2016, Andrew Zenk <azenk@umn.edu> (lastpass.py used as starting point)
 # Copyright (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)


### PR DESCRIPTION
##### SUMMARY
I am no longer using Ansible regularly, so I don't want to receive notifications about changes. (I could also simply remove myself as a maintainer entirely if that's preferable.)

It doesn't likely matter much, but the email in my copyright line is also defunct, so I fixed that.

##### ISSUE TYPE
- Docs Pull Request

(not sure which issue type was right here)

##### COMPONENT NAME
onepassword
