### PR TITLE
homebrew: re-order the default path

### DIFF
--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -45,7 +45,7 @@ options:
             - "A V(:) separated list of paths to search for C(brew) executable.
               Since a package (I(formula) in homebrew parlance) location is prefixed relative to the actual path of C(brew) command,
               providing an alternative C(brew) path enables managing different set of packages in an alternative location in the system."
-        default: '/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin'
+        default: '/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin'
         type: path
     state:
         description:
@@ -882,7 +882,7 @@ def main():
                 elements='str',
             ),
             path=dict(
-                default="/usr/local/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+                default="/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin",
                 required=False,
                 type='path',
             ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This will look for the recommended path first (/opt/homebrew).

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
homebrew

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
As a M1 user, I currently have two versions of homebrew:
- one in /opt/homebrew for regular usage
- one in /usr/homebrew to use with Rosetta, for stuff that I cannot run in ARM architecture

This means that the homebrew task fails at the moment because it will try and use the /usr one when I need it to run the regular /opt one.
For now, I need to set the path for each homebrew task in my playbook

Now, my case is probably not common, but this change should be slightly improve the lookup time as it favors the current and future Macs first.

