### PR TITLE
From now on automatically add period to new plugins in changelog, and use FQCNs

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -35,3 +35,6 @@ sections:
 - - known_issues
   - Known Issues
 title: Community General
+trivial_section_name: trivial
+use_fqcn: true
+add_plugin_period: true


### PR DESCRIPTION
##### SUMMARY
Use https://github.com/ansible-community/antsibull-changelog/pull/162.

Also harmonize changelog config, which means enabling FQCNs for new plugin/module mentions.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
