### PR TITLE
Fix incorrect parsing of headers containing equal character

### DIFF
--- a/changelogs/fragments/7303-mail-incorrect-header-parsing.yml
+++ b/changelogs/fragments/7303-mail-incorrect-header-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mail - skip headers containing equals characters due to missing maxsplit on header key/value parsing.

--- a/changelogs/fragments/7303-mail-incorrect-header-parsing.yml
+++ b/changelogs/fragments/7303-mail-incorrect-header-parsing.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - mail - skip headers containing equals characters due to missing maxsplit on header key/value parsing.
+  - mail - skip headers containing equals characters due to missing ``maxsplit`` on header key/value parsing (https://github.com/ansible-collections/community.general/pull/7303).

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -354,7 +354,7 @@ def main():
         # NOTE: Backward compatible with old syntax using '|' as delimiter
         for hdr in [x.strip() for x in header.split('|')]:
             try:
-                h_key, h_val = hdr.split('=')
+                h_key, h_val = hdr.split('=', 1)
                 h_val = to_native(Header(h_val, charset))
                 msg.add_header(h_key, h_val)
             except Exception:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix mail header parsing that skip headers containing equals characters due to missing maxsplit on header key/value parsing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
mail module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For example, the following mail module invocation trigger the bug:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Send email
  mail:
    host: "{{ smtp.host }}"
    port: "{{ smtp.port }}"
    secure: "{{ smtp.secure }}"
    username: "{{ smtp.username }}"
    password: "{{ smtp.password }}"
    subtype: "html"
    from: "{{ email.from }}"
    to: "{{ to }}"
    subject: "{{ subject }}"
    body: "{{ body }}"
    attach: "{{ email.attach | default(omit) }}"
    headers:
      - X-Protective-Marking="VER=2005.6, NS=2020.1.example.com, SEC=xfkrf, ORIGIN=noreply@example.com"
```
The `split("=")` function applied to split the header key and value generate an error because there are multiples `=` characters, but only 2 output values are expected. Adding a `maxsplit` of 1 to the split fix the behavior and extract correctly the header key and value.
