### PR TITLE
[keycloak_user_federation]: Adding option krbPrincipalAttribute

### DIFF
--- a/changelogs/fragments/7538-add-krbprincipalattribute-option.yml
+++ b/changelogs/fragments/7538-add-krbprincipalattribute-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation module - Add option for krbPrincipalAttribute (https://github.com/ansible-collections/community.general/pull/7538)

--- a/changelogs/fragments/7538-add-krbprincipalattribute-option.yml
+++ b/changelogs/fragments/7538-add-krbprincipalattribute-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_user_federation module - Add option for krbPrincipalAttribute (https://github.com/ansible-collections/community.general/pull/7538)
+  - keycloak_user_federation - add option for ``krbPrincipalAttribute`` (https://github.com/ansible-collections/community.general/pull/7538).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -350,6 +350,8 @@ options:
                       to the first part of his Kerberos principal. For instance, for principal 'john@KEYCLOAK.ORG',
                       it will assume that LDAP username is 'john'.
                 type: str
+                version_added: 8.1.0
+
             serverPrincipal:
                 description:
                     - Full name of server principal for HTTP service including server and domain name. For

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -347,8 +347,8 @@ options:
                     - Name of the LDAP attribute, which refers to Kerberos principal.
                       This is used to lookup appropriate LDAP user after successful Kerberos/SPNEGO authentication in Keycloak.
                       When this is empty, the LDAP user will be looked based on LDAP username corresponding
-                      to the first part of his Kerberos principal. For instance, for principal 'john@KEYCLOAK.ORG',
-                      it will assume that LDAP username is 'john'.
+                      to the first part of his Kerberos principal. For instance, for principal C(john@KEYCLOAK.ORG),
+                      it will assume that LDAP username is V(john).
                 type: str
                 version_added: 8.1.0
 

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -342,6 +342,14 @@ options:
                     - Name of kerberos realm.
                 type: str
 
+            krbPrincipalAttribute:
+                description:
+                    - Name of the LDAP attribute, which refers to Kerberos principal.
+                      This is used to lookup appropriate LDAP user after successful Kerberos/SPNEGO authentication in Keycloak.
+                      When this is empty, the LDAP user will be looked based on LDAP username corresponding
+                      to the first part of his Kerberos principal. For instance, for principal 'john@KEYCLOAK.ORG',
+                      it will assume that LDAP username is 'john'.
+                type: str
             serverPrincipal:
                 description:
                     - Full name of server principal for HTTP service including server and domain name. For
@@ -764,6 +772,7 @@ def main():
         readTimeout=dict(type='int'),
         searchScope=dict(type='str', choices=['1', '2'], default='1'),
         serverPrincipal=dict(type='str'),
+        krbPrincipalAttribute=dict(type='str'),
         startTls=dict(type='bool', default=False),
         syncRegistrations=dict(type='bool', default=False),
         trustEmail=dict(type='bool', default=False),

--- a/tests/unit/plugins/modules/test_keycloak_user_federation.py
+++ b/tests/unit/plugins/modules/test_keycloak_user_federation.py
@@ -326,6 +326,7 @@ class TestKeycloakUserFederation(ModuleTestCase):
                 'connectionPooling': True,
                 'pagination': True,
                 'allowKerberosAuthentication': False,
+                'krbPrincipalAttribute': 'krbPrincipalName',
                 'debug': False,
                 'useKerberosForPasswordAuthentication': False,
             },
@@ -373,6 +374,9 @@ class TestKeycloakUserFederation(ModuleTestCase):
                     ],
                     "enabled": [
                         "true"
+                    ],
+                    "krbPrincipalAttribute": [
+                        "krb5PrincipalName"
                     ],
                     "usernameLDAPAttribute": [
                         "uid"


### PR DESCRIPTION
##### SUMMARY
Adding option for krbPrincipalAttribute in `keycloak_user_federation`
Partially because we might need to change it, but also this is needed for idempotency

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
modules/keycloak_user_federation
