### PR TITLE
LXD moved to Canonical

### DIFF
--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -47,7 +47,7 @@ DOCUMENTATION = r'''
             - You need to set this password on the lxd server before
                 running this module using the following command
                 C(lxc config set core.trust_password <some random password>)
-                See U(https://www.stgraber.org/2016/04/18/lxd-api-direct-interaction/).
+                See U(https://documentation.ubuntu.com/lxd/en/latest/authentication/#adding-client-certificates-using-a-trust-password).
             - If O(trust_password) is set, this module send a request for authentication before sending any requests.
             type: str
         state:
@@ -359,7 +359,7 @@ class InventoryModule(BaseInventoryPlugin):
         Kwargs:
             None
         Source:
-            https://github.com/lxc/lxd/blob/master/doc/rest-api.md
+            https://documentation.ubuntu.com/lxd/en/latest/rest-api/
         Raises:
             None
         Returns:

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -34,23 +34,24 @@ options:
     project:
         description:
           - 'Project of an instance.
-            See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/projects/).'
         required: false
         type: str
         version_added: 4.8.0
     architecture:
         description:
           - 'The architecture for the instance (for example V(x86_64) or V(i686)).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).'
         type: str
         required: false
     config:
         description:
           - 'The config for the instance (for example V({"limits.cpu": "2"})).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).'
           - If the instance already exists and its "config" values in metadata
-            obtained from the LXD API U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#instances-containers-and-virtual-machines)
-            are different, this module tries to apply the configurations.
+            obtained from the LXD API U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get)
+            are different, then this module tries to apply the configurations
+            U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_put).
           - The keys starting with C(volatile.) are ignored for this comparison when O(ignore_volatile_options=true).
         type: dict
         required: false
@@ -73,13 +74,13 @@ options:
         description:
           - 'The devices for the instance
             (for example V({ "rootfs": { "path": "/dev/kvm", "type": "unix-char" }})).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).'
         type: dict
         required: false
     ephemeral:
         description:
           - Whether or not the instance is ephemeral (for example V(true) or V(false)).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1).
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/instances/instance_get).
         required: false
         type: bool
     source:
@@ -87,7 +88,7 @@ options:
           - 'The source for the instance
             (for example V({ "type": "image", "mode": "pull", "server": "https://images.linuxcontainers.org",
             "protocol": "lxd", "alias": "ubuntu/xenial/amd64" })).'
-          - 'See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1) for complete API documentation.'
+          - 'See U(https://documentation.ubuntu.com/lxd/en/latest/api/) for complete API documentation.'
           - 'Note that C(protocol) accepts two choices: V(lxd) or V(simplestreams).'
         required: false
         type: dict

--- a/plugins/modules/lxd_profile.py
+++ b/plugins/modules/lxd_profile.py
@@ -32,7 +32,7 @@ options:
     project:
         description:
          - 'Project of a profile.
-           See U(https://github.com/lxc/lxd/blob/master/doc/projects.md).'
+           See U(https://documentation.ubuntu.com/lxd/en/latest/projects/).'
         type: str
         required: false
         version_added: 4.8.0
@@ -43,12 +43,13 @@ options:
     config:
         description:
           - 'The config for the instance (e.g. {"limits.memory": "4GB"}).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#patch-3)'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/profiles/profile_get).'
           - If the profile already exists and its "config" value in metadata
             obtained from
             GET /1.0/profiles/<name>
-            U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#get-19)
-            are different, they this module tries to apply the configurations.
+            U(https://documentation.ubuntu.com/lxd/en/latest/api/#/profiles/profile_get)
+            are different, then this module tries to apply the configurations
+            U(https://documentation.ubuntu.com/lxd/en/latest/api/#/profiles/profile_put).
           - Not all config values are supported to apply the existing profile.
             Maybe you need to delete and recreate a profile.
         required: false
@@ -57,14 +58,14 @@ options:
         description:
           - 'The devices for the profile
             (e.g. {"rootfs": {"path": "/dev/kvm", "type": "unix-char"}).
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#patch-3)'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/profiles/profile_get).'
         required: false
         type: dict
     new_name:
         description:
           - A new name of a profile.
           - If this parameter is specified a profile will be renamed to this name.
-            See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-11)
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/profiles/profile_post).
         required: false
         type: str
     merge_profile:

--- a/plugins/modules/lxd_project.py
+++ b/plugins/modules/lxd_project.py
@@ -35,18 +35,19 @@ options:
     config:
         description:
           - 'The config for the project (for example V({"features.profiles": "true"})).
-            See U(https://linuxcontainers.org/lxd/docs/master/projects/).'
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/projects/project_get).'
           - If the project already exists and its "config" value in metadata
             obtained from
             C(GET /1.0/projects/<name>)
-            U(https://linuxcontainers.org/lxd/docs/master/api/#/projects/project_get)
-            are different, then this module tries to apply the configurations.
+            U(https://documentation.ubuntu.com/lxd/en/latest/api/#/projects/project_get)
+            are different, then this module tries to apply the configurations
+            U(https://documentation.ubuntu.com/lxd/en/latest/api/#/projects/project_put).
         type: dict
     new_name:
         description:
           - A new name of a project.
           - If this parameter is specified a project will be renamed to this name.
-            See U(https://linuxcontainers.org/lxd/docs/master/api/#/projects/project_post).
+            See U(https://documentation.ubuntu.com/lxd/en/latest/api/#/projects/project_post).
         required: false
         type: str
     merge_project:


### PR DESCRIPTION
##### SUMMARY

Update links to LXD docs since it moved from linuxcontainers.org to Canonical. See the official announcement: https://discourse.ubuntu.com/t/faq-lxd-has-been-moved-to-canonical/36709

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Update links to LXD docs in the LXD inventory plugin and the `lxd_{container,profile,project}` modules.