### PR TITLE
Netcup DNS: Add support for additional record types

### DIFF
--- a/changelogs/fragments/7489-netcup-dns-record-types.yml
+++ b/changelogs/fragments/7489-netcup-dns-record-types.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - netcup_dns - adds support for record types ``OPENPGPKEY``, ``SMIMEA`` and ``SSHFP`` (https://github.com/ansible-collections/community.general/pull/7489)

--- a/changelogs/fragments/7489-netcup-dns-record-types.yml
+++ b/changelogs/fragments/7489-netcup-dns-record-types.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - netcup_dns - adds support for record types ``OPENPGPKEY``, ``SMIMEA`` and ``SSHFP`` (https://github.com/ansible-collections/community.general/pull/7489)
+  - netcup_dns - adds support for record types ``OPENPGPKEY``, ``SMIMEA``, and ``SSHFP`` (https://github.com/ansible-collections/community.general/pull/7489).

--- a/plugins/modules/netcup_dns.py
+++ b/plugins/modules/netcup_dns.py
@@ -53,6 +53,9 @@ options:
   type:
     description:
       - Record type.
+      - Support for V(OPENPGPKEY), V(SMIMEA) and V(SSHFP) was added in community.general 8.1.0.
+      - Record types V(OPENPGPKEY) and V(SMIMEA) require nc-dnsapi >= 0.1.5
+      - Record type V(SSHFP) requires nc-dnsapi >= 0.1.6
     choices: ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS', 'OPENPGPKEY', 'SMIMEA', 'SSHFP']
     required: true
     type: str

--- a/plugins/modules/netcup_dns.py
+++ b/plugins/modules/netcup_dns.py
@@ -53,7 +53,7 @@ options:
   type:
     description:
       - Record type.
-    choices: ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS']
+    choices: ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS', 'OPENPGPKEY', 'SMIMEA', 'SSHFP']
     required: true
     type: str
   value:
@@ -213,7 +213,9 @@ def main():
 
             domain=dict(required=True),
             record=dict(required=False, default='@', aliases=['name']),
-            type=dict(required=True, choices=['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS']),
+            type=dict(required=True, choices=['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT',
+                                              'TLSA', 'NS', 'DS', 'OPENPGPKEY', 'SMIMEA',
+                                              'SSHFP']),
             value=dict(required=True),
             priority=dict(required=False, type='int'),
             solo=dict(required=False, type='bool', default=False),

--- a/plugins/modules/netcup_dns.py
+++ b/plugins/modules/netcup_dns.py
@@ -54,8 +54,8 @@ options:
     description:
       - Record type.
       - Support for V(OPENPGPKEY), V(SMIMEA) and V(SSHFP) was added in community.general 8.1.0.
-      - Record types V(OPENPGPKEY) and V(SMIMEA) require nc-dnsapi >= 0.1.5
-      - Record type V(SSHFP) requires nc-dnsapi >= 0.1.6
+      - Record types V(OPENPGPKEY) and V(SMIMEA) require nc-dnsapi >= 0.1.5.
+      - Record type V(SSHFP) requires nc-dnsapi >= 0.1.6.
     choices: ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS', 'OPENPGPKEY', 'SMIMEA', 'SSHFP']
     required: true
     type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The provider API for Netcup DNS has added support for additional DNS record types: OPENPGPKEY, SMIMEA and SSHFP.
This PR covers a trivial change to add these types to the list of choices.
The upstream library also already added that support (https://github.com/nbuchwitz/nc_dnsapi/pull/4 and https://github.com/nbuchwitz/nc_dnsapi/pull/8).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
netcup_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
