### PR TITLE
feat(lookup/bitwarden): add support for "session" arg

### DIFF
--- a/changelogs/fragments/7994-bitwarden-session-arg.yaml
+++ b/changelogs/fragments/7994-bitwarden-session-arg.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "bitwarden lookup plugin - add ``bw_session`` option, to pass session key instead of reading from env (https://github.com/ansible-collections/community.general/pull/7994)."

--- a/tests/unit/plugins/lookup/test_bitwarden.py
+++ b/tests/unit/plugins/lookup/test_bitwarden.py
@@ -158,3 +158,23 @@ class TestLookupModule(unittest.TestCase):
         record_name = record['name']
         with self.assertRaises(AnsibleError):
             self.lookup.run([record_name], field='password')
+
+    def test_bitwarden_plugin_without_session_option(self):
+        mock_bitwarden = MockBitwarden()
+        with patch("ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden", mock_bitwarden):
+            record = MOCK_RECORDS[0]
+            record_name = record['name']
+            session = 'session'
+
+            self.lookup.run([record_name], field=None)
+            self.assertIsNone(mock_bitwarden.session)
+
+    def test_bitwarden_plugin_session_option(self):
+        mock_bitwarden = MockBitwarden()
+        with patch("ansible_collections.community.general.plugins.lookup.bitwarden._bitwarden", mock_bitwarden):
+            record = MOCK_RECORDS[0]
+            record_name = record['name']
+            session = 'session'
+
+            self.lookup.run([record_name], field=None, bw_session=session)
+            self.assertEqual(mock_bitwarden.session, session)


### PR DESCRIPTION
##### SUMMARY

At the moment, the bitwarden lookup plugins requires that BW_SESSION env var is defined.
`bw` cli allows to pass that key via an argument: `--session <session>    Pass session key instead of reading from env.`

This PR add the support to provides the key from an option and provide it to the cli args.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.bitwarden - lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
