### PR TITLE
Support newer 'riak admin' sub-command beside legacy 'riak-admin' command

### DIFF
--- a/changelogs/fragments/8211-riak-admin-sub-command-support.yml
+++ b/changelogs/fragments/8211-riak-admin-sub-command-support.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "support riak admin sub-command in newer riak kv versions beside the legacy riak-admin main command"
+  - "riak - support ``riak admin`` sub-command in newer Riak KV versions beside the legacy ``riak-admin`` main command (https://github.com/ansible-collections/community.general/pull/8211)."
   

--- a/changelogs/fragments/8211-riak-admin-sub-command-support.yml
+++ b/changelogs/fragments/8211-riak-admin-sub-command-support.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "support riak admin sub-command in newer riak kv versions beside the legacy riak-admin main command"
+  

--- a/changelogs/fragments/8211-riak-admin-sub-command-support.yml
+++ b/changelogs/fragments/8211-riak-admin-sub-command-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "support riak admin sub-command in newer riak kv versions beside the legacy riak-admin main command"

--- a/changelogs/fragments/8211-riak-admin-sub-command-support.yml
+++ b/changelogs/fragments/8211-riak-admin-sub-command-support.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - "riak - support ``riak admin`` sub-command in newer Riak KV versions beside the legacy ``riak-admin`` main command (https://github.com/ansible-collections/community.general/pull/8211)."
-  

--- a/plugins/modules/riak.py
+++ b/plugins/modules/riak.py
@@ -126,7 +126,7 @@ def main():
 
     # make sure riak commands are on the path
     riak_bin = module.get_bin_path('riak')
-    riak_admin_bin = module.get_bin_path('riak-admin')
+    riak_admin_bin = module.get_bin_path('riak-admin') or riak_bin + ' admin'
 
     timeout = time.time() + 120
     while True:
@@ -216,7 +216,7 @@ def main():
                 module.fail_json(msg='Timeout waiting for handoffs.')
 
     if wait_for_service:
-        cmd = [riak_admin_bin, 'wait_for_service', 'riak_%s' % wait_for_service, node_name]
+        cmd = riak_admin_bin.split() + ['wait_for_service', 'riak_%s' % wait_for_service, node_name]
         rc, out, err = module.run_command(cmd)
         result['service'] = out
 

--- a/plugins/modules/riak.py
+++ b/plugins/modules/riak.py
@@ -126,7 +126,8 @@ def main():
 
     # make sure riak commands are on the path
     riak_bin = module.get_bin_path('riak')
-    riak_admin_bin = module.get_bin_path('riak-admin') or riak_bin + ' admin'
+    riak_admin_bin = module.get_bin_path('riak-admin')
+    riak_admin_bin = [riak_admin_bin] if riak_admin_bin is not None else [riak_bin, ' admin']
 
     timeout = time.time() + 120
     while True:
@@ -216,7 +217,7 @@ def main():
                 module.fail_json(msg='Timeout waiting for handoffs.')
 
     if wait_for_service:
-        cmd = riak_admin_bin.split() + ['wait_for_service', 'riak_%s' % wait_for_service, node_name]
+        cmd = riak_admin_bin + ['wait_for_service', 'riak_%s' % wait_for_service, node_name]
         rc, out, err = module.run_command(cmd)
         result['service'] = out
 

--- a/plugins/modules/riak.py
+++ b/plugins/modules/riak.py
@@ -93,7 +93,7 @@ from ansible.module_utils.urls import fetch_url
 
 
 def ring_check(module, riak_admin_bin):
-    cmd = '%s ringready' % riak_admin_bin
+    cmd = riak_admin_bin + ['ringready']
     rc, out, err = module.run_command(cmd)
     if rc == 0 and 'TRUE All nodes agree on the ring' in out:
         return True
@@ -127,7 +127,7 @@ def main():
     # make sure riak commands are on the path
     riak_bin = module.get_bin_path('riak')
     riak_admin_bin = module.get_bin_path('riak-admin')
-    riak_admin_bin = [riak_admin_bin] if riak_admin_bin is not None else [riak_bin, ' admin']
+    riak_admin_bin = [riak_admin_bin] if riak_admin_bin is not None else [riak_bin, 'admin']
 
     timeout = time.time() + 120
     while True:
@@ -165,7 +165,7 @@ def main():
             module.fail_json(msg=out)
 
     elif command == 'kv_test':
-        cmd = '%s test' % riak_admin_bin
+        cmd = riak_admin_bin + ['test']
         rc, out, err = module.run_command(cmd)
         if rc == 0:
             result['kv_test'] = out
@@ -176,7 +176,7 @@ def main():
         if nodes.count(node_name) == 1 and len(nodes) > 1:
             result['join'] = 'Node is already in cluster or staged to be in cluster.'
         else:
-            cmd = '%s cluster join %s' % (riak_admin_bin, target_node)
+            cmd = riak_admin_bin + ['cluster', 'join', target_node]
             rc, out, err = module.run_command(cmd)
             if rc == 0:
                 result['join'] = out
@@ -185,7 +185,7 @@ def main():
                 module.fail_json(msg=out)
 
     elif command == 'plan':
-        cmd = '%s cluster plan' % riak_admin_bin
+        cmd = riak_admin_bin + ['cluster', 'plan']
         rc, out, err = module.run_command(cmd)
         if rc == 0:
             result['plan'] = out
@@ -195,7 +195,7 @@ def main():
             module.fail_json(msg=out)
 
     elif command == 'commit':
-        cmd = '%s cluster commit' % riak_admin_bin
+        cmd = riak_admin_bin + ['cluster', 'commit']
         rc, out, err = module.run_command(cmd)
         if rc == 0:
             result['commit'] = out
@@ -207,7 +207,7 @@ def main():
     if wait_for_handoffs:
         timeout = time.time() + wait_for_handoffs
         while True:
-            cmd = '%s transfers' % riak_admin_bin
+            cmd = riak_admin_bin + ['transfers']
             rc, out, err = module.run_command(cmd)
             if 'No transfers active' in out:
                 result['handoffs'] = 'No transfers active.'


### PR DESCRIPTION
##### SUMMARY
Newer riak kv  versions don't provide the riak-admin command anymore but use the 'admin' as an sub-command to the 'riak' command.

Example: 
```
||/ Name           Version       Architecture Description
+++-==============-=============-============-=================================
ii  riak           3.0.8-OTP22.3 amd64        Riak KV Database

dpkg -L riak|fgrep sbin
/usr/sbin
/usr/sbin/riak
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
riak