### PR TITLE
fix(modules/terraform): handle multiline strings correctly in complex variables

### DIFF
--- a/changelogs/fragments/7535-terraform-fix-multiline-string-handling-in-complex-variables.yml
+++ b/changelogs/fragments/7535-terraform-fix-multiline-string-handling-in-complex-variables.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "terraform - fix multiline string handling in complex variables (https://github.com/ansible-collections/community.general/pull/7535)."

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -514,7 +514,7 @@ def main():
 
     def format_args(vars):
         if isinstance(vars, str):
-            return '"{string}"'.format(string=vars.replace('\\', '\\\\').replace('"', '\\"'))
+            return '"{string}"'.format(string=vars.replace('\\', '\\\\').replace('"', '\\"')).replace('\n', '\\n')
         elif isinstance(vars, bool):
             if vars:
                 return 'true'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Terraform needs newlines to be replaced with `\\n` when passing multiline strings inside complex variables.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When passing a multiline string inside a complex variable, like the `ca_certificate` in the example playbook below, Terraform complains.

```
- name: "Terraform
  hosts: "localhost"
  tasks:
    - name: "Run Terraform apply"
      community.general.terraform:
        project_path: "terraform"
        variables:
          postgresql:
            host: "{{ hostvars['db'].ansible_fqdn }}"
            port: 5432
            ca_certificate: "{{ hostvars['db'].postgresql_tls_cert }}"
        state: "present"
        complex_vars: true
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before the change, the approximate command run by the module is:
```paste below
terraform -var 'postgresql={host=\"hostname.test\",port=5432,ca_certificate=\"-----BEGIN CERTIFICATE-----\n[…]\n-----END CERTIFICATE-----\n\"}' apply
```

and the error is:
```
Error: Invalid multi-line string

  on <value for var.postgresql> line 1:
  (source code not available)

Quoted strings may not be split over multiple lines. To produce a multi-line
string, either use the \\n escape to represent a newline character or use the
"heredoc" multi-line template syntax.
```

After the change, the approximate command run by the module is:
```paste below
terraform -var 'postgresql={host=\"hostname.test\",port=5432,ca_certificate=\"-----BEGIN CERTIFICATE-----\\n[…]\\n-----END CERTIFICATE-----\\n\"}' apply
```

and there no error anymore.