### PR TITLE
Add --diff support for ldap_attrs module

### DIFF
--- a/changelogs/fragments/8073-ldap-attrs-diff.yml
+++ b/changelogs/fragments/8073-ldap-attrs-diff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ldap_attrs - Module now supports diff mode, showing which attributes are changed within an operation

--- a/changelogs/fragments/8073-ldap-attrs-diff.yml
+++ b/changelogs/fragments/8073-ldap-attrs-diff.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap_attrs - Module now supports diff mode, showing which attributes are changed within an operation
+  - ldap_attrs - module now supports diff mode, showing which attributes are changed within an operation (https://github.com/ansible-collections/community.general/pull/8073)

--- a/changelogs/fragments/8073-ldap-attrs-diff.yml
+++ b/changelogs/fragments/8073-ldap-attrs-diff.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ldap_attrs - module now supports diff mode, showing which attributes are changed within an operation (https://github.com/ansible-collections/community.general/pull/8073)
+  - ldap_attrs - module now supports diff mode, showing which attributes are changed within an operation (https://github.com/ansible-collections/community.general/pull/8073).

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -44,7 +44,7 @@ attributes:
   check_mode:
     support: full
   diff_mode:
-    support: none
+    support: full
 options:
   state:
     required: false

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -235,26 +235,38 @@ class LdapAttrs(LdapGeneric):
 
     def add(self):
         modlist = []
+        new_diff = {}
         for name, values in self.module.params['attributes'].items():
             norm_values = self._normalize_values(values)
+            added_values = []
             for value in norm_values:
                 if self._is_value_absent(name, value):
                     modlist.append((ldap.MOD_ADD, name, value))
-
-        return modlist
+                    added_values.append(value)
+            if added_values:
+                new_diff[name] = norm_values
+        return modlist, {}, new_diff
 
     def delete(self):
         modlist = []
+        old_diff = {}
+        new_diff = {}
         for name, values in self.module.params['attributes'].items():
             norm_values = self._normalize_values(values)
+            removed_values = []
             for value in norm_values:
                 if self._is_value_present(name, value):
+                    removed_values.append(value)
                     modlist.append((ldap.MOD_DELETE, name, value))
-
-        return modlist
+            if removed_values:
+                old_diff[name] = norm_values
+                new_diff[name] = [value for value in norm_values if value not in removed_values]
+        return modlist, old_diff, new_diff
 
     def exact(self):
         modlist = []
+        old_diff = {}
+        new_diff = {}
         for name, values in self.module.params['attributes'].items():
             norm_values = self._normalize_values(values)
             try:
@@ -272,8 +284,13 @@ class LdapAttrs(LdapGeneric):
                     modlist.append((ldap.MOD_DELETE, name, None))
                 else:
                     modlist.append((ldap.MOD_REPLACE, name, norm_values))
+                old_diff[name] = current
+                new_diff[name] = norm_values
+                if len(current) == 1 and len(norm_values) == 1:
+                    old_diff[name] = current[0]
+                    new_diff[name] = norm_values[0]
 
-        return modlist
+        return modlist, old_diff, new_diff
 
     def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
@@ -309,16 +326,18 @@ def main():
 
     # Instantiate the LdapAttr object
     ldap = LdapAttrs(module)
+    old = None
+    new = None
 
     state = module.params['state']
 
     # Perform action
     if state == 'present':
-        modlist = ldap.add()
+        modlist, old, new = ldap.add()
     elif state == 'absent':
-        modlist = ldap.delete()
+        modlist, old, new = ldap.delete()
     elif state == 'exact':
-        modlist = ldap.exact()
+        modlist, old, new = ldap.exact()
 
     changed = False
 
@@ -331,7 +350,7 @@ def main():
             except Exception as e:
                 module.fail_json(msg="Attribute action failed.", details=to_native(e))
 
-    module.exit_json(changed=changed, modlist=modlist)
+    module.exit_json(changed=changed, modlist=modlist, diff={"before": old, "after": new})
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ldap_attrs.py
+++ b/plugins/modules/ldap_attrs.py
@@ -45,6 +45,7 @@ attributes:
     support: full
   diff_mode:
     support: full
+    version_added: 8.5.0
 options:
   state:
     required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds support for the  `--diff` mode for the `ldap_attrs` module. For the other `ldap` modules this does not really make sense, as `ldap_search` is read-only and for `ldap_entry` there is only a change if the entry is not there at all (so the state is quite clear).
We would like to use this kind of feature for internal use of the module.

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
`ldap_attrs`

##### ADDITIONAL INFORMATION

Right now, the module does not search for all available attributes at the same time. The `--diff` mode therefore has difficulties if we are only adding/deleting single values of a multi value attribute to detect what was there before and what would be the final state.
With `--exact`, we're replacing everything, therefore this issue is not present there. 
I'm not sure about the policy on this repo, whether a potentially misleading  diff is worse than none. Could also change that to not use "before" and "after", but going for "prepared" and a message like "`<key>: Added value(s) [<value1>, <value2>]" for the `present` or `absent` state. We are only using the `exact` state, so partial diff support only for that state would be fine to us.

Furthermore, attributes are not shown in the `--diff` if they are on the server, but not used within the module (probably not an issue).

Yeah well, as you can see from the longish message here I also want to get the discussion going. I'll add the fragment as soon as the discussions here are cleared up and the path for the PR is more clear.