### PR TITLE
Simplify regex for identifying order number in DN (#7646)

### DIFF
--- a/changelogs/fragments/7646-fix-order-number-detection-in-dn.yml
+++ b/changelogs/fragments/7646-fix-order-number-detection-in-dn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ldap - previously the order number (if present) was expected to follow an equals sign in the DN. This makes it so the order number string is identified correctly anywhere within the DN (https://github.com/ansible-collections/community.general/issues/7646).

--- a/plugins/module_utils/ldap.py
+++ b/plugins/module_utils/ldap.py
@@ -139,5 +139,7 @@ class LdapGeneric(object):
 
     def _xorder_dn(self):
         # match X_ORDERed DNs
-        regex = r"\w+=\{\d+\}.+"
-        return re.match(regex, self.module.params['dn']) is not None
+        regex = r".+\{\d+\}.+"
+        explode_dn = ldap.dn.explode_dn(self.module.params['dn'])
+
+        return re.match(regex, explode_dn[0]) is not None


### PR DESCRIPTION
##### SUMMARY
Assume that if a string of digits occurs between curly braces anywhere in the DN, that this is an order number. The sequence does not necessarily have to occur after an equals sign. Fixes #7646.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/ldap.py

##### ADDITIONAL INFORMATION
This fixes behaviour when the `xorder_discovery` parameter is set to `auto` (default).