### PR TITLE
Change MH to use the module_utils.vardict.VarDict

### DIFF
--- a/changelogs/fragments/8226-mh-vardict.yml
+++ b/changelogs/fragments/8226-mh-vardict.yml
@@ -1,0 +1,10 @@
+deprecated_features:
+  - ModuleHelper vars module_utils - bump deprecation of ``VarMeta``, ``VarDict`` and ``VarsMixin`` to version 11.0.0 (https://github.com/ansible-collections/community.general/pull/8226).
+  - ModuleHelper module_utils - deprecate use of ``VarsMixin`` in favor of using the ``VardDict`` module_utils (https://github.com/ansible-collections/community.general/pull/8226).
+minor_changes:
+  - gconftool2 - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).
+  - kernel_blacklist - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).
+  - opkg - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).
+  - pipx - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).
+  - xfconf - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).
+  - xfconf_info - use ``ModuleHelper`` with ``VarDict`` (https://github.com/ansible-collections/community.general/pull/8226).

--- a/plugins/module_utils/mh/mixins/vars.py
+++ b/plugins/module_utils/mh/mixins/vars.py
@@ -14,7 +14,7 @@ class VarMeta(object):
     """
     DEPRECATION WARNING
 
-    This class is deprecated and will be removed in community.general 10.0.0
+    This class is deprecated and will be removed in community.general 11.0.0
     Modules should use the VarDict from plugins/module_utils/vardict.py instead.
     """
 
@@ -70,7 +70,7 @@ class VarDict(object):
     """
     DEPRECATION WARNING
 
-    This class is deprecated and will be removed in community.general 10.0.0
+    This class is deprecated and will be removed in community.general 11.0.0
     Modules should use the VarDict from plugins/module_utils/vardict.py instead.
     """
     def __init__(self):
@@ -139,7 +139,7 @@ class VarsMixin(object):
     """
     DEPRECATION WARNING
 
-    This class is deprecated and will be removed in community.general 10.0.0
+    This class is deprecated and will be removed in community.general 11.0.0
     Modules should use the VarDict from plugins/module_utils/vardict.py instead.
     """
     def __init__(self, module=None):

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# (c) 2020, Alexei Znamensky <russoz@gmail.com>
-# Copyright (c) 2020, Ansible Project
+# (c) 2020-2024, Alexei Znamensky <russoz@gmail.com>
+# Copyright (c) 2020-2024, Ansible Project
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -67,7 +67,10 @@ class ModuleHelper(DeprecateAttrsMixin, ModuleHelperBase):
         self.update_vars(meta={"fact": True}, **kwargs)
 
     def _vars_changed(self):
-        return any(self.vars.has_changed(v) for v in self.vars.change_vars())
+        if self.use_old_vardict:
+            return any(self.vars.has_changed(v) for v in self.vars.change_vars())
+
+        return self.vars.has_changed
 
     def has_changed(self):
         return self.changed or self._vars_changed()

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -10,11 +10,12 @@ __metaclass__ = type
 
 from ansible.module_utils.common.dict_transformations import dict_merge
 
-from ansible_collections.community.general.plugins.module_utils.vardict import VarDict as NewVarDict
+from ansible_collections.community.general.plugins.module_utils.vardict import VarDict as NewVarDict  # remove "as NewVarDictt" in 11.0.0
 # (TODO: remove AnsibleModule!) pylint: disable-next=unused-import
-from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase, AnsibleModule  # noqa: F401
+from ansible_collections.community.general.plugins.module_utils.mh.base import AnsibleModule          # noqa: F401   DEPRECATED, remove in 11.0.0
+from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
-from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarDict as OldVarDict
+from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarDict         # remove in 11.0.0
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.deprecate_attrs import DeprecateAttrsMixin
 
 
@@ -24,20 +25,23 @@ class ModuleHelper(DeprecateAttrsMixin, ModuleHelperBase):
     diff_params = ()
     change_params = ()
     facts_params = ()
-    use_old_vardict = True
+    use_old_vardict = True      # remove in 11.0.0
+    mute_vardict_deprecation = False
 
     def __init__(self, module=None):
-        super(ModuleHelper, self).__init__(module)
-        if self.use_old_vardict:
-            self.vars = OldVarDict()
-            self.module.deprecate(
-                "This class is using the old VarDict from ModuleHelper, which is deprecated. "
-                "Set the class variable use_old_vardict to False and make the necessary adjustments."
-                "The old VarDict class will be removed in community.general 11.0.0",
-                version="11.0.0", collection_name="community.general"
-            )
+        if self.use_old_vardict:  # remove first half of the if in 11.0.0
+            self.vars = VarDict()
+            super(ModuleHelper, self).__init__(module)
+            if not self.mute_vardict_deprecation:
+                self.module.deprecate(
+                    "This class is using the old VarDict from ModuleHelper, which is deprecated. "
+                    "Set the class variable use_old_vardict to False and make the necessary adjustments."
+                    "The old VarDict class will be removed in community.general 11.0.0",
+                    version="11.0.0", collection_name="community.general"
+                )
         else:
             self.vars = NewVarDict()
+            super(ModuleHelper, self).__init__(module)
 
         for name, value in self.module.params.items():
             self.vars.set(

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -10,12 +10,14 @@ __metaclass__ = type
 
 from ansible.module_utils.common.dict_transformations import dict_merge
 
-from ansible_collections.community.general.plugins.module_utils.vardict import VarDict as NewVarDict  # remove "as NewVarDictt" in 11.0.0
+from ansible_collections.community.general.plugins.module_utils.vardict import VarDict as _NewVarDict  # remove "as NewVarDict" in 11.0.0
 # (TODO: remove AnsibleModule!) pylint: disable-next=unused-import
-from ansible_collections.community.general.plugins.module_utils.mh.base import AnsibleModule          # noqa: F401   DEPRECATED, remove in 11.0.0
+from ansible_collections.community.general.plugins.module_utils.mh.base import AnsibleModule  # noqa: F401 DEPRECATED, remove in 11.0.0
 from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
-from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarDict         # remove in 11.0.0
+# (TODO: remove mh.mixins.vars!) pylint: disable-next=unused-import
+from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarsMixin, VarDict as _OldVarDict  # noqa: F401 remove in 11.0.0
+from ansible_collections.community.general.plugins.module_utils.mh.mixins.deps import DependencyMixin
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.deprecate_attrs import DeprecateAttrsMixin
 
 
@@ -30,7 +32,7 @@ class ModuleHelper(DeprecateAttrsMixin, ModuleHelperBase):
 
     def __init__(self, module=None):
         if self.use_old_vardict:  # remove first half of the if in 11.0.0
-            self.vars = VarDict()
+            self.vars = _OldVarDict()
             super(ModuleHelper, self).__init__(module)
             if not self.mute_vardict_deprecation:
                 self.module.deprecate(
@@ -40,7 +42,7 @@ class ModuleHelper(DeprecateAttrsMixin, ModuleHelperBase):
                     version="11.0.0", collection_name="community.general"
                 )
         else:
-            self.vars = NewVarDict()
+            self.vars = _NewVarDict()
             super(ModuleHelper, self).__init__(module)
 
         for name, value in self.module.params.items():

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -18,7 +18,7 @@ from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars i
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.deprecate_attrs import DeprecateAttrsMixin
 
 
-class ModuleHelper(DeprecateAttrsMixin, VarsMixin, ModuleHelperBase):
+class ModuleHelper(DeprecateAttrsMixin, ModuleHelperBase):
     facts_name = None
     output_params = ()
     diff_params = ()

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -17,7 +17,6 @@ from ansible_collections.community.general.plugins.module_utils.mh.base import M
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
 # (TODO: remove mh.mixins.vars!) pylint: disable-next=unused-import
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.vars import VarsMixin, VarDict as _OldVarDict  # noqa: F401 remove in 11.0.0
-from ansible_collections.community.general.plugins.module_utils.mh.mixins.deps import DependencyMixin
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.deprecate_attrs import DeprecateAttrsMixin
 
 

--- a/plugins/module_utils/mh/module_helper.py
+++ b/plugins/module_utils/mh/module_helper.py
@@ -10,6 +10,7 @@ __metaclass__ = type
 
 from ansible.module_utils.common.dict_transformations import dict_merge
 
+from ansible_collections.community.general.plugins.module_utils.vardict import VarDict
 # (TODO: remove AnsibleModule!) pylint: disable-next=unused-import
 from ansible_collections.community.general.plugins.module_utils.mh.base import ModuleHelperBase, AnsibleModule  # noqa: F401
 from ansible_collections.community.general.plugins.module_utils.mh.mixins.state import StateMixin
@@ -25,7 +26,7 @@ class ModuleHelper(DeprecateAttrsMixin, VarsMixin, ModuleHelperBase):
     facts_params = ()
 
     def __init__(self, module=None):
-        super(ModuleHelper, self).__init__(module)
+        self.vars = VarDict()
         for name, value in self.module.params.items():
             self.vars.set(
                 name, value,

--- a/plugins/modules/gconftool2.py
+++ b/plugins/modules/gconftool2.py
@@ -123,6 +123,7 @@ class GConftool(StateModuleHelper):
         ],
         supports_check_mode=True,
     )
+    use_old_vardict = False
 
     def __init_module__(self):
         self.runner = gconftool2_runner(self.module, check_rc=True)

--- a/plugins/modules/kernel_blacklist.py
+++ b/plugins/modules/kernel_blacklist.py
@@ -67,6 +67,7 @@ class Blacklist(StateModuleHelper):
         ),
         supports_check_mode=True,
     )
+    mute_vardict_deprecation = True
 
     def __init_module__(self):
         self.pattern = re.compile(r'^blacklist\s+{0}$'.format(re.escape(self.vars.name)))

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -127,6 +127,7 @@ class Opkg(StateModuleHelper):
             executable=dict(type="path"),
         ),
     )
+    use_old_vardict = False
 
     def __init_module__(self):
         self.vars.set("install_c", 0, output=False, change=True)

--- a/plugins/modules/pipx.py
+++ b/plugins/modules/pipx.py
@@ -201,6 +201,7 @@ class PipX(StateModuleHelper):
         ],
         supports_check_mode=True,
     )
+    use_old_vardict = False
 
     def _retrieve_installed(self):
         def process_list(rc, out, err):

--- a/plugins/modules/xfconf.py
+++ b/plugins/modules/xfconf.py
@@ -187,6 +187,7 @@ class XFConfProperty(StateModuleHelper):
         required_together=[('value', 'value_type')],
         supports_check_mode=True,
     )
+    use_old_vardict = False
 
     default_state = 'present'
 
@@ -196,7 +197,7 @@ class XFConfProperty(StateModuleHelper):
                                                                                  self.vars.channel)
         self.vars.set('previous_value', self._get())
         self.vars.set('type', self.vars.value_type)
-        self.vars.meta('value').set(initial_value=self.vars.previous_value)
+        self.vars.set_meta('value', initial_value=self.vars.previous_value)
 
     def process_command_output(self, rc, out, err):
         if err.rstrip() == self.does_not:

--- a/plugins/modules/xfconf_info.py
+++ b/plugins/modules/xfconf_info.py
@@ -139,6 +139,7 @@ class XFConfInfo(ModuleHelper):
         ),
         supports_check_mode=True,
     )
+    use_old_vardict = False
 
     def __init_module__(self):
         self.runner = xfconf_runner(self.module, check_rc=True)
@@ -176,7 +177,7 @@ class XFConfInfo(ModuleHelper):
             proc = self._process_list_properties
 
         with self.runner.context('list_arg channel property', output_process=proc) as ctx:
-            result = ctx.run(**self.vars)
+            result = ctx.run(**self.vars.as_dict())
 
         if not self.vars.list_arg and self.vars.is_array:
             output = "value_array"

--- a/tests/integration/targets/module_helper/library/mstate.py
+++ b/tests/integration/targets/module_helper/library/mstate.py
@@ -49,6 +49,7 @@ class MState(StateModuleHelper):
             state=dict(type='str', choices=['join', 'b_x_a', 'c_x_a', 'both_x_a', 'nop'], default='join'),
         ),
     )
+    use_old_vardict = False
 
     def __init_module__(self):
         self.vars.set('result', "abc", diff=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The objects in `plugins/module_utils/mh/mixins/vars.py` are set to be removed in community.general 10.0.0, and  the `ModuleHelper` class still depends on it.

This PR severs that dependency by making use of the more generic code in `plugins/module_utils/vardict.py`.

While this make look simple, there are many modules depending on `ModuleHelper` today, so we must be careful with the impact of this change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/mh/module_helper.py
