### PR TITLE
improvements to the keycloak_realm_key module

### DIFF
--- a/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
+++ b/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - keycloak_realm_key - the ``provider_id``` option now supports RSA encryption key usage (value ``rsa-enc``) (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``provider_id`` option now supports RSA encryption key usage (value ``rsa-enc``) (https://github.com/ansible-collections/community.general/pull/7698).
   - keycloak_realm_key - the ``config.algorithm`` option now supports 8 additional key algorithms (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key - the ``config.certificate`` parameter is now defaulted to an empty string value (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key - the ``config.certificate`` parameter value is no longer marked as ``no_log=True`` (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``config.certificate`` option is now defaulted to an empty string value (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``config.certificate`` option value is no longer defined with ``no_log=True`` (https://github.com/ansible-collections/community.general/pull/7698).

--- a/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
+++ b/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
@@ -1,5 +1,4 @@
 minor_changes:
   - keycloak_realm_key - the ``provider_id`` option now supports RSA encryption key usage (value ``rsa-enc``) (https://github.com/ansible-collections/community.general/pull/7698).
   - keycloak_realm_key - the ``config.algorithm`` option now supports 8 additional key algorithms (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key - the ``config.certificate`` option is now defaulted to an empty string value (https://github.com/ansible-collections/community.general/pull/7698).
   - keycloak_realm_key - the ``config.certificate`` option value is no longer defined with ``no_log=True`` (https://github.com/ansible-collections/community.general/pull/7698).

--- a/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
+++ b/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - keycloak_realm_key module now supports rsa enc key usage (`rsa-enc`) via `provider_id` parameter (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key module now supports 8 additional key algorithms via `config.algorithm` parameter (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key module now sets a default empty string for `config.certificate` parameter instead of forcing user to specify a value (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key module no longer hides log messages for the `config.certificate` parameter value (https://github.com/ansible-collections/community.general/pull/7698).

--- a/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
+++ b/changelogs/fragments/7698-improvements-to-keycloak_realm_key.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - keycloak_realm_key module now supports rsa enc key usage (`rsa-enc`) via `provider_id` parameter (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key module now supports 8 additional key algorithms via `config.algorithm` parameter (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key module now sets a default empty string for `config.certificate` parameter instead of forcing user to specify a value (https://github.com/ansible-collections/community.general/pull/7698).
-  - keycloak_realm_key module no longer hides log messages for the `config.certificate` parameter value (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``provider_id``` option now supports RSA encryption key usage (value ``rsa-enc``) (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``config.algorithm`` option now supports 8 additional key algorithms (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``config.certificate`` parameter is now defaulted to an empty string value (https://github.com/ansible-collections/community.general/pull/7698).
+  - keycloak_realm_key - the ``config.certificate`` parameter value is no longer marked as ``no_log=True`` (https://github.com/ansible-collections/community.general/pull/7698).

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -123,7 +123,7 @@ options:
                       key must match O(config.algorithm) and O(provider_id).
                     - If you want Keycloak to automatically generate a certificate using your private key
                       then set this to an empty string.
-                default: ''
+                required: true
                 type: str
 notes:
     - Current value of the private key cannot be fetched from Keycloak.
@@ -157,6 +157,7 @@ EXAMPLES = '''
     auth_realm: master
     config:
       private_key: "{{ private_key }}"
+      certificate: ""
       enabled: true
       active: true
       priority: 120
@@ -270,7 +271,7 @@ def main():
                     ],
                 ),
                 private_key=dict(type='str', required=True, no_log=True),
-                certificate=dict(type='str', default='')
+                certificate=dict(type='str', required=True)
             )
         )
     )

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -120,7 +120,7 @@ options:
                       key must match O(config.algorithm) and O(provider_id).
                     - If you want Keycloak to automatically generate a certificate using your private key
                       then set this to an empty string.
-                required: false
+                default: ''
                 type: str
 notes:
     - Current value of the private key cannot be fetched from Keycloak.
@@ -251,7 +251,21 @@ def main():
                 active=dict(type='bool', default=True),
                 enabled=dict(type='bool', default=True),
                 priority=dict(type='int', required=True),
-                algorithm=dict(type='str', default='RS256', choices=['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'RSA1_5', 'RSA-OAEP', 'RSA-OAEP-256']),
+                algorithm=dict(
+                    type="str",
+                    default="RS256",
+                    choices=[
+                        "RS256",
+                        "RS384",
+                        "RS512",
+                        "PS256",
+                        "PS384",
+                        "PS512",
+                        "RSA1_5",
+                        "RSA-OAEP",
+                        "RSA-OAEP-256",
+                    ],
+                ),
                 private_key=dict(type='str', required=True, no_log=True),
                 certificate=dict(type='str', default='')
             )

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -74,6 +74,7 @@ options:
     provider_id:
         description:
             - The name of the "provider ID" for the key.
+            - The value V(rsa-enc) has been added in community.general 8.2.0.
         choices: ['rsa', 'rsa-enc']
         default: 'rsa'
         type: str
@@ -102,6 +103,8 @@ options:
             algorithm:
                 description:
                     - Key algorithm.
+                    - The values V(RS384), V(RS512), V(PS256), V(PS384), V(PS512), V(RSA1_5),
+                      V(RSA-OAEP), V(RSA-OAEP-256) have been added in community.general 8.2.0.
                 default: RS256
                 choices: ['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'RSA1_5', 'RSA-OAEP', 'RSA-OAEP-256']
                 type: str

--- a/plugins/modules/keycloak_realm_key.py
+++ b/plugins/modules/keycloak_realm_key.py
@@ -74,7 +74,7 @@ options:
     provider_id:
         description:
             - The name of the "provider ID" for the key.
-        choices: ['rsa']
+        choices: ['rsa', 'rsa-enc']
         default: 'rsa'
         type: str
     config:
@@ -103,7 +103,7 @@ options:
                 description:
                     - Key algorithm.
                 default: RS256
-                choices: ['RS256']
+                choices: ['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'RSA1_5', 'RSA-OAEP', 'RSA-OAEP-256']
                 type: str
             private_key:
                 description:
@@ -120,7 +120,7 @@ options:
                       key must match O(config.algorithm) and O(provider_id).
                     - If you want Keycloak to automatically generate a certificate using your private key
                       then set this to an empty string.
-                required: true
+                required: false
                 type: str
 notes:
     - Current value of the private key cannot be fetched from Keycloak.
@@ -244,16 +244,16 @@ def main():
         name=dict(type='str', required=True),
         force=dict(type='bool', default=False),
         parent_id=dict(type='str', required=True),
-        provider_id=dict(type='str', default='rsa', choices=['rsa']),
+        provider_id=dict(type='str', default='rsa', choices=['rsa', 'rsa-enc']),
         config=dict(
             type='dict',
             options=dict(
                 active=dict(type='bool', default=True),
                 enabled=dict(type='bool', default=True),
                 priority=dict(type='int', required=True),
-                algorithm=dict(type='str', default='RS256', choices=['RS256']),
+                algorithm=dict(type='str', default='RS256', choices=['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'RSA1_5', 'RSA-OAEP', 'RSA-OAEP-256']),
                 private_key=dict(type='str', required=True, no_log=True),
-                certificate=dict(type='str', required=True, no_log=True)
+                certificate=dict(type='str', default='')
             )
         )
     )


### PR DESCRIPTION
##### SUMMARY
This PR makes the following improvements to the `keycloak_realm_key` module:

- adds support for RSA enc key usage `rsa-enc`
- adds support for an additional 8 key algorithms
- fixes a bug where the user must specify a certificate (no longer required)
- removes `no_log` for certificate since this is not sensitive information

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module: `keycloak_realm_key`

##### ADDITIONAL INFORMATION
Tested against Keycloak `v22.0.4` API.

