### PR TITLE
Fix for #7692, ipa sudo rule deny command with cmdcategory

### DIFF
--- a/changelogs/fragments/7692-fix-ipa-sudo-rule.yml
+++ b/changelogs/fragments/7692-fix-ipa-sudo-rule.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_sudorule - fixes issue create rule with both deny_cmdgroup and cmdcategory set (https://github.com/ansible-collections/community.general/issues/7692)
+  - ipa_sudorule - fixes issue create rule with both ``deny_cmdgroup`` and ``cmdcategory`` set (https://github.com/ansible-collections/community.general/issues/7692).

--- a/changelogs/fragments/7692-fix-ipa-sudo-rule.yml
+++ b/changelogs/fragments/7692-fix-ipa-sudo-rule.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_sudorule - fixes issue create rule with both deny_cmdgroup and cmdcategory set (https://github.com/ansible-collections/community.general/issues/7692)

--- a/plugins/modules/ipa_sudorule.py
+++ b/plugins/modules/ipa_sudorule.py
@@ -384,12 +384,10 @@ def ensure(module, client):
                 client.sudorule_add_allow_command_group(name=name, item=cmdgroup)
 
         if deny_cmd is not None:
-            changed = category_changed(module, client, 'cmdcategory', ipa_sudorule) or changed
             if not module.check_mode:
                 client.sudorule_add_deny_command(name=name, item=deny_cmd)
 
         if deny_cmdgroup is not None:
-            changed = category_changed(module, client, 'cmdcategory', ipa_sudorule) or changed
             if not module.check_mode:
                 client.sudorule_add_deny_command_group(name=name, item=deny_cmdgroup)
 
@@ -483,9 +481,7 @@ def main():
                          runasextusers=dict(type='list', elements='str'))
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=[['cmdcategory', 'cmd'],
-                                               ['cmdcategory', 'deny_cmd'],
                                                ['cmdcategory', 'cmdgroup'],
-                                               ['cmdcategory', 'deny_cmdgroup'],
                                                ['hostcategory', 'host'],
                                                ['hostcategory', 'hostgroup'],
                                                ['usercategory', 'user'],


### PR DESCRIPTION
##### SUMMARY
fixes #7692.

Corrects an issue preventing deny_cmd or deny_cmdgroup from working correctly with cmdcategory being assigned in the same rule.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
ipa_sudorule

