### PR TITLE
Updates `lxd_container` to support new LXD API

### DIFF
--- a/changelogs/fragments/lxd-instances-api-endpoint-added.yml
+++ b/changelogs/fragments/lxd-instances-api-endpoint-added.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "lxd_container - uses ``/1.0/instances`` API endpoint, if available. Falls back to ``/1.0/containers`` or ``/1.0/virtual-machines``. Fixes issue when using Incus or LXD 5.19 due to migrating to ``/1.0/instances`` endpoint. (https://github.com/ansible-collections/community.general/pull/7980)."

--- a/changelogs/fragments/lxd-instances-api-endpoint-added.yml
+++ b/changelogs/fragments/lxd-instances-api-endpoint-added.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "lxd_container - uses ``/1.0/instances`` API endpoint, if available. Falls back to ``/1.0/containers`` or ``/1.0/virtual-machines``. Fixes issue when using Incus or LXD 5.19 due to migrating to ``/1.0/instances`` endpoint. (https://github.com/ansible-collections/community.general/pull/7980)."
+  - "lxd_container - uses ``/1.0/instances`` API endpoint, if available. Falls back to ``/1.0/containers`` or ``/1.0/virtual-machines``. Fixes issue when using Incus or LXD 5.19 due to migrating to ``/1.0/instances`` endpoint (https://github.com/ansible-collections/community.general/pull/7980)."

--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -436,12 +436,12 @@ ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
-    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source'
+    'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source', 'type'
 ]
 
 # CONFIG_CREATION_PARAMS is a list of attribute names that are only applied
 # on instance creation.
-CONFIG_CREATION_PARAMS = ['source']
+CONFIG_CREATION_PARAMS = ['source', 'type']
 
 
 class LXDContainerManagement(object):
@@ -466,13 +466,6 @@ class LXDContainerManagement(object):
         self.wait_for_container = self.module.params['wait_for_container']
 
         self.type = self.module.params['type']
-
-        # LXD Rest API provides additional endpoints for creating containers and virtual-machines.
-        self.api_endpoint = None
-        if self.type == 'container':
-            self.api_endpoint = '/1.0/containers'
-        elif self.type == 'virtual-machine':
-            self.api_endpoint = '/1.0/virtual-machines'
 
         self.key_file = self.module.params.get('client_key')
         if self.key_file is None:
@@ -499,6 +492,18 @@ class LXDContainerManagement(object):
             )
         except LXDClientException as e:
             self.module.fail_json(msg=e.msg)
+
+        # LXD (3.19) Rest API provides instances endpoint, failback to containers and virtual-machines
+        # https://documentation.ubuntu.com/lxd/en/latest/rest-api/#instances-containers-and-virtual-machines
+        self.api_endpoint = '/1.0/instances'
+        check_api_endpoint = self.client.do('GET', '{0}?project='.format(self.api_endpoint), ok_error_codes=[404])
+
+        if check_api_endpoint['error_code'] == 404:
+            if self.type == 'container':
+                self.api_endpoint = '/1.0/containers'
+            elif self.type == 'virtual-machine':
+                self.api_endpoint = '/1.0/virtual-machines'
+
         self.trust_password = self.module.params.get('trust_password', None)
         self.actions = []
         self.diff = {'before': {}, 'after': {}}
@@ -551,6 +556,8 @@ class LXDContainerManagement(object):
             url = '{0}?{1}'.format(url, urlencode(url_params))
         config = self.config.copy()
         config['name'] = self.name
+        if self.type not in self.api_endpoint:
+            config['type'] = self.type
         if not self.module.check_mode:
             self.client.do('POST', url, config, wait_for_container=self.wait_for_container)
         self.actions.append('create')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates the `lxd_container` module to work with the new LXD API which deprecates `/1.0/containers` and `/1.0/virtual-machines` and adds `/1.0/instances`. It tries to keep backwards compatibility with a try and catch compared to detecting the API version then determining which API endpoint to use.

> It also adds support for Incus

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes  #7853

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- [x] Bugfix Pull Request
- [ ] Docs Pull Request
- [x] Feature Pull Request
- [ ] New Module/Plugin Pull Request
- [ ] Refactoring Pull Request
- [ ] Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`lxd_container`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
