### PR TITLE
Add github_app_access_token lookup plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -234,6 +234,8 @@ files:
   $lookups/filetree.py:
     maintainers: dagwieers
   $lookups/flattened.py: {}
+  $lookups/github_app_access_token.py:
+    maintainers: weisheng-p
   $lookups/hiera.py:
     maintainers: jparrill
   $lookups/keyring.py: {}

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -71,7 +71,9 @@ from ansible.utils.display import Display
 
 if HAS_JWT:
     jwt_instance = JWT()
-
+else:
+    jwk_from_pem = None
+    jwt_instance = None
 
 display = Display()
 

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
         type: str
       app_id:
         description:
-        - Your Github App Id, you can find this in the settings page
+        - Your GitHub App ID, you can find this in the settings page.
         required: true
         type: str
       installation_id:

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
     requirements:
       - jwt (https://github.com/GehirnInc/python-jwt)
     description:
-      - This generates a Github access token that can be used with a git command, if you use a Github App.
+      - This generates a Github access token that can be used with a C(git) command, if you use a Github App.
     options:
       key_path:
         description:

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -23,15 +23,15 @@ DOCUMENTATION = '''
         type: path
       app_id:
         description:
-        - Your GitHub App ID, you can find this in the settings page.
+        - Your GitHub App ID, you can find this in the Settings page.
         required: true
         type: str
       installation_id:
         description:
-        - The installation id that contains the git repo you would like access to
-        - As of 2023-12-24, this can be found via settings page > integrations > application. The last part of the url in the
-          configure button is the installation id.
-        - Alternatively, you can use PyGithub (https://github.com/PyGithub/PyGithub) to get your installation id
+        - The installation ID that contains the git repository you would like access to.
+        - As of 2023-12-24, this can be found via Settings page > Integrations > Application. The last part of the URL in the
+          configure button is the installation ID.
+        - Alternatively, you can use PyGithub (U(https://github.com/PyGithub/PyGithub)) to get your installation ID.
         required: true
         type: str
       token_expiry:
@@ -55,7 +55,7 @@ EXAMPLES = '''
 
 RETURN = '''
   _raw:
-    description: A one-element list containing your github access token
+    description: A one-element list containing your GitHub access token.
     type: list
     elements: str
 '''

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, Poh Wei Sheng <weisheng-p@hotmail.sg>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: github_app_access_token
+    author:
+      - Poh Wei Sheng (@weisheng-p)
+    short_description: Generats Github App Access token
+    version_added: '3.1.0'
+    requirements:
+      - jwt (https://github.com/GehirnInc/python-jwt)
+    description:
+      - This generates a Github access token that can be used with a git command, if you use a Github App.
+    options:
+      key_path:
+        description:
+        - Path to your private key
+        required: true
+        type: str
+      app_id:
+        description:
+        - Your Github App Id, you can find this in the settings page
+        required: true
+        type: str
+      installation_id:
+        description:
+        - The installation id that contains the git repo you would like access to
+        - As of 2023-12-24, this can be found via settings page > integrations > application. The last part of the url in the configure button is the installation id.
+        - Alternatively, you can use PyGithub (https://github.com/PyGithub/PyGithub) to get your installation id
+        required: true
+        type: str
+'''
+
+EXAMPLES = '''
+- name: "Get access token to be used for git checkout" with app_id=123456, installation_id=64209
+  ansible.builtin.git:
+    repo: https://x-access-token:{{ lookup('github_app_token', key_path='/home/to_your/key', app_id='123456', installation_id='64209') }}@github.com/hidden_user/super-secret-repo.git
+    dest: /srv/checkout
+'''
+
+RETURN = '''
+  _raw:
+    description: A one-element list containing your github access token
+    type: list
+    elements: str
+'''
+
+
+try:
+    from jwt import JWT, jwk_from_pem
+    HAS_JWT = True
+except ImportError:
+    HAS_JWT = False
+
+import time
+import json
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+if HAS_JWT:
+    jwt_instance = JWT()
+
+
+display = Display()
+
+def read_key(path):
+    try:
+        with open(path, 'rb') as pem_file:
+            return jwk_from_pem(pem_file.read())
+    except Exception as e:
+        raise AnsibleError("Error while parsing key file: {0}".format(e))
+
+def encode_jwt(app_id, jwk, exp=600):
+    now = int(time.time())
+    payload = {
+        'iat': now,
+        'exp': now + exp,
+        'iss': app_id,
+    }
+    try:
+        return jwt_instance.encode(payload, jwk, alg='RS256')
+    except Exception as e:
+        raise AnsibleError("Error while encoding jwt: {0}".format(e))
+
+def post_request(generated_jwt, installation_id):
+    github_api_url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
+    headers = {
+            "Authorization": f'Bearer {generated_jwt}',
+            "Accept": "application/vnd.github.v3+json",
+    }
+    try:
+        response = open_url(github_api_url, headers=headers, method='POST')
+    except HTTPError as e:
+        try:
+            error_body = json.loads(e.read().decode())
+            display.vvv("Error returned: {0}".format(error_body))
+        except Exception:
+            error_body = {}
+        if e.code == 404:
+            raise AnsibleError("Github return error. Please confirm your installationd_id value is valid")
+        elif e.code == 401:
+            raise AnsibleError("Github return error. Please confirm your private key is valid")
+        raise AnsibleError("Unexpected data returned: {0} -- {1}".format(e, error_body))
+    response_body = response.read()
+    try:
+        json_data = json.loads(response_body.decode('utf-8'))
+    except json.decoder.JSONDecodeError as e:
+        raise AnsibleError("Error while dencoding JSON respone from github: {0}".format(e))
+    return json_data.get('token')
+
+def get_token(key_path, app_id, installation_id):
+    jwk = read_key(key_path)
+    generated_jwt = encode_jwt(app_id, jwk)
+    return post_request(generated_jwt, installation_id)
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        if not HAS_JWT:
+            raise AnsibleError('Python jwt library is required. '
+                               'Please install using "pip install jwt"')
+
+        self.set_options(var_options=variables, direct=kwargs)
+        
+        t = get_token(
+                kwargs['key_path'],
+                kwargs['app_id'],
+                kwargs['installation_id'])
+
+        return [t]

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
     author:
       - Poh Wei Sheng (@weisheng-p)
     short_description: This plugin generates Github App Access token
-    version_added: '3.1.0'
+    version_added: '8.2.0'
     requirements:
       - jwt (https://github.com/GehirnInc/python-jwt)
     description:

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -29,16 +29,21 @@ DOCUMENTATION = '''
       installation_id:
         description:
         - The installation id that contains the git repo you would like access to
-        - As of 2023-12-24, this can be found via settings page > integrations > application. The last part of the url in the configure button is the installation id.
+        - As of 2023-12-24, this can be found via settings page > integrations > application. The last part of the url in the
+          configure button is the installation id.
         - Alternatively, you can use PyGithub (https://github.com/PyGithub/PyGithub) to get your installation id
         required: true
         type: str
 '''
 
 EXAMPLES = '''
-- name: "Get access token to be used for git checkout" with app_id=123456, installation_id=64209
+- name: Get access token to be used for git checkout with app_id=123456, installation_id=64209
   ansible.builtin.git:
-    repo: https://x-access-token:{{ lookup('github_app_token', key_path='/home/to_your/key', app_id='123456', installation_id='64209') }}@github.com/hidden_user/super-secret-repo.git
+    repo: >
+        https://x-access-token:{{ lookup('github_app_token',
+                                  key_path='/home/to_your/key',
+                                  app_id='123456',
+                                  installation_id='64209') }}@github.com/hidden_user/super-secret-repo.git
     dest: /srv/checkout
 '''
 
@@ -70,12 +75,14 @@ if HAS_JWT:
 
 display = Display()
 
+
 def read_key(path):
     try:
         with open(path, 'rb') as pem_file:
             return jwk_from_pem(pem_file.read())
     except Exception as e:
         raise AnsibleError("Error while parsing key file: {0}".format(e))
+
 
 def encode_jwt(app_id, jwk, exp=600):
     now = int(time.time())
@@ -89,11 +96,12 @@ def encode_jwt(app_id, jwk, exp=600):
     except Exception as e:
         raise AnsibleError("Error while encoding jwt: {0}".format(e))
 
+
 def post_request(generated_jwt, installation_id):
     github_api_url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
     headers = {
-            "Authorization": f'Bearer {generated_jwt}',
-            "Accept": "application/vnd.github.v3+json",
+        "Authorization": f'Bearer {generated_jwt}',
+        "Accept": "application/vnd.github.v3+json",
     }
     try:
         response = open_url(github_api_url, headers=headers, method='POST')
@@ -115,10 +123,12 @@ def post_request(generated_jwt, installation_id):
         raise AnsibleError("Error while dencoding JSON respone from github: {0}".format(e))
     return json_data.get('token')
 
+
 def get_token(key_path, app_id, installation_id):
     jwk = read_key(key_path)
     generated_jwt = encode_jwt(app_id, jwk)
     return post_request(generated_jwt, installation_id)
+
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
@@ -127,10 +137,10 @@ class LookupModule(LookupBase):
                                'Please install using "pip install jwt"')
 
         self.set_options(var_options=variables, direct=kwargs)
-        
+
         t = get_token(
-                kwargs['key_path'],
-                kwargs['app_id'],
-                kwargs['installation_id'])
+            kwargs['key_path'],
+            kwargs['app_id'],
+            kwargs['installation_id'])
 
         return [t]

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -44,12 +44,13 @@ DOCUMENTATION = '''
 EXAMPLES = '''
 - name: Get access token to be used for git checkout with app_id=123456, installation_id=64209
   ansible.builtin.git:
-    repo: >
-        https://x-access-token:{{ lookup('github_app_token',
-                                  key_path='/home/to_your/key',
-                                  app_id='123456',
-                                  installation_id='64209') }}@github.com/hidden_user/super-secret-repo.git
+    repo: >-
+      https://x-access-token:{{ github_token }}@github.com/hidden_user/super-secret-repo.git
     dest: /srv/checkout
+  vars:
+    github_token: >-
+      lookup('github_app_token', key_path='/home/to_your/key',
+             app_id='123456', installation_id='64209')
 '''
 
 RETURN = '''

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -18,9 +18,9 @@ DOCUMENTATION = '''
     options:
       key_path:
         description:
-        - Path to your private key
+        - Path to your private key.
         required: true
-        type: str
+        type: path
       app_id:
         description:
         - Your GitHub App ID, you can find this in the settings page.
@@ -34,6 +34,11 @@ DOCUMENTATION = '''
         - Alternatively, you can use PyGithub (https://github.com/PyGithub/PyGithub) to get your installation id
         required: true
         type: str
+      token_expiry:
+        description:
+        - how long the token should last for in seconds
+        default: 600
+        type: int
 '''
 
 EXAMPLES = '''
@@ -126,9 +131,9 @@ def post_request(generated_jwt, installation_id):
     return json_data.get('token')
 
 
-def get_token(key_path, app_id, installation_id):
+def get_token(key_path, app_id, installation_id, expiry=600):
     jwk = read_key(key_path)
-    generated_jwt = encode_jwt(app_id, jwk)
+    generated_jwt = encode_jwt(app_id, jwk, exp=expiry)
     return post_request(generated_jwt, installation_id)
 
 
@@ -141,8 +146,10 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
 
         t = get_token(
-            kwargs['key_path'],
-            kwargs['app_id'],
-            kwargs['installation_id'])
+            self.get_option('key_path'),
+            self.get_option('app_id'),
+            self.get_option('installation_id'),
+            self.get_option('token_expiry'),
+        )
 
         return [t]

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -9,7 +9,7 @@ DOCUMENTATION = '''
     name: github_app_access_token
     author:
       - Poh Wei Sheng (@weisheng-p)
-    short_description: Generats Github App Access token
+    short_description: This plugin generates Github App Access token
     version_added: '3.1.0'
     requirements:
       - jwt (https://github.com/GehirnInc/python-jwt)

--- a/plugins/lookup/github_app_access_token.py
+++ b/plugins/lookup/github_app_access_token.py
@@ -9,7 +9,7 @@ DOCUMENTATION = '''
     name: github_app_access_token
     author:
       - Poh Wei Sheng (@weisheng-p)
-    short_description: This plugin generates Github App Access token
+    short_description: Obtain short-lived Github App Access tokens
     version_added: '8.2.0'
     requirements:
       - jwt (https://github.com/GehirnInc/python-jwt)
@@ -36,7 +36,7 @@ DOCUMENTATION = '''
         type: str
       token_expiry:
         description:
-        - how long the token should last for in seconds
+        - How long the token should last for in seconds.
         default: 600
         type: int
 '''

--- a/tests/unit/plugins/lookup/test_github_app_access_token.py
+++ b/tests/unit/plugins/lookup/test_github_app_access_token.py
@@ -14,15 +14,16 @@ from ansible_collections.community.general.tests.unit.compat.mock import (
     mock_open
 )
 from ansible.plugins.loader import lookup_loader
-from ansible_collections.community.general.plugins.lookup import github_app_access_token
 
 
 class MockJWT(MagicMock):
     def encode(self, payload, key, alg):
         return 'Foobar'
-    
+
+
 class MockResponse(MagicMock):
     response_token = 'Bar'
+
     def read(self):
         return json.dumps({
             "token": self.response_token,

--- a/tests/unit/plugins/lookup/test_github_app_access_token.py
+++ b/tests/unit/plugins/lookup/test_github_app_access_token.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023, Poh Wei Sheng <weisheng-p@hotmail.sg>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import json
+
+from ansible_collections.community.general.tests.unit.compat import unittest
+from ansible_collections.community.general.tests.unit.compat.mock import (
+    patch,
+    MagicMock,
+    mock_open
+)
+from ansible.plugins.loader import lookup_loader
+from ansible_collections.community.general.plugins.lookup import github_app_access_token
+
+
+class MockJWT(MagicMock):
+    def encode(self, payload, key, alg):
+        return 'Foobar'
+    
+class MockResponse(MagicMock):
+    response_token = 'Bar'
+    def read(self):
+        return json.dumps({
+            "token": self.response_token,
+        }).encode('utf-8')
+
+class MockOpenUrl(MagicMock):
+    @staticmethod
+    def post(cls, url, headers={}):
+        return MockResponse()
+
+class TestLookupModule(unittest.TestCase):
+
+    def test_get_token(self):
+        with patch.multiple("ansible_collections.community.general.plugins.lookup.github_app_access_token",
+                            open=mock_open(read_data="foo_bar"),
+                            open_url=MagicMock(return_value=MockResponse()),
+                            jwk_from_pem=MagicMock(return_value='private_key'),
+                            JWT=MockJWT,
+                            HAS_JWT=True):
+            lookup = lookup_loader.get('community.general.github_app_access_token')
+            self.assertListEqual(
+                [MockResponse.response_token],
+                lookup.run(
+                    [],
+                    key_path="key",
+                    app_id="app_id",
+                    installation_id="installation_id"
+                )
+            )

--- a/tests/unit/plugins/lookup/test_github_app_access_token.py
+++ b/tests/unit/plugins/lookup/test_github_app_access_token.py
@@ -46,6 +46,7 @@ class TestLookupModule(unittest.TestCase):
                     [],
                     key_path="key",
                     app_id="app_id",
-                    installation_id="installation_id"
+                    installation_id="installation_id",
+                    token_expiry=600
                 )
             )

--- a/tests/unit/plugins/lookup/test_github_app_access_token.py
+++ b/tests/unit/plugins/lookup/test_github_app_access_token.py
@@ -28,10 +28,6 @@ class MockResponse(MagicMock):
             "token": self.response_token,
         }).encode('utf-8')
 
-class MockOpenUrl(MagicMock):
-    @staticmethod
-    def post(cls, url, headers={}):
-        return MockResponse()
 
 class TestLookupModule(unittest.TestCase):
 

--- a/tests/unit/plugins/lookup/test_github_app_access_token.py
+++ b/tests/unit/plugins/lookup/test_github_app_access_token.py
@@ -36,7 +36,7 @@ class TestLookupModule(unittest.TestCase):
                             open=mock_open(read_data="foo_bar"),
                             open_url=MagicMock(return_value=MockResponse()),
                             jwk_from_pem=MagicMock(return_value='private_key'),
-                            JWT=MockJWT,
+                            jwt_instance=MockJWT(),
                             HAS_JWT=True):
             lookup = lookup_loader.get('community.general.github_app_access_token')
             self.assertListEqual(

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -52,3 +52,6 @@ proxmoxer ; python_version > '3.6'
 #requirements for nomad_token modules
 python-nomad < 2.0.0 ; python_version <= '3.6'
 python-nomad >= 2.0.0 ; python_version >= '3.7'
+
+#requirements for github app lookup
+jwt

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -52,6 +52,3 @@ proxmoxer ; python_version > '3.6'
 #requirements for nomad_token modules
 python-nomad < 2.0.0 ; python_version <= '3.6'
 python-nomad >= 2.0.0 ; python_version >= '3.7'
-
-#requirements for github app lookup
-jwt


### PR DESCRIPTION
##### SUMMARY
This enable us to use github app to generate github access token. This access token can be used for regular git commands as shown in the examples

Using github app to authenticate instead of a private key that is tied to a user provides a lot of flexibility to an organisation
- free up a paid seat for deployment user
- better control around user depature events

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
`github_app_access_token`

