### PR TITLE
cargo: use the correct path when checking installation status fixing idempotency issue.

### DIFF
--- a/changelogs/fragments/7970-fix-cargo-path-idempotency.yaml
+++ b/changelogs/fragments/7970-fix-cargo-path-idempotency.yaml
@@ -6,4 +6,5 @@ bugfixes:
     location, before running ``cargo install``. This resulted in a false
     ``changed`` state.
     Also the removal of packeges using ``state: absent`` failed, as the
-    installation check did not use the given parameter."
+    installation check did not use the given parameter
+    (https://github.com/ansible-collections/community.general/pull/7970)."

--- a/changelogs/fragments/7970-fix-cargo-path-idempotency.yaml
+++ b/changelogs/fragments/7970-fix-cargo-path-idempotency.yaml
@@ -1,0 +1,9 @@
+bugfixes:
+  - "cargo - fix idempotency issues when using a custom installation path
+    for packages (using the ``--path`` parameter).
+    The initial installation runs fine, but subsequent runs use the
+    ``get_installed()`` function which did not check the given installation
+    location, before running ``cargo install``. This resulted in a false
+    ``changed`` state.
+    Also the removal of packeges using ``state: absent`` failed, as the
+    installation check did not use the given parameter."

--- a/plugins/modules/cargo.py
+++ b/plugins/modules/cargo.py
@@ -137,6 +137,10 @@ class Cargo(object):
 
     def get_installed(self):
         cmd = ["install", "--list"]
+        if self.path:
+            cmd.append("--root")
+            cmd.append(self.path)
+
         data, dummy = self._exec(cmd, True, False, False)
 
         package_regex = re.compile(r"^([\w\-]+) v(.+):$")


### PR DESCRIPTION
##### SUMMARY
There is a problem when using the optional 'path' parameter. The initial installation works fine, but when running the module again the get_installed function, which is supposed to check the installation state does not use the parameter, thus a new installation is attempted, this again is registered by cargo install itself, but leads to a false 'changed' status, breaking ansibles' idempotency.
A similar problem occurs when removing packages.

This fix makes the get_installed function aware of the optional 'path' parameter.
 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cargo


