### PR TITLE
ini_file - support optional spaces around section names

### DIFF
--- a/changelogs/fragments/8075-optional-space-around-section-names.yaml
+++ b/changelogs/fragments/8075-optional-space-around-section-names.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ini_file - support optional spaces between section names and their surrounding brackets (https://github.com/ansible-collections/community.general/pull/8075)."

--- a/plugins/modules/ini_file.py
+++ b/plugins/modules/ini_file.py
@@ -304,9 +304,11 @@ def do_ini(module, filename, section=None, option=None, values=None,
     before = after = []
     section_lines = []
 
+    section_pattern = re.compile(to_text(r'^\[\s*%s\s*]' % re.escape(section.strip())))
+
     for index, line in enumerate(ini_lines):
         # find start and end of section
-        if line.startswith(u'[%s]' % section):
+        if section_pattern.match(line):
             within_section = True
             section_start = index
         elif line.startswith(u'['):

--- a/tests/integration/targets/ini_file/tasks/main.yml
+++ b/tests/integration/targets/ini_file/tasks/main.yml
@@ -47,3 +47,6 @@
 
     - name: include tasks to test modify_inactive_option
       include_tasks: tests/06-modify_inactive_option.yml
+
+    - name: include tasks to test optional spaces in section headings
+      include_tasks: tests/07-section_name_spaces.yml

--- a/tests/integration/targets/ini_file/tasks/tests/07-section_name_spaces.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/07-section_name_spaces.yml
@@ -1,0 +1,93 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+## testing support for optional spaces between brackets and section names
+
+- name: Test-section_name_spaces 1 (does legacy workaround still work) - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: "[ foo ]\n; bar=baz\n"
+
+- name: Test-section_name_spaces 1 - update with optional spaces specified
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: ' foo '
+    option: bar
+    value: frelt
+  register: result
+
+- name: Test-section_name_spaces 1 - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-section_name_spaces 1 - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: "[ foo ]\nbar = frelt\n"
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is changed
+      - result.msg == 'option changed'
+
+
+- name: Test-section_name_spaces 2 (optional spaces omitted) - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: "[ foo ]\nbar=baz\n"
+
+- name: Test-section_name_spaces 2 - update without optional spaces
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: foo
+    option: bar
+    value: frelt
+    ignore_spaces: true
+  register: result
+
+- name: Test-section_name_spaces 2 - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-section_name_spaces 2 - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: "[ foo ]\nbar = frelt\n"
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is changed
+      - result.msg == 'option changed'
+
+
+- name: Test-section_name_spaces 3 (legacy workaround when not required) - create test file
+  ansible.builtin.copy:  # noqa risky-file-permissions
+    dest: "{{ output_file }}"
+    content: "[foo]\n; bar=baz\n"
+
+- name: Test-section_name_spaces 3 - update with optional spaces specified
+  community.general.ini_file:  # noqa risky-file-permissions
+    path: "{{ output_file }}"
+    section: ' foo '
+    option: bar
+    value: frelt
+  register: result
+
+- name: Test-section_name_spaces 3 - read content from output file
+  ansible.builtin.slurp:
+    src: "{{ output_file }}"
+  register: output_content
+
+- name: Test-section_name_spaces 3 - verify results
+  vars:
+    actual_content: "{{ output_content.content | b64decode }}"
+    expected_content: "[foo]\nbar = frelt\n"
+  ansible.builtin.assert:
+    that:
+      - actual_content == expected_content
+      - result is changed
+      - result.msg == 'option changed'

--- a/tests/integration/targets/ini_file/tasks/tests/07-section_name_spaces.yml
+++ b/tests/integration/targets/ini_file/tasks/tests/07-section_name_spaces.yml
@@ -8,7 +8,9 @@
 - name: Test-section_name_spaces 1 (does legacy workaround still work) - create test file
   ansible.builtin.copy:  # noqa risky-file-permissions
     dest: "{{ output_file }}"
-    content: "[ foo ]\n; bar=baz\n"
+    content: |
+      [ foo ]
+      ; bar=baz
 
 - name: Test-section_name_spaces 1 - update with optional spaces specified
   community.general.ini_file:  # noqa risky-file-permissions
@@ -26,7 +28,9 @@
 - name: Test-section_name_spaces 1 - verify results
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
-    expected_content: "[ foo ]\nbar = frelt\n"
+    expected_content: |
+      [ foo ]
+      bar = frelt
   ansible.builtin.assert:
     that:
       - actual_content == expected_content
@@ -37,7 +41,9 @@
 - name: Test-section_name_spaces 2 (optional spaces omitted) - create test file
   ansible.builtin.copy:  # noqa risky-file-permissions
     dest: "{{ output_file }}"
-    content: "[ foo ]\nbar=baz\n"
+    content: |
+      [ foo ]
+      bar=baz"
 
 - name: Test-section_name_spaces 2 - update without optional spaces
   community.general.ini_file:  # noqa risky-file-permissions
@@ -67,7 +73,9 @@
 - name: Test-section_name_spaces 3 (legacy workaround when not required) - create test file
   ansible.builtin.copy:  # noqa risky-file-permissions
     dest: "{{ output_file }}"
-    content: "[foo]\n; bar=baz\n"
+    content: |
+      [foo]
+      ; bar=baz
 
 - name: Test-section_name_spaces 3 - update with optional spaces specified
   community.general.ini_file:  # noqa risky-file-permissions
@@ -85,7 +93,9 @@
 - name: Test-section_name_spaces 3 - verify results
   vars:
     actual_content: "{{ output_content.content | b64decode }}"
-    expected_content: "[foo]\nbar = frelt\n"
+    expected_content: |
+      [foo]
+      bar = frelt
   ansible.builtin.assert:
     that:
       - actual_content == expected_content


### PR DESCRIPTION
ini_file - Support optional spaces between section names and their surrounding brackets

##### SUMMARY
Some ini files have spaces between some of their section names and the brackets that enclose them. This is documented in the `openssl.cnf(5)` man page. In order to manage files such as `openssl.cnf` with ini_file before now, one would have to include spaces in the section name like this:
```yaml
    section: ' crypto_policy '
    option: Options
    value: UnsafeLegacyRenegotiation
```
This change implements matching section headers with such optional spaces, removing the need to include those spaces in the task's `section:` parameter. Existing tasks using the workaround above will continue to work, even in cases where spaces in section headers are subsequently removed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ini_file

##### ADDITIONAL INFORMATION
Here's an actual "legacy" production `ini_file task`. Note the spaces in the section name. These spaces have been necessary because the target file has these spaces already.
```yaml
    - name: Configure UnsafeLegacyRenegotiation in /etc/pki/tls/openssl.cnf
      community.general.ini_file:
        path: /etc/pki/tls/openssl.cnf
        section: ' crypto_policy '
        option: Options
        value: UnsafeLegacyRenegotiation
        state: present
        exclusive: false
        create: false
        backup: true
```
After this change, those spaces are no longer necessary. Furthermore, the above task will continue to work even if someone removes the spaces from the target file's `crypto_policy` section header.
