### PR TITLE
keycloak_user_federation: fix diff of empty `krbPrincipalAttribute`

### DIFF
--- a/changelogs/fragments/8320-keycloak_user_federation-fix-diff-krbPrincipalAttribute.yaml
+++ b/changelogs/fragments/8320-keycloak_user_federation-fix-diff-krbPrincipalAttribute.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_user_federation - fix diff of empty ``krbPrincipalAttribute`` (https://github.com/ansible-collections/community.general/pull/8320).

--- a/plugins/modules/keycloak_user_federation.py
+++ b/plugins/modules/keycloak_user_federation.py
@@ -719,6 +719,9 @@ def sanitize(comp):
         compcopy['config'] = dict((k, v[0]) for k, v in compcopy['config'].items())
         if 'bindCredential' in compcopy['config']:
             compcopy['config']['bindCredential'] = '**********'
+        # an empty string is valid for krbPrincipalAttribute but is filtered out in diff
+        if 'krbPrincipalAttribute' not in compcopy['config']:
+            compcopy['config']['krbPrincipalAttribute'] = ''
     if 'mappers' in compcopy:
         for mapper in compcopy['mappers']:
             if 'config' in mapper:


### PR DESCRIPTION
##### SUMMARY

`krbPrincipalAttribute` is supposed to have an empty string as a valid value.
https://github.com/ansible-collections/community.general/blob/bc609d74a023e3ea3b2c5621c1ea8de2b5d3ee17/plugins/modules/keycloak_user_federation.py#L346

Without this bugfix, an `ansible-playbook ... --check --diff`run will always show an empty string in the diff if you pass en empty string to `config.krbPrincipalAttribute`.

```
TASK [kc1 - realm-1 - test-2 - Create or update a Keycloak kerberos enabled user_federation] ********************************************************************************************************************************************
--- before
+++ after
@@ -17,6 +17,7 @@
         "importEnabled": "false",
         "kerberosRealm": "EXAMPLE.NET",
         "keyTab": "/mnt/ad2",
+        "krbPrincipalAttribute": "",
         "pagination": "false",
         "priority": "0",
         "rdnLDAPAttribute": "sAMAccountName",
```

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

keycloak_user_federation


