### PR TITLE
Fix check mode in iptables_state for incomplete iptables-save files along with integration tests

### DIFF
--- a/changelogs/fragments/8029-iptables-state-restore-check-mode.yml
+++ b/changelogs/fragments/8029-iptables-state-restore-check-mode.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - iptables_state - Fix idempotency issues when restoring incomplete iptables dumps and add target state as data structure to output (https://github.com/ansible-collections/community.general/issues/8029).
+  - iptables_state - fix idempotency issues when restoring incomplete iptables dumps (https://github.com/ansible-collections/community.general/issues/8029).

--- a/changelogs/fragments/8029-iptables-state-restore-check-mode.yml
+++ b/changelogs/fragments/8029-iptables-state-restore-check-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iptables_state - Fix idempotency issues when restoring incomplete iptables dumps and add target state as data structure to output (https://github.com/ansible-collections/community.general/issues/8029).

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -207,7 +207,9 @@ saved:
       "# Completed"
     ]
 tables:
-  description: The iptables we have interest for when module starts.
+  description: 
+    - The iptables on the system before the module has run, separated by table.
+    - If the option O(table) is used, only this table is included.
   type: dict
   contains:
     table:
@@ -233,6 +235,36 @@ tables:
       ]
     }
   returned: always
+tables_after:
+  description: 
+    - The iptables on the system after the module has run, separated by table.
+    - If the option O(table) is used, only this table is included.
+    - If the module fails and no changes are made, O(tables_after) will have the same content as O(tables)
+  type: dict
+  contains:
+    table:
+      description: Policies and rules for all chains of the named table.
+      type: list
+      elements: str
+  sample: |-
+    {
+      "filter": [
+        ":INPUT ACCEPT",
+        ":FORWARD ACCEPT",
+        ":OUTPUT ACCEPT",
+        "-A INPUT -i lo -j ACCEPT",
+        "-A INPUT -p icmp -j ACCEPT",
+        "-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT",
+        "-A INPUT -j REJECT --reject-with icmp-host-prohibited"
+      ],
+      "nat": [
+        ":PREROUTING ACCEPT",
+        ":INPUT ACCEPT",
+        ":OUTPUT ACCEPT",
+        ":POSTROUTING ACCEPT"
+      ]
+    }
+  returned: Only if O(state=restored)
 '''
 
 
@@ -550,6 +582,7 @@ def main():
                 stdout=stdout,
                 stderr=stderr,
                 tables=tables_before,
+                tables_after=tables_before,
                 initial_state=initial_state,
                 restored=state_to_restore,
                 applied=False)
@@ -584,6 +617,7 @@ def main():
                 stdout=stdout,
                 stderr=stderr,
                 tables=tables_before,
+                tables_after=tables_before,
                 initial_state=initial_state,
                 restored=state_to_restore,
                 applied=False)

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -592,7 +592,7 @@ def main():
         restored_state = filter_and_format_state(stdout)
 
     if restored_state not in (initref_state, initial_state):
-        tables_after = parse_per_table_state(restored_state.join('\n'))
+        tables_after = parse_per_table_state('\n'.join(restored_state))
         for table_after in tables_after:
             if table_after not in tables_before:
                 changed = True

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -592,10 +592,16 @@ def main():
         restored_state = filter_and_format_state(stdout)
     tables_after = parse_per_table_state('\n'.join(restored_state))
     if restored_state not in (initref_state, initial_state):
-        for table_after in tables_after:
-            if table_after not in tables_before:
+        for table_name, table_content in tables_after.items():
+            if table_name not in tables_before:
+                # Would initialize a table, which doesn't exist yet
                 changed = True
                 break
+            if tables_before[table_name] != table_content:
+                # Content of some table changes
+                changed = True
+                break
+            
 
     if _back is None or module.check_mode:
         module.exit_json(

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -601,7 +601,6 @@ def main():
                 # Content of some table changes
                 changed = True
                 break
-            
 
     if _back is None or module.check_mode:
         module.exit_json(

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -592,7 +592,7 @@ def main():
         restored_state = filter_and_format_state(stdout)
 
     if restored_state not in (initref_state, initial_state):
-        tables_after = parse_per_table_state(state_to_restore)
+        tables_after = parse_per_table_state(restored_state.join('\n'))
         for table_after in tables_after:
             if table_after not in tables_before:
                 changed = True

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -585,12 +585,9 @@ def main():
         restored_state = filter_and_format_state(stdout)
 
     if restored_state not in (initref_state, initial_state):
-        if module.check_mode:
+        tables_after = per_table_state(SAVECOMMAND, stdout)
+        if tables_after != tables_before:
             changed = True
-        else:
-            tables_after = per_table_state(SAVECOMMAND, stdout)
-            if tables_after != tables_before:
-                changed = True
 
     if _back is None or module.check_mode:
         module.exit_json(

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -589,13 +589,14 @@ def main():
         for table_after in tables_after:
             if table_after not in tables_before:
                 changed = True
-                break 
+                break
 
     if _back is None or module.check_mode:
         module.exit_json(
             changed=changed,
             cmd=cmd,
             tables=tables_before,
+            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -353,18 +353,19 @@ def parse_per_table_state(all_states_dump):
     '''
     lines = filter_and_format_state(all_states_dump)
     tables = dict()
-    current_table=''
-    current_list=list()
+    current_table = ''
+    current_list = list()
     for line in lines:
         if re.match(r'^[*](filter|mangle|nat|raw|security)$'):
-            current_table = line[1:] 
+            current_table = line[1:]
             continue
         if line == 'COMMIT':
-            tables[current_table] = current_list 
+            tables[current_table] = current_list
             current_table = ''
             current_list = list()
             continue
         current_list.append(line)
+    return tables
 
 
 def main():

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -364,6 +364,8 @@ def parse_per_table_state(all_states_dump):
             current_table = ''
             current_list = list()
             continue
+        if line.startswith('# '):
+            continue
         current_list.append(line)
     return tables
 
@@ -590,7 +592,7 @@ def main():
         restored_state = filter_and_format_state(stdout)
 
     if restored_state not in (initref_state, initial_state):
-        tables_after = parse_per_table_state(restored_state)
+        tables_after = parse_per_table_state(state_to_restore)
         for table_after in tables_after:
             if table_after not in tables_before:
                 changed = True

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -601,7 +601,6 @@ def main():
             changed=changed,
             cmd=cmd,
             tables=tables_before,
-            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -356,7 +356,7 @@ def parse_per_table_state(all_states_dump):
     current_table = ''
     current_list = list()
     for line in lines:
-        if re.match(r'^[*](filter|mangle|nat|raw|security)$'):
+        if re.match(r'^[*](filter|mangle|nat|raw|security)$', line):
             current_table = line[1:]
             continue
         if line == 'COMMIT':

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -590,9 +590,8 @@ def main():
 
         (rc, stdout, stderr) = module.run_command(SAVECOMMAND, check_rc=True)
         restored_state = filter_and_format_state(stdout)
-
+    tables_after = parse_per_table_state('\n'.join(restored_state))
     if restored_state not in (initref_state, initial_state):
-        tables_after = parse_per_table_state('\n'.join(restored_state))
         for table_after in tables_after:
             if table_after not in tables_before:
                 changed = True
@@ -603,6 +602,7 @@ def main():
             changed=changed,
             cmd=cmd,
             tables=tables_before,
+            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)
@@ -628,6 +628,7 @@ def main():
             changed=changed,
             cmd=cmd,
             tables=tables_before,
+            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)
@@ -651,6 +652,7 @@ def main():
         msg=msg,
         cmd=cmd,
         tables=tables_before,
+        tables_after=tables_after,
         initial_state=initial_state,
         restored=restored_state,
         applied=False)

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -235,36 +235,6 @@ tables:
       ]
     }
   returned: always
-tables_after:
-  description:
-    - The iptables on the system after the module has run, separated by table.
-    - If the option table is used, only this table is included.
-    - If the module fails and no changes are made, tables_after will have the same content as tables
-  type: dict
-  contains:
-    table:
-      description: Policies and rules for all chains of the named table.
-      type: list
-      elements: str
-  sample: |-
-    {
-      "filter": [
-        ":INPUT ACCEPT",
-        ":FORWARD ACCEPT",
-        ":OUTPUT ACCEPT",
-        "-A INPUT -i lo -j ACCEPT",
-        "-A INPUT -p icmp -j ACCEPT",
-        "-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT",
-        "-A INPUT -j REJECT --reject-with icmp-host-prohibited"
-      ],
-      "nat": [
-        ":PREROUTING ACCEPT",
-        ":INPUT ACCEPT",
-        ":OUTPUT ACCEPT",
-        ":POSTROUTING ACCEPT"
-      ]
-    }
-  returned: Only if O(state=restored)
 '''
 
 
@@ -582,7 +552,6 @@ def main():
                 stdout=stdout,
                 stderr=stderr,
                 tables=tables_before,
-                tables_after=tables_before,
                 initial_state=initial_state,
                 restored=state_to_restore,
                 applied=False)
@@ -617,7 +586,6 @@ def main():
                 stdout=stdout,
                 stderr=stderr,
                 tables=tables_before,
-                tables_after=tables_before,
                 initial_state=initial_state,
                 restored=state_to_restore,
                 applied=False)
@@ -641,7 +609,6 @@ def main():
             changed=changed,
             cmd=cmd,
             tables=tables_before,
-            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)
@@ -667,7 +634,6 @@ def main():
             changed=changed,
             cmd=cmd,
             tables=tables_before,
-            tables_after=tables_after,
             initial_state=initial_state,
             restored=restored_state,
             applied=True)
@@ -691,7 +657,6 @@ def main():
         msg=msg,
         cmd=cmd,
         tables=tables_before,
-        tables_after=tables_after,
         initial_state=initial_state,
         restored=restored_state,
         applied=False)

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -586,8 +586,10 @@ def main():
 
     if restored_state not in (initref_state, initial_state):
         tables_after = per_table_state(SAVECOMMAND, stdout)
-        if tables_after != tables_before:
-            changed = True
+        for table_after in tables_after:
+            if table_after not in tables_before:
+                changed = True
+                break 
 
     if _back is None or module.check_mode:
         module.exit_json(

--- a/plugins/modules/iptables_state.py
+++ b/plugins/modules/iptables_state.py
@@ -207,7 +207,7 @@ saved:
       "# Completed"
     ]
 tables:
-  description: 
+  description:
     - The iptables on the system before the module has run, separated by table.
     - If the option O(table) is used, only this table is included.
   type: dict
@@ -236,10 +236,10 @@ tables:
     }
   returned: always
 tables_after:
-  description: 
+  description:
     - The iptables on the system after the module has run, separated by table.
-    - If the option O(table) is used, only this table is included.
-    - If the module fails and no changes are made, O(tables_after) will have the same content as O(tables)
+    - If the option table is used, only this table is included.
+    - If the module fails and no changes are made, tables_after will have the same content as tables
   type: dict
   contains:
     table:

--- a/tests/integration/targets/iptables_state/tasks/main.yml
+++ b/tests/integration/targets/iptables_state/tasks/main.yml
@@ -29,6 +29,12 @@
       when:
         - xtables_lock is undefined
 
+    - name: include tasks to test partial restore files
+      include_tasks: tests/02-partial-restore.yml
+      when:
+        - xtables_lock is undefined
+
+
     - name: include tasks to test rollbacks
       include_tasks: tests/10-rollback.yml
       when:

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -1,0 +1,53 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: "create initial rule set to use"
+  copy:
+    dest: "{{ iptables_tests }}"
+    content: |
+      *filter
+      :INPUT ACCEPT [0:0]
+      -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
+      COMMIT
+      *nat
+      :POSTROUTING ACCEPT [151:17304]
+      -A POSTROUTING -o eth0 -j MASQUERADE
+
+- name: "Restore initial state"
+  iptables_state:
+    path: "{{ iptables_tests }}"
+    state: restored
+
+- name: "create partial ruleset only specifying input"
+  copy:
+    dest: "{{ iptables_tests }}"
+    content: |
+      *filter
+      :INPUT ACCEPT [0:0]
+      -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
+      COMMIT
+
+- name: "Restore initial state"
+  iptables_state:
+    path: "{{ iptables_tests }}"
+    state: restored
+  check_mode: true
+  register: iptables_state
+
+- name: "assert that no changed are detected in check mode"
+  assert:
+    that:
+      - iptables_state is not changed
+
+- name: "Restore initial state"
+  iptables_state:
+    path: "{{ iptables_tests }}"
+    state: restored
+  register: iptables_state
+
+- name: "assert that no changed are made"
+  assert:
+    that:
+      - iptables_state is not changed

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -9,9 +9,14 @@
     content: |
       *filter
       :INPUT ACCEPT [0:0]
+      :OUTPUT ACCEPT [0:0]
+      :FORWARD ACCEPT [0:0]
       -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
       COMMIT
       *nat
+      :PREROUTING ACCEPT [151:17304]
+      :INPUT ACCEPT [151:17304]
+      :OUTPUT ACCEPT [151:17304]
       :POSTROUTING ACCEPT [151:17304]
       -A POSTROUTING -o eth0 -j MASQUERADE
       COMMIT
@@ -29,6 +34,8 @@
     content: |
       *filter
       :INPUT ACCEPT [0:0]
+      :OUTPUT ACCEPT [0:0]
+      :FORWARD ACCEPT [0:0]
       -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
       COMMIT
 

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: "create initial rule set to use"
+- name: "Create initial rule set to use"
   copy:
     dest: "{{ iptables_tests }}"
     content: |
@@ -19,8 +19,10 @@
   iptables_state:
     path: "{{ iptables_tests }}"
     state: restored
+  async: "{{ ansible_timeout }}"
+  poll: 0
 
-- name: "create partial ruleset only specifying input"
+- name: "Create partial ruleset only specifying input"
   copy:
     dest: "{{ iptables_tests }}"
     content: |
@@ -29,25 +31,30 @@
       -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
       COMMIT
 
-- name: "Restore initial state"
+- name: "Check restoring partial state"
   iptables_state:
     path: "{{ iptables_tests }}"
     state: restored
   check_mode: true
+  async: "{{ ansible_timeout }}"
+  poll: 0
   register: iptables_state
 
-- name: "assert that no changed are detected in check mode"
+
+- name: "assert that no changes are detected in check mode"
   assert:
     that:
       - iptables_state is not changed
 
-- name: "Restore initial state"
+- name: "Restore partial state"
   iptables_state:
     path: "{{ iptables_tests }}"
     state: restored
   register: iptables_state
+  async: "{{ ansible_timeout }}"
+  poll: 0
 
-- name: "assert that no changed are made"
+- name: "assert that no changes are made"
   assert:
     that:
       - iptables_state is not changed

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -9,8 +9,8 @@
     content: |
       *filter
       :INPUT ACCEPT [0:0]
-      :OUTPUT ACCEPT [0:0]
       :FORWARD ACCEPT [0:0]
+      :OUTPUT ACCEPT [0:0]
       -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
       COMMIT
       *nat
@@ -34,8 +34,8 @@
     content: |
       *filter
       :INPUT ACCEPT [0:0]
-      :OUTPUT ACCEPT [0:0]
       :FORWARD ACCEPT [0:0]
+      :OUTPUT ACCEPT [0:0]
       -A INPUT -m state --state NEW,ESTABLISHED -j ACCEPT
       COMMIT
 

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -14,6 +14,7 @@
       *nat
       :POSTROUTING ACCEPT [151:17304]
       -A POSTROUTING -o eth0 -j MASQUERADE
+      COMMIT
 
 - name: "Restore initial state"
   iptables_state:

--- a/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
+++ b/tests/integration/targets/iptables_state/tasks/tests/02-partial-restore.yml
@@ -37,8 +37,6 @@
     path: "{{ iptables_tests }}"
     state: restored
   check_mode: true
-  async: "{{ ansible_timeout }}"
-  poll: 0
   register: iptables_state
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes https://github.com/ansible-collections/community.general/issues/7463

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes.   Bugfix Pull Request -->

- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

iptables_state

##### ADDITIONAL INFORMATION

This PR first attempted to reproduce the behavior observed in https://github.com/ansible-collections/community.general/issues/7463 through integration tests. iptables-save doesn't work in docker, so this was tested against the azure pipeline through this PR, please excuse the commit spam.

https://github.com/ansible-collections/community.general/commit/a58bc16f2fb9ef4e5e60346abad4474db6d4933a was able reproduce the issue in https://github.com/ansible-collections/community.general/issues/7463 based on incomplete iptables-save files. Initially, all tables are empty and uninitialized, which will make iptables-save return nothing for them.

For example when creating a nat rule and then deleting it, an output of iptables-save may look like this:

```
        "*filter",
        ":INPUT ACCEPT [0:0]",
        ":FORWARD DROP [0:0]",
        ":OUTPUT ACCEPT [0:0]",
        "COMMIT",
        "*nat",
        ":PREROUTING ACCEPT [0:0]",
        ":INPUT ACCEPT [0:0]",
        ":OUTPUT ACCEPT [0:0]",
        ":POSTROUTING ACCEPT [0:0]",
        "COMMIT",
```
while one on a new container/machine which has never had a nat rule will look like this:

```
        "*filter",
        ":INPUT ACCEPT [0:0]",
        ":FORWARD DROP [0:0]",
        ":OUTPUT ACCEPT [0:0]",
        "COMMIT",
```

This broke the existing check_mode checks, which did simple string comparison. Most likely there were also edge cases outside of check mode in regards to uninitialized tables of existing iptables-save dumps, which would report changes when restoring them, despite nothing changing. This is only the case for iptables-save files created through means other than this module.

To circument this I implemented parsing of iptables-save dumps into a simple data structure based on preexisting code.  If a table currently has some kind of state (including rules) but is not referenced in the iptables-save dump, it will not be touched by iptables-restore and now handled properly by this module.

I also added the tables `tables_after` after restoring as a data structure, similar to the already existing state `tables` before running the module

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

