### PR TITLE
Fix the homebrew module failing because of warnings

### DIFF
--- a/changelogs/fragments/8406-fix-homebrew-cask-warning.yaml
+++ b/changelogs/fragments/8406-fix-homebrew-cask-warning.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - do not fail when brew prints warnings (https://github.com/ansible-collections/community.general/pull/8406, https://github.com/ansible-collections/community.general/issues/7044).

--- a/plugins/modules/homebrew.py
+++ b/plugins/modules/homebrew.py
@@ -415,9 +415,9 @@ class Homebrew(object):
         if self.force_formula:
             cmd.append("--formula")
         rc, out, err = self.module.run_command(cmd)
-        if err:
+        if rc != 0:
             self.failed = True
-            self.message = err.strip()
+            self.message = err.strip() or ("Unknown failure with exit code %d" % rc)
             raise HomebrewException(self.message)
         data = json.loads(out)
 

--- a/tests/integration/targets/homebrew/tasks/docker.yml
+++ b/tests/integration/targets/homebrew/tasks/docker.yml
@@ -12,20 +12,6 @@
     path: "{{ brew_which.stdout }}"
   register: brew_stat
 
-- name: MACOS | Install docker without --formula
-  community.general.homebrew:
-    name: docker
-    state: present
-  become: true
-  become_user: "{{ brew_stat.stat.pw_name }}"
-  ignore_errors: true
-  register: result
-
-- name: Check that installing docker without --formula raises warning
-  assert:
-    that:
-      - result is failed
-
 - name: MACOS | Install docker
   community.general.homebrew:
     name: docker


### PR DESCRIPTION
Instead of checking if there is an error message, which can also be a warning, we now check the return code.

This commit fixes #8229 #7044

##### SUMMARY
Fixes #8229
Fixes #7044

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
homebrew