### PR TITLE
More docs cleanup

### DIFF
--- a/plugins/callback/say.py
+++ b/plugins/callback/say.py
@@ -18,8 +18,6 @@ DOCUMENTATION = '''
     short_description: notify using software speech synthesizer
     description:
       - This plugin will use the C(say) or C(espeak) program to "speak" about play events.
-    notes:
-      - In Ansible 2.8, this callback has been renamed from C(osx_say) into M(community.general.say).
 '''
 
 import platform

--- a/plugins/callback/slack.py
+++ b/plugins/callback/slack.py
@@ -18,7 +18,6 @@ DOCUMENTATION = '''
     short_description: Sends play events to a Slack channel
     description:
         - This is an ansible callback plugin that sends status updates to a Slack channel during playbook execution.
-        - Before Ansible 2.4 only environment variables were available for configuring this plugin.
     options:
       webhook_url:
         required: true

--- a/plugins/callback/syslog_json.py
+++ b/plugins/callback/syslog_json.py
@@ -16,7 +16,6 @@ DOCUMENTATION = '''
     short_description: sends JSON events to syslog
     description:
       - This plugin logs ansible-playbook and ansible runs to a syslog server in JSON format.
-      - Before Ansible 2.9 only environment variables were available for configuration.
     options:
       server:
         description: Syslog server that will receive the event.

--- a/plugins/inventory/gitlab_runners.py
+++ b/plugins/inventory/gitlab_runners.py
@@ -14,7 +14,6 @@ DOCUMENTATION = '''
       - Stefan Heitmüller (@morph027) <stefan.heitmueller@gmx.com>
     short_description: Ansible dynamic inventory plugin for GitLab runners.
     requirements:
-        - python >= 2.7
         - python-gitlab > 1.8.0
     extends_documentation_fragment:
         - constructed

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -12,7 +12,6 @@ DOCUMENTATION = r'''
       - Luke Murphy (@decentral1se)
     short_description: Ansible dynamic inventory plugin for Linode.
     requirements:
-        - python >= 2.7
         - linode_api4 >= 2.0.0
     description:
         - Reads inventories from the Linode API v4.

--- a/plugins/lookup/etcd.py
+++ b/plugins/lookup/etcd.py
@@ -54,7 +54,7 @@ EXAMPLES = '''
   ansible.builtin.debug:
     msg: "{{ lookup('community.general.etcd', 'foo', 'bar', 'baz') }}"
 
-- name: "since Ansible 2.5 you can set server options inline"
+- name: "you can set server options inline"
   ansible.builtin.debug:
     msg: "{{ lookup('community.general.etcd', 'foo', version='v2', url='http://192.168.0.27:4001') }}"
 '''
@@ -62,7 +62,7 @@ EXAMPLES = '''
 RETURN = '''
     _raw:
         description:
-            - list of values associated with input keys
+            - List of values associated with input keys.
         type: list
         elements: string
 '''

--- a/plugins/modules/ali_instance.py
+++ b/plugins/modules/ali_instance.py
@@ -253,7 +253,7 @@ options:
 author:
     - "He Guimin (@xiaozhu36)"
 requirements:
-    - "python >= 3.6"
+    - "Python >= 3.6"
     - "footmark >= 1.19.0"
 extends_documentation_fragment:
     - community.general.alicloud

--- a/plugins/modules/ali_instance_info.py
+++ b/plugins/modules/ali_instance_info.py
@@ -31,7 +31,6 @@ short_description: Gather information on instances of Alibaba Cloud ECS
 description:
      - This module fetches data from the Open API in Alicloud.
        The module must be called from within the ECS instance itself.
-     - This module was called C(ali_instance_facts) before Ansible 2.9. The usage did not change.
 
 attributes:
     check_mode:
@@ -61,7 +60,7 @@ options:
 author:
     - "He Guimin (@xiaozhu36)"
 requirements:
-    - "python >= 3.6"
+    - "Python >= 3.6"
     - "footmark >= 1.13.0"
 extends_documentation_fragment:
     - community.general.alicloud

--- a/plugins/modules/archive.py
+++ b/plugins/modules/archive.py
@@ -36,7 +36,6 @@ options:
   format:
     description:
       - The type of compression to use.
-      - Support for xz was added in Ansible 2.5.
     type: str
     choices: [ bz2, gz, tar, xz, zip ]
     default: gz

--- a/plugins/modules/atomic_container.py
+++ b/plugins/modules/atomic_container.py
@@ -21,7 +21,6 @@ notes:
     - Host should support C(atomic) command
 requirements:
     - atomic
-    - "python >= 2.6"
 extends_documentation_fragment:
     - community.general.attributes
 attributes:

--- a/plugins/modules/atomic_host.py
+++ b/plugins/modules/atomic_host.py
@@ -21,7 +21,6 @@ notes:
     - Host should be an atomic platform (verified by existence of '/run/ostree-booted' file).
 requirements:
   - atomic
-  - python >= 2.6
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/atomic_image.py
+++ b/plugins/modules/atomic_image.py
@@ -21,7 +21,6 @@ notes:
     - Host should support C(atomic) command.
 requirements:
   - atomic
-  - python >= 2.6
 extends_documentation_fragment:
   - community.general.attributes
 attributes:

--- a/plugins/modules/bzr.py
+++ b/plugins/modules/bzr.py
@@ -45,8 +45,7 @@ options:
     force:
         description:
             - If V(true), any modified files in the working
-              tree will be discarded.  Before Ansible 1.9 the default
-              value was V(true).
+              tree will be discarded.
         type: bool
         default: false
     executable:

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -13,8 +13,6 @@ DOCUMENTATION = r'''
 module: cloudflare_dns
 author:
 - Michael Gruener (@mgruener)
-requirements:
-   - python >= 2.6
 short_description: Manage Cloudflare DNS records
 description:
    - "Manages dns records via the Cloudflare API, see the docs: U(https://api.cloudflare.com/)."
@@ -99,7 +97,6 @@ options:
     description:
     - Service protocol. Required for O(type=SRV) and O(type=TLSA).
     - Common values are TCP and UDP.
-    - Before Ansible 2.6 only TCP and UDP were available.
     type: str
   proxied:
     description:
@@ -151,7 +148,6 @@ options:
   type:
     description:
       - The type of DNS record to create. Required if O(state=present).
-      - O(type=DS), O(type=SSHFP), and O(type=TLSA) were added in Ansible 2.7.
     type: str
     choices: [ A, AAAA, CNAME, DS, MX, NS, SPF, SRV, SSHFP, TLSA, CAA, TXT ]
   value:

--- a/plugins/modules/elasticsearch_plugin.py
+++ b/plugins/modules/elasticsearch_plugin.py
@@ -69,7 +69,6 @@ options:
     plugin_bin:
         description:
             - Location of the plugin binary. If this file is not found, the default plugin binaries will be used.
-            - The default changed in Ansible 2.4 to None.
         type: path
     plugin_dir:
         description:

--- a/plugins/modules/github_release.py
+++ b/plugins/modules/github_release.py
@@ -94,7 +94,7 @@ EXAMPLES = '''
     repo: testrepo
     action: latest_release
 
-- name: Get latest release of test repo using username and password. Ansible 2.4.
+- name: Get latest release of test repo using username and password
   community.general.github_release:
     user: testuser
     password: secret123

--- a/plugins/modules/github_webhook_info.py
+++ b/plugins/modules/github_webhook_info.py
@@ -14,7 +14,6 @@ module: github_webhook_info
 short_description: Query information about GitHub webhooks
 description:
   - "Query information about GitHub webhooks"
-  - This module was called C(github_webhook_facts) before Ansible 2.9. The usage did not change.
 requirements:
   - "PyGithub >= 1.3.5"
 extends_documentation_fragment:

--- a/plugins/modules/gitlab_branch.py
+++ b/plugins/modules/gitlab_branch.py
@@ -16,7 +16,6 @@ description:
 author:
   - paytroff (@paytroff)
 requirements:
-  - python >= 2.7
   - python-gitlab >= 2.3.0
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_deploy_key.py
+++ b/plugins/modules/gitlab_deploy_key.py
@@ -20,7 +20,6 @@ author:
   - Marcus Watkins (@marwatk)
   - Guillaume Martinez (@Lunik)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_group.py
+++ b/plugins/modules/gitlab_group.py
@@ -20,7 +20,6 @@ author:
   - Werner Dijkerman (@dj-wasabi)
   - Guillaume Martinez (@Lunik)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -21,7 +21,6 @@ description:
 author:
   - Florent Madiot (@scodeman)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -21,7 +21,6 @@ author:
   - Marcus Watkins (@marwatk)
   - Guillaume Martinez (@Lunik)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -23,7 +23,6 @@ description:
 author:
   - Benedikt Braunger (@benibr)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_merge_request.py
+++ b/plugins/modules/gitlab_merge_request.py
@@ -26,7 +26,6 @@ description:
 author:
   - zvaraondrej (@zvaraondrej)
 requirements:
-  - Python >= 2.7
   - python-gitlab >= 2.3.0
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_project.py
+++ b/plugins/modules/gitlab_project.py
@@ -21,7 +21,6 @@ author:
   - Werner Dijkerman (@dj-wasabi)
   - Guillaume Martinez (@Lunik)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -18,7 +18,6 @@ description:
 author:
   - "Markus Bergholz (@markuman)"
 requirements:
-  - python >= 2.7
   - python-gitlab python module
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_protected_branch.py
+++ b/plugins/modules/gitlab_protected_branch.py
@@ -16,7 +16,6 @@ description:
 author:
   - "Werner Dijkerman (@dj-wasabi)"
 requirements:
-  - python >= 2.7
   - python-gitlab >= 2.3.0
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -30,7 +30,6 @@ author:
   - Samy Coenen (@SamyCoenen)
   - Guillaume Martinez (@Lunik)
 requirements:
-  - python >= 2.7
   - python-gitlab >= 1.5.0
 extends_documentation_fragment:
   - community.general.auth_basic

--- a/plugins/modules/gitlab_user.py
+++ b/plugins/modules/gitlab_user.py
@@ -27,7 +27,6 @@ author:
   - Lennert Mertens (@LennertMertens)
   - Stef Graces (@stgrace)
 requirements:
-  - python >= 2.7
   - python-gitlab python module
   - administrator rights on the GitLab server
 extends_documentation_fragment:

--- a/plugins/modules/hg.py
+++ b/plugins/modules/hg.py
@@ -43,8 +43,7 @@ options:
         type: str
     force:
         description:
-            - Discards uncommitted changes. Runs C(hg update -C).  Prior to
-              Ansible 1.9, the default was V(true).
+            - Discards uncommitted changes. Runs C(hg update -C).
         type: bool
         default: false
     purge:

--- a/plugins/modules/hpilo_info.py
+++ b/plugins/modules/hpilo_info.py
@@ -19,8 +19,6 @@ description:
   These information includes hardware and network related information useful
   for provisioning (e.g. macaddress, uuid).
 - This module requires the C(hpilo) python module.
-- This module was called C(hpilo_facts) before Ansible 2.9, returning C(ansible_facts).
-  Note that the M(community.general.hpilo_info) module no longer returns C(ansible_facts)!
 extends_documentation_fragment:
 - community.general.attributes
 - community.general.attributes.info_module

--- a/plugins/modules/idrac_redfish_info.py
+++ b/plugins/modules/idrac_redfish_info.py
@@ -16,8 +16,6 @@ description:
   - Builds Redfish URIs locally and sends them to remote iDRAC controllers to
     get information back.
   - For use with Dell EMC iDRAC operations that require Redfish OEM extensions.
-  - This module was called C(idrac_redfish_facts) before Ansible 2.9, returning C(ansible_facts).
-    Note that the M(community.general.idrac_redfish_info) module no longer returns C(ansible_facts)!
 extends_documentation_fragment:
   - community.general.attributes
   - community.general.attributes.info_module

--- a/plugins/modules/imgadm.py
+++ b/plugins/modules/imgadm.py
@@ -62,9 +62,6 @@ options:
         description:
           - Image UUID. Can either be a full UUID or V(*) for all images.
         type: str
-
-requirements:
-    - python >= 2.6
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/influxdb_database.py
+++ b/plugins/modules/influxdb_database.py
@@ -17,7 +17,6 @@ description:
     - Manage InfluxDB databases.
 author: "Kamil Szczygiel (@kamsz)"
 requirements:
-    - "python >= 2.6"
     - "influxdb >= 0.9"
     - requests
 attributes:

--- a/plugins/modules/influxdb_query.py
+++ b/plugins/modules/influxdb_query.py
@@ -16,7 +16,6 @@ description:
   - Query data points from InfluxDB.
 author: "René Moser (@resmo)"
 requirements:
-  - "python >= 2.6"
   - "influxdb >= 0.9"
 attributes:
   check_mode:

--- a/plugins/modules/influxdb_retention_policy.py
+++ b/plugins/modules/influxdb_retention_policy.py
@@ -17,7 +17,6 @@ description:
     - Manage InfluxDB retention policies.
 author: "Kamil Szczygiel (@kamsz)"
 requirements:
-    - "python >= 2.6"
     - "influxdb >= 0.9"
     - requests
 attributes:

--- a/plugins/modules/influxdb_user.py
+++ b/plugins/modules/influxdb_user.py
@@ -18,7 +18,6 @@ description:
   - Manage InfluxDB users.
 author: "Vitaliy Zhhuta (@zhhuta)"
 requirements:
-  - "python >= 2.6"
   - "influxdb >= 0.9"
 attributes:
   check_mode:

--- a/plugins/modules/influxdb_write.py
+++ b/plugins/modules/influxdb_write.py
@@ -16,7 +16,6 @@ description:
   - Write data points into InfluxDB.
 author: "René Moser (@resmo)"
 requirements:
-  - "python >= 2.6"
   - "influxdb >= 0.9"
 attributes:
   check_mode:

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -23,8 +23,7 @@ description:
   - Manage (add, remove, change) individual settings in an INI-style file without having
     to manage the file as a whole with, say, M(ansible.builtin.template) or M(ansible.builtin.assemble).
   - Adds missing sections if they don't exist.
-  - Before Ansible 2.0, comments are discarded when the source file is read, and therefore will not show up in the destination file.
-  - Since Ansible 2.3, this module adds missing ending newlines to files to keep in line with the POSIX standard, even when
+  - This module adds missing ending newlines to files to keep in line with the POSIX standard, even when
     no other modifications need to be applied.
 attributes:
   check_mode:
@@ -35,7 +34,6 @@ options:
   path:
     description:
       - Path to the INI-style file; this file is created if required.
-      - Before Ansible 2.3 this option was only usable as O(dest).
     type: path
     required: true
     aliases: [ dest ]
@@ -133,7 +131,6 @@ options:
     version_added: 7.1.0
 notes:
    - While it is possible to add an O(option) without specifying a O(value), this makes no sense.
-   - As of Ansible 2.3, the O(dest) option has been changed to O(path) as default, but O(dest) still works as well.
    - As of community.general 3.2.0, UTF-8 BOM markers are discarded when reading files.
 author:
     - Jan-Piet Mens (@jpmens)
@@ -141,7 +138,6 @@ author:
 '''
 
 EXAMPLES = r'''
-# Before Ansible 2.3, option 'dest' was used instead of 'path'
 - name: Ensure "fav=lemonade is in section "[drinks]" in specified file
   community.general.ini_file:
     path: /etc/conf

--- a/plugins/modules/ipmi_boot.py
+++ b/plugins/modules/ipmi_boot.py
@@ -93,7 +93,6 @@ options:
     type: bool
     default: false
 requirements:
-  - "python >= 2.6"
   - pyghmi
 author: "Bulat Gaifullin (@bgaifullin) <gaifullinbf@gmail.com>"
 '''

--- a/plugins/modules/ipmi_power.py
+++ b/plugins/modules/ipmi_power.py
@@ -90,7 +90,6 @@ options:
         type: str
 
 requirements:
-  - "python >= 2.6"
   - pyghmi
 author: "Bulat Gaifullin (@bgaifullin) <gaifullinbf@gmail.com>"
 '''

--- a/plugins/modules/irc.py
+++ b/plugins/modules/irc.py
@@ -50,8 +50,7 @@ options:
   color:
     type: str
     description:
-      - Text color for the message. ("none" is a valid option in 1.6 or later, in 1.6 and prior, the default color is black, not "none").
-        Added 11 more colors in version 2.0.
+      - Text color for the message.
     default: "none"
     choices: [ "none", "white", "black", "blue", "green", "red", "brown", "purple", "orange", "yellow", "light_green", "teal", "light_cyan",
                "light_blue", "pink", "gray", "light_gray"]

--- a/plugins/modules/iso_create.py
+++ b/plugins/modules/iso_create.py
@@ -19,7 +19,6 @@ author:
   - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 requirements:
   - "pycdlib"
-  - "python >= 2.7"
 version_added: '0.2.0'
 
 extends_documentation_fragment:

--- a/plugins/modules/iso_customize.py
+++ b/plugins/modules/iso_customize.py
@@ -20,7 +20,6 @@ author:
   - Yuhua Zou (@ZouYuhua) <zouy@vmware.com>
 requirements:
   - "pycdlib"
-  - "python >= 2.7"
 version_added: '5.8.0'
 
 extends_documentation_fragment:

--- a/plugins/modules/iso_extract.py
+++ b/plugins/modules/iso_extract.py
@@ -70,9 +70,6 @@ options:
 notes:
 - Only the file checksum (content) is taken into account when extracting files
   from the ISO image. If O(force=false), only checks the presence of the file.
-- In Ansible 2.3 this module was using C(mount) and C(umount) commands only,
-  requiring root access. This is no longer needed with the introduction of 7zip
-  for extraction.
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/jenkins_job_info.py
+++ b/plugins/modules/jenkins_job_info.py
@@ -15,7 +15,6 @@ module: jenkins_job_info
 short_description: Get information about Jenkins jobs
 description:
   - This module can be used to query information about which Jenkins jobs which already exists.
-  - This module was called C(jenkins_job_facts) before Ansible 2.9. The usage did not change.
 requirements:
   - "python-jenkins >= 0.4.12"
 extends_documentation_fragment:

--- a/plugins/modules/layman.py
+++ b/plugins/modules/layman.py
@@ -19,7 +19,6 @@ description:
   - Uses Layman to manage an additional repositories for the Portage package manager on Gentoo Linux.
     Please note that Layman must be installed on a managed node prior using this module.
 requirements:
-  - "python >= 2.6"
   - layman python module
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/linode.py
+++ b/plugins/modules/linode.py
@@ -163,7 +163,6 @@ options:
     type: bool
     default: true
 requirements:
-    - python >= 2.6
     - linode-python
 author:
 - Vincent Viallet (@zbal)

--- a/plugins/modules/linode_v4.py
+++ b/plugins/modules/linode_v4.py
@@ -14,7 +14,6 @@ module: linode_v4
 short_description: Manage instances on the Linode cloud
 description: Manage instances on the Linode cloud.
 requirements:
-  - python >= 2.7
   - linode_api4 >= 2.0.0
 author:
   - Luke Murphy (@decentral1se)

--- a/plugins/modules/lvg.py
+++ b/plugins/modules/lvg.py
@@ -42,7 +42,7 @@ options:
     - "The size of the physical extent. O(pesize) must be a power of 2 of at least 1 sector
        (where the sector size is the largest sector size of the PVs currently used in the VG),
        or at least 128KiB."
-    - Since Ansible 2.6, pesize can be optionally suffixed by a UNIT (k/K/m/M/g/G), default unit is megabyte.
+    - O(pesize) can be optionally suffixed by a UNIT (k/K/m/M/g/G), default unit is megabyte.
     type: str
     default: "4"
   pv_options:

--- a/plugins/modules/memset_memstore_info.py
+++ b/plugins/modules/memset_memstore_info.py
@@ -18,7 +18,6 @@ notes:
       following minimum scope - C(memstore.usage).
 description:
     - Retrieve Memstore product usage information.
-    - This module was called C(memset_memstore_facts) before Ansible 2.9. The usage did not change.
 extends_documentation_fragment:
     - community.general.attributes
     - community.general.attributes.info_module

--- a/plugins/modules/memset_server_info.py
+++ b/plugins/modules/memset_server_info.py
@@ -18,7 +18,6 @@ notes:
       following minimum scope - C(server.info).
 description:
     - Retrieve server information.
-    - This module was called C(memset_server_facts) before Ansible 2.9. The usage did not change.
 extends_documentation_fragment:
     - community.general.attributes
     - community.general.attributes.info_module

--- a/plugins/modules/mssql_db.py
+++ b/plugins/modules/mssql_db.py
@@ -71,7 +71,6 @@ notes:
    - Requires the pymssql Python package on the remote host. For Ubuntu, this
      is as easy as pip install pymssql (See M(ansible.builtin.pip).)
 requirements:
-   - python >= 2.7
    - pymssql
 author: Vedit Firat Arig (@vedit)
 '''

--- a/plugins/modules/mssql_script.py
+++ b/plugins/modules/mssql_script.py
@@ -73,7 +73,6 @@ notes:
    - Requires the pymssql Python package on the remote host. For Ubuntu, this
      is as easy as C(pip install pymssql) (See M(ansible.builtin.pip).)
 requirements:
-   - python >= 2.7
    - pymssql
 
 author:

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -60,9 +60,8 @@ options:
         description:
             - This is the type of device or network connection that you wish to create or modify.
             - Type V(dummy) is added in community.general 3.5.0.
-            - Type V(generic) is added in Ansible 2.5.
-            - Type V(infiniband) is added in community.general 2.0.0.
             - Type V(gsm) is added in community.general 3.7.0.
+            - Type V(infiniband) is added in community.general 2.0.0.
             - Type V(loopback) is added in community.general 8.1.0.
             - Type V(macvlan) is added in community.general 6.6.0.
             - Type V(wireguard) is added in community.general 4.3.0.

--- a/plugins/modules/nsupdate.py
+++ b/plugins/modules/nsupdate.py
@@ -67,7 +67,6 @@ options:
         description:
             - DNS record will be modified on this O(zone).
             - When omitted DNS will be queried to attempt finding the correct zone.
-            - Starting with Ansible 2.7 this parameter is optional.
         type: str
     record:
         description:

--- a/plugins/modules/odbc.py
+++ b/plugins/modules/odbc.py
@@ -48,7 +48,6 @@ options:
       default: true
       version_added: 1.3.0
 requirements:
-  - "python >= 2.6"
   - "pyodbc"
 
 notes:

--- a/plugins/modules/one_image_info.py
+++ b/plugins/modules/one_image_info.py
@@ -14,7 +14,6 @@ module: one_image_info
 short_description: Gather information on OpenNebula images
 description:
   - Gather information on OpenNebula images.
-  - This module was called C(one_image_facts) before Ansible 2.9. The usage did not change.
 requirements:
   - pyone
 extends_documentation_fragment:

--- a/plugins/modules/oneandone_firewall_policy.py
+++ b/plugins/modules/oneandone_firewall_policy.py
@@ -110,7 +110,6 @@ options:
 
 requirements:
   - "1and1"
-  - "python >= 2.6"
 
 author:
   -  "Amel Ajdinovic (@aajdinov)"

--- a/plugins/modules/oneandone_load_balancer.py
+++ b/plugins/modules/oneandone_load_balancer.py
@@ -148,7 +148,6 @@ options:
 
 requirements:
      - "1and1"
-     - "python >= 2.6"
 
 author:
   - Amel Ajdinovic (@aajdinov)

--- a/plugins/modules/oneandone_monitoring_policy.py
+++ b/plugins/modules/oneandone_monitoring_policy.py
@@ -207,7 +207,6 @@ options:
 
 requirements:
   - "1and1"
-  - "python >= 2.6"
 
 author:
   -  "Amel Ajdinovic (@aajdinov)"

--- a/plugins/modules/oneandone_private_network.py
+++ b/plugins/modules/oneandone_private_network.py
@@ -95,7 +95,6 @@ options:
 
 requirements:
      - "1and1"
-     - "python >= 2.6"
 
 author:
   - Amel Ajdinovic (@aajdinov)

--- a/plugins/modules/oneandone_public_ip.py
+++ b/plugins/modules/oneandone_public_ip.py
@@ -81,7 +81,6 @@ options:
 
 requirements:
      - "1and1"
-     - "python >= 2.6"
 
 author:
   - Amel Ajdinovic (@aajdinov)

--- a/plugins/modules/oneandone_server.py
+++ b/plugins/modules/oneandone_server.py
@@ -148,7 +148,6 @@ options:
 
 requirements:
   - "1and1"
-  - "python >= 2.6"
 
 author:
   -  "Amel Ajdinovic (@aajdinov)"

--- a/plugins/modules/onepassword_info.py
+++ b/plugins/modules/onepassword_info.py
@@ -26,9 +26,6 @@ description:
     - M(community.general.onepassword_info) wraps the C(op) command line utility to fetch data about one or more 1Password items.
     - A fatal error occurs if any of the items being searched for can not be found.
     - Recommend using with the C(no_log) option to avoid logging the values of the secrets being retrieved.
-    - This module was called C(onepassword_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.onepassword_info) module no longer returns C(ansible_facts)!
-      You must now use the C(register) keyword to use the facts in other tasks.
 extends_documentation_fragment:
     - community.general.attributes
     - community.general.attributes.info_module

--- a/plugins/modules/oneview_datacenter_info.py
+++ b/plugins/modules/oneview_datacenter_info.py
@@ -13,8 +13,6 @@ module: oneview_datacenter_info
 short_description: Retrieve information about the OneView Data Centers
 description:
     - Retrieve information about the OneView Data Centers.
-    - This module was called C(oneview_datacenter_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_datacenter_info) module no longer returns C(ansible_facts)!
 requirements:
     - "hpOneView >= 2.0.1"
 author:

--- a/plugins/modules/oneview_enclosure_info.py
+++ b/plugins/modules/oneview_enclosure_info.py
@@ -14,8 +14,6 @@ module: oneview_enclosure_info
 short_description: Retrieve information about one or more Enclosures
 description:
     - Retrieve information about one or more of the Enclosures from OneView.
-    - This module was called C(oneview_enclosure_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_enclosure_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_ethernet_network_info.py
+++ b/plugins/modules/oneview_ethernet_network_info.py
@@ -13,8 +13,6 @@ module: oneview_ethernet_network_info
 short_description: Retrieve the information about one or more of the OneView Ethernet Networks
 description:
     - Retrieve the information about one or more of the Ethernet Networks from OneView.
-    - This module was called C(oneview_ethernet_network_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_ethernet_network_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_fc_network_info.py
+++ b/plugins/modules/oneview_fc_network_info.py
@@ -13,8 +13,6 @@ module: oneview_fc_network_info
 short_description: Retrieve the information about one or more of the OneView Fibre Channel Networks
 description:
     - Retrieve the information about one or more of the Fibre Channel Networks from OneView.
-    - This module was called C(oneview_fc_network_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_fc_network_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_fcoe_network.py
+++ b/plugins/modules/oneview_fcoe_network.py
@@ -14,7 +14,7 @@ short_description: Manage OneView FCoE Network resources
 description:
     - Provides an interface to manage FCoE Network resources. Can create, update, or delete.
 requirements:
-    - "python >= 2.7.9"
+    - "Python >= 2.7.9"
     - "hpOneView >= 4.0.0"
 author: "Felipe Bulsoni (@fgbulsoni)"
 attributes:

--- a/plugins/modules/oneview_fcoe_network_info.py
+++ b/plugins/modules/oneview_fcoe_network_info.py
@@ -13,8 +13,6 @@ module: oneview_fcoe_network_info
 short_description: Retrieve the information about one or more of the OneView FCoE Networks
 description:
     - Retrieve the information about one or more of the FCoE Networks from OneView.
-    - This module was called C(oneview_fcoe_network_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_fcoe_network_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_logical_interconnect_group_info.py
+++ b/plugins/modules/oneview_logical_interconnect_group_info.py
@@ -14,8 +14,6 @@ module: oneview_logical_interconnect_group_info
 short_description: Retrieve information about one or more of the OneView Logical Interconnect Groups
 description:
     - Retrieve information about one or more of the Logical Interconnect Groups from OneView
-    - This module was called C(oneview_logical_interconnect_group_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_logical_interconnect_group_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_network_set_info.py
+++ b/plugins/modules/oneview_network_set_info.py
@@ -13,8 +13,6 @@ module: oneview_network_set_info
 short_description: Retrieve information about the OneView Network Sets
 description:
     - Retrieve information about the Network Sets from OneView.
-    - This module was called C(oneview_network_set_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_network_set_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/oneview_san_manager_info.py
+++ b/plugins/modules/oneview_san_manager_info.py
@@ -13,8 +13,6 @@ module: oneview_san_manager_info
 short_description: Retrieve information about one or more of the OneView SAN Managers
 description:
     - Retrieve information about one or more of the SAN Managers from OneView
-    - This module was called C(oneview_san_manager_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.oneview_san_manager_info) module no longer returns C(ansible_facts)!
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/plugins/modules/osx_defaults.py
+++ b/plugins/modules/osx_defaults.py
@@ -64,7 +64,6 @@ options:
     description:
       - The state of the user defaults.
       - If set to V(list) will query the given parameter specified by O(key). Returns V(null) is nothing found or mis-spelled.
-      - V(list) added in Ansible 2.8.
     type: str
     choices: [ absent, list, present ]
     default: present

--- a/plugins/modules/packet_ip_subnet.py
+++ b/plugins/modules/packet_ip_subnet.py
@@ -86,7 +86,6 @@ options:
 
 requirements:
      - "packet-python >= 1.35"
-     - "python >= 2.6"
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/packet_project.py
+++ b/plugins/modules/packet_project.py
@@ -76,7 +76,6 @@ options:
     type: str
 
 requirements:
-    - "python >= 2.6"
     - "packet-python >= 1.40"
 
 '''

--- a/plugins/modules/packet_sshkey.py
+++ b/plugins/modules/packet_sshkey.py
@@ -57,7 +57,6 @@ options:
     type: path
 
 requirements:
-  - "python >= 2.6"
   - packet-python
 
 '''

--- a/plugins/modules/packet_volume.py
+++ b/plugins/modules/packet_volume.py
@@ -122,7 +122,6 @@ options:
         type: str
 
 requirements:
-  - "python >= 2.6"
   - "packet-python >= 1.35"
 
 '''

--- a/plugins/modules/packet_volume_attachment.py
+++ b/plugins/modules/packet_volume_attachment.py
@@ -73,7 +73,6 @@ options:
     type: str
 
 requirements:
-  - "python >= 2.6"
   - "packet-python >= 1.35"
 
 '''

--- a/plugins/modules/pamd.py
+++ b/plugins/modules/pamd.py
@@ -88,7 +88,7 @@ options:
       control and module_path.
     - With either V(before) or V(after) O(new_type), O(new_control), and O(new_module_path) must all be specified.
     - If state is V(args_absent) or V(args_present), O(new_type), O(new_control), and O(new_module_path) will be ignored.
-    - State V(absent) will remove the rule.  The V(absent) state was added in Ansible 2.4.
+    - State V(absent) will remove the rule.
     type: str
     choices: [ absent, before, after, args_absent, args_present, updated ]
     default: updated

--- a/plugins/modules/pkgin.py
+++ b/plugins/modules/pkgin.py
@@ -30,7 +30,7 @@ author:
 notes:
     - "Known bug with pkgin < 0.8.0: if a package is removed and another
       package depends on it, the other package will be silently removed as
-      well.  New to Ansible 1.9: check-mode support."
+      well."
 extends_documentation_fragment:
     - community.general.attributes
 attributes:

--- a/plugins/modules/pkgng.py
+++ b/plugins/modules/pkgng.py
@@ -32,12 +32,6 @@ options:
         description:
             - Name or list of names of packages to install/remove.
             - "With O(name=*), O(state=latest) will operate, but O(state=present) and O(state=absent) will be noops."
-            - >
-                Warning: In Ansible 2.9 and earlier this module had a misfeature
-                where O(name=*) with O(state=latest) or O(state=present) would
-                install every package from every package repository, filling up
-                the machines disk. Avoid using them unless you are certain that
-                your role will only be used with newer versions.
         required: true
         aliases: [pkg]
         type: list
@@ -45,7 +39,6 @@ options:
     state:
         description:
             - State of the package.
-            - 'Note: V(latest) added in Ansible 2.7.'
         choices: [ 'present', 'latest', 'absent' ]
         required: false
         default: present

--- a/plugins/modules/profitbricks.py
+++ b/plugins/modules/profitbricks.py
@@ -142,7 +142,6 @@ options:
 
 requirements:
      - "profitbricks"
-     - "python >= 2.6"
 author: Matt Baldwin (@baldwinSPC) <baldwin@stackpointcloud.com>
 '''
 

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -13,8 +13,8 @@ DOCUMENTATION = '''
 module: proxmox
 short_description: Management of instances in Proxmox VE cluster
 description:
-  - allows you to create/delete/stop instances in Proxmox VE cluster
-  - Starting in Ansible 2.1, it automatically detects containerization type (lxc for PVE 4, openvz for older)
+  - Allows you to create/delete/stop instances in Proxmox VE cluster.
+  - The module automatically detects containerization type (lxc for PVE 4, openvz for older).
   - Since community.general 4.0.0 on, there are no more default values, see O(proxmox_default_behavior).
 attributes:
   check_mode:

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -86,7 +86,7 @@ options:
 
 notes:
   - Requires proxmoxer and requests modules on host. These modules can be installed with pip.
-requirements: [ "proxmoxer", "python >= 2.7", "requests" ]
+requirements: [ "proxmoxer", "requests" ]
 author: Jeffrey van Pelt (@Thulium-Drake)
 extends_documentation_fragment:
     - community.general.proxmox.documentation

--- a/plugins/modules/pubnub_blocks.py
+++ b/plugins/modules/pubnub_blocks.py
@@ -27,7 +27,6 @@ author:
   - PubNub <support@pubnub.com> (@pubnub)
   - Sergey Mamontov <sergey@pubnub.com> (@parfeon)
 requirements:
-  - "python >= 2.7"
   - "pubnub_blocks_client >= 1.0"
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/python_requirements_info.py
+++ b/plugins/modules/python_requirements_info.py
@@ -12,7 +12,6 @@ module: python_requirements_info
 short_description: Show python path and assert dependency versions
 description:
   - Get info about available Python requirements on the target host, including listing required libraries and gathering versions.
-  - This module was called C(python_requirements_facts) before Ansible 2.9. The usage did not change.
 extends_documentation_fragment:
   - community.general.attributes
   - community.general.attributes.info_module

--- a/plugins/modules/rax_dns_record.py
+++ b/plugins/modules/rax_dns_record.py
@@ -90,11 +90,9 @@ options:
 notes:
   - "It is recommended that plays utilizing this module be run with
     C(serial: 1) to avoid exceeding the API request limit imposed by
-    the Rackspace CloudDNS API"
+    the Rackspace CloudDNS API."
   - To manipulate a C(PTR) record either C(loadbalancer) or C(server) must be
-    supplied
-  - As of version 1.7, the O(type) field is required and no longer defaults to an C(A) record.
-  - C(PTR) record support was added in version 1.7
+    supplied.
 author: "Matt Martz (@sivel)"
 extends_documentation_fragment:
   - community.general.rackspace

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -16,8 +16,6 @@ description:
   - Builds Redfish URIs locally and sends them to remote OOB controllers to
     get information back.
   - Information retrieved is placed in a location specified by the user.
-  - This module was called C(redfish_facts) before Ansible 2.9, returning C(ansible_facts).
-    Note that the M(community.general.redfish_info) module no longer returns C(ansible_facts)!
 extends_documentation_fragment:
   - community.general.attributes
   - community.general.attributes.info_module

--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -123,8 +123,7 @@ options:
         description:
             - Upon successful registration, auto-consume available subscriptions
             - |
-              Added in favor of the deprecated O(autosubscribe) option in
-              Ansible 2.5; please note that O(autosubscribe) will be removed in
+              Please note that the alias O(autosubscribe) will be removed in
               community.general 9.0.0.
         type: bool
         aliases: [autosubscribe]

--- a/plugins/modules/sendgrid.py
+++ b/plugins/modules/sendgrid.py
@@ -24,7 +24,6 @@ notes:
     account."
   - "In order to use api_key, cc, bcc, attachments, from_name, html_body, headers
     you must pip install sendgrid"
-  - "Since Ansible 2.2 O(username) and O(password) are not required if you supply an O(api_key)"
 requirements:
   - sendgrid Python library 1.6.22 or lower (Sendgrid API V2 supported)
 extends_documentation_fragment:
@@ -39,12 +38,12 @@ options:
     type: str
     description:
       - Username for logging into the SendGrid account.
-      - Since 2.2 it is only required if O(api_key) is not supplied.
+      - It is only required if O(api_key) is not supplied.
   password:
     type: str
     description:
       - Password that corresponds to the username.
-      - Since 2.2 it is only required if O(api_key) is not supplied.
+      - It is only required if O(api_key) is not supplied.
   from_address:
     type: str
     description:

--- a/plugins/modules/sl_vm.py
+++ b/plugins/modules/sl_vm.py
@@ -173,7 +173,6 @@ options:
     default: 600
     type: int
 requirements:
-    - python >= 2.6
     - softlayer >= 4.1.1
 author:
 - Matt Colton (@mcltn)

--- a/plugins/modules/slack.py
+++ b/plugins/modules/slack.py
@@ -121,7 +121,6 @@ options:
     description:
       - Allow text to use default colors - use the default of 'normal' to not send a custom color bar at the start of the message.
       - Allowed values for color can be one of 'normal', 'good', 'warning', 'danger', any valid 3 digit or 6 digit hex color value.
-      - Specifying value in hex is supported since Ansible 2.8.
     default: 'normal'
   attachments:
     type: list

--- a/plugins/modules/smartos_image_info.py
+++ b/plugins/modules/smartos_image_info.py
@@ -15,8 +15,6 @@ module: smartos_image_info
 short_description: Get SmartOS image details
 description:
     - Retrieve information about all installed images on SmartOS.
-    - This module was called C(smartos_image_facts) before Ansible 2.9, returning C(ansible_facts).
-      Note that the M(community.general.smartos_image_info) module no longer returns C(ansible_facts)!
 author: Adam Števko (@xen0l)
 extends_documentation_fragment:
     - community.general.attributes

--- a/plugins/modules/spectrum_model_attrs.py
+++ b/plugins/modules/spectrum_model_attrs.py
@@ -21,8 +21,6 @@ author:
 notes:
     - Tested on CA Spectrum version 10.4.2.0.189.
     - Model creation and deletion are not possible with this module. For that use M(community.general.spectrum_device) instead.
-requirements:
-    - 'python >= 2.7'
 extends_documentation_fragment:
     - community.general.attributes
 attributes:

--- a/plugins/modules/spotinst_aws_elastigroup.py
+++ b/plugins/modules/spotinst_aws_elastigroup.py
@@ -19,7 +19,6 @@ description:
     token = <YOUR TOKEN>
     Full documentation available at https://help.spotinst.com/hc/en-us/articles/115003530285-Ansible-
 requirements:
-  - python >= 2.7
   - spotinst_sdk >= 1.0.38
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/supervisorctl.py
+++ b/plugins/modules/supervisorctl.py
@@ -28,7 +28,6 @@ options:
     description:
       - The name of the supervisord program or group to manage.
       - The name will be taken as group name when it ends with a colon V(:).
-      - Group support is only available in Ansible version 1.6 or later.
       - If O(name=all), all programs and program groups will be managed.
     required: true
   config:

--- a/plugins/modules/svr4pkg.py
+++ b/plugins/modules/svr4pkg.py
@@ -56,7 +56,7 @@ options:
     type: str
   response_file:
     description:
-      - Specifies the location of a response file to be used if package expects input on install. (added in Ansible 1.4)
+      - Specifies the location of a response file to be used if package expects input on install.
     required: false
     type: str
   zone:

--- a/plugins/modules/terraform.py
+++ b/plugins/modules/terraform.py
@@ -83,7 +83,6 @@ options:
     description:
       - The path to a variables file for Terraform to fill into the TF
         configurations. This can accept a list of paths to multiple variables files.
-      - Up until Ansible 2.9, this option was usable as O(variables_file).
     type: list
     elements: path
     aliases: [ 'variables_file' ]

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -22,9 +22,6 @@ description:
     On AIX, C(chtz) is used.
   - Make sure that the zoneinfo files are installed with the appropriate OS package, like C(tzdata) (usually always installed,
     when not using a minimal installation like Alpine Linux).
-  - As of Ansible 2.3 support was added for SmartOS and BSDs.
-  - As of Ansible 2.4 support was added for macOS.
-  - As of Ansible 2.9 support was added for AIX 6.1+
   - Windows and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
 extends_documentation_fragment:
   - community.general.attributes

--- a/plugins/modules/timezone.py
+++ b/plugins/modules/timezone.py
@@ -51,7 +51,8 @@ options:
 notes:
   - On SmartOS the C(sm-set-timezone) utility (part of the smtools package) is required to set the zone timezone
   - On AIX only Olson/tz database timezones are usable (POSIX is not supported).
-    - An OS reboot is also required on AIX for the new timezone setting to take effect.
+    An OS reboot is also required on AIX for the new timezone setting to take effect.
+    Note that AIX 6.1+ is needed (OS level 61 or newer).
 author:
   - Shinichi TAMURA (@tmshn)
   - Jasper Lievisse Adriaanse (@jasperla)

--- a/plugins/modules/vertica_info.py
+++ b/plugins/modules/vertica_info.py
@@ -15,8 +15,6 @@ module: vertica_info
 short_description: Gathers Vertica database facts
 description:
   - Gathers Vertica database information.
-  - This module was called C(vertica_facts) before Ansible 2.9, returning C(ansible_facts).
-    Note that the M(community.general.vertica_info) module no longer returns C(ansible_facts)!
 extends_documentation_fragment:
   - community.general.attributes
   - community.general.attributes.info_module

--- a/plugins/modules/vmadm.py
+++ b/plugins/modules/vmadm.py
@@ -354,8 +354,6 @@ options:
     description:
       - ZFS pool the VM's zone dataset will be created in.
     type: str
-requirements:
-    - python >= 2.6
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/xattr.py
+++ b/plugins/modules/xattr.py
@@ -27,7 +27,6 @@ options:
   path:
     description:
       - The full path of the file/object to get the facts of.
-      - Before 2.3 this option was only usable as O(name).
     type: path
     required: true
     aliases: [ name ]
@@ -61,8 +60,6 @@ options:
         otherwise acts on symlink itself.
     type: bool
     default: true
-notes:
-  - As of Ansible 2.3, the O(name) option has been changed to O(path) as default, but O(name) still works as well.
 author:
   - Brian Coca (@bcoca)
 '''

--- a/plugins/modules/xenserver_guest.py
+++ b/plugins/modules/xenserver_guest.py
@@ -44,7 +44,6 @@ notes:
   useful for bootstrapping newly deployed VMs, much less for reconfiguring existing ones. More info here:
   U(https://support.citrix.com/article/CTX226713)'
 requirements:
-- python >= 2.6
 - XenAPI
 attributes:
   check_mode:

--- a/plugins/modules/xenserver_guest_info.py
+++ b/plugins/modules/xenserver_guest_info.py
@@ -27,9 +27,7 @@ notes:
    accessing XenServer host in trusted environment or use C(https://) scheme explicitly.'
 - 'To use C(https://) scheme for C(hostname) you have to either import host certificate to your OS certificate store or use C(validate_certs: no)
    which requires XenAPI library from XenServer 7.2 SDK or newer and Python 2.7.9 or newer.'
-- This module was called C(xenserver_guest_facts) before Ansible 2.9. The usage did not change.
 requirements:
-- python >= 2.6
 - XenAPI
 options:
   name:

--- a/plugins/modules/xenserver_guest_powerstate.py
+++ b/plugins/modules/xenserver_guest_powerstate.py
@@ -28,7 +28,6 @@ notes:
 - 'To use C(https://) scheme for C(hostname) you have to either import host certificate to your OS certificate store or use C(validate_certs: no)
    which requires XenAPI library from XenServer 7.2 SDK or newer and Python 2.7.9 or newer.'
 requirements:
-- python >= 2.6
 - XenAPI
 attributes:
   check_mode:

--- a/plugins/modules/znode.py
+++ b/plugins/modules/znode.py
@@ -81,7 +81,6 @@ options:
         version_added: '6.5.0'
 requirements:
     - kazoo >= 2.1
-    - python >= 2.6
 author: "Trey Perry (@treyperry)"
 '''
 


### PR DESCRIPTION
##### SUMMARY
We no longer have to mention when something was added/removed/changed in Ansible 1.x or 2.x. This documentation is about the collection, and these changes refer to changes before the code moved into this collection.

Also the collection is Python 2.7+ now, so we don't have to mention that a module requires Python 2.6+ or Python 2.7+ anymore.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various
