### PR TITLE
Add `modify_inactive_option` option to `ini_file` module to ignore matching commented key:value pairs

### DIFF
--- a/changelogs/fragments/7401-ini-file-modify-inactive-option.yaml
+++ b/changelogs/fragments/7401-ini-file-modify-inactive-option.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ini_file - add `modify_inactive_option` option (https://github.com/ansible-collections/community.general/pull/7401).

--- a/changelogs/fragments/7401-ini-file-modify-inactive-option.yaml
+++ b/changelogs/fragments/7401-ini-file-modify-inactive-option.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ini_file - add `modify_inactive_option` option (https://github.com/ansible-collections/community.general/pull/7401).
+  - ini_file - add ``modify_inactive_option`` option (https://github.com/ansible-collections/community.general/pull/7401).

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -118,11 +118,12 @@ options:
     default: false
   modify_inactive_option:
     description:
-      - Do not replace a commented line that matches the given option. This is useful when you want to keep example
+      - By default the module replaces a commented line that matches the given option.
+      - Set this option to V(false) to avoid this. This is useful when you want to keep example.
        key:value pairs for documentation purposes.
     type: bool
     default: true
-    version_added: 7.6.0
+    version_added: 8.0.0
   follow:
     description:
     - This flag indicates that filesystem links, if they exist, should be followed.

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -119,8 +119,8 @@ options:
   modify_inactive_option:
     description:
       - By default the module replaces a commented line that matches the given option.
-      - Set this option to V(false) to avoid this. This is useful when you want to keep example
-        key:value pairs for documentation purposes.
+      - Set this option to V(false) to avoid this. This is useful when you want to keep commented example
+        C(key=value) pairs for documentation purposes.
     type: bool
     default: true
     version_added: 8.0.0

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -122,7 +122,7 @@ options:
        key:value pairs for documentation purposes.
     type: bool
     default: true
-    version_added: TO_BE_UPDATED
+    version_added: 7.6.0
   follow:
     description:
     - This flag indicates that filesystem links, if they exist, should be followed.

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -119,8 +119,8 @@ options:
   modify_inactive_option:
     description:
       - By default the module replaces a commented line that matches the given option.
-      - Set this option to V(false) to avoid this. This is useful when you want to keep example.
-       key:value pairs for documentation purposes.
+      - Set this option to V(false) to avoid this. This is useful when you want to keep example
+        key:value pairs for documentation purposes.
     type: bool
     default: true
     version_added: 8.0.0

--- a/tests/integration/targets/ini_file/tasks/main.yml
+++ b/tests/integration/targets/ini_file/tasks/main.yml
@@ -44,3 +44,6 @@
 
     - name: include tasks to test ignore_spaces
       include_tasks: tests/05-ignore_spaces.yml
+
+    - name: include tasks to test modify_inactive_option
+      include_tasks: tests/06-modify_inactive_option.yml

--- a/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/06-modify_inactive_option.yml
@@ -1,0 +1,123 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+## testing modify_inactive_option option
+
+- name: test-modify_inactive_option 1 - create test file
+  copy:
+    content: |
+
+      [section1]
+      # Uncomment the line below to enable foo
+      # foo = bar
+
+    dest: "{{ output_file }}"
+
+- name: test-modify_inactive_option 1 - set value for foo with modify_inactive_option set to true
+  ini_file:
+    path: "{{ output_file }}"
+    section: section1
+    option: foo
+    value: bar
+    modify_inactive_option: true
+  register: result1
+
+- name: test-modify_inactive_option 1 - read content from output file
+  slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: test-modify_inactive_option 1 - set expected content and get current ini file content
+  set_fact:
+    expected1: |
+
+      [section1]
+      # Uncomment the line below to enable foo
+      foo = bar
+
+    content1: "{{ output_content.content | b64decode }}"
+
+- name: test-modify_inactive_option 1 - assert 'changed' is true, content is OK and option changed
+  assert:
+    that:
+      - result1 is changed
+      - result1.msg == 'option changed'
+      - content1 == expected1
+
+
+- name: test-modify_inactive_option 2 - create test file
+  copy:
+    content: |
+
+      [section1]
+      # Uncomment the line below to enable foo
+      # foo = bar
+
+    dest: "{{ output_file }}"
+
+- name: test-modify_inactive_option 2 - set value for foo with modify_inactive_option set to false
+  ini_file:
+    path: "{{ output_file }}"
+    section: section1
+    option: foo
+    value: bar
+    modify_inactive_option: false
+  register: result2
+
+- name: test-modify_inactive_option 2 - read content from output file
+  slurp:
+      src: "{{ output_file }}"
+  register: output_content
+
+- name: test-modify_inactive_option 2 - set expected content and get current ini file content
+  set_fact:
+    expected2: |
+
+      [section1]
+      foo = bar
+      # Uncomment the line below to enable foo
+      # foo = bar
+
+    content2: "{{ output_content.content | b64decode }}"
+
+- name: test-modify_inactive_option 2 - assert 'changed' is true and content is OK and option added
+  assert:
+    that:
+      - result2 is changed
+      - result2.msg == 'option added'
+      - content2 == expected2
+
+
+- name: test-modify_inactive_option 3 - remove foo=bar with modify_inactive_option set to true to ensure it doesn't have effect for removal
+  ini_file:
+    path: "{{ output_file }}"
+    section: section1
+    option: foo
+    value: bar
+    modify_inactive_option: true
+    state: absent
+  register: result3
+
+- name: test-modify_inactive_option 3 - read content from output file
+  slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: test-modify_inactive_option 3 - set expected content and get current ini file content
+  set_fact:
+    expected3: |
+  
+      [section1]
+      # Uncomment the line below to enable foo
+      # foo = bar
+
+    content3: "{{ output_content.content | b64decode }}"
+
+- name: test-modify_inactive_option 3 - assert 'changed' is true and content is OK and active option removed
+  assert:
+    that:
+      - result3 is changed
+      - result3.msg == 'option changed'
+      - content3 == expected3


### PR DESCRIPTION
##### SUMMARY

Add new `modify_inactive_option` option to the `ini_file` module which, when set to false, will not modify a matching commented-out (inactive) option, and will instead add a new line for the given `option: value`. 

For example, with the `file.ini` that looks like this

```ini
[section]
# foo = bar
```

The following task

```yaml
ini_file:
    path: file.ini
    section: section
    option: foo
    value: bar
    modify_inactive_option: true
```

will produce the following output

```ini
[section]
foo = bar
```

Whereas

```yaml
ini_file:
    path: file.ini
    section: section
    option: foo
    value: bar
    modify_inactive_option: false
```

Will produce this

```ini
[section]
foo = bar
# foo = bar
```

Fixes https://github.com/ansible-collections/community.general/issues/7297

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ini_file

##### ADDITIONAL INFORMATION
