### PR TITLE
allow specifying a 1Password account ID

### DIFF
--- a/changelogs/fragments/7308-onepassword-multi-acc.yml
+++ b/changelogs/fragments/7308-onepassword-multi-acc.yml
@@ -1,2 +1,3 @@
 minor_changes:
-  - onepassword - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).
+  - onepassword lookup plugin - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).
+  - onepassword_raw lookup plugin - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).

--- a/changelogs/fragments/7308-onepassword-multi-acc.yml
+++ b/changelogs/fragments/7308-onepassword-multi-acc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - onepassword - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).

--- a/changelogs/fragments/7308-onepassword-multi-acc.yml
+++ b/changelogs/fragments/7308-onepassword-multi-acc.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - onepassword lookup plugin - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).
-  - onepassword_raw lookup plugin - introduce ``account_id`` option which allows specifying which account to use. (https://github.com/ansible-collections/community.general/pull/7308).
+  - onepassword lookup plugin - introduce ``account_id`` option which allows specifying which account to use (https://github.com/ansible-collections/community.general/pull/7308).
+  - onepassword_raw lookup plugin - introduce ``account_id`` option which allows specifying which account to use (https://github.com/ansible-collections/community.general/pull/7308).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -521,7 +521,7 @@ class OnePassCLIv2(OnePassCLIBase):
             # if there are any previously configured accounts.
             args = ["account", "get"]
             if self.account_id:
-              args.extend(["--account", self.account_id])
+                args.extend(["--account", self.account_id])
             elif self.subdomain:
                 account = "{subdomain}.{domain}".format(subdomain=self.subdomain, domain=self.domain)
                 args.extend(["--account", account])

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -40,6 +40,8 @@ DOCUMENTATION = '''
         description: The 1Password subdomain to authenticate against.
       account_id:
         description: The account ID to target.
+        type: str
+        version_added: 7.5.0
       username:
         description: The username used to sign in.
       secret_key:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -99,9 +99,9 @@ EXAMPLES = """
                 username='tweety@acme.com',
                 secret_key=vault_secret_key)
 
-- name: Retrieve password from specific account 
+- name: Retrieve password from specific account
   ansible.builtin.debug:
-    var: lookup('community.general.onepassword', 
+    var: lookup('community.general.onepassword',
                 'HAL 9000',
                 account_id='abc123')
 """
@@ -130,7 +130,16 @@ from ansible_collections.community.general.plugins.module_utils.onepassword impo
 class OnePassCLIBase(with_metaclass(abc.ABCMeta, object)):
     bin = "op"
 
-    def __init__(self, subdomain=None, domain="1password.com", username=None, secret_key=None, master_password=None, service_account_token=None, account_id=None):
+    def __init__(
+        self,
+        subdomain=None,
+        domain="1password.com",
+        username=None,
+        secret_key=None,
+        master_password=None,
+        service_account_token=None,
+        account_id=None,
+    ):
         self.subdomain = subdomain
         self.domain = domain
         self.username = username

--- a/plugins/lookup/onepassword_raw.py
+++ b/plugins/lookup/onepassword_raw.py
@@ -35,6 +35,10 @@ DOCUMENTATION = '''
         version_added: 6.0.0
         default: '1password.com'
         type: str
+      account_id:
+        description: The account ID to target.
+        type: str
+        version_added: 7.5.0
       username:
         description: The username used to sign in.
       secret_key:
@@ -52,6 +56,7 @@ DOCUMENTATION = '''
         performed an initial sign in (meaning C(~/.op/config exists)), then only the O(master_password) is required.
         You may optionally specify O(subdomain) in this scenario, otherwise the last used subdomain will be used by C(op).
       - This lookup can perform an initial login by providing O(subdomain), O(username), O(secret_key), and O(master_password).
+      - Can target a specific account by providing the O(account_id).
       - Due to the B(very) sensitive nature of these credentials, it is B(highly) recommended that you only pass in the minimal credentials
         needed at any given time. Also, store these credentials in an Ansible Vault using a key that is equal to or greater in strength
         to the 1Password master password.
@@ -96,8 +101,9 @@ class LookupModule(LookupBase):
         secret_key = self.get_option("secret_key")
         master_password = self.get_option("master_password")
         service_account_token = self.get_option("service_account_token")
+        account_id = self.get_option("account_id")
 
-        op = OnePass(subdomain, domain, username, secret_key, master_password, service_account_token)
+        op = OnePass(subdomain, domain, username, secret_key, master_password, service_account_token, account_id)
         op.assert_logged_in()
 
         values = []


### PR DESCRIPTION
##### SUMMARY
Add support for multiple 1Password accounts.

Currently, when 1password is logged into multiple accounts, `community.general.onepassword` always defaults to the first account in the list and there is no way to select any other account. This PR introduces a new option `account_id` which allow specifying which account to use.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.general.onepassword`

