### PR TITLE
Pkgin fixes

### DIFF
--- a/changelogs/fragments/pkgin.yml
+++ b/changelogs/fragments/pkgin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pkgin - pkgin (pkgsrc package manager used by SmartOS) raises erratic exceptions and spurious "changed" instead of "ok".

--- a/changelogs/fragments/pkgin.yml
+++ b/changelogs/fragments/pkgin.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pkgin - pkgin (pkgsrc package manager used by SmartOS) raises erratic exceptions and spurious "changed" instead of "ok".
+  - pkgin - pkgin (pkgsrc package manager used by SmartOS) raises erratic exceptions and spurious ``changed=true`` (https://github.com/ansible-collections/community.general/pull/7971).

--- a/plugins/modules/pkgin.py
+++ b/plugins/modules/pkgin.py
@@ -176,8 +176,8 @@ def query_package(module, name):
             #     '>' - installed but newer than the repository version
 
             if (package in ('reading local summary...',
-                           'processing local summary...',
-                           'downloading pkg_summary.xz done.')) or \
+                            'processing local summary...',
+                            'downloading pkg_summary.xz done.')) or \
                (package.startswith('processing remote summary (')):
                 continue
 

--- a/plugins/modules/pkgin.py
+++ b/plugins/modules/pkgin.py
@@ -174,6 +174,13 @@ def query_package(module, name):
             #     '<' - installed but out of date
             #     '=' - installed and up to date
             #     '>' - installed but newer than the repository version
+
+            if (package in ('reading local summary...',
+                           'processing local summary...',
+                           'downloading pkg_summary.xz done.')) or \
+               (package.startswith('processing remote summary (')):
+                continue
+
             pkgname_with_version, raw_state = package.split(splitchar)[0:2]
 
             # Search for package, stripping version
@@ -317,7 +324,7 @@ def do_upgrade_packages(module, full=False):
         format_pkgin_command(module, cmd))
 
     if rc == 0:
-        if re.search('^nothing to do.\n$', out):
+        if re.search('^(.*\n|)nothing to do.\n$', out):
             module.exit_json(changed=False, msg="nothing left to upgrade")
     else:
         module.fail_json(msg="could not %s packages" % cmd, stdout=out, stderr=err)


### PR DESCRIPTION
##### SUMMARY

pkgin module raises sporadic exceptions and spurious "changed" status instead of "ok".

The reason is that modern "pkgin" can produce extra text lines beside the final "nothing to do.". We ignore those extra lines.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

pkgin

##### ADDITIONAL INFORMATION
```paste below

```
