### PR TITLE
CI: python-memcached 1.60 needs Python 3.6+

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -6,7 +6,8 @@ unittest2 ; python_version < '2.7'
 importlib ; python_version < '2.7'
 
 # requirement for the memcached cache plugin
-python-memcached
+python-memcached < 1.60 ; python_version < '3.6'
+python-memcached ; python_version >= '3.6'
 
 # requirement for the redis cache plugin
 redis


### PR DESCRIPTION
##### SUMMARY
It uses type hinting.

(The failures only happen on stable-6 and stable-7.)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
