### PR TITLE
Fix and re-enable cmd_runner tests

### DIFF
--- a/tests/integration/targets/cmd_runner/action_plugins/_unsafe_assert.py
+++ b/tests/integration/targets/cmd_runner/action_plugins/_unsafe_assert.py
@@ -1,0 +1,56 @@
+# Copyright 2012, Dag Wieers <dag@wieers.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.playbook.conditional import Conditional
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    ''' Fail with custom message '''
+
+    _requires_connection = False
+
+    _VALID_ARGS = frozenset(('msg', 'that'))
+
+    def _make_safe(self, text):
+        # A simple str(text) won't do it since AnsibleUnsafeText is clever :-)
+        return ''.join(chr(ord(x)) for x in text)
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if 'that' not in self._task.args:
+            raise AnsibleError('conditional required in "that" string')
+
+        fail_msg = 'Assertion failed'
+        success_msg = 'All assertions passed'
+
+        thats = self._task.args['that']
+
+        cond = Conditional(loader=self._loader)
+        result['_ansible_verbose_always'] = True
+
+        for that in thats:
+            cond.when = [str(self._make_safe(that))]
+            test_result = cond.evaluate_conditional(templar=self._templar, all_vars=task_vars)
+            if not test_result:
+                result['failed'] = True
+                result['evaluated_to'] = test_result
+                result['assertion'] = that
+
+                result['msg'] = fail_msg
+
+                return result
+
+        result['changed'] = False
+        result['msg'] = success_msg
+        return result

--- a/tests/integration/targets/cmd_runner/aliases
+++ b/tests/integration/targets/cmd_runner/aliases
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 azp/posix/2
-disabled  # TODO

--- a/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
+++ b/tests/integration/targets/cmd_runner/tasks/test_cmd_echo.yml
@@ -24,5 +24,5 @@
   ignore_errors: "{{ item.expect_error | default(omit) }}"
 
 - name: check results ({{ item.name }})
-  assert:
+  _unsafe_assert:
     that: "{{ item.assertions }}"


### PR DESCRIPTION
##### SUMMARY
Follow-up to #7625. This was more complex than I hoped for, since passing in evaluated things to `assert` always triggers the error. So I had to replace assert by a simplified version of it that "makes safe" the conditions passed. Making an `AnsibleUnsafeText` safe is a bit tricky, the easiest way I found was splitting it into chars, converting each char to an integer with `ord()`, and converting it back with `chr()`. Not very elegant, but works (at least for the texts that this test has to handle).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
cmd_runner
