### PR TITLE
CI: temporarily skip passwordstore tests on Debian/Ubuntu

### DIFF
--- a/tests/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -15,3 +15,5 @@
     # The pass package is no longer available in EPEL, so only test on Fedora, OpenSUSE, FreeBSD, macOS, and Ubuntu
     # https://lists.zx2c4.com/pipermail/password-store/2019-July/003689.html
     - ansible_facts.distribution in ['FreeBSD', 'MacOSX', 'openSUSE Leap', 'Ubuntu']
+    # TODO Currently the Debian package is broken: https://github.com/gopasspw/gopass/issues/2728
+    - ansible_facts.os_family != 'Debian'


### PR DESCRIPTION
##### SUMMARY
Currently the Debian package is broken, see https://github.com/gopasspw/gopass/issues/2728

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
passwordstore lookup
