### PR TITLE
Add ssh_config module option for identities_only

### DIFF
--- a/changelogs/fragments/7704-ssh_config_identities_only_option.yml
+++ b/changelogs/fragments/7704-ssh_config_identities_only_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - new feature to set ``IdentitiesOnly`` option to ``yes`` or ``no`` (https://github.com/ansible-collections/community.general/pull/7704).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -74,10 +74,10 @@ options:
     type: path
   identities_only:
     description:
-      - Specifies that ssh should only use the configured authentication 
+      - Specifies that ssh should only use the configured authentication
         identity and certificate files (either the default files, or
         those explicitly configured in the ssh_config files or passed on
-        the ssh command-line), even if ssh-agent or a PKCS11Provider or 
+        the ssh command-line), even if ssh-agent or a PKCS11Provider or
         SecurityKeyProvider offers more identities.
     type: bool
     version_added: 8.2.0

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -74,9 +74,9 @@ options:
     type: path
   identities_only:
     description:
-      - Specifies that ssh should only use the configured authentication
+      - Specifies that SSH should only use the configured authentication
         identity and certificate files (either the default files, or
-        those explicitly configured in the ssh_config files or passed on
+        those explicitly configured in the C(ssh_config) files or passed on
         the ssh command-line), even if ssh-agent or a PKCS11Provider or
         SecurityKeyProvider offers more identities.
     type: bool

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -72,6 +72,15 @@ options:
         when connecting to this host.
       - File need to exist and have mode V(0600) to be valid.
     type: path
+  identities_only:
+    description:
+      - Specifies that ssh should only use the configured authentication 
+        identity and certificate files (either the default files, or
+        those explicitly configured in the ssh_config files or passed on
+        the ssh command-line), even if ssh-agent or a PKCS11Provider or 
+        SecurityKeyProvider offers more identities.
+    type: bool
+    version_added: 8.2.0
   user_known_hosts_file:
     description:
       - Sets the user known hosts file option.
@@ -245,6 +254,7 @@ class SSHConfig(object):
             hostname=self.params.get('hostname'),
             port=self.params.get('port'),
             identity_file=self.params.get('identity_file'),
+            identities_only=convert_bool(self.params.get('identities_only')),
             user=self.params.get('remote_user'),
             strict_host_key_checking=self.params.get('strict_host_key_checking'),
             user_known_hosts_file=self.params.get('user_known_hosts_file'),
@@ -342,6 +352,7 @@ def main():
             hostname=dict(type='str'),
             host_key_algorithms=dict(type='str', no_log=False),
             identity_file=dict(type='path'),
+            identities_only=dict(type='bool'),
             port=dict(type='str'),
             proxycommand=dict(type='str', default=None),
             proxyjump=dict(type='str', default=None),

--- a/tests/integration/targets/ssh_config/tasks/options.yml
+++ b/tests/integration/targets/ssh_config/tasks/options.yml
@@ -16,6 +16,7 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -48,6 +49,7 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -69,6 +71,7 @@
     proxycommand: "ssh jumphost.example.com -W %h:%p"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -94,6 +97,7 @@
       - "'proxycommand ssh jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly yes' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
@@ -105,6 +109,7 @@
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    identities_only: false
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
@@ -128,6 +133,7 @@
     proxycommand: "ssh new-jumphost.example.com -W %h:%p"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    identities_only: false
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
@@ -154,6 +160,7 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
@@ -185,6 +192,7 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
@@ -234,6 +242,7 @@
       - "'proxycommand ssh new-jumphost.example.com -W %h:%p' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' not in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"
@@ -253,6 +262,7 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -285,6 +295,7 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -306,6 +317,7 @@
     proxyjump: "jumphost.example.com"
     forward_agent: true
     host_key_algorithms: "+ssh-rsa"
+    identities_only: true
     controlmaster: "auto"
     controlpath: "~/.ssh/sockets/%r@%h-%p"
     controlpersist: yes
@@ -331,6 +343,7 @@
       - "'proxyjump jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent yes' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-rsa' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly yes' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' in slurp_ssh_config['content'] | b64decode"
@@ -342,6 +355,7 @@
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    identities_only: false
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
@@ -365,6 +379,7 @@
     proxyjump: "new-jumphost.example.com"
     forward_agent: false
     host_key_algorithms: "+ssh-ed25519"
+    identities_only: false
     controlmaster: no
     controlpath: "~/.ssh/new-sockets/%r@%h-%p"
     controlpersist: "600"
@@ -391,6 +406,7 @@
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
@@ -422,6 +438,7 @@
       - "'proxyjump new-jumphost.example.com' in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster no' in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/new-sockets/%r@%h-%p' in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist 600' in slurp_ssh_config['content'] | b64decode"
@@ -471,6 +488,7 @@
       - "'proxyjump new-jumphost.example.com' not in slurp_ssh_config['content'] | b64decode"
       - "'forwardagent no' not in slurp_ssh_config['content'] | b64decode"
       - "'hostkeyalgorithms +ssh-ed25519' not in slurp_ssh_config['content'] | b64decode"
+      - "'identitiesonly no' not in slurp_ssh_config['content'] | b64decode"
       - "'controlmaster auto' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpath ~/.ssh/sockets/%r@%h-%p' not in slurp_ssh_config['content'] | b64decode"
       - "'controlpersist yes' not in slurp_ssh_config['content'] | b64decode"


### PR DESCRIPTION
##### SUMMARY
New feature to set IdentitiesOnly option via ssh_config module.

Fixes #4801

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
The change allows to set IdentitiesOnly option to either yes or no.