### PR TITLE
Fix icinga2_host requiring ip key.

### DIFF
--- a/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
+++ b/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - icinga2_host - the ``ip`` option is no longer required, since Icinga 2 allows for an empty address attribute (https://github.com/ansible-collections/community.general/pull/7452).

--- a/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
+++ b/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - icinga2_host - fix module requiring ip key while Icinga 2 allows for empty address attribute (https://github.com/ansible-collections/community.general/pull/7452).
+  - icinga2_host - the ``ip`` option is no longer required, since Icinga 2 allows for an empty address attribute (https://github.com/ansible-collections/community.general/pull/7452).

--- a/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
+++ b/changelogs/fragments/7452-fix-icinga2_host-requiring-ip-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - icinga2_host - fix module requiring ip key while Icinga 2 allows for empty address attribute (https://github.com/ansible-collections/community.general/pull/7452).

--- a/plugins/modules/icinga2_host.py
+++ b/plugins/modules/icinga2_host.py
@@ -106,6 +106,7 @@ options:
     type: str
     description:
       - The IP address of the host.
+      - This is no longer required since community.general 8.0.0.
   variables:
     type: dict
     description:

--- a/plugins/modules/icinga2_host.py
+++ b/plugins/modules/icinga2_host.py
@@ -106,7 +106,6 @@ options:
     type: str
     description:
       - The IP address of the host.
-    required: true
   variables:
     type: dict
     description:
@@ -243,7 +242,7 @@ def main():
         template=dict(default=None),
         check_command=dict(default="hostalive"),
         display_name=dict(default=None),
-        ip=dict(required=True),
+        ip=dict(),
         variables=dict(type='dict', default=None),
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR allows `icinga2_host` to create hosts without having to provide an `ip` address.  
This is in line with what Icinga 2 allows you to do. Even though useful, no address is strictly necessary. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #5248

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

icinga2_host
