### PR TITLE
gitlab_issue: use search instead of title

### DIFF
--- a/changelogs/fragments/7847-gitlab-issue-title.yml
+++ b/changelogs/fragments/7847-gitlab-issue-title.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_issue - fix behavior to search gitlab issue, using `search` keyword instead of `title` (https://github.com/ansible-collections/community.general/issues/7846).

--- a/changelogs/fragments/7847-gitlab-issue-title.yml
+++ b/changelogs/fragments/7847-gitlab-issue-title.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - gitlab_issue - fix behavior to search gitlab issue, using `search` keyword instead of `title` (https://github.com/ansible-collections/community.general/issues/7846).
+  - gitlab_issue - fix behavior to search GitLab issue, using ``search`` keyword instead of ``title`` (https://github.com/ansible-collections/community.general/issues/7846).

--- a/plugins/modules/gitlab_issue.py
+++ b/plugins/modules/gitlab_issue.py
@@ -183,7 +183,7 @@ class GitlabIssue(object):
     def get_issue(self, title, state_filter):
         issues = []
         try:
-            issues = self.project.issues.list(query_parameters={"search": title, "in": "title", "state": state_filter} )
+            issues = self.project.issues.list(query_parameters={"search": title, "in": "title", "state": state_filter})
         except gitlab.exceptions.GitlabGetError as e:
             self._module.fail_json(msg="Failed to list the Issues: %s" % to_native(e))
 

--- a/plugins/modules/gitlab_issue.py
+++ b/plugins/modules/gitlab_issue.py
@@ -183,7 +183,7 @@ class GitlabIssue(object):
     def get_issue(self, title, state_filter):
         issues = []
         try:
-            issues = self.project.issues.list(search=title, state=state_filter)
+            issues = self.project.issues.list(query_parameters={"search": title, "in": "title", "state": state_filter} )
         except gitlab.exceptions.GitlabGetError as e:
             self._module.fail_json(msg="Failed to list the Issues: %s" % to_native(e))
 

--- a/plugins/modules/gitlab_issue.py
+++ b/plugins/modules/gitlab_issue.py
@@ -183,7 +183,7 @@ class GitlabIssue(object):
     def get_issue(self, title, state_filter):
         issues = []
         try:
-            issues = self.project.issues.list(title=title, state=state_filter)
+            issues = self.project.issues.list(search=title, state=state_filter)
         except gitlab.exceptions.GitlabGetError as e:
             self._module.fail_json(msg="Failed to list the Issues: %s" % to_native(e))
 


### PR DESCRIPTION
##### SUMMARY
Title is an absent filter into python-gitlab library.

Fixes #7846 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`gitlab_issue`

