### PR TITLE
Fixed payload format

### DIFF
--- a/changelogs/fragments/7754-fixed-payload-format.yml
+++ b/changelogs/fragments/7754-fixed-payload-format.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.general.statusio_maintenance - fix error caused by incorrectly formed api data payload. was raising Failed to create maintenance HTTP Error 400 Bad Request caused by bad data type for date/time and deprecated dict keys.

--- a/changelogs/fragments/7754-fixed-payload-format.yml
+++ b/changelogs/fragments/7754-fixed-payload-format.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - community.general.statusio_maintenance - fix error caused by incorrectly formed api data payload. was raising Failed to create maintenance HTTP Error 400 Bad Request caused by bad data type for date/time and deprecated dict keys.
+  - statusio_maintenance - fix error caused by incorrectly formed API data payload. Was raising "Failed to create maintenance HTTP Error 400 Bad Request" caused by bad data type for date/time and deprecated dict keys (https://github.com/ansible-collections/community.general/pull/7754).

--- a/plugins/modules/statusio_maintenance.py
+++ b/plugins/modules/statusio_maintenance.py
@@ -286,25 +286,24 @@ def create_maintenance(auth_headers, url, statuspage, host_ids,
                        returned_date, maintenance_notify_now,
                        maintenance_notify_72_hr, maintenance_notify_24_hr,
                        maintenance_notify_1_hr):
-    returned_dates = [[x] for x in returned_date]
     component_id = []
     container_id = []
     for val in host_ids:
         component_id.append(val['component_id'])
         container_id.append(val['container_id'])
+    infrastructure_id = [i + '-' + j for i, j in zip(component_id, container_id)]
     try:
         values = json.dumps({
             "statuspage_id": statuspage,
-            "components": component_id,
-            "containers": container_id,
             "all_infrastructure_affected": str(int(all_infrastructure_affected)),
+            "infrastructure_affected": infrastructure_id,
             "automation": str(int(automation)),
             "maintenance_name": title,
             "maintenance_details": desc,
-            "date_planned_start": returned_dates[0],
-            "time_planned_start": returned_dates[1],
-            "date_planned_end": returned_dates[2],
-            "time_planned_end": returned_dates[3],
+            "date_planned_start": returned_date[0],
+            "time_planned_start": returned_date[1],
+            "date_planned_end": returned_date[2],
+            "time_planned_end": returned_date[3],
             "maintenance_notify_now": str(int(maintenance_notify_now)),
             "maintenance_notify_72_hr": str(int(maintenance_notify_72_hr)),
             "maintenance_notify_24_hr": str(int(maintenance_notify_24_hr)),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes the REST API Payload format to work with the current status.io API

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
There was no known bugfix issue for this. I discovered it this week and found a fix.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
bugfixes:
  - community.general.statusio_maintenance - fix error caused by incorrectly formed api data payload. was raising ``Failed to create maintenance: HTTP Error 400: Bad Request`` caused by bad data type for date/time and deprecated dict keys.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.statusio_maintenance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- API dates and times are expecting string but original module provided list type.  Author added a step to turn the  list of strings into a list of list items, containing one string each.  I removed that step and correctly parse the strings into the payload.

The current status.io API requires a combined infrastructure ID, in the form of 'component_id-container_id'.  I have not been able to find any change history on the API to show when this changed from what the original module was sending but the individual  component_id and container_id are no longer supported.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i hosts.txt status-io-maintenance.yml

PLAY [Status.IO maintenance update] **************************************************************************************************************

TASK [Create a maintenance window for 60 minutes on server1 and server2] *************************************************************************
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "Failed to create maintenance: HTTP Error 400: Bad Request"}

PLAY RECAP ***************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


$ ansible-playbook -i hosts.txt status-io-maintenance.yml

PLAY [Status.IO maintenance update] **************************************************************************************************************

TASK [Create a maintenance window for 60 minutes on server1 and server2] *************************************************************************
changed: [localhost]

PLAY RECAP ***************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```
