### PR TITLE
apt_rpm: fix package install check

### DIFF
--- a/changelogs/fragments/8263-apt_rpm-install-check.yml
+++ b/changelogs/fragments/8263-apt_rpm-install-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "apt_rpm - when checking whether packages were installed after running ``apt-get -y install <packages>``, only the last package name was checked (https://github.com/ansible-collections/community.general/pull/8263)."

--- a/plugins/modules/apt_rpm.py
+++ b/plugins/modules/apt_rpm.py
@@ -281,7 +281,7 @@ def install_packages(module, pkgspec, allow_upgrade=False):
         rc, out, err = module.run_command("%s -y install %s" % (APT_PATH, packages), environ_update={"LANG": "C"})
 
         installed = True
-        for packages in pkgspec:
+        for package in pkgspec:
             if not query_package_provides(module, package, allow_upgrade=False):
                 installed = False
 


### PR DESCRIPTION
##### SUMMARY
The for loop variable is `packages`, but the loop body uses `package`. This is obviously a typo, causing the loop to check the same package (from a previous `for` loop) multiple times.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_rpm
