### PR TITLE
Remove Fedora 36 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -319,8 +319,8 @@ stages:
         parameters:
           testFormat: 2.14/linux/{0}
           targets:
-            - name: Fedora 36
-              test: fedora36
+            - name: Alpine 3
+              test: alpine3
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Seems like Fedora 36 fails in CI (https://dev.azure.com/ansible/community.general/_build/results?buildId=96617&view=results, https://dev.azure.com/ansible/community.general/_build/results?buildId=96636&view=results, https://dev.azure.com/ansible/community.general/_build/results?buildId=96637&view=results).

Remove it from the CI matrix and replace it with something else.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
