### PR TITLE
Add support for docker-v2 protocol in Keycloak modules

### DIFF
--- a/changelogs/fragments/8215-add-docker-v2-protocol.yml
+++ b/changelogs/fragments/8215-add-docker-v2-protocol.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Added `docker-v2` protocol support to `keycloak_client`, `keycloak_clientscope`, `keycloak_clienttemplate`, enhancing alignment with Keycloak's protocol options.
+  - keycloak_client, keycloak_clientscope, keycloak_clienttemplate - added ``docker-v2`` protocol support, enhancing alignment with Keycloak's protocol options (https://github.com/ansible-collections/community.general/issues/8215, https://github.com/ansible-collections/community.general/pull/8216).

--- a/changelogs/fragments/8215-add-docker-v2-protocol.yml
+++ b/changelogs/fragments/8215-add-docker-v2-protocol.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added `docker-v2` protocol support to `keycloak_client`, `keycloak_clientscope`, `keycloak_clienttemplate`, enhancing alignment with Keycloak's protocol options.

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -248,6 +248,7 @@ options:
         description:
             - Type of client.
             - At creation only, default value will be V(openid-connect) if O(protocol) is omitted.
+            - The V(docker-v2) value was added in community.general 8.6.0.
         type: str
         choices: ['openid-connect', 'saml', 'docker-v2']
 

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -724,6 +724,7 @@ import copy
 
 PROTOCOL_OPENID_CONNECT = 'openid-connect'
 PROTOCOL_SAML = 'saml'
+PROTOCOL_DOCKER_V2= 'docker_v2'
 CLIENT_META_DATA = ['authorizationServicesEnabled']
 
 
@@ -785,7 +786,7 @@ def main():
         consentText=dict(type='str'),
         id=dict(type='str'),
         name=dict(type='str'),
-        protocol=dict(type='str', choices=[PROTOCOL_OPENID_CONNECT, PROTOCOL_SAML]),
+        protocol=dict(type='str', choices=[PROTOCOL_OPENID_CONNECT, PROTOCOL_SAML, PROTOCOL_DOCKER_V2]),
         protocolMapper=dict(type='str'),
         config=dict(type='dict'),
     )
@@ -819,7 +820,7 @@ def main():
         authorization_services_enabled=dict(type='bool', aliases=['authorizationServicesEnabled']),
         public_client=dict(type='bool', aliases=['publicClient']),
         frontchannel_logout=dict(type='bool', aliases=['frontchannelLogout']),
-        protocol=dict(type='str', choices=[PROTOCOL_OPENID_CONNECT, PROTOCOL_SAML]),
+        protocol=dict(type='str', choices=[PROTOCOL_OPENID_CONNECT, PROTOCOL_SAML, PROTOCOL_DOCKER_V2]),
         attributes=dict(type='dict'),
         full_scope_allowed=dict(type='bool', aliases=['fullScopeAllowed']),
         node_re_registration_timeout=dict(type='int', aliases=['nodeReRegistrationTimeout']),

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -249,7 +249,7 @@ options:
             - Type of client.
             - At creation only, default value will be V(openid-connect) if O(protocol) is omitted.
         type: str
-        choices: ['openid-connect', 'saml']
+        choices: ['openid-connect', 'saml', 'docker-v2']
 
     full_scope_allowed:
         description:
@@ -393,7 +393,7 @@ options:
             protocol:
                 description:
                     - This specifies for which protocol this protocol mapper is active.
-                choices: ['openid-connect', 'saml']
+                choices: ['openid-connect', 'saml', 'docker-v2']
                 type: str
 
             protocolMapper:

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -724,7 +724,7 @@ import copy
 
 PROTOCOL_OPENID_CONNECT = 'openid-connect'
 PROTOCOL_SAML = 'saml'
-PROTOCOL_DOCKER_V2= 'docker_v2'
+PROTOCOL_DOCKER_V2= 'docker-v2'
 CLIENT_META_DATA = ['authorizationServicesEnabled']
 
 

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -724,7 +724,7 @@ import copy
 
 PROTOCOL_OPENID_CONNECT = 'openid-connect'
 PROTOCOL_SAML = 'saml'
-PROTOCOL_DOCKER_V2= 'docker-v2'
+PROTOCOL_DOCKER_V2 = 'docker-v2'
 CLIENT_META_DATA = ['authorizationServicesEnabled']
 
 

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -79,6 +79,7 @@ options:
     protocol:
         description:
             - Type of client.
+            - The V(docker-v2) value was added in community.general 8.6.0.
         choices: ['openid-connect', 'saml', 'wsfed', 'docker-v2']
         type: str
 

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -79,7 +79,7 @@ options:
     protocol:
         description:
             - Type of client.
-        choices: ['openid-connect', 'saml', 'wsfed']
+        choices: ['openid-connect', 'saml', 'wsfed', 'docker_v2']
         type: str
 
     protocol_mappers:
@@ -95,7 +95,7 @@ options:
                 description:
                     - This specifies for which protocol this protocol mapper.
                     - is active.
-                choices: ['openid-connect', 'saml', 'wsfed']
+                choices: ['openid-connect', 'saml', 'wsfed', 'docker_v2']
                 type: str
 
             protocolMapper:
@@ -330,7 +330,7 @@ def main():
     protmapper_spec = dict(
         id=dict(type='str'),
         name=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker_v2']),
         protocolMapper=dict(type='str'),
         config=dict(type='dict'),
     )
@@ -341,7 +341,7 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         description=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker_v2']),
         attributes=dict(type='dict'),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
     )

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -79,7 +79,7 @@ options:
     protocol:
         description:
             - Type of client.
-        choices: ['openid-connect', 'saml', 'wsfed', 'docker_v2']
+        choices: ['openid-connect', 'saml', 'wsfed', 'docker-v2']
         type: str
 
     protocol_mappers:
@@ -95,7 +95,7 @@ options:
                 description:
                     - This specifies for which protocol this protocol mapper.
                     - is active.
-                choices: ['openid-connect', 'saml', 'wsfed', 'docker_v2']
+                choices: ['openid-connect', 'saml', 'wsfed', 'docker-v2']
                 type: str
 
             protocolMapper:
@@ -330,7 +330,7 @@ def main():
     protmapper_spec = dict(
         id=dict(type='str'),
         name=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker_v2']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker-v2']),
         protocolMapper=dict(type='str'),
         config=dict(type='dict'),
     )
@@ -341,7 +341,7 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         description=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker_v2']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'wsfed', 'docker-v2']),
         attributes=dict(type='dict'),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
     )

--- a/plugins/modules/keycloak_clienttemplate.py
+++ b/plugins/modules/keycloak_clienttemplate.py
@@ -68,6 +68,7 @@ options:
     protocol:
         description:
             - Type of client template.
+            - The V(docker-v2) value was added in community.general 8.6.0.
         choices: ['openid-connect', 'saml', 'docker-v2']
         type: str
 

--- a/plugins/modules/keycloak_clienttemplate.py
+++ b/plugins/modules/keycloak_clienttemplate.py
@@ -68,7 +68,7 @@ options:
     protocol:
         description:
             - Type of client template.
-        choices: ['openid-connect', 'saml']
+        choices: ['openid-connect', 'saml', 'docker_v2']
         type: str
 
     full_scope_allowed:
@@ -107,7 +107,7 @@ options:
             protocol:
                 description:
                     - This specifies for which protocol this protocol mapper is active.
-                choices: ['openid-connect', 'saml']
+                choices: ['openid-connect', 'saml', 'docker_v2']
                 type: str
 
             protocolMapper:
@@ -292,7 +292,7 @@ def main():
         consentText=dict(type='str'),
         id=dict(type='str'),
         name=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker_v2']),
         protocolMapper=dict(type='str'),
         config=dict(type='dict'),
     )
@@ -304,7 +304,7 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         description=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker_v2']),
         attributes=dict(type='dict'),
         full_scope_allowed=dict(type='bool'),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec),

--- a/plugins/modules/keycloak_clienttemplate.py
+++ b/plugins/modules/keycloak_clienttemplate.py
@@ -68,7 +68,7 @@ options:
     protocol:
         description:
             - Type of client template.
-        choices: ['openid-connect', 'saml', 'docker_v2']
+        choices: ['openid-connect', 'saml', 'docker-v2']
         type: str
 
     full_scope_allowed:
@@ -107,7 +107,7 @@ options:
             protocol:
                 description:
                     - This specifies for which protocol this protocol mapper is active.
-                choices: ['openid-connect', 'saml', 'docker_v2']
+                choices: ['openid-connect', 'saml', 'docker-v2']
                 type: str
 
             protocolMapper:
@@ -292,7 +292,7 @@ def main():
         consentText=dict(type='str'),
         id=dict(type='str'),
         name=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker_v2']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker-v2']),
         protocolMapper=dict(type='str'),
         config=dict(type='dict'),
     )
@@ -304,7 +304,7 @@ def main():
         id=dict(type='str'),
         name=dict(type='str'),
         description=dict(type='str'),
-        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker_v2']),
+        protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker-v2']),
         attributes=dict(type='dict'),
         full_scope_allowed=dict(type='bool'),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec),


### PR DESCRIPTION
##### SUMMARY
This pull request introduces the addition of the "docker-v2" protocol support to the `keycloak_client`, `keycloak_clientscope`, and `keycloak_clienttemplate` modules within the community.general collection. The "docker-v2" protocol is a valid and supported option in Keycloak, which is crucial for configurations involving Docker registry authentication, among others. Fixes #8215.


<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- `keycloak_client`
- `keycloak_clientscope`
- `keycloak_clienttemplate` 

##### ADDITIONAL INFORMATION
I have enhanced the `protocol` parameter across the `keycloak_client`, `keycloak_clientscope`, and `keycloak_clienttemplate` modules to include the "docker-v2" option. It's important to note that the existing protocol choices varied across different modules — some were limited to `['openid-connect', 'saml']`, while others used Python constants to define the choices. I've respected the existing structure and conventions in each module, only extending them to include "docker-v2".

For instance, if a module's protocol choices were previously defined as:

```python
protocol=dict(type='str', choices=['openid-connect', 'saml'])
```
I have updated this to
```python
protocol=dict(type='str', choices=['openid-connect', 'saml', 'docker-v2'])
```
And similarly, for modules using Python constants to define protocol choices, I've appended "docker-v2" to the existing list without altering the existing structure.

The documentation for each affected module has been updated to include "docker-v2" as a valid protocol option.

The modifications were tested to confirm that the "docker-v2" protocol is recognized and behaves as expected across the updated modules. I encourage further testing by the community to validate these changes across various usage scenarios.  

I have _not_ verified the potential error message from the Keycloak API when this option is used when the keycloak server has not activated the docker-v2 protocol, (disabled by default and enabled by running `bin/standalone.sh|bat -Dkeycloak.profile.feature.docker=enabled` starting the service, see (https://www.keycloak.org/server/features).


