### PR TITLE
Add missing `id` parameter into pacman_key documentation examples.

### DIFF
--- a/plugins/modules/pacman_key.py
+++ b/plugins/modules/pacman_key.py
@@ -88,11 +88,13 @@ options:
 EXAMPLES = '''
 - name: Import a key via local file
   community.general.pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
     data: "{{ lookup('file', 'keyfile.asc') }}"
     state: present
 
 - name: Import a key via remote file
   community.general.pacman_key:
+    id: 01234567890ABCDE01234567890ABCDE12345678
     file: /tmp/keyfile.asc
     state: present
 


### PR DESCRIPTION
Key ID is a mandatory parameter, and the examples which miss it are incorrect.

##### SUMMARY

The documentation for pacman_key module includes incorrect examples which miss key ID. Given that key ID is a mandatory parameter (and the documentation clearly states this), the examples missing the key need to be fixed.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`modules/pacman_key`