### PR TITLE
 Fixing incorrect string encapsulation for -backend-config.

### DIFF
--- a/changelogs/fragments/7301-fix-backend-config-string-encapsulation.yml
+++ b/changelogs/fragments/7301-fix-backend-config-string-encapsulation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "terraform module - prevents `-backend-config` option double encapsulating with `shlex_quote` function. (https://github.com/ansible-collections/community.general/pull/7301)."

--- a/changelogs/fragments/7301-fix-backend-config-string-encapsulation.yml
+++ b/changelogs/fragments/7301-fix-backend-config-string-encapsulation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "terraform module - prevents `-backend-config` option double encapsulating with `shlex_quote` function. (https://github.com/ansible-collections/community.general/pull/7301)."
+  - "terraform - prevents ``-backend-config`` option double encapsulating with ``shlex_quote`` function. (https://github.com/ansible-collections/community.general/pull/7301)."

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -325,7 +325,7 @@ def init_plugins(bin_path, project_path, backend_config, backend_config_files, i
         for key, val in backend_config.items():
             command.extend([
                 '-backend-config',
-                shlex_quote('{0}={1}'.format(key, val))
+                '{0}={1}'.format(key, val)
             ])
     if backend_config_files:
         for f in backend_config_files:


### PR DESCRIPTION
 Removing shlex_quote.

##### SUMMARY

This FIX solves the following issues:

- https://github.com/ansible-collections/community.general/issues/5016

- https://github.com/ansible-collections/community.general/issues/6517

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
Removed the `shlex_quote` from the backend-config command line argument.

```paste below

```
