### PR TITLE
keycloak_client: add sorted defaultClientScopes and optionalClientScopes to normalizations

### DIFF
--- a/changelogs/fragments/8223-keycloak_client-additional-normalizations.yaml
+++ b/changelogs/fragments/8223-keycloak_client-additional-normalizations.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - add sorted ``defaultClientScopes`` and ``optionalClientScopes`` to normalizations (https://github.com/ansible-collections/community.general/pull/8223).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -742,6 +742,12 @@ def normalise_cr(clientrep, remove_ids=False):
     if 'attributes' in clientrep:
         clientrep['attributes'] = list(sorted(clientrep['attributes']))
 
+    if 'defaultClientScopes' in clientrep:
+        clientrep['defaultClientScopes'] = list(sorted(clientrep['defaultClientScopes']))
+
+    if 'optionalClientScopes' in clientrep:
+        clientrep['optionalClientScopes'] = list(sorted(clientrep['optionalClientScopes']))
+
     if 'redirectUris' in clientrep:
         clientrep['redirectUris'] = list(sorted(clientrep['redirectUris']))
 


### PR DESCRIPTION
##### SUMMARY
keycloak_client: Add sorted `defaultClientScopes` and `optionalClientScopes` to normalizations.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_client

##### ADDITIONAL INFORMATION
Without this code, `ansible-playbook --check --diff`will show changes because a unsorted list is diffed.