### PR TITLE
java_cert: add cert_content argument

### DIFF
--- a/changelogs/fragments/8153-java_cert-add-cert_content-arg.yml
+++ b/changelogs/fragments/8153-java_cert-add-cert_content-arg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - java_cert - add ``cert_content`` argument (https://github.com/ansible-collections/community.general/pull/8153).

--- a/plugins/modules/java_cert.py
+++ b/plugins/modules/java_cert.py
@@ -46,6 +46,7 @@ options:
       - Content of the certificate used to create the keystore.
       - Exactly one of O(cert_url), O(cert_path), O(cert_content), or O(pkcs12_path) is required to load certificate.
     type: str
+    version_added: 8.6.0
   cert_alias:
     description:
       - Imported certificate alias.


### PR DESCRIPTION
##### SUMMARY
Adding the ability to create a keystore using a certificate stored in the `cert_content` variable. 
Fixes #8034.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.general.java_cert