### PR TITLE
onepassword lookup - Make section and field case insensitive

### DIFF
--- a/changelogs/fragments/7564-onepassword-lookup-case-insensitive.yaml
+++ b/changelogs/fragments/7564-onepassword-lookup-case-insensitive.yaml
@@ -1,4 +1,4 @@
 bugfixes:
   - >-
     onepassword lookup plugin - field and section titles are now case insensitive when using
-    op CLI version two or later (https://github.com/ansible-collections/community.general/pull/7564)
+    op CLI version two or later. This matches the behavior of version one (https://github.com/ansible-collections/community.general/pull/7564).

--- a/changelogs/fragments/7564-onepassword-lookup-case-insensitive.yaml
+++ b/changelogs/fragments/7564-onepassword-lookup-case-insensitive.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    onepassword lookup plugin - field and section titles are now case insensitive when using
+    op CLI version two or later (https://github.com/ansible-collections/community.general/pull/7564)

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -466,10 +466,10 @@ class OnePassCLIv2(OnePassCLIBase):
 
                 # If the field name doesn't exist in the section, match on the value of "label"
                 # then "id" and return "value"
-                if field.get("label").lower() == field_name:
+                if field.get("label", "").lower() == field_name:
                     return field.get("value", "")
 
-                if field.get("id").lower() == field_name:
+                if field.get("id", "").lower() == field_name:
                     return field.get("value", "")
 
             # Look at the section data and get an identifier. The value of 'id' is either a unique ID

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -96,6 +96,14 @@ from ansible.module_utils.six import with_metaclass
 from ansible_collections.community.general.plugins.module_utils.onepassword import OnePasswordConfig
 
 
+def _lower_if_possible(value):
+    """Return the lower case version value, otherwise return the value"""
+    try:
+        return value.lower()
+    except AttributeError:
+        return value
+
+
 class OnePassCLIBase(with_metaclass(abc.ABCMeta, object)):
     bin = "op"
 
@@ -457,7 +465,7 @@ class OnePassCLIv2(OnePassCLIBase):
             }
         """
         data = json.loads(data_json)
-        field_name = field_name.lower()
+        field_name = _lower_if_possible(field_name)
         for field in data.get("fields", []):
             if section_title is None:
                 # If the field name exists in the section, return that value
@@ -476,10 +484,7 @@ class OnePassCLIv2(OnePassCLIBase):
             # or a human-readable string. If a 'label' field exists, prefer that since
             # it is the value visible in the 1Password UI when both 'id' and 'label' exist.
             section = field.get("section", {})
-            try:
-                section_title = section_title.lower()
-            except AttributeError:
-                pass
+            section_title = _lower_if_possible(section_title)
 
             current_section_title = section.get("label", section.get("id", "")).lower()
             if section_title == current_section_title:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -457,6 +457,7 @@ class OnePassCLIv2(OnePassCLIBase):
             }
         """
         data = json.loads(data_json)
+        field_name = field_name.lower()
         for field in data.get("fields", []):
             if section_title is None:
                 # If the field name exists in the section, return that value
@@ -465,17 +466,22 @@ class OnePassCLIv2(OnePassCLIBase):
 
                 # If the field name doesn't exist in the section, match on the value of "label"
                 # then "id" and return "value"
-                if field.get("label") == field_name:
+                if field.get("label").lower() == field_name:
                     return field.get("value", "")
 
-                if field.get("id") == field_name:
+                if field.get("id").lower() == field_name:
                     return field.get("value", "")
 
             # Look at the section data and get an identifier. The value of 'id' is either a unique ID
             # or a human-readable string. If a 'label' field exists, prefer that since
             # it is the value visible in the 1Password UI when both 'id' and 'label' exist.
             section = field.get("section", {})
-            current_section_title = section.get("label", section.get("id"))
+            try:
+                section_title = section_title.lower()
+            except AttributeError:
+                pass
+
+            current_section_title = section.get("label", section.get("id", "")).lower()
             if section_title == current_section_title:
                 # In the correct section. Check "label" then "id" for the desired field_name
                 if field.get("label") == field_name:

--- a/tests/unit/plugins/lookup/onepassword_common.py
+++ b/tests/unit/plugins/lookup/onepassword_common.py
@@ -107,7 +107,7 @@ MOCK_ENTRIES = {
             "queries": ["Omitted values"],
             "kwargs": {
                 "field": "section-label-without-value",
-                "section": "section-without-values"
+                "section": "Section-Without-Values"
             },
             "expected": [""],
             "output": load_file("v2_out_04.json")

--- a/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_01.json
+++ b/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_01.json
@@ -13,10 +13,10 @@
     "additional_information": "Jan 18, 2015, 08:13:38",
     "fields": [
         {
-            "id": "password",
+            "id": "Password",
             "type": "CONCEALED",
             "purpose": "PASSWORD",
-            "label": "password",
+            "label": "Password",
             "value": "OctoberPoppyNuttyDraperySabbath",
             "reference": "op://Test Vault/Authy Backup/password",
             "password_details": {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was a regression in behavior when adding support for op v2.

Fixes #6000 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`plugins/lookup/onepassword.py`
