### PR TITLE
Added startup configuration option

### DIFF
--- a/changelogs/fragments/8038-proxmox-startup.yml
+++ b/changelogs/fragments/8038-proxmox-startup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox - adds ``startup`` parameters to configure startup order, startup delay and shutdown delay. (https://github.com/ansible-collections/community.general/pull/8038).

--- a/changelogs/fragments/8038-proxmox-startup.yml
+++ b/changelogs/fragments/8038-proxmox-startup.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - proxmox - adds ``startup`` parameters to configure startup order, startup delay and shutdown delay. (https://github.com/ansible-collections/community.general/pull/8038).
+  - proxmox - adds ``startup`` parameters to configure startup order, startup delay and shutdown delay (https://github.com/ansible-collections/community.general/pull/8038).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -81,6 +81,14 @@ options:
     type: list
     elements: str
     version_added: 2.0.0
+  startup:
+    description:
+      - Specifies the startup order of the container.
+      - order=# - where # is a non-negative number defining the general startup order. Shutdown in done with reverse ordering. 
+      - up=# - where # is in seconds, which specifies a delay to wait before the next VM is started 
+      - down=# - where # is in seconds, which specifies a delay to wait before the next VM is stopped.
+    type: list
+    elements: str
   mounts:
     description:
       - specifies additional mounts (separate disks) for the container. As a hash/dictionary defining mount points
@@ -761,6 +769,7 @@ def main():
         ]),
         onboot=dict(type='bool'),
         features=dict(type='list', elements='str'),
+        startup=dict(type='list', elements='str'),
         storage=dict(default='local'),
         cpuunits=dict(type='int'),
         nameserver=dict(),
@@ -859,6 +868,9 @@ def main():
                                               features=",".join(module.params["features"])
                                               if module.params["features"] is not None
                                               else None,
+                                              startup=",".join(module.params["startup"])
+                                              if module.params["startup"] is not None
+                                              else None,
                                               description=module.params["description"],
                                               hookscript=module.params["hookscript"],
                                               timezone=module.params["timezone"],
@@ -912,6 +924,7 @@ def main():
                                     force=ansible_to_proxmox_bool(module.params['force']),
                                     pubkey=module.params['pubkey'],
                                     features=",".join(module.params['features']) if module.params['features'] is not None else None,
+                                    startup=",".join(module.params['startup']) if module.params['startup'] is not None else None,
                                     unprivileged=ansible_to_proxmox_bool(module.params['unprivileged']),
                                     description=module.params['description'],
                                     hookscript=module.params['hookscript'],

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -89,6 +89,7 @@ options:
       - Use C(down=#) where C(#) is in seconds, to specify a delay to wait before the next VM is stopped.
     type: list
     elements: str
+    version_added: 8.5.0
   mounts:
     description:
       - specifies additional mounts (separate disks) for the container. As a hash/dictionary defining mount points

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -84,8 +84,8 @@ options:
   startup:
     description:
       - Specifies the startup order of the container.
-      - order=# - where # is a non-negative number defining the general startup order. Shutdown in done with reverse ordering. 
-      - up=# - where # is in seconds, which specifies a delay to wait before the next VM is started 
+      - order=# - where # is a non-negative number defining the general startup order. Shutdown in done with reverse ordering.
+      - up=# - where # is in seconds, which specifies a delay to wait before the next VM is started.
       - down=# - where # is in seconds, which specifies a delay to wait before the next VM is stopped.
     type: list
     elements: str

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -84,9 +84,9 @@ options:
   startup:
     description:
       - Specifies the startup order of the container.
-      - order=# - where # is a non-negative number defining the general startup order. Shutdown in done with reverse ordering.
-      - up=# - where # is in seconds, which specifies a delay to wait before the next VM is started.
-      - down=# - where # is in seconds, which specifies a delay to wait before the next VM is stopped.
+      - Use C(order=#) where C(#) is a non-negative number to define the general startup order. Shutdown in done with reverse ordering.
+      - Use C(up=#) where C(#) is in seconds, to specify a delay to wait before the next VM is started.
+      - Use C(down=#) where C(#) is in seconds, to specify a delay to wait before the next VM is stopped.
     type: list
     elements: str
   mounts:


### PR DESCRIPTION
##### SUMMARY
Currently all containers that are created using this module start at the same time at system boot. In order to be able to reflect service dependencies and spread initial startup load proxmox supports the configuration of a startup parameter. This pull request adds the option to configure startup behavior of lxc containers. It works well in conjunction with onboot and allows to set startup order, startup delay and shutdown delay.

Changelog Fragment
  - proxmox - adds ``startup`` parameters for configuring startup order, startup delay and shutdown delay.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox

##### ADDITIONAL INFORMATION
```
sample usage:
startup: 
      - order=10
      - up=50
      - down=20
    
```
