### PR TITLE
modprobe: create /etc/modprobe.d and /etc/modules-load.d if they don't exist.

### DIFF
--- a/changelogs/fragments/7717-modprobe-check-before-persist.yml
+++ b/changelogs/fragments/7717-modprobe-check-before-persist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modprobe - persisting modules files or modprobe files could trigger a FileNotFoundError if ``/etc/modprobe.d`` or ``/etc/modules-load.d`` did not exist. Relevant functions now create the directories if they not exist to avoid crashing the module (https://github.com/ansible-collections/community.general/issues/7717).

--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -161,6 +161,8 @@ class Modprobe(object):
         return params
 
     def create_module_file(self):
+        if not os.path.exists(MODULES_LOAD_LOCATION):
+            os.makedirs(MODULES_LOAD_LOCATION, exist_ok=True)
         file_path = os.path.join(MODULES_LOAD_LOCATION,
                                  self.name + '.conf')
         with open(file_path, 'w') as file:
@@ -173,6 +175,8 @@ class Modprobe(object):
         return '\n'.join(file_content) + '\n'
 
     def create_module_options_file(self):
+        if not os.path.exists(PARAMETERS_FILES_LOCATION):
+            os.makedirs(PARAMETERS_FILES_LOCATION, exist_ok=True)
         new_file_path = os.path.join(PARAMETERS_FILES_LOCATION,
                                      self.name + '.conf')
         with open(new_file_path, 'w') as file:

--- a/plugins/modules/modprobe.py
+++ b/plugins/modules/modprobe.py
@@ -160,9 +160,17 @@ class Modprobe(object):
 
         return params
 
+    def ensure_directory_exists(self, directory):
+        if not os.path.exists(directory):
+            # exist_ok is not available in python 2.7
+            try:
+                os.makedirs(directory)
+            except OSError as e:
+                if e.errno != os.errno.EEXIST:
+                    raise
+
     def create_module_file(self):
-        if not os.path.exists(MODULES_LOAD_LOCATION):
-            os.makedirs(MODULES_LOAD_LOCATION, exist_ok=True)
+        self.ensure_directory_exists(MODULES_LOAD_LOCATION)
         file_path = os.path.join(MODULES_LOAD_LOCATION,
                                  self.name + '.conf')
         with open(file_path, 'w') as file:
@@ -175,8 +183,7 @@ class Modprobe(object):
         return '\n'.join(file_content) + '\n'
 
     def create_module_options_file(self):
-        if not os.path.exists(PARAMETERS_FILES_LOCATION):
-            os.makedirs(PARAMETERS_FILES_LOCATION, exist_ok=True)
+        self.ensure_directory_exists(PARAMETERS_FILES_LOCATION)
         new_file_path = os.path.join(PARAMETERS_FILES_LOCATION,
                                      self.name + '.conf')
         with open(new_file_path, 'w') as file:


### PR DESCRIPTION
##### SUMMARY
See #7717. This is a followup to #8005, which addressed one part of the problem but not the other.

As pointed out [here](https://github.com/ansible-collections/community.general/pull/8005#issuecomment-1962887147), #8005 did not fully fix the problem with persisting modules.

It's a little more difficult to find a best path forward with this part of the problem. 

Briefly, #8005 makes it safe to list files in `/etc/modules-load.d` and `/etc/modprobe.d`, if the directories do not exist, by simply returning empty lists. 

Whether we should attempt to create these directories if they do not exist when directed to persist modules seems a bit ambiguous to me. The directories may not exist because, for instance, someone is executing from a Mac and accidentally ran a task against `localhost`. My understanding is that `/etc/modules-load.d` is a `systemd` artifact and so creating the directory on a `sysvinit` system might mislead the user.

The documentation currently includes the following line:

>Note: This option works only with distributions that use `systemd` when set to values other than `disabled`.

So perhaps that's not an issue.

I don't really have strong feelings about this 🙂 but wanted to flag this for discussion.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modprobe

##### ADDITIONAL INFORMATION
I'm kind of an idiot; please don't hesitate to suggest improvements.

I thought about adding test coverage for the module, but I believe it would require more substantial rewriting and I'm not very experienced with automated testing in Python. I was thinking create a temporary directory, persist some modules with and without preexisting directories, etc etc etc. I can do the work but I'd open a separate ticket.

**EDIT**: It looks like this might not work as written:

in Python 3:

```
>           mkdir(name, mode)
E           PermissionError: [Errno 13] Permission denied: '/etc/modprobe.d'
```

So I'll need to revisit (after work 🙂).