### PR TITLE
Disable ansible_galaxy_install tests until Galaxy is fixed

### DIFF
--- a/tests/integration/targets/ansible_galaxy_install/aliases
+++ b/tests/integration/targets/ansible_galaxy_install/aliases
@@ -6,3 +6,4 @@ azp/posix/3
 destructive
 skip/python2.6
 context/controller  # While this is not really true, this module mainly is run on the controller, *and* needs access to the ansible-galaxy CLI tool
+disabled  # TODO wait until Galaxy is fixed


### PR DESCRIPTION
##### SUMMARY
https://forum.ansible.com/t/cannot-install-some-roles-anymore-tries-to-import-from-github-user-none/2018

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible_galaxy_install
