### PR TITLE
Prevent parted warnings in script mode

### DIFF
--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted - resize : Use --fix option by default (--fix from parted 3.4.64 and up. If you use a old version, the -f is not used)
+  - parted : On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted - resize : Use --fix option by default (Note: --fix from parted 3.4.64 and up. If you use a old version, the -f is not used)
+  - parted - resize : Use --fix option by default (--fix from parted 3.4.64 and up. If you use a old version, the -f is not used)

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted: On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)
+  - parted - On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+parted - resize : Use --fix option by default (Note: --fix from parted 3.4.64 and up. If you use a old version, the -f is not used)

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted - On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)
+  - parted - on resize, use ``--fix`` option if available (https://github.com/ansible-collections/community.general/pull/7304).

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-parted - resize : Use --fix option by default (Note: --fix from parted 3.4.64 and up. If you use a old version, the -f is not used)
+  - parted - resize : Use --fix option by default (Note: --fix from parted 3.4.64 and up. If you use a old version, the -f is not used)

--- a/changelogs/fragments/7304-prevent-parted-warnings.yml
+++ b/changelogs/fragments/7304-prevent-parted-warnings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - parted : On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)
+  - parted: On resize, use --fix option if available (https://github.com/ansible-collections/community.general/pull/7304)

--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -570,7 +570,7 @@ def parted(script, device, align):
         align_option = ''
 
     if script and not module.check_mode:
-        command = "%s -s -m %s %s -- %s" % (parted_exec, align_option, device, script)
+        command = "%s -s -f -m %s %s -- %s" % (parted_exec, align_option, device, script)
         rc, out, err = module.run_command(command)
 
         if rc != 0:

--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -568,9 +568,7 @@ def check_parted_fix():
     global parted_exec  # pylint: disable=global-variable-not-assigned
 
     parted_major, parted_minor, revision = parted_version()
-    if (parted_major == 3 and parted_minor == 4 and revision >= 64):
-        return True
-    if (parted_major == 3 and parted_minor >= 5) or parted_major > 3:
+    if (parted_major, parted_minor, revision) >= (3, 4, 64):
         return True
 
     return False

--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -559,21 +559,6 @@ def parted_version():
     return major, minor, rev
 
 
-def check_parted_fix():
-    """
-    Determines if parted have option --fix (-f). Versions prior
-    to 3.4.64 don't have it. For more information see:
-    http://savannah.gnu.org/news/?id=10114
-    """
-    global parted_exec  # pylint: disable=global-variable-not-assigned
-
-    parted_major, parted_minor, revision = parted_version()
-    if (parted_major, parted_minor, revision) >= (3, 4, 64):
-        return True
-
-    return False
-
-
 def parted(script, device, align):
     """
     Runs a parted script.
@@ -584,7 +569,12 @@ def parted(script, device, align):
     if align == 'undefined':
         align_option = ''
 
-    if check_parted_fix():
+    """
+    Use option --fix (-f) if available. Versions prior
+    to 3.4.64 don't have it. For more information see:
+    http://savannah.gnu.org/news/?id=10114
+    """
+    if parted_version() >= (3, 4, 64):
         script_option = '-s -f'
     else:
         script_option = '-s'

--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -570,7 +570,7 @@ def check_parted_fix():
     parted_major, parted_minor, revision = parted_version()
     if (parted_major == 3 and parted_minor == 4 and revision >= 64):
         return True
-    if (parted_major == 3 and parted_minor >= 5) or parted_major >3:
+    if (parted_major == 3 and parted_minor >= 5) or parted_major > 3:
         return True
 
     return False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add automatic answer "fix" when script mode -s is used with parted version >= 3.4.64

Comments from the project parted :
automatically answer exceptions with "fix" in script mode, which is useful for:
GPT header not including full disk size;
moving the backup GPT table to the end of the disk;
MAC fix missing partition map entry;
etc.
see: https://www.mail-archive.com/parted-devel@alioth-lists.debian.net/msg00369.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1653 #1461

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
minor_changes:
  - parted - on resize, use ``--fix`` option if available
  
##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
parted

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

just use -f with -s and resizepart in the same command.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

Before:
When you enhance the drive on the vcenter, and refresh in the OS, the community.general.parted with resize=true hang like that:

Warning: Not all of the space available to /dev/sdx appears to be used, you can fix the GPT to use all of the space (an extra xxxxx blocks) or continue with the current setting? 
Error: Unable to satisfy all constraints on the partition.

After:
the resize is done correctly.

```
