### PR TITLE
Set resources payload as a list

### DIFF
--- a/changelogs/fragments/7151-fix-keycloak_authz_permission-incorrect-resource-payload.yml
+++ b/changelogs/fragments/7151-fix-keycloak_authz_permission-incorrect-resource-payload.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_authz_permission - resource payload variable for scope-based permission was constructed as a string, when it needs to be a list, even for a single item. (https://github.com/ansible-collections/community.general/issues/7151).
+  - keycloak_authz_permission - resource payload variable for scope-based permission was constructed as a string, when it needs to be a list, even for a single item (https://github.com/ansible-collections/community.general/issues/7151).

--- a/changelogs/fragments/7151-fix-keycloak_authz_permission-incorrect-resource-payload.yml
+++ b/changelogs/fragments/7151-fix-keycloak_authz_permission-incorrect-resource-payload.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_authz_permission - resource payload variable for scope-based permission was constructed as a string, when it needs to be a list, even for a single item. (https://github.com/ansible-collections/community.general/issues/7151).

--- a/plugins/modules/keycloak_authz_permission.py
+++ b/plugins/modules/keycloak_authz_permission.py
@@ -330,7 +330,7 @@ def main():
             if not r:
                 module.fail_json(msg='Unable to find authorization resource with name %s for client %s in realm %s' % (resources[0], cid, realm))
             else:
-                payload['resources'] = r['_id']
+                payload['resources'].append(r['_id'])
 
             for rs in r['scopes']:
                 resource_scopes.append(rs['id'])


### PR DESCRIPTION
##### SUMMARY
Fixes #7151 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_authz_permission

##### ADDITIONAL INFORMATION

Before change, debug message was:
```
"msg": "Could not create update permission view.members.permission.group.f90a06ec-3d04-4e2e-8e43-e4faec6dc4a8 for client fc7011b1-ec2d-4e94-a53b-9f0a76b292c3 in realm testrealm: HTTP Error 500: Internal Server Error"
```
After change, task completes successfully:
```
PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```