### PR TITLE
Add templating support to Icinga2 Inventory

### DIFF
--- a/changelogs/fragments/7996-Add templating support to Icinga2 Inventory.yml
+++ b/changelogs/fragments/7996-Add templating support to Icinga2 Inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - icinga2 inventory - add Jinja2 templating support to url, user and password paramenters.

--- a/changelogs/fragments/7996-Add templating support to Icinga2 Inventory.yml
+++ b/changelogs/fragments/7996-Add templating support to Icinga2 Inventory.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - icinga2 inventory - add Jinja2 templating support to url, user and password paramenters.
+  - icinga2 inventory plugin - add Jinja2 templating support to ``url``, ``user``, and ``password`` paramenters (https://github.com/ansible-collections/community.general/issues/7074, https://github.com/ansible-collections/community.general/pull/7996).

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -286,10 +286,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         if self.templar.is_template(self.icinga2_url):
             self.icinga2_url = self.templar.template(variable=self.icinga2_url, disable_lookups=False)
-        if self.templar.is_template(self.user):
-            self.user = self.templar.template(variable=self.user, disable_lookups=False)
-        if self.templar.is_template(self.password):
-            self.password = self.templar.template(variable=self.password, disable_lookups=False)
+        if self.templar.is_template(self.icinga2_user):
+            self.icinga2_user = self.templar.template(variable=self.icinga2_user, disable_lookups=False)
+        if self.templar.is_template(self.icinga2_password):
+            self.icinga2_password = self.templar.template(variable=self.icinga2_password, disable_lookups=False)
 
         self.icinga2_url = self.icinga2_url.rstrip('/') + '/v1'
 

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -277,12 +277,22 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._read_config_data(path)
 
         # Store the options from the YAML file
-        self.icinga2_url = self.get_option('url').rstrip('/') + '/v1'
+        self.icinga2_url = self.get_option('url')
         self.icinga2_user = self.get_option('user')
         self.icinga2_password = self.get_option('password')
         self.ssl_verify = self.get_option('validate_certs')
         self.host_filter = self.get_option('host_filter')
         self.inventory_attr = self.get_option('inventory_attr')
+
+        if self.templar.is_template(self.icinga2_url):
+            self.icinga2_url=self.templar.template(variable=self.icinga2_url,disable_lookups=False)
+        if self.templar.is_template(self.user):
+            self.user=self.templar.template(variable=self.user,disable_lookups=False)
+        if self.templar.is_template(self.password):
+            self.password=self.templar.template(variable=self.password,disable_lookups=False)
+
+        self.icinga2_url = self.icinga2_url.rstrip('/') + '/v1'
+
         # Not currently enabled
         # self.cache_key = self.get_cache_key(path)
         # self.use_cache = cache and self.get_option('cache')

--- a/plugins/inventory/icinga2.py
+++ b/plugins/inventory/icinga2.py
@@ -285,11 +285,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.inventory_attr = self.get_option('inventory_attr')
 
         if self.templar.is_template(self.icinga2_url):
-            self.icinga2_url=self.templar.template(variable=self.icinga2_url,disable_lookups=False)
+            self.icinga2_url = self.templar.template(variable=self.icinga2_url, disable_lookups=False)
         if self.templar.is_template(self.user):
-            self.user=self.templar.template(variable=self.user,disable_lookups=False)
+            self.user = self.templar.template(variable=self.user, disable_lookups=False)
         if self.templar.is_template(self.password):
-            self.password=self.templar.template(variable=self.password,disable_lookups=False)
+            self.password = self.templar.template(variable=self.password, disable_lookups=False)
 
         self.icinga2_url = self.icinga2_url.rstrip('/') + '/v1'
 


### PR DESCRIPTION
##### SUMMARY
This PR adds templating support to Icinga2 inventory plugin.

Fixes #7074 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
icinga2.py inventory

##### ADDITIONAL INFORMATION
With this pr, the url, user and password parameters support Jinja2 templating.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```YAML
plugin: community.general.icinga2
url: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:endpoint') }}"
user: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:user') }}"
password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/my/secret:password') }}"
host_filter: \"linux\" in host.groups
validate_certs: false  # only do this when connecting to localhost!
inventory_attr: display_name

```
