### PR TITLE
git_config: support multiple values for same name

### DIFF
--- a/changelogs/fragments/7242-multi-values-for-same-name-in-git-config.yml
+++ b/changelogs/fragments/7242-multi-values-for-same-name-in-git-config.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - "git_config - allow multiple git configs for the same name with the new ``add_mode`` option (https://github.com/ansible-collections/community.general/pull/7260)."
+    - "git_config - the ``after`` and ``before`` fields in the ``diff`` of the return value can be a list instead of a string in case more configs with the same key are affected (https://github.com/ansible-collections/community.general/pull/7260)."
+    - "git_config - when a value is unset, all configs with the same key are unset (https://github.com/ansible-collections/community.general/pull/7260)."

--- a/tests/integration/targets/git_config/files/gitconfig
+++ b/tests/integration/targets/git_config/files/gitconfig
@@ -4,3 +4,8 @@
 
 [http]
         proxy = foo
+
+[push]
+pushoption = merge_request.create
+pushoption = merge_request.draft
+pushoption = merge_request.target=foobar

--- a/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
+++ b/tests/integration/targets/git_config/tasks/get_set_state_present_file.yml
@@ -30,3 +30,4 @@
       - set_result.diff.after == option_value + "\n"
       - get_result is not changed
       - get_result.config_value == option_value
+...

--- a/tests/integration/targets/git_config/tasks/main.yml
+++ b/tests/integration/targets/git_config/tasks/main.yml
@@ -13,6 +13,7 @@
   import_tasks: setup.yml
 
 - block:
+    - import_tasks: set_value.yml
     # testing parameters exclusion: state and list_all
     - import_tasks: exclusion_state_list-all.yml
     # testing get/set option without state
@@ -31,5 +32,7 @@
     - import_tasks: unset_check_mode.yml
     # testing for case in issue #1776
     - import_tasks: set_value_with_tilde.yml
+    - import_tasks: set_multi_value.yml
+    - import_tasks: unset_multi_value.yml
   when: git_installed is succeeded and git_version.stdout is version(git_version_supporting_includes, ">=")
 ...

--- a/tests/integration/targets/git_config/tasks/set_multi_value.yml
+++ b/tests/integration/targets/git_config/tasks/set_multi_value.yml
@@ -1,0 +1,79 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- import_tasks: setup_no_value.yml
+
+- name: setting value
+  git_config:
+    name: push.pushoption
+    add_mode: add
+    value: "{{ item }}"
+    state: present
+    scope: global
+  loop:
+    - 'merge_request.create'
+    - 'merge_request.draft'
+    - 'merge_request.target=foobar'
+  register: set_result1
+
+- name: setting value
+  git_config:
+    name: push.pushoption
+    add_mode: add
+    value: "{{ item }}"
+    state: present
+    scope: global
+  loop:
+    - 'merge_request.create'
+    - 'merge_request.draft'
+    - 'merge_request.target=foobar'
+  register: set_result2
+
+- name: getting the multi-value
+  git_config:
+    name: push.pushoption
+    scope: global
+  register: get_single_result
+
+- name: getting all values for the single option
+  git_config_info:
+    name: push.pushoption
+    scope: global
+  register: get_all_result
+
+- name: replace-all values
+  git_config:
+    name: push.pushoption
+    add_mode: replace-all
+    value: merge_request.create
+    state: present
+    scope: global
+  register: set_result3
+
+- name: assert set changed and value is correct
+  assert:
+    that:
+      - set_result1.results[0] is changed
+      - set_result1.results[1] is changed
+      - set_result1.results[2] is changed
+      - set_result2.results[0] is not changed
+      - set_result2.results[1] is not changed
+      - set_result2.results[2] is not changed
+      - set_result3 is changed
+      - get_single_result.config_value == 'merge_request.create'
+      - 'get_all_result.config_values == {"push.pushoption": ["merge_request.create", "merge_request.draft", "merge_request.target=foobar"]}'
+
+- name: assert the diffs are also right
+  assert:
+    that:
+      - set_result1.results[0].diff.before == "\n"
+      - set_result1.results[0].diff.after == "merge_request.create\n"
+      - set_result1.results[1].diff.before == "merge_request.create\n"
+      - set_result1.results[1].diff.after == ["merge_request.create", "merge_request.draft"]
+      - set_result1.results[2].diff.before == ["merge_request.create", "merge_request.draft"]
+      - set_result1.results[2].diff.after == ["merge_request.create", "merge_request.draft", "merge_request.target=foobar"]
+      - set_result3.diff.before == ["merge_request.create", "merge_request.draft", "merge_request.target=foobar"]
+      - set_result3.diff.after == "merge_request.create\n"
+...

--- a/tests/integration/targets/git_config/tasks/set_value.yml
+++ b/tests/integration/targets/git_config/tasks/set_value.yml
@@ -3,27 +3,25 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#- import_tasks: setup_no_value.yml
+- import_tasks: setup_no_value.yml
 
 - name: setting value
   git_config:
-    name: core.hooksPath
-    value: '~/foo/bar'
-    state: present
+    name: core.name
+    value: foo
     scope: global
   register: set_result1
 
-- name: setting value again
+- name: setting another value for same name
   git_config:
-    name: core.hooksPath
-    value: '~/foo/bar'
-    state: present
+    name: core.name
+    value: bar
     scope: global
   register: set_result2
 
 - name: getting value
   git_config:
-    name: core.hooksPath
+    name: core.name
     scope: global
   register: get_result
 
@@ -31,7 +29,11 @@
   assert:
     that:
       - set_result1 is changed
-      - set_result2 is not changed
+      - set_result2 is changed
       - get_result is not changed
-      - get_result.config_value == '~/foo/bar'
+      - get_result.config_value == 'bar'
+      - set_result1.diff.before == "\n"
+      - set_result1.diff.after == "foo\n"
+      - set_result2.diff.before == "foo\n"
+      - set_result2.diff.after == "bar\n"
 ...

--- a/tests/integration/targets/git_config/tasks/unset_multi_value.yml
+++ b/tests/integration/targets/git_config/tasks/unset_multi_value.yml
@@ -1,0 +1,28 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- import_tasks: setup_value.yml
+
+- name: unsetting "push.pushoption"
+  git_config:
+    name: push.pushoption
+    scope: global
+    state: absent
+  register: unset_result
+
+- name: getting all pushoptions values
+  git_config_info:
+    name: push.pushoption
+    scope: global
+  register: get_all_result
+
+- name: assert unsetting muti-values
+  assert:
+    that:
+      - unset_result is changed
+      - 'get_all_result.config_values == {"push.pushoption": []}'
+      - unset_result.diff.before == ["merge_request.create", "merge_request.draft", "merge_request.target=foobar"]
+      - unset_result.diff.after == "\n"
+...


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With git, it is possible to have more configs for the same name. e.g.

```
[push]
        pushoption = merge_request.create
        pushoption = merge_request.draft
```

Setting multiple values for the same name is currently not possible. Existing configs where multiple values for the same name are existing cannot be read out at all with the current `git_config`.

This MR supports setting and reading multi-values in the git config.



<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

git_config
