### PR TITLE
puppet_utils: Do not force lang for cmd

### DIFF
--- a/changelogs/fragments/puppet_lang_force.yml
+++ b/changelogs/fragments/puppet_lang_force.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - puppet - add option ``environment_lang`` to set the environment language encoding. Defaults to lang ``C``. It is recommended
+     to set it to ``C.UTF-8`` or ``en_US.UTF-8`` depending on what is available on your system. (https://github.com/ansible-collections/community.general/issues/8000)

--- a/plugins/module_utils/puppet.py
+++ b/plugins/module_utils/puppet.py
@@ -107,5 +107,6 @@ def puppet_runner(module):
             verbose=cmd_runner_fmt.as_bool("--verbose"),
         ),
         check_rc=False,
+        force_lang=module.params["environment_lang"],
     )
     return runner

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -116,6 +116,15 @@ options:
       - Whether to print file changes details
     type: bool
     default: false
+  environment_lang:
+    description:
+      - The lang environment to use when running the puppet agent.
+      - The default value, V(C), is supported on every system, but can lead to encoding errors if UTF-8 is used in the output
+      - Use V(C.UTF-8) or V(en_US.UTF-8) or similar UTF-8 supporting locales in case of problems. You need to make sure
+        the selected locale is supported on the system the puppet agent runs on.
+    type: str
+    default: C
+    version_added: 8.6.0
 requirements:
 - puppet
 author:
@@ -208,6 +217,7 @@ def main():
             debug=dict(type='bool', default=False),
             verbose=dict(type='bool', default=False),
             use_srv_records=dict(type='bool'),
+            environment_lang=dict(type='str', default='C'),
         ),
         supports_check_mode=True,
         mutually_exclusive=[


### PR DESCRIPTION
##### SUMMARY
The shell environment used forces by default the lang to be "C". This can result that puppet fails with the error message `invalid byte sequence in US-ASCII`.

Fixes #8000

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
puppet
