### PR TITLE
Deactivate FreeBSD 13.1 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -231,8 +231,8 @@ stages:
               test: rhel/8.7
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            # - name: FreeBSD 13.1
+            #   test: freebsd/13.1
             - name: FreeBSD 12.4
               test: freebsd/12.4
           groups:


### PR DESCRIPTION
##### SUMMARY
For some reason FreeBSD 13.1 is failing in CI.

https://dev.azure.com/ansible/community.general/_build/results?buildId=97978&view=logs&j=1bf9ea86-1ae4-50f8-a658-c30224b24a2f&t=5ef134f3-dd8b-5e8c-c39d-91226d8bb08d

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
