### PR TITLE
mssql_script: make module Python 2 compatible

### DIFF
--- a/changelogs/fragments/7821-mssql_script-py2.yml
+++ b/changelogs/fragments/7821-mssql_script-py2.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mssql_script - make the module work with Python 2 (https://github.com/ansible-collections/community.general/issues/7818, https://github.com/ansible-collections/community.general/pull/7821)."

--- a/plugins/modules/mssql_script.py
+++ b/plugins/modules/mssql_script.py
@@ -283,7 +283,7 @@ def run_module():
     # Process the script into batches
     queries = []
     current_batch = []
-    for statement in script.splitlines(keepends=True):
+    for statement in script.splitlines(True):
         # Ignore the Byte Order Mark, if found
         if statement.strip() == '\uFEFF':
             continue


### PR DESCRIPTION
##### SUMMARY
`splitlines()` does not accept kwargs on Python 2, only positional parameters.

Fixes #7818.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mssql_script
