### PR TITLE
fix(modules/gitlab_runner): Use correct argument to list all runners

### DIFF
--- a/changelogs/fragments/7790-gitlab-runner-api-pagination.yml
+++ b/changelogs/fragments/7790-gitlab-runner-api-pagination.yml
@@ -1,2 +1,8 @@
 bugfixes:
   - gitlab_runner - fix pagination when checking for existing runners (https://github.com/ansible-collections/community.general/pull/7790).
+
+minor_changes:
+  - gitlab_deploy_key, gitlab_group_members, gitlab_group_variable, gitlab_hook,
+    gitlab_instance_variable, gitlab_project_badge, gitlab_project_variable,
+    gitlab_user - improve API pagination and compatibility with different versions
+    of ``python-gitlab`` (https://github.com/ansible-collections/community.general/pull/7790).

--- a/changelogs/fragments/7790-gitlab-runner-api-pagination.yml
+++ b/changelogs/fragments/7790-gitlab-runner-api-pagination.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_runner - fix pagination when checking for existing runners (https://github.com/ansible-collections/community.general/pull/7790).

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -21,15 +21,30 @@ except ImportError:
 
 import traceback
 
+
+def _determine_list_all_kwargs(version):
+    gitlab_version = LooseVersion(version)
+    if gitlab_version >= LooseVersion('4.0.0'):
+        # 4.0.0 removed 'as_list'
+        return {'iterator': True, 'per_page': 100}
+    elif gitlab_version >= LooseVersion('3.7.0'):
+        # 3.7.0 added 'get_all'
+        return {'as_list': False, 'get_all': True, 'per_page': 100}
+    else:
+        return {'as_list': False, 'all': True, 'per_page': 100}
+
+
 GITLAB_IMP_ERR = None
 try:
     import gitlab
     import requests
     HAS_GITLAB_PACKAGE = True
+    list_all_kwargs = _determine_list_all_kwargs(gitlab.__version__)
 except Exception:
     gitlab = None
     GITLAB_IMP_ERR = traceback.format_exc()
     HAS_GITLAB_PACKAGE = False
+    list_all_kwargs = {}
 
 
 def auth_argument_spec(spec=None):

--- a/plugins/modules/gitlab_deploy_key.py
+++ b/plugins/modules/gitlab_deploy_key.py
@@ -120,7 +120,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_project, gitlab_authentication, gitlab
+    auth_argument_spec, find_project, gitlab_authentication, gitlab, list_all_kwargs
 )
 
 
@@ -208,8 +208,7 @@ class GitLabDeployKey(object):
     @param key_title Title of the key
     '''
     def find_deploy_key(self, project, key_title):
-        deploy_keys = project.keys.list(all=True)
-        for deploy_key in deploy_keys:
+        for deploy_key in project.keys.list(**list_all_kwargs):
             if (deploy_key.title == key_title):
                 return deploy_key
 

--- a/plugins/modules/gitlab_group_members.py
+++ b/plugins/modules/gitlab_group_members.py
@@ -160,7 +160,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab
+    auth_argument_spec, gitlab_authentication, gitlab, list_all_kwargs
 )
 
 
@@ -171,16 +171,20 @@ class GitLabGroup(object):
 
     # get user id if the user exists
     def get_user_id(self, gitlab_user):
-        user_exists = self._gitlab.users.list(username=gitlab_user, all=True)
-        if user_exists:
-            return user_exists[0].id
+        return next(
+            (u.id for u in self._gitlab.users.list(username=gitlab_user, **list_all_kwargs)),
+            None
+        )
 
     # get group id if group exists
     def get_group_id(self, gitlab_group):
-        groups = self._gitlab.groups.list(search=gitlab_group, all=True)
-        for group in groups:
-            if group.full_path == gitlab_group:
-                return group.id
+        return next(
+            (
+                g.id for g in self._gitlab.groups.list(search=gitlab_group, **list_all_kwargs)
+                if g.full_path == gitlab_group
+            ),
+            None
+        )
 
     # get all members in a group
     def get_members_in_a_group(self, gitlab_group_id):

--- a/plugins/modules/gitlab_group_variable.py
+++ b/plugins/modules/gitlab_group_variable.py
@@ -206,7 +206,8 @@ group_variable:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables
+    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables,
+    list_all_kwargs
 )
 
 
@@ -221,14 +222,7 @@ class GitlabGroupVariables(object):
         return self.repo.groups.get(group_name)
 
     def list_all_group_variables(self):
-        page_nb = 1
-        variables = []
-        vars_page = self.group.variables.list(page=page_nb)
-        while len(vars_page) > 0:
-            variables += vars_page
-            page_nb += 1
-            vars_page = self.group.variables.list(page=page_nb)
-        return variables
+        return list(self.group.variables.list(**list_all_kwargs))
 
     def create_variable(self, var_obj):
         if self._module.check_mode:

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -169,7 +169,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, find_project, gitlab_authentication
+    auth_argument_spec, find_project, gitlab_authentication, list_all_kwargs
 )
 
 
@@ -264,8 +264,7 @@ class GitLabHook(object):
     @param hook_url Url to call on event
     '''
     def find_hook(self, project, hook_url):
-        hooks = project.hooks.list(all=True)
-        for hook in hooks:
+        for hook in project.hooks.list(**list_all_kwargs):
             if (hook.url == hook_url):
                 return hook
 

--- a/plugins/modules/gitlab_instance_variable.py
+++ b/plugins/modules/gitlab_instance_variable.py
@@ -138,7 +138,8 @@ instance_variable:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, filter_returned_variables
+    auth_argument_spec, gitlab_authentication, filter_returned_variables,
+    list_all_kwargs
 )
 
 
@@ -149,14 +150,7 @@ class GitlabInstanceVariables(object):
         self._module = module
 
     def list_all_instance_variables(self):
-        page_nb = 1
-        variables = []
-        gl_varibales_page = self.instance.variables.list(page=page_nb)
-        while len(gl_varibales_page) > 0:
-            variables += gl_varibales_page
-            page_nb += 1
-            gl_varibales_page = self.instance.variables.list(page=page_nb)
-        return variables
+        return list(self.instance.variables.list(**list_all_kwargs))
 
     def create_variable(self, var_obj):
         if self._module.check_mode:

--- a/plugins/modules/gitlab_project_badge.py
+++ b/plugins/modules/gitlab_project_badge.py
@@ -97,7 +97,7 @@ from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, find_project
+    auth_argument_spec, gitlab_authentication, find_project, list_all_kwargs
 )
 
 
@@ -105,7 +105,7 @@ def present_strategy(module, gl, project, wished_badge):
     changed = False
 
     existing_badge = None
-    for badge in project.badges.list(iterator=True):
+    for badge in project.badges.list(**list_all_kwargs):
         if badge.image_url == wished_badge["image_url"]:
             existing_badge = badge
             break
@@ -135,7 +135,7 @@ def absent_strategy(module, gl, project, wished_badge):
     changed = False
 
     existing_badge = None
-    for badge in project.badges.list(iterator=True):
+    for badge in project.badges.list(**list_all_kwargs):
         if badge.image_url == wished_badge["image_url"]:
             existing_badge = badge
             break

--- a/plugins/modules/gitlab_project_variable.py
+++ b/plugins/modules/gitlab_project_variable.py
@@ -225,7 +225,8 @@ from ansible.module_utils.api import basic_auth_argument_spec
 
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables
+    auth_argument_spec, gitlab_authentication, filter_returned_variables, vars_to_variables,
+    list_all_kwargs
 )
 
 
@@ -240,14 +241,7 @@ class GitlabProjectVariables(object):
         return self.repo.projects.get(project_name)
 
     def list_all_project_variables(self):
-        page_nb = 1
-        variables = []
-        vars_page = self.project.variables.list(page=page_nb)
-        while len(vars_page) > 0:
-            variables += vars_page
-            page_nb += 1
-            vars_page = self.project.variables.list(page=page_nb)
-        return variables
+        return list(self.project.variables.list(**list_all_kwargs))
 
     def create_variable(self, var_obj):
         if self._module.check_mode:

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -219,7 +219,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, gitlab
+    auth_argument_spec, gitlab_authentication, gitlab, list_all_kwargs
 )
 
 
@@ -342,10 +342,7 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def find_runner(self, description):
-        if LooseVersion(gitlab.__version__) < LooseVersion('3.6.0'):
-            runners = self._runners_endpoint(as_list=False)
-        else:
-            runners = self._runners_endpoint(iterator=True)
+        runners = self._runners_endpoint(**list_all_kwargs)
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -342,7 +342,10 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def find_runner(self, description):
-        runners = self._runners_endpoint(iterator=True)
+        if LooseVersion(gitlab.__version__) < LooseVersion('3.6.0'):
+            runners = self._runners_endpoint(as_list=False)
+        else:
+            runners = self._runners_endpoint(iterator=True)
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner

--- a/plugins/modules/gitlab_runner.py
+++ b/plugins/modules/gitlab_runner.py
@@ -342,7 +342,7 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def find_runner(self, description):
-        runners = self._runners_endpoint(as_list=False)
+        runners = self._runners_endpoint(iterator=True)
 
         for runner in runners:
             # python-gitlab 2.2 through at least 2.5 returns a list of dicts for list() instead of a Runner


### PR DESCRIPTION
##### SUMMARY
python-gitlab 4.0.0 removed support for the `as_list=False` parameter. This functionality is now available as `iterator=True`.

Without this change, the module actually only retrieves the first 20 results, which can lead to non-idempotent behavior, such as registering a runner again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_runner

##### ADDITIONAL INFORMATION
I am using community.general 8.1.0, python-gitlab 4.2.0 and a self-hosted instance of GitLab,
and was trying to register a new instance runner. Initial registration was successful, but if I run the playbook again,
a new runner (with the same description value) would be registered.

When I ran again using `--check`, I get `AttributeError: 'bool' object has no attribute '_attrs'`
(which is a separate bug that I will write up), but `module_stderr` also includes:

    UserWarning: Calling a `list()` method without specifying `get_all=True` or `iterator=True` will return a maximum of 20 items. Your query returned 20 of 46 items. See https://python-gitlab.readthedocs.io/en/v4.2.0/api-usage.html#pagination for more details. If this was done intentionally, then this warning can be supressed by adding the argument `get_all=False` to the `list()` call.

The [python-gitlab docs on pagination](https://python-gitlab.readthedocs.io/en/stable/api-usage.html#pagination) call this out:

> Prior to python-gitlab 3.6.0 the argument `as_list` was used instead of `iterator`. `as_list=False` is the equivalent of `iterator=True`.