### PR TITLE
Add support for Oem params

### DIFF
--- a/changelogs/fragments/7330-redfish-utils-oem-params.yml
+++ b/changelogs/fragments/7330-redfish-utils-oem-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_utils module utils - add support for ``Oem parameters`` in the ``MultipartHTTPPushUpdate`` command in ``redfish_command`` feature (https://github.com/ansible-collections/community.general/issues/7331).

--- a/changelogs/fragments/7330-redfish-utils-oem-params.yml
+++ b/changelogs/fragments/7330-redfish-utils-oem-params.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_utils module utils - add support for ``Oem parameters`` in the ``MultipartHTTPPushUpdate`` command in ``redfish_command`` feature (https://github.com/ansible-collections/community.general/issues/7331).
+  - redfish_command - add new option ``update_oem_params`` for the ``MultipartHTTPPushUpdate`` command (https://github.com/ansible-collections/community.general/issues/7331).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1745,6 +1745,7 @@ class RedfishUtils(object):
         image_file = update_opts.get('update_image_file')
         targets = update_opts.get('update_targets')
         apply_time = update_opts.get('update_apply_time')
+        oem_params = update_opts.get('update_oem_params')
 
         # Ensure the image file is provided
         if not image_file:
@@ -1775,6 +1776,8 @@ class RedfishUtils(object):
             payload["Targets"] = targets
         if apply_time:
             payload["@Redfish.OperationApplyTime"] = apply_time
+        if oem_params:
+            payload["Oem"] = oem_params
         multipart_payload = {
             'UpdateParameters': {'content': json.dumps(payload), 'mime_type': 'application/json'},
             'UpdateFile': {'filename': image_file, 'content': image_payload, 'mime_type': 'application/octet-stream'}

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -208,7 +208,6 @@ options:
     description:
       - Properties for HTTP Multipart Push Updates.
     type: dict
-    default: {}
     version_added: '7.5.0'
   update_handle:
     required: false
@@ -801,7 +800,7 @@ def main():
             update_image_file=dict(type='path'),
             update_protocol=dict(),
             update_targets=dict(type='list', elements='str', default=[]),
-            update_oem_params=dict(type='dict', default={}),
+            update_oem_params=dict(type='dict'),
             update_creds=dict(
                 type='dict',
                 options=dict(

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -203,6 +203,12 @@ options:
       - InMaintenanceWindowOnReset
       - OnStartUpdateRequest
     version_added: '6.1.0'
+  update_oem_params:
+    required: false
+    description:
+      - Properties for HTTP Multipart Push Updates.
+    type: dict
+    default: {}
   update_handle:
     required: false
     description:

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -601,6 +601,8 @@ EXAMPLES = '''
       update_image_file: ~/images/myupdate.img
       update_targets:
         - /redfish/v1/UpdateService/FirmwareInventory/BMC
+      update_oem_params:
+        PreserveConfiguration: false
 
   - name: Perform requested operations to continue the update
     community.general.redfish_command:
@@ -792,6 +794,7 @@ def main():
             update_image_file=dict(type='path'),
             update_protocol=dict(),
             update_targets=dict(type='list', elements='str', default=[]),
+            update_oem_params=dict(type='dict', default={}),
             update_creds=dict(
                 type='dict',
                 options=dict(
@@ -874,6 +877,7 @@ def main():
         'update_targets': module.params['update_targets'],
         'update_creds': module.params['update_creds'],
         'update_apply_time': module.params['update_apply_time'],
+        'update_oem_params': module.params['update_oem_params'],
         'update_handle': module.params['update_handle'],
     }
 

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -209,6 +209,7 @@ options:
       - Properties for HTTP Multipart Push Updates.
     type: dict
     default: {}
+    version_added: '7.5.0'
   update_handle:
     required: false
     description:


### PR DESCRIPTION
Possible resolution to https://github.com/ansible-collections/community.general/issues/7331

Add support for Oem parameters in the MultipartHTTPPushUpdate command of `redfish_command`