### PR TITLE
keycloak_realm: add normalizations for enabledEventTypes, and supportedLocales

### DIFF
--- a/changelogs/fragments/8224-keycloak_realm-add-normalizations.yaml
+++ b/changelogs/fragments/8224-keycloak_realm-add-normalizations.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_realm - add normalizations for ``enabledEventTypes`` and ``supportedLocales`` (https://github.com/ansible-collections/community.general/pull/8224).


### PR DESCRIPTION
##### SUMMARY
keycloak_realm: Add sorted `defaultClientScopes` and `optionalClientScopes` to normalizations.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_realm

##### ADDITIONAL INFORMATION
Without this code, `ansible-playbook --check --diff`will show changes because a unsorted list is diffed.
It uses the same approach as for `keycloak_client` in https://github.com/ansible-collections/community.general/blob/6c8f949ba950309931d8931f4820b99707898850/plugins/modules/keycloak_client.py#L730