### PR TITLE
plugins/inventory/lxd: add server_cert option

### DIFF
--- a/changelogs/fragments/7392-lxd-inventory-server-cert.yml
+++ b/changelogs/fragments/7392-lxd-inventory-server-cert.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - lxd inventory plugin - add ``server_cert`` option for trust anchor to use for TLS verification of server certificates (https://github.com/ansible-collections/community.general/pull/7392).
+  - lxd inventory plugin - add ``server_check_hostname`` option to disable hostname verification of server certificates (https://github.com/ansible-collections/community.general/pull/7392).

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -41,6 +41,20 @@ DOCUMENTATION = r'''
             aliases: [ cert_file ]
             default: $HOME/.config/lxc/client.crt
             type: path
+        server_cert:
+            description:
+            - The server certificate file path.
+            type: path
+            version_added: 8.0.0
+        server_check_hostname:
+            description:
+            - This option controls if the server's hostname is checked as part of the HTTPS connection verification.
+              This can be useful to disable, if for example, the server certificate provided (see O(server_cert) option)
+              does not cover a name matching the one used to communicate with the server. Such mismatch is common as LXD
+              generates self-signed server certificates by default.
+            type: bool
+            default: true
+            version_added: 8.0.0
         trust_password:
             description:
             - The client trusted password.
@@ -286,7 +300,7 @@ class InventoryModule(BaseInventoryPlugin):
         urls = (url for url in url_list if self.validate_url(url))
         for url in urls:
             try:
-                socket_connection = LXDClient(url, self.client_key, self.client_cert, self.debug)
+                socket_connection = LXDClient(url, self.client_key, self.client_cert, self.debug, self.server_cert, self.server_check_hostname)
                 return socket_connection
             except LXDClientException as err:
                 error_storage[url] = err
@@ -1078,6 +1092,8 @@ class InventoryModule(BaseInventoryPlugin):
         try:
             self.client_key = self.get_option('client_key')
             self.client_cert = self.get_option('client_cert')
+            self.server_cert = self.get_option('server_cert')
+            self.server_check_hostname = self.get_option('server_check_hostname')
             self.project = self.get_option('project')
             self.debug = self.DEBUG
             self.data = {}  # store for inventory-data

--- a/plugins/module_utils/lxd.py
+++ b/plugins/module_utils/lxd.py
@@ -41,7 +41,7 @@ class LXDClientException(Exception):
 
 
 class LXDClient(object):
-    def __init__(self, url, key_file=None, cert_file=None, debug=False):
+    def __init__(self, url, key_file=None, cert_file=None, debug=False, server_cert_file=None, server_check_hostname=True):
         """LXD Client.
 
         :param url: The URL of the LXD server. (e.g. unix:/var/lib/lxd/unix.socket or https://127.0.0.1)
@@ -52,6 +52,10 @@ class LXDClient(object):
         :type cert_file: ``str``
         :param debug: The debug flag. The request and response are stored in logs when debug is true.
         :type debug: ``bool``
+        :param server_cert_file: The path of the server certificate file.
+        :type server_cert_file: ``str``
+        :param server_check_hostname: Whether to check the server's hostname as part of TLS verification.
+        :type debug: ``bool``
         """
         self.url = url
         self.debug = debug
@@ -61,6 +65,10 @@ class LXDClient(object):
             self.key_file = key_file
             parts = generic_urlparse(urlparse(self.url))
             ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            if server_cert_file:
+                # Check that the received cert is signed by the provided server_cert_file
+                ctx.load_verify_locations(cafile=server_cert_file)
+            ctx.check_hostname = server_check_hostname
             ctx.load_cert_chain(cert_file, keyfile=key_file)
             self.connection = HTTPSConnection(parts.get('netloc'), context=ctx)
         elif url.startswith('unix:'):


### PR DESCRIPTION
##### SUMMARY
It is common for lxd servers to use self-signed certificates. Providing the server
certificate allows to do verification of the HTTPS connection. When this option is
used, the hostname part of the url doesn't need to match one of the Subject Alternate
Names (SANs) of the certificate. This is essentially certificate pinning.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/lxd
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION

If you interact with remote LXD servers, you will often run into servers using self-signed certificate as that's how LXD creates it's own certificate by default (see https://github.com/canonical/lxd/blob/main/lxd/util/encryption.go#L41-L57 and https://github.com/canonical/lxd/blob/main/shared/cert.go#L308-L383).

When using the CLI client `lxc`, the server certificate is essentially saved on disk and used as CA for the given connection. It essentially does certificate pinning and disable hostname verification because the remote name can be arbitrary (picked by the client). Here's an example:

```
$ lxc remote list | head -n5
+-------------------------------+---------------------------------------------------+---------------+-------------+--------+--------+--------+
|             NAME              |                        URL                        |   PROTOCOL    |  AUTH TYPE  | PUBLIC | STATIC | GLOBAL |
+-------------------------------+---------------------------------------------------+---------------+-------------+--------+--------+--------+
| c2d                           | https://c2d.example.com:8443                | lxd           | tls         | NO     | NO     | NO     |
+-------------------------------+---------------------------------------------------+---------------+-------------+--------+--------+--------+
```

The certificate for this remote going by the `c2d` name has the following properties:

```
$ openssl x509 -text -in ~/snap/lxd/common/config/servercerts/c2d.crt | grep -wF c2d
        Issuer: O = linuxcontainers.org, CN = root@c2d
        Subject: O = linuxcontainers.org, CN = root@c2d
                DNS:c2d, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1
```

It's a self-signed certificate (Issuer == Subject) and the SANs list covers the hostname only (not the FQDN). As such, `lxc` is simply doing certificate pinning to verify the connection.

This PR, brings the same concept to the lxd inventory plugin by adding an extra option to provide the certificate to use for verification (`server_cert`). Here's what an inventory `lxd.yml` would look like for the given `c2d` remote:

```
$ cat lxd.yml 
plugin: community.general.lxd
url: "https://c2d.example.com:8443"
server_cert: "/home/foo/snap/lxd/common/config/servercerts/c2d.crt"
client_cert: "/home/foo/snap/lxd/common/config/client.crt"
client_key: "/home/foo/snap/lxd/common/config/client.key"
```

```
$ ansible-inventory -i lxd.yml --list -y
all:
  children:
    ungrouped:
      hosts:
        bar-container:
          ansible_connection: ssh
          ansible_host: 192.0.2.1
          ansible_lxd_os: ubuntu
          ansible_lxd_profile:
          - default
          ansible_lxd_project: default
          ansible_lxd_release: jammy
          ansible_lxd_state: running
          ansible_lxd_type: container
```

```
$ lxc list c2d:bar
+------+---------+------------------+--------------------+-----------+-----------+
| NAME |  STATE  |       IPV4       |        IPV6        |   TYPE    | SNAPSHOTS |
+------+---------+------------------+--------------------+-----------+-----------+
| bar  | RUNNING | 192.0.2.1 (eth0) | 2001:db8::1 (eth0) | CONTAINER | 4         |
+------+---------+------------------+--------------------+-----------+-----------+

```