### PR TITLE
Add LinkStatus to Ethernet Interface attribute list

### DIFF
--- a/changelogs/fragments/7318-add-linkstatus-attribute-to-nic-inventory.yml
+++ b/changelogs/fragments/7318-add-linkstatus-attribute-to-nic-inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_info - adds ``LinkStatus`` to NIC inventory (https://github.com/ansible-collections/community.general/pull/7318).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2460,7 +2460,7 @@ class RedfishUtils(object):
         result = {}
         properties = ['Name', 'Id', 'Description', 'FQDN', 'IPv4Addresses', 'IPv6Addresses',
                       'NameServers', 'MACAddress', 'PermanentMACAddress',
-                      'SpeedMbps', 'MTUSize', 'AutoNeg', 'Status']
+                      'SpeedMbps', 'MTUSize', 'AutoNeg', 'Status', 'LinkStatus']
         response = self.get_request(self.root_uri + resource_uri)
         if response['ret'] is False:
             return response


### PR DESCRIPTION
##### SUMMARY
Add `LinkStatus` attribute to Ethernet Interface description.
Fixes #7317 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
redfish_utils

##### ADDITIONAL INFORMATION

Before:
```
    "redfish_facts": {                                                          
        "nic": {                       
            "entries": [                                                        
                [                                                               
                    {                  
                        "resource_uri": "/redfish/v1/Systems/1/"
                    },                                                          
                    [        
                        { 
                            "IPv4Addresses": [],
                            "IPv6Addresses": [],
                            "Id": "1",
                            "MACAddress": "ff:ff:ff:ff:ff:ff",
                            "Name": "",                                                                                                                         
                            "NameServers": [],                                                                                                                  
                            "SpeedMbps": null,
                            "Status": {                                                                                                                         
                                "Health": "OK",                                                                                                                 
                                "State": "Enabled"                                                                                                              
                            }
                        }
                  ]
                ]
            ],
            "ret": true
        }
    }
```

After:
```
    "redfish_facts": {                                                          
        "nic": {                       
            "entries": [                                                        
                [                                                               
                    {                  
                        "resource_uri": "/redfish/v1/Systems/1/"
                    },                                                          
                    [        
                        { 
                            "IPv4Addresses": [],
                            "IPv6Addresses": [],
                            "Id": "1",
                            "LinkStatus": "LinkUp",
                            "MACAddress": "ff:ff:ff:ff:ff:ff",
                            "Name": "",                                                                                                                         
                            "NameServers": [],                                                                                                                  
                            "SpeedMbps": null,
                            "Status": {                                                                                                                         
                                "Health": "OK",                                                                                                                 
                                "State": "Enabled"                                                                                                              
                            }
                        }
                  ]
                ]
            ],
            "ret": true
        }
    }
```
