### PR TITLE
infiniband and bond interfaces can receive MTU settings too

### DIFF
--- a/changelogs/fragments/7499-allow-mtu-setting-on-bond-and-infiniband-interfaces.yml
+++ b/changelogs/fragments/7499-allow-mtu-setting-on-bond-and-infiniband-interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - allow for the setting of ``MTU`` for ``infiniband`` and ``bond`` interface types

--- a/changelogs/fragments/7499-allow-mtu-setting-on-bond-and-infiniband-interfaces.yml
+++ b/changelogs/fragments/7499-allow-mtu-setting-on-bond-and-infiniband-interfaces.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - nmcli - allow for the setting of ``MTU`` for ``infiniband`` and ``bond`` interface types
+  - nmcli - allow for the setting of ``MTU`` for ``infiniband`` and ``bond`` interface types (https://github.com/ansible-collections/community.general/pull/7499).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1960,7 +1960,10 @@ class Nmcli(object):
 
     @property
     def mtu_setting(self):
-        return '802-3-ethernet.mtu'
+        if self.type == 'infiniband':
+            return 'infiniband.mtu'
+        else:
+            return '802-3-ethernet.mtu'
 
     @staticmethod
     def mtu_to_string(mtu):

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1950,8 +1950,10 @@ class Nmcli(object):
     @property
     def mtu_conn_type(self):
         return self.type in (
+            'bond',
             'dummy',
             'ethernet',
+            'infiniband',
             'team-slave',
             'vlan',
         )

--- a/tests/unit/plugins/modules/test_nmcli.py
+++ b/tests/unit/plugins/modules/test_nmcli.py
@@ -1445,7 +1445,8 @@ ipv4.may-fail:                          yes
 ipv6.method:                            auto
 ipv6.ignore-auto-dns:                   no
 ipv6.ignore-auto-routes:                no
-infiniband.transport-mode               datagram
+infiniband.mtu:                         auto
+infiniband.transport-mode:              datagram
 """
 
 TESTCASE_INFINIBAND_STATIC_MODIFY_TRANSPORT_MODE = [


### PR DESCRIPTION
##### SUMMARY
Infiniband and bond interface types can also receive MTU settings

Changelog:
Enabling setting of MTU on bond and Infiniband interfaces

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION
I think this is pretty straight-forward... I don't know what else to add.