### PR TITLE
Fix errors in hpe specific get methods

### DIFF
--- a/changelogs/fragments/7951-fix-redfish_info-exception.yml
+++ b/changelogs/fragments/7951-fix-redfish_info-exception.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "redfish_info - correct uncaught exception when attempting to retrieve `Chassis` information"
+  - "redfish_info - correct uncaught exception when attempting to retrieve ``Chassis`` information (https://github.com/ansible-collections/community.general/pull/7952)."

--- a/changelogs/fragments/7951-fix-redfish_info-exception.yml
+++ b/changelogs/fragments/7951-fix-redfish_info-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "redfish_info - correct uncaught exception when attempting to retrieve `Chassis` information"

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -2907,8 +2907,7 @@ class RedfishUtils(object):
 
         # Get a list of all Chassis and build URIs, then get all PowerSupplies
         # from each Power entry in the Chassis
-        chassis_uri_list = self.chassis_uris
-        for chassis_uri in chassis_uri_list:
+        for chassis_uri in self.chassis_uris:
             response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
@@ -3495,33 +3494,30 @@ class RedfishUtils(object):
         result = {}
         key = "Thermal"
         # Go through list
-        for chassis_uri in self.chassis_uri_list:
+        for chassis_uri in self.chassis_uris:
             response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
             result['ret'] = True
             data = response['data']
-            oem = data.get['Oem']
-            hpe = oem.get['Hpe']
-            thermal_config = hpe.get('ThermalConfiguration')
-        result["current_thermal_config"] = thermal_config
-        return result
+            val = data.get('Oem', {}).get('Hpe', {}).get('ThermalConfiguration')
+            if val is not None:
+                return {"ret": True, "current_thermal_config": val}
+        return {"ret": False}
 
     def get_hpe_fan_percent_min(self):
         result = {}
         key = "Thermal"
         # Go through list
-        for chassis_uri in self.chassis_uri_list:
+        for chassis_uri in self.chassis_uris:
             response = self.get_request(self.root_uri + chassis_uri)
             if response['ret'] is False:
                 return response
-            result['ret'] = True
             data = response['data']
-            oem = data.get['Oem']
-            hpe = oem.get['Hpe']
-            fan_percent_min_config = hpe.get('FanPercentMinimum')
-        result["fan_percent_min"] = fan_percent_min_config
-        return result
+            val = data.get('Oem', {}).get('Hpe', {}).get('FanPercentMinimum')
+            if val is not None:
+                return {"ret": True, "fan_percent_min": val}
+        return {"ret": False}
 
     def delete_volumes(self, storage_subsystem_id, volume_ids):
         # Find the Storage resource from the requested ComputerSystem resource


### PR DESCRIPTION
##### SUMMARY
While using the `redfish_info` module against some HPE hardware I encountered a variety of uncaught exceptions. After tracing it back I found these two methods to be the culprit. As they have a variety of syntax and logical errors.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
redfish

##### ADDITIONAL INFORMATION
It is worth noting that these methods and their inclusion in the `all` `commands` to the `Chassis` `category` of the `redfish_info` module does result in attempting to get information from OEM/Vendor specific extensions in a module which seems to otherwise attempt to only cover the generic redfish interface.

Additionally, due to the way these methods have been implemented, they both return a single value even when multiple chassis uris have a matching api command to return min fan speed and thermal configuration. I've left that logic as is so that consumers of this module do not experience breakage from a change in the "shape" of the returned data.

Ultimately I /think/ that these methods and the codepath that calls them should be removed in a future release and we should consider adding a deprecation warning.

Resolves #7951

<!--- Paste verbatim command output below, e.g. before and after your change -->
before the change

```
$ ansible -m community.general.redfish_info -a '{"category": ["Chassis"], "command": "all", "baseuri": "<redacted>", "username": "administrator", "password": "<redacted>"}' -i localhost, -c local localhost

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'RedfishUtils' object has no attribute 'chassis_uri_list'
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/drawks/.ansible/tmp/ansible-tmp-1707250729.0465906-2384637-17649427234300/AnsiballZ_redfish_info.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/drawks/.ansible/tmp/ansible-tmp-1707250729.0465906-2384637-17649427234300/AnsiballZ_redfish_info.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/drawks/.ansible/tmp/ansible-tmp-1707250729.0465906-2384637-17649427234300/AnsiballZ_redfish_info.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.redfish_info', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.redfish_info', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.9/runpy.py\", line 225, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.general.redfish_info_payload_paa25mq4/ansible_community.general.redfish_info_payload.zip/ansible_collections/community/general/plugins/modules/redfish_info.py\", line 568, in <module>\n  File \"/tmp/ansible_community.general.redfish_info_payload_paa25mq4/ansible_community.general.redfish_info_payload.zip/ansible_collections/community/general/plugins/modules/redfish_info.py\", line 501, in main\n  File \"/tmp/ansible_community.general.redfish_info_payload_paa25mq4/ansible_community.general.redfish_info_payload.zip/ansible_collections/community/general/plugins/module_utils/redfish_utils.py\", line 3225, in get_hpe_thermal_config\nAttributeError: 'RedfishUtils' object has no attribute 'chassis_uri_list'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

```

after:

```
localhost | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "redfish_facts": {
        "chassis": {
            "entries": [
< snip>
                    {
                        "Chassis": {
                            "Status": {
                                "Health": "OK"
                            }
                        }
                    }
                ]
            ],
            "ret": true
        },
        "hpe_fan_percent_min": {
            "ret": false
        },
        "hpe_thermal_config": {
            "ret": false
        },
        "psu": {
            "msg": "Key PowerSupplies not found",
            "ret": false
        },
        "thermals": {
            "entries": [
                {
                    "Name": "01-Inlet Ambient",
                    "PhysicalContext": "Intake",
                    "ReadingCelsius": 16,
< snip >
}

```