### PR TITLE
ini_file: documentation for 'section' to stop mentioning that null can be passed

### DIFF
--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -43,8 +43,8 @@ options:
     description:
       - Section name in INI file. This is added if O(state=present) automatically when
         a single value is being set.
-      - If left empty, being omitted, or being set to V(null), the O(option) will be placed before the first O(section).
-      - Using V(null) is also required if the config format does not support sections.
+      - If being omitted, the O(option) will be placed before the first O(section).
+      - Omitting O(section) is also required if the config format does not support sections.
     type: str
   option:
     description:
@@ -178,6 +178,13 @@ EXAMPLES = r'''
       - coke
       - pepsi
     mode: '0600'
+    state: present
+
+- name: Add "beverage=lemon juice" outside a section in specified file
+  community.general.ini_file:
+    path: /etc/conf
+    option: beverage
+    value: lemon juice
     state: present
 '''
 


### PR DESCRIPTION
##### SUMMARY
Fixes #6708.

(Originally `section` was required and `null`/`none` had to be passed to tell the module not to use a section. This stopped working with ansible-core 2.15.0 since then `null`/`none` are no longer accepted for `str` options; see #6404.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ini_file
