### PR TITLE
Implemented raw_post without actions

### DIFF
--- a/changelogs/fragments/7746-raw_post-without-actions.yml
+++ b/changelogs/fragments/7746-raw_post-without-actions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - xcc_redfish_command - added support for raw_post without a specific action info (https://github.com/ansible-collections/community.general/pull/7746).

--- a/changelogs/fragments/7746-raw_post-without-actions.yml
+++ b/changelogs/fragments/7746-raw_post-without-actions.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - xcc_redfish_command - added support for raw_post without a specific action info (https://github.com/ansible-collections/community.general/pull/7746).
+  - xcc_redfish_command - added support for raw POSTs (``command=PostResource`` in ``category=Raw``) without a specific action info (https://github.com/ansible-collections/community.general/pull/7746).

--- a/plugins/modules/xcc_redfish_command.py
+++ b/plugins/modules/xcc_redfish_command.py
@@ -604,9 +604,9 @@ class XCCRedfishUtils(RedfishUtils):
             return response
         if 'Actions' not in response['data']:
             if resource_uri_has_actions:
-              return {'ret': False, 'msg': "Actions property not found in %s" % action_base_uri}
+                return {'ret': False, 'msg': "Actions property not found in %s" % action_base_uri}
             else:
-              response['data']['Actions'] = {}
+                response['data']['Actions'] = {}
 
         # check resouce_uri with target uri found in action base uri data
         action_found = False

--- a/plugins/modules/xcc_redfish_command.py
+++ b/plugins/modules/xcc_redfish_command.py
@@ -592,8 +592,9 @@ class XCCRedfishUtils(RedfishUtils):
     def raw_post_resource(self, resource_uri, request_body):
         if resource_uri is None:
             return {'ret': False, 'msg': "resource_uri is missing"}
+        resource_uri_has_actions = True
         if '/Actions/' not in resource_uri:
-            return {'ret': False, 'msg': "Bad uri %s. Keyword /Actions/ should be included in uri" % resource_uri}
+            resource_uri_has_actions = False
         if request_body is None:
             return {'ret': False, 'msg': "request_body is missing"}
         # get action base uri data for further checking
@@ -602,7 +603,10 @@ class XCCRedfishUtils(RedfishUtils):
         if response['ret'] is False:
             return response
         if 'Actions' not in response['data']:
-            return {'ret': False, 'msg': "Actions property not found in %s" % action_base_uri}
+            if resource_uri_has_actions:
+              return {'ret': False, 'msg': "Actions property not found in %s" % action_base_uri}
+            else:
+              response['data']['Actions'] = {}
 
         # check resouce_uri with target uri found in action base uri data
         action_found = False
@@ -634,7 +638,7 @@ class XCCRedfishUtils(RedfishUtils):
                     else:
                         action_target_uri_list.append(response['data']['Actions']['Oem'][key]['target'])
 
-        if not action_found:
+        if not action_found and resource_uri_has_actions:
             return {'ret': False,
                     'msg': 'Specified resource_uri is not a supported action target uri, please specify a supported target uri instead. Supported uri: %s'
                     % (str(action_target_uri_list))}


### PR DESCRIPTION
##### SUMMARY
Implemented support for resource post without specifying any actions.
This change is useful for adding users, alert recipients, etc, using raw_post.

The behavior of the module is not affected by the changes made. 

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
xcc_redfish_command

##### ADDITIONAL INFORMATION

This has been tested on Lenovo ThinkSystem SR630 V2 BMC Version: 3.81 and Lenovo ThinkSystem SR650 BMC Version: 9.87

See the following example:

INVENTORY:
```
all:
  hosts:
    xzansible-test:
      ansible_host: 1.2.3.4
      ansible_user: USERID
      ansible_password: PASSW0RD

post task for poweron server(with action in resource_uri):

- name: PowerOn server
  community.general.xcc_redfish_command:
    category: Raw
    command: PostResource
    baseuri: "1.2.3.4"
    username: "USERID"
    password: "PASSW0RD"
    resource_uri: "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
    request_body:
      ResetType: "On"

TASK [PowerOn server] ******************************************************************************************************************************************************
changed: [xzansible-test]

post task for adding mail recipient:
- name: Create mail alert recipients
  community.general.xcc_redfish_command:
    category: Raw
    command: PostResource
    baseuri: "1.2.3.4"
    username: "USERID"
    password: "PASSW0RD"
    resource_uri: "/redfish/v1/Managers/1/Oem/Lenovo/Recipients"
    request_body:
      Id: "4"
      RecipientSettings:
        RecipientName: "test"
        Address: "test@test.com"
        AlertType: "Email"
        Enabledstate: true
        IncludeEventLog: true

TASK [Create mail alert recipients] *****************************************************************************************************************************************
fatal: [xzansible-test]: FAILED! => {"msg": "Bad uri /redfish/v1/Managers/1/Oem/Lenovo/Recipients. Keyword /Actions/ should be included in uri"}

after changes:
TASK [Create mail alert recipients] *****************************************************************************************************************************************
changed: [xzansible-test] => { "msg": "Action was successful"}
```

