### PR TITLE
proxmox_kvm - new param to support unsafe updates

### DIFF
--- a/changelogs/fragments/7843-proxmox_kvm-update_unsafe.yml
+++ b/changelogs/fragments/7843-proxmox_kvm-update_unsafe.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox_kvm - Add parameter `update_unsafe` to avoid limitations when updating dangerous values. (https://github.com/ansible-collections/community.general/pull/7843).
+  - proxmox_kvm - add parameter ``update_unsafe`` to avoid limitations when updating dangerous values (https://github.com/ansible-collections/community.general/pull/7843).

--- a/changelogs/fragments/7843-proxmox_kvm-update_unsafe.yml
+++ b/changelogs/fragments/7843-proxmox_kvm-update_unsafe.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - Add parameter `update_unsafe` to avoid limitations when updating dangerous values. (https://github.com/ansible-collections/community.general/pull/7843).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -522,12 +522,14 @@ options:
       - If V(true), the VM will be updated with new value.
       - Because of the operations of the API and security reasons, I have disabled the update of the following parameters
         O(net), O(virtio), O(ide), O(sata), O(scsi). Per example updating O(net) update the MAC address and C(virtio) create always new disk...
+        This security feature can be disabled by setting the O(update_unsafe) to V(true).
       - Update of O(pool) is disabled. It needs an additional API endpoint not covered by this module.
     type: bool
     default: false
   update_unsafe:
     description:
-      - If V(true), does not enforce limitations on parameters O(net), O(virtio), O(ide), O(sata), and O(scsi).
+      - If V(true), do not enforce limitations on parameters O(net), O(virtio), O(ide), O(sata), O(scsi), O(efidisk0), and O(tpmstate0).
+        Use this option with caution because an improper configuration might result in a permanent loss of data (e.g. disk recreated).
     type: bool
     default: false
     version_added: 8.3.0

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -532,7 +532,7 @@ options:
         Use this option with caution because an improper configuration might result in a permanent loss of data (e.g. disk recreated).
     type: bool
     default: false
-    version_added: 8.3.0
+    version_added: 8.4.0
   vcpus:
     description:
       - Sets number of hotplugged vcpus.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -527,7 +527,7 @@ options:
     default: false
   update_unsafe:
     description:
-      - If V(true), does not enforce limitations on parameters O(net), O(virtio), O(ide), O(sata), O(scsi).
+      - If V(true), does not enforce limitations on parameters O(net), O(virtio), O(ide), O(sata), and O(scsi).
     type: bool
     default: false
     version_added: 8.3.0
@@ -1041,7 +1041,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         # If update, don't update disk (virtio, efidisk0, tpmstate0, ide, sata, scsi) and network interface, unless update_unsafe=True
         # pool parameter not supported by qemu/<vmid>/config endpoint on "update" (PVE 6.2) - only with "create"
         if update:
-            if update_unsafe is not True:
+            if update_unsafe is False:
                 if 'virtio' in kwargs:
                     del kwargs['virtio']
                 if 'sata' in kwargs:


### PR DESCRIPTION
##### SUMMARY
Add parameter `update_unsafe` to avoid limitations when updating dangerous values.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
This simply allows to override the limits present on specific config options during `update`.
