### PR TITLE
supervisorctl: stop process before removing it

### DIFF
--- a/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
+++ b/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - stop matching running processes before removing them

--- a/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
+++ b/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - stop matching running processes before removing them
+  - supervisorctl - stop matching running processes before removing them (https://github.com/ansible-collections/community.general/pull/7284).

--- a/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
+++ b/changelogs/fragments/7284-supervisorctl-stop-before-remove.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - supervisorctl - stop matching running processes before removing them (https://github.com/ansible-collections/community.general/pull/7284).
+  - supervisorctl - allow to stop matching running processes before removing them with ``stop_before_removing=true`` (https://github.com/ansible-collections/community.general/pull/7284).

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -70,7 +70,8 @@ options:
 notes:
   - When O(state=present), the module will call C(supervisorctl reread) then C(supervisorctl add) if the program/group does not exist.
   - When O(state=restarted), the module will call C(supervisorctl update) then call C(supervisorctl restart).
-  - When O(state=absent), the module will call C(supervisorctl reread) then C(supervisorctl remove) to remove the target program/group. If the program/group is still running, the action will fail. If you want to stop the program/group before removing, use O(stop_before_removing=true).
+  - When O(state=absent), the module will call C(supervisorctl reread) then C(supervisorctl remove) to remove the target program/group.
+    If the program/group is still running, the action will fail. If you want to stop the program/group before removing, use O(stop_before_removing=true).
 requirements: [ "supervisorctl" ]
 author:
     - "Matt Wright (@mattupstate)"

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -231,7 +231,7 @@ def main():
             module.exit_json(changed=False, name=name, state=state)
 
         take_action_on_processes(processes, lambda s: s in ('RUNNING', 'STARTING'), 'stop', 'stopped')
-      
+
         if module.check_mode:
             module.exit_json(changed=True)
         run_supervisorctl('reread', check_rc=True)

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -215,9 +215,13 @@ def main():
             if status_filter(status):
                 to_take_action_on.append(process_name)
 
-        if len(to_take_action_on) == 0 and exit_module:
+        if len(to_take_action_on) == 0:
+            if not exit_module:
+                return
             module.exit_json(changed=False, name=name, state=state)
-        if module.check_mode and exit_module:
+        if module.check_mode:
+            if not exit_module:
+                return
             module.exit_json(changed=True)
         for process_name in to_take_action_on:
             rc, out, err = run_supervisorctl(action, process_name, check_rc=True)

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -215,9 +215,9 @@ def main():
             if status_filter(status):
                 to_take_action_on.append(process_name)
 
-        if len(to_take_action_on) == 0:
+        if len(to_take_action_on) == 0 and exit_module:
             module.exit_json(changed=False, name=name, state=state)
-        if module.check_mode:
+        if module.check_mode and exit_module:
             module.exit_json(changed=True)
         for process_name in to_take_action_on:
             rc, out, err = run_supervisorctl(action, process_name, check_rc=True)

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -230,6 +230,8 @@ def main():
         if len(processes) == 0:
             module.exit_json(changed=False, name=name, state=state)
 
+        take_action_on_processes(processes, lambda s: s in ('RUNNING', 'STARTING'), 'stop', 'stopped')
+      
         if module.check_mode:
             module.exit_json(changed=True)
         run_supervisorctl('reread', check_rc=True)

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -59,6 +59,7 @@ options:
       - Use O(stop_before_removing=true) to stop the program/group before removing it
     required: false
     default: false
+    version_added: 7.5.0
   signal:
     type: str
     description:


### PR DESCRIPTION
##### SUMMARY
Stop the processes before removing them.

This is needed to create a idempotent playbook. You should not have to explicitly stop a supervisor process before removing it. If you would, then the stop action on all subsequent calls will fail since the process does not exists on supervisor since you removed it at the first call.

It's like any process manager. If you `apt remove <some-daemon>`, you don't have to stop explicitly stop the deamon before.

This way, even with a running process, you just have to mark it `absent` to stop/remove it. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
supervisorctl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
TASK [Delete supervisor process] *************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: |-
    ERROR: process/group still running: foo
  name: foo
  state: absent
```

Now:

```
TASK [Delete supervisor process] *************************************************************************************************************************************************************
changed: [localhost]
```