### PR TITLE
uptimerobot.py: fixed missing api actions

### DIFF
--- a/changelogs/fragments/7458-uptimerobot-add-missing-api-action.yml
+++ b/changelogs/fragments/7458-uptimerobot-add-missing-api-action.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - added all missing actions offered by the uptimerobot api (v2)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added all missing API actions that uptimerobot offers.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
breaking_changes:
  - uptimerobot - requires api_key, action and optional params dictionary with additional parameters for the api call
##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
uptimerobot.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The module was only able to `start` and `stop` monitors. With this pull request this was extended to all uptimerobot actions defined on [https://uptimerobot.com/api/](https://uptimerobot.com/api/).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
