### PR TITLE
Add accept-new as valid option for ssh_config host key checking

### DIFF
--- a/changelogs/fragments/8257-ssh-config-hostkey-support-accept-new.yaml
+++ b/changelogs/fragments/8257-ssh-config-hostkey-support-accept-new.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ssh_config - allow accept-new as valid value for strict_host_key_checking (https://github.com/ansible-collections/community.general/pull/8257).
+  - ssh_config - allow ``accept-new`` as valid value for ``strict_host_key_checking`` (https://github.com/ansible-collections/community.general/pull/8257).

--- a/changelogs/fragments/8257-ssh-config-hostkey-support-accept-new.yaml
+++ b/changelogs/fragments/8257-ssh-config-hostkey-support-accept-new.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - allow accept-new as valid value for strict_host_key_checking (https://github.com/ansible-collections/community.general/pull/8257).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -88,6 +88,7 @@ options:
   strict_host_key_checking:
     description:
       - Whether to strictly check the host key when doing connections to the remote host.
+      - The value V(accept-new) is supported since community.general 8.6.0.
     choices: [ 'yes', 'no', 'ask', 'accept-new' ]
     type: str
   proxycommand:
@@ -370,7 +371,7 @@ def main():
             strict_host_key_checking=dict(
                 type='str',
                 default=None,
-                choices=['yes', 'no', 'ask', 'accept-new']
+                choices=['yes', 'no', 'ask', 'accept-new'],
             ),
             controlmaster=dict(type='str', default=None, choices=['yes', 'no', 'ask', 'auto', 'autoask']),
             controlpath=dict(type='str', default=None),

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -88,7 +88,7 @@ options:
   strict_host_key_checking:
     description:
       - Whether to strictly check the host key when doing connections to the remote host.
-    choices: [ 'yes', 'no', 'ask' ]
+    choices: [ 'yes', 'no', 'ask', 'accept-new' ]
     type: str
   proxycommand:
     description:
@@ -370,7 +370,7 @@ def main():
             strict_host_key_checking=dict(
                 type='str',
                 default=None,
-                choices=['yes', 'no', 'ask']
+                choices=['yes', 'no', 'ask', 'accept-new']
             ),
             controlmaster=dict(type='str', default=None, choices=['yes', 'no', 'ask', 'auto', 'autoask']),
             controlpath=dict(type='str', default=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes https://github.com/ansible-collections/community.general/issues/8177

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

ssh_config

##### ADDITIONAL INFORMATION

As described in https://github.com/ansible-collections/community.general/issues/8177

> [OpenSSH 7.6](https://www.openssh.com/txt/release-7.6) introduced a new value accept-new for StrictHostKeyChecking which allows for automatically adding fingerprints for new hosts in ~/.ssh/know_hosts but still block the connection attempt if the fingerprint changes (eg. MITM attack).

This PR adds this value to the valid settings for `strict_host_key_checking`
