### PR TITLE
Adding deprecation for timeout parameter from 10 to 60 for redfish_info, redfish_config and redfish_command

### DIFF
--- a/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
+++ b/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-  - redfish_info, redfish_config, redfish_command - adding deprectation for timeout parameter from 10 to 60 (https://github.com/ansible-collections/community.general/pull/7295).
+  - redfish_info, redfish_config, redfish_command - the default value ``10`` for the ``timeout`` option is deprecated and will change to ``60`` in community.general 9.0.0 (https://github.com/ansible-collections/community.general/pull/7295).

--- a/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
+++ b/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_info, redfish_config, redfish_command - adding deprectation for timeout parameter from 10 to 60 (https://github.com/ansible-collections/community.general/pull/7295).

--- a/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
+++ b/changelogs/fragments/7295-adding_deprecation_for_timeout_in_redfish_info_config_command.yml
@@ -1,2 +1,2 @@
-minor_changes:
+deprecated_features:
   - redfish_info, redfish_config, redfish_command - adding deprectation for timeout parameter from 10 to 60 (https://github.com/ansible-collections/community.general/pull/7295).

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -110,7 +110,7 @@ options:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
       - The default value for this param is C(10) but that is being deprecated
-        and it will be replaced with C(60) in community.general 7.5.0.
+        and it will be replaced with C(60) in community.general 9.0.0.
     type: int
   boot_override_mode:
     description:

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -836,7 +836,7 @@ def main():
             'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
                 10, 60
             ),
-            version='7.5.0',
+            version='9.0.0',
             collection_name='community.general'
         )
 

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -109,7 +109,8 @@ options:
   timeout:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
-    default: 10
+      - The default value for this param is C(10) but that is being deprecated
+        and it will be replaced with C(60) in community.general 7.5.0.
     type: int
   boot_override_mode:
     description:
@@ -782,7 +783,7 @@ def main():
             update_username=dict(type='str', aliases=["account_updatename"]),
             account_properties=dict(type='dict', default={}),
             bootdevice=dict(),
-            timeout=dict(type='int', default=10),
+            timeout=dict(type='int'),
             uefi_target=dict(),
             boot_next=dict(),
             boot_override_mode=dict(choices=['Legacy', 'UEFI']),
@@ -828,6 +829,16 @@ def main():
         ],
         supports_check_mode=False
     )
+
+    if module.params['timeout'] is None:
+        timeout = 10
+        module.deprecate(
+            'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
+                10, 60
+            ),
+            version='7.5.0',
+            collection_name='community.general'
+        )
 
     category = module.params['category']
     command_list = module.params['command']

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -64,6 +64,8 @@ options:
   timeout:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
+      - The default value for this param is C(10) but that is being deprecated
+        and it will be replaced with C(60) in community.general 7.5.0.
     default: 10
     type: int
   boot_order:
@@ -331,7 +333,7 @@ def main():
             password=dict(no_log=True),
             auth_token=dict(no_log=True),
             bios_attributes=dict(type='dict', default={}),
-            timeout=dict(type='int', default=10),
+            timeout=dict(type='int'),
             boot_order=dict(type='list', elements='str', default=[]),
             network_protocols=dict(
                 type='dict',
@@ -361,6 +363,16 @@ def main():
         ],
         supports_check_mode=False
     )
+
+    if module.params['timeout'] is None:
+        timeout = 10
+        module.deprecate(
+            'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
+                10, 60
+            ),
+            version='7.5.0',
+            collection_name='community.general'
+        )
 
     category = module.params['category']
     command_list = module.params['command']

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -66,7 +66,6 @@ options:
       - Timeout in seconds for HTTP requests to OOB controller.
       - The default value for this param is C(10) but that is being deprecated
         and it will be replaced with C(60) in community.general 7.5.0.
-    default: 10
     type: int
   boot_order:
     required: false

--- a/plugins/modules/redfish_config.py
+++ b/plugins/modules/redfish_config.py
@@ -65,7 +65,7 @@ options:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
       - The default value for this param is C(10) but that is being deprecated
-        and it will be replaced with C(60) in community.general 7.5.0.
+        and it will be replaced with C(60) in community.general 9.0.0.
     type: int
   boot_order:
     required: false
@@ -369,7 +369,7 @@ def main():
             'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
                 10, 60
             ),
-            version='7.5.0',
+            version='9.0.0',
             collection_name='community.general'
         )
 

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -62,7 +62,6 @@ options:
       - Timeout in seconds for HTTP requests to OOB controller.
       - The default value for this param is C(10) but that is being deprecated
         and it will be replaced with C(60) in community.general 7.5.0.
-    default: 10
     type: int
   update_handle:
     required: false

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -61,7 +61,7 @@ options:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
       - The default value for this param is C(10) but that is being deprecated
-        and it will be replaced with C(60) in community.general 7.5.0.
+        and it will be replaced with C(60) in community.general 9.0.0.
     type: int
   update_handle:
     required: false
@@ -408,7 +408,7 @@ def main():
             'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
                 10, 60
             ),
-            version='7.5.0',
+            version='9.0.0',
             collection_name='community.general'
         )
 

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -60,6 +60,8 @@ options:
   timeout:
     description:
       - Timeout in seconds for HTTP requests to OOB controller.
+      - The default value for this param is C(10) but that is being deprecated
+        and it will be replaced with C(60) in community.general 7.5.0.
     default: 10
     type: int
   update_handle:
@@ -386,7 +388,7 @@ def main():
             username=dict(),
             password=dict(no_log=True),
             auth_token=dict(no_log=True),
-            timeout=dict(type='int', default=10),
+            timeout=dict(type='int'),
             update_handle=dict(),
         ),
         required_together=[
@@ -400,6 +402,16 @@ def main():
         ],
         supports_check_mode=True,
     )
+
+    if module.params['timeout'] is None:
+        timeout = 10
+        module.deprecate(
+            'The default value {0} for parameter param1 is being deprecated and it will be replaced by {1}'.format(
+                10, 60
+            ),
+            version='7.5.0',
+            collection_name='community.general'
+        )
 
     # admin credentials used for authentication
     creds = {'user': module.params['username'],


### PR DESCRIPTION
SUMMARY
Adding deprecation notice for timeout parameter.
Old value was 10. Proposed new value is 60.
Suggesting an increase in the timeout since we observed delayed responses from Gen11 servers while testing.

ISSUE TYPE
- Feature Pull Request
- New Module/Plugin Pull Request

COMPONENT NAME
redfish_info.py
redfish_config.py
redfish_command.py