### PR TITLE
redhat_subscription: fix D-Bus option for consumer type on older distros

### DIFF
--- a/changelogs/fragments/7378-redhat_subscription-dbus-consumer-type.yaml
+++ b/changelogs/fragments/7378-redhat_subscription-dbus-consumer-type.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - |
+    redhat_subscription - use the right D-Bus options for the consumer type when
+    registering a RHEL system older than 9 or a RHEL 9 system older than 9.2
+    and using ``consumer_type``
+    (https://github.com/ansible-collections/community.general/pull/7378).

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -572,7 +572,34 @@ class Rhsm(object):
 
         register_opts = {}
         if consumer_type:
-            register_opts['consumer_type'] = consumer_type
+            # The option for the consumer type used to be 'type' in versions
+            # of RHEL before 9 & in RHEL 9 before 9.2, and then it changed to
+            # 'consumer_type'; since the Register*() D-Bus functions reject
+            # unknown options, we have to pass the right option depending on
+            # the version -- funky.
+            def supports_option_consumer_type():
+                # subscription-manager in any supported Fedora version
+                # has the new option.
+                if distro_id == 'fedora':
+                    return True
+                # Check for RHEL 9 >= 9.2, or RHEL >= 10.
+                if distro_id == 'rhel' and \
+                   ((distro_version[0] == 9 and distro_version[1] >= 2) or
+                       distro_version[0] >= 10):
+                    return True
+                # CentOS: since the change was only done in EL 9, then there is
+                # only CentOS Stream for 9, and thus we can assume it has the
+                # latest version of subscription-manager.
+                if distro_id == 'centos' and distro_version[0] >= 9:
+                    return True
+                # Unknown or old distro: assume it does not support
+                # the new option.
+                return False
+
+            consumer_type_key = 'type'
+            if supports_option_consumer_type():
+                consumer_type_key = 'consumer_type'
+            register_opts[consumer_type_key] = consumer_type
         if consumer_name:
             register_opts['name'] = consumer_name
         if consumer_id:


### PR DESCRIPTION
##### SUMMARY

subscription-manager 1.29.32 renames the `type` D-Bus registration option to `consumer_type`; this means that the right option must be passed according to the distro type & version.

Copy the same approach done for environments, tweaking the version needed: this change is found in RHEL 9.2+ and supported Fedora versions.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription
