### PR TITLE
Correct apk docu to not include spaces in package name

### DIFF
--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -35,7 +35,7 @@ options:
     default: false
   name:
     description:
-      - A package name, like V(foo), or multiple packages, like V(foo, bar).
+      - A package name, like V(foo), or multiple packages, like V(foo,bar). Do not include additional whitespace when specifying multiple packages.
     type: list
     elements: str
   no_cache:

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -35,7 +35,9 @@ options:
     default: false
   name:
     description:
-      - A package name, like V(foo), or multiple packages, like V(foo,bar). Do not include additional whitespace when specifying multiple packages.
+      - A package name, like V(foo), or multiple packages, like V(foo,bar).
+      - Do not include additional whitespace when specifying multiple packages as a string.
+        Prefer YAML lists over comma-separating multiple package names.
     type: list
     elements: str
   no_cache:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible-collections/community.general/issues/7990

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
apk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

https://github.com/ansible-collections/community.general/issues/7990 encountered behavior, where apk was not idempotent. This was because they specified the packages to install as

```
name: "ca-certificates, less, ncurses-terminfo-base, krb5-libs, libgcc, libintl, libssl1.1, libstdc++, tzdata, userspace-rcu, zlib, icu-libs, tar"
```
which got parsed as:

```
    "invocation": {
        "module_args": {
            "available": false,
            "name": [
                "ca-certificates",
                " less",
                " ncurses-terminfo-base",
                " krb5-libs",
                " libgcc",
                " libintl",
                " libssl1.1",
                " libstdc++",
                " tzdata",
                " userspace-rcu",
                " zlib",
                " icu-libs",
                " tar"
            ],
            "no_cache": true,
            "repository": null,
            "state": "present",
            "update_cache": false,
            "upgrade": false,
            "world": "/etc/apk/world"
        }
    },
```

with an extra space in front of the package names, due to parsing the list by splitting on `,`. The docu currently suggests including whitespace when specifying a list like this, which will work, but not be idempotent, due to the regex on `/etc/apk/world` always failing. Thus this PR adjusts the docu accordingly.


Instead of this PR it'd also be possible to trim parsed package names in apk automatically. That would likely make for a better user experience, but could result in cases where the module doesn't do exactly as told. Then again though whitespace can never be part of a package name, can it?

 If trimming package names is the preferred solution here, I'd be happy to implement that instead.

<!--- Paste verbatim command output below, e.g. before and after your change -->
