### PR TITLE
change fail_not_found to False for zypper absent

### DIFF
--- a/changelogs/fragments/7423-change-fail_not_found-to-False-for-zypper-absent.yml
+++ b/changelogs/fragments/7423-change-fail_not_found-to-False-for-zypper-absent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "zypper - change remove operation (``status=absent``) to not fail on 104 status (https://github.com/ansible-collections/community.general/pull/7423)."

--- a/plugins/modules/zypper.py
+++ b/plugins/modules/zypper.py
@@ -327,9 +327,9 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
     elif rc in [0, 102, 103, 106]:
         # zypper exit codes
         # 0: success
-        # 106: signature verification failed
-        # 102: ZYPPER_EXIT_INF_REBOOT_NEEDED - Returned after a successful installation of a patch which requires reboot of computer.
-        # 103: zypper was upgraded, run same command again
+        # 102: ZYPPER_EXIT_INF_REBOOT_NEEDED - returned after a successful installation of a patch which requires reboot of computer.
+        # 103: ZYPPER_EXIT_INF_RESTART_NEEDED - zypper was upgraded, run same command again
+        # 106: ZYPPER_EXIT_INF_REPOS_SKIPPED - signature verification failed
         if packages is None:
             firstrun = True
             packages = {}
@@ -504,7 +504,7 @@ def package_absent(m, name):
     cmd.extend([p.name + p.version for p in packages])
 
     retvals['cmd'] = cmd
-    result, retvals['rc'], retvals['stdout'], retvals['stderr'] = parse_zypper_xml(m, cmd)
+    result, retvals['rc'], retvals['stdout'], retvals['stderr'] = parse_zypper_xml(m, cmd, fail_not_found=False)
     return result, retvals
 
 


### PR DESCRIPTION
##### SUMMARY
For the _zypper_ module, when doing a remove operation (`state: absent`), the current design causes the
task to fail whenever zypper returns a 104 status. This status, called `ZYPPER_EXIT_INF_CAP_NOT_FOUND`, indicates
that zypper could not fully complete the remove because one of the package arguments could not be found
on the system.

I believe that the task should not fail, as our intention is to remove the package(s) from the system... if it cannot be found on the system, then that is exactly the intention. Furthermore, with `--non-interaction`, the remove operation will still try to remove any package(s) it does find on the system.

This MR changes the behaviour of zypper `status: absent` to not fail on status return 104.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module zypper

##### ADDITIONAL INFORMATION