### PR TITLE
Fix: incus connection plugin treats inventory_hostname incorrectly in remote config

### DIFF
--- a/changelogs/fragments/7874-incus_connection_treats_inventory_hostname_as_literal_in_remotes.yml
+++ b/changelogs/fragments/7874-incus_connection_treats_inventory_hostname_as_literal_in_remotes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "incus connection plugin - treats ``inventory_hostname`` as a variable instead of a literal in remote connections.  (https://github.com/ansible-collections/community.general/issues/7874)."
+  - "incus connection plugin - treats ``inventory_hostname`` as a variable instead of a literal in remote connections (https://github.com/ansible-collections/community.general/issues/7874)."

--- a/changelogs/fragments/7874-incus_connection_treats_inventory_hostname_as_literal_in_remotes.yml
+++ b/changelogs/fragments/7874-incus_connection_treats_inventory_hostname_as_literal_in_remotes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "incus connection plugin - treats ``inventory_hostname`` as a variable instead of a literal in remote connections.  (https://github.com/ansible-collections/community.general/issues/7874)."

--- a/plugins/connection/incus.py
+++ b/plugins/connection/incus.py
@@ -21,6 +21,7 @@ DOCUMENTATION = """
             - The instance identifier.
         default: inventory_hostname
         vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: ansible_incus_host
       executable:


### PR DESCRIPTION
##### SUMMARY

Fixes #7874 


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
incus connection plugin

##### ADDITIONAL INFORMATION
similar to the LXD plugin Fix.  https://github.com/ansible-collections/community.general/pull/4912

