### PR TITLE
feat: implement timestamp callback plugin to show simple timestamp for each header

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -89,6 +89,8 @@ files:
     maintainers: ryancurrah
   $callbacks/syslog_json.py:
     maintainers: imjoseangel
+  $callbacks/timestamp.py:
+    maintainers: kurokobo
   $callbacks/unixy.py:
     labels: unixy
     maintainers: akatch

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -32,7 +32,7 @@ DOCUMENTATION = r"""
       description:
         - Format of the timestamp shown to user in 1989 C standard format.
         - >
-          Refer to U(the Python documentation,https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
+          Refer to L(the Python documentation,https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
           for the available format codes.
       ini:
         - section: callback_timestamp

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, kurokobo <kurokobo@protonmail.com>
+# Copyright (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -67,6 +68,8 @@ def banner(self, msg, color=None, cows=True):
     Prints a header-looking line with cowsay or stars with length depending on terminal width (3 minimum) with trailing timestamp
 
     Based on the banner method of Display class from ansible.utils.display
+
+    https://github.com/ansible/ansible/blob/4403519afe89138042108e237aef317fd5f09c33/lib/ansible/utils/display.py#L511
     """
     timestamp = get_datetime_now(self.timestamp_tzinfo).strftime(self.timestamp_format_string)
     timestamp_len = get_text_width(timestamp) + 1  # +1 for leading space

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -57,7 +57,7 @@ def get_datetime_now(tz):
     return datetime.now(tz=tz)
 
 
-def banner(self, msg: str, color: str | None = None, cows: bool = True) -> None:
+def banner(self, msg, color=None, cows=True):
     """
     Prints a header-looking line with cowsay or stars with length depending on terminal width (3 minimum) with trailing timestamp
 

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -31,7 +31,9 @@ DOCUMENTATION = r"""
     format_string:
       description:
         - Format of the timestamp shown to user in 1989 C standard format.
-        - Refer to U(the Python documentation,https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) for the available format codes.
+        - >
+          Refer to U(the Python documentation,https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
+          for the available format codes.
       ini:
         - section: callback_timestamp
           key: format_string

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -35,6 +35,7 @@ DOCUMENTATION = r"""
       env:
         - name: ANSIBLE_CALLBACK_TIMESTAMP_FORMAT_STRING
       default: "%H:%M:%S"
+      type: string
   extends_documentation_fragment:
     - ansible.builtin.default_callback
     - ansible.builtin.result_format_callback

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, kurokobo <kurokobo@protonmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+  name: timestamp
+  type: stdout
+  short_description: Adds simple timestamp for each header
+  version_added: 9.0.0  # for collections, use the collection version, not the Ansible version
+  description:
+    - This callback adds simple timestamp for each header
+  author: kurokobo (@kurokobo)
+  options:
+    timezone:
+      description: timezone to use for the timestamp in IANA time zone format (for example C(America/New_York), C(Asia/Tokyo)). Ignored on Python < 3.9
+      ini:
+        - section: callback_timestamp
+          key: timezone
+      env:
+        - name: ANSIBLE_CALLBACK_TIMESTAMP_TIMEZONE
+      default: ""
+    format_string:
+      description: format of the string shown to user
+      ini:
+        - section: callback_timestamp
+          key: format_string
+      env:
+        - name: ANSIBLE_CALLBACK_TIMESTAMP_FORMAT_STRING
+      default: "%H:%M:%S"
+  extends_documentation_fragment:
+    - ansible.builtin.default_callback
+    - ansible.builtin.result_format_callback
+"""
+
+
+from ansible.plugins.callback.default import CallbackModule as Default
+from ansible.utils.display import get_text_width
+from ansible.module_utils.common.text.converters import to_text
+from datetime import datetime
+import types
+import sys
+
+# Store whether the zoneinfo module is available
+_ZONEINFO_AVAILABLE = sys.version_info >= (3, 9)
+
+
+def get_datetime_now(tz):
+    """
+    Returns the current timestamp with the specified timezone
+    """
+    return datetime.now(tz=tz)
+
+
+def banner(self, msg: str, color: str | None = None, cows: bool = True) -> None:
+    """
+    Prints a header-looking line with cowsay or stars with length depending on terminal width (3 minimum) with trailing timestamp
+
+    Based on the banner method of Display class from ansible.utils.display
+    """
+    timestamp = get_datetime_now(self.timestamp_tzinfo).strftime(self.timestamp_format_string)
+    timestamp_len = get_text_width(timestamp) + 1  # +1 for leading space
+
+    msg = to_text(msg)
+    if self.b_cowsay and cows:
+        try:
+            self.banner_cowsay("%s @ %s" % (msg, timestamp))
+            return
+        except OSError:
+            self.warning("somebody cleverly deleted cowsay or something during the PB run.  heh.")
+
+    msg = msg.strip()
+    try:
+        star_len = self.columns - get_text_width(msg) - timestamp_len
+    except EnvironmentError:
+        star_len = self.columns - len(msg) - timestamp_len
+    if star_len <= 3:
+        star_len = 3
+    stars = "*" * star_len
+    self.display("\n%s %s %s" % (msg, stars, timestamp), color=color)
+
+
+class CallbackModule(Default):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = "stdout"
+    CALLBACK_NAME = "community.general.timestamp"
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+        # Replace the banner method of the display object with the custom one
+        self._display.banner = types.MethodType(banner, self._display)
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+
+        # Store zoneinfo for specified timezone if available
+        tzinfo = None
+        if _ZONEINFO_AVAILABLE and self.get_option("timezone"):
+            from zoneinfo import ZoneInfo
+
+            tzinfo = ZoneInfo(self.get_option("timezone"))
+
+        # Inject options into the display object
+        setattr(self._display, "timestamp_tzinfo", tzinfo)
+        setattr(self._display, "timestamp_format_string", self.get_option("format_string"))

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r"""
   name: timestamp
   type: stdout
   short_description: Adds simple timestamp for each header
-  version_added: 9.0.0  # for collections, use the collection version, not the Ansible version
+  version_added: 9.0.0
   description:
     - This callback adds simple timestamp for each header
   author: kurokobo (@kurokobo)

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -28,7 +28,8 @@ DOCUMENTATION = r"""
         - name: ANSIBLE_CALLBACK_TIMESTAMP_TIMEZONE
       type: string
     format_string:
-      description: format of the string shown to user
+      description:
+        - Format of the string shown to user.
       ini:
         - section: callback_timestamp
           key: format_string

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -26,7 +26,7 @@ DOCUMENTATION = r"""
           key: timezone
       env:
         - name: ANSIBLE_CALLBACK_TIMESTAMP_TIMEZONE
-      default: ""
+      type: string
     format_string:
       description: format of the string shown to user
       ini:

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -18,7 +18,9 @@ DOCUMENTATION = r"""
   author: kurokobo (@kurokobo)
   options:
     timezone:
-      description: timezone to use for the timestamp in IANA time zone format (for example C(America/New_York), C(Asia/Tokyo)). Ignored on Python < 3.9
+      description:
+        - Timezone to use for the timestamp in IANA time zone format.
+        - For example C(America/New_York), C(Asia/Tokyo)). Ignored on Python < 3.9.
       ini:
         - section: callback_timestamp
           key: timezone

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r"""
   short_description: Adds simple timestamp for each header
   version_added: 9.0.0
   description:
-    - This callback adds simple timestamp for each header
+    - This callback adds simple timestamp for each header.
   author: kurokobo (@kurokobo)
   options:
     timezone:

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -29,7 +29,8 @@ DOCUMENTATION = r"""
       type: string
     format_string:
       description:
-        - Format of the string shown to user.
+        - Format of the timestamp shown to user in 1989 C standard format.
+        - Refer to U(the Python documentation,https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) for the available format codes.
       ini:
         - section: callback_timestamp
           key: format_string

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -45,7 +45,7 @@ DOCUMENTATION = r"""
     - plugin: ansible.posix.profile_tasks
       plugin_type: callback
       description: >
-        You can use ansible.posix.profile_tasks callback plugin to time individual tasks and overall execution time
+        You can use P(ansible.posix.profile_tasks#callback) callback plugin to time individual tasks and overall execution time
         with detailed timestamps.
   extends_documentation_fragment:
     - ansible.builtin.default_callback

--- a/plugins/callback/timestamp.py
+++ b/plugins/callback/timestamp.py
@@ -41,6 +41,12 @@ DOCUMENTATION = r"""
         - name: ANSIBLE_CALLBACK_TIMESTAMP_FORMAT_STRING
       default: "%H:%M:%S"
       type: string
+  seealso:
+    - plugin: ansible.posix.profile_tasks
+      plugin_type: callback
+      description: >
+        You can use ansible.posix.profile_tasks callback plugin to time individual tasks and overall execution time
+        with detailed timestamps.
   extends_documentation_fragment:
     - ansible.builtin.default_callback
     - ansible.builtin.result_format_callback

--- a/tests/integration/targets/callback_timestamp/aliases
+++ b/tests/integration/targets/callback_timestamp/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) 2024, kurokobo <kurokobo@protonmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or <https://www.gnu.org/licenses/gpl-3.0.txt>)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/1
+needs/target/callback

--- a/tests/integration/targets/callback_timestamp/tasks/main.yml
+++ b/tests/integration/targets/callback_timestamp/tasks/main.yml
@@ -5,8 +5,8 @@
 ####################################################################
 
 # Copyright (c) 2024, kurokobo <kurokobo@protonmail.com>
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or <https://www.gnu.org/licenses/gpl-3.0.txt>)
-# SPDX-License-Identifier: GPL-3.0-or-lat
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Run tests
   include_role:

--- a/tests/integration/targets/callback_timestamp/tasks/main.yml
+++ b/tests/integration/targets/callback_timestamp/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) 2024, kurokobo <kurokobo@protonmail.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or <https://www.gnu.org/licenses/gpl-3.0.txt>)
+# SPDX-License-Identifier: GPL-3.0-or-lat
+
+- name: Run tests
+  include_role:
+    name: callback
+  vars:
+    tests:
+      - name: Enable timestamp in the default length
+        environment:
+          ANSIBLE_NOCOLOR: 'true'
+          ANSIBLE_FORCE_COLOR: 'false'
+          ANSIBLE_STDOUT_CALLBACK: community.general.timestamp
+          ANSIBLE_CALLBACK_TIMESTAMP_FORMAT_STRING: "15:04:05"
+        playbook: |
+          - hosts: testhost
+            gather_facts: false
+            tasks:
+              - name: Sample task name
+                debug:
+                  msg: sample debug msg
+        expected_output: [
+          "",
+          "PLAY [testhost] ******************************************************* 15:04:05",
+          "",
+          "TASK [Sample task name] *********************************************** 15:04:05",
+          "ok: [testhost] => {",
+          "    \"msg\": \"sample debug msg\"",
+          "}",
+          "",
+          "PLAY RECAP ************************************************************ 15:04:05",
+          "testhost                   : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   "
+        ]
+
+      - name: Enable timestamp in the longer length
+        environment:
+          ANSIBLE_NOCOLOR: 'true'
+          ANSIBLE_FORCE_COLOR: 'false'
+          ANSIBLE_STDOUT_CALLBACK: community.general.timestamp
+          ANSIBLE_CALLBACK_TIMESTAMP_FORMAT_STRING: "2006-01-02T15:04:05"
+        playbook: |
+          - hosts: testhost
+            gather_facts: false
+            tasks:
+              - name: Sample task name
+                debug:
+                  msg: sample debug msg
+        expected_output: [
+          "",
+          "PLAY [testhost] ******************************************** 2006-01-02T15:04:05",
+          "",
+          "TASK [Sample task name] ************************************ 2006-01-02T15:04:05",
+          "ok: [testhost] => {",
+          "    \"msg\": \"sample debug msg\"",
+          "}",
+          "",
+          "PLAY RECAP ************************************************* 2006-01-02T15:04:05",
+          "testhost                   : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   "
+        ]

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,5 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
+plugins/callback/timestamp.py validate-modules:invalid-documentation
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,5 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
+plugins/callback/timestamp.py validate-modules:invalid-documentation
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR introduce new callback plugin to show simple timestamp for each header line.

This plugin reduces the number of `*`'s in the header by the number of characters in the timestamp, and display the timestamp on the far right.

![image](https://github.com/ansible-collections/community.general/assets/2920259/f312ecb3-3702-43a9-8f01-4fc2b4e5be29)

On the output screen of an AWX job, a timestamp appears in each header by default. This PR implements this timestamp idea as a callback plugin.

![image](https://github.com/ansible-collections/community.general/assets/2920259/cb60b996-7e50-4519-9af5-cedcf2b32dff)

There is a plugin that can be used for a similar purpose, [`ansible.posix.profile_tasks`](https://docs.ansible.com/ansible/latest/collections/ansible/posix/profile_tasks_callback.html), but it adds a new line for displaying the timestamps, which complicates the output.
The plugin in this PR is as simple as possible and provides only minimal information, so it is not at all obtrusive to keep it enabled at all times.

Available options:

- `timezone`: Users can specify timezone for the timestamp. This is helpful for containerized ansible environment. **Ignored on Python < 3.9**
- `format_string`: The format string for timestamp

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- New Module/Plugin Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

timestamp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Tested with:

```bash
ansible-test sanity --docker -v plugins/callback/timestamp.py
ansible-test integration --docker -v callback_timestamp
```

This is the first time for me to send PR for this collection. I have a few concerns and would love to hear any input. Thanks!

- Is this plugin appropriate for community.general in the first place?
- The timezone is set using [ZoneInfo](https://docs.python.org/3/library/zoneinfo.html), which was added in Python 3.9. This means it will not work in Python 3.8. This collection [requires Ansible 2.13 or higher](https://github.com/ansible-collections/community.general/blob/main/meta/runtime.yml#L6), and [Ansible 2.13 supports Python 3.8](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#support-life). However, since it is already EOL, this plugin has decided to ignore the user-provided timezone setting for Python 3.8 and below, simplifying the implementation. Is this a good practice?
- About the test. I tried to write an integration test, but I cannot use the `callback` role like other callback plugins because the timestamp changes each time it is executed. For this reason I am only testing that the timestamp format is given a fixed string and that at least the timestamp is displayed in the proper position without the header line being folded back (this is the core feature of this plugin that has to be tested at least). Should I implement the test more rigorously?

If this should not continue, feel free to close it. Thanks in advance! 😃 