### PR TITLE
Close elastic APM client to release connections

### DIFF
--- a/changelogs/fragments/7517-elastic-close-client.yaml
+++ b/changelogs/fragments/7517-elastic-close-client.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - elastic callback plugin - close elastic client to not leak resources (https://github.com/ansible-collections/community.general/pull/7517).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Close elastic-apm client to not leak urllib3 connections.

Fix #7518 and is related to https://github.com/elastic/apm-agent-python/issues/1912

Review with "hide whitespaces" enabled.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`community.general.plugins.callback.elastic`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Running anything with elastic source can cause a `Closing the transport connection timed out.`, because elastic client is not closed.

A small example can trigger the issue.

```python
from ansible_collections.community.general.plugins.callback.elastic import ElasticSource

source = ElasticSource("")
apm_cli = source.init_apm_client("http://localhost:8200", "service", None, None, None)
# Uncomment line below to fix the warning
# apm_cli.close()
```

```console
$ python -Wd unclosed.py
sys:1: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 38722), raddr=('127.0.0.1', 8200)>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
# Uncomment apm_cli.close()
$ python -Wd closed.py
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
