### PR TITLE
sudoers: added an XOR check

### DIFF
--- a/changelogs/fragments/suders-user-group-xor.yaml
+++ b/changelogs/fragments/suders-user-group-xor.yaml
@@ -1,3 +1,3 @@
 bugfixes:
   - |
-    Suders module needs either user, or group, set but never both.
+    Suders module needs to have either user, or group, set.

--- a/changelogs/fragments/suders-user-group-xor.yaml
+++ b/changelogs/fragments/suders-user-group-xor.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - |
+    Suders module needs either user, or group, set but never both.

--- a/changelogs/fragments/suders-user-group-xor.yaml
+++ b/changelogs/fragments/suders-user-group-xor.yaml
@@ -1,3 +1,3 @@
 bugfixes:
   - |
-    Suders module needs to have either user, or group, set.
+    sudoers - one of the ``user`` and ``group`` options must be supplied. In case none was supplied, the module crashed (https://github.com/ansible-collections/community.general/pull/7823).

--- a/plugins/modules/sudoers.py
+++ b/plugins/modules/sudoers.py
@@ -203,8 +203,6 @@ class Sudoers(object):
             owner = self.user
         elif self.group is not None:
             owner = '%{group}'.format(group=self.group)
-        else:
-            raise Exception('Username (user), or groupname (group) needs to be set, but not both at the same time')
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''
@@ -294,6 +292,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         mutually_exclusive=[['user', 'group']],
+        required_one_of=[['user', 'group']],
         supports_check_mode=True,
         required_if=[('state', 'present', ['commands'])],
     )

--- a/plugins/modules/sudoers.py
+++ b/plugins/modules/sudoers.py
@@ -199,6 +199,8 @@ class Sudoers(object):
         return content_matches and mode_matches
 
     def content(self):
+        if bool(self.user) == bool(self.group):
+            raise Exception('Username (user), or groupname (group) needs to be set, but not both at the same time')
         if self.user:
             owner = self.user
         elif self.group:

--- a/plugins/modules/sudoers.py
+++ b/plugins/modules/sudoers.py
@@ -199,12 +199,12 @@ class Sudoers(object):
         return content_matches and mode_matches
 
     def content(self):
-        if bool(self.user) == bool(self.group):
-            raise Exception('Username (user), or groupname (group) needs to be set, but not both at the same time')
-        if self.user:
+        if self.user is not None:
             owner = self.user
-        elif self.group:
+        elif self.group is not None:
             owner = '%{group}'.format(group=self.group)
+        else:
+            raise Exception('Username (user), or groupname (group) needs to be set, but not both at the same time')
 
         commands_str = ', '.join(self.commands)
         nopasswd_str = 'NOPASSWD:' if self.nopassword else ''


### PR DESCRIPTION
##### SUMMARY
Old way it just failed with 'local variable owner referenced before assignment'. Now it returns a better error message if group or user is missing, or if both are set


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
module sudoers

