### PR TITLE
fix #7600 add hookscript parameter to proxmox_kvm

### DIFF
--- a/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
+++ b/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "proxmox_kvm - support the ``hookscript`` parameter
+  - "proxmox_kvm - support the ``hookscript`` parameter (https://github.com/ansible-collections/community.general/issues/7600)

--- a/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
+++ b/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "proxmox_kvm - support the ``hookscript`` parameter

--- a/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
+++ b/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "proxmox_kvm - support the ``hookscript`` parameter (https://github.com/ansible-collections/community.general/issues/7600)"
+  - "proxmox_kvm - support the ``hookscript`` parameter (https://github.com/ansible-collections/community.general/issues/7600)."

--- a/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
+++ b/changelogs/fragments/7600-proxmox_kvm-hookscript.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "proxmox_kvm - support the ``hookscript`` parameter (https://github.com/ansible-collections/community.general/issues/7600)
+  - "proxmox_kvm - support the ``hookscript`` parameter (https://github.com/ansible-collections/community.general/issues/7600)"

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -196,6 +196,10 @@ options:
       - Used only with clone
     type: bool
     default: true
+  hookscript:
+    description:
+      - Script that will be executed during various steps in the containers lifetime.
+    type: str
   hostpci:
     description:
       - Specify a hash/dictionary of map host pci devices into guest. O(hostpci='{"key":"value", "key":"value"}').
@@ -867,6 +871,17 @@ EXAMPLES = '''
     name: spynal
     node: sabrewulf-2
     migrate: true
+
+- name: Add hookscript to existing VM
+  community.general.proxmox_kvm:
+    api_user: root@pam
+    api_password: secret
+    api_host: helldorado
+    vmid: 999
+    node: sabrewulf
+    hookscript: local:snippets/hookscript.pl
+    update: true
+
 '''
 
 RETURN = '''
@@ -1214,6 +1229,7 @@ def main():
         format=dict(type='str', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk', 'unspecified']),
         freeze=dict(type='bool'),
         full=dict(type='bool', default=True),
+        hookscript=dict(type='str'),
         hostpci=dict(type='dict'),
         hotplug=dict(type='str'),
         hugepages=dict(choices=['any', '2', '1024']),
@@ -1432,6 +1448,7 @@ def main():
                               efidisk0=module.params['efidisk0'],
                               force=module.params['force'],
                               freeze=module.params['freeze'],
+                              hookscript=module.params['hookscript'],
                               hostpci=module.params['hostpci'],
                               hotplug=module.params['hotplug'],
                               hugepages=module.params['hugepages'],

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -200,6 +200,7 @@ options:
     description:
       - Script that will be executed during various steps in the containers lifetime.
     type: str
+    version_added: 8.1.0
   hostpci:
     description:
       - Specify a hash/dictionary of map host pci devices into guest. O(hostpci='{"key":"value", "key":"value"}').


### PR DESCRIPTION
##### SUMMARY

Fixes #7600 add hookscript parameter to proxmox_kvm module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION

The parameter was present in PROXMOX VE as early as [April 2019](https://forum.proxmox.com/threads/how-to-use-new-hookscript-feature.53388/).
It had been added to the `proxmox.py` module in #245 on May 18, 2020 but not to `proxmox_kvm.py`.
This PR adds it.
