### PR TITLE
module_utils/ipa.py: fix regex when parsing version

### DIFF
--- a/changelogs/fragments/8175-get_ipa_version_regex.yml
+++ b/changelogs/fragments/8175-get_ipa_version_regex.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa - fix get version regex im ipa module_utils (https://github.com/ansible-collections/community.general/pull/8175)

--- a/changelogs/fragments/8175-get_ipa_version_regex.yml
+++ b/changelogs/fragments/8175-get_ipa_version_regex.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa - fix get version regex im ipa module_utils (https://github.com/ansible-collections/community.general/pull/8175)
+  - ipa - fix get version regex in IPA module_utils (https://github.com/ansible-collections/community.general/pull/8175).

--- a/plugins/module_utils/ipa.py
+++ b/plugins/module_utils/ipa.py
@@ -104,7 +104,7 @@ class IPAClient(object):
 
     def get_ipa_version(self):
         response = self.ping()['summary']
-        ipa_ver_regex = re.compile(r'IPA server version (\d\.\d\.\d).*')
+        ipa_ver_regex = re.compile(r'IPA server version (\d+\.\d+\.\d+).*')
         version_match = ipa_ver_regex.match(response)
         ipa_version = None
         if version_match:


### PR DESCRIPTION
##### SUMMARY

Fix module_utils/ipa.py regex to parsing freeipa version

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
module_utils/ipa.py

##### ADDITIONAL INFORMATION

Right regex for parsing
https://regex101.com/r/s2ecr6/1

