### PR TITLE
timezone tests: do not restore original timezone if it wasn't known (value 'n/a')

### DIFF
--- a/tests/integration/targets/timezone/tasks/main.yml
+++ b/tests/integration/targets/timezone/tasks/main.yml
@@ -93,4 +93,4 @@
         - name: Restore original system timezone - {{ original_timezone.diff.before.name }}
           timezone:
             name: "{{ original_timezone.diff.before.name }}"
-          when: original_timezone is changed
+          when: original_timezone is changed and original_timezone.diff.before.name != 'n/a'


### PR DESCRIPTION
##### SUMMARY
In some cases, such as the OpenSuSE tests, this always causes the timezone tests to be run twice because the first run fails when it tries to "restore" a time zone called `n/a`.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
timezone
