### PR TITLE
fix(opentelemetry): close span even if no logs are sent

### DIFF
--- a/changelogs/fragments/8367-fix-close-span-if-no-logs.yaml
+++ b/changelogs/fragments/8367-fix-close-span-if-no-logs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "opentelemetry callback plugin - close spans always (https://github.com/ansible-collections/community.general/pull/8367)."

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -350,7 +350,8 @@ class OpenTelemetrySource(object):
         if not disable_logs:
             # This will avoid populating span attributes to the logs
             span.add_event(task_data.dump, attributes={} if disable_attributes_in_logs else attributes)
-            span.end(end_time=host_data.finish)
+        # Close span always
+        span.end(end_time=host_data.finish)
 
     def set_span_attributes(self, span, attributes):
         """ update the span attributes with the given attributes if not None """


### PR DESCRIPTION
##### SUMMARY

Fixes a regression caused by https://github.com/ansible-collections/community.general/pull/6531

So spans were not closed when sending logs were disabled.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

`opentelemetry`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
