### PR TITLE
Zuul third-party-check: disable ansible-doc part of galaxy-importer

### DIFF
--- a/tests/galaxy-importer.cfg
+++ b/tests/galaxy-importer.cfg
@@ -1,0 +1,8 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[galaxy-importer]
+# This is only needed to make Zuul's third-party-check happy.
+# It is not needed by anything else.
+run_ansible_doc=false


### PR DESCRIPTION
##### SUMMARY
Disable the ansible-doc part of the galaxy-importer run of Zuul's third-party-check.

Should stop the constant failing of it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
