### PR TITLE
CI: rename devel to stable-2.17, move stable-2.14 from AZP to GHA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -99,19 +99,6 @@ stages:
             - test: 2
             - test: 3
             - test: 4
-  - stage: Sanity_2_14
-    displayName: Sanity 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Test {0}
-          testFormat: 2.14/sanity/{0}
-          targets:
-            - test: 1
-            - test: 2
-            - test: 3
-            - test: 4
 ### Units
   - stage: Units_2_17
     displayName: Units 2.17
@@ -151,16 +138,6 @@ stages:
           targets:
             - test: 3.5
             - test: "3.10"
-  - stage: Units_2_14
-    displayName: Units 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.14/units/{0}/1
-          targets:
-            - test: 3.9
 
 ## Remote
   - stage: Remote_2_17_extra_vms
@@ -241,24 +218,6 @@ stages:
             - 1
             - 2
             - 3
-  - stage: Remote_2_14
-    displayName: Remote 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            - name: RHEL 9.0
-              test: rhel/9.0
-            #- name: macOS 12.0
-            #  test: macos/12.0
-            #- name: FreeBSD 12.4
-            #  test: freebsd/12.4
-          groups:
-            - 1
-            - 2
-            - 3
 
 ### Docker
   - stage: Docker_2_17
@@ -311,20 +270,6 @@ stages:
               test: fedora37
             - name: CentOS 7
               test: centos7
-          groups:
-            - 1
-            - 2
-            - 3
-  - stage: Docker_2_14
-    displayName: Docker 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/linux/{0}
-          targets:
-            - name: Alpine 3
-              test: alpine3
           groups:
             - 1
             - 2
@@ -384,16 +329,6 @@ stages:
           testFormat: 2.15/generic/{0}/1
           targets:
             - test: '3.9'
-  - stage: Generic_2_14
-    displayName: Generic 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Python {0}
-          testFormat: 2.14/generic/{0}/1
-          targets:
-            - test: '3.10'
 
   - stage: Summary
     condition: succeededOrFailed()
@@ -401,25 +336,20 @@ stages:
       - Sanity_2_17
       - Sanity_2_16
       - Sanity_2_15
-      - Sanity_2_14
       - Units_2_17
       - Units_2_16
       - Units_2_15
-      - Units_2_14
       - Remote_2_17_extra_vms
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15
-      - Remote_2_14
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
-      - Docker_2_14
       - Docker_community_2_17
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
 #      - Generic_2_17
 #      - Generic_2_16
 #      - Generic_2_15
-#      - Generic_2_14
     jobs:
       - template: templates/coverage.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -59,14 +59,14 @@ pool: Standard
 
 stages:
 ### Sanity
-  - stage: Sanity_devel
-    displayName: Sanity devel
+  - stage: Sanity_2_17
+    displayName: Sanity 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Test {0}
-          testFormat: devel/sanity/{0}
+          testFormat: 2.17/sanity/{0}
           targets:
             - test: 1
             - test: 2
@@ -113,14 +113,14 @@ stages:
             - test: 3
             - test: 4
 ### Units
-  - stage: Units_devel
-    displayName: Units devel
+  - stage: Units_2_17
+    displayName: Units 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/units/{0}/1
+          testFormat: 2.17/units/{0}/1
           targets:
             - test: 3.7
             - test: 3.8
@@ -163,13 +163,13 @@ stages:
             - test: 3.9
 
 ## Remote
-  - stage: Remote_devel_extra_vms
-    displayName: Remote devel extra VMs
+  - stage: Remote_2_17_extra_vms
+    displayName: Remote 2.17 extra VMs
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.17/{0}
           targets:
             - name: Alpine 3.19
               test: alpine/3.19
@@ -179,13 +179,13 @@ stages:
               test: ubuntu/22.04
           groups:
             - vm
-  - stage: Remote_devel
-    displayName: Remote devel
+  - stage: Remote_2_17
+    displayName: Remote 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}
+          testFormat: 2.17/{0}
           targets:
             - name: macOS 14.3
               test: macos/14.3
@@ -261,13 +261,13 @@ stages:
             - 3
 
 ### Docker
-  - stage: Docker_devel
-    displayName: Docker devel
+  - stage: Docker_2_17
+    displayName: Docker 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}
+          testFormat: 2.17/linux/{0}
           targets:
             - name: Fedora 39
               test: fedora39
@@ -331,13 +331,13 @@ stages:
             - 3
 
 ### Community Docker
-  - stage: Docker_community_devel
-    displayName: Docker (community images) devel
+  - stage: Docker_community_2_17
+    displayName: Docker (community images) 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux-community/{0}
+          testFormat: 2.17/linux-community/{0}
           targets:
             - name: Debian Bullseye
               test: debian-bullseye/3.9
@@ -351,14 +351,14 @@ stages:
             - 3
 
 ### Generic
-  - stage: Generic_devel
-    displayName: Generic devel
+  - stage: Generic_2_17
+    displayName: Generic 2.17
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           nameFormat: Python {0}
-          testFormat: devel/generic/{0}/1
+          testFormat: 2.17/generic/{0}/1
           targets:
             - test: '3.7'
             - test: '3.12'
@@ -398,26 +398,26 @@ stages:
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
-      - Sanity_devel
+      - Sanity_2_17
       - Sanity_2_16
       - Sanity_2_15
       - Sanity_2_14
-      - Units_devel
+      - Units_2_17
       - Units_2_16
       - Units_2_15
       - Units_2_14
-      - Remote_devel_extra_vms
-      - Remote_devel
+      - Remote_2_17_extra_vms
+      - Remote_2_17
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14
-      - Docker_devel
+      - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
-      - Docker_community_devel
+      - Docker_community_2_17
 # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
-#      - Generic_devel
+#      - Generic_2_17
 #      - Generic_2_16
 #      - Generic_2_15
 #      - Generic_2_14

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,6 +32,7 @@ jobs:
           - '2.11'
           - '2.12'
           - '2.13'
+          - '2.14'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will
@@ -85,6 +86,8 @@ jobs:
             python: '2.7'
           - ansible: '2.13'
             python: '3.8'
+          - ansible: '2.14'
+            python: '3.9'
 
     steps:
       - name: >-
@@ -257,6 +260,24 @@ jobs:
           # - ansible: '2.13'
           #   docker: default
           #   python: '3.9'
+          #   target: azp/generic/1/
+          # 2.14
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/1/
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/2/
+          - ansible: '2.14'
+            docker: alpine3
+            python: ''
+            target: azp/posix/3/
+          # Right now all generic tests are disabled. Uncomment when at least one of them is re-enabled.
+          # - ansible: '2.14'
+          #   docker: default
+          #   python: '3.10'
           #   target: azp/generic/1/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you encounter abusive behavior violating the [Ansible Code of Conduct](https:
 
 ## Tested with Ansible
 
-Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16 releases and the current development version of ansible-core. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
+Tested with the current ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases. Ansible-core versions before 2.11.0 are not supported. This includes all ansible-base 2.10 and Ansible 2.9 releases.
 
 Parts of this collection will not work with ansible-core 2.11 on Python 3.12+.
 


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
