### PR TITLE
Add option to proxmox dynamic inventory to exclude nodes

### DIFF
--- a/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
+++ b/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox inventory plugin - adds an option to exclude nodes from the dynamic inventory generation and fixes https://github.com/ansible-collections/community.general/issues/6714. The new setting is optional, not using this option will behave as usual.

--- a/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
+++ b/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox inventory plugin - adds an option to exclude nodes from the dynamic inventory generation and fixes https://github.com/ansible-collections/community.general/issues/6714. The new setting is optional, not using this option will behave as usual.
+  - proxmox inventory plugin - adds an option to exclude nodes from the dynamic inventory generation. The new setting is optional, not using this option will behave as usual (https://github.com/ansible-collections/community.general/issues/6714, https://github.com/ansible-collections/community.general/pull/7437).

--- a/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
+++ b/changelogs/fragments/7437-proxmox-inventory-add-exclude-nodes.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - proxmox inventory plugin - adds an option to exclude nodes from the dynamic inventory generation. The new setting is optional, not using this option will behave as usual (https://github.com/ansible-collections/community.general/issues/6714, https://github.com/ansible-collections/community.general/pull/7437).

--- a/changelogs/fragments/7461-proxmox-inventory-add-exclude-nodes.yaml
+++ b/changelogs/fragments/7461-proxmox-inventory-add-exclude-nodes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox inventory plugin - adds an option to exclude nodes from the dynamic inventory generation. The new setting is optional, not using this option will behave as usual (https://github.com/ansible-collections/community.general/issues/6714, https://github.com/ansible-collections/community.general/pull/7461).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -120,6 +120,7 @@ DOCUMENTATION = '''
         description: Exclude proxmox nodes (and their groups) from the inventory output.
         type: bool
         default: false
+        version_added: 8.1.0
       filters:
         version_added: 4.6.0
         description: A list of Jinja templates that allow filtering hosts.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -610,8 +610,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if name is not None:
                     hosts.append(name)
 
-            # removes node host at the end of this node-specific loop 
-            if self.exclude_nodes: self.inventory.remove_host(self.inventory.hosts[node['node']]) 
         # gather vm's in pools
         self._populate_pool_groups(hosts)
 

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -117,7 +117,7 @@ DOCUMENTATION = '''
         type: bool
         default: false
       exclude_nodes:
-        description: Exclude proxmox nodes (and their groups) from the inventory output.
+        description: Exclude proxmox nodes and the nodes-group from the inventory output.
         type: bool
         default: false
         version_added: 8.1.0

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -614,7 +614,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._populate_pool_groups(hosts)
 
         # removes the general node-group from the inventory list
-        if self.exclude_nodes: self.inventory.remove_group(nodes_group)
+        if self.exclude_nodes:
+            self.inventory.remove_group(nodes_group)
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_REQUESTS:

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -730,7 +730,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
         'facts_prefix': 'proxmox_',
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
-        'qemu_extended_statuses': False
+        'qemu_extended_statuses': False,
         'exclude_nodes':False
     }
 
@@ -777,7 +777,7 @@ def test_populate_exclude_nodes(inventory, mocker):
     for node in ['testnode', 'testnode2']:
         assert node not in inventory.inventory.hosts
     # make sure that nodes group is absent
-    assert ('%s_nodes' % (inventory.group_prefix) not in inventory.inventory.groups
+    assert ('%s_nodes' % (inventory.group_prefix)) not in inventory.inventory.groups
     # make sure that nodes are not in the "ungrouped" group 
     for node in ['testnode', 'testnode2']:
         assert node not in inventory.inventory.get_groups_dict()["ungrouped"]

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -654,7 +654,7 @@ def test_populate(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': True,
-        'exclude_nodes' : False
+        'exclude_nodes': False
     }
 
     # bypass authentication and API fetch calls
@@ -733,7 +733,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes' : False
+        'exclude_nodes': False
     }
 
     # bypass authentication and API fetch calls
@@ -765,7 +765,7 @@ def test_populate_exclude_nodes(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes' : True
+        'exclude_nodes': True
     }
 
     # bypass authentication and API fetch calls

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -652,7 +652,8 @@ def test_populate(inventory, mocker):
         'facts_prefix': 'proxmox_',
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
-        'qemu_extended_statuses': True
+        'qemu_extended_statuses': True,
+        'exclude_nodes':False
     }
 
     # bypass authentication and API fetch calls
@@ -730,6 +731,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False
+        'exclude_nodes':False
     }
 
     # bypass authentication and API fetch calls
@@ -743,3 +745,39 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # make sure that ['prelaunch', 'paused'] are not in the group list
     for group in ['paused', 'prelaunch']:
         assert ('%sall_%s' % (inventory.group_prefix, group)) not in inventory.inventory.groups
+
+
+def test_populate_exclude_nodes(inventory, mocker):
+    # module settings
+    inventory.proxmox_user = 'root@pam'
+    inventory.proxmox_password = 'password'
+    inventory.proxmox_url = 'https://localhost:8006'
+    inventory.group_prefix = 'proxmox_'
+    inventory.facts_prefix = 'proxmox_'
+    inventory.strict = False
+
+    opts = {
+        'group_prefix': 'proxmox_',
+        'facts_prefix': 'proxmox_',
+        'want_facts': True,
+        'want_proxmox_nodes_ansible_host': True,
+        'qemu_extended_statuses': False,
+        'exclude_nodes':True
+    }
+
+    # bypass authentication and API fetch calls
+    inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
+    inventory._get_json = mocker.MagicMock(side_effect=get_json)
+    inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    inventory._can_add_host = mocker.MagicMock(return_value=True)
+    inventory._populate()
+
+    # make sure that nodes are not in the inventory
+    for node in ['testnode', 'testnode2']:
+        assert node not in inventory.inventory.hosts
+    # make sure that nodes group is absent
+    assert ('%s_nodes' % (inventory.group_prefix) not in inventory.inventory.groups
+    # make sure that nodes are not in the "ungrouped" group 
+    for node in ['testnode', 'testnode2']:
+        assert node not in inventory.inventory.get_groups_dict()["ungrouped"]

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -653,7 +653,7 @@ def test_populate(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': True,
-        'exclude_nodes':False
+        'exclude_nodes': False
     }
 
     # bypass authentication and API fetch calls
@@ -731,7 +731,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes':False
+        'exclude_nodes': False
     }
 
     # bypass authentication and API fetch calls
@@ -762,7 +762,7 @@ def test_populate_exclude_nodes(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes':True
+        'exclude_nodes': True
     }
 
     # bypass authentication and API fetch calls
@@ -778,6 +778,6 @@ def test_populate_exclude_nodes(inventory, mocker):
         assert node not in inventory.inventory.hosts
     # make sure that nodes group is absent
     assert ('%s_nodes' % (inventory.group_prefix)) not in inventory.inventory.groups
-    # make sure that nodes are not in the "ungrouped" group 
+    # make sure that nodes are not in the "ungrouped" group
     for node in ['testnode', 'testnode2']:
         assert node not in inventory.inventory.get_groups_dict()["ungrouped"]

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -646,6 +646,7 @@ def test_populate(inventory, mocker):
     inventory.group_prefix = 'proxmox_'
     inventory.facts_prefix = 'proxmox_'
     inventory.strict = False
+    inventory.exclude_nodes = False
 
     opts = {
         'group_prefix': 'proxmox_',
@@ -653,7 +654,7 @@ def test_populate(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': True,
-        'exclude_nodes': False
+        'exclude_nodes' : False
     }
 
     # bypass authentication and API fetch calls
@@ -724,6 +725,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
     inventory.group_prefix = 'proxmox_'
     inventory.facts_prefix = 'proxmox_'
     inventory.strict = False
+    inventory.exclude_nodes = False
 
     opts = {
         'group_prefix': 'proxmox_',
@@ -731,7 +733,7 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes': False
+        'exclude_nodes' : False
     }
 
     # bypass authentication and API fetch calls
@@ -755,6 +757,7 @@ def test_populate_exclude_nodes(inventory, mocker):
     inventory.group_prefix = 'proxmox_'
     inventory.facts_prefix = 'proxmox_'
     inventory.strict = False
+    inventory.exclude_nodes = True
 
     opts = {
         'group_prefix': 'proxmox_',
@@ -762,7 +765,7 @@ def test_populate_exclude_nodes(inventory, mocker):
         'want_facts': True,
         'want_proxmox_nodes_ansible_host': True,
         'qemu_extended_statuses': False,
-        'exclude_nodes': True
+        'exclude_nodes' : True
     }
 
     # bypass authentication and API fetch calls


### PR DESCRIPTION
##### SUMMARY
This pull request enables users of the proxmox inventory source to exclude the proxmox-nodes from the ansible-host list at will. The default of the new setting `exclude_nodes` is to include nodes, so it it should stay compatible to the current usage. If `exclude_node` is true, nodes will not be added at all to the inventory. This option is implicitly mutually exclusive with composite-vars for nodes, since, well if you exclude nodes, you don't need composite vars for them.

**TODO**: I could only test this implementation on my single-node proxmox cluster, I'd be glad if someone else could verify this implementation on a multi-node-cluster.

This PR fixes #6714 .

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
!component =plugins/inventory/proxmox.py

##### ADDITIONAL INFORMATION

before:
```
ubuntu@adm: ansible-inventory -i test.proxmox.yaml --graph
@all:
  |--@ungrouped:
  |--@proxmox_all_lxc:
  |--@proxmox_all_qemu:
  |  |--mail
  |  |--git
  |  |--web
  |--@proxmox_all_running:
  |  |--mail
  |  |--git
  |  |--web
  |--@proxmox_all_stopped:
  |--@proxmox_all_prelaunch:
  |--@proxmox_all_paused:
  |--@proxmox_nodes:
  |  |--hypervisor
  |--@proxmox_hypervisor_lxc:
  |--@proxmox_hypervisor_qemu:
  |  |--git
  |  |--mail
  |  |--web
```

after:
```
ubuntu@adm: ansible-inventory -i test.proxmox.yaml --graph
 @all:
  |--@ungrouped:
  |--@proxmox_all_lxc:
  |--@proxmox_all_qemu:
  |  |--web
  |  |--git
  |  |--mail
  |--@proxmox_all_running:
  |  |--web
  |  |--git
  |  |--mail
  |--@proxmox_all_stopped:
  |--@proxmox_all_prelaunch:
  |--@proxmox_all_paused:
  |--@proxmox_hypervisor_lxc:
  |--@proxmox_hypervisor_qemu:
  |  |--web
  |  |--git
  |  |--mail
```
