### PR TITLE
CI: add stable-2.17, bump devel to 2.18, move stable-2.14 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -73,6 +73,19 @@ stages:
             - test: 3
             - test: 4
             - test: extra
+  - stage: Sanity_2_17
+    displayName: Sanity 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Test {0}
+          testFormat: 2.17/sanity/{0}
+          targets:
+            - test: 1
+            - test: 2
+            - test: 3
+            - test: 4
   - stage: Sanity_2_16
     displayName: Sanity 2.16
     dependsOn: []
@@ -128,6 +141,17 @@ stages:
             - test: '3.10'
             - test: '3.11'
             - test: '3.12'
+  - stage: Units_2_17
+    displayName: Units 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.17/units/{0}/1
+          targets:
+            - test: 3.7
+            - test: "3.12"
   - stage: Units_2_16
     displayName: Units 2.16
     dependsOn: []
@@ -191,10 +215,22 @@ stages:
               test: macos/14.3
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.3
-              test: freebsd/13.3
             - name: FreeBSD 14.0
               test: freebsd/14.0
+          groups:
+            - 1
+            - 2
+            - 3
+  - stage: Remote_2_17
+    displayName: Remote 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/{0}
+          targets:
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
           groups:
             - 1
             - 2
@@ -275,6 +311,18 @@ stages:
               test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
+          groups:
+            - 1
+            - 2
+            - 3
+  - stage: Docker_2_17
+    displayName: Docker 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/linux/{0}
+          targets:
             - name: Alpine 3.19
               test: alpine319
           groups:
@@ -360,6 +408,17 @@ stages:
           nameFormat: Python {0}
           testFormat: devel/generic/{0}/1
           targets:
+            - test: '3.8'
+            - test: '3.11'
+  - stage: Generic_2_17
+    displayName: Generic 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: Python {0}
+          testFormat: 2.17/generic/{0}/1
+          targets:
             - test: '3.7'
             - test: '3.12'
   - stage: Generic_2_16
@@ -399,25 +458,30 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Sanity_devel
+      - Sanity_2_17
       - Sanity_2_16
       - Sanity_2_15
       - Sanity_2_14
       - Units_devel
+      - Units_2_17
       - Units_2_16
       - Units_2_15
       - Units_2_14
       - Remote_devel_extra_vms
       - Remote_devel
+      - Remote_2_17
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14
       - Docker_devel
+      - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
+#      - Generic_2_17
 #      - Generic_2_16
 #      - Generic_2_15
 #      - Generic_2_14

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -112,19 +112,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_14
-    displayName: Sanity 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.14/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_devel
     displayName: Units devel
@@ -175,16 +162,6 @@ stages:
           targets:
             - test: 3.5
             - test: "3.10"
-  - stage: Units_2_14
-    displayName: Units 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.14/units/{0}/1
-          targets:
-            - test: 3.9
 
 ## Remote
   - stage: Remote_devel_extra_vms
@@ -277,24 +254,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            #- name: macOS 12.0
-            #  test: macos/12.0
-            - name: RHEL 9.0
-              test: rhel/9.0
-            #- name: FreeBSD 12.4
-            #  test: freebsd/12.4
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_devel
@@ -359,20 +318,6 @@ stages:
               test: fedora37
             - name: CentOS 7
               test: centos7
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_14
-    displayName: Docker 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/linux/{0}
-          targets:
-            - name: Alpine 3
-              test: alpine3
           groups:
             - 1
             - 2
@@ -443,16 +388,6 @@ stages:
           testFormat: 2.15/generic/{0}/1
           targets:
             - test: '3.9'
-  - stage: Generic_2_14
-    displayName: Generic 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.14/generic/{0}/1
-          targets:
-            - test: '3.10'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -461,29 +396,24 @@ stages:
       - Sanity_2_17
       - Sanity_2_16
       - Sanity_2_15
-      - Sanity_2_14
       - Units_devel
       - Units_2_17
       - Units_2_16
       - Units_2_15
-      - Units_2_14
       - Remote_devel_extra_vms
       - Remote_devel
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15
-      - Remote_2_14
       - Docker_devel
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
-      - Docker_2_14
       - Docker_community_devel
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_devel
 #      - Generic_2_17
 #      - Generic_2_16
 #      - Generic_2_15
-#      - Generic_2_14
     jobs:
       - template: templates/coverage.yml

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         ansible:
           - '2.13'
+          - '2.14'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -72,6 +73,8 @@ jobs:
             python: '2.7'
           - ansible: '2.13'
             python: '3.8'
+          - ansible: '2.14'
+            python: '3.9'
 
     steps:
       - name: >-
@@ -148,10 +151,28 @@ jobs:
             docker: alpine3
             python: ''
             target: azp/posix/3/
+          # 2.14
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/3/
           # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
           # - ansible: '2.13'
           #   docker: default
           #   python: '3.9'
+          #   target: azp/generic/1/
+          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+          # - ansible: '2.14'
+          #   docker: default
+          #   python: '3.10'
           #   target: azp/generic/1/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16 releases and the current development version of ansible-core. Ansible-core versions before 2.13.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, ansible-core 2.17 releases and the current development version of ansible-core. Ansible-core versions before 2.13.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,17 @@
+plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice
+plugins/modules/homectl.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/modules/homectl.py import-3.12  # Uses deprecated stdlib library 'crypt'
+plugins/modules/iptables_state.py validate-modules:undocumented-parameter             # params _back and _timeout used by action plugin
+plugins/modules/lxc_container.py validate-modules:use-run-command-not-popen
+plugins/modules/osx_defaults.py validate-modules:parameter-state-invalid-choice
+plugins/modules/parted.py validate-modules:parameter-state-invalid-choice
+plugins/modules/rax_files_objects.py use-argspec-type-path                            # module deprecated - removed in 9.0.0
+plugins/modules/rax_files.py validate-modules:parameter-state-invalid-choice          # module deprecated - removed in 9.0.0
+plugins/modules/rax.py use-argspec-type-path                                          # module deprecated - removed in 9.0.0
+plugins/modules/rhevm.py validate-modules:parameter-state-invalid-choice
+plugins/modules/udm_user.py import-3.11  # Uses deprecated stdlib library 'crypt'
+plugins/modules/udm_user.py import-3.12  # Uses deprecated stdlib library 'crypt'
+plugins/modules/xfconf.py validate-modules:return-syntax-error
+plugins/module_utils/univention_umc.py pylint:use-yield-from  # suggested construct does not work with Python 2
+tests/unit/compat/mock.py pylint:use-yield-from  # suggested construct does not work with Python 2
+tests/unit/plugins/modules/test_gio_mime.yaml no-smart-quotes

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
