### PR TITLE
[datadog_monitor] - Migrate datadog_monitor module parameter from locked to restricted_roles

### DIFF
--- a/plugins/modules/datadog_monitor.py
+++ b/plugins/modules/datadog_monitor.py
@@ -191,7 +191,7 @@ options:
         description:
           - An array listing the UUIDs of the roles allowed to edit the monitor.
           - Monitor editing includes updates to the monitor configuration, deleting the monitor, and muting of the monitor for any amount of time.
-          - Role UUIDs can be pulled from the Roles API - https://docs.datadoghq.com/api/latest/roles/.
+          - Role UUIDs can be pulled from the Roles API - see U(https://docs.datadoghq.com/api/latest/roles/) for details.
         type: list
         elements: str
         version_added: 8.6.0


### PR DESCRIPTION
Fixes: #8192

##### SUMMARY
 Migrate datadog_monitor module parameter from locked to restricted_roles. locked parameter is deprecated and will soonish lead to failures when deploying datadog monitors.

##### COMPONENT NAME
datadog_monitor

##### ADDITIONAL INFORMATION
Increase your datadog-api-client version to a version, which supports the locked_parameter

```paste below
datadog-api-client==2.23.0

```
