### PR TITLE
[ssh_config] Add support for ControlMaster

### DIFF
--- a/changelogs/fragments/7456-add-ssh-control-master.yml
+++ b/changelogs/fragments/7456-add-ssh-control-master.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - adds ``controlmaster``, ``controlpath`` and ``controlpersist`` parameters (https://github.com/ansible-collections/community.general/pull/7456).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -193,6 +193,14 @@ from ansible_collections.community.general.plugins.module_utils._stormssh import
 from ansible_collections.community.general.plugins.module_utils.ssh import determine_config_file
 
 
+def convert_bool(value):
+    if value is True:
+        return 'yes'
+    if value is False:
+        return 'no'
+    return None
+
+
 class SSHConfig(object):
     def __init__(self, module):
         self.module = module
@@ -235,16 +243,11 @@ class SSHConfig(object):
             proxycommand=self.params.get('proxycommand'),
             proxyjump=self.params.get('proxyjump'),
             host_key_algorithms=self.params.get('host_key_algorithms'),
+            forward_agent=convert_bool(self.params.get('forward_agent')),
             controlmaster=self.params.get('controlmaster'),
             controlpath=self.params.get('controlpath'),
             controlpersist=self.params.get('controlpersist'),
         )
-
-        # Convert True / False to 'yes' / 'no' for usage in ssh_config
-        if self.params['forward_agent'] is True:
-            args['forward_agent'] = 'yes'
-        if self.params['forward_agent'] is False:
-            args['forward_agent'] = 'no'
 
         config_changed = False
         hosts_changed = []

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -201,6 +201,14 @@ def convert_bool(value):
     return None
 
 
+def fix_bool_str(value):
+    if value == 'True':
+        return 'yes'
+    if value == 'False':
+        return 'no'
+    return value
+
+
 class SSHConfig(object):
     def __init__(self, module):
         self.module = module
@@ -246,7 +254,7 @@ class SSHConfig(object):
             forward_agent=convert_bool(self.params.get('forward_agent')),
             controlmaster=self.params.get('controlmaster'),
             controlpath=self.params.get('controlpath'),
-            controlpersist=self.params.get('controlpersist'),
+            controlpersist=fix_bool_str(self.params.get('controlpersist')),
         )
 
         config_changed = False

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -108,6 +108,22 @@ options:
       - Sets the C(HostKeyAlgorithms) option.
     type: str
     version_added: 6.1.0
+  controlmaster:
+    description:
+      - Sets the C(ControlMaster) option.
+    choices: [ 'yes', 'no', 'ask', 'auto', 'autoask' ]
+    type: str
+    version_added: 8.1.0
+  controlpath:
+    description:
+      - Sets the C(ControlPath) option.
+    type: str
+    version_added: 8.1.0
+  controlpersist:
+    description:
+      - Sets the C(ControlPersist) option.
+    type: str
+    version_added: 8.1.0
 requirements:
 - paramiko
 '''
@@ -219,6 +235,9 @@ class SSHConfig(object):
             proxycommand=self.params.get('proxycommand'),
             proxyjump=self.params.get('proxyjump'),
             host_key_algorithms=self.params.get('host_key_algorithms'),
+            controlmaster=self.params.get('controlmaster'),
+            controlpath=self.params.get('controlpath'),
+            controlpersist=self.params.get('controlpersist'),
         )
 
         # Convert True / False to 'yes' / 'no' for usage in ssh_config
@@ -320,9 +339,13 @@ def main():
             ssh_config_file=dict(default=None, type='path'),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             strict_host_key_checking=dict(
+                type='str',
                 default=None,
                 choices=['yes', 'no', 'ask']
             ),
+            controlmaster=dict(type='str', default=None, choices=['yes', 'no', 'ask', 'auto', 'autoask']),
+            controlpath=dict(type='str', default=None),
+            controlpersist=dict(type='str', default=None),
             user=dict(default=None, type='str'),
             user_known_hosts_file=dict(type='str', default=None),
         ),

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -16,6 +16,9 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add
   check_mode: true
@@ -45,6 +48,9 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add
 
@@ -63,6 +69,9 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add_again
 
@@ -85,6 +94,9 @@
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -93,6 +105,9 @@
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    controlmaster: no
+    controlpath: "~/.ssh/new-sockets/%r@%h-%p"
+    controlpersist: "600"
     state: present
   register: options_update
 
@@ -113,6 +128,9 @@
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    controlmaster: no
+    controlpath: "~/.ssh/new-sockets/%r@%h-%p"
+    controlpersist: "600"
     state: present
   register: options_update
 
@@ -136,6 +154,9 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -164,6 +185,9 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -210,6 +234,9 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
 
 # Proxycommand and ProxyJump are mutually exclusive. 
 # Reset ssh_config before testing options with proxyjump
@@ -226,6 +253,9 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add
   check_mode: true
@@ -255,6 +285,9 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add
 
@@ -273,6 +306,9 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    controlmaster: "auto"
+    controlpath: "~/.ssh/sockets/%r@%h-%p"
+    controlpersist: "yes"
     state: present
   register: options_add_again
 
@@ -295,6 +331,9 @@
       - "'proxyjump jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Update host
   community.general.ssh_config:
@@ -303,6 +342,9 @@
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    controlmaster: no
+    controlpath: "~/.ssh/new-sockets/%r@%h-%p"
+    controlpersist: "600"
     state: present
   register: options_update
 
@@ -323,6 +365,9 @@
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    controlmaster: no
+    controlpath: "~/.ssh/new-sockets/%r@%h-%p"
+    controlpersist: "600"
     state: present
   register: options_update
 
@@ -346,6 +391,9 @@
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
 
 - name: Options - Ensure no update in case option exist in ssh_config file but wasn't defined in playbook
   community.general.ssh_config:
@@ -374,6 +422,9 @@
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
 
 - name: Debug
   debug:
@@ -420,3 +471,6 @@
       - "'proxyjump new-jumphost.example.com' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
+      - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -18,7 +18,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add
   check_mode: true
@@ -50,7 +50,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add
 
@@ -71,7 +71,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add_again
 
@@ -255,7 +255,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add
   check_mode: true
@@ -287,7 +287,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add
 
@@ -308,7 +308,7 @@
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
-    controlpersist: "yes"
+    controlpersist: yes
     state: present
   register: options_add_again
 


### PR DESCRIPTION
##### SUMMARY
Add support for [`ControlMaster`](https://man.openbsd.org/ssh_config.5#ControlMaster) (with [`ControlPath`](https://man.openbsd.org/ssh_config.5#ControlPath), [`ControlPersist`](https://man.openbsd.org/ssh_config.5#ControlPersist)) SSH config options.

Second commit also converts `bool` to `str` correctly for options which allow `yes` / `no` in addition to other values as YAML `yes` / `no` is parsed as `True` / `False` but `ssh_config` needs `"yes"` / `"no"`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
_None_