### PR TITLE
feat(lookup/merge_variables): Add all hosts mode to collect configuration across multiple hosts

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -255,7 +255,7 @@ files:
     labels: manifold
     maintainers: galanoff
   $lookups/merge_variables.py:
-    maintainers: rlenferink m-a-r-k-e
+    maintainers: rlenferink m-a-r-k-e alpex8
   $lookups/onepass:
     labels: onepassword
     maintainers: samdoran

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -68,7 +68,7 @@ DOCUMENTATION = """
             accross different hosts (for example a service on a host with its database on another host).
         type: list
         elements: str
-        version_added: 8.4.0
+        version_added: 8.5.0
 """
 
 EXAMPLES = """

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -65,7 +65,7 @@ DOCUMENTATION = """
       groups:
         description:
           - Search for variables accross hosts that belong to the given groups. This allows to collect configuration pieces
-             accross different hosts (for example a service on a host with its database on another host).
+            accross different hosts (for example a service on a host with its database on another host).
         type: list
         elements: str
         version_added: 8.4.0

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
     short_description: merge variables with a certain suffix
     description:
         - This lookup returns the merged result of all variables in scope that match the given prefixes, suffixes, or
-         regular expressions, optionally.
+          regular expressions, optionally.
     version_added: 6.5.0
     options:
       _terms:

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -177,7 +177,7 @@ class LookupModule(LookupBase):
     def _is_host_in_allowed_groups(self, host_groups):
         if 'all' in self._groups:
             return True
-        
+
         group_intersection = [host_group_name for host_group_name in host_groups if host_group_name in self._groups]
         if group_intersection:
             return True

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -161,8 +161,9 @@ class LookupModule(LookupBase):
                         host_result = self._merge_vars(term, initial_value, variables["hostvars"][host])
 
                         if cross_host_merge_result is None:
-                            cross_host_merge_result = host_result
-                            cross_host_var_type = _verify_and_get_type(cross_host_merge_result)
+                            if host_result:
+                                cross_host_merge_result = host_result
+                                cross_host_var_type = _verify_and_get_type(cross_host_merge_result)
                         else:
                             if host_result:
                                 if cross_host_var_type == "dict":

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -157,7 +157,7 @@ class LookupModule(LookupBase):
                 cross_host_merge_result = None
                 cross_host_var_type = ""
                 for host in variables["hostvars"]:
-                    if self._is_host_in_allowed_groups(variables["hostvars"][host]['group_names']):
+                    if self._is_host_in_allowed_groups(variables["hostvars"][host]["group_names"]):
                         host_result = self._merge_vars(term, initial_value, variables["hostvars"][host])
 
                         if cross_host_merge_result is None:

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -154,23 +154,10 @@ class LookupModule(LookupBase):
             if not self._groups:  # consider only own variables
                 ret.append(self._merge_vars(term, initial_value, variables))
             else:  # consider variables of hosts in given groups
-                cross_host_merge_result = None
-                cross_host_var_type = ""
+                cross_host_merge_result = initial_value
                 for host in variables["hostvars"]:
                     if self._is_host_in_allowed_groups(variables["hostvars"][host]["group_names"]):
-                        host_result = self._merge_vars(term, initial_value, variables["hostvars"][host])
-
-                        if cross_host_merge_result is None:
-                            if host_result:
-                                cross_host_merge_result = host_result
-                                cross_host_var_type = _verify_and_get_type(cross_host_merge_result)
-                        else:
-                            if host_result:
-                                if cross_host_var_type == "dict":
-                                    cross_host_merge_result = self._merge_dict(host_result, cross_host_merge_result, [""])
-                                else:
-                                    cross_host_merge_result += host_result
-
+                        cross_host_merge_result = self._merge_vars(term, cross_host_merge_result, variables["hostvars"][host])
                 ret.append(cross_host_merge_result)
 
         return ret

--- a/tests/integration/targets/lookup_merge_variables/runme.sh
+++ b/tests/integration/targets/lookup_merge_variables/runme.sh
@@ -11,3 +11,6 @@ ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
 ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
 ANSIBLE_MERGE_VARIABLES_PATTERN_TYPE=suffix \
     ansible-playbook test_with_env.yml "$@"
+
+ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
+    ansible-playbook -vvv -i test_inventory_all_hosts.yml test_all_hosts.yml "$@"

--- a/tests/integration/targets/lookup_merge_variables/runme.sh
+++ b/tests/integration/targets/lookup_merge_variables/runme.sh
@@ -13,4 +13,4 @@ ANSIBLE_MERGE_VARIABLES_PATTERN_TYPE=suffix \
     ansible-playbook test_with_env.yml "$@"
 
 ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
-    ansible-playbook -vvv -i test_inventory_all_hosts.yml test_all_hosts.yml "$@"
+    ansible-playbook -i test_inventory_all_hosts.yml test_all_hosts.yml "$@"

--- a/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
@@ -4,41 +4,42 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Test merge_variables lookup plugin
-  hosts: test_group
+- name: Test merge_variables lookup plugin (multiple hosts)
+  hosts: host0
   gather_facts: false
   tasks:
-    - name: Test merge dicts of same host, exclude matching variable of other host
+    - name: Test merge dicts via all group
       delegate_to: localhost
       vars:
-        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_ex', pattern_type='suffix', all_hosts=True) }}"
+        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_ex', pattern_type='suffix', groups=['all']) }}"
       block:
-        - name: Print the merged dict
+        - name: Test merge dicts via all group - Print the merged dict
           ansible.builtin.debug:
             msg: "{{ merged_dict }}"
 
-        - name: Validate that the dict is complete
+        - name: Test merge dicts via all group - Validate that the dict is complete
+          ansible.builtin.assert:
+            that:
+              - "(merged_dict.keys() | list | length) == 4"
+              - "'item1' in merged_dict"
+              - "'item2' in merged_dict"
+              - "'item3' in merged_dict"
+              - "'list_item' in merged_dict"
+              - "merged_dict.list_item | length == 3"
+    - name: Test merge dicts via two of three groups
+      delegate_to: localhost
+      vars:
+        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_in', pattern_type='suffix', groups=['dummy1', 'dummy2']) }}"
+      block:
+        - name: Test merge dicts via two of three groups - Print the merged dict
+          ansible.builtin.debug:
+            msg: "{{ merged_dict }}"
+
+        - name: Test merge dicts via two of three groups - Validate that the dict is complete
           ansible.builtin.assert:
             that:
               - "(merged_dict.keys() | list | length) == 3"
               - "'item1' in merged_dict"
               - "'item2' in merged_dict"
-              - "'list_item' in merged_dict"
-              - "merged_dict.list_item | length == 2"
-    - name: Test merge dicts of same host, include matching variable of other host
-      delegate_to: localhost
-      vars:
-        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_in', pattern_type='suffix', all_hosts=True) }}"
-      block:
-        - name: Print the merged dict
-          ansible.builtin.debug:
-            msg: "{{ merged_dict }}"
-
-        - name: Validate that the dict is complete
-          ansible.builtin.assert:
-            that:
-              - "(merged_dict.keys() | list | length) == 4"
-              - "'item1' in merged_dict"
-              - "'item3' in merged_dict"
               - "'list_item' in merged_dict"
               - "merged_dict.list_item | length == 2"

--- a/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
@@ -1,0 +1,44 @@
+---
+# Copyright (c) 2020, Thales Netherlands
+# Copyright (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Test merge_variables lookup plugin
+  hosts: test_group
+  gather_facts: false
+  tasks:
+    - name: Test merge dicts of same host, exclude matching variable of other host
+      delegate_to: localhost
+      vars:
+        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_ex', pattern_type='suffix', all_hosts=True) }}"
+      block:
+        - name: Print the merged dict
+          ansible.builtin.debug:
+            msg: "{{ merged_dict }}"
+
+        - name: Validate that the dict is complete
+          ansible.builtin.assert:
+            that:
+              - "(merged_dict.keys() | list | length) == 3"
+              - "'item1' in merged_dict"
+              - "'item2' in merged_dict"
+              - "'list_item' in merged_dict"
+              - "merged_dict.list_item | length == 2"
+    - name: Test merge dicts of same host, include matching variable of other host
+      delegate_to: localhost
+      vars:
+        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_in', pattern_type='suffix', all_hosts=True) }}"
+      block:
+        - name: Print the merged dict
+          ansible.builtin.debug:
+            msg: "{{ merged_dict }}"
+
+        - name: Validate that the dict is complete
+          ansible.builtin.assert:
+            that:
+              - "(merged_dict.keys() | list | length) == 4"
+              - "'item1' in merged_dict"
+              - "'item3' in merged_dict"
+              - "'list_item' in merged_dict"
+              - "merged_dict.list_item | length == 2"

--- a/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_all_hosts.yml
@@ -43,3 +43,22 @@
               - "'item2' in merged_dict"
               - "'list_item' in merged_dict"
               - "merged_dict.list_item | length == 2"
+    - name: Test merge dicts via two of three groups with inital value
+      delegate_to: localhost
+      vars:
+        initial_dict:
+          initial: initial_value
+        merged_dict: "{{ lookup('community.general.merge_variables', '__merge_dict_in', initial_value=initial_dict, pattern_type='suffix', groups=['dummy1', 'dummy2']) }}"
+      block:
+        - name: Test merge dicts via two of three groups with inital value - Print the merged dict
+          ansible.builtin.debug:
+            msg: "{{ merged_dict }}"
+
+        - name: Test merge dicts via two of three groups with inital value - Validate that the dict is complete
+          ansible.builtin.assert:
+            that:
+              - "(merged_dict.keys() | list | length) == 4"
+              - "'item1' in merged_dict"
+              - "'item2' in merged_dict"
+              - "'list_item' in merged_dict"
+              - "merged_dict.list_item | length == 2"

--- a/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
@@ -12,12 +12,13 @@ all:
         item1: value1
         list_item:
           - test1
+
       testdict2__merge_dict_ex:
         item2: value2
         list_item:
           - test2
 
-      testdict1__merge_dict_in:
+      testdict__merge_dict_in:
         item1: value1
         list_item:
           - test1
@@ -27,12 +28,13 @@ all:
         list_item:
           - test3
 
-      testdict3__merge_dict_in:
+      testdict__merge_dict_in:
         item2: value2
         list_item:
           - test2
+
     host3:
-      testdict3__merge_dict_in:
+      testdict__merge_dict_in:
         item3: value3
         list_item:
           - test3

--- a/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
@@ -6,6 +6,7 @@
 
 all:
   hosts:
+    host0:
     host1:
       testdict1__merge_dict_ex:
         item1: value1
@@ -27,11 +28,23 @@ all:
           - test3
 
       testdict3__merge_dict_in:
-        target_inventory_hostname: host1
+        item2: value2
+        list_item:
+          - test2
+    host3:
+      testdict3__merge_dict_in:
         item3: value3
         list_item:
           - test3
 
-test_group:
+dummy1:
   hosts:
     host1:
+
+dummy2:
+  hosts:
+    host2:
+
+dummy3:
+  hosts:
+    host3:

--- a/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_inventory_all_hosts.yml
@@ -1,0 +1,37 @@
+---
+# Copyright (c) 2020, Thales Netherlands
+# Copyright (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+all:
+  hosts:
+    host1:
+      testdict1__merge_dict_ex:
+        item1: value1
+        list_item:
+          - test1
+      testdict2__merge_dict_ex:
+        item2: value2
+        list_item:
+          - test2
+
+      testdict1__merge_dict_in:
+        item1: value1
+        list_item:
+          - test1
+    host2:
+      testdict3__merge_dict_ex:
+        item3: value3
+        list_item:
+          - test3
+
+      testdict3__merge_dict_in:
+        target_inventory_hostname: host1
+        item3: value3
+        list_item:
+          - test3
+
+test_group:
+  hosts:
+    host1:

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -24,7 +24,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         self.merge_vars_lookup = merge_variables.LookupModule(loader=self.loader, templar=self.templar)
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[['item1'], ['item3']])
     def test_merge_list(self, mock_set_options, mock_get_option, mock_template):
         results = self.merge_vars_lookup.run(['__merge_list'], {
@@ -36,7 +36,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         self.assertEqual(results, [['item1', 'item3']])
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[['initial_item'], 'ignore', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[['initial_item'], 'ignore', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[['item1'], ['item3']])
     def test_merge_list_with_initial_value(self, mock_set_options, mock_get_option, mock_template):
         results = self.merge_vars_lookup.run(['__merge_list'], {
@@ -48,7 +48,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         self.assertEqual(results, [['initial_item', 'item1', 'item3']])
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
                                                     {'item2': 'test', 'list_item': ['test2']}])
     def test_merge_dict(self, mock_set_options, mock_get_option, mock_template):
@@ -73,7 +73,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
 
     @patch.object(AnsiblePlugin, 'set_options')
     @patch.object(AnsiblePlugin, 'get_option', side_effect=[{'initial_item': 'random value', 'list_item': ['test0']},
-                                                            'ignore', 'suffix'])
+                                                            'ignore', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
                                                     {'item2': 'test', 'list_item': ['test2']}])
     def test_merge_dict_with_initial_value(self, mock_set_options, mock_get_option, mock_template):
@@ -98,7 +98,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         ])
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'warn', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'warn', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[{'item': 'value1'}, {'item': 'value2'}])
     @patch.object(Display, 'warning')
     def test_merge_dict_non_unique_warning(self, mock_set_options, mock_get_option, mock_template, mock_display):
@@ -111,7 +111,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         self.assertEqual(results, [{'item': 'value2'}])
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'error', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'error', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[{'item': 'value1'}, {'item': 'value2'}])
     def test_merge_dict_non_unique_error(self, mock_set_options, mock_get_option, mock_template):
         with self.assertRaises(AnsibleError):
@@ -121,7 +121,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
             })
 
     @patch.object(AnsiblePlugin, 'set_options')
-    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix'])
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', False, None])
     @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
                                                     ['item2', 'item3']])
     def test_merge_list_and_dict(self, mock_set_options, mock_get_option, mock_template):
@@ -133,3 +133,94 @@ class TestMergeVariablesLookup(unittest.TestCase):
                 },
                 'testdict__merge_var': ['item2', 'item3']
             })
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', True, None])
+    @patch.object(Templar, 'template', side_effect=[
+        {'var': [{'item1': 'value1', 'item2': 'value2'}]},
+        {'var': [{'item5': 'value5', 'item6': 'value6'}]},
+    ])
+    def test_merge_all_hosts_dict_implicit_target(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_var'], {
+            'inventory_hostname': 'host1',
+            'hostvars': {
+                'host1': {
+                    'inventory_hostname': 'host1',
+                    '1testlist__merge_var': {
+                        'var': [{'item1': 'value1', 'item2': 'value2'}]
+                    },
+                    '2otherlist__merge_var': {
+                        'var': [{'item5': 'value5', 'item6': 'value6'}]
+                    }
+                }
+            }
+        })
+
+        self.assertEqual(results, [
+            {'var': [
+                {'item1': 'value1', 'item2': 'value2'},
+                {'item5': 'value5', 'item6': 'value6'}
+            ]}
+        ])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', True, None])
+    @patch.object(Templar, 'template', side_effect=[
+        {'var': [{'item1': 'value1', 'item2': 'value2'}]},
+        {'var': [{'item5': 'value5', 'item6': 'value6'}]},
+    ])
+    def test_merge_all_hosts_dict_explicit_target(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_var'], {
+            'inventory_hostname': 'host1',
+            'hostvars': {
+                'host1': {
+                    'inventory_hostname': 'host1',
+                    '1testlist__merge_var': {
+                        'target_inventory_hostname': 'host1',
+                        'var': [{'item1': 'value1', 'item2': 'value2'}]
+                    },
+                    '2otherlist__merge_var': {
+                        'target_inventory_hostname': 'host1',
+                        'var': [{'item5': 'value5', 'item6': 'value6'}]
+                    }
+                }
+            }
+        })
+
+        self.assertEqual(results, [
+            {'var': [
+                {'item1': 'value1', 'item2': 'value2'},
+                {'item5': 'value5', 'item6': 'value6'}
+            ]}
+        ])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, 'ignore', 'suffix', True, 'target'])
+    @patch.object(Templar, 'template', side_effect=[
+        {'var': [{'item1': 'value1', 'item2': 'value2'}]},
+        {'var': [{'item5': 'value5', 'item6': 'value6'}]},
+    ])
+    def test_merge_all_hosts_dict_explicit_target_renamed(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_var'], {
+            'inventory_hostname': 'host1',
+            'hostvars': {
+                'host1': {
+                    'inventory_hostname': 'host1',
+                    '1testlist__merge_var': {
+                        'target': 'host1',
+                        'var': [{'item1': 'value1', 'item2': 'value2'}]
+                    },
+                    '2otherlist__merge_var': {
+                        'target': 'host1',
+                        'var': [{'item5': 'value5', 'item6': 'value6'}]
+                    }
+                }
+            }
+        })
+
+        self.assertEqual(results, [
+            {'var': [
+                {'item1': 'value1', 'item2': 'value2'},
+                {'item5': 'value5', 'item6': 'value6'}
+            ]}
+        ])

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -264,7 +264,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
                 'host1': {
                     'group_names': ['dummy1'],
                     'inventory_hostname': 'host1',
-                    '1testlist__merge_var': ['item1']                        
+                    '1testlist__merge_var': ['item1']
                 },
                 'host2': {
                     'group_names': ['dummy2'],

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -149,7 +149,6 @@ class TestMergeVariablesLookup(unittest.TestCase):
                     'inventory_hostname': 'host1',
                     '1testlist__merge_var': {
                         'var': [{'item1': 'value1', 'item2': 'value2'}]
-                        
                     }
                 },
                 'host2': {
@@ -184,7 +183,6 @@ class TestMergeVariablesLookup(unittest.TestCase):
                     'inventory_hostname': 'host1',
                     '1testlist__merge_var': {
                         'var': [{'item1': 'value1', 'item2': 'value2'}]
-                        
                     }
                 },
                 'host2': {
@@ -226,7 +224,6 @@ class TestMergeVariablesLookup(unittest.TestCase):
                     'inventory_hostname': 'host1',
                     '1testlist__merge_var': {
                         'var': [{'item1': 'value1', 'item2': 'value2'}]
-                        
                     }
                 },
                 'host2': {


### PR DESCRIPTION
##### SUMMARY

This modifies the lookup plugin merge_variables. It's adding an all_hosts mode which allows to merge variables which have their pieces distributed across multiple hosts.  
I would like to give an example where this is useful. Lets start with:

* A generic database host without any further database/user configuration deployed via a role that is also able to maintain databases, users etc.
* Another host running a web service which is using the database service running on the remote host

How could you provide the configuration for the service to the database? The current merge_variables lookup plugin does not help here, because it's limited to the variables of the same host.

###### Configuration options

* You could add the configuration directly to the database host.
  * Either as host_vars or via a custom group
  * You may have the information on database name, user, password redundantly
* You could use hostvars['<service_host>'] from the database host to access its variables
* You could kind of create your own semantic and create a group per service and collect configuration elements from all those groups like:
  * ```yaml
    # db1-host.yml

    _default_databases:
      - name: db1
        owner: db1owner
    pg_databases:
      "{{ 
        _default_databases + 
        _service_a_databases | default([]) +
        _service_b_databases | default([]) +
        .... 
      }}"


    # service-a-host.yml

    _service_a_databases:
      - name: srv_a_db
        owner: srv_a_owner
    ```

There may be other strategies to handle this, but this is what I did so far in my projects. In the end at scale they all turned out to be cumbersome and difficult to maintain, because I felt forced to hop around too much files.

###### Cross Host Configuration Discovery

With the extended lookup I can add the configuration for the database, user, etc. where I need it - which where the whole service configuration is defined. The database role will use the lookup to pick up the relevant pieces of that configuration and use it for the configuration of the database instance.

```yaml
  # db1-host.yml

  - name: Discover Database Configuration
    set_fact:
      pg_databases: "{{ (lookup('community.general.merge_variables', 'database_config__', pattern_type='prefix', all_hosts=True)).databases }}"

  # service-a-host
  database_config__service_a_databases:
    target_inventory_hostname: db1-host
    databases:
      - name: srv_a_db
        owner: srv_a_owner

  # service-a-host
  database_config__service_b_databases:
    target_inventory_hostname: db1-host
    databases:
      - name: srv_b_db
        owner: srv_b_owner
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/lookup/merge_variables

##### ADDITIONAL INFORMATION

To the existing merge_variables lookup I introduced two additional parameters:

* all_hosts - To run the lookup plugin in all hosts mode
* target_host_property 
  * This property is to indicate how the optional key is named that controls which hosts are allowed to pick up configuration pieces.
  * It's default value is 'target_inventory_hostname'.
  * If configuration pieces does not have this property set, those pieces are only allowed to be picked up by the same host, which is basically the behavior when all_hosts mode is turned off. But to avoid having two lookup invocations (same host with all_hosts = False, other hosts with all_hosts = True) I added this for convenience.

For the all_hosts mode I tried to reuse as much as possible of the existing code. The added unit tests are using the all_hosts mode, but in that context I didn't really found out how to test the added feature. Thus the idea of that unit tests is more to show that the extension didn't break something.

