### PR TITLE
feature(gitlab): add 'ca_path' option

### DIFF
--- a/changelogs/fragments/7472-gitlab-add-ca-path-option.yml
+++ b/changelogs/fragments/7472-gitlab-add-ca-path-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab modules - add ``ca_path`` option (https://github.com/ansible-collections/community.general/pull/7472).

--- a/plugins/doc_fragments/gitlab.py
+++ b/plugins/doc_fragments/gitlab.py
@@ -29,4 +29,9 @@ options:
       - GitLab CI job token for logging in.
     type: str
     version_added: 4.2.0
+  ca_path:
+    description:
+      - The CA certificates bundle to use to verify GitLab server certificate.
+    type: str
+    version_added: 8.1.0
 '''


### PR DESCRIPTION
##### SUMMARY
This PR adds a `ca_path` option to gitlab modules. This new option allows to use a custom CA certificates bundle to verify GitLab server certificate.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
all gitlab modules

##### ADDITIONAL INFORMATION
N/A

Fixes #3007 