### PR TITLE
lint and fix polkit examples

### DIFF
--- a/changelogs/fragments/polkit-become.yml
+++ b/changelogs/fragments/polkit-become.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - machinectl - lint polkit rule example
-  - run0 - lint and fix polkit rule example

--- a/changelogs/fragments/polkit-become.yml
+++ b/changelogs/fragments/polkit-become.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - machinectl - lint polkit rule example
+  - run0 - lint and fix polkit rule example

--- a/plugins/become/machinectl.py
+++ b/plugins/become/machinectl.py
@@ -78,12 +78,13 @@ DOCUMENTATION = '''
 EXAMPLES = r'''
 # A polkit rule needed to use the module with a non-root user.
 # See the Notes section for details.
-60-machinectl-fast-user-auth.rules: |
-    polkit.addRule(function(action, subject) {
-        if(action.id == "org.freedesktop.machine1.host-shell" && subject.isInGroup("wheel")) {
-            return polkit.Result.AUTH_SELF_KEEP;
-        }
-    });
+/etc/polkit-1/rules.d/60-machinectl-fast-user-auth.rules: |
+  polkit.addRule(function(action, subject) {
+    if(action.id == "org.freedesktop.machine1.host-shell" &&
+      subject.isInGroup("wheel")) {
+        return polkit.Result.AUTH_SELF_KEEP;
+    }
+  });
 '''
 
 from re import compile as re_compile

--- a/plugins/become/run0.py
+++ b/plugins/become/run0.py
@@ -69,13 +69,13 @@ EXAMPLES = r"""
 # An example polkit rule that allows the user 'ansible' in the 'wheel' group
 # to execute commands using run0 without authentication.
 /etc/polkit-1/rules.d/60-run0-fast-user-auth.rules: |
-    polkit.addRule(function(action, subject) {
-      if(action.id == "org.freedesktop.systemd1.manage-units" &&
-        subject.isInGroup("wheel")
-        subject.user == "ansible") {
+  polkit.addRule(function(action, subject) {
+    if(action.id == "org.freedesktop.systemd1.manage-units" &&
+      subject.isInGroup("wheel") &&
+      subject.user == "ansible") {
         return polkit.Result.YES;
-      }
-    });
+    }
+  });
 """
 
 from re import compile as re_compile


### PR DESCRIPTION
##### SUMMARY

This PR:
- lints the `polkit` rule examples in the `machinectl` and `run0` become modules (https://standardjs.com/rules.html#rules)
- fixes the `polkit` rule example for the `run0` become module (missing `&&`) 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME

`machinectl`
`run0`
