### PR TITLE
Update lxd_container.py documentation.

### DIFF
--- a/plugins/modules/lxd_container.py
+++ b/plugins/modules/lxd_container.py
@@ -400,7 +400,7 @@ EXAMPLES = '''
           protocol: simplestreams
           type: image
           mode: pull
-          server: https://images.linuxcontainers.org
+          server: [...] # URL to the image server
           alias: debian/11
         timeout: 600
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two small changes:
  -  use APT module. The previous example would always return 'modified' 
  - Remove Debian example. The example does not work anymore after https://linuxcontainers.org/ did drop LXD support.

trivial:
  - Fix LXD container documentation after https://linuxcontainers.org/ did drop LXD support.

##### ISSUE TYPE
  - Docs Pull Request

##### COMPONENT NAME
lxd_container

##### ADDITIONAL INFORMATION
none