### PR TITLE
Remove FreeBSD 12.4 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -233,8 +233,8 @@ stages:
               test: rhel/7.9
             # - name: FreeBSD 13.1
             #   test: freebsd/13.1
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
+            # - name: FreeBSD 12.4
+            #   test: freebsd/12.4
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Looks like it was removed from FreeBSD's side.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
