### PR TITLE
Lxd instance not found fix false positives

### DIFF
--- a/changelogs/fragments/lxd-instance-not-found-avoid-false-positives.yml
+++ b/changelogs/fragments/lxd-instance-not-found-avoid-false-positives.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "lxd connection plugin - tighten the detection logic for lxd ``Instance not found`` errors, to avoid false detection on unrelated errors such as ``/usr/bin/python3: not found``."
+  - "lxd connection plugin - tighten the detection logic for lxd ``Instance not found`` errors, to avoid false detection on unrelated errors such as ``/usr/bin/python3: not found`` (https://github.com/ansible-collections/community.general/pull/7521)."

--- a/changelogs/fragments/lxd-instance-not-found-avoid-false-positives.yml
+++ b/changelogs/fragments/lxd-instance-not-found-avoid-false-positives.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "lxd connection plugin - tighten the detection logic for lxd ``Instance not found`` errors, to avoid false detection on unrelated errors such as ``/usr/bin/python3: not found``."

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -101,6 +101,8 @@ class Connection(ConnectionBase):
             self.get_option("executable"), "-c", cmd
         ])
 
+        self._display.vvvvv(u"EXEC {0}".format(local_cmd), host=self._host())
+
         local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         in_data = to_bytes(in_data, errors='surrogate_or_strict', nonstring='passthru')
 
@@ -109,6 +111,8 @@ class Connection(ConnectionBase):
 
         stdout = to_text(stdout)
         stderr = to_text(stderr)
+
+        self._display.vvvvv(u"EXEC lxc output: {0} {1}".format(stdout, stderr), host=self._host())
 
         if "is not running" in stderr:
             raise AnsibleConnectionFailure("instance not running: %s" % self._host())

--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -117,7 +117,7 @@ class Connection(ConnectionBase):
         if "is not running" in stderr:
             raise AnsibleConnectionFailure("instance not running: %s" % self._host())
 
-        if "not found" in stderr:
+        if stderr.strip() == "Error: Instance not found" or stderr.strip() == "error: not found":
             raise AnsibleConnectionFailure("instance not found: %s" % self._host())
 
         return process.returncode, stdout, stderr


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

lxd: avoid false positives in "instance not found" detection in the lxd connection plugin

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
lxd connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
fatal: [my-rpi-399]: UNREACHABLE! => {
    "changed": false,
    "msg": "instance not found: my-rpi-399",
    "unreachable": true
}

```
after:

```
fatal: [my-rpi-399]: FAILED! => {
    "ansible_facts": {},
    "changed": false,
    "failed_modules": {
        "ansible.legacy.setup": {
            "failed": true,
            "module_stderr": "/bin/sh: 1: /usr/bin/python3: not found\nError: Command not found\n",
            "module_stdout": "",
            "msg": "The module failed to execute correctly, you probably need to set the interpreter.\nSee stdout/stderr for the exact error",
            "rc": 127
        }
    },
    "msg": "The following modules failed to execute: ansible.legacy.setup\n"
}
```