### PR TITLE
Fix callback/selective task print being long

### DIFF
--- a/changelogs/fragments/7374-fix-selective-callback-taskname-length.yml
+++ b/changelogs/fragments/7374-fix-selective-callback-taskname-length.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "selective callback plugin - fix length of task name lines in output always being 3 characters longer than desired (https://github.com/ansible-collections/community.general/pull/7374)."

--- a/plugins/callback/selective.py
+++ b/plugins/callback/selective.py
@@ -115,8 +115,8 @@ class CallbackModule(CallbackBase):
             line_length = 120
             if self.last_skipped:
                 print()
-            msg = colorize("# {0} {1}".format(task_name,
-                                              '*' * (line_length - len(task_name))), 'bold')
+            line = "# {0} ".format(task_name)
+            msg = colorize("{0}{1}".format(line, '*' * (line_length - len(line))), 'bold')
             print(msg)
 
     def _indent_text(self, text, indent_level):


### PR DESCRIPTION
##### SUMMARY
When printing the task name section of command output, previously the line was always 3 chars longer than `line_length` which is meant to limit width. This was due to the length check simply looking at the `task_name`, and not including the 3 formatting characters added in the string directly (`# {0} `). 

To fix this, I pulled these characters out into a separate variable then did the length check on that.

bugfixes:
  - selective - fix task name output using improper length check and going over the defined width limit

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
selective

##### ADDITIONAL INFORMATION
Note that there are many other checks in this plugin that also do not properly follow the `line_length` variable for one reason or another. I will submit fixes for those later in a separate PR as they are not as trivial to resolve. 

