### PR TITLE
feat(opentelemetry): support flag to export spans in a given file

### DIFF
--- a/changelogs/fragments/8363-opentelemetry-export-to-a-file.yml
+++ b/changelogs/fragments/8363-opentelemetry-export-to-a-file.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - opentelemetry - add support for exporting spans in a file via ``ANSIBLE_OPENTELEMETRY_STORE_SPANS_IN_FILE`` (https://github.com/ansible-collections/community.general/issues/7888, https://github.com/ansible-collections/community.general/pull/8363).

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -295,7 +295,7 @@ class OpenTelemetrySource(object):
                                     disable_logs,
                                     disable_attributes_in_logs,
                                     otel_exporter_otlp_traces_protocol,
-                                    in_memory_span_exporter):
+                                    store_spans_in_file):
         """ generate distributed traces from the collected TaskData and HostData """
 
         tasks = []
@@ -312,8 +312,7 @@ class OpenTelemetrySource(object):
         )
 
         otel_exporter = None
-        # Only to support running the UTs
-        if in_memory_span_exporter:
+        if store_spans_in_file:
             otel_exporter = InMemorySpanExporter()
             processor = SimpleSpanProcessor(otel_exporter)
         else:

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -134,6 +134,7 @@ examples: |
 '''
 
 import getpass
+import json
 import os
 import socket
 import sys
@@ -651,7 +652,6 @@ class CallbackModule(CallbackBase):
             spans = [json.loads(span.to_json()) for span in otel_exporter.get_finished_spans()]
             with open(self.store_spans_in_file, "w", encoding="utf-8") as output:
                 json.dump({"spans": spans}, output, indent=4)
-
 
     def v2_runner_on_async_failed(self, result, **kwargs):
         self.errors += 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Added support to store the exported spans in a file.

This is useful for adding UTs, as explained in https://github.com/open-telemetry/opentelemetry-python/blob/eef2015edd0d7c0a85840fd7bd1c7d57f1a8c2ee/opentelemetry-sdk/src/opentelemetry/sdk/trace/export/in_memory_span_exporter.py#L23-L27

For instance, I can now configure this plugin to run in isolation and validate it works as expected:
- https://github.com/v1v/otel-ansible-callback-plugin/blob/main/test_pytest.py

I don't know whether we could revisit https://github.com/ansible-collections/community.general/pull/4871 so I could try to add the UTs to this project, rather than using my proposal in https://github.com/v1v/otel-ansible-callback-plugin.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`plugins/callback/opentelemetry`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
