### PR TITLE
fix vm removal in proxmox_pool_member.py

### DIFF
--- a/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.py
+++ b/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.py
@@ -1,2 +1,0 @@
-bugfixes:
-  - proxmox_pool_member - absent state for type vm did not delete vms from the pools (https://github.com/ansible-collections/community.general/pull/7464)

--- a/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.py
+++ b/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.py
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_pool_member - absent state for type vm did not delete vms from the pools (https://github.com/ansible-collections/community.general/pull/7464)

--- a/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.yml
+++ b/changelogs/fragments/7464-fix-vm-removal-in-proxmox_pool_member.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_pool_member - absent state for type VM did not delete VMs from the pools (https://github.com/ansible-collections/community.general/pull/7464).

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -192,7 +192,7 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                     self.module.exit_json(changed=False, poolid=poolid, member=member,
                                           diff=diff, msg="VM {0} is not part of the pool {1}".format(member, poolid))
 
-                all_members_after.remove(member)
+                all_members_after.remove(vmid)
 
                 if not self.module.check_mode:
                     self.proxmox_api.pools(poolid).put(vms=[vmid], delete=1)


### PR DESCRIPTION
##### SUMMARY
Fix non working feature of the module

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
community.general.proxmox_pool_member

##### ADDITIONAL INFORMATION
In the original version the vm doesn't get removed from the proxmox pool when "state: absent" is set in the task, it always errors with "'Failed to delete a member (12345) from the pool TestPool: list.remove(x): x not in list'"

Try the example in the documentation for "Remove VM from the Proxmox VE pool using VM name" 
https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_pool_member_module.html#examples

Before:
```
  invocation:
    module_args:
      api_host: localhost
      api_password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      api_token_id: null
      api_token_secret: null
      api_user: root@pam
      member: '12345'
      poolid: TestPool
      state: absent
      type: vm
      validate_certs: false
  msg: 'Failed to delete a member (12345) from the pool TestPool: list.remove(x): x not in list'
```

After:
```
"msg": "Member 12345 deleted from the pool TestPool", "invocation": {"module_args": {"api_user": "root@pam", "api_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "api_host": "localhost", "poolid": "TestPool", "member": "12345", "state": "absent", "validate_certs": false, "type": "vm", "api_token_id": null, "api_token_secret": null}}
```