### PR TITLE
CI: Add FreeBSD 13.3 and 14.0 for devel, move FreeBSD 13.2 to stable-2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -191,8 +191,10 @@ stages:
               test: macos/14.3
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
+            - name: FreeBSD 14.0
+              test: freebsd/14.0
           groups:
             - 1
             - 2
@@ -211,8 +213,8 @@ stages:
               test: rhel/9.2
             - name: RHEL 8.8
               test: rhel/8.8
-            #- name: FreeBSD 13.2
-            #  test: freebsd/13.2
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
           groups:
             - 1
             - 2

--- a/tests/integration/targets/filter_jc/aliases
+++ b/tests/integration/targets/filter_jc/aliases
@@ -4,3 +4,5 @@
 
 azp/posix/2
 skip/python2.7  # jc only supports python3.x
+skip/freebsd13.3  # FIXME - ruyaml compilation fails
+skip/freebsd14.0  # FIXME - ruyaml compilation fails

--- a/tests/integration/targets/iso_extract/aliases
+++ b/tests/integration/targets/iso_extract/aliases
@@ -13,3 +13,5 @@ skip/rhel9.2  # FIXME
 skip/rhel9.3  # FIXME
 skip/freebsd12.4  # FIXME
 skip/freebsd13.2  # FIXME
+skip/freebsd13.3  # FIXME
+skip/freebsd14.0  # FIXME

--- a/tests/integration/targets/pkgng/tasks/freebsd.yml
+++ b/tests/integration/targets/pkgng/tasks/freebsd.yml
@@ -515,11 +515,18 @@
   # NOTE: FreeBSD 13.2 fails to update the package catalogue for unknown reasons (someone with FreeBSD
   #       knowledge has to take a look)
   #
+  # NOTE: FreeBSD 13.3 fails to update the package catalogue for unknown reasons (someone with FreeBSD
+  #       knowledge has to take a look)
+  #
+  # NOTE: FreeBSD 14.0 fails to update the package catalogue for unknown reasons (someone with FreeBSD
+  #       knowledge has to take a look)
+  #
   # See also
   # https://github.com/ansible-collections/community.general/issues/5795
   when: >-
     (ansible_distribution_version is version('12.01', '>=') and ansible_distribution_version is version('12.3', '<'))
-    or ansible_distribution_version is version('13.3', '>=')
+    or (ansible_distribution_version is version('13.4', '>=') and ansible_distribution_version is version('14.0', '<'))
+    or ansible_distribution_version is version('14.1', '>=')
   block:
     - name: Setup testjail
       include_tasks: setup-testjail.yml


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-freebsd-13-3-14-0-and-deprecated-13-2/4503

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
