### PR TITLE
Adding releases events option to gitlab_hook module

### DIFF
--- a/changelogs/fragments/7956-adding-releases_events-option-to-gitlab_hook-module.yaml
+++ b/changelogs/fragments/7956-adding-releases_events-option-to-gitlab_hook-module.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - gitlab_hook - adds ``releases_events`` parameter for supporting Releases events triggers on GitLab hooks (https://github.com/ansible-collections/community.general/pull/7956).

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -97,6 +97,11 @@ options:
       - Trigger hook on wiki events.
     type: bool
     default: false
+  releases_events:
+    description:
+      - Trigger hook on release events.
+    type: book
+    default: false
   hook_validate_certs:
     description:
       - Whether GitLab will do SSL verification when triggering the hook.
@@ -201,6 +206,7 @@ class GitLabHook(object):
                 'job_events': options['job_events'],
                 'pipeline_events': options['pipeline_events'],
                 'wiki_page_events': options['wiki_page_events'],
+                'releases_events': options['releases_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
                 'token': options['token'],
             })
@@ -216,6 +222,7 @@ class GitLabHook(object):
                 'job_events': options['job_events'],
                 'pipeline_events': options['pipeline_events'],
                 'wiki_page_events': options['wiki_page_events'],
+                'releases_events': options['releases_events'],
                 'enable_ssl_verification': options['enable_ssl_verification'],
                 'token': options['token'],
             })
@@ -302,6 +309,7 @@ def main():
         job_events=dict(type='bool', default=False),
         pipeline_events=dict(type='bool', default=False),
         wiki_page_events=dict(type='bool', default=False),
+        releases_events=dict(type='bool', default=False),
         hook_validate_certs=dict(type='bool', default=False, aliases=['enable_ssl_verification']),
         token=dict(type='str', no_log=True),
     ))
@@ -339,6 +347,7 @@ def main():
     job_events = module.params['job_events']
     pipeline_events = module.params['pipeline_events']
     wiki_page_events = module.params['wiki_page_events']
+    releases_events = module.params['releases_events']
     enable_ssl_verification = module.params['hook_validate_certs']
     hook_token = module.params['token']
 
@@ -369,6 +378,7 @@ def main():
             "job_events": job_events,
             "pipeline_events": pipeline_events,
             "wiki_page_events": wiki_page_events,
+            "releases_events": releases_events,
             "enable_ssl_verification": enable_ssl_verification,
             "token": hook_token,
         }):

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -100,7 +100,7 @@ options:
   releases_events:
     description:
       - Trigger hook on release events.
-    type: book
+    type: bool
     default: false
   hook_validate_certs:
     description:

--- a/plugins/modules/gitlab_hook.py
+++ b/plugins/modules/gitlab_hook.py
@@ -101,7 +101,7 @@ options:
     description:
       - Trigger hook on release events.
     type: bool
-    default: false
+    version_added: '8.4.0'
   hook_validate_certs:
     description:
       - Whether GitLab will do SSL verification when triggering the hook.
@@ -309,7 +309,7 @@ def main():
         job_events=dict(type='bool', default=False),
         pipeline_events=dict(type='bool', default=False),
         wiki_page_events=dict(type='bool', default=False),
-        releases_events=dict(type='bool', default=False),
+        releases_events=dict(type='bool', default=None),
         hook_validate_certs=dict(type='bool', default=False, aliases=['enable_ssl_verification']),
         token=dict(type='str', no_log=True),
     ))


### PR DESCRIPTION
##### SUMMARY
Adding support for Release Events trigger on gitlab_hook module.
Release Events trigger is defined in GitLab documentation https://docs.gitlab.com/ee/api/projects.html#hooks

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_hook
