### PR TITLE
infiniband can be a slave too

### DIFF
--- a/changelogs/fragments/7569-infiniband-slave-support.yml
+++ b/changelogs/fragments/7569-infiniband-slave-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - allow for ``infiniband`` slaves of ``bond`` interface types (https://github.com/ansible-collections/community.general/pull/7569).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -2004,6 +2004,7 @@ class Nmcli(object):
             'bridge-slave',
             'team-slave',
             'wifi',
+            'infiniband',
         )
 
     @property


### PR DESCRIPTION
##### SUMMARY
Infiniband can be a slave too

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- nmcli.py

##### ADDITIONAL INFORMATION
Without this change, attempting to enslave an infiniband interface "pretends" to do something, but never actually works.