### PR TITLE
CI: ansible-core devel removed Python 3.7 support, no longer allows 'vars:' with lists

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -122,7 +122,6 @@ stages:
           nameFormat: Python {0}
           testFormat: devel/units/{0}/1
           targets:
-            - test: 3.7
             - test: 3.8
             - test: 3.9
             - test: '3.10'

--- a/tests/integration/targets/lookup_lmdb_kv/test.yml
+++ b/tests/integration/targets/lookup_lmdb_kv/test.yml
@@ -19,13 +19,13 @@
       - item.0 == 'nl'
       - item.1 == 'Netherlands'
     vars:
-    - lmdb_kv_db: jp.mdb
+      lmdb_kv_db: jp.mdb
     with_community.general.lmdb_kv:
     - n*
   - assert:
       that:
       - item == 'Belgium'
     vars:
-    - lmdb_kv_db: jp.mdb
+      lmdb_kv_db: jp.mdb
     with_community.general.lmdb_kv:
     - be


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-drops-support-for-python-3-7/4736

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
