### PR TITLE
Change tab to space in SSHFP requests

### DIFF
--- a/changelogs/fragments/7653-fix-cloudflare-lookup.yml
+++ b/changelogs/fragments/7653-fix-cloudflare-lookup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudflare_dns - fix cloudflare lookup of SHFP records in ``cloudflare_dns`` module (https://github.com/ansible-collections/community.general/issues/7652).  

--- a/changelogs/fragments/7653-fix-cloudflare-lookup.yml
+++ b/changelogs/fragments/7653-fix-cloudflare-lookup.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cloudflare_dns - fix cloudflare lookup of SHFP records in ``cloudflare_dns`` module (https://github.com/ansible-collections/community.general/issues/7652).  
+  - cloudflare_dns - fix Cloudflare lookup of SHFP records (https://github.com/ansible-collections/community.general/issues/7652).  

--- a/plugins/modules/cloudflare_dns.py
+++ b/plugins/modules/cloudflare_dns.py
@@ -634,7 +634,7 @@ class CloudflareAPI(object):
                 content = str(params['key_tag']) + '\t' + str(params['algorithm']) + '\t' + str(params['hash_type']) + '\t' + params['value']
         elif params['type'] == 'SSHFP':
             if not (params['value'] is None or params['value'] == ''):
-                content = str(params['algorithm']) + '\t' + str(params['hash_type']) + '\t' + params['value']
+                content = str(params['algorithm']) + ' ' + str(params['hash_type']) + ' ' + params['value'].upper()
         elif params['type'] == 'TLSA':
             if not (params['value'] is None or params['value'] == ''):
                 content = str(params['cert_usage']) + '\t' + str(params['selector']) + '\t' + str(params['hash_type']) + '\t' + params['value']
@@ -747,7 +747,7 @@ class CloudflareAPI(object):
                 if (attr is None) or (attr == ''):
                     self.module.fail_json(msg="You must provide algorithm, hash_type and a value to create this record type")
             sshfp_data = {
-                "fingerprint": params['value'],
+                "fingerprint": params['value'].upper(),
                 "type": params['hash_type'],
                 "algorithm": params['algorithm'],
             }
@@ -757,7 +757,7 @@ class CloudflareAPI(object):
                 'data': sshfp_data,
                 "ttl": params['ttl'],
             }
-            search_value = str(params['algorithm']) + '\t' + str(params['hash_type']) + '\t' + params['value']
+            search_value = str(params['algorithm']) + ' ' + str(params['hash_type']) + ' ' + params['value']
 
         if params['type'] == 'TLSA':
             for attr in [params['port'], params['proto'], params['cert_usage'], params['selector'], params['hash_type'], params['value']]:


### PR DESCRIPTION
Cloudflare uses space and not tab when you search for SSHFP records

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #7652 

Cloudflare does not use tabs but space in SSHFP records when you search for them
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
cloudflare_dns

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
