### PR TITLE
terraform: fix diff when state is absent

### DIFF
--- a/changelogs/fragments/7963-fix-terraform-diff-absent.yml
+++ b/changelogs/fragments/7963-fix-terraform-diff-absent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - terraform - fix ``diff_mode`` in state ``absent`` and when terraform ``resource_changes`` does not exist (https://github.com/ansible-collections/community.general/pull/7963).


### PR DESCRIPTION
##### SUMMARY
We used `terraform plan` to get the diff outputs, but it seems the module doesn't create a plan when the state is `absent`. Therefore, in this change, we will create a Terraform plan if the state is `absent` and `diff_mode` or `check_mode` is `True`.

Additionally, we will ignore the diff if there are no `resource_changes` in the TF plan. This is necessary when the state is absent and there are no resources to destroy.

Fix #7958 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform
