### PR TITLE
CI: remove skip/python2.6 from aliases

### DIFF
--- a/tests/integration/targets/ansible_galaxy_install/aliases
+++ b/tests/integration/targets/ansible_galaxy_install/aliases
@@ -4,5 +4,4 @@
 
 azp/posix/3
 destructive
-skip/python2.6
 context/controller  # While this is not really true, this module mainly is run on the controller, *and* needs access to the ansible-galaxy CLI tool

--- a/tests/integration/targets/etcd3/aliases
+++ b/tests/integration/targets/etcd3/aliases
@@ -8,5 +8,4 @@ skip/aix
 skip/osx
 skip/macos
 skip/freebsd
-skip/python2.6 # installing etcd3 python module will fail on python < 2.7
 disabled  # see https://github.com/ansible-collections/community.general/issues/322

--- a/tests/integration/targets/filter_counter/aliases
+++ b/tests/integration/targets/filter_counter/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict/aliases
+++ b/tests/integration/targets/filter_dict/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_dict_kv/aliases
+++ b/tests/integration/targets/filter_dict_kv/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_from_csv/aliases
+++ b/tests/integration/targets/filter_from_csv/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_groupby_as_dict/aliases
+++ b/tests/integration/targets/filter_groupby_as_dict/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/3
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_hashids/aliases
+++ b/tests/integration/targets/filter_hashids/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/python2.7  # jc only supports python3.x

--- a/tests/integration/targets/filter_json_query/aliases
+++ b/tests/integration/targets/filter_json_query/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/aix

--- a/tests/integration/targets/filter_lists_mergeby/aliases
+++ b/tests/integration/targets/filter_lists_mergeby/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_path_join_shim/aliases
+++ b/tests/integration/targets/filter_path_join_shim/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_random_mac/aliases
+++ b/tests/integration/targets/filter_random_mac/aliases
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller
 skip/aix

--- a/tests/integration/targets/filter_time/aliases
+++ b/tests/integration/targets/filter_time/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_unicode_normalize/aliases
+++ b/tests/integration/targets/filter_unicode_normalize/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_version_sort/aliases
+++ b/tests/integration/targets/filter_version_sort/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # filters are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/homebrew/aliases
+++ b/tests/integration/targets/homebrew/aliases
@@ -7,4 +7,3 @@ skip/aix
 skip/freebsd
 skip/rhel
 skip/docker
-skip/python2.6

--- a/tests/integration/targets/homebrew_cask/aliases
+++ b/tests/integration/targets/homebrew_cask/aliases
@@ -7,4 +7,3 @@ skip/aix
 skip/freebsd
 skip/rhel
 skip/docker
-skip/python2.6

--- a/tests/integration/targets/ipify_facts/aliases
+++ b/tests/integration/targets/ipify_facts/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6

--- a/tests/integration/targets/iso_create/aliases
+++ b/tests/integration/targets/iso_create/aliases
@@ -5,4 +5,3 @@
 azp/posix/1
 destructive
 skip/aix
-skip/python2.6

--- a/tests/integration/targets/iso_customize/aliases
+++ b/tests/integration/targets/iso_customize/aliases
@@ -8,6 +8,5 @@ destructive
 skip/aix
 skip/freebsd
 skip/alpine
-skip/python2.6
 skip/docker
 needs/root

--- a/tests/integration/targets/lookup_cartesian/aliases
+++ b/tests/integration/targets/lookup_cartesian/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/1
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_dependent/aliases
+++ b/tests/integration/targets/lookup_dependent/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_dig/aliases
+++ b/tests/integration/targets/lookup_dig/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_etcd3/aliases
+++ b/tests/integration/targets/lookup_etcd3/aliases
@@ -10,5 +10,4 @@ skip/aix
 skip/osx
 skip/macos
 skip/freebsd
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller
 disabled  # see https://github.com/ansible-collections/community.general/issues/322

--- a/tests/integration/targets/lookup_flattened/aliases
+++ b/tests/integration/targets/lookup_flattened/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_lmdb_kv/aliases
+++ b/tests/integration/targets/lookup_lmdb_kv/aliases
@@ -5,4 +5,3 @@
 azp/posix/2
 destructive
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_merge_variables/aliases
+++ b/tests/integration/targets/lookup_merge_variables/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/1
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_passwordstore/aliases
+++ b/tests/integration/targets/lookup_passwordstore/aliases
@@ -6,6 +6,5 @@ azp/posix/1
 destructive
 skip/aix
 skip/rhel
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller
 skip/osx  # FIXME https://github.com/ansible-collections/community.general/issues/2978
 skip/macos  # FIXME https://github.com/ansible-collections/community.general/issues/2978

--- a/tests/integration/targets/lookup_random_pet/aliases
+++ b/tests/integration/targets/lookup_random_pet/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_random_string/aliases
+++ b/tests/integration/targets/lookup_random_string/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/lookup_random_words/aliases
+++ b/tests/integration/targets/lookup_random_words/aliases
@@ -4,4 +4,3 @@
 
 azp/posix/2
 skip/aix
-skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/monit/aliases
+++ b/tests/integration/targets/monit/aliases
@@ -9,6 +9,5 @@ skip/osx
 skip/macos
 skip/freebsd
 skip/aix
-skip/python2.6  # python-daemon package used in integration tests requires >=2.7
 skip/rhel  # FIXME
 unstable  # TODO: the tests fail a lot; 'unstable' only requires them to pass when the module itself has been modified

--- a/tests/integration/targets/odbc/aliases
+++ b/tests/integration/targets/odbc/aliases
@@ -12,4 +12,3 @@ skip/rhel9.1
 skip/rhel9.2
 skip/rhel9.3
 skip/freebsd
-skip/python2.6

--- a/tests/integration/targets/ssh_config/aliases
+++ b/tests/integration/targets/ssh_config/aliases
@@ -4,6 +4,5 @@
 
 azp/posix/2
 destructive
-skip/python2.6  # stromssh only supports python3
 skip/python2.7  # stromssh only supports python3
 skip/freebsd # stromssh installation fails on freebsd


### PR DESCRIPTION
##### SUMMARY
Since community.general 8.0.0 we no longer support any ansible-core version that supports Python 2.6.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
