### PR TITLE
fixes #7918 - onepassword lookup fails if field name contains uppercase letters and section is specified

### DIFF
--- a/changelogs/fragments/7919-onepassword-fieldname-casing.yaml
+++ b/changelogs/fragments/7919-onepassword-fieldname-casing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - onepassword - lookup failed for fields that were in sections and had uppercase letters in the label/id. Field lookups are now case insensitive in all cases (https://github.com/ansible-collections/community.general/pull/7919).

--- a/changelogs/fragments/7919-onepassword-fieldname-casing.yaml
+++ b/changelogs/fragments/7919-onepassword-fieldname-casing.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - onepassword - lookup failed for fields that were in sections and had uppercase letters in the label/id. Field lookups are now case insensitive in all cases (https://github.com/ansible-collections/community.general/pull/7919).
+  - onepassword lookup plugin - failed for fields that were in sections and had uppercase letters in the label/ID. Field lookups are now case insensitive in all cases (https://github.com/ansible-collections/community.general/pull/7919).

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -492,7 +492,7 @@ class OnePassCLIv2(OnePassCLIBase):
                 if field.get("label", "").lower() == field_name:
                     return field.get("value", "")
 
-                if field.get("id") == field_name:
+                if field.get("id", "").lower() == field_name:
                     return field.get("value", "")
 
         return ""

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -489,7 +489,7 @@ class OnePassCLIv2(OnePassCLIBase):
             current_section_title = section.get("label", section.get("id", "")).lower()
             if section_title == current_section_title:
                 # In the correct section. Check "label" then "id" for the desired field_name
-                if field.get("label").lower() == field_name:
+                if field.get("label", "").lower() == field_name:
                     return field.get("value", "")
 
                 if field.get("id") == field_name:

--- a/plugins/lookup/onepassword.py
+++ b/plugins/lookup/onepassword.py
@@ -489,7 +489,7 @@ class OnePassCLIv2(OnePassCLIBase):
             current_section_title = section.get("label", section.get("id", "")).lower()
             if section_title == current_section_title:
                 # In the correct section. Check "label" then "id" for the desired field_name
-                if field.get("label") == field_name:
+                if field.get("label").lower() == field_name:
                     return field.get("value", "")
 
                 if field.get("id") == field_name:

--- a/tests/unit/plugins/lookup/onepassword_common.py
+++ b/tests/unit/plugins/lookup/onepassword_common.py
@@ -123,5 +123,173 @@ MOCK_ENTRIES = {
             "expected": [""],
             "output": load_file("v2_out_04.json")
         },
+        {
+            # Query item without section by lowercase id (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "lowercaseid",
+            },
+            "expected": ["lowercaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by lowercase id (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "LOWERCASEID",
+            },
+            "expected": ["lowercaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by lowercase label (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "lowercaselabel",
+            },
+            "expected": ["lowercaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by lowercase label (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "LOWERCASELABEL",
+            },
+            "expected": ["lowercaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by mixed case id (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "MiXeDcAsEiD",
+            },
+            "expected": ["mixedcaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by mixed case id (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "mixedcaseid",
+            },
+            "expected": ["mixedcaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by mixed case label (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "MiXeDcAsElAbEl",
+            },
+            "expected": ["mixedcaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item without section by mixed case label (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "mixedcaselabel",
+            },
+            "expected": ["mixedcaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase id (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "sectionlowercaseid",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionlowercaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase id (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "SECTIONLOWERCASEID",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionlowercaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase label (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "sectionlowercaselabel",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionlowercaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase label (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "SECTIONLOWERCASELABEL",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionlowercaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase id (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "SeCtIoNmIxEdCaSeId",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionmixedcaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase id (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "sectionmixedcaseid",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionmixedcaseid"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase label (case matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "SeCtIoNmIxEdCaSeLaBeL",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionmixedcaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
+        {
+            # Query item with section by lowercase label (case not matching)
+            "vault_name": "Test Vault",
+            "queries": ["LabelCasing"],
+            "kwargs": {
+                "field": "sectionmixedcaselabel",
+                "section": "section-with-values",
+            },
+            "expected": ["sectionmixedcaselabel"],
+            "output": load_file("v2_out_05.json")
+        },
     ],
 }

--- a/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_05.json
+++ b/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_05.json
@@ -1,0 +1,102 @@
+{
+  "id": "bgqegp3xcxnpfkb45olwigpkpi",
+  "title": "LabelCasing",
+  "version": 1,
+  "vault": {
+    "id": "stpebbaccrq72xulgouxsk4p7y",
+    "name": "Private"
+  },
+  "category": "LOGIN",
+  "last_edited_by": "WOUTERRUYBH7BFPHMZ2KKGL6AU",
+  "created_at": "2023-09-12T08:30:07Z",
+  "updated_at": "2023-09-12T08:30:07Z",
+  "additional_information": "fluxility",
+  "sections": [
+    {
+      "id": "7osqcvd43i75teocdzbb6d7mie",
+      "label": "section-with-values"
+    }
+  ],
+  "fields": [
+    {
+      "id": "lowercaseid",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "label0",
+      "value": "lowercaseid",
+      "reference": "op://Testcase/LabelCasing/lowercase"
+    },
+    {
+      "id": "MiXeDcAsEiD",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "label1",
+      "value": "mixedcaseid",
+      "reference": "op://Testcase/LabelCasing/lowercase"
+    },
+    {
+      "id": "id1",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "lowercaselabel",
+      "value": "lowercaselabel",
+      "reference": "op://Testcase/LabelCasing/lowercase"
+    },
+    {
+      "id": "id2",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "MiXeDcAsElAbEl",
+      "value": "mixedcaselabel",
+      "reference": "op://Testcase/LabelCasing/lowercase"
+    },
+    {
+      "id": "sectionlowercaseid",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "label2",
+      "value": "sectionlowercaseid",
+      "reference": "op://Testcase/LabelCasing/lowercase",
+      "section": {
+        "id": "7osqcvd43i75teocdzbb6d7mie",
+        "label": "section-with-values"
+      }
+    },
+    {
+      "id": "SeCtIoNmIxEdCaSeId",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "label3",
+      "value": "sectionmixedcaseid",
+      "reference": "op://Testcase/LabelCasing/lowercase",
+      "section": {
+        "id": "7osqcvd43i75teocdzbb6d7mie",
+        "label": "section-with-values"
+      }
+    },
+    {
+      "id": "id3",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "sectionlowercaselabel",
+      "value": "sectionlowercaselabel",
+      "reference": "op://Testcase/LabelCasing/lowercase",
+      "section": {
+        "id": "7osqcvd43i75teocdzbb6d7mie",
+        "label": "section-with-values"
+      }
+    },
+    {
+      "id": "id2",
+      "type": "STRING",
+      "purpose": "USERNAME",
+      "label": "SeCtIoNmIxEdCaSeLaBeL",
+      "value": "sectionmixedcaselabel",
+      "reference": "op://Testcase/LabelCasing/lowercase",
+      "section": {
+        "id": "7osqcvd43i75teocdzbb6d7mie",
+        "label": "section-with-values"
+      }
+    }
+  ]
+}

--- a/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_05.json.license
+++ b/tests/unit/plugins/lookup/onepassword_fixtures/v2_out_05.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: 2022, Ansible Project


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes #7918
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.onepassword lookup plugin
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
