### PR TITLE
Handle remote_addr change in lxc connection plugin

### DIFF
--- a/changelogs/fragments/7373-lxc-remote-addr-change.yml
+++ b/changelogs/fragments/7373-lxc-remote-addr-change.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
-  - lxc connection plugin - Properly handle a change of the remote_addr option (https://github.com/ansible-collections/community.general/pull/7373).
+minor_changes:
+  - lxc connection plugin - properly handle a change of the ``remote_addr`` option (https://github.com/ansible-collections/community.general/pull/7373).

--- a/changelogs/fragments/7373-lxc-remote-addr-change.yml
+++ b/changelogs/fragments/7373-lxc-remote-addr-change.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - lxc connection plugin - Properly handle a change of the remote_addr option (https://github.com/ansible-collections/community.general/pull/7373).

--- a/plugins/connection/lxc.py
+++ b/plugins/connection/lxc.py
@@ -71,10 +71,11 @@ class Connection(ConnectionBase):
             msg = "lxc python bindings are not installed"
             raise errors.AnsibleError(msg)
 
-        if self.container:
+        container_name = self.get_option('remote_addr')
+        if self.container and self.container_name == container_name:
             return
 
-        self.container_name = self.get_option('remote_addr')
+        self.container_name = container_name
 
         self._display.vvv("THIS IS A LOCAL LXC DIR", host=self.container_name)
         self.container = _lxc.Container(self.container_name)

--- a/tests/unit/plugins/connection/test_lxc.py
+++ b/tests/unit/plugins/connection/test_lxc.py
@@ -27,11 +27,17 @@ def lxc(request):
     """
     liblxc_present = getattr(request, 'param', True)
 
-    class ContainerMock(mock.MagicMock):
+    class ContainerMock():
+        # dict of container name to its state
+        _container_states = {}
+
         def __init__(self, name):
             super(ContainerMock, self).__init__()
             self.name = name
-            self.state = 'STARTED'
+
+        @property
+        def state(self):
+            return ContainerMock._container_states.get(self.name, 'STARTED')
 
     liblxc_module_mock = mock.MagicMock()
     liblxc_module_mock.Container = ContainerMock
@@ -84,3 +90,15 @@ class TestLXCConnectionClass():
 
         conn._connect()
         assert conn.container_name == container_name
+
+    def test_error_when_stopped(self, lxc):
+        """Test that on connect an error is thrown if the container is stopped."""
+        play_context = PlayContext()
+        in_stream = StringIO()
+        conn = connection_loader.get('lxc', play_context, in_stream)
+        conn.set_option('remote_addr', 'my-container')
+
+        lxc._lxc.Container._container_states['my-container'] = 'STOPPED'
+
+        with pytest.raises(AnsibleError, match='my-container is not running'):
+            conn._connect()


### PR DESCRIPTION
##### SUMMARY
Detect if the `remote_addr` option changed, and properly "reconnect" aka update the internal state of the plugin instance.

This implements a suggestion from [#7369](https://github.com/ansible-collections/community.general/pull/7369/files#r1349765954).

Also add a test for the stopped container error, including some minor modification to the fixture. I didn't want to open a separate PR just for this, hence it is included here.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lxc

##### ADDITIONAL INFORMATION
