### PR TITLE
ipa_user: add global choice to unset userauthtype from IPA user

### DIFF
--- a/changelogs/fragments/7981-unset-user-auth-types.yaml
+++ b/changelogs/fragments/7981-unset-user-auth-types.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ipa_user - add choice ``global`` in ``userauthtype`` to unset ``userauthtype`` from an IPA user (https://github.com/ansible-collections/community.general/pull/7981).


### PR DESCRIPTION
##### SUMMARY
To unset authentication methods for ipa_user, a new global option has been added to the ``userauthtype`` attribute. When selected, this removes the user's specific userauthtype settings FreeIPA use the globally configured default authentication methods in FreeIPA.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipa_user

##### ADDITIONAL INFORMATION
according to the [IPA documentation](https://freeipa.readthedocs.io/en/latest/api/user_add.html) the ``ipauserauthtype`` only accepts these values

> ipauserauthtype : [StrEnum](https://freeipa.readthedocs.io/en/latest/api/StrEnum.html#strenum)
> 
> Values: (‘password’, ‘radius’, ‘otp’, ‘pkinit’, ‘hardened’, ‘idp’, ‘passkey’)

Setting the ``userauthtype`` default to an empty ``list`` seems ideal, but it might introduce compatibility issues with previous versions. I'd love to hear your thoughts and ideas on how to move forward effectively.

