### PR TITLE
Add REUSE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Build Status](https://dev.azure.com/ansible/community.general/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.general/_build?definitionId=31)
 [![EOL CI](https://github.com/ansible-collections/community.general/workflows/EOL%20CI/badge.svg?event=push)](https://github.com/ansible-collections/community.general/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.general)](https://codecov.io/gh/ansible-collections/community.general)
+[![REUSE status](https://api.reuse.software/badge/github.com/ansible-collections/community.general)](https://api.reuse.software/info/github.com/ansible-collections/community.general)
 
 This repository contains the `community.general` Ansible Collection. The collection is a part of the Ansible package and includes many modules and plugins supported by Ansible community which are not part of more specialized community collections.
 


### PR DESCRIPTION
##### SUMMARY
Fixes #8364. The badge looks like this:

[![REUSE status](https://api.reuse.software/badge/github.com/ansible-collections/community.general)](https://api.reuse.software/info/github.com/ansible-collections/community.general)

@mxmehl thanks for the reminder :) Is it possible to include the branch name to check for the badge for backporting this to the stable branches, or is the badge only available for the repository's main branch?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md
