### PR TITLE
Add option to proxmox dynamic inventory to exclude nodes

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -610,8 +610,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if name is not None:
                     hosts.append(name)
 
-            # removes node host at the end of this node-specific loop 
-            if self.exclude_nodes: self.inventory.remove_host(self.inventory.hosts[node['node']]) 
         # gather vm's in pools
         self._populate_pool_groups(hosts)
 


### PR DESCRIPTION
##### SUMMARY
This pull request enables users of the proxmox inventory source to exclude the proxmox-nodes from the ansible-host list at will. The default of the new setting `exclude_nodes` is to include nodes, so it it should stay compatible to the current usage.

**TODO**: I could only test this implementation on my single-node proxmox cluster, I'd be glad if someone else could verify this implementation on a multi-node-cluster.

This PR fixes #6714 .

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
!component =plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION

before:
```
ubuntu@adm: ansible-inventory -i test.proxmox.yaml --graph
@all:
  |--@ungrouped:
  |--@proxmox_all_lxc:
  |--@proxmox_all_qemu:
  |  |--mail
  |  |--git
  |  |--web
  |--@proxmox_all_running:
  |  |--mail
  |  |--git
  |  |--web
  |--@proxmox_all_stopped:
  |--@proxmox_all_prelaunch:
  |--@proxmox_all_paused:
  |--@proxmox_nodes:
  |  |--hypervisor
  |--@proxmox_hypervisor_lxc:
  |--@proxmox_hypervisor_qemu:
  |  |--git
  |  |--mail
  |  |--web
```

after:
```
ubuntu@adm: ansible-inventory -i test.proxmox.yaml --graph
 @all:
  |--@ungrouped:
  |--@proxmox_all_lxc:
  |--@proxmox_all_qemu:
  |  |--web
  |  |--git
  |  |--mail
  |--@proxmox_all_running:
  |  |--web
  |  |--git
  |  |--mail
  |--@proxmox_all_stopped:
  |--@proxmox_all_prelaunch:
  |--@proxmox_all_paused:
  |--@proxmox_hypervisor_lxc:
  |--@proxmox_hypervisor_qemu:
  |  |--web
  |  |--git
  |  |--mail
```
