### PR TITLE
Add toggle for verbose logging to pkg5.py

### DIFF
--- a/changelogs/fragments/8379-verbose-mode-pkg5.yml
+++ b/changelogs/fragments/8379-verbose-mode-pkg5.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pkg5 - add support for non-silent execution (https://github.com/ansible-collections/community.general/issues/8379).

--- a/changelogs/fragments/8379-verbose-mode-pkg5.yml
+++ b/changelogs/fragments/8379-verbose-mode-pkg5.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - pkg5 - add support for non-silent execution (https://github.com/ansible-collections/community.general/issues/8379).
+  - pkg5 - add support for non-silent execution (https://github.com/ansible-collections/community.general/issues/8379, https://github.com/ansible-collections/community.general/pull/8382).

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -56,9 +56,10 @@ options:
     default: true
   verbose:
     description:
-      - Toggles quiet execution on or off
+      - Set to true to disable quiet execution.
     type: bool
     default: false
+    version_added: 9.0.0
 '''
 EXAMPLES = '''
 - name: Install Vim

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -54,6 +54,11 @@ options:
       - Refresh publishers before execution.
     type: bool
     default: true
+  verbose:
+    description:
+      - Toggles quiet execution on or off
+    type: bool
+    default: false
 '''
 EXAMPLES = '''
 - name: Install Vim
@@ -90,6 +95,7 @@ def main():
             accept_licenses=dict(type='bool', default=False, aliases=['accept', 'accept_licences']),
             be_name=dict(type='str'),
             refresh=dict(type='bool', default=True),
+            verbose=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -156,9 +162,14 @@ def ensure(module, state, packages, params):
     else:
         no_refresh = ['--no-refresh']
 
+    if params['verbose']:
+        verbosity = []
+    else:
+        verbosity = ['-q']
+
     to_modify = list(filter(behaviour[state]['filter'], packages))
     if to_modify:
-        rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + no_refresh + ['-q', '--'] + to_modify)
+        rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + no_refresh + verbosity + ['--'] + to_modify)
         response['rc'] = rc
         response['results'].append(out)
         response['msg'] += err

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -56,7 +56,7 @@ options:
     default: true
   verbose:
     description:
-      - Set to true to disable quiet execution.
+      - Set to V(true) to disable quiet execution.
     type: bool
     default: false
     version_added: 9.0.0

--- a/plugins/modules/pkg5.py
+++ b/plugins/modules/pkg5.py
@@ -169,7 +169,8 @@ def ensure(module, state, packages, params):
 
     to_modify = list(filter(behaviour[state]['filter'], packages))
     if to_modify:
-        rc, out, err = module.run_command(['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + no_refresh + verbosity + ['--'] + to_modify)
+        rc, out, err = module.run_command(
+            ['pkg', behaviour[state]['subcommand']] + dry_run + accept_licenses + beadm + no_refresh + verbosity + ['--'] + to_modify)
         response['rc'] = rc
         response['results'].append(out)
         response['msg'] += err


### PR DESCRIPTION
Updated params for community.general.pkg5 with 'verbose' mode (defaults to False, which is existing silent execution behavior) to allow users to toggle verbose to True, which disables the '-q' flag that was hardcoded in the original module

##### SUMMARY

Fixes: #8379

Add a simple boolean to enable the user of the pkg5 module to enable verbose mode, which removes the previously hardcoded -q flag from the command string.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pkg5

##### ADDITIONAL INFORMATION
The existing module.run_command included the arguments -q hardcoded. I added a user-driven boolean that removes the '-q' if the user sets the flag to true


```
BEFORE:
"results": [
"\nA clone of SRU-11.4.45.0.1 exists and has been updated and activated.\nOn the next boot the Boot Environment be://rpool/11.4.68.0.1.164.2 will be\nmounted on '/'. Reboot when ready to switch to this updated BE.\n\n"
],


AFTER:
"results": [
      " Startup: Refreshing catalog 'solaris' ... Done\n Startup: Refreshing catalog 'solarisstudio' ... Done\nPlanning: Solver setup ... Done\nPlanning: Running solver ... Done\nPlanning: Finding local manifests ... Done\nPlanning: Package planning ... Done\nPlanning: Merging actions ... Done\nPlanning: Checking for conflicting actions ... Done\nPlanning: Consolidating action changes ... Done\nPlanning: Evaluating mediators ... Done\nPlanning: Planning completed in 252.14 seconds\n            Packages to remove:                70\n           Packages to install:               145\n            Packages to update:               840\n            Packages to change:                 2\n           Mediators to change:                 3\n       Create boot environment:               Yes\n     Activate boot environment:               Yes\n      Name of boot environment: 11.4.68.0.1.164.2\nCreate backup boot environment:                No\n\nRemoved Packages:\n\n  communication/im/libotr\n  communication/im/pidgin\n  communication/im/pidgin-gnome-keyring\n  communication/im/pidgin-otr\n  database/mysql-57/library\n  ...\n  65 additional removed packages. Use 'pkg history' to view the full list.\n\nRelease Notes:\n  \npkg://solaris/network/ssh\n  Updated versions of OpenSSH may change the default configuration\n  including addition or removal of ciphers or other features.\n  \n  If this system has a customised sshd_config(5) or ssh_config(5)\n  file you should review and may need to update it before using the\n  updated version of OpenSSH delivered by this package.\n  \n  Note that users may also have settings in their HOME/.ssh/config\n  that need updating.\n  \n  If the sshd_config references features removed by this version the\n  svc:/network/ssh:default service may be in the maintenance\n  state on the next reboot or after installation of this package.\n  \n  For more information review the release notes for OpenSSH\n  in /usr/share/doc/release-notes/openssh/\n  \npkg://solaris/service/network/ldap/openldap\n  \n  Requirements to transition from one version of OpenLDAP to another.\n  \n   *Only required if the system is being used as an OpenLDAP server.*\n  \n  Ordinarily  a system  is being  used as  an OpenLDAP  server when  SMF\n  service instance ldap/server:openldap is  enabled and online.  Part of\n  the transition  *must be completed  before booting* into the  new Boot\n  Environment (BE). For further information refer to instructions in the\n  new BE in /usr/share/doc/release-notes/openldap-transition.txt:\n  \n    rbe=$(beadm list -o name,flags|awk '$2~\"N\"{next}$2~\"R\"{print $1}')\n    dir=\"\"; [[ -n $rbe ]] && dir=$(mktemp -d) && beadm mount $rbe $dir\n    cp $dir/usr/share/doc/release-notes/openldap-transition.txt /tmp\n    [[ -n $rbe ]] && beadm unmount $rbe && rmdir $dir\n    less /tmp/openldap-transition.txt\n  \n  IF YOU DIDN'T READ THE INSTRUCTIONS AND YOU ARE RUNNING THE NEW SYSTEM\n  AND NOTHING IS WORKING, RECOVER BY BOOTING THE PREVIOUS BOOT ENVIRONMENT.\n  \n  \n  \npkg://solaris/system/file-system/smb\n  NOTICE: The old, insecure SMB1 client (ie smbfs) is provided only for\n  legacy application support and may be removed in a future Support \n  Repository Update (SRU) of Oracle Solaris.\n  \npkg://solaris/system/network/ldap/openldap\n  \n  OpenLDAP 2.6 CLI and developer changes\n  \n  Please note that\n  - Common options '-h' and '-p' on ldap commands have been deprecated\n    since OpenLDAP 2.4 and were officially removed in 2.6.  Currently a\n    reprieve has been put in place to accept both options and display a\n    warning if used with remedial advice to use '-H URI'.  The warning\n    can be disabled if environment variable LDAP_OPT_REPRIEVE is set.\n    Beware though that a future update will remove those options or\n    worse repurpose them!  Stop using them now, and modify your scripts.\n  \n  - Directory /usr/include/openldap is deprecated, headers are now in\n    standard location; /usr/include.  Modify projects as necessary, a\n    compatibility link has been provided which will be removed in the\n    future.\n  \n  \n  \npkg://solaris/print/filter/qpdf\n  QPDF now uses OpenSSL 3 for managing encrypted files. \n  \n  Reading PDF files encoded with RC4 and/or MD5 require installation and\n  configuration of the OpenSSL legacy provider package:\n  \n      pkg:/library/security/openssl-3/legacy-provider\n  \n  Documentation for weak cryptography in QPDF and OpenSSL 3:\n  \n      https://qpdf.readthedocs.io/en/stable/weak-crypto.html\n      https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html\n  \npkg://solaris/editor/vim/vim-core\n  Vim 9.0 brings incompatible change in vim scripts written in Lua; Lua arrays\n  are now one-based, while they used to be zero-based.\n  \npkg://solaris/system/core-os\n  From Oracle Solaris 11.4.66 onwards the default time stamp has\n  a fractional time stamp with a default precision of milliseconds.\n  \n  To restore the original syslogd time stamp, change the time_precision\n  using svccfg:\n  \n  \tsvccfg -s system-log:default setprop config/time_precision = 0\n  \tsvccfg -s system-log:default refresh\n  \npkg://solaris/system/core-os\n  From Oracle Solaris 11.4 SRU48 onwards, global crashdump directory\n  /var/share/crash is a separate file system. On upgrade to 11.4 SRU48\n  or later any existing contents of /var/share/crash will be preserved\n  in a directory /var/share/historical-crash.\n  \n  Crash dumps can take up significant space, so after upgrading to\n  11.4 SRU48 you should examine the contents of /var/share/historical-crash\n  and remove the directory and crashdumps if they are no longer needed to\n  pursue diagnosis of an unsolved panic.\n  \npkg://solaris/library/pcre\n  The previous version of the Perl Compatible Regular Expression library,\n  libpcre, will be removed in a future release of Oracle Solaris.\n  Software using libpcre should migrate to the current version, libpcre2.\n  \npkg://solaris/system/network\n  From Oracle Solaris 11.4.61 onwards, systems which utilize dhcp options\n  to configure node DNS client \"server list\" and \"domain\" parameters and \n  where the dhcp server is also configured to supply a \"Domain Search List\" \n  (dhcp option 119), will have the DNS client \"search\" parameter configured\n  using the search list from the dhcp option.\n  \npkg://solaris/print/filter/ghostscript/fonts/gnu-gs-fonts-other\n  gnu-gs-fonts-other fonts will be removed in the future.\n  \npkg://solaris/service/network/dns/bind\n  This version of BIND may introduce incompatible changes when\n  updating from BIND 9.11.x or BIND 9.16.x.  For further information\n  refer to /usr/share/doc/release-notes/bind-transition.txt\n  \npkg://solaris/print/filter/ghostscript/fonts/gnu-gs-fonts-std\n  gnu-gs-fonts-std fonts will be removed in the future.\n  \npkg://solaris/network/legacy-remote-bsd-utilities\n  The legacy network clients in the network/legacy-remote-bsd-utilities package\n  use unencrypted protocols, and have no protection against spoofing or snooping\n  of traffic.  Additionally, the protocol used by the rdate command cannot\n  handle dates past February 7, 2036.\n  \n  These clients may be removed in future releases of Oracle Solaris.\n  \npkg://solaris/service/network/legacy-remote-bsd-services\n  The legacy network services in the service/network/legacy-remote-bsd-services\n  package use unencrypted protocols, and have no protection against spoofing\n  or snooping of traffic.\n  \n  These servers may be removed in future releases of Oracle Solaris.\n\nDownload:     0/73367 items     0.0/1658.0MB  0% complete \nDownload:  1099/73367 items    30.7/1658.0MB  1% complete (6.0M/s)\nDownload:  2566/73367 items    41.0/1658.0MB  2% complete (4.0M/s)\nDownload:  3324/73367 items   188.0/1658.0MB  11% complete (15.7M/s)\nDownload:  4566/73367 items   238.5/1658.0MB  14% complete (20.0M/s)\nDownload:  6261/73367 items   249.7/1658.0MB  15% complete (7.0M/s)\nDownload:  7884/73367 items   263.1/1658.0MB  15% complete (2.5M/s)\nDownload:  9173/73367 items   283.2/1658.0MB  17% complete (3.4M/s)\nDownload: 10688/73367 items   336.0/1658.0MB  20% complete (7.3M/s)\nDownload: 12355/73367 items   361.0/1658.0MB  21% complete (7.8M/s)\nDownload: 13932/73367 items   375.2/1658.0MB  22% complete (3.9M/s)\nDownload: 15607/73367 items   385.1/1658.0MB  23% complete (2.4M/s)\nDownload: 17297/73367 items   404.9/1658.0MB  24% complete (2.9M/s)\nDownload: 18969/73367 items   425.9/1658.0MB  25% complete (4.1M/s)\nDownload: 20459/73367 items   461.8/1658.0MB  27% complete (5.7M/s)\nDownload: 21556/73367 items   567.1/1658.0MB  34% complete (14.1M/s)\nDownload: 23218/73367 items   581.5/1658.0MB  35% complete (12.0M/s)\nDownload: 24397/73367 items   633.8/1658.0MB  38% complete (6.8M/s)\nDownload: 25767/73367 items   645.1/1658.0MB  38% complete (6.3M/s)\nDownload: 27348/73367 items   662.4/1658.0MB  39% complete (2.8M/s)\nDownload: 30305/73367 items   691.7/1658.0MB  41% complete (2.6M/s)\nDownload: 32232/73367 items   723.5/1658.0MB  43% complete (4.0M/s)\nDownload: 34602/73367 items   731.2/1658.0MB  44% complete (3.5M/s)\nDownload: 36437/73367 items   739.9/1658.0MB  44% complete (1.1M/s)\nDownload: 38496/73367 items   751.7/1658.0MB  45% complete (1.7M/s)\nDownload: 40043/73367 items   777.4/1658.0MB  46% complete (3.6M/s)\nDownload: 41080/73367 items   916.3/1658.0MB  55% complete (16.4M/s)\nDownload: 42726/73367 items   936.5/1658.0MB  56% complete (15.8M/s)\nDownload: 44614/73367 items   959.9/1658.0MB  57% complete (4.2M/s)\nDownload: 46366/73367 items   979.0/1658.0MB  59% complete (4.2M/s)\nDownload: 48217/73367 items  1001.6/1658.0MB  60% complete (4.2M/s)\nDownload: 49991/73367 items  1025.3/1658.0MB  61% complete (4.7M/s)\nDownload: 51303/73367 items  1152.2/1658.0MB  69% complete (15.1M/s)\nDownload: 53028/73367 items  1168.0/1658.0MB  70% complete (14.3M/s)\nDownload: 54778/73367 items  1191.4/1658.0MB  71% complete (3.9M/s)\nDownload: 56726/73367 items  1217.5/1658.0MB  73% complete (4.6M/s)\nDownload: 58365/73367 items  1241.5/1658.0MB  74% complete (4.7M/s)\nDownload: 59372/73367 items  1272.4/1658.0MB  76% complete (5.7M/s)\nDownload: 60957/73367 items  1301.4/1658.0MB  78% complete (5.7M/s)\nDownload: 62195/73367 items  1332.5/1658.0MB  80% complete (6.0M/s)\nDownload: 63657/73367 items  1353.8/1658.0MB  81% complete (5.3M/s)\nDownload: 64912/73367 items  1420.8/1658.0MB  85% complete (7.2M/s)\nDownload: 66017/73367 items  1442.1/1658.0MB  86% complete (7.1M/s)\nDownload: 67375/73367 items  1458.8/1658.0MB  87% complete (3.8M/s)\nDownload: 68687/73367 items  1486.7/1658.0MB  89% complete (4.2M/s)\nDownload: 70184/73367 items  1619.2/1658.0MB  97% complete (15.6M/s)\nDownload: 71365/73367 items  1631.7/1658.0MB  98% complete (14.3M/s)\nDownload: 72793/73367 items  1636.5/1658.0MB  98% complete (1.8M/s)\nDownload: Completed 1.62 GB in 238.33 seconds (6.7M/s)\n Actions:      1/127455 actions (Removing old actions)\n Actions:   4786/127455 actions (Removing old actions)\n Actions:   7952/127455 actions (Removing old actions)\n Actions:  11102/127455 actions (Removing old actions)\n Actions:  13886/127455 actions (Removing old actions)\n Actions:  16599/127455 actions (Removing old actions)\n Actions:  20568/127455 actions (Removing old actions)\n Actions:  33932/127455 actions (Installing new actions)\n Actions:  46068/127455 actions (Installing new actions)\n Actions:  48311/127455 actions (Installing new actions)\n Actions:  52687/127455 actions (Installing new actions)\n Actions:  56594/127455 actions (Installing new actions)\n Actions:  60381/127455 actions (Installing new actions)\n Actions:  63782/127455 actions (Installing new actions)\n Actions:  67642/127455 actions (Installing new actions)\n Actions:  70912/127455 actions (Installing new actions)\n Actions:  80084/127455 actions (Updating modified actions)\n Actions:  83467/127455 actions (Updating modified actions)\n Actions:  85295/127455 actions (Updating modified actions)\n Actions:  86888/127455 actions (Updating modified actions)\n Actions:  89289/127455 actions (Updating modified actions)\n Actions:  91194/127455 actions (Updating modified actions)\n Actions:  93512/127455 actions (Updating modified actions)\n Actions:  94238/127455 actions (Updating modified actions)\n Actions:  95870/127455 actions (Updating modified actions)\n Actions:  97895/127455 actions (Updating modified actions)\n Actions: 100344/127455 actions (Updating modified actions)\n Actions: 101741/127455 actions (Updating modified actions)\n Actions: 104129/127455 actions (Updating modified actions)\n Actions: 106508/127455 actions (Updating modified actions)\n Actions: 108988/127455 actions (Updating modified actions)\n Actions: 110606/127455 actions (Updating modified actions)\n Actions: 112333/127455 actions (Updating modified actions)\n Actions: 113840/127455 actions (Updating modified actions)\n Actions: 115961/127455 actions (Updating modified actions)\n Actions: 117584/127455 actions (Updating modified actions)\n Actions: 119990/127455 actions (Updating modified actions)\n Actions: 122551/127455 actions (Updating modified actions)\n Actions: 126105/127455 actions (Updating modified actions)\n Actions: 126963/127455 actions (Updating modified actions)\n Actions: Completed 127455 actions in 214.94 seconds.\n Done\n Done\n Done\n Done\n Done\n\nA clone of SRU-11.4.45.0.1 exists and has been updated and activated.\nOn the next boot the Boot Environment be://rpool/11.4.68.0.1.164.2 will be\nmounted on '/'.  Reboot when ready to switch to this updated BE.\n\n Done\n"
    ],

```
