### PR TITLE
Aix filesystem crfs issue

### DIFF
--- a/changelogs/fragments/aix_filesystem-crfs-issue.yml
+++ b/changelogs/fragments/aix_filesystem-crfs-issue.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - aix_filesystem - fix issue with empty list items in crfs logic and option order

--- a/changelogs/fragments/aix_filesystem-crfs-issue.yml
+++ b/changelogs/fragments/aix_filesystem-crfs-issue.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - aix_filesystem - fix issue with empty list items in crfs logic and option order
+  - aix_filesystem - fix issue with empty list items in crfs logic and option order (https://github.com/ansible-collections/community.general/pull/8052).

--- a/plugins/modules/aix_filesystem.py
+++ b/plugins/modules/aix_filesystem.py
@@ -366,46 +366,46 @@ def create_fs(
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
             cmd = [crfs_cmd]
-          
+
             cmd.append("-v")
             cmd.append(fs_type)
- 
+
             if vg:
                 (flag, value) = vg.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             if device:
                 (flag, value) = device.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             cmd.append("-m")
             cmd.append(filesystem)
- 
+
             if mount_group:
                 (flag, value) = mount_group.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             if auto_mount:
                 (flag, value) = auto_mount.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             if account_subsystem:
                 (flag, value) = account_subsystem.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             cmd.append("-p")
             cmd.append(permissions)
- 
+
             if size:
                 (flag, value) = size.split()
                 cmd.append(flag)
                 cmd.append(value)
- 
+
             if attributes:
                 splitted_attributes = attributes.split()
                 cmd.append("-a")

--- a/plugins/modules/aix_filesystem.py
+++ b/plugins/modules/aix_filesystem.py
@@ -365,7 +365,28 @@ def create_fs(
         # Creates a LVM file system.
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
-            cmd = [crfs_cmd, "-v", fs_type, "-m", filesystem, vg, device, mount_group, auto_mount, account_subsystem, "-p", permissions, size, "-a", attributes]
+            cmd = [ crfs_cmd ]
+            cmd.append("-v")
+            cmd.append(fs_type)
+            if device:
+                cmd.append(device)
+            cmd.append("-m")
+            cmd.append(filesystem)
+            if vg:
+                cmd.append(vg)
+            if mount_group:
+                cmd.append(mount_group)
+            if auto_mount:
+                cmd.append(automount)
+            if account_subsystem:
+                cmd.append(account_subsystem)
+            cmd.append("-p")
+            cmd.append(permissions)
+            if size:
+                cmd.append(size)
+            if attributes:
+                cmd.append(attributes)
+
             rc, crfs_out, err = module.run_command(cmd)
 
             if rc == 10:

--- a/plugins/modules/aix_filesystem.py
+++ b/plugins/modules/aix_filesystem.py
@@ -366,26 +366,51 @@ def create_fs(
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
             cmd = [crfs_cmd]
+          
             cmd.append("-v")
             cmd.append(fs_type)
+ 
+            if vg:
+                (flag, value) = vg.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             if device:
-                cmd.append(device)
+                (flag, value) = device.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             cmd.append("-m")
             cmd.append(filesystem)
-            if vg:
-                cmd.append(vg)
+ 
             if mount_group:
-                cmd.append(mount_group)
+                (flag, value) = mount_group.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             if auto_mount:
-                cmd.append(auto_mount)
+                (flag, value) = auto_mount.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             if account_subsystem:
-                cmd.append(account_subsystem)
+                (flag, value) = account_subsystem.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             cmd.append("-p")
             cmd.append(permissions)
+ 
             if size:
-                cmd.append(size)
+                (flag, value) = size.split()
+                cmd.append(flag)
+                cmd.append(value)
+ 
             if attributes:
-                cmd.append(attributes)
+                splitted_attributes = attributes.split()
+                cmd.append("-a")
+                for value in splitted_attributes:
+                    cmd.append(value)
 
             rc, crfs_out, err = module.run_command(cmd)
 
@@ -482,7 +507,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             account_subsystem=dict(type='bool', default=False),
-            attributes=dict(type='list', elements='str', default=["agblksize='4096'", "isnapshot='no'"]),
+            attributes=dict(type='list', elements='str', default=["agblksize=4096", "isnapshot=no"]),
             auto_mount=dict(type='bool', default=True),
             device=dict(type='str'),
             filesystem=dict(type='str', required=True),

--- a/plugins/modules/aix_filesystem.py
+++ b/plugins/modules/aix_filesystem.py
@@ -38,8 +38,8 @@ options:
     type: list
     elements: str
     default:
-      - agblksize='4096'
-      - isnapshot='no'
+      - agblksize=4096
+      - isnapshot=no
   auto_mount:
     description:
       - File system is automatically mounted at system restart.

--- a/plugins/modules/aix_filesystem.py
+++ b/plugins/modules/aix_filesystem.py
@@ -365,7 +365,7 @@ def create_fs(
         # Creates a LVM file system.
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
-            cmd = [ crfs_cmd ]
+            cmd = [crfs_cmd]
             cmd.append("-v")
             cmd.append(fs_type)
             if device:
@@ -377,7 +377,7 @@ def create_fs(
             if mount_group:
                 cmd.append(mount_group)
             if auto_mount:
-                cmd.append(automount)
+                cmd.append(auto_mount)
             if account_subsystem:
                 cmd.append(account_subsystem)
             cmd.append("-p")


### PR DESCRIPTION
Change the crfs logic and fields, since empty options and order seem to be an issue.

this quick fix seems to solve it

##### SUMMARY
Empty fields seem to cause an issue with the crfs command. Also the -d device tag needs to be the second flag.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_filesystem

##### ADDITIONAL INFORMATION
The aix_filesystem crfs was giving this error:
``` json
    "stderr": "Usage: crfs -v Vfs {-g Volumegroup | -d Device} -m Mountpoint\n\t[-u Mountgroup] [-A {yes|no}] [-t {yes|no}] [-p {ro|rw}]\n \t[-l Logpartitions] [-n nodename] [-a Attribute=Value]",
    "stderr_lines": [
        "Usage: crfs -v Vfs {-g Volumegroup | -d Device} -m Mountpoint",
        "\t[-u Mountgroup] [-A {yes|no}] [-t {yes|no}] [-p {ro|rw}]",
        " \t[-l Logpartitions] [-n nodename] [-a Attribute=Value]"
    ],
```
