### PR TITLE
irc module: add validate_certs, rename use_ssl to use_tls (keeping use_ssl as an alias)

### DIFF
--- a/changelogs/fragments/7550-irc-use_tls-validate_certs.yml
+++ b/changelogs/fragments/7550-irc-use_tls-validate_certs.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "irc - add ``validate_certs`` option, and rename ``use_ssl`` to ``use_tls``, while keeping ``use_ssl`` as an alias.
+     The default value for ``validate_certs`` is ``false`` for backwards compatibility. We recommend to every user of
+     this module to explicitly set ``use_tls=true`` and `validate_certs=true`` whenever possible, especially when
+     communicating to IRC servers over the internet (https://github.com/ansible-collections/community.general/pull/7550)."

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -79,11 +79,15 @@ options:
       - Timeout to use while waiting for successful registration and join
         messages, this is to prevent an endless loop
     default: 30
-  use_ssl:
+  use_tls:
     description:
       - Designates whether TLS/SSL should be used when connecting to the IRC server
+      - O(use_tls) is available since community.general 8.1.0, before the option
+        was exlusively called O(use_ssl). The latter is now an alias of O(use_tls).
     type: bool
     default: false
+    aliases:
+      - use_ssl
   part:
     description:
       - Designates whether user should part from channel after sending message or not.
@@ -150,7 +154,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, key=None, topic=None,
-             nick="ansible", color='none', passwd=False, timeout=30, use_ssl=False, part=True, style=None):
+             nick="ansible", color='none', passwd=False, timeout=30, use_tls=False, part=True, style=None):
     '''send message to IRC'''
     nick_to = [] if nick_to is None else nick_to
 
@@ -194,7 +198,7 @@ def send_msg(msg, server='localhost', port='6667', channel=None, nick_to=None, k
     message = styletext + colortext + msg
 
     irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if use_ssl:
+    if use_tls:
         if getattr(ssl, 'PROTOCOL_TLS', None) is not None:
             # Supported since Python 2.7.13
             context = ssl.SSLContext(ssl.PROTOCOL_TLS)
@@ -282,7 +286,7 @@ def main():
             passwd=dict(no_log=True),
             timeout=dict(type='int', default=30),
             part=dict(type='bool', default=True),
-            use_ssl=dict(type='bool', default=False)
+            use_tls=dict(type='bool', default=False, aliases=['use_ssl']),
         ),
         supports_check_mode=True,
         required_one_of=[['channel', 'nick_to']]
@@ -301,12 +305,12 @@ def main():
     key = module.params["key"]
     passwd = module.params["passwd"]
     timeout = module.params["timeout"]
-    use_ssl = module.params["use_ssl"]
+    use_tls = module.params["use_tls"]
     part = module.params["part"]
     style = module.params["style"]
 
     try:
-        send_msg(msg, server, port, channel, nick_to, key, topic, nick, color, passwd, timeout, use_ssl, part, style)
+        send_msg(msg, server, port, channel, nick_to, key, topic, nick, color, passwd, timeout, use_tls, part, style)
     except Exception as e:
         module.fail_json(msg="unable to send to IRC: %s" % to_native(e), exception=traceback.format_exc())
 

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -84,7 +84,7 @@ options:
       - Designates whether TLS/SSL should be used when connecting to the IRC server
       - O(use_tls) is available since community.general 8.1.0, before the option
         was exlusively called O(use_ssl). The latter is now an alias of O(use_tls).
-      - B(Note): for security reasons, you should always set O(use_tls=true) and
+      - B(Note:) for security reasons, you should always set O(use_tls=true) and
         O(validate_certs=true) whenever possible.
     type: bool
     default: false
@@ -107,7 +107,7 @@ options:
       - If set to V(false), the SSL certificates will not be validated.
       - This should always be set to V(true). Using V(false) is unsafe and should only be done
         if the network between between Ansible and the IRC server is known to be safe.
-      - B(Note): for security reasons, you should always set O(use_tls=true) and
+      - B(Note:) for security reasons, you should always set O(use_tls=true) and
         O(validate_certs=true) whenever possible.
     default: false
     type: bool

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -124,6 +124,8 @@ EXAMPLES = '''
 - name: Send a message to an IRC channel from nick ansible
   community.general.irc:
     server: irc.example.net
+    use_tls: true
+    validate_certs: true
     channel: #t1
     msg: Hello world
 
@@ -132,6 +134,8 @@ EXAMPLES = '''
     module: irc
     port: 6669
     server: irc.example.net
+    use_tls: true
+    validate_certs: true
     channel: #t1
     msg: 'All finished at {{ ansible_date_time.iso8601 }}'
     color: red
@@ -142,6 +146,8 @@ EXAMPLES = '''
     module: irc
     port: 6669
     server: irc.example.net
+    use_tls: true
+    validate_certs: true
     channel: #t1
     nick_to:
       - nick1

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -84,6 +84,8 @@ options:
       - Designates whether TLS/SSL should be used when connecting to the IRC server
       - O(use_tls) is available since community.general 8.1.0, before the option
         was exlusively called O(use_ssl). The latter is now an alias of O(use_tls).
+      - B(Note): for security reasons, you should always set O(use_tls=true) and
+        O(validate_certs=true) whenever possible.
     type: bool
     default: false
     aliases:
@@ -105,6 +107,8 @@ options:
       - If set to V(false), the SSL certificates will not be validated.
       - This should always be set to V(true). Using V(false) is unsafe and should only be done
         if the network between between Ansible and the IRC server is known to be safe.
+      - B(Note): for security reasons, you should always set O(use_tls=true) and
+        O(validate_certs=true) whenever possible.
     default: false
     type: bool
     version_added: 8.1.0


### PR DESCRIPTION
##### SUMMARY
This PR currently contains #7542, I will rebase once that's merged.

Right now the `irc` module does **not** validate TLS certificates. This adds an option which allows to change that behavior.

Also the `use_ssl` option should rather be called `use_tls`. I've renamed it and added the old name `use_ssl` as an alias.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
irc
