### PR TITLE
add BootProgress property to redfish_info

### DIFF
--- a/changelogs/fragments/7626-redfish-info-add-boot-progress-property.yml
+++ b/changelogs/fragments/7626-redfish-info-add-boot-progress-property.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_info - adding the BootProgress property when getting Systems info (https://github.com/ansible-collections/community.general/pull/7626)

--- a/changelogs/fragments/7626-redfish-info-add-boot-progress-property.yml
+++ b/changelogs/fragments/7626-redfish-info-add-boot-progress-property.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - redfish_info - adding the BootProgress property when getting Systems info (https://github.com/ansible-collections/community.general/pull/7626)
+  - redfish_info - adding the ``BootProgress`` property when getting ``Systems`` info (https://github.com/ansible-collections/community.general/pull/7626).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2955,7 +2955,7 @@ class RedfishUtils(object):
         result = {}
         inventory = {}
         # Get these entries, but does not fail if not found
-        properties = ['Status', 'HostName', 'PowerState', 'Model', 'Manufacturer',
+        properties = ['Status', 'HostName', 'PowerState', 'BootProgress', 'Model', 'Manufacturer',
                       'PartNumber', 'SystemType', 'AssetTag', 'ServiceTag',
                       'SerialNumber', 'SKU', 'BiosVersion', 'MemorySummary',
                       'ProcessorSummary', 'TrustedModules', 'Name', 'Id']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the BootProgress field to redfish_info systems properties. This should expose things like LastState to determine if the host reported booting into OS OR if there were boot failures/issues. This will be available on hosts running Redfish 1.13+ based on the DMTF documentation and should prove useful for checking the boot state/status of hosts post-reboot/reset.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
"BootProgress": {
                "LastState": "OSRunning"
            },
```
