### PR TITLE
Usage of executable flag within community.general.easy_install module

### DIFF
--- a/plugins/modules/easy_install.py
+++ b/plugins/modules/easy_install.py
@@ -84,6 +84,12 @@ EXAMPLES = '''
   community.general.easy_install:
     name: bottle
     virtualenv: /webapps/myapp/venv
+
+- name: Install or update pip
+  community.general.easy_install:
+    name: pip
+    state: latest
+    executable: /path/to/your/easy_install
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
The executable parameter allows you to specify the explicit executable or the pathname to the executable to be used to run easy_install for a specific version of Python installed in the system.


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
executable

