### PR TITLE
Support identity_agent in ssh_config

### DIFF
--- a/changelogs/fragments/8258-ssh_config-support-identity-agent.yml
+++ b/changelogs/fragments/8258-ssh_config-support-identity-agent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh_config - add parameter identity_agent (https://github.com/ansible-collections/community.general/pull/8258).

--- a/plugins/modules/ssh_config.py
+++ b/plugins/modules/ssh_config.py
@@ -66,6 +66,13 @@ options:
     description:
       - Specifies the user to log in as.
     type: str
+  identity_agent:
+    description:
+      - Path to the UNIX-domain socket used to communicate with the
+        authentication agent.
+      - Setting the socket name to none disables the use of an
+        authentication agent.
+    type: path
   identity_file:
     description:
       - The path to an identity file (SSH private key) that will be used
@@ -258,6 +265,7 @@ class SSHConfig(object):
         args = dict(
             hostname=self.params.get('hostname'),
             port=self.params.get('port'),
+            identity_agent=self.params.get('identity_agent'),
             identity_file=self.params.get('identity_file'),
             identities_only=convert_bool(self.params.get('identities_only')),
             user=self.params.get('remote_user'),
@@ -357,6 +365,7 @@ def main():
             host=dict(type='str', required=True),
             hostname=dict(type='str'),
             host_key_algorithms=dict(type='str', no_log=False),
+            identity_agent=dict(type='path'),
             identity_file=dict(type='path'),
             identities_only=dict(type='bool'),
             port=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes https://github.com/ansible-collections/community.general/issues/7435

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->

- Feature Pull Request


##### COMPONENT NAME
ssh_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Implements support for the option `IdentityAgent` in `ssh_config`


```
IdentityAgent

  Specifies the UNIX-domain socket used to communicate with the authentication agent.
  
  This option overrides the SSH_AUTH_SOCK environment variable and can be used to select a specific agent. Setting the socket name to none disables the use of an authentication agent. If the string "SSH_AUTH_SOCK" is specified, the location of the socket will be read from the SSH_AUTH_SOCK environment variable. Otherwise if the specified value begins with a ‘$’ character, then it will be treated as an environment variable containing the location of the socket.
  
  Arguments to IdentityAgent may use the tilde syntax to refer to a user's home directory, the tokens described in the [TOKENS](https://man.openbsd.org/ssh_config#TOKENS) section and environment variables as described in the [ENVIRONMENT VARIABLES](https://man.openbsd.org/ssh_config#ENVIRONMENT_VARIABLES) section.
``