### PR TITLE
Fix bug caused by txt records longer than 255 characters

### DIFF
--- a/changelogs/fragments/8227-chunk-txt-records-over-255-characters.yml
+++ b/changelogs/fragments/8227-chunk-txt-records-over-255-characters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Fix bug causes by TXT records over 255 characters (https://github.com/ansible-collections/community.general/pull/8227).

--- a/plugins/modules/nsupdate.py
+++ b/plugins/modules/nsupdate.py
@@ -253,6 +253,9 @@ class RecordManager(object):
         self.dns_rc = 0
 
     def txt_helper(self, entry):
+        if len(entry) > 255:
+            entry = [entry[i:i+255] for i in range(0, len(entry), 255)]
+            entry = '" "'.join(entry)
         if entry[0] == '"' and entry[-1] == '"':
             return entry
         return '"{text}"'.format(text=entry)


### PR DESCRIPTION
DNS Python rejects TXT records [longer than 255 characters](https://github.com/rthalley/dnspython/issues/292)

##### SUMMARY
DNS Python rejects TXT records [longer than 255 characters](https://github.com/rthalley/dnspython/issues/292)

This can be fixed by the following methods:
* User can manually split up TXT records into the appropriate sized chunks: This solution is not intuitive because one needs to be aware of how spaces are treated inside SPF records and they need to be very good at counting their string lengths.
* A jinja2 based solution can include macros but is very messy
* A custom ansible filter can be written in ansible 
* Finally, we can just chunk the string in the existing txt record helper.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nsupdate

##### ADDITIONAL INFORMATION
Make a TXT record that is longer than 255 characters, such as many SPF or DKIM records. 

Before:
```
failed: [localhost] (item=longtxt IN TXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "record": "longtxt",
        "type": "TXT",
        "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
    }
}
```

After:
```
changed: [localhost] => (item=longtxt IN TXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) => {
    "ansible_loop_var": "item",
    "changed": true,
    "dns_rc": 0,
    "dns_rc_str": "NOERROR",
    "item": {
        "record": "longtxt",
        "type": "TXT",
        "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
    },
    "record": {
        "record": "longtxt",
        "ttl": 3600,
        "type": "TXT",
        "value": [
            "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" \"a\""
        ],
        "zone": "example.com."
    }
}
```