### PR TITLE
Skip odbc tests on Python 2.6 and CentOS 7

### DIFF
--- a/tests/integration/targets/odbc/aliases
+++ b/tests/integration/targets/odbc/aliases
@@ -11,3 +11,4 @@ skip/rhel9.0
 skip/rhel9.1
 skip/rhel9.2
 skip/freebsd
+skip/python2.6

--- a/tests/integration/targets/odbc/tasks/main.yml
+++ b/tests/integration/targets/odbc/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - when:
     - ansible_os_family != 'Archlinux'  # TODO install driver from AUR: https://aur.archlinux.org/packages/psqlodbc
+    - ansible_os_family != 'RedHat' or ansible_distribution_major_version != '7'  # CentOS 7 stopped working
   block:
 
     #


### PR DESCRIPTION
##### SUMMARY
Fixes CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
odbc tests
