### PR TITLE
Revert "Disable ansible_galaxy_install tests until Galaxy is fixed (#7440)"

### DIFF
--- a/tests/integration/targets/ansible_galaxy_install/aliases
+++ b/tests/integration/targets/ansible_galaxy_install/aliases
@@ -6,4 +6,3 @@ azp/posix/3
 destructive
 skip/python2.6
 context/controller  # While this is not really true, this module mainly is run on the controller, *and* needs access to the ansible-galaxy CLI tool
-disabled  # TODO wait until Galaxy is fixed


### PR DESCRIPTION
##### SUMMARY
This reverts commit f7532c7d9dea16e81f2f5535504951d819a52e51.

Undoes #7440.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible_galaxy_install
