### PR TITLE
docs: add seealso and notes for yaml callback plugin

### DIFF
--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
       - plugin: ansible.builtin.default
         plugin_type: callback
         description: >
-          There is a parameter C(result_format) in P(ansible.builtin.default#callback) that allows you to change the output format to YAML.
+          There is a parameter O(ansible.builtin.default#callback:result_format) in P(ansible.builtin.default#callback) that allows you to change the output format to YAML.
     notes:
-      - With ansible-core 2.13 or newer, you can instead specify C(yaml) for the parameter C(result_format) in P(ansible.builtin.default#callback).
+      - With ansible-core 2.13 or newer, you can instead specify V(yaml) for the parameter O(ansible.builtin.default#callback:result_format) in P(ansible.builtin.default#callback).
 '''
 
 import yaml

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -23,9 +23,12 @@ DOCUMENTATION = '''
       - plugin: ansible.builtin.default
         plugin_type: callback
         description: >
-          There is a parameter O(ansible.builtin.default#callback:result_format) in P(ansible.builtin.default#callback) that allows you to change the output format to YAML.
+          There is a parameter O(ansible.builtin.default#callback:result_format) in P(ansible.builtin.default#callback)
+          that allows you to change the output format to YAML.
     notes:
-      - With ansible-core 2.13 or newer, you can instead specify V(yaml) for the parameter O(ansible.builtin.default#callback:result_format) in P(ansible.builtin.default#callback).
+      - >
+        With ansible-core 2.13 or newer, you can instead specify V(yaml) for the parameter O(ansible.builtin.default#callback:result_format)
+        in P(ansible.builtin.default#callback).
 '''
 
 import yaml

--- a/plugins/callback/yaml.py
+++ b/plugins/callback/yaml.py
@@ -19,6 +19,13 @@ DOCUMENTATION = '''
       - default_callback
     requirements:
       - set as stdout in configuration
+    seealso:
+      - plugin: ansible.builtin.default
+        plugin_type: callback
+        description: >
+          There is a parameter C(result_format) in P(ansible.builtin.default#callback) that allows you to change the output format to YAML.
+    notes:
+      - With ansible-core 2.13 or newer, you can instead specify C(yaml) for the parameter C(result_format) in P(ansible.builtin.default#callback).
 '''
 
 import yaml

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,5 +1,6 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/callback/timestamp.py validate-modules:invalid-documentation
+plugins/callback/yaml.py validate-modules:invalid-documentation
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,5 +1,6 @@
 .azure-pipelines/scripts/publish-codecov.py replace-urlopen
 plugins/callback/timestamp.py validate-modules:invalid-documentation
+plugins/callback/yaml.py validate-modules:invalid-documentation
 plugins/lookup/etcd.py validate-modules:invalid-documentation
 plugins/lookup/etcd3.py validate-modules:invalid-documentation
 plugins/modules/consul_session.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds `seealso` and `notes` for `community.general.yaml` callback plugin.

Since the new built-in parameter `result_format = yaml` for `ansible.builtin.default` callback plugin was introduced in ansible-core 2.13, most users now can get YAML output with the built-in functionality without having to use `community.general.yaml`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

This PR does not contain any changelog fragmen since this is a doc-only change.

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

yaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Tested locally with:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-test sanity --docker -v plugins/callback/yaml.py
ansible-test integration --docker -v callback_yaml
```
