### PR TITLE
CI: make sure that Python 2.7 unit tests also run with AZP

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -137,6 +137,7 @@ stages:
           nameFormat: Python {0}
           testFormat: 2.16/units/{0}/1
           targets:
+            - test: 2.7
             - test: 3.6
             - test: "3.11"
   - stage: Units_2_15


### PR DESCRIPTION
##### SUMMARY
Currently they only run with GHA.

Ref: https://github.com/ansible-collections/community.general/pull/7418#issuecomment-1785975830

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
