### PR TITLE
ejabberd_user: Fix class documentation

### DIFF
--- a/plugins/modules/ejabberd_user.py
+++ b/plugins/modules/ejabberd_user.py
@@ -86,7 +86,7 @@ class EjabberdUser(object):
     object manages user creation and deletion using ejabberdctl.  The following
     commands are currently supported:
         * ejabberdctl register
-        * ejabberdctl deregister
+        * ejabberdctl unregister
     """
 
     def __init__(self, module):


### PR DESCRIPTION
##### SUMMARY
This replaces the wrong command of `ejabberdctl deregister` with the proper command `ejabberdctl unregister`.
The proper command is [used within the code](https://github.com/ansible-collections/community.general/blob/74c15c12418bf2f7e1dcac1a88657c8aefaeeb6d/plugins/modules/ejabberd_user.py#L162). Only the class documentation was incorrect.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ejabberd_user
