### PR TITLE
Detection of already installed homebrew cask

### DIFF
--- a/changelogs/fragments/7870-homebrew-cask-installed-detection.yml
+++ b/changelogs/fragments/7870-homebrew-cask-installed-detection.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - homebrew - detect already installed formulae and casks using json output from brew info (https://github.com/ansible-collections/community.general/issues/864).
+  - homebrew - detect already installed formulae and casks using JSON output from ``brew info`` (https://github.com/ansible-collections/community.general/issues/864).

--- a/changelogs/fragments/7870-homebrew-cask-installed-detection.yml
+++ b/changelogs/fragments/7870-homebrew-cask-installed-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - detect already installed formulae and casks using json output from brew info (https://github.com/ansible-collections/community.general/issues/864).

--- a/tests/integration/targets/homebrew/tasks/casks.yml
+++ b/tests/integration/targets/homebrew/tasks/casks.yml
@@ -35,7 +35,7 @@
 #      - upgrade_option_result.changed
 
 - vars:
-    package_name: 1clipboard
+    package_name: kitty
 
   block:
   - name: Make sure {{ package_name }} package is not installed

--- a/tests/integration/targets/homebrew/tasks/casks.yml
+++ b/tests/integration/targets/homebrew/tasks/casks.yml
@@ -1,0 +1,99 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Test code for the homebrew module.
+# Copyright (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Find brew binary
+  command: which brew
+  register: brew_which
+  when: ansible_distribution in ['MacOSX']
+
+- name: Get owner of brew binary
+  stat:
+    path: "{{ brew_which.stdout }}"
+  register: brew_stat
+  when: ansible_distribution in ['MacOSX']
+
+#- name: Use ignored-pinned option while upgrading all
+#  homebrew:
+#    upgrade_all: true
+#    upgrade_options: ignore-pinned
+#  become: true
+#  become_user: "{{ brew_stat.stat.pw_name }}"
+#  register: upgrade_option_result
+#  environment:
+#    HOMEBREW_NO_AUTO_UPDATE: True
+
+#- assert:
+#    that:
+#      - upgrade_option_result.changed
+
+- vars:
+    package_name: 1clipboard
+
+  block:
+  - name: Make sure {{ package_name }} package is not installed
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+
+  - name: Again install {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+
+  - name: Uninstall {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+
+  - name: Again uninstall {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed

--- a/tests/integration/targets/homebrew/tasks/formulae.yml
+++ b/tests/integration/targets/homebrew/tasks/formulae.yml
@@ -1,0 +1,99 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Test code for the homebrew module.
+# Copyright (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Find brew binary
+  command: which brew
+  register: brew_which
+  when: ansible_distribution in ['MacOSX']
+
+- name: Get owner of brew binary
+  stat:
+    path: "{{ brew_which.stdout }}"
+  register: brew_stat
+  when: ansible_distribution in ['MacOSX']
+
+#- name: Use ignored-pinned option while upgrading all
+#  homebrew:
+#    upgrade_all: true
+#    upgrade_options: ignore-pinned
+#  become: true
+#  become_user: "{{ brew_stat.stat.pw_name }}"
+#  register: upgrade_option_result
+#  environment:
+#    HOMEBREW_NO_AUTO_UPDATE: True
+
+#- assert:
+#    that:
+#      - upgrade_option_result.changed
+
+- vars:
+    package_name: gnu-tar
+
+  block:
+  - name: Make sure {{ package_name }} package is not installed
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+
+  - name: Install {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+
+  - name: Again install {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: present
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed
+
+  - name: Uninstall {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - package_result.changed
+
+  - name: Again uninstall {{ package_name }} package using homebrew
+    homebrew:
+      name: "{{ package_name }}"
+      state: absent
+      update_homebrew: false
+    become: true
+    become_user: "{{ brew_stat.stat.pw_name }}"
+    register: package_result
+
+  - assert:
+      that:
+        - not package_result.changed

--- a/tests/integration/targets/homebrew/tasks/main.yml
+++ b/tests/integration/targets/homebrew/tasks/main.yml
@@ -9,91 +9,9 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Find brew binary
-  command: which brew
-  register: brew_which
-  when: ansible_distribution in ['MacOSX']
-
-- name: Get owner of brew binary
-  stat:
-    path: "{{ brew_which.stdout }}"
-  register: brew_stat
-  when: ansible_distribution in ['MacOSX']
-
-#- name: Use ignored-pinned option while upgrading all
-#  homebrew:
-#    upgrade_all: true
-#    upgrade_options: ignore-pinned
-#  become: true
-#  become_user: "{{ brew_stat.stat.pw_name }}"
-#  register: upgrade_option_result
-#  environment:
-#    HOMEBREW_NO_AUTO_UPDATE: True
-
-#- assert:
-#    that:
-#      - upgrade_option_result.changed
-
-- vars:
-    package_name: gnu-tar
-
+- block:
+  - include_tasks: 'formulae.yml'
+ 
+- when: ansible_distribution in ['MacOSX']
   block:
-  - name: Make sure {{ package_name }} package is not installed
-    homebrew:
-      name: "{{ package_name }}"
-      state: absent
-      update_homebrew: false
-    become: true
-    become_user: "{{ brew_stat.stat.pw_name }}"
-
-  - name: Install {{ package_name }} package using homebrew
-    homebrew:
-      name: "{{ package_name }}"
-      state: present
-      update_homebrew: false
-    become: true
-    become_user: "{{ brew_stat.stat.pw_name }}"
-    register: package_result
-
-  - assert:
-      that:
-        - package_result.changed
-
-  - name: Again install {{ package_name }} package using homebrew
-    homebrew:
-      name: "{{ package_name }}"
-      state: present
-      update_homebrew: false
-    become: true
-    become_user: "{{ brew_stat.stat.pw_name }}"
-    register: package_result
-
-  - assert:
-      that:
-        - not package_result.changed
-
-  - name: Uninstall {{ package_name }} package using homebrew
-    homebrew:
-      name: "{{ package_name }}"
-      state: absent
-      update_homebrew: false
-    become: true
-    become_user: "{{ brew_stat.stat.pw_name }}"
-    register: package_result
-
-  - assert:
-      that:
-        - package_result.changed
-
-  - name: Again uninstall {{ package_name }} package using homebrew
-    homebrew:
-      name: "{{ package_name }}"
-      state: absent
-      update_homebrew: false
-    become: true
-    become_user: "{{ brew_stat.stat.pw_name }}"
-    register: package_result
-
-  - assert:
-      that:
-        - not package_result.changed
+    - include_tasks: 'casks.yml'


### PR DESCRIPTION
Use json output v2 to check if formulae and casks are installed

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #864 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
modules/homebrew

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The current method to check if a cask or formulae is installed tries to detect a string (`Built from source` or `Poured from bottle`) piece in the output, but for casks the strings aren't present anymore (example below). The suggested solution for it is use the json output of the command to check the `installed` field that contains a list of installed versions for formulae or a installed string version for casks.

`brew info firefox` output
```
==> firefox: 121.0.1 (auto_updates)
https://www.mozilla.org/firefox/
/usr/local/Caskroom/firefox/121.0.1 (226B)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/f/firefox.rb
==> Name
Mozilla Firefox
==> Description
Web browser
==> Languages
af, ar, be, bg, bn, ca, cs, de, en-CA, en-GB, en, eo, es-AR, es-CL, es-ES, fa, ff, fi, fr, gl, gn, gu, he, hi, in, it, ja, ka, ko, mr, my, ne, nl, pa-IN, pl, pt-BR, pt, ru, si, sq, sr, sv, ta, te, th, tl, tr, uk, ur, zh-TW, zh
==> Artifacts
Firefox.app (App)
/usr/local/Caskroom/firefox/121.0.1/firefox.wrapper.sh -> firefox (Binary)
==> Analytics
install: 11,427 (30 days), 34,823 (90 days), 118,245 (365 days)
```

`brew info --json=v2 firefox | jq '.casks[0].installed'` output (with jq for brevity)
```json
"121.0.1"
```
