### PR TITLE
🔐 Load `OP_SERVICE_ACCOUNT_TOKEN` from ENVs

### DIFF
--- a/plugins/doc_fragments/onepassword.py
+++ b/plugins/doc_fragments/onepassword.py
@@ -58,7 +58,11 @@ options:
 '''
 
     LOOKUP = r'''
-options: {}
+options:
+  service_account_token:
+    env:
+      - name: OP_SERVICE_ACCOUNT_TOKEN
+        version_added: 8.2.0
 notes:
   - This lookup will use an existing 1Password session if one exists. If not, and you have already
     performed an initial sign in (meaning C(~/.op/config), C(~/.config/op/config) or C(~/.config/.op/config) exists), then only the

--- a/plugins/doc_fragments/onepassword.py
+++ b/plugins/doc_fragments/onepassword.py
@@ -40,6 +40,8 @@ options:
       - The access key for a service account.
       - Only works with 1Password CLI version 2 or later.
     type: str
+    env:
+      - name: OP_SERVICE_ACCOUNT_TOKEN
   vault:
     description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
     type: str

--- a/plugins/doc_fragments/onepassword.py
+++ b/plugins/doc_fragments/onepassword.py
@@ -40,8 +40,6 @@ options:
       - The access key for a service account.
       - Only works with 1Password CLI version 2 or later.
     type: str
-    env:
-      - name: OP_SERVICE_ACCOUNT_TOKEN
   vault:
     description: Vault containing the item to retrieve (case-insensitive). If absent will search all vaults.
     type: str

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -598,7 +598,7 @@ class OnePass(object):
         self.username = username
         self.secret_key = secret_key
         self.master_password = master_password
-        self.service_account_token = service_account_token
+        self.service_account_token = service_account_token or os.environ.get("OP_SERVICE_ACCOUNT_TOKEN")
         self.account_id = account_id
         self.connect_host = connect_host
         self.connect_token = connect_token

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -598,7 +598,7 @@ class OnePass(object):
         self.username = username
         self.secret_key = secret_key
         self.master_password = master_password
-        self.service_account_token = service_account_token or os.environ.get("OP_SERVICE_ACCOUNT_TOKEN")
+        self.service_account_token = service_account_token
         self.account_id = account_id
         self.connect_host = connect_host
         self.connect_token = connect_token


### PR DESCRIPTION
##### SUMMARY

Use `OP_SERVICE_ACCOUNT_TOKEN` environment variable as the default `service_account_token` when available.
This allows for a more concise developer experience:
```yaml
tasks:
  # Before
  - debug: msg={{ lookup('community.general.onepassword', 'secret', field='username', vault='my-vault', service_account_token=...) }}
  
  # After
  - debug: msg={{ lookup('community.general.onepassword', 'secret', field='username', vault='my-vault') }}
```

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- `plugins/lookup/onepassword.py`

