### PR TITLE
redhat_subscription: stop rhsm service only if RHEL version is > 7.3

### DIFF
--- a/plugins/modules/redhat_subscription.py
+++ b/plugins/modules/redhat_subscription.py
@@ -547,7 +547,7 @@ class Rhsm(object):
         # - with subscription-manager < 1.26.5-1 (in RHEL < 8.2);
         #   fixed later by https://github.com/candlepin/subscription-manager/pull/2175
         # - sporadically: https://bugzilla.redhat.com/show_bug.cgi?id=2049296
-        if distro_id == 'fedora' or distro_version[0] >= 7:
+        if distro_id == 'fedora' or (distro_version[0] >= 7 and distro_version[1] > 3):
             cmd = ['systemctl', 'stop', 'rhsm']
             self.module.run_command(cmd, check_rc=True, expand_user_and_vars=False)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #7622 the rhsm service is available on RHEL version above 7.3 only.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ADDITIONAL INFORMATION
Deploy a RHEL 7.3 VM and register it to RHSM using the redhat_subscription module.

