### PR TITLE
Fix the ability to run Composer "working_dir" dependent commands

### DIFF
--- a/changelogs/fragments/3787-pass-composer-working-dir.yml
+++ b/changelogs/fragments/3787-pass-composer-working-dir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - composer module - fix impossible to run working_dir dependent commands. `community.general.composer` was throwing an error when trying to run a working_dir dependent command, because it tried to get the command help without passing the working_dir (https://github.com/ansible-collections/community.general/issues/3787).

--- a/changelogs/fragments/3787-pass-composer-working-dir.yml
+++ b/changelogs/fragments/3787-pass-composer-working-dir.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - composer module - fix impossible to run working_dir dependent commands. `community.general.composer` was throwing an error when trying to run a working_dir dependent command, because it tried to get the command help without passing the working_dir (https://github.com/ansible-collections/community.general/issues/3787).
+  - composer - fix impossible to run ``working_dir`` dependent commands. The module was throwing an error when trying to run a ``working_dir`` dependent command, because it tried to get the command help without passing the ``working_dir`` (https://github.com/ansible-collections/community.general/issues/3787).

--- a/plugins/modules/composer.py
+++ b/plugins/modules/composer.py
@@ -170,9 +170,14 @@ def get_available_options(module, command='install'):
     return command_help_json['definition']['options']
 
 
-def composer_command(module, command, arguments="", options=None, global_command=False):
+def composer_command(module, command, arguments="", options=None):
     if options is None:
         options = []
+
+    global_command = module.params['global_command']
+
+    if not global_command:
+        options.extend(['--working-dir', "'%s'" % module.params['working_dir']])
 
     if module.params['executable'] is None:
         php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
@@ -217,7 +222,6 @@ def main():
         module.fail_json(msg="Use the 'arguments' param for passing arguments with the 'command'")
 
     arguments = module.params['arguments']
-    global_command = module.params['global_command']
     available_options = get_available_options(module=module, command=command)
 
     options = []
@@ -233,9 +237,6 @@ def main():
         if option in available_options:
             option = "--%s" % option
             options.append(option)
-
-    if not global_command:
-        options.extend(['--working-dir', "'%s'" % module.params['working_dir']])
 
     option_params = {
         'prefer_source': 'prefer-source',
@@ -260,7 +261,7 @@ def main():
         else:
             module.exit_json(skipped=True, msg="command '%s' does not support check mode, skipping" % command)
 
-    rc, out, err = composer_command(module, command, arguments, options, global_command)
+    rc, out, err = composer_command(module, command, arguments, options)
 
     if rc != 0:
         output = parse_out(err)


### PR DESCRIPTION
##### SUMMARY

When the composer plugin runs a command, it searches for the command available options using `composer help`.
However, some composer commands are not available globally, but only in a given working directory. Therefore, it is required to pass the `working_dir` parameter to all composer command invocation that is not a global command.

Fixes #3787 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

composer module

##### ADDITIONAL INFORMATION

Before this change, the execution of:

```yaml
- name: Compile the .env.local file to PHP
  community.general.composer:
    command: symfony:dump-env
    working_dir: "/path/to/my/directory"
    arguments: prod
```

was throwing an error:

```
fatal: FAILED! => {"changed": false, "msg": "There are no commands defined in the \"symfony\" namespace. help [--format FORMAT] [--raw] [--] [<command_name>]"}
```

