### PR TITLE
Fix  pagination issue in community.general.github_deploy_key

### DIFF
--- a/changelogs/fragments/7375-fix-github-deploy-key-pagination.yml
+++ b/changelogs/fragments/7375-fix-github-deploy-key-pagination.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "github_deploy_key - Fix pagination behaviour causing a crash when only a single page of deploy keys exist."
+  - "github_deploy_key - fix pagination behaviour causing a crash when only a single page of deploy keys exist (https://github.com/ansible-collections/community.general/pull/7375)."

--- a/changelogs/fragments/7375-fix-github-deploy-key-pagination.yml
+++ b/changelogs/fragments/7375-fix-github-deploy-key-pagination.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "github_deploy_key - Fix pagination behaviour causing a crash when only a single page of deploy keys exist."

--- a/plugins/modules/github_deploy_key.py
+++ b/plugins/modules/github_deploy_key.py
@@ -227,7 +227,7 @@ class GithubDeployKey(object):
                 yield self.module.from_json(resp.read())
 
                 links = {}
-                for x, y in findall(r'<([^>]+)>;\s*rel="(\w+)"', info["link"]):
+                for x, y in findall(r'<([^>]+)>;\s*rel="(\w+)"', info.get("link", '')):
                     links[y] = x
 
                 url = links.get('next')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #5929. 

I also encountered this error, though unrelated to the use of `force`. The bug is caused by the pagination code in the module. If Deploy Keys exist, but not enough to paginate, the pagination check would raise a `KeyError`. Setting a default value for the lookup is sufficient to fix the module.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
github_deploy_key
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue #5929 for a discussion of how to trigger the bug.
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [(Locally) Push the deploy key to jupiler] *****************************************************************************************************************************************************
task path: /Users/padraic/Documents/bitbucket_to_github/migrate_machines/migrate_repos.yaml:62
The full traceback is:
Traceback (most recent call last):
  File "/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py", line 107, in <module>
    _ansiballz_main()
  File "/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible.modules.my_github_deploy_key', init_globals=dict(_module_fqn='ansible.modules.my_github_deploy_key', _modlib_path=modlib_path),
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py", line 340, in <module>
  File "/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py", line 328, in main
  File "/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py", line 231, in get_existing_key
  File "/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py", line 223, in paginate
KeyError: 'link'
fatal: [***.zensor.be -> 127.0.0.1]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/padraic/.ansible/tmp/ansible-tmp-1696887982.857162-24605-9050136827119/AnsiballZ_my_github_deploy_key.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.my_github_deploy_key', init_globals=dict(_module_fqn='ansible.modules.my_github_deploy_key', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py\", line 340, in <module>\n  File \"/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py\", line 328, in main\n  File \"/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py\", line 231, in get_existing_key\n  File \"/var/folders/ps/dwlk96k15fl7_csnxt2q57dc0000gn/T/ansible_my_github_deploy_key_payload_oim22357/ansible_my_github_deploy_key_payload.zip/ansible/modules/my_github_deploy_key.py\", line 223, in paginate\nKeyError: 'link'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
After:
```
TASK [(Locally) Push the deploy key to jupiler] *****************************************************************************************************************************************************
changed: [**** -> 127.0.0.1]
```