### PR TITLE
modprobe: Avoid FileNotFoundError when directories don't exist.

### DIFF
--- a/changelogs/fragments/7717-prevent-modprobe-error.yml
+++ b/changelogs/fragments/7717-prevent-modprobe-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modprobe - Listing modules files or modprobe files could trigger a FileNotFoundError if /etc/modprobe.d or /etc/modules-load.d did not exist. Relevant functions now return empty lists if the directories do not exist. (https://github.com/ansible-collections/community.general/issues/7717).

--- a/changelogs/fragments/7717-prevent-modprobe-error.yml
+++ b/changelogs/fragments/7717-prevent-modprobe-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - modprobe - Listing modules files or modprobe files could trigger a FileNotFoundError if /etc/modprobe.d or /etc/modules-load.d did not exist. Relevant functions now return empty lists if the directories do not exist. (https://github.com/ansible-collections/community.general/issues/7717).
+  - modprobe - listing modules files or modprobe files could trigger a FileNotFoundError if ``/etc/modprobe.d`` or ``/etc/modules-load.d`` did not exist. Relevant functions now return empty lists if the directories do not exist to avoid crashing the module (https://github.com/ansible-collections/community.general/issues/7717).

--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -232,12 +232,16 @@ class Modprobe(object):
 
     @property
     def modules_files(self):
+        if not os.path.isdir(MODULES_LOAD_LOCATION):
+            return []
         modules_paths = [os.path.join(MODULES_LOAD_LOCATION, path)
                          for path in os.listdir(MODULES_LOAD_LOCATION)]
         return [path for path in modules_paths if os.path.isfile(path)]
 
     @property
     def modprobe_files(self):
+        if not os.path.isdir(PARAMETERS_FILES_LOCATION):
+            return []
         modules_paths = [os.path.join(PARAMETERS_FILES_LOCATION, path)
                          for path in os.listdir(PARAMETERS_FILES_LOCATION)]
         return [path for path in modules_paths if os.path.isfile(path)]


### PR DESCRIPTION
##### SUMMARY
Fixes #7717.

The error reported is as follows:

```
failed: [k8s07] (item=ip_vs_lc) => {"ansible_loop_var": "item", "changed": false, "item": "ip_vs_lc", "module_stderr": "Traceback (most recent call last):
  File \"<stdin>\", line 107, in <module>
  File \"<stdin>\", line 99, in _ansiballz_main
  File \"<stdin>\", line 47, in invoke_module
  File \"/opt/bin/pypy3/lib/pypy3.9/runpy.py\", line 213, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/opt/bin/pypy3/lib/pypy3.9/runpy.py\", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File \"/opt/bin/pypy3/lib/pypy3.9/runpy.py\", line 87, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 320, in <module>
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 312, in main
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 219, in load_module_permanent
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 148, in params_is_set
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 154, in permanent_params
  File \"/tmp/ansible_community.general.modprobe_payload_nper0d8d/ansible_community.general.modprobe_payload.zip/ansible_collections/community/general/plugins/modules/modprobe.py\", line 242, in modprobe_files
FileNotFoundError: [Errno 2] No such file or directory: '/etc/modprobe.d'
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```

Looking at `modprobe.py`, I saw the following:

```python
    @property
    def modules_files(self):
        modules_paths = [os.path.join(MODULES_LOAD_LOCATION, path)
                         for path in os.listdir(MODULES_LOAD_LOCATION)]
        return [path for path in modules_paths if os.path.isfile(path)]

    @property
    def modprobe_files(self):
        modules_paths = [os.path.join(PARAMETERS_FILES_LOCATION, path)
                         for path in os.listdir(PARAMETERS_FILES_LOCATION)]
        return [path for path in modules_paths if os.path.isfile(path)]
```

`os.listdir()` will throw a `FileNotFoundError` error if `MODULES_LOAD_LOCATION` and `PARAMETERS_FILES_LOCATION` do not exist. I believe, though, that it's consistent and reasonable and probably minimally harmful to simply return an empty list under these circumstances.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modprobe

##### ADDITIONAL INFORMATION
~Still gotta do the changelog fragment. I haven't forgotten though 🙂~ Changelog fragment added.

This is my first Ansible-related PR; please let me know what I can fix or improve.
