### PR TITLE
[stable-6] CI: devel → stable-2.16, move stable-2.13 to EOL CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -59,14 +59,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_16
+    displayName: Sanity 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.16/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -99,28 +99,15 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_13
-    displayName: Sanity 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.13/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_16
+    displayName: Units 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.16/units/{0}/1
           targets:
             - test: 2.7
             - test: 3.6
@@ -150,26 +137,15 @@ stages:
           testFormat: 2.14/units/{0}/1
           targets:
             - test: 3.9
-  - stage: Units_2_13
-    displayName: Units 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.13/units/{0}/1
-          targets:
-            - test: 2.7
-            - test: 3.8
 
 ## Remote
-  - stage: Remote_devel_extra_vms
-    displayName: Remote devel extra VMs
+  - stage: Remote_2_16_extra_vms
+    displayName: Remote 2.16 extra VMs
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.16/{0}
           targets:
             - name: Alpine 3.18
               test: alpine/3.18
@@ -179,13 +155,13 @@ stages:
               test: ubuntu/22.04
           groups:
             - vm
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: Remote_2_16
+    displayName: Remote 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.16/{0}
           targets:
             - name: macOS 13.2
               test: macos/13.2
@@ -237,33 +213,15 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_13
-    displayName: Remote 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}
-          targets:
-            - name: macOS 12.0
-              test: macos/12.0
-            - name: RHEL 8.5
-              test: rhel/8.5
-            #- name: FreeBSD 13.1
-            #  test: freebsd/13.1
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_16
+    displayName: Docker 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.16/linux/{0}
           targets:
             - name: Fedora 38
               test: fedora38
@@ -309,33 +267,15 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Docker_2_13
-    displayName: Docker 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/linux/{0}
-          targets:
-            - name: Fedora 35
-              test: fedora35
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: Alpine 3
-              test: alpine3
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: Docker_community_2_16
+    displayName: Docker (community images) 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
+          testFormat: 2.16/linux-community/{0}
           targets:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
@@ -349,14 +289,14 @@ stages:
             - 3
 
 ### Generic
-  - stage: Generic_devel
-    displayName: Generic devel
+  - stage: Generic_2_16
+    displayName: Generic 2.16
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/generic/{0}/1
+          testFormat: 2.16/generic/{0}/1
           targets:
             - test: 2.7
             - test: '3.11'
@@ -380,42 +320,27 @@ stages:
           testFormat: 2.14/generic/{0}/1
           targets:
             - test: '3.10'
-  - stage: Generic_2_13
-    displayName: Generic 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.13/generic/{0}/1
-          targets:
-            - test: 3.9
 
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
-      - Sanity_2_13
       - Sanity_2_14
       - Sanity_2_15
-      - Units_devel
-      - Units_2_13
+      - Sanity_2_16
       - Units_2_14
       - Units_2_15
-      - Remote_devel_extra_vms
-      - Remote_devel
-      - Remote_2_13
+      - Units_2_16
       - Remote_2_14
       - Remote_2_15
-      - Docker_devel
-      - Docker_2_13
+      - Remote_2_16
+      - Remote_2_16_extra_vms
       - Docker_2_14
       - Docker_2_15
-      - Docker_community_devel
+      - Docker_2_16
+      - Docker_community_2_16
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-#      - Generic_devel
-#      - Generic_2_13
 #      - Generic_2_14
 #      - Generic_2_15
+#      - Generic_2_16
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,6 +31,7 @@ jobs:
         ansible:
           - '2.11'
           - '2.12'
+          - '2.13'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -79,6 +80,10 @@ jobs:
           - ansible: '2.12'
             python: '2.6'
           - ansible: '2.12'
+            python: '3.8'
+          - ansible: '2.13'
+            python: '2.7'
+          - ansible: '2.13'
             python: '3.8'
 
     steps:
@@ -210,6 +215,48 @@ jobs:
           # - ansible: '2.12'
           #   docker: default
           #   python: '3.8'
+          #   target: azp/generic/1/
+          # 2.13
+          - ansible: '2.13'
+            docker: fedora35
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.13'
+            docker: fedora35
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.13'
+            docker: fedora35
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.13'
+            docker: opensuse15py2
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.13'
+            docker: opensuse15py2
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.13'
+            docker: opensuse15py2
+            python: ''
+            target: azp/posix/3/
+          - ansible: '2.13'
+            docker: alpine3
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.13'
+            docker: alpine3
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.13'
+            docker: alpine3
+            python: ''
+            target: azp/posix/3/
+          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+          # - ansible: '2.13'
+          #   docker: default
+          #   python: '3.9'
           #   target: azp/generic/1/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15 releases and the current development version of ansible-core. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, and ansible-core 2.16 releases. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 Parts of this collection will not work with ansible-core 2.11 on Python 3.12+.
 


### PR DESCRIPTION
##### SUMMARY
ansible-core stable-2.16 has been branched.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
