### PR TITLE
Removed the redundant unicode prefixes

### DIFF
--- a/plugins/lookup/revbitspss.py
+++ b/plugins/lookup/revbitspss.py
@@ -100,7 +100,7 @@ class LookupModule(LookupBase):
         result = []
         for term in terms:
             try:
-                display.vvv(u"Secret Server lookup of Secret with ID %s" % term)
+                display.vvv("Secret Server lookup of Secret with ID %s" % term)
                 result.append({term: secret_server.get_pam_secret(term)})
             except Exception as error:
                 raise AnsibleError("Secret Server lookup failure: %s" % error.message)


### PR DESCRIPTION
##### SUMMARY
This pull request removes a redundant unicode prefix in the revbitspss.py lookup plugin. The prefix was not necessary for Python 3 and has been cleaned up to streamline the code.


<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/lookup/revbitspss.py

##### ADDITIONAL INFORMATION

The line in the code was using a unicode prefix for a string, which is a remnant from Python 2 compatibility. This prefix has been removed to align with Python 3 standards, where all strings are unicode by default.

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change
```paste below
display.vvv(u"Secret Server lookup of Secret with ID %s" % term)

```
After the change
```paste below
display.vvv("Secret Server lookup of Secret with ID %s" % term)

```