### PR TITLE
ssh_config: Add add_keys_to_agent option

### DIFF
--- a/changelogs/fragments/7703-ssh_config_add_keys_to_agent_option.yml
+++ b/changelogs/fragments/7703-ssh_config_add_keys_to_agent_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - new feature to set ``AddKeysToAgent`` option to ``yes`` or ``no`` (https://github.com/ansible-collections/community.general/pull/7703).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -97,6 +97,11 @@ options:
       - Sets the C(ForwardAgent) option.
     type: bool
     version_added: 4.0.0
+  add_keys_to_agent:
+    description:
+      - Sets the C(AddKeysToAgent) option.
+    type: bool
+    version_added: 8.2.0
   ssh_config_file:
     description:
       - SSH config file.
@@ -252,6 +257,7 @@ class SSHConfig(object):
             proxyjump=self.params.get('proxyjump'),
             host_key_algorithms=self.params.get('host_key_algorithms'),
             forward_agent=convert_bool(self.params.get('forward_agent')),
+            add_keys_to_agent=convert_bool(self.params.get('add_keys_to_agent')),
             controlmaster=self.params.get('controlmaster'),
             controlpath=self.params.get('controlpath'),
             controlpersist=fix_bool_str(self.params.get('controlpersist')),
@@ -346,6 +352,7 @@ def main():
             proxycommand=dict(type='str', default=None),
             proxyjump=dict(type='str', default=None),
             forward_agent=dict(type='bool'),
+            add_keys_to_agent=dict(type='bool'),
             remote_user=dict(type='str'),
             ssh_config_file=dict(default=None, type='path'),
             state=dict(type='str', default='present', choices=['present', 'absent']),

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -15,6 +15,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -47,6 +48,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -68,6 +70,7 @@
     host: "options.example.com"
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -93,6 +96,7 @@
     that:
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -104,6 +108,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
@@ -127,6 +132,7 @@
     host: "options.example.com"
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
@@ -153,6 +159,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -184,6 +191,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -233,6 +241,7 @@
     that:
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
@@ -252,6 +261,7 @@
     host: "options.example.com"
     proxyjump: "jumphost.example.com"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -284,6 +294,7 @@
     host: "options.example.com"
     proxyjump: "jumphost.example.com"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -305,6 +316,7 @@
     host: "options.example.com"
     proxyjump: "jumphost.example.com"
     forward_agent: true
+    add_keys_to_agent: true
     host_key_algorithms: "+ssh-rsa"
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
@@ -330,6 +342,7 @@
     that:
       - "'proxyjump jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -341,6 +354,7 @@
     host: "options.example.com"
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
@@ -364,6 +378,7 @@
     host: "options.example.com"
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
+    add_keys_to_agent: false
     host_key_algorithms: "+ssh-ed25519"
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
@@ -390,6 +405,7 @@
     that:
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -421,6 +437,7 @@
     that:
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
@@ -470,6 +487,7 @@
     that:
       - "'proxyjump new-jumphost.example.com' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
+      - "'addkeystoagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"


### PR DESCRIPTION
##### SUMMARY
New feature to set AddKeysToAgent option via ssh_config module.

Fixes #4802 


<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
The change allows to set AddKeysToAgent option to either yes or no.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
