### PR TITLE
passwordstore tests: re-enable gopass on Debian-like systems

### DIFF
--- a/tests/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/tests/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -15,5 +15,3 @@
     # The pass package is no longer available in EPEL, so only test on Fedora, OpenSUSE, FreeBSD, macOS, and Ubuntu
     # https://lists.zx2c4.com/pipermail/password-store/2019-July/003689.html
     - ansible_facts.distribution in ['FreeBSD', 'MacOSX', 'openSUSE Leap', 'Ubuntu']
-    # TODO Currently the Debian package is broken: https://github.com/gopasspw/gopass/issues/2728
-    - ansible_facts.os_family != 'Debian'


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/gopasspw/gopass/issues/2728
Ref: https://github.com/gopasspw/gopass/releases/tag/v1.15.11

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
passwordstore lookup tests
