### PR TITLE
bug(lookup/merge_variables): Fix rendering foreign variables

### DIFF
--- a/changelogs/fragments/8303-fix-rendering-foreign-variables.yaml
+++ b/changelogs/fragments/8303-fix-rendering-foreign-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "merge_variables lookup plugin - fixing cross host merge: providing access to foreign hosts variables to the perspective of the host that is performing the merge (https://github.com/ansible-collections/community.general/pull/8303)."

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -159,7 +159,7 @@ class LookupModule(LookupBase):
                     if self._is_host_in_allowed_groups(variables["hostvars"][host]["group_names"]):
                         host_variables = dict(variables["hostvars"].raw_get(host))
                         host_variables["hostvars"] = variables["hostvars"]  # re-add hostvars
-                        cross_host_merge_result = self._merge_vars(term, cross_host_merge_result, host_variables)  
+                        cross_host_merge_result = self._merge_vars(term, cross_host_merge_result, host_variables)
                 ret.append(cross_host_merge_result)
 
         return ret

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -157,7 +157,9 @@ class LookupModule(LookupBase):
                 cross_host_merge_result = initial_value
                 for host in variables["hostvars"]:
                     if self._is_host_in_allowed_groups(variables["hostvars"][host]["group_names"]):
-                        cross_host_merge_result = self._merge_vars(term, cross_host_merge_result, variables["hostvars"][host])
+                        host_variables = dict(variables["hostvars"].raw_get(host))
+                        host_variables["hostvars"] = variables["hostvars"]  # re-add hostvars
+                        cross_host_merge_result = self._merge_vars(term, cross_host_merge_result, host_variables)  
                 ret.append(cross_host_merge_result)
 
         return ret

--- a/plugins/lookup/merge_variables.py
+++ b/plugins/lookup/merge_variables.py
@@ -197,7 +197,8 @@ class LookupModule(LookupBase):
             result = initial_value
 
         for var_name in var_merge_names:
-            var_value = self._templar.template(variables[var_name])  # Render jinja2 templates
+            with self._templar.set_temporary_context(available_variables=variables):  # tmp. switch renderer to context of current variables
+                var_value = self._templar.template(variables[var_name])  # Render jinja2 templates
             var_type = _verify_and_get_type(var_value)
 
             if prev_var_type is None:

--- a/tests/integration/targets/lookup_merge_variables/runme.sh
+++ b/tests/integration/targets/lookup_merge_variables/runme.sh
@@ -14,3 +14,6 @@ ANSIBLE_MERGE_VARIABLES_PATTERN_TYPE=suffix \
 
 ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
     ansible-playbook -i test_inventory_all_hosts.yml test_all_hosts.yml "$@"
+
+ANSIBLE_LOG_PATH=/tmp/ansible-test-merge-variables \
+    ansible-playbook -i test_cross_host_merge_inventory.yml test_cross_host_merge_play.yml "$@"

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
@@ -22,12 +22,12 @@ common:
 consumer:
   vars:
     service_data: "{{ provider_instances.servicedata1 }}"
-    merge2__1: "{{ service_data }}"  # fails for host1; would work if using provider_instances directly here, as it is a variable host1 owns
+    merge2__1: "{{ service_data }}"  # service_data is a variable only known to host2, so normally it´s not available for host1 that is performing the merge
   hosts:
     host2:
 
 provider:
   vars:
-    merge1: "{{ lookup('community.general.merge_variables', 'merge2__', pattern_type='prefix', groups=['consumer']) }}"
+    merge_result: "{{ lookup('community.general.merge_variables', 'merge2__', pattern_type='prefix', groups=['consumer']) }}"
   hosts:
     host1:

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
@@ -1,4 +1,9 @@
 ---
+# Copyright (c) 2020, Thales Netherlands
+# Copyright (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 common:
   vars:
     provider_instances:

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_inventory.yml
@@ -1,0 +1,28 @@
+---
+common:
+  vars:
+    provider_instances:
+      servicedata1:
+        host: "{{ hostvars[groups['provider'] | first].inventory_hostname }}"
+        user: usr
+        pass: pwd
+      servicedata2:
+        host: down
+        user: usr2
+        pass: pwd2
+  hosts:
+    host1:
+    host2:
+
+consumer:
+  vars:
+    service_data: "{{ provider_instances.servicedata1 }}"
+    merge2__1: "{{ service_data }}"  # fails for host1; would work if using provider_instances directly here, as it is a variable host1 owns
+  hosts:
+    host2:
+
+provider:
+  vars:
+    merge1: "{{ lookup('community.general.merge_variables', 'merge2__', pattern_type='prefix', groups=['consumer']) }}"
+  hosts:
+    host1:

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -9,9 +9,6 @@
   connection: local
   gather_facts: false
   tasks:
-    - name: Merge Cross Group Variables
-      ansible.builtin.set_fact:
-        merge_result: "{{ merge1 }}"
     - name: Print merge result
       ansible.builtin.debug:
         msg: "{{ merge_result }}"

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -15,7 +15,7 @@
     - name: Print merge result
       ansible.builtin.debug:
         msg: "{{ merge_result }}"
-    - name: Validate Merge Result
+    - name: Validate merge result
       ansible.builtin.assert:
         that:
           - "merge_result | length == 3"

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -12,7 +12,7 @@
     - name: Merge Cross Group Variables
       ansible.builtin.set_fact:
         merge_result: "{{ merge1 }}"
-    - name: Show Merge Result
+    - name: Print merge result
       ansible.builtin.debug:
         msg: "{{ merge_result }}"
     - name: Validate Merge Result

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Demonstrate Merging Host Reference Variables
+- name: Test merge_variables lookup plugin (merging host reference variables)
   hosts: host1
   connection: local
   gather_facts: false

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -1,0 +1,19 @@
+---
+- name: Demonstrate Merging Host Reference Variables
+  hosts: host1
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Merge Cross Group Variables
+      ansible.builtin.set_fact:
+        merge_result: "{{ merge1 }}"
+    - name: Show Merge Result
+      ansible.builtin.debug:
+        msg: "{{ merge_result }}"
+    - name: Validate Merge Result
+      ansible.builtin.assert:
+        that:
+          - "merge_result | length == 3"
+          - "merge_result.host == 'host1'"
+          - "merge_result.user == 'usr'"
+          - "merge_result.pass == 'pwd'"

--- a/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
+++ b/tests/integration/targets/lookup_merge_variables/test_cross_host_merge_play.yml
@@ -1,4 +1,9 @@
 ---
+# Copyright (c) 2020, Thales Netherlands
+# Copyright (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 - name: Demonstrate Merging Host Reference Variables
   hosts: host1
   connection: local

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -18,6 +18,17 @@ from ansible_collections.community.general.plugins.lookup import merge_variables
 
 
 class TestMergeVariablesLookup(unittest.TestCase):
+    class _HostVars(dict):
+
+        def __getattr__(self, item):
+            return super().__getitem__(item)
+
+        def __setattr__(self, item, value):
+            return super().__setitem__(item, value)
+
+        def raw_get(self, host):
+            return super().__getitem__(host)
+
     def setUp(self):
         self.loader = DictDataLoader({})
         self.templar = Templar(loader=self.loader, variables={})
@@ -141,25 +152,28 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_all(self, mock_set_options, mock_get_option, mock_template):
-        results = self.merge_vars_lookup.run(['__merge_var'], {
-            'inventory_hostname': 'host1',
-            'hostvars': {
-                'host1': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host1',
-                    '1testlist__merge_var': {
-                        'var': [{'item1': 'value1', 'item2': 'value2'}]
-                    }
-                },
-                'host2': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host2',
-                    '2otherlist__merge_var': {
-                        'var': [{'item5': 'value5', 'item6': 'value6'}]
-                    }
+        hostvars = self._HostVars({
+            'host1': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host1',
+                '1testlist__merge_var': {
+                    'var': [{'item1': 'value1', 'item2': 'value2'}]
+                }
+            },
+            'host2': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host2',
+                '2otherlist__merge_var': {
+                    'var': [{'item5': 'value5', 'item6': 'value6'}]
                 }
             }
         })
+        variables = {
+            'inventory_hostname': 'host1',
+            'hostvars': hostvars
+        }
+
+        results = self.merge_vars_lookup.run(['__merge_var'], variables)
 
         self.assertEqual(results, [
             {'var': [
@@ -175,32 +189,35 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_single(self, mock_set_options, mock_get_option, mock_template):
-        results = self.merge_vars_lookup.run(['__merge_var'], {
-            'inventory_hostname': 'host1',
-            'hostvars': {
-                'host1': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host1',
-                    '1testlist__merge_var': {
-                        'var': [{'item1': 'value1', 'item2': 'value2'}]
-                    }
-                },
-                'host2': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host2',
-                    '2otherlist__merge_var': {
-                        'var': [{'item5': 'value5', 'item6': 'value6'}]
-                    }
-                },
-                'host3': {
-                    'group_names': ['dummy2'],
-                    'inventory_hostname': 'host3',
-                    '3otherlist__merge_var': {
-                        'var': [{'item3': 'value3', 'item4': 'value4'}]
-                    }
+        hostvars = self._HostVars({
+            'host1': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host1',
+                '1testlist__merge_var': {
+                    'var': [{'item1': 'value1', 'item2': 'value2'}]
+                }
+            },
+            'host2': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host2',
+                '2otherlist__merge_var': {
+                    'var': [{'item5': 'value5', 'item6': 'value6'}]
+                }
+            },
+            'host3': {
+                'group_names': ['dummy2'],
+                'inventory_hostname': 'host3',
+                '3otherlist__merge_var': {
+                    'var': [{'item3': 'value3', 'item4': 'value4'}]
                 }
             }
         })
+        variables = {
+            'inventory_hostname': 'host1',
+            'hostvars': hostvars
+        }
+        
+        results = self.merge_vars_lookup.run(['__merge_var'], variables)
 
         self.assertEqual(results, [
             {'var': [
@@ -216,32 +233,34 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_multiple(self, mock_set_options, mock_get_option, mock_template):
-        results = self.merge_vars_lookup.run(['__merge_var'], {
-            'inventory_hostname': 'host1',
-            'hostvars': {
-                'host1': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host1',
-                    '1testlist__merge_var': {
-                        'var': [{'item1': 'value1', 'item2': 'value2'}]
-                    }
-                },
-                'host2': {
-                    'group_names': ['dummy2'],
-                    'inventory_hostname': 'host2',
-                    '2otherlist__merge_var': {
-                        'var': [{'item5': 'value5', 'item6': 'value6'}]
-                    }
-                },
-                'host3': {
-                    'group_names': ['dummy3'],
-                    'inventory_hostname': 'host3',
-                    '3otherlist__merge_var': {
-                        'var': [{'item3': 'value3', 'item4': 'value4'}]
-                    }
+        hostvars = self._HostVars({
+            'host1': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host1',
+                '1testlist__merge_var': {
+                    'var': [{'item1': 'value1', 'item2': 'value2'}]
+                }
+            },
+            'host2': {
+                'group_names': ['dummy2'],
+                'inventory_hostname': 'host2',
+                '2otherlist__merge_var': {
+                    'var': [{'item5': 'value5', 'item6': 'value6'}]
+                }
+            },
+            'host3': {
+                'group_names': ['dummy3'],
+                'inventory_hostname': 'host3',
+                '3otherlist__merge_var': {
+                    'var': [{'item3': 'value3', 'item4': 'value4'}]
                 }
             }
         })
+        variables = {
+            'inventory_hostname': 'host1',
+            'hostvars': hostvars
+        }
+        results = self.merge_vars_lookup.run(['__merge_var'], variables)
 
         self.assertEqual(results, [
             {'var': [
@@ -257,26 +276,27 @@ class TestMergeVariablesLookup(unittest.TestCase):
         ['item5'],
     ])
     def test_merge_list_group_multiple(self, mock_set_options, mock_get_option, mock_template):
-        print()
-        results = self.merge_vars_lookup.run(['__merge_var'], {
-            'inventory_hostname': 'host1',
-            'hostvars': {
-                'host1': {
-                    'group_names': ['dummy1'],
-                    'inventory_hostname': 'host1',
-                    '1testlist__merge_var': ['item1']
-                },
-                'host2': {
-                    'group_names': ['dummy2'],
-                    'inventory_hostname': 'host2',
-                    '2otherlist__merge_var': ['item5']
-                },
-                'host3': {
-                    'group_names': ['dummy3'],
-                    'inventory_hostname': 'host3',
-                    '3otherlist__merge_var': ['item3']
-                }
+        hostvars = self._HostVars({
+            'host1': {
+                'group_names': ['dummy1'],
+                'inventory_hostname': 'host1',
+                '1testlist__merge_var': ['item1']
+            },
+            'host2': {
+                'group_names': ['dummy2'],
+                'inventory_hostname': 'host2',
+                '2otherlist__merge_var': ['item5']
+            },
+            'host3': {
+                'group_names': ['dummy3'],
+                'inventory_hostname': 'host3',
+                '3otherlist__merge_var': ['item3']
             }
         })
+        variables = {
+            'inventory_hostname': 'host1',
+            'hostvars': hostvars
+        }
+        results = self.merge_vars_lookup.run(['__merge_var'], variables)
 
         self.assertEqual(results, [['item1', 'item5']])

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -18,7 +18,7 @@ from ansible_collections.community.general.plugins.lookup import merge_variables
 
 
 class TestMergeVariablesLookup(unittest.TestCase):
-    class _HostVars(dict):
+    class HostVarsMock(dict):
 
         def __getattr__(self, item):
             return super().__getitem__(item)
@@ -152,7 +152,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_all(self, mock_set_options, mock_get_option, mock_template):
-        hostvars = self._HostVars({
+        hostvars = self.HostVarsMock({
             'host1': {
                 'group_names': ['dummy1'],
                 'inventory_hostname': 'host1',
@@ -189,7 +189,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_single(self, mock_set_options, mock_get_option, mock_template):
-        hostvars = self._HostVars({
+        hostvars = self.HostVarsMock({
             'host1': {
                 'group_names': ['dummy1'],
                 'inventory_hostname': 'host1',
@@ -233,7 +233,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         {'var': [{'item5': 'value5', 'item6': 'value6'}]},
     ])
     def test_merge_dict_group_multiple(self, mock_set_options, mock_get_option, mock_template):
-        hostvars = self._HostVars({
+        hostvars = self.HostVarsMock({
             'host1': {
                 'group_names': ['dummy1'],
                 'inventory_hostname': 'host1',
@@ -276,7 +276,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
         ['item5'],
     ])
     def test_merge_list_group_multiple(self, mock_set_options, mock_get_option, mock_template):
-        hostvars = self._HostVars({
+        hostvars = self.HostVarsMock({
             'host1': {
                 'group_names': ['dummy1'],
                 'inventory_hostname': 'host1',

--- a/tests/unit/plugins/lookup/test_merge_variables.py
+++ b/tests/unit/plugins/lookup/test_merge_variables.py
@@ -216,7 +216,7 @@ class TestMergeVariablesLookup(unittest.TestCase):
             'inventory_hostname': 'host1',
             'hostvars': hostvars
         }
-        
+
         results = self.merge_vars_lookup.run(['__merge_var'], variables)
 
         self.assertEqual(results, [


### PR DESCRIPTION
##### SUMMARY

The changes in this MR address an issue when using the merge_variables lookup with the `groups` parameter to merge variables across different hosts.

In the current implementation there are two issues left:

1. It isn`t possible to use the `hostvars` Variable using `ansible -m debug` or the ansible-console whenever there was a merge_variable usage with filled `groups` parameter in the used inventory. The result is an exception.
2. When using merge_variables with the `groups` parameter filled it isn`t possible to use variables from other hosts that are unknown (not set, not derived from a group membership) to the host which is invoking merge_variables. The reason is that the context of the Jinja Wrapper is bound the host that is executing the lookup.

I have created an small [example project](https://github.com/alpex8/ansible-merge-variables-cross-host-test) that shows the issue. I also added an integration test here based on that project.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/lookup/merge_variables

##### ADDITIONAL INFORMATION

The reason for the exception when using the hostvars variable is that internally the Variables are stored in a HostVars instance, which is a wrapper of the Mapping class and it overrides the `__get_item__` method. In that implementation the `hostvars` property is intentionally removed from the originally given variables whenever some other hosts varialbes are requested (e.g. via `variables["hostvars"][host]`). There is already the older issue https://github.com/ansible/ansible/issues/17806#issuecomment-853930524 this is discussing this.

However when rendering jinja expression that include some `hostvars` references that property is required. To handle that issue the `hostvars` property is explicitly added after the variables of a foreign host were retrieved. This is done locally in the context of the plugin, to avoid any kind of global implications. 

The second adjustment addresses the issue that the renderer (self._templar) is initialized with the context of the variables of the host that invokes the merge_variables lookup. As a consequence variables that are only available to some other host are unknown in that context and rendering does fail if they include any references to such variables (see example project). To solve that issue the `set_temporary_context` method of the templar instance is used to 'switch' the context temporarily to the perspective of the current host. Using this context it is possible to perform the rendering.

I had to adjust the unit tests that are dealing with cross host merge and provide some tiny bit of the HostVars Class API, because the plugin needs to call the `raw_get` method.