### PR TITLE
using timeout parameter within community.general.mail module

### DIFF
--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -214,7 +214,7 @@ EXAMPLES = r'''
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
     body: System {{ ansible_hostname }} has been successfully provisioned.
-    secure: starttls 
+    secure: starttls
 '''
 
 import os

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -205,24 +205,16 @@ EXAMPLES = r'''
     body: System {{ ansible_hostname }} has been successfully provisioned.
     secure: starttls
 
-- name: Sending an e-mail using StartTLS, remote server, custom EHLO
+- name: Sending an e-mail using StartTLS, remote server, custom EHLO and timeout of 10 seconds
   community.general.mail:
     host: some.smtp.host.tld
     port: 25
+    timeout: 10
     ehlohost: my-resolvable-hostname.tld
     to: John Smith <john.smith@example.com>
     subject: Ansible-report
     body: System {{ ansible_hostname }} has been successfully provisioned.
-    secure: starttls
-
- - name: Sending an email with a timeout
-   community.general.mail:
-    host: localhost
-    port: 25
-    to: John Smith <john.smith@example.com>
-    subject: Ansible-report
-    body: System {{ ansible_hostname }} has been successfully provisioned.
-    timeout: 10  
+    secure: starttls 
 '''
 
 import os

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -214,6 +214,15 @@ EXAMPLES = r'''
     subject: Ansible-report
     body: System {{ ansible_hostname }} has been successfully provisioned.
     secure: starttls
+
+ - name: Sending an email with a timeout
+   community.general.mail:
+    host: localhost
+    port: 25
+    to: John Smith <john.smith@example.com>
+    subject: Ansible-report
+    body: System {{ ansible_hostname }} has been successfully provisioned.
+    timeout: 10  
 '''
 
 import os

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -205,7 +205,7 @@ EXAMPLES = r'''
     body: System {{ ansible_hostname }} has been successfully provisioned.
     secure: starttls
 
-- name: Sending an e-mail using StartTLS, remote server, custom EHLO and timeout of 10 seconds
+- name: Sending an e-mail using StartTLS, remote server, custom EHLO, and timeout of 10 seconds
   community.general.mail:
     host: some.smtp.host.tld
     port: 25


### PR DESCRIPTION
##### SUMMARY
In this playbook, the timeout parameter is set to 10 seconds, which will make Ansible attempt to establish a connection to the mail server, and if it takes longer than 10 seconds, the operation will time out.


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
community.general.mail
