### PR TITLE
redhat_subscription: use D-Bus registration on RHEL 7 only on 7.4+

### DIFF
--- a/changelogs/fragments/000-redhat_subscription-dbus-on-7.4-plus.yaml
+++ b/changelogs/fragments/000-redhat_subscription-dbus-on-7.4-plus.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - |
+    redhat_subscription - use the D-Bus registration on RHEL 7 only on 7.4 and
+    greater; older versions of RHEL 7 do not have it
+    (https://github.com/ansible-collections/community.general/issues/7622,
+    https://github.com/ansible-collections/community.general/pull/7624).

--- a/tests/unit/plugins/modules/test_redhat_subscription.py
+++ b/tests/unit/plugins/modules/test_redhat_subscription.py
@@ -29,6 +29,8 @@ def patch_redhat_subscription(mocker):
                  return_value='/testbin/subscription-manager')
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.Rhsm._can_connect_to_dbus',
                  return_value=False)
+    mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.Rhsm._has_dbus_interface',
+                 return_value=False)
     mocker.patch('ansible_collections.community.general.plugins.modules.redhat_subscription.getuid',
                  return_value=0)
 


### PR DESCRIPTION
##### SUMMARY

subscription-manager does not provide a D-Bus interface in versions of RHEL 7 older than 7.4.

Fixes #7622

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

redhat_subscription
