### PR TITLE
gitlab modules: do not crash if python-gitlab isn't there

### DIFF
--- a/changelogs/fragments/8158-gitlab-version-check.yml
+++ b/changelogs/fragments/8158-gitlab-version-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "gitlab_issue, gitlab_label, gitlab_milestone - avoid crash during version comparison when the python-gitlab Python module is not installed (https://github.com/ansible-collections/community.general/pull/8158)."

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -81,16 +81,23 @@ def find_group(gitlab_instance, identifier):
     return group
 
 
-def ensure_gitlab_package(module):
+def ensure_gitlab_package(module, min_version=None):
     if not HAS_GITLAB_PACKAGE:
         module.fail_json(
             msg=missing_required_lib("python-gitlab", url='https://python-gitlab.readthedocs.io/en/stable/'),
             exception=GITLAB_IMP_ERR
         )
+    gitlab_version = gitlab.__version__
+    if min_version is not None and LooseVersion(gitlab_version) < LooseVersion(min_version):
+        module.fail_json(
+            msg="This module requires python-gitlab Python module >= %s "
+                "(installed version: %s). Please upgrade python-gitlab to version %s or above."
+                % (min_version, gitlab_version, min_version)
+        )
 
 
-def gitlab_authentication(module):
-    ensure_gitlab_package(module)
+def gitlab_authentication(module, min_version=None):
+    ensure_gitlab_package(module, min_version=min_version)
 
     gitlab_url = module.params['api_url']
     validate_certs = module.params['validate_certs']

--- a/plugins/modules/gitlab_issue.py
+++ b/plugins/modules/gitlab_issue.py
@@ -143,7 +143,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.common.text.converters import to_native, to_text
 
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
     auth_argument_spec, gitlab_authentication, gitlab, find_project, find_group
 )
@@ -330,13 +329,8 @@ def main():
     state_filter = module.params['state_filter']
     title = module.params['title']
 
-    gitlab_version = gitlab.__version__
-    if LooseVersion(gitlab_version) < LooseVersion('2.3.0'):
-        module.fail_json(msg="community.general.gitlab_issue requires python-gitlab Python module >= 2.3.0 (installed version: [%s])."
-                             " Please upgrade python-gitlab to version 2.3.0 or above." % gitlab_version)
-
     # check prerequisites and connect to gitlab server
-    gitlab_instance = gitlab_authentication(module)
+    gitlab_instance = gitlab_authentication(module, min_version='2.3.0')
 
     this_project = find_project(gitlab_instance, project)
     if this_project is None:

--- a/plugins/modules/gitlab_label.py
+++ b/plugins/modules/gitlab_label.py
@@ -222,9 +222,8 @@ labels_obj:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, find_group, find_project, gitlab
+    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, find_group, find_project
 )
 
 
@@ -450,14 +449,7 @@ def main():
     label_list = module.params['labels']
     state = module.params['state']
 
-    gitlab_version = gitlab.__version__
-    _min_gitlab = '3.2.0'
-    if LooseVersion(gitlab_version) < LooseVersion(_min_gitlab):
-        module.fail_json(msg="community.general.gitlab_label requires python-gitlab Python module >= %s "
-                             "(installed version: [%s]). Please upgrade "
-                             "python-gitlab to version %s or above." % (_min_gitlab, gitlab_version, _min_gitlab))
-
-    gitlab_instance = gitlab_authentication(module)
+    gitlab_instance = gitlab_authentication(module, min_version='3.2.0')
 
     # find_project can return None, but the other must exist
     gitlab_project_id = find_project(gitlab_instance, gitlab_project)

--- a/plugins/modules/gitlab_milestone.py
+++ b/plugins/modules/gitlab_milestone.py
@@ -206,9 +206,8 @@ milestones_obj:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.api import basic_auth_argument_spec
 
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.general.plugins.module_utils.gitlab import (
-    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, find_group, find_project, gitlab
+    auth_argument_spec, gitlab_authentication, ensure_gitlab_package, find_group, find_project
 )
 from datetime import datetime
 
@@ -452,14 +451,7 @@ def main():
     milestone_list = module.params['milestones']
     state = module.params['state']
 
-    gitlab_version = gitlab.__version__
-    _min_gitlab = '3.2.0'
-    if LooseVersion(gitlab_version) < LooseVersion(_min_gitlab):
-        module.fail_json(msg="community.general.gitlab_milestone requires python-gitlab Python module >= %s "
-                             "(installed version: [%s]). Please upgrade "
-                             "python-gitlab to version %s or above." % (_min_gitlab, gitlab_version, _min_gitlab))
-
-    gitlab_instance = gitlab_authentication(module)
+    gitlab_instance = gitlab_authentication(module, min_version='3.2.0')
 
     # find_project can return None, but the other must exist
     gitlab_project_id = find_project(gitlab_instance, gitlab_project)


### PR DESCRIPTION
##### SUMMARY
Some GitLab modules crash if python-gitlab isn't installed since they access `gitlab.__version__` before checking whether python-gitlab is there.

This PR adds a generic method to check for a minimal version that is always run after checking the presence of python-version and uses it in these modules.

Ref: https://forum.ansible.com/t/attributeerror-nonetype-object-has-no-attribute-version/4611

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_issue
gitlab_label
gitlab_milestone
