### PR TITLE
use smaller snap, add disabled to aliases

### DIFF
--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -11,3 +11,4 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/docker
+disabled

--- a/tests/integration/targets/snap/aliases
+++ b/tests/integration/targets/snap/aliases
@@ -11,4 +11,3 @@ skip/freebsd
 skip/osx
 skip/macos
 skip/docker
-disabled

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -15,6 +15,7 @@
       ansible.builtin.include_tasks: test.yml
     - name: Include test_channel
       ansible.builtin.include_tasks: test_channel.yml
+    # TODO: Find bettter package to download and install from sources - cider 1.6.0 takes over 35 seconds to install
     # - name: Include test_dangerous
     #   ansible.builtin.include_tasks: test_dangerous.yml
     - name: Include test_3dash

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -13,12 +13,10 @@
   block:
     - name: Include test
       ansible.builtin.include_tasks: test.yml
-    # TODO: Find better package to install from a channel - microk8s installation takes multiple minutes, and even removal takes one minute!
-    # - name: Include test_channel
-    #   ansible.builtin.include_tasks: test_channel.yml
-    # TODO: Find bettter package to download and install from sources - cider 1.6.0 takes over 35 seconds to install
-    # - name: Include test_dangerous
-    #   ansible.builtin.include_tasks: test_dangerous.yml
+    - name: Include test_channel
+      ansible.builtin.include_tasks: test_channel.yml
+    - name: Include test_dangerous
+      ansible.builtin.include_tasks: test_dangerous.yml
     - name: Include test_3dash
       ansible.builtin.include_tasks: test_3dash.yml
     - name: Include test_empty_list

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -15,8 +15,8 @@
       ansible.builtin.include_tasks: test.yml
     - name: Include test_channel
       ansible.builtin.include_tasks: test_channel.yml
-    - name: Include test_dangerous
-      ansible.builtin.include_tasks: test_dangerous.yml
+    # - name: Include test_dangerous
+    #   ansible.builtin.include_tasks: test_dangerous.yml
     - name: Include test_3dash
       ansible.builtin.include_tasks: test_3dash.yml
     - name: Include test_empty_list

--- a/tests/integration/targets/snap/tasks/main.yml
+++ b/tests/integration/targets/snap/tasks/main.yml
@@ -15,7 +15,7 @@
       ansible.builtin.include_tasks: test.yml
     - name: Include test_channel
       ansible.builtin.include_tasks: test_channel.yml
-    # TODO: Find bettter package to download and install from sources - cider 1.6.0 takes over 35 seconds to install
+    # TODO: Find better package to download and install from sources - cider 1.6.0 takes over 35 seconds to install
     # - name: Include test_dangerous
     #   ansible.builtin.include_tasks: test_dangerous.yml
     - name: Include test_3dash

--- a/tests/integration/targets/snap/tasks/test_channel.yml
+++ b/tests/integration/targets/snap/tasks/test_channel.yml
@@ -5,47 +5,44 @@
 
 # NOTE This is currently disabled for performance reasons!
 
-- name: Make sure package is not installed (microk8s)
+- name: Make sure package is not installed (wisdom)
   community.general.snap:
-    name: microk8s
+    name: wisdom
     state: absent
 
 # Test for https://github.com/ansible-collections/community.general/issues/1606
-- name: Install package (microk8s)
+- name: Install package (wisdom)
   community.general.snap:
-    name: microk8s
-    classic: true
+    name: wisdom
     state: present
-  register: install_microk8s
+  register: install_wisdom
 
-- name: Install package with channel (microk8s)
+- name: Install package with channel (wisdom)
   community.general.snap:
-    name: microk8s
-    classic: true
-    channel: 1.20/stable
+    name: wisdom
     state: present
-  register: install_microk8s_chan
+    channel: latest/edge
+  register: install_wisdom_chan
 
-- name: Install package with channel (microk8s) again
+- name: Install package with channel (wisdom) again
   community.general.snap:
-    name: microk8s
-    classic: true
-    channel: 1.20/stable
+    name: wisdom
     state: present
-  register: install_microk8s_chan_again
+    channel: latest/edge
+  register: install_wisdom_chan_again
 
-- name: Remove package (microk8s)
+- name: Remove package (wisdom)
   community.general.snap:
-    name: microk8s
+    name: wisdom
     state: absent
-  register: remove_microk8s
+  register: remove_wisdom
 
 - assert:
     that:
-      - install_microk8s is changed
-      - install_microk8s_chan is changed
-      - install_microk8s_chan_again is not changed
-      - remove_microk8s is changed
+      - install_wisdom is changed
+      - install_wisdom_chan is changed
+      - install_wisdom_chan_again is not changed
+      - remove_wisdom is changed
 
 - name: Install package (shellcheck)
   community.general.snap:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Testing `snap` is intrinsically heavier loaded than testing other "regular" modules. Thus, adding the `disabled` tag to its `aliases` file.

We can still run the test when needed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
snap
