### PR TITLE
Fix lxc plugin options

### DIFF
--- a/changelogs/fragments/7369-fix-lxc-options.yml
+++ b/changelogs/fragments/7369-fix-lxc-options.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - lxc - properly evaluate options (https://github.com/ansible-collections/community.general/pull/7369).

--- a/changelogs/fragments/7369-fix-lxc-options.yml
+++ b/changelogs/fragments/7369-fix-lxc-options.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - lxc - properly evaluate options (https://github.com/ansible-collections/community.general/pull/7369).
+  - lxc connection plugin - properly evaluate options (https://github.com/ansible-collections/community.general/pull/7369).

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -17,6 +17,7 @@ DOCUMENTATION = '''
       remote_addr:
         description:
             - Container identifier
+        default: inventory_hostname
         vars:
             - name: inventory_hostname
             - name: ansible_host

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -68,7 +68,7 @@ class Connection(ConnectionBase):
         super(Connection, self)._connect()
 
         if not HAS_LIBLXC:
-            msg = "lxc bindings for python2 are not installed"
+            msg = "lxc python bindings are not installed"
             raise errors.AnsibleError(msg)
 
         if self.container:

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -17,7 +17,6 @@ DOCUMENTATION = '''
       remote_addr:
         description:
             - Container identifier
-        default: inventory_hostname
         vars:
             - name: inventory_hostname
             - name: ansible_host
@@ -60,7 +59,7 @@ class Connection(ConnectionBase):
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
-        self.container_name = self._play_context.remote_addr
+        self.container_name = None
         self.container = None
 
     def _connect(self):
@@ -73,6 +72,8 @@ class Connection(ConnectionBase):
 
         if self.container:
             return
+
+        self.container_name = self.get_option('remote_addr')
 
         self._display.vvv("THIS IS A LOCAL LXC DIR", host=self.container_name)
         self.container = _lxc.Container(self.container_name)
@@ -118,7 +119,7 @@ class Connection(ConnectionBase):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
         # python2-lxc needs bytes. python3-lxc needs text.
-        executable = to_native(self._play_context.executable, errors='surrogate_or_strict')
+        executable = to_native(self.get_option('executable'), errors='surrogate_or_strict')
         local_cmd = [executable, '-c', to_native(cmd, errors='surrogate_or_strict')]
 
         read_stdout, write_stdout = None, None

--- a/tests/unit/plugins/connection/test_lxc.py
+++ b/tests/unit/plugins/connection/test_lxc.py
@@ -71,3 +71,16 @@ class TestLXCConnectionClass():
 
         with pytest.raises(AnsibleError, match='lxc python bindings are not installed'):
             conn._connect()
+
+    def test_remote_addr_option(self):
+        """Test that the remote_addr option is used"""
+        play_context = PlayContext()
+        in_stream = StringIO()
+        conn = connection_loader.get('lxc', play_context, in_stream)
+
+        container_name = 'my-container'
+        conn.set_option('remote_addr', container_name)
+        assert conn.get_option('remote_addr') == container_name
+
+        conn._connect()
+        assert conn.container_name == container_name

--- a/tests/unit/plugins/connection/test_lxc.py
+++ b/tests/unit/plugins/connection/test_lxc.py
@@ -29,7 +29,7 @@ def lxc(request):
 
     class ContainerMock(mock.MagicMock):
         def __init__(self, name):
-            super().__init__()
+            super(ContainerMock, self).__init__()
             self.name = name
             self.state = 'STARTED'
 

--- a/tests/unit/plugins/connection/test_lxc.py
+++ b/tests/unit/plugins/connection/test_lxc.py
@@ -11,6 +11,7 @@ import sys
 
 from io import StringIO
 
+from ansible.errors import AnsibleError
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible_collections.community.general.tests.unit.compat import mock
@@ -60,3 +61,13 @@ class TestLXCConnectionClass():
         conn = connection_loader.get('lxc', play_context, in_stream)
         assert conn
         assert isinstance(conn, lxc.Connection)
+
+    @pytest.mark.parametrize('lxc', [False], indirect=True)
+    def test_lxc_connection_liblxc_error(self, lxc):
+        """Test that on connect an error is thrown if liblxc is not present."""
+        play_context = PlayContext()
+        in_stream = StringIO()
+        conn = connection_loader.get('lxc', play_context, in_stream)
+
+        with pytest.raises(AnsibleError, match='lxc python bindings are not installed'):
+            conn._connect()


### PR DESCRIPTION
##### SUMMARY
Because the lxc plugin was only using `PlayContext` properties, using host vars like `ansible_lxc_host` didn't work. This is fixed by instead using the `get_option` method inherited from `AnsiblePlugin`. The options are not yet available in the `__init__` function, so the determination of the container name is moved to the `_connect` method, which is the first time it is actually needed. The default for the `remote_addr` option is removed, because the string `inventory_hostname` is not very useful. At all. This seams to have been spread with copy&paste and a bit of cargo culting. The variable priority already takes care of setting the value.

Add a fixture to allow testing the lxc connection plugin both with and without liblxc being present. Also change the test from unittest to pytest, and add more tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc

##### ADDITIONAL INFORMATION