### PR TITLE
Bugfix: keycloak_identity_provider does not handle mapper changes properly

### DIFF
--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -542,10 +542,14 @@ def main():
                     old_mapper = dict()
             new_mapper = old_mapper.copy()
             new_mapper.update(change)
-            if new_mapper != old_mapper:
-                if changeset.get('mappers') is None:
-                    changeset['mappers'] = list()
-                changeset['mappers'].append(new_mapper)
+
+            if changeset.get('mappers') is None:
+                changeset['mappers'] = list()
+            # eventually this holds all desired mappers, unchanged, modified and newly added
+            changeset['mappers'].append(new_mapper)
+
+        # ensure idempotency in case module.params.mappers is not sorted by name
+        changeset['mappers'] = sorted(changeset['mappers'], key=lambda x: x.get('name'))
 
     # Prepare the desired values using the existing values (non-existence results in a dict that is save to use as a basis)
     desired_idp = before_idp.copy()

--- a/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
@@ -109,7 +109,7 @@
     that:
       - result is not changed
 
-- name: Update existing identity provider (with change)
+- name: Update existing identity provider (with change, no mapper change)
   community.general.keycloak_identity_provider:
     auth_keycloak_url: "{{ url }}"
     auth_realm: "{{ admin_realm }}"
@@ -131,6 +131,109 @@
       - result is changed
       - result.existing.enabled == true
       - result.end_state.enabled == false
+
+- name: Update existing identity provider (delete mapper)
+  community.general.keycloak_identity_provider:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "{{ idp }}"
+    state: present
+    mappers:
+      - name: "first_name"
+        identityProviderAlias: "{{ idp }}"
+        identityProviderMapper: "oidc-user-attribute-idp-mapper"
+        config:
+          claim: "first_name"
+          user.attribute: "first_name"
+          syncMode: "INHERIT"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert identity provider updated
+  assert:
+    that:
+      - result is changed
+      - result.existing.mappers | length == 2
+      - result.end_state.mappers | length == 1
+      - result.end_state.mappers[0].name == "first_name"
+
+- name: Update existing identity provider (add mapper)
+  community.general.keycloak_identity_provider:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "{{ idp }}"
+    state: present
+    mappers:
+      - name: "last_name"
+        identityProviderAlias: "{{ idp }}"
+        identityProviderMapper: "oidc-user-attribute-idp-mapper"
+        config:
+          claim: "last_name"
+          user.attribute: "last_name"
+          syncMode: "INHERIT"
+      - name: "first_name"
+        identityProviderAlias: "{{ idp }}"
+        identityProviderMapper: "oidc-user-attribute-idp-mapper"
+        config:
+          claim: "first_name"
+          user.attribute: "first_name"
+          syncMode: "INHERIT"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert identity provider updated
+  assert:
+    that:
+      - result is changed
+      - result.existing.mappers | length == 1
+      - result.end_state.mappers | length == 2
+
+- name: Update existing identity provider (no change, test mapper idempotency)
+  community.general.keycloak_identity_provider:
+    auth_keycloak_url: "{{ url }}"
+    auth_realm: "{{ admin_realm }}"
+    auth_username: "{{ admin_user }}"
+    auth_password: "{{ admin_password }}"
+    realm: "{{ realm }}"
+    alias: "{{ idp }}"
+    state: present
+    mappers:
+      - name: "last_name"
+        identityProviderAlias: "{{ idp }}"
+        identityProviderMapper: "oidc-user-attribute-idp-mapper"
+        config:
+          claim: "last_name"
+          user.attribute: "last_name"
+          syncMode: "INHERIT"
+      - name: "first_name"
+        identityProviderAlias: "{{ idp }}"
+        identityProviderMapper: "oidc-user-attribute-idp-mapper"
+        config:
+          claim: "first_name"
+          user.attribute: "first_name"
+          syncMode: "INHERIT"
+  register: result
+
+- name: Debug
+  debug:
+    var: result
+
+- name: Assert identity provider updated
+  assert:
+    that:
+      - result is not changed
 
 - name: Delete existing identity provider
   community.general.keycloak_identity_provider:

--- a/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
@@ -35,14 +35,14 @@
       syncMode: FORCE
     mappers:
       - name: "first_name"
-        identityProviderAlias: "oidc-idp"
+        identityProviderAlias: "{{ idp }}"
         identityProviderMapper: "oidc-user-attribute-idp-mapper"
         config:
           claim: "first_name"
           user.attribute: "first_name"
           syncMode: "INHERIT"
       - name: "last_name"
-        identityProviderAlias: "oidc-idp"
+        identityProviderAlias: "{{ idp }}"
         identityProviderMapper: "oidc-user-attribute-idp-mapper"
         config:
           claim: "last_name"
@@ -84,14 +84,14 @@
       syncMode: FORCE
     mappers:
       - name: "first_name"
-        identityProviderAlias: "oidc-idp"
+        identityProviderAlias: "{{ idp }}"
         identityProviderMapper: "oidc-user-attribute-idp-mapper"
         config:
           claim: "first_name"
           user.attribute: "first_name"
           syncMode: "INHERIT"
       - name: "last_name"
-        identityProviderAlias: "oidc-idp"
+        identityProviderAlias: "{{ idp }}"
         identityProviderMapper: "oidc-user-attribute-idp-mapper"
         config:
           claim: "last_name"


### PR DESCRIPTION
##### SUMMARY
keycloak_identity_provider mapper processing contained a bug which resulted in incorrect behaviour in the following cases:

* deleting an existing mapper - nothing happened
* adding a new mapper to a non-empty list - the new mapper was added, the pre-existing mappers were removed
* repeated calls without modified configuration were not idempotent if the mappers were not ordered by name in task specification

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_identity_provider

##### ADDITIONAL INFORMATION

Issue was caused by `dict.update()` function being used to merge old and new states, without considering it does not recursively process nested lists and dictionaries.

Regression tests for all 3 cases have been added to `tests/integration/targets/keycloak_identity_provider/tasks/main.yml`