### PR TITLE
CI: for some reason async-timeout doesn't seem to get installed on Python 3.11

### DIFF
--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -11,6 +11,7 @@ python-memcached ; python_version >= '3.6'
 
 # requirement for the redis cache plugin
 redis
+async-timeout ; python_version == '3.11'
 
 # requirement for the linode module
 linode-python  # APIv3


### PR DESCRIPTION
##### SUMMARY
This makes the redis Python library fail. Happens only on devel though...

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
