### PR TITLE
Add documentation stubs for undocumented module options

### DIFF
--- a/plugins/modules/consul.py
+++ b/plugins/modules/consul.py
@@ -122,6 +122,16 @@ options:
         description:
           - Name for the service check. Required if standalone, ignored if
             part of service definition.
+    check_node:
+        description:
+          - Node name.
+          # TODO: properly document!
+        type: str
+    check_host:
+        description:
+          - Host name.
+          # TODO: properly document!
+        type: str
     ttl:
         type: str
         description:

--- a/plugins/modules/manageiq_provider.py
+++ b/plugins/modules/manageiq_provider.py
@@ -75,6 +75,7 @@ options:
 
   provider:
     description: Default endpoint connection information, required if state is true.
+    type: dict
     suboptions:
       hostname:
         type: str
@@ -104,9 +105,30 @@ options:
       certificate_authority:
         type: str
         description: The CA bundle string with custom certificates. defaults to None.
+      path:
+        type: str
+        description:
+          - TODO needs documentation.
+      project:
+        type: str
+        description:
+          - TODO needs documentation.
+      role:
+        type: str
+        description:
+          - TODO needs documentation.
+      subscription:
+        type: str
+        description:
+          - TODO needs documentation.
+      uid_ems:
+        type: str
+        description:
+          - TODO needs documentation.
 
   metrics:
     description: Metrics endpoint connection information.
+    type: dict
     suboptions:
       hostname:
         type: str
@@ -139,9 +161,26 @@ options:
       path:
         type: str
         description: Database name for oVirt metrics. Defaults to V(ovirt_engine_history).
+      project:
+        type: str
+        description:
+          - TODO needs documentation.
+      role:
+        type: str
+        description:
+          - TODO needs documentation.
+      subscription:
+        type: str
+        description:
+          - TODO needs documentation.
+      uid_ems:
+        type: str
+        description:
+          - TODO needs documentation.
 
   alerts:
     description: Alerts endpoint connection information.
+    type: dict
     suboptions:
       hostname:
         type: str
@@ -171,9 +210,30 @@ options:
       certificate_authority:
         type: str
         description: The CA bundle string with custom certificates. defaults to None.
+      path:
+        type: str
+        description:
+          - TODO needs documentation.
+      project:
+        type: str
+        description:
+          - TODO needs documentation.
+      role:
+        type: str
+        description:
+          - TODO needs documentation.
+      subscription:
+        type: str
+        description:
+          - TODO needs documentation.
+      uid_ems:
+        type: str
+        description:
+          - TODO needs documentation.
 
   ssh_keypair:
     description: SSH key pair used for SSH connections to all hosts in this provider.
+    type: dict
     suboptions:
       hostname:
         type: str
@@ -191,6 +251,43 @@ options:
         type: bool
         default: true
         aliases: [ verify_ssl ]
+      security_protocol:
+        type: str
+        choices: ['ssl-with-validation','ssl-with-validation-custom-ca','ssl-without-validation', 'non-ssl']
+        description:
+          - TODO needs documentation.
+      certificate_authority:
+        type: str
+        description:
+          - TODO needs documentation.
+      password:
+        type: str
+        description:
+          - TODO needs documentation.
+      path:
+        type: str
+        description:
+          - TODO needs documentation.
+      project:
+        type: str
+        description:
+          - TODO needs documentation.
+      role:
+        type: str
+        description:
+          - TODO needs documentation.
+      subscription:
+        type: str
+        description:
+          - TODO needs documentation.
+      uid_ems:
+        type: str
+        description:
+          - TODO needs documentation.
+      port:
+        type: int
+        description:
+          - TODO needs documentation.
 '''
 
 EXAMPLES = '''

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -4,15 +4,9 @@
 .azure-pipelines/scripts/publish-codecov.py future-import-boilerplate
 .azure-pipelines/scripts/publish-codecov.py metaclass-boilerplate
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,13 +1,7 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,15 +1,9 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,16 +1,10 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,14 +1,8 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,14 +1,8 @@
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,14 +1,8 @@
-plugins/modules/consul.py validate-modules:doc-missing-type
-plugins/modules/consul.py validate-modules:undocumented-parameter
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
 plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
 plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
 plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
 plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
-plugins/modules/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec   # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:doc-missing-type                # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:parameter-type-not-in-doc       # missing docs on suboptions
-plugins/modules/manageiq_provider.py validate-modules:undocumented-parameter          # missing docs on suboptions
 plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
 plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
 plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0


### PR DESCRIPTION
##### SUMMARY
The consul and the manageiq_provider modules have a bunch of undocumented module options. Make sure that they at least show up in the documentation, and that it's clear they need more docs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
consul
manageiq_provider
