### PR TITLE
Add proxmox_node_info module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1033,13 +1033,13 @@ files:
     maintainers: helldorado
   $modules/proxmox_nic.py:
     maintainers: Kogelvis
+  $modules/proxmox_node_info.py:
+    maintainers: jwbernin
   $modules/proxmox_tasks_info:
     maintainers: paginabianca
   $modules/proxmox_template.py:
     ignore: skvidal
     maintainers: UnderGreen
-  $modules/proxmox_node_info.py:
-    maintainers: jwbernin
   $modules/pubnub_blocks.py:
     maintainers: parfeon pubnub
   $modules/pulp_repo.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1038,6 +1038,8 @@ files:
   $modules/proxmox_template.py:
     ignore: skvidal
     maintainers: UnderGreen
+  $modules/proxmox_node_info.py:
+    maintainers: jwbernin
   $modules/pubnub_blocks.py:
     maintainers: parfeon pubnub
   $modules/pulp_repo.py:

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -16,7 +16,7 @@ short_description: Retrieve information about one or more Proxmox VE nodes
 version_added: 8.2.0
 description:
   - Retrieve information about one or more Proxmox VE nodes.
-author: John Berninger (@jberning)
+author: John Berninger (@jwbernin)
 extends_documentation_fragment:
   - community.general.proxmox.documentation
   - community.general.attributes

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright John Berninger (@jberning) <john.berninger at gmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: proxmox_node_info
+short_description: Retrieve information about one or more Proxmox VE nodes
+version_added: 8.2.0
+description:
+  - Retrieve information about one or more Proxmox VE nodes.
+author: John Berninger (@jberning)
+extends_documentation_fragment:
+  - community.general.proxmox.documentation
+  - community.general.attributes
+  - community.general.attributes.info_module
+'''
+
+
+EXAMPLES = '''
+- name: List existing nodes
+  community.general.proxmox_node_info:
+    api_host: proxmox1
+    api_user: root@pam
+    api_password: "{{ password | default(omit) }}"
+    api_token_id: "{{ token_id | default(omit) }}"
+    api_token_secret: "{{ token_secret | default(omit) }}"
+  register: proxmox_nodes
+'''
+
+
+RETURN = '''
+proxmox_nodes:
+    description: List of Proxmox VE nodes.
+    returned: always, but can be empty
+    type: list
+    elements: dict
+    contains:
+      cpu:
+        description: Current CPU usage in fractional shares of this host's total available CPU.
+        returned: on success
+        type: float
+      disk:
+        description: Current local disk usage of this host.
+        returned: on success
+        type: int
+      id:
+        description: identity of the node
+        returned: on success
+        type: str
+      level:
+        description: Support level. Can be blank if not under a paid support contract.
+        returned: on success
+        type: str
+      maxcpu:
+        description: Total number of available CPUs on this host.
+        returned: on success
+        type: int
+      maxdisk:
+        description: Size of local disk in bytes.
+        returned: on success
+        type: int
+      maxmem:
+        description: Memory size in bytes.
+        returned: on success
+        type: int
+      mem:
+        description: Used memory in bytes.
+        returned: on success
+        type: int
+      node:
+        description: Short hostname of this node.
+        returned: on success
+        type: str
+      ssl_fingerprint:
+        description: SSL fingerprint of the node certificate.
+        returned: on success
+        type: str
+      status:
+        description: Node status
+        returned: on success
+        type: str
+      type:
+        description: Object type being returned.
+        returned: on success
+        type: str
+      uptime:
+        description: Node uptime in seconds.
+        returned: on success
+        type: int
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.general.plugins.module_utils.proxmox import (
+    proxmox_auth_argument_spec, ProxmoxAnsible)
+
+
+class ProxmoxNodeInfoAnsible(ProxmoxAnsible):
+    def get_nodes(self):
+        nodes = self.proxmox_api.nodes()
+        return nodes
+
+
+def proxmox_node_info_argument_spec():
+    return dict()
+
+
+def main():
+    module_args = proxmox_auth_argument_spec()
+    node_info_args = proxmox_node_info_argument_spec()
+    module_args.update(node_info_args)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_one_of=[('api_password', 'api_token_id')],
+        required_together=[('api_token_id', 'api_token_secret')],
+        supports_check_mode=True
+    )
+    result = dict(
+        changed=False
+    )
+
+    proxmox = ProxmoxNodeInfoAnsible(module)
+
+    nodes = proxmox.get_nodes()
+    result['proxmox_nodes'] = nodes
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -105,7 +105,7 @@ from ansible_collections.community.general.plugins.module_utils.proxmox import (
 
 class ProxmoxNodeInfoAnsible(ProxmoxAnsible):
     def get_nodes(self):
-        nodes = self.proxmox_api.nodes()
+        nodes = self.proxmox_api.nodes.get()
         return nodes
 
 

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -52,7 +52,7 @@ proxmox_nodes:
         returned: on success
         type: int
       id:
-        description: identity of the node
+        description: Identity of the node.
         returned: on success
         type: str
       level:
@@ -84,7 +84,7 @@ proxmox_nodes:
         returned: on success
         type: str
       status:
-        description: Node status
+        description: Node status.
         returned: on success
         type: str
       type:
@@ -122,7 +122,7 @@ def main():
         argument_spec=module_args,
         required_one_of=[('api_password', 'api_token_id')],
         required_together=[('api_token_id', 'api_token_secret')],
-        supports_check_mode=True
+        supports_check_mode=True,
     )
     result = dict(
         changed=False

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -577,3 +577,20 @@
         - results_kvm_destroy is changed
         - results_kvm_destroy.vmid == {{ vmid }}
         - results_kvm_destroy.msg == "VM {{ vmid }} removed"
+
+- name: Retrieve information about nodes
+  proxmox_node_info:
+    api_host: "{{ api_host }}"
+    api_user: "{{ user }}@{{ domain }}"
+    api_password: "{{ api_password | default(omit) }}"
+    api_token_id: "{{ api_token_id | default(omit) }}"
+    api_token_secret: "{{ api_token_secret | default(omit) }}"
+    validate_certs: "{{ validate_certs }}"
+  register: results
+
+- assert:
+    that:
+    - results is not changed
+    - results.proxmox_nodes is defined
+    - results.proxmox_nodes|length >= 1
+    - results.proxmox_nodes[0].type == 'node'


### PR DESCRIPTION
Restarted PR due to erroneous update/p…

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a module to retrieve basic information about Proxmox nodes. Design is based on existing proxmox_domain_info module

Fixes #7686 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request
- New Module/Plugin Pull Request

##### COMPONENT NAME
proxmox_node_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
