### PR TITLE
Disable ejabberd tests on Arch Linux

### DIFF
--- a/tests/integration/targets/ejabberd_user/tasks/main.yml
+++ b/tests/integration/targets/ejabberd_user/tasks/main.yml
@@ -10,7 +10,8 @@
 
 - name: Bail out if not supported
   ansible.builtin.meta: end_play
-  when: ansible_distribution in ('Alpine', 'openSUSE Leap', 'CentOS', 'Fedora')
+  # TODO: remove Archlinux from the list
+  when: ansible_distribution in ('Alpine', 'openSUSE Leap', 'CentOS', 'Fedora', 'Archlinux')
 
 
 - name: Remove ejabberd


### PR DESCRIPTION
##### SUMMARY
They currently fail since one of the packages that `ejabberd` depends on has been removed from the Arch package repositories.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ejabberd
