### PR TITLE
bitwarden_secrets_manager: implement rate limit retry with backoff

### DIFF
--- a/plugins/lookup/bitwarden_secrets_manager.py
+++ b/plugins/lookup/bitwarden_secrets_manager.py
@@ -70,6 +70,7 @@ RETURN = """
 """
 
 from subprocess import Popen, PIPE
+from time import sleep
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_text
@@ -84,10 +85,27 @@ class BitwardenSecretsManagerException(AnsibleLookupError):
 class BitwardenSecretsManager(object):
     def __init__(self, path='bws'):
         self._cli_path = path
+        self._max_retries = 3
+        self._retry_delay = 1
 
     @property
     def cli_path(self):
         return self._cli_path
+
+    def _run_with_retry(self, args, stdin=None, retries=0):
+        if retries > self._max_retries:
+            raise BitwardenSecretsManagerException("Max retries exceeded. Unable to retrieve secret.")
+
+        out, err, rc = self._run(args, stdin)
+
+        if "Too many requests" in err:
+            delay = self._retry_delay * (2 ** retries)
+            sleep(delay)
+            return self._run_with_retry(args, stdin, retries + 1)
+        elif rc != 0:
+            raise BitwardenSecretsManagerException(f"Command failed with return code {rc}: {err}")
+
+        return out, err, rc
 
     def _run(self, args, stdin=None):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
@@ -107,7 +125,7 @@ class BitwardenSecretsManager(object):
             'get', 'secret', secret_id
         ]
 
-        out, err, rc = self._run(params)
+        out, err, rc = self._run_with_retry(params)
         if rc != 0:
             raise BitwardenSecretsManagerException(to_text(err))
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
Fixes #8230 

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Refactoring Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
bitwarden_secrets_manager

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
