### PR TITLE
Added proxmox module default  group

### DIFF
--- a/changelogs/fragments/8074-proxmox-add-module-default-group.yml
+++ b/changelogs/fragments/8074-proxmox-add-module-default-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_* - Added proxmox module default group (https://github.com/ansible-collections/community.general/pull/8074).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -12,6 +12,23 @@ action_groups:
     - consul_role
     - consul_session
     - consul_token
+  proxmox:
+    - proxmox
+    - proxmox_disk
+    - proxmox_domain_info
+    - proxmox_group_info
+    - proxmox_kvm
+    - proxmox_nic
+    - proxmox_node_info
+    - proxmox_pool
+    - proxmox_pool_member
+    - proxmox_snap
+    - proxmox_storage_contents_info
+    - proxmox_storage_info
+    - proxmox_tasks_info
+    - proxmox_template
+    - proxmox_user_info
+    - proxmox_vm_info
 plugin_routing:
   connection:
     docker:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

Added proxmox module defoult  group.
https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_module_defaults.html#module-defaults-groups

This eliminates the need to specify common parameters such as `api_user` for each task.

As below:

```yaml
- hosts: proxmox
  module_defaults:
    group/community.general.proxmox:
      api_host: proxmoxhost
      api_user: root@pam
      api_password: passowrd 

  tasks:
    - name: Gather VM Info
      community.general.proxmox_vm_info:
        type: qemu
        node: node01

    - name: List existing nodes
      community.general.proxmox_node_info:
      register: proxmox_nodes
```

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Relateted forum topic https://forum.ansible.com/t/import-role-and-module-defaults/4277
