### PR TITLE
CI: Add rhel/9.3 for devel, remove rhel/9.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -189,8 +189,8 @@ stages:
           targets:
             - name: macOS 13.2
               test: macos/13.2
-            - name: RHEL 9.2
-              test: rhel/9.2
+            - name: RHEL 9.3
+              test: rhel/9.3
             - name: FreeBSD 13.2
               test: freebsd/13.2
           groups:
@@ -207,6 +207,8 @@ stages:
           targets:
             #- name: macOS 13.2
             #  test: macos/13.2
+            - name: RHEL 9.2
+              test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
             #- name: FreeBSD 13.2

--- a/tests/integration/targets/django_manage/aliases
+++ b/tests/integration/targets/django_manage/aliases
@@ -17,3 +17,4 @@ skip/rhel8.8
 skip/rhel9.0
 skip/rhel9.1
 skip/rhel9.2
+skip/rhel9.3

--- a/tests/integration/targets/homectl/aliases
+++ b/tests/integration/targets/homectl/aliases
@@ -10,3 +10,4 @@ skip/macos
 skip/rhel9.0  # See https://www.reddit.com/r/Fedora/comments/si7nzk/homectl/
 skip/rhel9.1  # See https://www.reddit.com/r/Fedora/comments/si7nzk/homectl/
 skip/rhel9.2  # See https://www.reddit.com/r/Fedora/comments/si7nzk/homectl/
+skip/rhel9.3  # See https://www.reddit.com/r/Fedora/comments/si7nzk/homectl/

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -10,5 +10,6 @@ skip/osx  # FIXME
 skip/rhel9.0  # FIXME
 skip/rhel9.1  # FIXME
 skip/rhel9.2  # FIXME
+skip/rhel9.3  # FIXME
 skip/freebsd12.4  # FIXME
 skip/freebsd13.2  # FIXME

--- a/tests/integration/targets/odbc/aliases
+++ b/tests/integration/targets/odbc/aliases
@@ -10,5 +10,6 @@ skip/rhel8.0
 skip/rhel9.0
 skip/rhel9.1
 skip/rhel9.2
+skip/rhel9.3
 skip/freebsd
 skip/python2.6

--- a/tests/integration/targets/setup_snap/tasks/D-RedHat-9.3.yml
+++ b/tests/integration/targets/setup_snap/tasks/D-RedHat-9.3.yml
@@ -1,0 +1,6 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Do nothing

--- a/tests/integration/targets/ufw/aliases
+++ b/tests/integration/targets/ufw/aliases
@@ -12,6 +12,7 @@ skip/rhel8.0  # FIXME
 skip/rhel9.0  # FIXME
 skip/rhel9.1  # FIXME
 skip/rhel9.2  # FIXME
+skip/rhel9.3  # FIXME
 skip/docker
 needs/root
 needs/target/setup_epel


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-rhel-9-3-and-deprecated-rhel-9-2/2336
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/62

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
