### PR TITLE
fix(homebrew): give correct error message when become true used

### DIFF
--- a/changelogs/fragments/8048-fix-homebrew-module-error-reporting-on-become-true.yaml
+++ b/changelogs/fragments/8048-fix-homebrew-module-error-reporting-on-become-true.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - error returned from brew command was ignored and tried to parse empty JSON. Fix now checks for an error and raises it to give accurate error message to users (https://github.com/ansible-collections/community.general/issues/8047).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -488,6 +488,10 @@ class Homebrew(object):
             self.current_package,
         ]
         rc, out, err = self.module.run_command(cmd)
+        if err:
+            self.failed = True
+            self.message = err.strip()
+            raise HomebrewException(self.message)
         data = json.loads(out)
 
         return _check_package_in_json(data, "formulae") or _check_package_in_json(data, "casks")


### PR DESCRIPTION
##### SUMMARY
Fixes #8047, where using `become: true` with homebrew would not give a useful error message, by raising the error thrown by brew command.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
homebrew

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
###### dev.yaml
```yaml
- hosts: localhost
  become: true
  tasks:
    - name: Install Git
      community.general.homebrew:
        name: git
        state: present
    - name: Install ZSH
      community.general.homebrew:
        name: zsh
        state: present
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Before
```console
% sudo ansible-playbook dev.yaml -e 'ansible_python_interpreter=/opt/homebrew/bin/python3.10'
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] **********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Install Git] ********************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/var/root/.ansible/tmp/ansible-tmp-1709159481.450751-75442-19469324576457/AnsiballZ_homebrew.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/var/root/.ansible/tmp/ansible-tmp-1709159481.450751-75442-19469324576457/AnsiballZ_homebrew.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/var/root/.ansible/tmp/ansible-tmp-1709159481.450751-75442-19469324576457/AnsiballZ_homebrew.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.general.plugins.modules.homebrew', init_globals=dict(_module_fqn='ansible_collections.community.general.plugins.modules.homebrew', _modlib_path=modlib_path),\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 986, in <module>\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 971, in main\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 464, in run\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 541, in _run\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 657, in _install_packages\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 615, in _install_current_package\n  File \"/tmp/ansible_community.general.homebrew_payload_2r9s6y84/ansible_community.general.homebrew_payload.zip/ansible_collections/community/general/plugins/modules/homebrew.py\", line 496, in _current_package_is_installed\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py\", line 346, in loads\n    return _default_decoder.decode(s)\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py\", line 337, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n  File \"/opt/homebrew/Cellar/python@3.10/3.10.13_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py\", line 355, in raw_decode\n    raise JSONDecodeError(\"Expecting value\", s, err.value) from None\njson.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP ****************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```

###### After
```console
% sudo ansible-playbook dev.yaml -e 'ansible_python_interpreter=/opt/homebrew/bin/python3.10'
Password:
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] **********************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Install Git] ********************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error: Running Homebrew as root is extremely dangerous and no longer supported.\nAs Homebrew does not drop privileges on installation you would be giving all\nbuild scripts full access to your system."}

PLAY RECAP ****************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```
