### PR TITLE
Fixes #7389 - NMCLI issue with creating a wifi bridge-slave

### DIFF
--- a/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
+++ b/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - fix connection.slave-type wired to 'bond' and not with parameter 'slave_type' in case of connection type wifi
+  - nmcli - fix connection.slave-type wired to 'bond' and not with parameter 'slave_type' in case of connection type wifi (https://github.com/ansible-collections/community.general/issues/7389)

--- a/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
+++ b/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - nmcli - fix connection.slave-type wired to 'bond' and not with parameter 'slave_type' in case of connection type wifi (https://github.com/ansible-collections/community.general/issues/7389)
+  - nmcli - fix ``connection.slave-type`` wired to ``bond`` and not with parameter ``slave_type`` in case of connection type ``wifi`` (https://github.com/ansible-collections/community.general/issues/7389).

--- a/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
+++ b/changelogs/fragments/7389-nmcli-issue-with-creating-a-wifi-bridge-slave.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fix connection.slave-type wired to 'bond' and not with parameter 'slave_type' in case of connection type wifi

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1832,7 +1832,7 @@ class Nmcli(object):
         elif self.type == 'wifi':
             options.update({
                 '802-11-wireless.ssid': self.ssid,
-                'connection.slave-type': self.slave_type if self.master else None,
+                'connection.slave-type': ('bond' if self.slave_type is None else self.slave_type) if self.master else None,
             })
             if self.wifi:
                 for name, value in self.wifi.items():

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1832,7 +1832,7 @@ class Nmcli(object):
         elif self.type == 'wifi':
             options.update({
                 '802-11-wireless.ssid': self.ssid,
-                'connection.slave-type': 'bond' if self.master else None,
+                'connection.slave-type': self.slave_type if self.master else None,
             })
             if self.wifi:
                 for name, value in self.wifi.items():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #7389 

Hi, I've solved the problem from the issue #7389 changing the value of the 'connection.slave-type' in case of a 'wifi' type connection.
The parameter is now wired to 'slave_type' parameter from task, instead of 'bond'

in nmcli.py
```python
        elif self.type == 'wifi':
               options.update({
                '802-11-wireless.ssid': self.ssid,
                'connection.slave-type': self.slave_type if self.master else None,
            })
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
nmcli module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
