### PR TITLE
fix(opentelemetry): avoid storing inmemory if logs are disabled

### DIFF
--- a/changelogs/fragments/8373-honour-disable-logs.yaml
+++ b/changelogs/fragments/8373-honour-disable-logs.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - opentelemetry callback plugin - honour the disable_logs to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
+  - opentelemetry callback plugin - honour the ``disable_logs`` to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
     

--- a/changelogs/fragments/8373-honour-disable-logs.yaml
+++ b/changelogs/fragments/8373-honour-disable-logs.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - opentelemetry callback plugin - honour the ``disable_logs`` option to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
+  - opentelemetry callback plugin - honour the ``disable_logs`` option to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8373).
     

--- a/changelogs/fragments/8373-honour-disable-logs.yaml
+++ b/changelogs/fragments/8373-honour-disable-logs.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - opentelemetry callback plugin - honour the disable_logs to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
+    

--- a/changelogs/fragments/8373-honour-disable-logs.yaml
+++ b/changelogs/fragments/8373-honour-disable-logs.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - opentelemetry callback plugin - honour the ``disable_logs`` to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
+  - opentelemetry callback plugin - honour the ``disable_logs`` option to avoid storing task results since they are not used regardless (https://github.com/ansible-collections/community.general/pull/8133).
     

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -497,6 +497,12 @@ class CallbackModule(CallbackBase):
         # See https://github.com/open-telemetry/opentelemetry-specification/issues/740
         self.traceparent = self.get_option('traceparent')
 
+    def dump_results(result):
+        """ dump the results if disable_logs is not enabled """
+        if self.disable_logs:
+            return ""
+        return self._dump_results(result._result)
+
     def v2_playbook_on_start(self, playbook):
         self.ansible_playbook = basename(playbook._file_name)
 
@@ -542,42 +548,27 @@ class CallbackModule(CallbackBase):
             status = 'failed'
             self.errors += 1
 
-        # avoid storing task results if it's logs are disabled
-        dump = ""
-        if not self.disable_logs:
-            dump = self._dump_results(result._result)
-
         self.opentelemetry.finish_task(
             self.tasks_data,
             status,
             result,
-            dump
+            self.dump_results(result)
         )
 
     def v2_runner_on_ok(self, result):
-        # avoid storing task results if it's logs are disabled
-        dump = ""
-        if not self.disable_logs:
-            dump = self._dump_results(result._result)
-
         self.opentelemetry.finish_task(
             self.tasks_data,
             'ok',
             result,
-            dump
+            self.dump_results(result)
         )
 
     def v2_runner_on_skipped(self, result):
-        # avoid storing task results if it's logs are disabled
-        dump = ""
-        if not self.disable_logs:
-            dump = self._dump_results(result._result)
-
         self.opentelemetry.finish_task(
             self.tasks_data,
             'skipped',
             result,
-            dump
+            self.dump_results(result)
         )
 
     def v2_playbook_on_include(self, included_file):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -542,27 +542,42 @@ class CallbackModule(CallbackBase):
             status = 'failed'
             self.errors += 1
 
+        # avoid storing task results if it's logs are disabled
+        dump = ""
+        if not self.disable_logs
+            dump = self._dump_results(result._result)
+
         self.opentelemetry.finish_task(
             self.tasks_data,
             status,
             result,
-            self._dump_results(result._result)
+            dump
         )
 
     def v2_runner_on_ok(self, result):
+        # avoid storing task results if it's logs are disabled
+        dump = ""
+        if not self.disable_logs
+            dump = self._dump_results(result._result)
+
         self.opentelemetry.finish_task(
             self.tasks_data,
             'ok',
             result,
-            self._dump_results(result._result)
+            dump
         )
 
     def v2_runner_on_skipped(self, result):
+        # avoid storing task results if it's logs are disabled
+        dump = ""
+        if not self.disable_logs
+            dump = self._dump_results(result._result)
+
         self.opentelemetry.finish_task(
             self.tasks_data,
             'skipped',
             result,
-            self._dump_results(result._result)
+            dump
         )
 
     def v2_playbook_on_include(self, included_file):

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -529,7 +529,7 @@ class CallbackModule(CallbackBase):
 
         self.otel_exporter_otlp_traces_protocol = self.get_option('otel_exporter_otlp_traces_protocol')
 
-    def dump_results(result):
+    def dump_results(self, result):
         """ dump the results if disable_logs is not enabled """
         if self.disable_logs:
             return ""

--- a/plugins/callback/opentelemetry.py
+++ b/plugins/callback/opentelemetry.py
@@ -544,7 +544,7 @@ class CallbackModule(CallbackBase):
 
         # avoid storing task results if it's logs are disabled
         dump = ""
-        if not self.disable_logs
+        if not self.disable_logs:
             dump = self._dump_results(result._result)
 
         self.opentelemetry.finish_task(
@@ -557,7 +557,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_ok(self, result):
         # avoid storing task results if it's logs are disabled
         dump = ""
-        if not self.disable_logs
+        if not self.disable_logs:
             dump = self._dump_results(result._result)
 
         self.opentelemetry.finish_task(
@@ -570,7 +570,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_skipped(self, result):
         # avoid storing task results if it's logs are disabled
         dump = ""
-        if not self.disable_logs
+        if not self.disable_logs:
             dump = self._dump_results(result._result)
 
         self.opentelemetry.finish_task(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Workaround for https://github.com/ansible-collections/community.general/issues/8353

Let's skip storing large datasets if the logs are disabled. This should help with the existing memory issues, so users can disable the logs. While we can figure out how to fix the underlying issue with storing large datasets.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins/callback/opentelemetry`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
