### PR TITLE
Refer to LXD containers/VMs as instances

### DIFF
--- a/plugins/connection/lxd.py
+++ b/plugins/connection/lxd.py
@@ -10,9 +10,9 @@ __metaclass__ = type
 DOCUMENTATION = '''
     author: Matt Clay (@mattclay) <matt@mystile.com>
     name: lxd
-    short_description: Run tasks in lxc containers via lxc CLI
+    short_description: Run tasks in LXD instances via C(lxc) CLI
     description:
-        - Run commands or put/fetch files to an existing lxc container using lxc CLI
+        - Run commands or put/fetch files to an existing instance using C(lxc) CLI.
     options:
       remote_addr:
         description:
@@ -26,7 +26,7 @@ DOCUMENTATION = '''
             - name: ansible_lxd_host
       executable:
         description:
-            - shell to use for execution inside container
+            - Shell to use for execution inside instance.
         default: /bin/sh
         vars:
             - name: ansible_executable
@@ -71,7 +71,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("lxc command not found in PATH")
 
         if self._play_context.remote_user is not None and self._play_context.remote_user != 'root':
-            self._display.warning('lxd does not support remote_user, using container default: root')
+            self._display.warning('lxd does not support remote_user, using default: root')
 
     def _host(self):
         """ translate remote_addr to lxd (short) hostname """

--- a/plugins/inventory/lxd.py
+++ b/plugins/inventory/lxd.py
@@ -470,7 +470,7 @@ class InventoryModule(BaseInventoryPlugin):
         Helper to get the preferred interface provide by neme pattern from 'prefered_instance_network_interface'.
 
         Args:
-            str(containe_name): name of instance
+            str(instance_name): name of instance
         Kwargs:
             None
         Raises:
@@ -495,7 +495,7 @@ class InventoryModule(BaseInventoryPlugin):
         Helper to get the VLAN_ID from the instance
 
         Args:
-            str(containe_name): name of instance
+            str(instance_name): name of instance
         Kwargs:
             None
         Raises:


### PR DESCRIPTION
##### SUMMARY

It's been a long while that LXD knows how to manage VMs in addition to containers. Since it grew support for VMs, the more generic term of `instance` is used throughout the LXD documentation (https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/).

This PR updates the remaining occurrences of container to replace them with instance for clarity.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/connection/lxd
plugins/inventory/lxd
