### PR TITLE
keycloak_client: avoid TypeError if `result["attributes"]` is a list

### DIFF
--- a/changelogs/fragments/8403-fix-typeerror-in-keycloak-client.yaml
+++ b/changelogs/fragments/8403-fix-typeerror-in-keycloak-client.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_client - fix TypeError in sanitize_cr function. The function expected a dict where in some cases a list might occur (https://github.com/ansible-collections/community.general/pull/8403).

--- a/changelogs/fragments/8403-fix-typeerror-in-keycloak-client.yaml
+++ b/changelogs/fragments/8403-fix-typeerror-in-keycloak-client.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - keycloak_client - fix TypeError in sanitize_cr function. The function expected a dict where in some cases a list might occur (https://github.com/ansible-collections/community.general/pull/8403).
+  - keycloak_client - fix TypeError when sanitizing the ``saml.signing.private.key`` attribute in the module's diff or state output. The ``sanitize_cr`` function expected a dict where in some cases a list might occur (https://github.com/ansible-collections/community.general/pull/8403).

--- a/plugins/modules/keycloak_client.py
+++ b/plugins/modules/keycloak_client.py
@@ -775,8 +775,9 @@ def sanitize_cr(clientrep):
     if 'secret' in result:
         result['secret'] = 'no_log'
     if 'attributes' in result:
-        if 'saml.signing.private.key' in result['attributes']:
-            result['attributes']['saml.signing.private.key'] = 'no_log'
+        attributes = result['attributes']
+        if isinstance(attributes, dict) and 'saml.signing.private.key' in attributes:
+            attributes['saml.signing.private.key'] = 'no_log'
     return normalise_cr(result)
 
 


### PR DESCRIPTION
##### SUMMARY

This fixes a TypeError in the keycloak_client module.

Longer description:

As `sanitize_cr` might be executed after `normalise_cr`, `result['attributes']` can be of type list and we run into:

> TypeError: list indices must be integers or slices, not str

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME

`keycloak_client`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Full stack trace (keycloak_client.py got renamed to `mdz_keycloak_client.py`):

```
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1716369175.8611605-165495-177683398669149/AnsiballZ_mdz_keycloak_client.py", line 107, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1716369175.8611605-165495-177683398669149/AnsiballZ_mdz_keycloak_client.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1716369175.8611605-165495-177683398669149/AnsiballZ_mdz_keycloak_client.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible.modules.mdz_keycloak_client', init_globals=dict(_module_fqn='ansible.modules.mdz_keycloak_client', _modlib_path=modlib_path),
  File "/usr/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_mdz_keycloak_client_payload_uw8ct1px/ansible_mdz_keycloak_client_payload.zip/ansible/modules/mdz_keycloak_client.py", line 999, in <module>
  File "/tmp/ansible_mdz_keycloak_client_payload_uw8ct1px/ansible_mdz_keycloak_client_payload.zip/ansible/modules/mdz_keycloak_client.py", line 956, in main
  File "/tmp/ansible_mdz_keycloak_client_payload_uw8ct1px/ansible_mdz_keycloak_client_payload.zip/ansible/modules/mdz_keycloak_client.py", line 779, in sanitize_cr
TypeError: list indices must be integers or slices, not str

```
