### PR TITLE
feat(lookup/bitwarden): add support for fetching all items from a collection

### DIFF
--- a/changelogs/fragments/8013-bitwarden-full-collection-item-list.yaml
+++ b/changelogs/fragments/8013-bitwarden-full-collection-item-list.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "bitwarden lookup plugin - allows to fetch all records of a given collection ID, by allowing to pass an empty value for ``search_value`` when ``collection_id`` is provided (https://github.com/ansible-collections/community.general/pull/8013)."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

At the moment the lookup plugin allows to fetch items matching a mandatory search value.
It will be useful to retrieve the full item list for a given collection.

This PR allows to fetch all items of a given collection id, by letting `search_value` optional when `collection_id` is provided.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.bitwarden - lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- `bw` cli documentation: https://bitwarden.com/help/cli/#list

<!--- Paste verbatim command output below, e.g. before and after your change -->
