### PR TITLE
Improve performance of the bitwarden lookup plugin

### DIFF
--- a/changelogs/fragments/bitwarden-lookup-performance.yaml
+++ b/changelogs/fragments/bitwarden-lookup-performance.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - bitwarden lookup plugin: When looking for items using an item id, the item is now accessed directly with bw get item instead of searching through all items. 
+This doubles the lookup speed.

--- a/changelogs/fragments/bitwarden-lookup-performance.yaml
+++ b/changelogs/fragments/bitwarden-lookup-performance.yaml
@@ -1,3 +1,2 @@
 minor_changes:
-  - bitwarden lookup plugin: When looking for items using an item id, the item is now accessed directly with bw get item instead of searching through all items. 
-This doubles the lookup speed.
+  - "bitwarden lookup plugin - when looking for items using an item ID, the item is now accessed directly with ``bw get item`` instead of searching through all items. This doubles the lookup speed (https://github.com/ansible-collections/community.general/pull/6619)."

--- a/changelogs/fragments/bitwarden-lookup-performance.yaml
+++ b/changelogs/fragments/bitwarden-lookup-performance.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "bitwarden lookup plugin - when looking for items using an item ID, the item is now accessed directly with ``bw get item`` instead of searching through all items. This doubles the lookup speed (https://github.com/ansible-collections/community.general/pull/6619)."
+  - "bitwarden lookup plugin - when looking for items using an item ID, the item is now accessed directly with ``bw get item`` instead of searching through all items. This doubles the lookup speed (https://github.com/ansible-collections/community.general/pull/7468)."

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -113,9 +113,9 @@ class Bitwarden(object):
 
         # Prepare set of params for Bitwarden CLI
         if search_field == 'id':
-          params = ['get', 'item', search_value]
+            params = ['get', 'item', search_value]
         else:
-          params = ['list', 'items', '--search', search_value]
+            params = ['list', 'items', '--search', search_value]
 
         if collection_id:
             params.extend(['--collectionid', collection_id])
@@ -125,7 +125,7 @@ class Bitwarden(object):
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
         if search_field == 'id':
-          initial_matches = [initial_matches]
+            initial_matches = [initial_matches]
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -112,7 +112,10 @@ class Bitwarden(object):
         """
 
         # Prepare set of params for Bitwarden CLI
-        params = ['list', 'items', '--search', search_value]
+        if search_field == 'id':
+          params = ['get', 'item', search_value]
+        else:
+          params = ['list', 'items', '--search', search_value]
 
         if collection_id:
             params.extend(['--collectionid', collection_id])
@@ -121,7 +124,8 @@ class Bitwarden(object):
 
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
-
+        if search_field == 'id':
+          initial_matches = [initial_matches]
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -127,7 +127,7 @@ class Bitwarden(object):
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
         if search_field == 'id':
-            if initial_matches == None:
+            if initial_matches is None:
                 initial_matches = []
             else:
                 initial_matches = [initial_matches]

--- a/plugins/lookup/bitwarden.py
+++ b/plugins/lookup/bitwarden.py
@@ -104,6 +104,8 @@ class Bitwarden(object):
         out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()
         if rc != expected_rc:
+            if len(args) > 2 and args[0] == 'get' and args[1] == 'item' and b'Not found.' in err:
+                return 'null', ''
             raise BitwardenException(err)
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 
@@ -125,7 +127,10 @@ class Bitwarden(object):
         # This includes things that matched in different fields.
         initial_matches = AnsibleJSONDecoder().raw_decode(out)[0]
         if search_field == 'id':
-            initial_matches = [initial_matches]
+            if initial_matches == None:
+                initial_matches = []
+            else:
+                initial_matches = [initial_matches]
         # Filter to only include results from the right field.
         return [item for item in initial_matches if item[search_field] == search_value]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The bitwarden lookup plugin searches through all items using `bw list items --search`, which takes a lot of time. However, when looking for an item using the item id, there is a much faster way: `bw get item  <itemid>`. This PR introduces this method for every lookup that uses the item's id, while keeping backwards compatibility.

This work is based on #6619. The open review comment there has been addressed.

##### ISSUE TYPE
- Feature / Performance Pull Request

##### COMPONENT NAME
bitwarden

##### ADDITIONAL INFORMATION
_None_