### PR TITLE
xinetd no longer exists; use mdadm instead

### DIFF
--- a/tests/integration/targets/pacman/tasks/remove_nosave.yml
+++ b/tests/integration/targets/pacman/tasks/remove_nosave.yml
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - vars:
-    package_name: xinetd
-    config_file: /etc/xinetd.conf
+    package_name: mdadm
+    config_file: /etc/mdadm.conf
   block:
     - name: Make sure that {{ package_name }} is not installed
       pacman:
         name: '{{ package_name }}'
         state: absent
+
     - name: Make sure {{config_file}}.pacsave file doesn't exist
       file:
         path: '{{config_file}}.pacsave'
@@ -32,6 +33,7 @@
       pacman:
         name: '{{ package_name }}'
         state: absent
+
     - name: Make sure {{config_file}}.pacsave exists
       stat:
         path: '{{config_file}}.pacsave'


### PR DESCRIPTION
##### SUMMARY
xintd is no longer a package in Arch; use mdadm instead.

(Failing nightlies: https://dev.azure.com/ansible/community.general/_build/results?buildId=90587&view=logs&j=89290267-74d5-5b3e-330d-ba0f2945add4&t=0ecc9edb-08fd-5c6e-50b9-4c9e0e2c0b70&l=9348)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pacman
