### PR TITLE
Move version_added for consul docs fragment to modules

### DIFF
--- a/plugins/doc_fragments/consul.py
+++ b/plugins/doc_fragments/consul.py
@@ -56,5 +56,4 @@ attributes:
     support: full
     membership:
       - community.general.consul
-    version_added: 8.3.0
 """

--- a/plugins/modules/consul_policy.py
+++ b/plugins/modules/consul_policy.py
@@ -33,6 +33,8 @@ attributes:
     version_added: 8.3.0
     details:
       - In check mode the diff will miss operational attributes.
+  action_group:
+    version_added: 8.3.0
 options:
   state:
     description:

--- a/plugins/modules/consul_role.py
+++ b/plugins/modules/consul_role.py
@@ -32,6 +32,8 @@ attributes:
     details:
       - In check mode the diff will miss operational attributes.
     version_added: 8.3.0
+  action_group:
+    version_added: 8.3.0
 options:
   name:
     description:

--- a/plugins/modules/consul_session.py
+++ b/plugins/modules/consul_session.py
@@ -29,6 +29,8 @@ attributes:
         support: none
     diff_mode:
         support: none
+    action_group:
+        version_added: 8.3.0
 options:
     id:
         description:

--- a/plugins/modules/consul_token.py
+++ b/plugins/modules/consul_token.py
@@ -31,6 +31,8 @@ attributes:
     support: partial
     details:
       - In check mode the diff will miss operational attributes.
+  action_group:
+    version_added: 8.3.0
 options:
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
Subset of #8334 that's not related to proxmox.

Simply removes the `version_added` from the consul docs fragment, since that docs fragment should rather be used by modules which later on add the docs fragment.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
consul docs fragment
