### PR TITLE
feat(gitlab modules): remove basic auth

### DIFF
--- a/changelogs/fragments/8405-gitlab-remove-basic-auth.yml
+++ b/changelogs/fragments/8405-gitlab-remove-basic-auth.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - gitlab modules - remove basic auth feature (https://github.com/ansible-collections/community.general/pull/8405).


### PR DESCRIPTION
##### SUMMARY
This PR removes ability to authenticate against GitLab API using Basic Auth (deprecated in #8383).

**Note : This is a breaking change.**

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gitlab_deploy_key
gitlab_project_badge
gitlab_hook
gitlab_project_variable
gitlab_label
gitlab_instance_variable
gitlab_project_members
gitlab_project_access_token
gitlab_group_access_token
gitlab_merge_request
gitlab_branch
gitlab_project
gitlab_milestone
gitlab_runner
gitlab_protected_branch
gitlab_group_variable
gitlab_user
gitlab_group_members
gitlab_group
gitlab_issue

##### ADDITIONAL INFORMATION
N/A
