### PR TITLE
Allow custom providerId in keycloak_user_federation

### DIFF
--- a/changelogs/fragments/7789-keycloak-user-federation-custom-provider-type.yml
+++ b/changelogs/fragments/7789-keycloak-user-federation-custom-provider-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation - allow custom user storage providers to be set through ```provider_id``` (https://github.com/ansible-collections/community.general/pull/7789)

--- a/changelogs/fragments/7789-keycloak-user-federation-custom-provider-type.yml
+++ b/changelogs/fragments/7789-keycloak-user-federation-custom-provider-type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - keycloak_user_federation - allow custom user storage providers to be set through ```provider_id``` (https://github.com/ansible-collections/community.general/pull/7789)
+  - keycloak_user_federation - allow custom user storage providers to be set through ``provider_id`` (https://github.com/ansible-collections/community.general/pull/7789).

--- a/changelogs/fragments/keycloak-user-federation-custom-provider-type.yml
+++ b/changelogs/fragments/keycloak-user-federation-custom-provider-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_user_federation - allow custom user storage providers to be set through ```provider_id```

--- a/changelogs/fragments/keycloak-user-federation-custom-provider-type.yml
+++ b/changelogs/fragments/keycloak-user-federation-custom-provider-type.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - keycloak_user_federation - allow custom user storage providers to be set through ```provider_id```

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -64,7 +64,7 @@ options:
 
     provider_id:
         description:
-            - Provider for this user federation.
+            - Provider for this user federation. In addition to the listed choices, a custom user storage provider can be used.
         aliases:
             - providerId
         type: str
@@ -805,7 +805,7 @@ def main():
         realm=dict(type='str', default='master'),
         id=dict(type='str'),
         name=dict(type='str'),
-        provider_id=dict(type='str', aliases=['providerId'], choices=['ldap', 'kerberos', 'sssd']),
+        provider_id=dict(type='str', aliases=['providerId']),
         provider_type=dict(type='str', aliases=['providerType'], default='org.keycloak.storage.UserStorageProvider'),
         parent_id=dict(type='str', aliases=['parentId']),
         mappers=dict(type='list', elements='dict', options=mapper_spec),

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -64,7 +64,7 @@ options:
 
     provider_id:
         description:
-            - Provider for this user federation. Built in providers are 'ldap', 'kerberos' and 'ssd'.
+            - Provider for this user federation. Built-in providers are V(ldap), V(kerberos), and V(sssd).
               Custom user storage providers can also be used.
         aliases:
             - providerId

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -64,14 +64,11 @@ options:
 
     provider_id:
         description:
-            - Provider for this user federation. In addition to the listed choices, a custom user storage provider can be used.
+            - Provider for this user federation. Built in providers are 'ldap', 'kerberos' and 'ssd'.
+              Custom user storage providers can also be used.
         aliases:
             - providerId
         type: str
-        choices:
-            - ldap
-            - kerberos
-            - sssd
 
     provider_type:
         description:


### PR DESCRIPTION
##### SUMMARY

Removes the restriction from the `keycloak_user_federation` module that `providerId` can only be `ldap`, `kerberos`, or `sssd`.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME

`keycloak_user_federation`

##### ADDITIONAL INFORMATION

Restricting the options for this fields prevents being able to manage custom federation adapters.
