### PR TITLE
Fix bond-slave honoring MTU

### DIFF
--- a/changelogs/fragments/8118-fix-bond-slave-honoring-mtu.yml
+++ b/changelogs/fragments/8118-fix-bond-slave-honoring-mtu.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nmcli - allow setting ``MTU`` for ``bond-slave`` interface types (https://github.com/ansible-collections/community.general/pull/8118).

--- a/plugins/modules/nmcli.py
+++ b/plugins/modules/nmcli.py
@@ -1952,6 +1952,7 @@ class Nmcli(object):
     def mtu_conn_type(self):
         return self.type in (
             'bond',
+            'bond-slave',
             'dummy',
             'ethernet',
             'infiniband',


### PR DESCRIPTION
The bond-slave type should honor the request
MTU value.

##### SUMMARY

It's not possible to set MTU on bond-slave today

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
