### PR TITLE
Add descriptive error message to Linode inventory plugin file checkin…

### DIFF
--- a/changelogs/fragments/8133-add-error-message-for-linode-inventory-plugin.yaml
+++ b/changelogs/fragments/8133-add-error-message-for-linode-inventory-plugin.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - Add descriptive error message for linode inventory plugin
+  - linode inventory plugin - add descriptive error message for linode inventory plugin (https://github.com/ansible-collections/community.general/pull/8133).
     

--- a/changelogs/fragments/8133-add-error-message-for-linode-inventory-plugin.yaml
+++ b/changelogs/fragments/8133-add-error-message-for-linode-inventory-plugin.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Add descriptive error message for linode inventory plugin
+    

--- a/plugins/inventory/linode.py
+++ b/plugins/inventory/linode.py
@@ -271,12 +271,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 strict=strict)
 
     def verify_file(self, path):
-        """Verify the Linode configuration file."""
+        """Verify the Linode configuration file.
+
+        Return true/false if the config-file is valid for this plugin
+
+        Args:
+            str(path): path to the config
+        Kwargs:
+            None
+        Raises:
+            None
+        Returns:
+            bool(valid): is valid config file"""
+        valid = False
         if super(InventoryModule, self).verify_file(path):
-            endings = ('linode.yaml', 'linode.yml')
-            if any((path.endswith(ending) for ending in endings)):
-                return True
-        return False
+            if path.endswith(("linode.yaml", "linode.yml")):
+                valid = True
+            else:
+                self.display.vvv('Inventory source not ending in "linode.yaml" or "linode.yml"')
+        return valid
 
     def parse(self, inventory, loader, path, cache=True):
         """Dynamically parse Linode the cloud inventory."""

--- a/tests/unit/plugins/inventory/test_linode.py
+++ b/tests/unit/plugins/inventory/test_linode.py
@@ -37,11 +37,25 @@ def test_missing_access_token_lookup(inventory):
         assert 'Could not retrieve Linode access token' in error_message
 
 
-def test_verify_file(tmp_path, inventory):
+def test_verify_file_yml(tmp_path, inventory):
     file = tmp_path / "foobar.linode.yml"
     file.touch()
     assert inventory.verify_file(str(file)) is True
 
 
+def test_verify_file_yaml(tmp_path, inventory):
+    file = tmp_path / "foobar.linode.yaml"
+    file.touch()
+    assert inventory.verify_file(str(file)) is True
+
+
+def test_verify_file_bad_config_yml(inventory):
+    assert inventory.verify_file("foobar.linode.yml") is False
+
+
+def test_verify_file_bad_config_yaml(inventory):
+    assert inventory.verify_file("foobar.linode.yaml") is False
+
+
 def test_verify_file_bad_config(inventory):
-    assert inventory.verify_file('foobar.linode.yml') is False
+    assert inventory.verify_file("foobar.wrongcloud.yml") is False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#6279 Raised issue with the linode inventory plugin validation function not providing a useful error message when it fails. Other inventory plugins do have useful error message on failure. This PR aligns the linode inventory plugin with other plugins.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #6279 

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.plugins.inventory.linode
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ansible-inventory -i foo.yml --list -vvv
ansible-inventory [core 2.16.4]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gideons/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gideons/.local/lib/python3.10/site-packages/ansible
  ansible collection location = /home/gideons/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/gideons/.local/bin/ansible-inventory
  python version = 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] (/usr/bin/python3)
  jinja version = 3.0.3
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
script declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
redirecting (type: inventory) ansible.builtin.linode to community.general.linode
toml declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
[WARNING]:  * Failed to parse /home/gideons/foo.yml with auto plugin: inventory source
'/home/gideons/foo.yml' could not be verified by inventory plugin 'linode'
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/auto.py", line 56, in parse
    raise AnsibleParserError("inventory source '{0}' could not be verified by inventory plugin '{1}'".format(path, plugin_name))
[WARNING]:  * Failed to parse /home/gideons/foo.yml with yaml plugin: Plugin configuration YAML file,
not YAML inventory
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/yaml.py", line 114, in parse
    raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
[WARNING]:  * Failed to parse /home/gideons/foo.yml with ini plugin: Invalid host pattern 'plugin:'
supplied, ending in ':' is not allowed, this character is reserved to provide a port.
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/ini.py", line 138, in parse
    raise AnsibleParserError(e)
[WARNING]: Unable to parse /home/gideons/foo.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}
```
After:
```
$ ANSIBLE_INVENTORY_PLUGINS=~/ansible-collections.community.general/ansible_collections/community/general/plugins/inventory ansible-inventory -i foo.yml --list -vvv
ansible-inventory [core 2.16.4]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gideons/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gideons/.local/lib/python3.10/site-packages/ansible
  ansible collection location = /home/gideons/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/gideons/.local/bin/ansible-inventory
  python version = 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] (/usr/bin/python3)
  jinja version = 3.0.3
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
script declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
Inventory source not ending in "linode.yaml" or "linode.yml"
toml declined parsing /home/gideons/foo.yml as it did not pass its verify_file() method
[WARNING]:  * Failed to parse /home/gideons/foo.yml with auto plugin: inventory source
'/home/gideons/foo.yml' could not be verified by inventory plugin 'linode'
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/auto.py", line 56, in parse
    raise AnsibleParserError("inventory source '{0}' could not be verified by inventory plugin '{1}'".format(path, plugin_name))
[WARNING]:  * Failed to parse /home/gideons/foo.yml with yaml plugin: Plugin configuration YAML file,
not YAML inventory
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/yaml.py", line 114, in parse
    raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')
[WARNING]:  * Failed to parse /home/gideons/foo.yml with ini plugin: Invalid host pattern 'plugin:'
supplied, ending in ':' is not allowed, this character is reserved to provide a port.
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/gideons/.local/lib/python3.10/site-packages/ansible/plugins/inventory/ini.py", line 138, in parse
    raise AnsibleParserError(e)
[WARNING]: Unable to parse /home/gideons/foo.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}
```
