### PR TITLE
Add an explicit `select` option to `portage` module

### DIFF
--- a/changelogs/fragments/8236-portage-select-feature.yml
+++ b/changelogs/fragments/8236-portage-select-feature.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - portage - adds the possibility to explicitely tell portage to write packages to world file.

--- a/changelogs/fragments/8236-portage-select-feature.yml
+++ b/changelogs/fragments/8236-portage-select-feature.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - portage - adds the possibility to explicitely tell portage to write packages to world file.
+  - portage - adds the possibility to explicitely tell portage to write packages to world file (https://github.com/ansible-collections/community.general/issues/6226, https://github.com/ansible-collections/community.general/pull/8236).

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -121,6 +121,12 @@ options:
     type: bool
     default: false
 
+  select:
+    description:
+      - Explicitely add the package to the world file
+    type: bool
+    default: false
+
   sync:
     description:
       - Sync package repositories first
@@ -374,6 +380,7 @@ def emerge_packages(module, packages):
         'loadavg': '--load-average',
         'backtrack': '--backtrack',
         'withbdeps': '--with-bdeps',
+        'select': '--select',
     }
 
     for flag, arg in emerge_flags.items():
@@ -523,6 +530,7 @@ def main():
             nodeps=dict(default=False, type='bool'),
             onlydeps=dict(default=False, type='bool'),
             depclean=dict(default=False, type='bool'),
+            select=dict(default=False, type='bool'),
             quiet=dict(default=False, type='bool'),
             verbose=dict(default=False, type='bool'),
             sync=dict(default=None, choices=['yes', 'web', 'no']),
@@ -543,6 +551,7 @@ def main():
             ['quiet', 'verbose'],
             ['quietbuild', 'verbose'],
             ['quietfail', 'verbose'],
+            ['oneshot', 'select'],
         ],
         supports_check_mode=True,
     )

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -123,9 +123,12 @@ options:
 
   select:
     description:
-      - Explicitely add the package to the world file
+      - If set to V(true), explicitely add the package to the world file.
+      - Please note that this option is not used for idempotency, it is only used
+        when actually installing a package.
     type: bool
     default: false
+    version_added: 8.6.0
 
   sync:
     description:

--- a/plugins/modules/portage.py
+++ b/plugins/modules/portage.py
@@ -127,7 +127,6 @@ options:
       - Please note that this option is not used for idempotency, it is only used
         when actually installing a package.
     type: bool
-    default: false
     version_added: 8.6.0
 
   sync:
@@ -533,7 +532,7 @@ def main():
             nodeps=dict(default=False, type='bool'),
             onlydeps=dict(default=False, type='bool'),
             depclean=dict(default=False, type='bool'),
-            select=dict(default=False, type='bool'),
+            select=dict(default=None, type='bool'),
             quiet=dict(default=False, type='bool'),
             verbose=dict(default=False, type='bool'),
             sync=dict(default=None, choices=['yes', 'web', 'no']),


### PR DESCRIPTION
##### SUMMARY

This patch permits to explicitly pass `--select=y` to portage, in order to tell it to write to world file. This is useful for users who setup Gentoo in a way that `oneshot` is the default (see original linked issue).

Fixes #6226

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
portage

##### ADDITIONAL INFORMATION
One can setup Portage with `EMERGE_DEFAULT_OPTS="--oneshot"` to reproduce. Not passing `select` option to the module in a task will keep the default behavior (nothing is passed to portage, so whatever the user have set in their default Portage options, the behavior is the same). Passing `select:true` as module option will allow users to make portage write to world file if oneshot is the default for them in Portage (and does not break users where it's not the default). The new option is of course exclusive with `oneshot` module parameter.
