### PR TITLE
Fix pacman tests in CI

### DIFF
--- a/tests/integration/targets/pacman/tasks/locally_installed_package.yml
+++ b/tests/integration/targets/pacman/tasks/locally_installed_package.yml
@@ -7,11 +7,12 @@
     package_name: ansible-test-foo
     username: ansible-regular-user
   block:
-    - name: Install fakeroot
+    - name: Install dependencies
       pacman:
         state: present
         name:
           - fakeroot
+          - debugedit
 
     - name: Create user
       user:


### PR DESCRIPTION
##### SUMMARY
Make sure the `debugedit` package is installed for building a package.

Ref: https://dev.azure.com/ansible/community.general/_build/results?buildId=106709&view=logs&j=89290267-74d5-5b3e-330d-ba0f2945add4&t=0ecc9edb-08fd-5c6e-50b9-4c9e0e2c0b70

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
pacman integration tests
