### PR TITLE
gitlab modules: deprecate basic auth method

### DIFF
--- a/changelogs/fragments/8383-deprecate-gitlab-basic-auth.yml
+++ b/changelogs/fragments/8383-deprecate-gitlab-basic-auth.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "gitlab modules - the basic auth method on GitLab API have been deprecated and will be removed in community.general 10.0.0 (https://github.com/ansible-collections/community.general/pull/8383)."

--- a/plugins/module_utils/gitlab.py
+++ b/plugins/module_utils/gitlab.py
@@ -115,6 +115,11 @@ def gitlab_authentication(module, min_version=None):
         # Changelog : https://github.com/python-gitlab/python-gitlab/releases/tag/v1.13.0
         # This condition allow to still support older version of the python-gitlab library
         if LooseVersion(gitlab.__version__) < LooseVersion("1.13.0"):
+            module.deprecate(
+                "GitLab basic auth is deprecated and will be removed in next major version, "
+                "using another auth method (API token or OAuth) is strongly recommended.",
+                version='10.0.0',
+                collection_name='community.general')
             gitlab_instance = gitlab.Gitlab(url=gitlab_url, ssl_verify=verify, email=gitlab_user, password=gitlab_password,
                                             private_token=gitlab_token, api_version=4)
         else:


### PR DESCRIPTION
##### SUMMARY
This PR deprecates basic auth for GitLab modules, since this auth method has been removed from GitLab a **long** time ago (in GitLab 9.5, released in August 2017, if I'm right).

It will allow to remove some specific code from `module_utils/gitlab.py` and enhance maintainability.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
gitlab_deploy_key
gitlab_project_badge
gitlab_hook
gitlab_project_variable
gitlab_label
gitlab_instance_variable
gitlab_project_members
gitlab_project_access_token
gitlab_group_access_token
gitlab_merge_request
gitlab_branch
gitlab_project
gitlab_milestone
gitlab_runner
gitlab_protected_branch
gitlab_group_variable
gitlab_user
gitlab_group_members
gitlab_group
gitlab_issue

##### ADDITIONAL INFORMATION
Another PR will follow to remove this code in `community.general` v9.0.0
