### PR TITLE
Add MarkDown changelog and use it by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Placeholder changelog
+
+This file is a placeholder; a version-specific `CHANGELOG-vX.md` will be generated during releases from fragments
+under `changelogs/fragments`. On release branches once a release has been created, consult the branch's version-specific
+file for changes that have occurred in that branch.

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See the [Releasing guidelines](https://github.com/ansible/community-docs/blob/ma
 
 ## Release notes
 
-See the [changelog](https://github.com/ansible-collections/community.general/blob/main/CHANGELOG.rst).
+See the [changelog](https://github.com/ansible-collections/community.general/blob/main/CHANGELOG.md).
 
 ## Roadmap
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -12,6 +12,9 @@ mention_ancestor: true
 flatmap: true
 new_plugins_after_name: removed_features
 notesdir: fragments
+output_formats:
+  - md
+  - rst
 prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sections:


### PR DESCRIPTION
##### SUMMARY
Uses https://github.com/ansible-community/antsibull-changelog/pull/139 to render the changelog both as RST and MarkDown. References the MarkDown version from README since GitHub stopped rendering the RST version.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
changelog
