### PR TITLE
Fix sanitize for keycloak_identitiy_provider.

### DIFF
--- a/changelogs/fragments/8355-keycloak-idp-sanitize.yaml
+++ b/changelogs/fragments/8355-keycloak-idp-sanitize.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - keycloak_identity_provider - fix sanitization of client secret (https://github.com/ansible-collections/community.general/pull/8355).

--- a/changelogs/fragments/8355-keycloak-idp-sanitize.yaml
+++ b/changelogs/fragments/8355-keycloak-idp-sanitize.yaml
@@ -1,2 +1,2 @@
-minor_changes:
-  - keycloak_identity_provider - fix sanitization of client secret (https://github.com/ansible-collections/community.general/pull/8355).
+security_fixes:
+  - keycloak_identity_provider - the client secret was not correctly sanitized by the module. The return values ``proposed``, ``existing``, and ``end_state``, as well as the diff, did contain the client secret unmasked (https://github.com/ansible-collections/community.general/pull/8355).

--- a/plugins/modules/keycloak_identity_provider.py
+++ b/plugins/modules/keycloak_identity_provider.py
@@ -437,7 +437,7 @@ def sanitize(idp):
     idpcopy = deepcopy(idp)
     if 'config' in idpcopy:
         if 'clientSecret' in idpcopy['config']:
-            idpcopy['clientSecret'] = '**********'
+            idpcopy['config']['clientSecret'] = '**********'
     return idpcopy
 
 

--- a/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
+++ b/tests/integration/targets/keycloak_identity_provider/tasks/main.yml
@@ -62,6 +62,7 @@
       - result.existing == {}
       - result.end_state.alias == "{{ idp }}"
       - result.end_state.mappers != []
+      - result.end_state.config.client_secret = "**********"
 
 - name: Update existing identity provider (no change)
   community.general.keycloak_identity_provider:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

The sanitize function did not properly sanitize the client secret.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
keycloak_identity_provider

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
