### PR TITLE
Make compatible with newer reuse versions

### DIFF
--- a/tests/integration/targets/setup_tls/files/ca_certificate.pem
+++ b/tests/integration/targets/setup_tls/files/ca_certificate.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN CERTIFICATE-----
 MIIDAjCCAeqgAwIBAgIJANguFROhaWocMA0GCSqGSIb3DQEBCwUAMDExIDAeBgNV
 BAMMF1RMU0dlblNlbGZTaWduZWR0Um9vdENBMQ0wCwYDVQQHDAQkJCQkMB4XDTE5

--- a/tests/integration/targets/setup_tls/files/ca_certificate.pem.license
+++ b/tests/integration/targets/setup_tls/files/ca_certificate.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/integration/targets/setup_tls/files/ca_key.pem
+++ b/tests/integration/targets/setup_tls/files/ca_key.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDqVt84czSxWnWW
 4Ng6hmKE3NarbLsycwtjrYBokV7Kk7Mp7PrBbYF05FOgSdJLvL6grlRSQK2VPsXd

--- a/tests/integration/targets/setup_tls/files/ca_key.pem.license
+++ b/tests/integration/targets/setup_tls/files/ca_key.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/integration/targets/setup_tls/files/client_certificate.pem
+++ b/tests/integration/targets/setup_tls/files/client_certificate.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN CERTIFICATE-----
 MIIDRjCCAi6gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAxMSAwHgYDVQQDDBdUTFNH
 ZW5TZWxmU2lnbmVkdFJvb3RDQTENMAsGA1UEBwwEJCQkJDAeFw0xOTAxMTEwODMz

--- a/tests/integration/targets/setup_tls/files/client_certificate.pem.license
+++ b/tests/integration/targets/setup_tls/files/client_certificate.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/integration/targets/setup_tls/files/client_key.pem
+++ b/tests/integration/targets/setup_tls/files/client_key.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAqDPjkNxwpwlAAM/Shhk8FgfYUG1HwGV5v7LZW9v7jgKd6zcM
 QJQrP4IspgRxOiLupqytNOlZ/mfYm6iKw9i7gjsXLtucvIKKhutk4HT+bGvcEfuf

--- a/tests/integration/targets/setup_tls/files/client_key.pem.license
+++ b/tests/integration/targets/setup_tls/files/client_key.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/integration/targets/setup_tls/files/server_certificate.pem
+++ b/tests/integration/targets/setup_tls/files/server_certificate.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN CERTIFICATE-----
 MIIDRjCCAi6gAwIBAgIBATANBgkqhkiG9w0BAQsFADAxMSAwHgYDVQQDDBdUTFNH
 ZW5TZWxmU2lnbmVkdFJvb3RDQTENMAsGA1UEBwwEJCQkJDAeFw0xOTAxMTEwODMz

--- a/tests/integration/targets/setup_tls/files/server_certificate.pem.license
+++ b/tests/integration/targets/setup_tls/files/server_certificate.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/integration/targets/setup_tls/files/server_key.pem
+++ b/tests/integration/targets/setup_tls/files/server_key.pem
@@ -1,7 +1,3 @@
-# Copyright (c) Ansible Project
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAyMBKx8AHrEQX3fR4mZJgd1WIdvHNUJBPSPJ2MhySl9mQVIQM
 yvofNAZHEySfeNuualsgAh/8JeeF3v6HxVBaxmuL89Ks+FJC/yiNDhsNvGOKpyna

--- a/tests/integration/targets/setup_tls/files/server_key.pem.license
+++ b/tests/integration/targets/setup_tls/files/server_key.pem.license
@@ -1,0 +1,3 @@
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
##### SUMMARY
Currently the reuse tests fail. Apparently `.pem` files are no longer scanned for copyright/license info.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
reuse test
