### PR TITLE
proxmox_disk: prevent trying to shrink disks

### DIFF
--- a/changelogs/fragments/7969-proxmox-disk-prevent-shrinking-attempts.yml
+++ b/changelogs/fragments/7969-proxmox-disk-prevent-shrinking-attempts.yml
@@ -1,0 +1,2 @@
+bugfixes: 
+  - proxmox_disk - the module doesn't detect that shrinking a disk is not supported and fails

--- a/changelogs/fragments/7969-proxmox-disk-prevent-shrinking-attempts.yml
+++ b/changelogs/fragments/7969-proxmox-disk-prevent-shrinking-attempts.yml
@@ -1,2 +1,2 @@
 bugfixes: 
-  - proxmox_disk - the module doesn't detect that shrinking a disk is not supported and fails
+  - proxmox_disk - the module did not detect that shrinking a disk is not supported and failed (https://github.com/ansible-collections/community.general/pull/7969).

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -816,6 +816,8 @@ def main():
             actual_size = disk_config['size']
             if size == actual_size:
                 module.exit_json(changed=False, vmid=vmid, msg="Disk %s is already %s size" % (disk, size))
+            elif size < actual_size:
+                module.fail_json(changed=False, vmid=vmid, msg="Disk %s is size %s, which is smaller than %s: shrinking disks is not supported" % (disk, actual_size, size))
             proxmox.proxmox_api.nodes(vm['node']).qemu(vmid).resize.set(disk=disk, size=size)
             module.exit_json(changed=True, vmid=vmid, msg="Disk %s resized in VM %s" % (disk, vmid))
         except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Shrinking Disks is not supported by the PVE API and should be prevented by the module:
https://pve.proxmox.com/wiki/Resize_disks

Currently, when the configured size of the disk is smaller than the actual size, the module reports a change, but the change isn't actually happening. The module doesn't detect that this fails.

This PR checks if the user tries to shrink the disk and then fails instead of contacting the PVE API.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- proxmox_disk
