### PR TITLE
CI: Move Alpine 3.18 docker to stable-2.16, add Alpine 3.19 docker, bump Alpine VM to 3.19

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -171,8 +171,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: Alpine 3.18
-              test: alpine/3.18
+            - name: Alpine 3.19
+              test: alpine/3.19
             # - name: Fedora 39
             #   test: fedora/39
             - name: Ubuntu 22.04
@@ -275,8 +275,8 @@ stages:
               test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
-            - name: Alpine 3
-              test: alpine3
+            - name: Alpine 3.19
+              test: alpine319
           groups:
             - 1
             - 2
@@ -293,6 +293,8 @@ stages:
               test: fedora38
             - name: openSUSE 15
               test: opensuse15
+            - name: Alpine 3
+              test: alpine3
           groups:
             - 1
             - 2


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-test-added-alpine-3-19-and-deprecated-3-18/4508

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
