### PR TITLE
refactor(gitlab modules): remove duplicate gitlab package check

### DIFF
--- a/changelogs/fragments/7486-gitlab-refactor-package-check.yml
+++ b/changelogs/fragments/7486-gitlab-refactor-package-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab modules - remove duplicate ``gitlab`` package check (https://github.com/ansible-collections/community.general/pull/7486).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -75,6 +75,8 @@ def ensure_gitlab_package(module):
 
 
 def gitlab_authentication(module):
+    ensure_gitlab_package(module)
+
     gitlab_url = module.params['api_url']
     validate_certs = module.params['validate_certs']
     ca_path = module.params['ca_path']
@@ -83,8 +85,6 @@ def gitlab_authentication(module):
     gitlab_token = module.params['api_token']
     gitlab_oauth_token = module.params['api_oauth_token']
     gitlab_job_token = module.params['api_job_token']
-
-    ensure_gitlab_package(module)
 
     verify = ca_path if validate_certs and ca_path else validate_certs
 

--- a/plugins/modules/gitlab_branch.py
+++ b/plugins/modules/gitlab_branch.py
@@ -84,7 +84,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, gitlab
 )
 
 
@@ -144,7 +144,9 @@ def main():
         ],
         supports_check_mode=False
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     project = module.params['project']
     branch = module.params['branch']
@@ -156,7 +158,6 @@ def main():
         module.fail_json(msg="community.general.gitlab_proteched_branch requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
                              " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
 
-    gitlab_instance = gitlab_authentication(module)
     this_gitlab = GitlabBranch(module=module, project=project, gitlab_instance=gitlab_instance)
 
     this_branch = this_gitlab.get_branch(branch)

--- a/plugins/modules/gitlab_deploy_key.py
+++ b/plugins/modules/gitlab_deploy_key.py
@@ -121,7 +121,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_project, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, find_project, gitlab_authentication, gitlab
 )
 
 
@@ -261,15 +261,15 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     state = module.params['state']
     project_identifier = module.params['project']
     key_title = module.params['title']
     key_keyfile = module.params['key']
     key_can_push = module.params['can_push']
-
-    gitlab_instance = gitlab_authentication(module)
 
     gitlab_deploy_key = GitLabDeployKey(module, gitlab_instance)
 

--- a/plugins/modules/gitlab_group.py
+++ b/plugins/modules/gitlab_group.py
@@ -178,7 +178,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_group, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, find_group, gitlab_authentication, gitlab
 )
 
 
@@ -355,7 +355,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     group_name = module.params['name']
     group_path = module.params['path']
@@ -369,8 +371,6 @@ def main():
     require_two_factor_authentication = module.params['require_two_factor_authentication']
     avatar_path = module.params['avatar_path']
     force_delete = module.params['force_delete']
-
-    gitlab_instance = gitlab_authentication(module)
 
     # Define default group_path based on group_name
     if group_path is None:

--- a/plugins/modules/gitlab_group_members.py
+++ b/plugins/modules/gitlab_group_members.py
@@ -160,7 +160,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, gitlab
 )
 
 
@@ -273,7 +273,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gl = gitlab_authentication(module)
 
     access_level_int = {
         'guest': gitlab.const.GUEST_ACCESS,
@@ -290,9 +292,6 @@ def main():
 
     if purge_users:
         purge_users = [access_level_int[level] for level in purge_users]
-
-    # connect to gitlab server
-    gl = gitlab_authentication(module)
 
     group = GitLabGroup(module, gl)
 

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -207,7 +207,7 @@ group_variable:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, filter_returned_variables, vars_to_variables
+    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables
 )
 
 
@@ -413,7 +413,9 @@ def main():
         ],
         supports_check_mode=True
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     purge = module.params['purge']
     var_list = module.params['vars']
@@ -427,8 +429,6 @@ def main():
     if state == 'present':
         if any(x['value'] is None for x in variables):
             module.fail_json(msg='value parameter is required in state present')
-
-    gitlab_instance = gitlab_authentication(module)
 
     this_gitlab = GitlabGroupVariables(module=module, gitlab_instance=gitlab_instance)
 

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -171,7 +171,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_project, gitlab_authentication, ensure_gitlab_package
+    auth_argument_spec, find_project, gitlab_authentication
 )
 
 
@@ -325,7 +325,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     state = module.params['state']
     project_identifier = module.params['project']
@@ -341,8 +343,6 @@ def main():
     wiki_page_events = module.params['wiki_page_events']
     enable_ssl_verification = module.params['hook_validate_certs']
     hook_token = module.params['token']
-
-    gitlab_instance = gitlab_authentication(module)
 
     gitlab_hook = GitLabHook(module, gitlab_instance)
 

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -139,7 +139,7 @@ instance_variable:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, filter_returned_variables
+    auth_argument_spec, gitlab_authentication, filter_returned_variables
 )
 
 
@@ -326,7 +326,9 @@ def main():
         ],
         supports_check_mode=True
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     purge = module.params['purge']
     state = module.params['state']
@@ -336,8 +338,6 @@ def main():
     if state == 'present':
         if any(x['value'] is None for x in variables):
             module.fail_json(msg='value parameter is required in state present')
-
-    gitlab_instance = gitlab_authentication(module)
 
     this_gitlab = GitlabInstanceVariables(module=module, gitlab_instance=gitlab_instance)
 

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -152,7 +152,7 @@ from ansible.module_utils.common.text.converters import to_native, to_text
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package, find_project
+    auth_argument_spec, gitlab_authentication, gitlab, find_project
 )
 
 
@@ -321,7 +321,9 @@ def main():
         ],
         supports_check_mode=True
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     project = module.params['project']
     source_branch = module.params['source_branch']
@@ -340,8 +342,6 @@ def main():
     if LooseVersion(gitlab_version) < LooseVersion('2.3.0'):
         module.fail_json(msg="community.general.gitlab_merge_request requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
                              " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
-
-    gitlab_instance = gitlab_authentication(module)
 
     this_project = find_project(gitlab_instance, project)
     if this_project is None:

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -340,7 +340,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_group, find_project, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, find_group, find_project, gitlab_authentication, gitlab
 )
 
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
@@ -558,7 +558,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     group_identifier = module.params['group']
     project_name = module.params['name']
@@ -595,8 +597,6 @@ def main():
     monitor_access_level = module.params['monitor_access_level']
     security_and_compliance_access_level = module.params['security_and_compliance_access_level']
     topics = module.params['topics']
-
-    gitlab_instance = gitlab_authentication(module)
 
     # Set project_path to project_name if it is empty.
     if project_path is None:

--- a/plugins/modules/gitlab_project_badge.py
+++ b/plugins/modules/gitlab_project_badge.py
@@ -97,7 +97,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, find_project, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, find_project
 )
 
 
@@ -159,12 +159,11 @@ state_strategy = {
 
 
 def core(module):
-    ensure_gitlab_package(module)
+    # check prerequisites and connect to gitlab server
+    gl = gitlab_authentication(module)
 
     gitlab_project = module.params['project']
     state = module.params['state']
-
-    gl = gitlab_authentication(module)
 
     project = find_project(gl, gitlab_project)
     # project doesn't exist

--- a/plugins/modules/gitlab_project_members.py
+++ b/plugins/modules/gitlab_project_members.py
@@ -163,7 +163,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, gitlab
 )
 
 
@@ -279,7 +279,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gl = gitlab_authentication(module)
 
     access_level_int = {
         'guest': gitlab.const.GUEST_ACCESS,
@@ -295,9 +297,6 @@ def main():
 
     if purge_users:
         purge_users = [access_level_int[level] for level in purge_users]
-
-    # connect to gitlab server
-    gl = gitlab_authentication(module)
 
     project = GitLabProjectMembers(module, gl)
 

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -221,13 +221,12 @@ project_variable:
       sample: ['ACCESS_KEY_ID', 'SECRET_ACCESS_KEY']
 '''
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, filter_returned_variables, vars_to_variables,
-    HAS_GITLAB_PACKAGE, GITLAB_IMP_ERR
+    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables
 )
 
 
@@ -436,10 +435,9 @@ def main():
         ],
         supports_check_mode=True
     )
-    ensure_gitlab_package(module)
 
-    if not HAS_GITLAB_PACKAGE:
-        module.fail_json(msg=missing_required_lib("python-gitlab"), exception=GITLAB_IMP_ERR)
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     purge = module.params['purge']
     var_list = module.params['vars']
@@ -453,8 +451,6 @@ def main():
     if state == 'present':
         if any(x['value'] is None for x in variables):
             module.fail_json(msg='value parameter is required for all variables in state present')
-
-    gitlab_instance = gitlab_authentication(module)
 
     this_gitlab = GitlabProjectVariables(module=module, gitlab_instance=gitlab_instance)
 

--- a/plugins/modules/gitlab_protected_branch.py
+++ b/plugins/modules/gitlab_protected_branch.py
@@ -83,7 +83,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, gitlab
 )
 
 
@@ -164,7 +164,9 @@ def main():
         ],
         supports_check_mode=True
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     project = module.params['project']
     name = module.params['name']
@@ -177,7 +179,6 @@ def main():
         module.fail_json(msg="community.general.gitlab_proteched_branch requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
                              " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
 
-    gitlab_instance = gitlab_authentication(module)
     this_gitlab = GitlabProtectedBranch(module=module, project=project, gitlab_instance=gitlab_instance)
 
     p_branch = this_gitlab.protected_branch_exist(name=name)

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -206,7 +206,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, gitlab_authentication, gitlab
 )
 
 
@@ -384,7 +384,9 @@ def main():
         ],
         supports_check_mode=True,
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     state = module.params['state']
     runner_description = module.params['description']
@@ -398,7 +400,6 @@ def main():
     project = module.params['project']
     group = module.params['group']
 
-    gitlab_instance = gitlab_authentication(module)
     gitlab_project = None
     gitlab_group = None
 

--- a/plugins/modules/gitlab_user.py
+++ b/plugins/modules/gitlab_user.py
@@ -234,7 +234,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_group, gitlab_authentication, gitlab, ensure_gitlab_package
+    auth_argument_spec, find_group, gitlab_authentication, gitlab
 )
 
 
@@ -616,7 +616,9 @@ def main():
             ('state', 'present', ['name', 'email']),
         )
     )
-    ensure_gitlab_package(module)
+
+    # check prerequisites and connect to gitlab server
+    gitlab_instance = gitlab_authentication(module)
 
     user_name = module.params['name']
     state = module.params['state']
@@ -634,8 +636,6 @@ def main():
     user_external = module.params['external']
     user_identities = module.params['identities']
     overwrite_identities = module.params['overwrite_identities']
-
-    gitlab_instance = gitlab_authentication(module)
 
     gitlab_user = GitLabUser(module, gitlab_instance)
     user_exists = gitlab_user.exists_user(user_username)


### PR DESCRIPTION
##### SUMMARY
This PR removes useless `ensure_gitlab_package(module)` checks in gitlab modules, since this check is already called by generic `gitlab_authentication(module)` method.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
all gitlab modules

##### ADDITIONAL INFORMATION
N/A