### PR TITLE
pnpm: version should not be latest when state is latest

### DIFF
--- a/changelogs/fragments/7339-pnpm-correct-version-when-state-latest.yml
+++ b/changelogs/fragments/7339-pnpm-correct-version-when-state-latest.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pnpm - set correct version when state is latest or version is not mentioned. Resolves previous idempotency problem (https://github.com/ansible-collections/community.general/pull/7339)

--- a/changelogs/fragments/7339-pnpm-correct-version-when-state-latest.yml
+++ b/changelogs/fragments/7339-pnpm-correct-version-when-state-latest.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pnpm - set correct version when state is latest or version is not mentioned. Resolves previous idempotency problem (https://github.com/ansible-collections/community.general/pull/7339)
+  - pnpm - set correct version when state is latest or version is not mentioned. Resolves previous idempotency problem (https://github.com/ansible-collections/community.general/pull/7339).

--- a/plugins/modules/pnpm.py
+++ b/plugins/modules/pnpm.py
@@ -189,6 +189,8 @@ class Pnpm(object):
             self.alias_name_ver = (self.alias_name_ver or "") + self.name
             if self.version is not None:
                 self.alias_name_ver = self.alias_name_ver + "@" + str(self.version)
+            else:
+                self.alias_name_ver = self.alias_name_ver + "@latest"
 
     def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -412,9 +414,6 @@ def main():
 
     if state == "absent" and name is None:
         module.fail_json(msg="Package name is required for uninstalling")
-
-    if state == "latest":
-        version = "latest"
 
     if globally:
         _rc, out, _err = module.run_command(executable + ["root", "-g"], check_rc=True)

--- a/tests/integration/targets/pnpm/tasks/main.yml
+++ b/tests/integration/targets/pnpm/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 ####################################################################
 # WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
@@ -13,7 +14,7 @@
 # Setup steps
 
 - name: Run tests on OSes
-  include_tasks: run.yml
+  ansible.builtin.include_tasks: run.yml
   vars:
     ansible_system_os: "{{ ansible_system | lower }}"
     nodejs_version: "{{ item.node_version }}"

--- a/tests/integration/targets/pnpm/tasks/run.yml
+++ b/tests/integration/targets/pnpm/tasks/run.yml
@@ -127,11 +127,6 @@
           - pnpm_reinstall is success
           - not (pnpm_reinstall is changed)
 
-    - name: Manually delete package
-      ansible.builtin.file:
-        path: "{{ remote_tmp_dir }}/node_modules/{{ package }}"
-        state: absent
-
     - name: Reinstall package
       pnpm:
         path: "{{ remote_tmp_dir }}"
@@ -146,7 +141,7 @@
       ansible.builtin.assert:
         that:
           - pnpm_fix_install is success
-          - pnpm_fix_install is changed
+          - not (pnpm_fix_install is changed)
 
     - name: Install package with version, without executable path
       pnpm:
@@ -281,6 +276,22 @@
       pnpm:
         name: "{{ package }}"
         state: present
+        global: true
+      environment:
+        PATH: "{{ pnpm_bin_path }}:{{ node_bin_path }}:{{ ansible_env.PATH }}"
+        PNPM_HOME: "{{ pnpm_bin_path }}"
+      register: pnpm_reinstall
+
+    - name: Assert that there is no change
+      ansible.builtin.assert:
+        that:
+          - pnpm_reinstall is success
+          - not (pnpm_reinstall is changed)
+
+    - name: Updating package globally, without explicit executable path
+      pnpm:
+        name: "{{ package }}"
+        state: latest
         global: true
       environment:
         PATH: "{{ pnpm_bin_path }}:{{ node_bin_path }}:{{ ansible_env.PATH }}"

--- a/tests/integration/targets/pnpm/tasks/run.yml
+++ b/tests/integration/targets/pnpm/tasks/run.yml
@@ -141,7 +141,7 @@
       ansible.builtin.assert:
         that:
           - pnpm_fix_install is success
-          - not (pnpm_fix_install is changed)
+          - pnpm_fix_install is not changed
 
     - name: Install package with version, without executable path
       pnpm:
@@ -302,7 +302,7 @@
       ansible.builtin.assert:
         that:
           - pnpm_reinstall is success
-          - not (pnpm_reinstall is changed)
+          - pnpm_reinstall is not changed
 
     - name: Remove package without dependency globally
       pnpm:


### PR DESCRIPTION
If version is forcefully set at latest when state is latest, the package will always be changed, as there is no version "latest" will ever be detected. It is better to keep it None.

##### SUMMARY
Fixes the idempotency problem when state is latest, Previously, version was set at latest when state was latest, so the package was updated every time. This should be fixed now.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
