### PR TITLE
Scaleway inventory: add support for new zones

### DIFF
--- a/plugins/module_utils/scaleway.py
+++ b/plugins/module_utils/scaleway.py
@@ -352,6 +352,13 @@ SCALEWAY_LOCATION = {
         'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/fr-par-2'
     },
 
+    'par3': {
+        'name': 'Paris 3',
+        'country': 'FR',
+        'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/fr-par-3',
+        'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/fr-par-3'
+    },
+
     'ams1': {
         'name': 'Amsterdam 1',
         'country': 'NL',
@@ -366,6 +373,20 @@ SCALEWAY_LOCATION = {
         'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/nl-ams-1'
     },
 
+    'ams2': {
+        'name': 'Amsterdam 2',
+        'country': 'NL',
+        'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/nl-ams-2',
+        'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/nl-ams-2'
+    },
+
+    'ams3': {
+        'name': 'Amsterdam 3',
+        'country': 'NL',
+        'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/nl-ams-3',
+        'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/nl-ams-3'
+    },
+
     'waw1': {
         'name': 'Warsaw 1',
         'country': 'PL',
@@ -378,6 +399,20 @@ SCALEWAY_LOCATION = {
         'country': 'PL',
         'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/pl-waw-1',
         'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/pl-waw-1'
+    },
+
+    'waw2': {
+        'name': 'Warsaw 2',
+        'country': 'PL',
+        'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/pl-waw-2',
+        'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/pl-waw-2'
+    },
+
+    'waw3': {
+        'name': 'Warsaw 3',
+        'country': 'PL',
+        'api_endpoint': 'https://api.scaleway.com/instance/v1/zones/pl-waw-3',
+        'api_endpoint_vpc': 'https://api.scaleway.com/vpc/v1/zones/pl-waw-3'
     },
 }
 


### PR DESCRIPTION
##### SUMMARY

Add support for `par3`, `ams2`, `ams3`, `waw2` and `waw3`.

Not sure what the long, uppercase-only names are used for, as they do not seem to follow a pattern, so did not add them.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
scaleway

##### ADDITIONAL INFORMATION
