### PR TITLE
Redfish: Updated message handling for update operations to skip message objects with missing MessageId properties

### DIFF
--- a/changelogs/fragments/7465-redfish-firmware-update-message-id-hardening.yml
+++ b/changelogs/fragments/7465-redfish-firmware-update-message-id-hardening.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redfish_command - fix usage of message parsing in ``SimpleUpdate`` and ``MultipartHTTPPushUpdate`` commands to treat the lack of a ``MessageId`` as no message (https://github.com/ansible-collections/community.general/issues/7465).

--- a/changelogs/fragments/7465-redfish-firmware-update-message-id-hardening.yml
+++ b/changelogs/fragments/7465-redfish-firmware-update-message-id-hardening.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - redfish_command - fix usage of message parsing in ``SimpleUpdate`` and ``MultipartHTTPPushUpdate`` commands to treat the lack of a ``MessageId`` as no message (https://github.com/ansible-collections/community.general/issues/7465).
+  - redfish_command - fix usage of message parsing in ``SimpleUpdate`` and ``MultipartHTTPPushUpdate`` commands to treat the lack of a ``MessageId`` as no message (https://github.com/ansible-collections/community.general/issues/7465, https://github.com/ansible-collections/community.general/pull/7471).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1658,7 +1658,10 @@ class RedfishUtils(object):
 
             # Scan the messages to see if next steps are needed
             for message in operation_results['messages']:
-                message_id = message['MessageId']
+                message_id = message.get('MessageId')
+                if message_id is None:
+                    # While this is invalid, treat the lack of a MessageId as "no message"
+                    continue
 
                 if message_id.startswith('Update.1.') and message_id.endswith('.OperationTransitionedToJob'):
                     # Operation rerouted to a job; update the status and handle


### PR DESCRIPTION
##### SUMMARY
Updated message handling for update operations to skip message objects with missing MessageId properties. While this is invalid, it's easy to handle and just move on to other messages to surface to the user.

Fix #7465

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_utils, redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Output after change.

```paste below
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "failed": false,
        "msg": "Action was successful",
        "return_values": {
            "update_status": {
                "handle": <REDACTED>,
                "messages": [],
                "resets_requested": [],
                "ret": true,
                "status": "New"
            }
        },
        "session": {}
    }
}
```
