### PR TITLE
xml: make module work with lxml 5.1.1

### DIFF
--- a/changelogs/fragments/8169-lxml.yml
+++ b/changelogs/fragments/8169-lxml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "xml - make module work with lxml 5.1.1, which removed some internals that the module was relying on (https://github.com/ansible-collections/community.general/pull/8169)."

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -436,11 +436,16 @@ def is_attribute(tree, xpath, namespaces):
     """ Test if a given xpath matches and that match is an attribute
 
     An xpath attribute search will only match one item"""
+
+    # lxml 5.1.1 removed etree._ElementStringResult, so we can no longer simply assume it's there
+    # (https://github.com/lxml/lxml/commit/eba79343d0e7ad1ce40169f60460cdd4caa29eb3)
+    ElementStringResult = getattr(etree, '_ElementStringResult', None)
+
     if xpath_matches(tree, xpath, namespaces):
         match = tree.xpath(xpath, namespaces=namespaces)
-        if isinstance(match[0], etree._ElementStringResult):
+        if isinstance(match[0], etree._ElementUnicodeResult):
             return True
-        elif isinstance(match[0], etree._ElementUnicodeResult):
+        elif ElementStringResult is not None and isinstance(match[0], ElementStringResult):
             return True
     return False
 


### PR DESCRIPTION
##### SUMMARY
lxml 5.1.1 includes https://github.com/lxml/lxml/commit/eba79343d0e7ad1ce40169f60460cdd4caa29eb3, which breaks the xml module since it assumes that `etree._ElementStringResult` exists.

On platforms that install lxml via pip, like macOS and RHEL 9, this was breaking the nightly tests (https://dev.azure.com/ansible/community.general/_build/results?buildId=107937&view=results).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xml
