### PR TITLE
mail module: add Message-ID header

### DIFF
--- a/changelogs/fragments/7740-add-message-id-header-to-mail-module.yml
+++ b/changelogs/fragments/7740-add-message-id-header-to-mail-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mail - add ``Message-ID`` header; which is required by some mail servers (https://github.com/ansible-collections/community.general/pull/7740).

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -348,7 +348,11 @@ def main():
     msg['From'] = formataddr((sender_phrase, sender_addr))
     msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = Header(subject, charset)
-    msg['Message-ID'] = make_msgid(domain='ansible')
+    try:
+        msg['Message-ID'] = make_msgid(domain='ansible')
+    except TypeError:
+        # `domain` is only available in Python 3
+        msg['Message-ID'] = make_msgid()
     msg.preamble = "Multipart message"
 
     for header in headers:

--- a/plugins/modules/mail.py
+++ b/plugins/modules/mail.py
@@ -221,7 +221,7 @@ import smtplib
 import ssl
 import traceback
 from email import encoders
-from email.utils import parseaddr, formataddr, formatdate
+from email.utils import parseaddr, formataddr, formatdate, make_msgid
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -348,6 +348,7 @@ def main():
     msg['From'] = formataddr((sender_phrase, sender_addr))
     msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = Header(subject, charset)
+    msg['Message-ID'] = make_msgid(domain='ansible')
     msg.preamble = "Multipart message"
 
     for header in headers:


### PR DESCRIPTION
##### SUMMARY

Add Message-ID header to emails sent with the mail module (mandatory to be accepted by some mail servers; such as Gmail)