### PR TITLE
Add support for SSHFP records to ipa_dnsrecord module

### DIFF
--- a/changelogs/fragments/8404-ipa_dnsrecord_sshfp.yml
+++ b/changelogs/fragments/8404-ipa_dnsrecord_sshfp.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ipa_dnsrecord - adds ``SSHFP`` record type for managing SSH fingerprints in FreeIPA DNS.
+  - ipa_dnsrecord - adds ``SSHFP`` record type for managing SSH fingerprints in FreeIPA DNS (https://github.com/ansible-collections/community.general/pull/8404).

--- a/changelogs/fragments/8404-ipa_dnsrecord_sshfp.yml
+++ b/changelogs/fragments/8404-ipa_dnsrecord_sshfp.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ipa_dnsrecord - adds ``SSHFP`` record type for managing SSH fingerprints in FreeIPA DNS.

--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -39,7 +39,7 @@ options:
     - "'A6', 'CNAME', 'DNAME' and 'TXT' are added in version 2.5."
     - "'SRV' and 'MX' are added in version 2.8."
     - "'NS' are added in comunity.general 8.2.0."
-    - "'SSHFP' are added in community.general 9.1.0"
+    - "'SSHFP' are added in community.general 9.1.0."
     required: false
     default: 'A'
     choices: ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT', 'SSHFP']

--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -35,13 +35,14 @@ options:
   record_type:
     description:
     - The type of DNS record name.
-    - Currently, 'A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'NS', 'PTR', 'TXT', 'SRV' and 'MX' are supported.
+    - Currently, 'A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'NS', 'PTR', 'TXT', 'SRV', 'MX' and 'SSHFP' are supported.
     - "'A6', 'CNAME', 'DNAME' and 'TXT' are added in version 2.5."
     - "'SRV' and 'MX' are added in version 2.8."
     - "'NS' are added in comunity.general 8.2.0."
+    - "'SSHFP' are added in community.general 9.0.1"
     required: false
     default: 'A'
-    choices: ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT']
+    choices: ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT', 'SSHFP']
     type: str
   record_value:
     description:
@@ -57,6 +58,7 @@ options:
     - In the case of 'TXT' record type, this will be a text.
     - In the case of 'SRV' record type, this will be a service record.
     - In the case of 'MX' record type, this will be a mail exchanger record.
+    - In the case of 'SSHFP' record type, this will be an SSH fingerprint record.
     type: str
   record_values:
     description:
@@ -71,6 +73,7 @@ options:
     - In the case of 'TXT' record type, this will be a text.
     - In the case of 'SRV' record type, this will be a service record.
     - In the case of 'MX' record type, this will be a mail exchanger record.
+    - In the case of 'SSHFP' record type, this will be an SSH fingerprint record.
     type: list
     elements: str
   record_ttl:
@@ -175,6 +178,20 @@ EXAMPLES = r'''
     ipa_host: ipa.example.com
     ipa_user: admin
     ipa_pass: ChangeMe!
+
+- name: Retrieve the current sshfp fingerprints
+  ansible.builtin.command: ssh-keyscan -D localhost
+  register: ssh_hostkeys
+
+- name: Update the SSHFP records in dns
+  community,general.ipa_dnsrecord:
+    name: "{{ inventory_hostname}}"
+    zone_name: example.com
+    record_type: 'SSHFP'
+    record_values: "{{ ssh_hostkeys.stdout.split('\n') | map('split', 'SSHFP ') | map('last') | list }}"
+    ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: ChangeMe!
 '''
 
 RETURN = r'''
@@ -228,6 +245,8 @@ class DNSRecordIPAClient(IPAClient):
                 item.update(srvrecord=value)
             elif details['record_type'] == 'MX':
                 item.update(mxrecord=value)
+            elif details['record_type'] == 'SSHFP':
+                item.update(sshfprecord=value)
 
             self._post_json(method='dnsrecord_add', name=zone_name, item=item)
 
@@ -266,6 +285,8 @@ def get_dnsrecord_dict(details=None):
         module_dnsrecord.update(srvrecord=details['record_values'])
     elif details['record_type'] == 'MX' and details['record_values']:
         module_dnsrecord.update(mxrecord=details['record_values'])
+    elif details['record_type'] == 'SSHFP' and details['record_values']:
+        module_dnsrecord.update(sshfprecord=details['record_values'])
 
     if details.get('record_ttl'):
         module_dnsrecord.update(dnsttl=details['record_ttl'])
@@ -328,7 +349,7 @@ def ensure(module, client):
 
 
 def main():
-    record_types = ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'NS', 'PTR', 'TXT', 'SRV', 'MX']
+    record_types = ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'NS', 'PTR', 'TXT', 'SRV', 'MX', 'SSHFP']
     argument_spec = ipa_argument_spec()
     argument_spec.update(
         zone_name=dict(type='str', required=True),

--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -184,7 +184,7 @@ EXAMPLES = r'''
   register: ssh_hostkeys
 
 - name: Update the SSHFP records in DNS
-  community,general.ipa_dnsrecord:
+  community.general.ipa_dnsrecord:
     name: "{{ inventory_hostname}}"
     zone_name: example.com
     record_type: 'SSHFP'

--- a/plugins/modules/ipa_dnsrecord.py
+++ b/plugins/modules/ipa_dnsrecord.py
@@ -39,7 +39,7 @@ options:
     - "'A6', 'CNAME', 'DNAME' and 'TXT' are added in version 2.5."
     - "'SRV' and 'MX' are added in version 2.8."
     - "'NS' are added in comunity.general 8.2.0."
-    - "'SSHFP' are added in community.general 9.0.1"
+    - "'SSHFP' are added in community.general 9.1.0"
     required: false
     default: 'A'
     choices: ['A', 'AAAA', 'A6', 'CNAME', 'DNAME', 'MX', 'NS', 'PTR', 'SRV', 'TXT', 'SSHFP']
@@ -183,7 +183,7 @@ EXAMPLES = r'''
   ansible.builtin.command: ssh-keyscan -D localhost
   register: ssh_hostkeys
 
-- name: Update the SSHFP records in dns
+- name: Update the SSHFP records in DNS
   community,general.ipa_dnsrecord:
     name: "{{ inventory_hostname}}"
     zone_name: example.com


### PR DESCRIPTION
##### SUMMARY
Adds record-type 'SSHFP' support to the ipa_dnsrecord module

Since I need the PR number for the changelog fragment, I'll have to add it later
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
ipa_dnsrecord

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
