### PR TITLE
module_utils/ipa.py: fix version regex

### DIFF
--- a/changelogs/fragments/8201-fix-ipa-version-parsing.yml
+++ b/changelogs/fragments/8201-fix-ipa-version-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils/ipa.py - fix FreeIPA version parsing supporting only single digits (https://github.com/ansible-collections/community.general/pull/8201).

--- a/plugins/module_utils/ipa.py
+++ b/plugins/module_utils/ipa.py
@@ -104,7 +104,7 @@ class IPAClient(object):
 
     def get_ipa_version(self):
         response = self.ping()['summary']
-        ipa_ver_regex = re.compile(r'IPA server version (\d\.\d\.\d).*')
+        ipa_ver_regex = re.compile(r'IPA server version (\d+\.\d+\.\d+).*')
         version_match = ipa_ver_regex.match(response)
         ipa_version = None
         if version_match:


### PR DESCRIPTION
##### SUMMARY
regex parsing the FreeIPA version only works for single digits.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_plugins/ipa.py
