### PR TITLE
Fix: apache2_mod_proxy python3 / BeautifulSoup4 support

### DIFF
--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -212,7 +212,7 @@ from ansible.module_utils.six import iteritems
 
 BEAUTIFUL_SOUP_IMP_ERR = None
 try:
-    from BeautifulSoup import BeautifulSoup
+    from bs4 import BeautifulSoup
 except ImportError:
     BEAUTIFUL_SOUP_IMP_ERR = traceback.format_exc()
     HAS_BEAUTIFULSOUP = False
@@ -272,11 +272,11 @@ class BalancerMember(object):
             except TypeError as exc:
                 self.module.fail_json(msg="Cannot parse balancer_member_page HTML! " + str(exc))
             else:
-                subsoup = soup.findAll('table')[1].findAll('tr')
-                keys = subsoup[0].findAll('th')
+                subsoup = soup.find_all('table')[1].find_all('tr')
+                keys = subsoup[0].find_all('th')
                 for valuesset in subsoup[1::1]:
                     if re.search(pattern=self.host, string=str(valuesset)):
-                        values = valuesset.findAll('td')
+                        values = valuesset.find_all('td')
                         return dict((keys[x].string, values[x].string) for x in range(0, len(keys)))
 
     def get_member_status(self):
@@ -345,7 +345,7 @@ class Balancer(object):
         except TypeError:
             self.module.fail_json(msg="Cannot parse balancer page HTML! " + str(self.page))
         else:
-            for element in soup.findAll('a')[1::1]:
+            for element in soup.find_all('a')[1::1]:
                 balancer_member_suffix = str(element.get('href'))
                 if not balancer_member_suffix:
                     self.module.fail_json(msg="Argument 'balancer_member_suffix' is empty!")

--- a/plugins/modules/apache2_mod_proxy.py
+++ b/plugins/modules/apache2_mod_proxy.py
@@ -18,8 +18,8 @@ description:
   - Set and/or get members' attributes of an Apache httpd 2.4 mod_proxy balancer
     pool, using HTTP POST and GET requests. The httpd mod_proxy balancer-member
     status page has to be enabled and accessible, as this module relies on parsing
-    this page. This module supports ansible check_mode, and requires BeautifulSoup
-    python module.
+    this page. This module supports ansible check_mode, and requires BeautifulSoup4
+    python3 module.
 extends_documentation_fragment:
   - community.general.attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY
Migrates from python2 beautifulsoup to python3 beautifulsoup4 module, in order to fix apache2_mod_proxy on python3.
Fixes #4167

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

No changelog fragment yet

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apache2_mod_proxy

##### ADDITIONAL INFORMATION
Changes made according to https://www.crummy.com/software/BeautifulSoup/bs4/doc/#porting-code-to-bs4