### PR TITLE
ssl.wrap_socket() was removed in Python 3.12

### DIFF
--- a/changelogs/fragments/7542-irc-logentries-ssl.yml
+++ b/changelogs/fragments/7542-irc-logentries-ssl.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "log_entries callback plugin - replace ``ssl.wrap_socket`` that was removed from Python 3.12 with code for creating a proper SSL context (https://github.com/ansible-collections/community.general/pull/7542)."
+  - "irc - replace ``ssl.wrap_socket`` that was removed from Python 3.12 with code for creating a proper SSL context (https://github.com/ansible-collections/community.general/pull/7542)."

--- a/plugins/callback/logentries.py
+++ b/plugins/callback/logentries.py
@@ -196,15 +196,11 @@ else:
     class TLSSocketAppender(PlainTextSocketAppender):
         def open_connection(self):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock = ssl.wrap_socket(
+            context = ssl.create_default_context(
+                purpose=ssl.Purpose.SERVER_AUTH,
+                cafile=certifi.where(), )
+            sock = context.wrap_socket(
                 sock=sock,
-                keyfile=None,
-                certfile=None,
-                server_side=False,
-                cert_reqs=ssl.CERT_REQUIRED,
-                ssl_version=getattr(
-                    ssl, 'PROTOCOL_TLSv1_2', ssl.PROTOCOL_TLSv1),
-                ca_certs=certifi.where(),
                 do_handshake_on_connect=True,
                 suppress_ragged_eofs=True, )
             sock.connect((self.LE_API, self.LE_TLS_PORT))

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -195,7 +195,13 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
 
     irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if use_ssl:
-        context = ssl.create_default_context()
+        if getattr(ssl, 'PROTOCOL_TLS', None) is not None:
+            # Supported since Python 2.7.13
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        else:
+            context = ssl.SSLContext()
+        context.verify_mode = ssl.CERT_NONE
+        # TODO: create a secure context with `context = ssl.create_default_context()` instead!
         irc = context.wrap_socket(irc)
     irc.connect((server, int(port)))
 

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -195,7 +195,8 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
 
     irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if use_ssl:
-        irc = ssl.wrap_socket(irc)
+        context = ssl.create_default_context()
+        irc = context.wrap_socket(irc)
     irc.connect((server, int(port)))
 
     if passwd:


### PR DESCRIPTION
##### SUMMARY
The irc module and the log_entries callback were still using it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
irc module
log_entries callback
