### PR TITLE
Proxmox remote pct connection

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -111,6 +111,9 @@ files:
   $connections/lxd.py:
     labels: lxd
     maintainers: mattclay
+  $connections/pct_remote.py:
+    labels: proxmox
+    maintainers: mietzen
   $connections/qubes.py:
     maintainers: kushaldas
   $connections/saltstack.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -111,7 +111,7 @@ files:
   $connections/lxd.py:
     labels: lxd
     maintainers: mattclay
-  $connections/pct_remote.py:
+  $connections/proxmox_pct_remote.py:
     labels: proxmox
     maintainers: mietzen
   $connections/qubes.py:

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -254,12 +254,12 @@ EXAMPLES = r"""
 #           ansible_host: 10.0.0.10
 #           proxmox_vmid: 100
 #           ansible_connection: community.general.pct_remote
-#           remote_user: ansible
+#           ansible_user: ansible
 #         container-2:
 #           ansible_host: 10.0.0.10
 #           proxmox_vmid: 200
 #           ansible_connection: community.general.pct_remote
-#           remote_user: ansible
+#           ansible_user: ansible
 #     proxmox:
 #       hosts:
 #         proxmox-1:
@@ -286,7 +286,7 @@ EXAMPLES = r"""
 # compose:
 #   ansible_host: "'10.0.0.10'"
 #   ansible_connection: "'community.general.pct_remote'"
-#   remote_user: "'ansible'"
+#   ansible_user: "'ansible'"
 #
 #
 # ----------------------

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -477,11 +477,6 @@ class Connection(ConnectionBase):
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
-    def _connect(self) -> Connection:
-        self.ssh = self._connect_uncached()
-        self._connected = True
-        return self
-
     def _set_log_channel(self, name: str) -> None:
         """ Mimic paramiko.SSHClient.set_log_channel """
         self._log_channel = name
@@ -508,7 +503,7 @@ class Connection(ConnectionBase):
 
         return sock_kwarg
 
-    def _connect_uncached(self) -> paramiko.SSHClient:
+    def _connect(self) -> Connection:
         """ activates the connection object """
 
         if paramiko is None:
@@ -596,7 +591,9 @@ class Connection(ConnectionBase):
                 raise AnsibleConnectionFailure(msg)
             else:
                 raise AnsibleConnectionFailure(msg)
-        return ssh
+        self.ssh = ssh
+        self._connected = True
+        return self
 
     def _any_keys_added(self) -> bool:
         for hostname, keys in self.ssh._host_keys.items():

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -192,10 +192,14 @@ options:
       - name: ansible_paramiko_timeout
     cli:
       - name: timeout
-    lock_file_timeout:
-        description: Number of seconds until the plugin gives up on trying to write a lock file when writing SSH known host keys.
-        type: int
-        default: 60
+  lock_file_timeout:
+    type: int
+    default: 60
+    description: Number of seconds until the plugin gives up on trying to write a lock file when writing SSH known host keys.
+    vars:
+      - name: ansible_lock_file_timeout
+    env:
+      - name: ANSIBLE_LOCK_FILE_TIMEOUT
   private_key_file:
     description:
       - Path to private key file to use for authentication.

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -824,6 +824,7 @@ class Connection(ConnectionBase):
 
                     os.rename(tmp_keyfile_name, self.keyfile)
                 except LockTimeout:
+                    pathlib.Path(tmp_keyfile_name).unlink(missing_ok=True)
                     raise AnsibleError(
                         f'writing lock file {tmp_keyfile_name} ran in to the timeout of {self.get_option("locktimeout")}s')
                 except Exception:

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -16,7 +16,7 @@ requirements:
   - paramiko
 description:
   - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via SSH.
-  - Use the Python SSH implementation (Paramiko) to connect to Proxmox.
+  - Uses the Python SSH implementation (Paramiko) to connect to the Proxmox host.
 version_added: "10.2.0"
 options:
   remote_addr:
@@ -88,14 +88,15 @@ options:
       - {key: use_rsa_sha2_algorithms, section: paramiko_connection}
     env:
       - {name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS}
-    default: True
+    default: true
     type: boolean
   host_key_auto_add:
-    description: "Automatically add host keys."
+    description: "Automatically add host keys to C(~/.ssh/known_hosts)."
     env:
       - name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD
     ini:
-      - {key: host_key_auto_add, section: paramiko_connection}
+      - key: host_key_auto_add
+        section: paramiko_connection
     type: boolean
   look_for_keys:
     default: True
@@ -137,7 +138,7 @@ options:
   host_key_checking:
     description: "Set this to V(false) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
     type: boolean
-    default: True
+    default: true
     env:
       - name: ANSIBLE_HOST_KEY_CHECKING
       - name: ANSIBLE_SSH_HOST_KEY_CHECKING
@@ -787,7 +788,7 @@ class Connection(ConnectionBase):
             # (This doesn't acquire the connection lock because it needs
             # to exclude only other known_hosts writers, not connections
             # that are starting up.)
-            lockfile = self.keyfile.replace('known_hosts', '.known_hosts.lock')
+            lockfile = os.path.join(os.path.dirname(self.keyfile, f'.{os.path.basename(self.keyfile)}.lock'))
             dirname = os.path.dirname(self.keyfile)
             makedirs_safe(dirname)
 

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Derived from paramiko_ssh.py (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# Derived from ansible/plugins/connection/paramiko_ssh.py (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 # Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
 # Copyright (c) 2024 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -222,6 +222,7 @@ DOCUMENTATION = r"""
       - >
         When NOT using this plugin as root, you need to have a become mechanism,
         e.g. C(sudo), installed on Proxmox and setup so we can run it without prompting for the password.
+        Inside the container we need a shell e.g. C(sh) and C(cat), for this plugin to work.
 """
 
 EXAMPLES = r"""
@@ -330,7 +331,7 @@ class MyAddPolicy(MissingHostKeyPolicy):
     and also prompt for input.
 
     Policy for automatically adding the hostname and new host key to the
-    local L{HostKeys} object, and saving it.  This is used by L{SSHClient}.
+    local L{HostKeys} object, and saving it. This is used by L{SSHClient}.
     """
 
     def __init__(self, connection: Connection) -> None:

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+# Based on paramiko_ssh.py (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (annotations, absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+    author: Nils Stein (@mietzen) <github.nstein@mailbox.org>
+    name: pct_remote
+    short_description: Run tasks in Proxmox LXC container instances using pct CLI via ssh
+    requirements:
+      - paramiko
+    description:
+      - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via ssh.
+      - Use the Python SSH implementation (Paramiko) to connect to Proxmox.
+    version_added: "9.1.0"
+    options:
+      remote_addr:
+        description:
+          - Address of the remote target
+        default: inventory_hostname
+        type: string
+        vars:
+          - name: inventory_hostname
+          - name: ansible_host
+          - name: ansible_ssh_host
+          - name: ansible_paramiko_host
+      port:
+        description: Remote port to connect to.
+        type: int
+        default: 22
+        ini:
+          - section: defaults
+            key: remote_port
+          - section: paramiko_connection
+            key: remote_port
+        env:
+          - name: ANSIBLE_REMOTE_PORT
+          - name: ANSIBLE_REMOTE_PARAMIKO_PORT
+        vars:
+          - name: ansible_port
+          - name: ansible_ssh_port
+          - name: ansible_paramiko_port
+        keyword:
+          - name: port
+      remote_user:
+        description:
+          - User to login/authenticate as.
+          - It can be set from the CLI via the C(--user) or C(-u) options.
+        type: string
+        vars:
+          - name: ansible_user
+          - name: ansible_ssh_user
+          - name: ansible_paramiko_user
+        env:
+          - name: ANSIBLE_REMOTE_USER
+          - name: ANSIBLE_PARAMIKO_REMOTE_USER
+        ini:
+          - section: defaults
+            key: remote_user
+          - section: paramiko_connection
+            key: remote_user
+        keyword:
+          - name: remote_user
+      password:
+        description:
+          - Secret used to either login the ssh server or as a passphrase for ssh keys that require it.
+          - It can be set from the CLI via the C(--ask-pass) option.
+        type: string
+        vars:
+          - name: ansible_password
+          - name: ansible_ssh_pass
+          - name: ansible_ssh_password
+          - name: ansible_paramiko_pass
+          - name: ansible_paramiko_password
+      use_rsa_sha2_algorithms:
+        description:
+          - Whether or not to enable RSA SHA2 algorithms for pubkeys and hostkeys.
+          - On paramiko versions older than 2.9, this only affects hostkeys.
+          - For behavior matching paramiko<2.9 set this to V(False).
+        vars:
+          - name: ansible_paramiko_use_rsa_sha2_algorithms
+        ini:
+          - section: paramiko_connection
+            key: use_rsa_sha2_algorithms
+        env:
+          - name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS
+        default: True
+        type: boolean
+      host_key_auto_add:
+        description: Automatically add host keys.
+        env:
+          - name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD
+        ini:
+          - section: paramiko_connection
+            key: host_key_auto_add
+        type: boolean
+      look_for_keys:
+        default: True
+        description: "False to disable searching for private key files in ~/.ssh/."
+        env:
+          - name: ANSIBLE_PARAMIKO_LOOK_FOR_KEYS
+        ini:
+          - section: paramiko_connection
+            key: look_for_keys
+        type: boolean
+      proxy_command:
+        default: ""
+        description:
+          - Proxy information for running the connection via a jumphost.
+          - Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
+        type: string
+        env:
+          - name: ANSIBLE_PARAMIKO_PROXY_COMMAND
+        ini:
+          - section: paramiko_connection
+            key: proxy_command
+        vars:
+          - name: ansible_paramiko_proxy_command
+      ssh_args:
+        description: Only used in parsing ProxyCommand for use in this plugin.
+        default: ""
+        type: string
+        ini:
+          - section: "ssh_connection"
+            key: "ssh_args"
+        env:
+          - name: ANSIBLE_SSH_ARGS
+        vars:
+          - name: ansible_ssh_args
+        deprecated:
+          why: In favor of the "proxy_command" option.
+          version: "0.1.0"
+          alternatives: proxy_command
+      ssh_common_args:
+        description: Only used in parsing ProxyCommand for use in this plugin.
+        type: string
+        ini:
+          - section: "ssh_connection"
+            key: "ssh_common_args"
+        env:
+          - name: ANSIBLE_SSH_COMMON_ARGS
+        vars:
+          - name: ansible_ssh_common_args
+        cli:
+          - name: ssh_common_args
+        default: ""
+        deprecated:
+          why: In favor of the "proxy_command" option.
+          version: "0.1.0"
+          alternatives: proxy_command
+      ssh_extra_args:
+        description: Only used in parsing ProxyCommand for use in this plugin.
+        type: string
+        vars:
+          - name: ansible_ssh_extra_args
+        env:
+          - name: ANSIBLE_SSH_EXTRA_ARGS
+        ini:
+          - key: ssh_extra_args
+            section: ssh_connection
+        cli:
+          - name: ssh_extra_args
+        default: ""
+        deprecated:
+          why: In favor of the "proxy_command" option.
+          version: "0.1.0"
+          alternatives: proxy_command
+      pty:
+        default: True
+        description: "SUDO usually requires a PTY, True to give a PTY and False to not give a PTY."
+        env:
+          - name: ANSIBLE_PARAMIKO_PTY
+        ini:
+          - key: pty
+            section: paramiko_connection
+        type: boolean
+      record_host_keys:
+        default: True
+        description: "Save the host keys to a file"
+        env:
+          - name: ANSIBLE_PARAMIKO_RECORD_HOST_KEYS
+        ini:
+          - section: paramiko_connection
+            key: record_host_keys
+        type: boolean
+      host_key_checking:
+        description: "Set this to V(False) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
+        type: boolean
+        default: True
+        env:
+          - name: ANSIBLE_HOST_KEY_CHECKING
+          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+          - name: ANSIBLE_PARAMIKO_HOST_KEY_CHECKING
+        ini:
+          - section: defaults
+            key: host_key_checking
+          - section: paramiko_connection
+            key: host_key_checking
+        vars:
+          - name: ansible_host_key_checking
+          - name: ansible_ssh_host_key_checking
+          - name: ansible_paramiko_host_key_checking
+      use_persistent_connections:
+        description: "Toggles the use of persistence for connections"
+        type: boolean
+        default: False
+        env:
+          - name: ANSIBLE_USE_PERSISTENT_CONNECTIONS
+        ini:
+          - section: defaults
+            key: use_persistent_connections
+      banner_timeout:
+        type: float
+        default: 30
+        description:
+          - Configures, in seconds, the amount of time to wait for the SSH
+            banner to be presented. This option is supported by paramiko
+            version 1.15.0 or newer.
+        ini:
+          - section: paramiko_connection
+            key: banner_timeout
+        env:
+          - name: ANSIBLE_PARAMIKO_BANNER_TIMEOUT
+      timeout:
+        type: int
+        default: 10
+        description: Number of seconds until the plugin gives up on failing to establish a TCP connection.
+        ini:
+          - section: defaults
+            key: timeout
+          - section: ssh_connection
+            key: timeout
+          - section: paramiko_connection
+            key: timeout
+        env:
+          - name: ANSIBLE_TIMEOUT
+          - name: ANSIBLE_SSH_TIMEOUT
+          - name: ANSIBLE_PARAMIKO_TIMEOUT
+        vars:
+          - name: ansible_ssh_timeout
+          - name: ansible_paramiko_timeout
+        cli:
+          - name: timeout
+      private_key_file:
+        description:
+          - Path to private key file to use for authentication.
+        type: string
+        ini:
+          - section: defaults
+            key: private_key_file
+          - section: paramiko_connection
+            key: private_key_file
+        env:
+          - name: ANSIBLE_PRIVATE_KEY_FILE
+          - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE
+        vars:
+          - name: ansible_private_key_file
+          - name: ansible_ssh_private_key_file
+          - name: ansible_paramiko_private_key_file
+        cli:
+          - name: private_key_file
+            option: "--private-key"
+      vmid:
+        description:
+          - Container ID
+        default: proxmox_vmid
+        vars:
+          - name: proxmox_vmid
+    notes:
+      - When NOT using this plugin as root, you need to have sudo installed on proxmox and setup so we can run it without prompting for the password.
+"""
+
+EXAMPLES = r"""
+# --------------------------------------------------------------
+# Setup sudo with passwordless access to pct for user 'ansible':
+# --------------------------------------------------------------
+# $ echo 'ansible ALL = (root) NOPASSWD: /usr/sbin/pct' > /etc/sudoers.d/ansible_pct
+#
+#
+# --------------------------------
+# Static inventory file: hosts.yml
+# --------------------------------
+# all:
+#   children:
+#     lxc:
+#       hosts:
+#         container-1:
+#           ansible_host: 10.0.0.10
+#           proxmox_vmid: 100
+#           ansible_connection: community.general.pct_remote
+#           remote_user: ansible
+#         container-2:
+#           ansible_host: 10.0.0.10
+#           proxmox_vmid: 200
+#           ansible_connection: community.general.pct_remote
+#           remote_user: ansible
+#     proxmox:
+#       hosts:
+#         proxmox-1:
+#           ansible_host: 10.0.0.10
+#
+#
+# ---------------------------------------------
+# Dynamic inventory file: inventory.proxmox.yml
+# ---------------------------------------------
+# plugin: community.general.proxmox
+# url: https://10.0.0.10:8006
+# validate_certs: false
+# user: ansible@pam
+# token_id: ansible
+# token_secret: !vault |
+#           $ANSIBLE_VAULT;1.1;AES256
+#           ...
+
+# want_facts: true
+# exclude_nodes: true
+# filters:
+#   - proxmox_vmtype == "lxc"
+# want_proxmox_nodes_ansible_host: false
+# compose:
+#   ansible_host: "'10.0.0.10'"
+#   ansible_connection: "'community.general.pct_remote'"
+#   remote_user: "'ansible'"
+#
+#
+# ----------------------
+# Playbook: playbook.yml
+# ----------------------
+---
+- hosts: lxc
+  tasks:
+    - debug:
+        msg: "This is coming from pct environment"
+"""
+
+from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.plugins.connection.paramiko_ssh import Connection as SSH_Connection
+from ansible.utils.display import Display
+import uuid
+import os
+
+
+display = Display()
+
+
+def become_command():
+    """Helper function to get become_command """
+    return os.getenv('ANSIBLE_BECOME_METHOD', default=C.DEFAULT_BECOME_METHOD)
+
+
+class Connection(SSH_Connection):
+    ''' SSH based connections (paramiko) to Proxmox pct '''
+    transport = 'community.general.pct_remote'
+
+    def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:
+        ''' execute a command inside the proxmox container '''
+        cmd = ['/usr/sbin/pct', 'exec',
+               self.get_option('vmid'), '--', cmd]
+        if self.get_option('remote_user') != 'root':
+            cmd = [become_command()] + cmd
+        return super().exec_command(' '.join(cmd), in_data=in_data, sudoable=sudoable)
+
+    def put_file(self, in_path: str, out_path: str) -> None:
+        ''' transfer a file from local to remote '''
+        temp_dir = '/tmp/ansible_pct_' + str(uuid.uuid4()).replace('-', '')[:6]
+        temp_file_path = f'{temp_dir}/{os.path.basename(in_path)}'
+        try:
+            super().exec_command(f'mkdir -p {temp_dir}')
+            super().put_file(in_path, temp_file_path)
+            cmd = ['/usr/sbin/pct', 'push',
+                   self.get_option('vmid'), temp_file_path, out_path]
+            if self.get_option('remote_user') != 'root':
+                cmd = [become_command()] + cmd
+            super().exec_command(' '.join(cmd))
+        except Exception as e:
+            raise AnsibleError(
+                'failed to transfer file to %s!\n%s' % (out_path, e))
+        finally:
+            super().exec_command(f'rm -rf {temp_dir}')
+
+    def fetch_file(self, in_path: str, out_path: str) -> None:
+        ''' save a remote file to the specified path '''
+        temp_dir = '/tmp/ansible_pct_' + str(uuid.uuid4()).replace('-', '')[:6]
+        temp_file_path = f'{temp_dir}/{os.path.basename(in_path)}'
+        try:
+            super().exec_command(f'mkdir -p {temp_dir}')
+            cmd = ['/usr/sbin/pct', 'pull',
+                   self.get_option('vmid'), in_path, temp_file_path]
+            if self.get_option('remote_user') != 'root':
+                cmd = [become_command()] + cmd
+            super().exec_command(' '.join(cmd))
+            super().fetch_file(temp_file_path, out_path)
+        except Exception as e:
+            raise AnsibleError(
+                'failed to transfer file from %s!\n%s' % (in_path, e))
+        finally:
+            super().exec_command(f'rm -rf {temp_dir}')

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -11,17 +11,17 @@ __metaclass__ = type
 DOCUMENTATION = r"""
     author: Nils Stein (@mietzen) <github.nstein@mailbox.org>
     name: pct_remote
-    short_description: Run tasks in Proxmox LXC container instances using pct CLI via ssh
+    short_description: Run tasks in Proxmox LXC container instances using pct CLI via SSH
     requirements:
       - paramiko
     description:
-      - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via ssh.
+      - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via SSH.
       - Use the Python SSH implementation (Paramiko) to connect to Proxmox.
-    version_added: "9.1.0"
+    version_added: "10.1.0"
     options:
       remote_addr:
         description:
-          - Address of the remote target
+          - Address of the remote target.
         default: inventory_hostname
         type: string
         vars:
@@ -50,7 +50,7 @@ DOCUMENTATION = r"""
       remote_user:
         description:
           - User to login/authenticate as.
-          - It can be set from the CLI via the C(--user) or C(-u) options.
+          - Can be set from the CLI via the C(--user) or C(-u) options.
         type: string
         vars:
           - name: ansible_user
@@ -68,8 +68,8 @@ DOCUMENTATION = r"""
           - name: remote_user
       password:
         description:
-          - Secret used to either login the ssh server or as a passphrase for ssh keys that require it.
-          - It can be set from the CLI via the C(--ask-pass) option.
+          - Secret used to either login the SSH server or as a passphrase for SSH keys that require it.
+          - Can be set from the CLI via the C(--ask-pass) option.
         type: string
         vars:
           - name: ansible_password
@@ -81,107 +81,53 @@ DOCUMENTATION = r"""
         description:
           - Whether or not to enable RSA SHA2 algorithms for pubkeys and hostkeys.
           - On paramiko versions older than 2.9, this only affects hostkeys.
-          - For behavior matching paramiko<2.9 set this to V(False).
+          - For behavior matching paramiko<2.9 set this to V(false).
         vars:
           - name: ansible_paramiko_use_rsa_sha2_algorithms
         ini:
-          - section: paramiko_connection
-            key: use_rsa_sha2_algorithms
+          - {key: use_rsa_sha2_algorithms, section: paramiko_connection}
         env:
-          - name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS
+          - {name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS}
         default: True
         type: boolean
       host_key_auto_add:
-        description: Automatically add host keys.
+        description: "Automatically add host keys."
         env:
           - name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD
         ini:
-          - section: paramiko_connection
-            key: host_key_auto_add
+          - {key: host_key_auto_add, section: paramiko_connection}
         type: boolean
       look_for_keys:
         default: True
-        description: "False to disable searching for private key files in ~/.ssh/."
+        description: "Set to V(false) to disable searching for private key files in C(~/.ssh/)."
         env:
           - name: ANSIBLE_PARAMIKO_LOOK_FOR_KEYS
         ini:
-          - section: paramiko_connection
-            key: look_for_keys
+          - {key: look_for_keys, section: paramiko_connection}
         type: boolean
       proxy_command:
         default: ""
         description:
           - Proxy information for running the connection via a jumphost.
-          - Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
         type: string
         env:
           - name: ANSIBLE_PARAMIKO_PROXY_COMMAND
         ini:
-          - section: paramiko_connection
-            key: proxy_command
+          - {key: proxy_command, section: paramiko_connection}
         vars:
           - name: ansible_paramiko_proxy_command
-      ssh_args:
-        description: Only used in parsing ProxyCommand for use in this plugin.
-        default: ""
-        type: string
-        ini:
-          - section: "ssh_connection"
-            key: "ssh_args"
-        env:
-          - name: ANSIBLE_SSH_ARGS
-        vars:
-          - name: ansible_ssh_args
-        deprecated:
-          why: In favor of the "proxy_command" option.
-          version: "0.1.0"
-          alternatives: proxy_command
-      ssh_common_args:
-        description: Only used in parsing ProxyCommand for use in this plugin.
-        type: string
-        ini:
-          - section: "ssh_connection"
-            key: "ssh_common_args"
-        env:
-          - name: ANSIBLE_SSH_COMMON_ARGS
-        vars:
-          - name: ansible_ssh_common_args
-        cli:
-          - name: ssh_common_args
-        default: ""
-        deprecated:
-          why: In favor of the "proxy_command" option.
-          version: "0.1.0"
-          alternatives: proxy_command
-      ssh_extra_args:
-        description: Only used in parsing ProxyCommand for use in this plugin.
-        type: string
-        vars:
-          - name: ansible_ssh_extra_args
-        env:
-          - name: ANSIBLE_SSH_EXTRA_ARGS
-        ini:
-          - key: ssh_extra_args
-            section: ssh_connection
-        cli:
-          - name: ssh_extra_args
-        default: ""
-        deprecated:
-          why: In favor of the "proxy_command" option.
-          version: "0.1.0"
-          alternatives: proxy_command
       pty:
         default: True
-        description: "SUDO usually requires a PTY, True to give a PTY and False to not give a PTY."
+        description: "C(sudo) usually requires a PTY, V(true) to give a PTY and V(false) to not give a PTY."
         env:
           - name: ANSIBLE_PARAMIKO_PTY
         ini:
-          - key: pty
-            section: paramiko_connection
+          - section: paramiko_connection
+            key: pty
         type: boolean
       record_host_keys:
         default: True
-        description: "Save the host keys to a file"
+        description: "Save the host keys to a file."
         env:
           - name: ANSIBLE_PARAMIKO_RECORD_HOST_KEYS
         ini:
@@ -189,7 +135,7 @@ DOCUMENTATION = r"""
             key: record_host_keys
         type: boolean
       host_key_checking:
-        description: "Set this to V(False) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
+        description: "Set this to V(false) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
         type: boolean
         default: True
         env:
@@ -206,7 +152,7 @@ DOCUMENTATION = r"""
           - name: ansible_ssh_host_key_checking
           - name: ansible_paramiko_host_key_checking
       use_persistent_connections:
-        description: "Toggles the use of persistence for connections"
+        description: "Toggles the use of persistence for connections."
         type: boolean
         default: False
         env:
@@ -267,12 +213,15 @@ DOCUMENTATION = r"""
             option: "--private-key"
       vmid:
         description:
-          - Container ID
+          - LXC Container ID
+        type: str
         default: proxmox_vmid
         vars:
           - name: proxmox_vmid
     notes:
-      - When NOT using this plugin as root, you need to have sudo installed on proxmox and setup so we can run it without prompting for the password.
+      - >
+        When NOT using this plugin as root, you need to have a become mechanism,
+        e.g. C(sudo), installed on Proxmox and setup so we can run it without prompting for the password.
 """
 
 EXAMPLES = r"""
@@ -338,15 +287,96 @@ EXAMPLES = r"""
         msg: "This is coming from pct environment"
 """
 
-from ansible import constants as C
-from ansible.errors import AnsibleError
-from ansible.plugins.connection.paramiko_ssh import Connection as SSH_Connection
-from ansible.utils.display import Display
-import uuid
+import fcntl
 import os
+import re
+import socket
+import tempfile
+import traceback
+import typing as t
+import uuid
+
+from ansible import constants as C
+from ansible.errors import (
+    AnsibleAuthenticationFailure,
+    AnsibleConnectionFailure,
+    AnsibleError,
+    AnsibleFileNotFound,
+)
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
+from ansible.module_utils.compat.paramiko import PARAMIKO_IMPORT_ERR, paramiko
+from ansible.module_utils.compat.version import LooseVersion
+from ansible.plugins.connection import ConnectionBase
+from ansible.utils.display import Display
+from ansible.utils.path import makedirs_safe
+from binascii import hexlify
+from shlex import quote
 
 
 display = Display()
+
+
+AUTHENTICITY_MSG = """
+paramiko: The authenticity of host '%s' can't be established.
+The %s key fingerprint is %s.
+Are you sure you want to continue connecting (yes/no)?
+"""
+
+# SSH Options Regex
+SETTINGS_REGEX = re.compile(r'(\w+)(?:\s*=\s*|\s+)(.+)')
+
+MissingHostKeyPolicy: type = object
+if paramiko:
+    MissingHostKeyPolicy = paramiko.MissingHostKeyPolicy
+
+
+class MyAddPolicy(MissingHostKeyPolicy):
+    """
+    Based on AutoAddPolicy in paramiko so we can determine when keys are added
+
+    and also prompt for input.
+
+    Policy for automatically adding the hostname and new host key to the
+    local L{HostKeys} object, and saving it.  This is used by L{SSHClient}.
+    """
+
+    def __init__(self, connection: Connection) -> None:
+        self.connection = connection
+        self._options = connection._options
+
+    def missing_host_key(self, client, hostname, key) -> None:
+
+        if all((self.connection.get_option('host_key_checking'), not self.connection.get_option('host_key_auto_add'))):
+
+            fingerprint = hexlify(key.get_fingerprint())
+            ktype = key.get_name()
+
+            if self.connection.get_option('use_persistent_connections') or self.connection.force_persistence:
+                # don't print the prompt string since the user cannot respond
+                # to the question anyway
+                raise AnsibleError(AUTHENTICITY_MSG[1:92] % (hostname, ktype, fingerprint))
+
+            inp = to_text(
+                display.prompt_until(AUTHENTICITY_MSG % (hostname, ktype, fingerprint), private=False),
+                errors='surrogate_or_strict'
+            )
+
+            if inp not in ['yes', 'y', '']:
+                raise AnsibleError("host connection rejected by user")
+
+        key._added_by_ansible_this_time = True
+
+        # existing implementation below:
+        client._host_keys.add(hostname, key.get_name(), key)
+
+        # host keys are actually saved in close() function below
+        # in order to control ordering.
+
+
+# keep connection objects on a per host basis to avoid repeated attempts to reconnect
+
+SSH_CONNECTION_CACHE: dict[str, paramiko.client.SSHClient] = {}
+SFTP_CONNECTION_CACHE: dict[str, paramiko.sftp_client.SFTPClient] = {}
 
 
 def become_command():
@@ -354,50 +384,428 @@ def become_command():
     return os.getenv('ANSIBLE_BECOME_METHOD', default=C.DEFAULT_BECOME_METHOD)
 
 
-class Connection(SSH_Connection):
+def shell():
+    return os.getenv('ANSIBLE_EXECUTABLE', default=C.DEFAULT_EXECUTABLE)
+
+
+class Connection(ConnectionBase):
     ''' SSH based connections (paramiko) to Proxmox pct '''
+
     transport = 'community.general.pct_remote'
+    _log_channel: str | None = None
+
+    def _cache_key(self) -> str:
+        return "%s__%s__" % (self.get_option('remote_addr'), self.get_option('remote_user'))
+
+    def _connect(self) -> Connection:
+        cache_key = self._cache_key()
+        if cache_key in SSH_CONNECTION_CACHE:
+            self.ssh = SSH_CONNECTION_CACHE[cache_key]
+        else:
+            self.ssh = SSH_CONNECTION_CACHE[cache_key] = self._connect_uncached()
+
+        self._connected = True
+        return self
+
+    def _set_log_channel(self, name: str) -> None:
+        """Mimic paramiko.SSHClient.set_log_channel"""
+        self._log_channel = name
+
+    def _parse_proxy_command(self, port: int = 22) -> dict[str, t.Any]:
+        proxy_command = self.get_option('proxy_command') or None
+
+        sock_kwarg = {}
+        if proxy_command:
+            replacers = {
+                '%h': self.get_option('remote_addr'),
+                '%p': port,
+                '%r': self.get_option('remote_user')
+            }
+            for find, replace in replacers.items():
+                proxy_command = proxy_command.replace(find, str(replace))
+            try:
+                sock_kwarg = {'sock': paramiko.ProxyCommand(proxy_command)}
+                display.vvv("CONFIGURE PROXY COMMAND FOR CONNECTION: %s" % proxy_command, host=self.get_option('remote_addr'))
+            except AttributeError:
+                display.warning('Paramiko ProxyCommand support unavailable. '
+                                'Please upgrade to Paramiko 1.9.0 or newer. '
+                                'Not using configured ProxyCommand')
+
+        return sock_kwarg
+
+    def _connect_uncached(self) -> paramiko.SSHClient:
+        """ activates the connection object """
+
+        if paramiko is None:
+            raise AnsibleError("paramiko is not installed: %s" % to_native(PARAMIKO_IMPORT_ERR))
+
+        port = self.get_option('port')
+        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self.get_option('remote_user'), port, self.get_option('remote_addr')),
+                    host=self.get_option('remote_addr'))
+
+        ssh = paramiko.SSHClient()
+
+        # Set pubkey and hostkey algorithms to disable, the only manipulation allowed currently
+        # is keeping or omitting rsa-sha2 algorithms
+        # default_keys: t.Tuple[str] = ()
+        paramiko_preferred_pubkeys = getattr(paramiko.Transport, '_preferred_pubkeys', ())
+        paramiko_preferred_hostkeys = getattr(paramiko.Transport, '_preferred_keys', ())
+        use_rsa_sha2_algorithms = self.get_option('use_rsa_sha2_algorithms')
+        disabled_algorithms: t.Dict[str, t.Iterable[str]] = {}
+        if not use_rsa_sha2_algorithms:
+            if paramiko_preferred_pubkeys:
+                disabled_algorithms['pubkeys'] = tuple(a for a in paramiko_preferred_pubkeys if 'rsa-sha2' in a)
+            if paramiko_preferred_hostkeys:
+                disabled_algorithms['keys'] = tuple(a for a in paramiko_preferred_hostkeys if 'rsa-sha2' in a)
+
+        # override paramiko's default logger name
+        if self._log_channel is not None:
+            ssh.set_log_channel(self._log_channel)
+
+        self.keyfile = os.path.expanduser("~/.ssh/known_hosts")
+
+        if self.get_option('host_key_checking'):
+            for ssh_known_hosts in ("/etc/ssh/ssh_known_hosts", "/etc/openssh/ssh_known_hosts"):
+                try:
+                    # TODO: check if we need to look at several possible locations, possible for loop
+                    ssh.load_system_host_keys(ssh_known_hosts)
+                    break
+                except IOError:
+                    pass  # file was not found, but not required to function
+            ssh.load_system_host_keys()
+
+        ssh_connect_kwargs = self._parse_proxy_command(port)
+
+        ssh.set_missing_host_key_policy(MyAddPolicy(self))
+
+        conn_password = self.get_option('password')
+
+        allow_agent = True
+
+        if conn_password is not None:
+            allow_agent = False
+
+        try:
+            key_filename = None
+            if self.get_option('private_key_file'):
+                key_filename = os.path.expanduser(self.get_option('private_key_file'))
+
+            # paramiko 2.2 introduced auth_timeout parameter
+            if LooseVersion(paramiko.__version__) >= LooseVersion('2.2.0'):
+                ssh_connect_kwargs['auth_timeout'] = self.get_option('timeout')
+
+            # paramiko 1.15 introduced banner timeout parameter
+            if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
+                ssh_connect_kwargs['banner_timeout'] = self.get_option('banner_timeout')
+
+            ssh.connect(
+                self.get_option('remote_addr').lower(),
+                username=self.get_option('remote_user'),
+                allow_agent=allow_agent,
+                look_for_keys=self.get_option('look_for_keys'),
+                key_filename=key_filename,
+                password=conn_password,
+                timeout=self.get_option('timeout'),
+                port=port,
+                disabled_algorithms=disabled_algorithms,
+                **ssh_connect_kwargs,
+            )
+        except paramiko.ssh_exception.BadHostKeyException as e:
+            raise AnsibleConnectionFailure('host key mismatch for %s' % e.hostname)
+        except paramiko.ssh_exception.AuthenticationException as e:
+            msg = 'Failed to authenticate: {0}'.format(to_text(e))
+            raise AnsibleAuthenticationFailure(msg)
+        except Exception as e:
+            msg = to_text(e)
+            if u"PID check failed" in msg:
+                raise AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible")
+            elif u"Private key file is encrypted" in msg:
+                msg = 'ssh %s@%s:%s : %s\nTo connect as a different user, use -u <username>.' % (
+                    self.get_option('remote_user'), self.get_options('remote_addr'), port, msg)
+                raise AnsibleConnectionFailure(msg)
+            else:
+                raise AnsibleConnectionFailure(msg)
+
+        return ssh
 
     def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:
         ''' execute a command inside the proxmox container '''
         cmd = ['/usr/sbin/pct', 'exec',
-               self.get_option('vmid'), '--', cmd]
+               str(self.get_option('vmid')), '--', shell(), '-c', quote(cmd)]
         if self.get_option('remote_user') != 'root':
             cmd = [become_command()] + cmd
-        return super().exec_command(' '.join(cmd), in_data=in_data, sudoable=sudoable)
+        return self._ssh_exec_command(' '.join(cmd), in_data=in_data, sudoable=sudoable)
 
     def put_file(self, in_path: str, out_path: str) -> None:
         ''' transfer a file from local to remote '''
         temp_dir = '/tmp/ansible_pct_' + str(uuid.uuid4()).replace('-', '')[:6]
         temp_file_path = f'{temp_dir}/{os.path.basename(in_path)}'
         try:
-            super().exec_command(f'mkdir -p {temp_dir}')
-            super().put_file(in_path, temp_file_path)
+            self._ssh_exec_command(f'mkdir -p {temp_dir}')
+            self._ssh_put_file(in_path, temp_file_path)
             cmd = ['/usr/sbin/pct', 'push',
-                   self.get_option('vmid'), temp_file_path, out_path]
+                   str(self.get_option('vmid')), temp_file_path, out_path]
             if self.get_option('remote_user') != 'root':
                 cmd = [become_command()] + cmd
-            super().exec_command(' '.join(cmd))
+            self._ssh_exec_command(' '.join(cmd))
         except Exception as e:
             raise AnsibleError(
                 'failed to transfer file to %s!\n%s' % (out_path, e))
         finally:
-            super().exec_command(f'rm -rf {temp_dir}')
+            self._ssh_exec_command(f'rm -rf {temp_dir}')
 
     def fetch_file(self, in_path: str, out_path: str) -> None:
         ''' save a remote file to the specified path '''
         temp_dir = '/tmp/ansible_pct_' + str(uuid.uuid4()).replace('-', '')[:6]
         temp_file_path = f'{temp_dir}/{os.path.basename(in_path)}'
         try:
-            super().exec_command(f'mkdir -p {temp_dir}')
+            self._ssh_exec_command(f'mkdir -p {temp_dir}')
             cmd = ['/usr/sbin/pct', 'pull',
-                   self.get_option('vmid'), in_path, temp_file_path]
+                   str(self.get_option('vmid')), in_path, temp_file_path]
             if self.get_option('remote_user') != 'root':
                 cmd = [become_command()] + cmd
-            super().exec_command(' '.join(cmd))
-            super().fetch_file(temp_file_path, out_path)
+            self._ssh_exec_command(' '.join(cmd))
+            self._ssh_fetch_file(temp_file_path, out_path)
         except Exception as e:
             raise AnsibleError(
                 'failed to transfer file from %s!\n%s' % (in_path, e))
         finally:
-            super().exec_command(f'rm -rf {temp_dir}')
+            self._ssh_exec_command(f'rm -rf {temp_dir}')
+
+    def _ssh_exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:
+        """ run a command on the remote host """
+
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+        if in_data:
+            raise AnsibleError("Internal Error: this module does not support optimized module pipelining")
+
+        bufsize = 4096
+
+        try:
+            self.ssh.get_transport().set_keepalive(5)
+            chan = self.ssh.get_transport().open_session()
+        except Exception as e:
+            text_e = to_text(e)
+            msg = u"Failed to open session"
+            if text_e:
+                msg += u": %s" % text_e
+            raise AnsibleConnectionFailure(to_native(msg))
+
+        # sudo usually requires a PTY (cf. requiretty option), therefore
+        # we give it one by default (pty=True in ansible.cfg), and we try
+        # to initialise from the calling environment when sudoable is enabled
+        if self.get_option('pty') and sudoable:
+            chan.get_pty(term=os.getenv('TERM', 'vt100'), width=int(os.getenv('COLUMNS', 0)), height=int(os.getenv('LINES', 0)))
+
+        display.vvv("EXEC %s" % cmd, host=self.get_option('remote_addr'))
+
+        cmd = to_bytes(cmd, errors='surrogate_or_strict')
+
+        no_prompt_out = b''
+        no_prompt_err = b''
+        become_output = b''
+
+        try:
+            chan.exec_command(cmd)
+            if self.become and self.become.expect_prompt():
+                passprompt = False
+                become_sucess = False
+                while not (become_sucess or passprompt):
+                    display.debug('Waiting for Privilege Escalation input')
+
+                    chunk = chan.recv(bufsize)
+                    display.debug("chunk is: %r" % chunk)
+                    if not chunk:
+                        if b'unknown user' in become_output:
+                            n_become_user = to_native(self.become.get_option('become_user'))
+                            raise AnsibleError('user %s does not exist' % n_become_user)
+                        else:
+                            break
+                            # raise AnsibleError('ssh connection closed waiting for password prompt')
+                    become_output += chunk
+
+                    # need to check every line because we might get lectured
+                    # and we might get the middle of a line in a chunk
+                    for line in become_output.splitlines(True):
+                        if self.become.check_success(line):
+                            become_sucess = True
+                            break
+                        elif self.become.check_password_prompt(line):
+                            passprompt = True
+                            break
+
+                if passprompt:
+                    if self.become:
+                        become_pass = self.become.get_option('become_pass')
+                        chan.sendall(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+                    else:
+                        raise AnsibleError("A password is required but none was supplied")
+                else:
+                    no_prompt_out += become_output
+                    no_prompt_err += become_output
+        except socket.timeout:
+            raise AnsibleError('ssh timed out waiting for privilege escalation.\n' + to_text(become_output))
+
+        stdout = b''.join(chan.makefile('rb', bufsize))
+        stderr = b''.join(chan.makefile_stderr('rb', bufsize))
+
+        return (chan.recv_exit_status(), no_prompt_out + stdout, no_prompt_out + stderr)
+
+    def _ssh_put_file(self, in_path: str, out_path: str) -> None:
+        """ transfer a file from local to remote """
+
+        super(Connection, self).put_file(in_path, out_path)
+
+        display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.get_option('remote_addr'))
+
+        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
+            raise AnsibleFileNotFound("file or module does not exist: %s" % in_path)
+
+        try:
+            self.sftp = self.ssh.open_sftp()
+        except Exception as e:
+            raise AnsibleError("failed to open a SFTP connection (%s)" % e)
+
+        try:
+            self.sftp.put(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
+        except IOError:
+            raise AnsibleError("failed to transfer file to %s" % out_path)
+
+    def _connect_sftp(self) -> paramiko.sftp_client.SFTPClient:
+
+        cache_key = "%s__%s__" % (self.get_option('remote_addr'), self.get_option('remote_user'))
+        if cache_key in SFTP_CONNECTION_CACHE:
+            return SFTP_CONNECTION_CACHE[cache_key]
+        else:
+            result = SFTP_CONNECTION_CACHE[cache_key] = self._connect().ssh.open_sftp()
+            return result
+
+    def _ssh_fetch_file(self, in_path: str, out_path: str) -> None:
+        """ save a remote file to the specified path """
+
+        super(Connection, self).fetch_file(in_path, out_path)
+
+        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.get_option('remote_addr'))
+
+        try:
+            self.sftp = self._connect_sftp()
+        except Exception as e:
+            raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
+
+        try:
+            self.sftp.get(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
+        except IOError:
+            raise AnsibleError("failed to transfer file from %s" % in_path)
+
+    def _any_keys_added(self) -> bool:
+
+        for hostname, keys in self.ssh._host_keys.items():
+            for keytype, key in keys.items():
+                added_this_time = getattr(key, '_added_by_ansible_this_time', False)
+                if added_this_time:
+                    return True
+        return False
+
+    def _save_ssh_host_keys(self, filename: str) -> None:
+        """
+        not using the paramiko save_ssh_host_keys function as we want to add new SSH keys at the bottom so folks
+        don't complain about it :)
+        """
+
+        if not self._any_keys_added():
+            return
+
+        path = os.path.expanduser("~/.ssh")
+        makedirs_safe(path)
+
+        with open(filename, 'w') as f:
+
+            for hostname, keys in self.ssh._host_keys.items():
+
+                for keytype, key in keys.items():
+
+                    # was f.write
+                    added_this_time = getattr(key, '_added_by_ansible_this_time', False)
+                    if not added_this_time:
+                        f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+
+            for hostname, keys in self.ssh._host_keys.items():
+
+                for keytype, key in keys.items():
+                    added_this_time = getattr(key, '_added_by_ansible_this_time', False)
+                    if added_this_time:
+                        f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+
+    def reset(self) -> None:
+        if not self._connected:
+            return
+        self.close()
+        self._connect()
+
+    def close(self) -> None:
+        """ terminate the connection """
+
+        cache_key = self._cache_key()
+        SSH_CONNECTION_CACHE.pop(cache_key, None)
+        SFTP_CONNECTION_CACHE.pop(cache_key, None)
+
+        if hasattr(self, 'sftp'):
+            if self.sftp is not None:
+                self.sftp.close()
+
+        if self.get_option('host_key_checking') and self.get_option('record_host_keys') and self._any_keys_added():
+
+            # add any new SSH host keys -- warning -- this could be slow
+            # (This doesn't acquire the connection lock because it needs
+            # to exclude only other known_hosts writers, not connections
+            # that are starting up.)
+            lockfile = self.keyfile.replace("known_hosts", ".known_hosts.lock")
+            dirname = os.path.dirname(self.keyfile)
+            makedirs_safe(dirname)
+
+            KEY_LOCK = open(lockfile, 'w')
+            fcntl.lockf(KEY_LOCK, fcntl.LOCK_EX)
+
+            try:
+                # just in case any were added recently
+
+                self.ssh.load_system_host_keys()
+                self.ssh._host_keys.update(self.ssh._system_host_keys)
+
+                # gather information about the current key file, so
+                # we can ensure the new file has the correct mode/owner
+
+                key_dir = os.path.dirname(self.keyfile)
+                if os.path.exists(self.keyfile):
+                    key_stat = os.stat(self.keyfile)
+                    mode = key_stat.st_mode
+                    uid = key_stat.st_uid
+                    gid = key_stat.st_gid
+                else:
+                    mode = 33188
+                    uid = os.getuid()
+                    gid = os.getgid()
+
+                # Save the new keys to a temporary file and move it into place
+                # rather than rewriting the file. We set delete=False because
+                # the file will be moved into place rather than cleaned up.
+
+                tmp_keyfile = tempfile.NamedTemporaryFile(dir=key_dir, delete=False)
+                os.chmod(tmp_keyfile.name, mode & 0o7777)
+                os.chown(tmp_keyfile.name, uid, gid)
+
+                self._save_ssh_host_keys(tmp_keyfile.name)
+                tmp_keyfile.close()
+
+                os.rename(tmp_keyfile.name, self.keyfile)
+
+            except Exception:
+
+                # unable to save keys, including scenario when key was invalid
+                # and caught earlier
+                traceback.print_exc()
+            fcntl.lockf(KEY_LOCK, fcntl.LOCK_UN)
+
+        self.ssh.close()
+        self._connected = False

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -9,231 +9,231 @@ from __future__ import (annotations, absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = r"""
-    author: Nils Stein (@mietzen) <github.nstein@mailbox.org>
-    name: pct_remote
-    short_description: Run tasks in Proxmox LXC container instances using pct CLI via SSH
-    requirements:
-      - paramiko
+author: Nils Stein (@mietzen) <github.nstein@mailbox.org>
+name: pct_remote
+short_description: Run tasks in Proxmox LXC container instances using pct CLI via SSH
+requirements:
+  - paramiko
+description:
+  - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via SSH.
+  - Use the Python SSH implementation (Paramiko) to connect to Proxmox.
+version_added: "10.2.0"
+options:
+  remote_addr:
     description:
-      - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via SSH.
-      - Use the Python SSH implementation (Paramiko) to connect to Proxmox.
-    version_added: "10.1.0"
-    options:
-      remote_addr:
-        description:
-          - Address of the remote target.
-        default: inventory_hostname
-        type: string
-        vars:
-          - name: inventory_hostname
-          - name: ansible_host
-          - name: ansible_ssh_host
-          - name: ansible_paramiko_host
-      port:
-        description: Remote port to connect to.
-        type: int
-        default: 22
-        ini:
-          - section: defaults
-            key: remote_port
-          - section: paramiko_connection
-            key: remote_port
-        env:
-          - name: ANSIBLE_REMOTE_PORT
-          - name: ANSIBLE_REMOTE_PARAMIKO_PORT
-        vars:
-          - name: ansible_port
-          - name: ansible_ssh_port
-          - name: ansible_paramiko_port
-        keyword:
-          - name: port
-      remote_user:
-        description:
-          - User to login/authenticate as.
-          - Can be set from the CLI via the C(--user) or C(-u) options.
-        type: string
-        vars:
-          - name: ansible_user
-          - name: ansible_ssh_user
-          - name: ansible_paramiko_user
-        env:
-          - name: ANSIBLE_REMOTE_USER
-          - name: ANSIBLE_PARAMIKO_REMOTE_USER
-        ini:
-          - section: defaults
-            key: remote_user
-          - section: paramiko_connection
-            key: remote_user
-        keyword:
-          - name: remote_user
-      password:
-        description:
-          - Secret used to either login the SSH server or as a passphrase for SSH keys that require it.
-          - Can be set from the CLI via the C(--ask-pass) option.
-        type: string
-        vars:
-          - name: ansible_password
-          - name: ansible_ssh_pass
-          - name: ansible_ssh_password
-          - name: ansible_paramiko_pass
-          - name: ansible_paramiko_password
-      use_rsa_sha2_algorithms:
-        description:
-          - Whether or not to enable RSA SHA2 algorithms for pubkeys and hostkeys.
-          - On paramiko versions older than 2.9, this only affects hostkeys.
-          - For behavior matching paramiko<2.9 set this to V(false).
-        vars:
-          - name: ansible_paramiko_use_rsa_sha2_algorithms
-        ini:
-          - {key: use_rsa_sha2_algorithms, section: paramiko_connection}
-        env:
-          - {name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS}
-        default: True
-        type: boolean
-      host_key_auto_add:
-        description: "Automatically add host keys."
-        env:
-          - name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD
-        ini:
-          - {key: host_key_auto_add, section: paramiko_connection}
-        type: boolean
-      look_for_keys:
-        default: True
-        description: "Set to V(false) to disable searching for private key files in C(~/.ssh/)."
-        env:
-          - name: ANSIBLE_PARAMIKO_LOOK_FOR_KEYS
-        ini:
-          - {key: look_for_keys, section: paramiko_connection}
-        type: boolean
-      proxy_command:
-        default: ""
-        description:
-          - Proxy information for running the connection via a jumphost.
-        type: string
-        env:
-          - name: ANSIBLE_PARAMIKO_PROXY_COMMAND
-        ini:
-          - {key: proxy_command, section: paramiko_connection}
-        vars:
-          - name: ansible_paramiko_proxy_command
-      pty:
-        default: True
-        description: "C(sudo) usually requires a PTY, V(true) to give a PTY and V(false) to not give a PTY."
-        env:
-          - name: ANSIBLE_PARAMIKO_PTY
-        ini:
-          - section: paramiko_connection
-            key: pty
-        type: boolean
-      record_host_keys:
-        default: True
-        description: "Save the host keys to a file."
-        env:
-          - name: ANSIBLE_PARAMIKO_RECORD_HOST_KEYS
-        ini:
-          - section: paramiko_connection
-            key: record_host_keys
-        type: boolean
-      host_key_checking:
-        description: "Set this to V(false) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
-        type: boolean
-        default: True
-        env:
-          - name: ANSIBLE_HOST_KEY_CHECKING
-          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
-          - name: ANSIBLE_PARAMIKO_HOST_KEY_CHECKING
-        ini:
-          - section: defaults
-            key: host_key_checking
-          - section: paramiko_connection
-            key: host_key_checking
-        vars:
-          - name: ansible_host_key_checking
-          - name: ansible_ssh_host_key_checking
-          - name: ansible_paramiko_host_key_checking
-      use_persistent_connections:
-        description: "Toggles the use of persistence for connections."
-        type: boolean
-        default: False
-        env:
-          - name: ANSIBLE_USE_PERSISTENT_CONNECTIONS
-        ini:
-          - section: defaults
-            key: use_persistent_connections
-      banner_timeout:
-        type: float
-        default: 30
-        description:
-          - Configures, in seconds, the amount of time to wait for the SSH
-            banner to be presented. This option is supported by paramiko
-            version 1.15.0 or newer.
-        ini:
-          - section: paramiko_connection
-            key: banner_timeout
-        env:
-          - name: ANSIBLE_PARAMIKO_BANNER_TIMEOUT
-      timeout:
-        type: int
-        default: 10
-        description: Number of seconds until the plugin gives up on failing to establish a TCP connection.
-        ini:
-          - section: defaults
-            key: timeout
-          - section: ssh_connection
-            key: timeout
-          - section: paramiko_connection
-            key: timeout
-        env:
-          - name: ANSIBLE_TIMEOUT
-          - name: ANSIBLE_SSH_TIMEOUT
-          - name: ANSIBLE_PARAMIKO_TIMEOUT
-        vars:
-          - name: ansible_ssh_timeout
-          - name: ansible_paramiko_timeout
-        cli:
-          - name: timeout
-      private_key_file:
-        description:
-          - Path to private key file to use for authentication.
-        type: string
-        ini:
-          - section: defaults
-            key: private_key_file
-          - section: paramiko_connection
-            key: private_key_file
-        env:
-          - name: ANSIBLE_PRIVATE_KEY_FILE
-          - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE
-        vars:
-          - name: ansible_private_key_file
-          - name: ansible_ssh_private_key_file
-          - name: ansible_paramiko_private_key_file
-        cli:
-          - name: private_key_file
-            option: "--private-key"
-      vmid:
-        description:
-          - LXC Container ID
-        type: int
-        vars:
-          - name: proxmox_vmid
-      proxmox_become_method:
-        description:
-          - Become command used in proxmox
-        type: str
-        default: sudo
-        vars:
-          - name: proxmox_become_method
-    notes:
-      - >
-        When NOT using this plugin as root, you need to have a become mechanism,
-        e.g. C(sudo), installed on Proxmox and setup so we can run it without prompting for the password.
-        Inside the container we need a shell e.g. C(sh) and C(cat), for this plugin to work.
+      - Address of the remote target.
+    default: inventory_hostname
+    type: string
+    vars:
+      - name: inventory_hostname
+      - name: ansible_host
+      - name: ansible_ssh_host
+      - name: ansible_paramiko_host
+  port:
+    description: Remote port to connect to.
+    type: int
+    default: 22
+    ini:
+      - section: defaults
+        key: remote_port
+      - section: paramiko_connection
+        key: remote_port
+    env:
+      - name: ANSIBLE_REMOTE_PORT
+      - name: ANSIBLE_REMOTE_PARAMIKO_PORT
+    vars:
+      - name: ansible_port
+      - name: ansible_ssh_port
+      - name: ansible_paramiko_port
+    keyword:
+      - name: port
+  remote_user:
+    description:
+      - User to login/authenticate as.
+      - Can be set from the CLI via the C(--user) or C(-u) options.
+    type: string
+    vars:
+      - name: ansible_user
+      - name: ansible_ssh_user
+      - name: ansible_paramiko_user
+    env:
+      - name: ANSIBLE_REMOTE_USER
+      - name: ANSIBLE_PARAMIKO_REMOTE_USER
+    ini:
+      - section: defaults
+        key: remote_user
+      - section: paramiko_connection
+        key: remote_user
+    keyword:
+      - name: remote_user
+  password:
+    description:
+      - Secret used to either login the SSH server or as a passphrase for SSH keys that require it.
+      - Can be set from the CLI via the C(--ask-pass) option.
+    type: string
+    vars:
+      - name: ansible_password
+      - name: ansible_ssh_pass
+      - name: ansible_ssh_password
+      - name: ansible_paramiko_pass
+      - name: ansible_paramiko_password
+  use_rsa_sha2_algorithms:
+    description:
+      - Whether or not to enable RSA SHA2 algorithms for pubkeys and hostkeys.
+      - On paramiko versions older than 2.9, this only affects hostkeys.
+      - For behavior matching paramiko<2.9 set this to V(false).
+    vars:
+      - name: ansible_paramiko_use_rsa_sha2_algorithms
+    ini:
+      - {key: use_rsa_sha2_algorithms, section: paramiko_connection}
+    env:
+      - {name: ANSIBLE_PARAMIKO_USE_RSA_SHA2_ALGORITHMS}
+    default: True
+    type: boolean
+  host_key_auto_add:
+    description: "Automatically add host keys."
+    env:
+      - name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD
+    ini:
+      - {key: host_key_auto_add, section: paramiko_connection}
+    type: boolean
+  look_for_keys:
+    default: True
+    description: "Set to V(false) to disable searching for private key files in C(~/.ssh/)."
+    env:
+      - name: ANSIBLE_PARAMIKO_LOOK_FOR_KEYS
+    ini:
+      - {key: look_for_keys, section: paramiko_connection}
+    type: boolean
+  proxy_command:
+    default: ""
+    description:
+      - Proxy information for running the connection via a jumphost.
+    type: string
+    env:
+      - name: ANSIBLE_PARAMIKO_PROXY_COMMAND
+    ini:
+      - {key: proxy_command, section: paramiko_connection}
+    vars:
+      - name: ansible_paramiko_proxy_command
+  pty:
+    default: True
+    description: "C(sudo) usually requires a PTY, V(true) to give a PTY and V(false) to not give a PTY."
+    env:
+      - name: ANSIBLE_PARAMIKO_PTY
+    ini:
+      - section: paramiko_connection
+        key: pty
+    type: boolean
+  record_host_keys:
+    default: True
+    description: "Save the host keys to a file."
+    env:
+      - name: ANSIBLE_PARAMIKO_RECORD_HOST_KEYS
+    ini:
+      - section: paramiko_connection
+        key: record_host_keys
+    type: boolean
+  host_key_checking:
+    description: "Set this to V(false) if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host."
+    type: boolean
+    default: True
+    env:
+      - name: ANSIBLE_HOST_KEY_CHECKING
+      - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+      - name: ANSIBLE_PARAMIKO_HOST_KEY_CHECKING
+    ini:
+      - section: defaults
+        key: host_key_checking
+      - section: paramiko_connection
+        key: host_key_checking
+    vars:
+      - name: ansible_host_key_checking
+      - name: ansible_ssh_host_key_checking
+      - name: ansible_paramiko_host_key_checking
+  use_persistent_connections:
+    description: "Toggles the use of persistence for connections."
+    type: boolean
+    default: False
+    env:
+      - name: ANSIBLE_USE_PERSISTENT_CONNECTIONS
+    ini:
+      - section: defaults
+        key: use_persistent_connections
+  banner_timeout:
+    type: float
+    default: 30
+    description:
+      - Configures, in seconds, the amount of time to wait for the SSH
+        banner to be presented. This option is supported by paramiko
+        version 1.15.0 or newer.
+    ini:
+      - section: paramiko_connection
+        key: banner_timeout
+    env:
+      - name: ANSIBLE_PARAMIKO_BANNER_TIMEOUT
+  timeout:
+    type: int
+    default: 10
+    description: Number of seconds until the plugin gives up on failing to establish a TCP connection.
+    ini:
+      - section: defaults
+        key: timeout
+      - section: ssh_connection
+        key: timeout
+      - section: paramiko_connection
+        key: timeout
+    env:
+      - name: ANSIBLE_TIMEOUT
+      - name: ANSIBLE_SSH_TIMEOUT
+      - name: ANSIBLE_PARAMIKO_TIMEOUT
+    vars:
+      - name: ansible_ssh_timeout
+      - name: ansible_paramiko_timeout
+    cli:
+      - name: timeout
+  private_key_file:
+    description:
+      - Path to private key file to use for authentication.
+    type: string
+    ini:
+      - section: defaults
+        key: private_key_file
+      - section: paramiko_connection
+        key: private_key_file
+    env:
+      - name: ANSIBLE_PRIVATE_KEY_FILE
+      - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE
+    vars:
+      - name: ansible_private_key_file
+      - name: ansible_ssh_private_key_file
+      - name: ansible_paramiko_private_key_file
+    cli:
+      - name: private_key_file
+        option: "--private-key"
+  vmid:
+    description:
+      - LXC Container ID
+    type: int
+    vars:
+      - name: proxmox_vmid
+  proxmox_become_method:
+    description:
+      - Become command used in proxmox
+    type: str
+    default: sudo
+    vars:
+      - name: proxmox_become_method
+notes:
+  - >
+    When NOT using this plugin as root, you need to have a become mechanism,
+    e.g. C(sudo), installed on Proxmox and setup so we can run it without prompting for the password.
+    Inside the container we need a shell e.g. C(sh) and C(cat), for this plugin to work.
 """
 
 EXAMPLES = r"""
 # --------------------------------------------------------------
-# Setup sudo with passwordless access to pct for user 'ansible':
+# Setup sudo with password less access to pct for user 'ansible':
 # --------------------------------------------------------------
 #
 # Open a Proxmox root shell and execute:
@@ -249,6 +249,78 @@ EXAMPLES = r"""
 # $ echo 'ansible ALL = (root) NOPASSWD: /usr/sbin/pct' > /etc/sudoers.d/ansible_pct
 #
 # Save the displayed private key and add it to your ssh-agent
+#
+# Or use ansible:
+# ---
+# - name: Setup ansible-pct user and configure environment on Proxmox host
+#   hosts: proxmox
+#   become: true
+#   gather_facts: false
+#
+#   tasks:
+#     - name: Create ansible user
+#       ansible.builtin.user:
+#         name: ansible
+#         comment: Ansible User
+#         home: /opt/ansible-pct
+#         shell: /bin/sh
+#         create_home: true
+#         system: true
+#
+#     - name: Create .ssh directory
+#       ansible.builtin.file:
+#         path: /opt/ansible-pct/.ssh
+#         state: directory
+#         owner: ansible
+#         group: ansible
+#         mode: '0700'
+#
+#     - name: Generate SSH key for ansible user
+#       community.crypto.openssh_keypair:
+#         path: /opt/ansible-pct/.ssh/ansible
+#         type: ed25519
+#         comment: 'ansible'
+#         force: true
+#         mode: '0600'
+#         owner: ansible
+#         group: ansible
+#
+#     - name: Set public key as authorized key
+#       ansible.builtin.copy:
+#         src: /opt/ansible-pct/.ssh/ansible.pub
+#         dest: /opt/ansible-pct/.ssh/authorized-keys
+#         remote_src: yes
+#         owner: ansible
+#         group: ansible
+#         mode: '0600'
+#
+#     - name: Add sudoers entry for ansible user
+#       ansible.builtin.copy:
+#         content: 'ansible ALL = (root) NOPASSWD: /usr/sbin/pct'
+#         dest: /etc/sudoers.d/ansible_pct
+#         owner: root
+#         group: root
+#         mode: '0440'
+#
+#     - name: Fetch private SSH key to localhost
+#       ansible.builtin.fetch:
+#         src: /opt/ansible-pct/.ssh/ansible
+#         dest: ~/.ssh/proxmox_ansible_private_key
+#         flat: yes
+#         fail_on_missing: true
+#
+#     - name: Clean up generated SSH keys
+#       ansible.builtin.file:
+#         path: /opt/ansible-pct/.ssh/ansible*
+#         state: absent
+#
+# - name: Configure private key permissions on localhost
+#   hosts: localhost
+#   tasks:
+#     - name: Set permissions for fetched private key
+#       ansible.builtin.file:
+#         path: ~/.ssh/proxmox_ansible_private_key
+#         mode: '0600'
 #
 # --------------------------------
 # Static inventory file: hosts.yml
@@ -330,11 +402,13 @@ from binascii import hexlify
 display = Display()
 
 
-AUTHENTICITY_MSG = """
-paramiko: The authenticity of host '%s' can't be established.
-The %s key fingerprint is %s.
-Are you sure you want to continue connecting (yes/no)?
-"""
+def authenticity_msg(hostname: str, ktype: str, fingerprint: str) -> str:
+    msg = f"""
+    paramiko: The authenticity of host '{hostname}' can't be established.
+    The {ktype} key fingerprint is {fingerprint}.
+    Are you sure you want to continue connecting (yes/no)?
+    """
+    return msg
 
 
 MissingHostKeyPolicy: type = object
@@ -366,15 +440,15 @@ class MyAddPolicy(MissingHostKeyPolicy):
             if self.connection.get_option('use_persistent_connections') or self.connection.force_persistence:
                 # don't print the prompt string since the user cannot respond
                 # to the question anyway
-                raise AnsibleError(AUTHENTICITY_MSG[1:92] % (hostname, ktype, fingerprint))
+                raise AnsibleError(authenticity_msg(hostname, ktype, fingerprint)[1:92])
 
             inp = to_text(
-                display.prompt_until(AUTHENTICITY_MSG % (hostname, ktype, fingerprint), private=False),
+                display.prompt_until(authenticity_msg(hostname, ktype, fingerprint), private=False),
                 errors='surrogate_or_strict'
             )
 
-            if inp not in ['yes', 'y', '']:
-                raise AnsibleError("host connection rejected by user")
+            if inp.lower() not in ['yes', 'y', '']:
+                raise AnsibleError('host connection rejected by user')
 
         key._added_by_ansible_this_time = True
 
@@ -400,7 +474,7 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
     def _cache_key(self) -> str:
-        return "%s__%s__" % (self.get_option('remote_addr'), self.get_option('remote_user'))
+        return f'{self.get_option("remote_addr")}__{self.get_option("remote_user")}__'
 
     def _connect(self) -> Connection:
         cache_key = self._cache_key()
@@ -430,7 +504,7 @@ class Connection(ConnectionBase):
                 proxy_command = proxy_command.replace(find, str(replace))
             try:
                 sock_kwarg = {'sock': paramiko.ProxyCommand(proxy_command)}
-                display.vvv("CONFIGURE PROXY COMMAND FOR CONNECTION: %s" % proxy_command, host=self.get_option('remote_addr'))
+                display.vvv(f'CONFIGURE PROXY COMMAND FOR CONNECTION: {proxy_command}', host=self.get_option('remote_addr'))
             except AttributeError:
                 display.warning('Paramiko ProxyCommand support unavailable. '
                                 'Please upgrade to Paramiko 1.9.0 or newer. '
@@ -442,10 +516,10 @@ class Connection(ConnectionBase):
         """ activates the connection object """
 
         if paramiko is None:
-            raise AnsibleError("paramiko is not installed: %s" % to_native(PARAMIKO_IMPORT_ERR))
+            raise AnsibleError(f'paramiko is not installed: {to_native(PARAMIKO_IMPORT_ERR)}')
 
         port = self.get_option('port')
-        display.vvv("ESTABLISH PARAMIKO SSH CONNECTION FOR USER: %s on PORT %s TO %s" % (self.get_option('remote_user'), port, self.get_option('remote_addr')),
+        display.vvv(f'ESTABLISH PARAMIKO SSH CONNECTION FOR USER: {self.get_option("remote_user")} on PORT {to_text(port)} TO {self.get_option("remote_addr")}',
                     host=self.get_option('remote_addr'))
 
         ssh = paramiko.SSHClient()
@@ -467,10 +541,10 @@ class Connection(ConnectionBase):
         if self._log_channel is not None:
             ssh.set_log_channel(self._log_channel)
 
-        self.keyfile = os.path.expanduser("~/.ssh/known_hosts")
+        self.keyfile = os.path.expanduser('~/.ssh/known_hosts')
 
         if self.get_option('host_key_checking'):
-            for ssh_known_hosts in ("/etc/ssh/ssh_known_hosts", "/etc/openssh/ssh_known_hosts"):
+            for ssh_known_hosts in ('/etc/ssh/ssh_known_hosts', '/etc/openssh/ssh_known_hosts'):
                 try:
                     ssh.load_system_host_keys(ssh_known_hosts)
                     break
@@ -512,17 +586,17 @@ class Connection(ConnectionBase):
                 **ssh_connect_kwargs,
             )
         except paramiko.ssh_exception.BadHostKeyException as e:
-            raise AnsibleConnectionFailure('host key mismatch for %s' % e.hostname)
+            raise AnsibleConnectionFailure(f'host key mismatch for {to_text(e.hostname)}')
         except paramiko.ssh_exception.AuthenticationException as e:
-            msg = 'Failed to authenticate: {0}'.format(to_text(e))
+            msg = f'Failed to authenticate: {e}'
             raise AnsibleAuthenticationFailure(msg)
         except Exception as e:
             msg = to_text(e)
-            if u"PID check failed" in msg:
-                raise AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible")
-            elif u"Private key file is encrypted" in msg:
-                msg = 'ssh %s@%s:%s : %s\nTo connect as a different user, use -u <username>.' % (
-                    self.get_option('remote_user'), self.get_options('remote_addr'), port, msg)
+            if u'PID check failed' in msg:
+                raise AnsibleError('paramiko version issue, please upgrade paramiko on the machine running ansible')
+            elif u'Private key file is encrypted' in msg:
+                msg = f'ssh {self.get_option("remote_user")}@{self.get_options("remote_addr")}:{port} : ' + \
+                    f'{msg}\nTo connect as a different user, use -u <username>.'
                 raise AnsibleConnectionFailure(msg)
             else:
                 raise AnsibleConnectionFailure(msg)
@@ -545,7 +619,7 @@ class Connection(ConnectionBase):
         if not self._any_keys_added():
             return
 
-        path = os.path.expanduser("~/.ssh")
+        path = os.path.expanduser('~/.ssh')
         makedirs_safe(path)
 
         with open(filename, 'w') as f:
@@ -554,20 +628,20 @@ class Connection(ConnectionBase):
                     # was f.write
                     added_this_time = getattr(key, '_added_by_ansible_this_time', False)
                     if not added_this_time:
-                        f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+                        f.write(f'{hostname} {keytype} {key.get_base64()}\n')
 
             for hostname, keys in self.ssh._host_keys.items():
                 for keytype, key in keys.items():
                     added_this_time = getattr(key, '_added_by_ansible_this_time', False)
                     if added_this_time:
-                        f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
+                        f.write(f'{hostname} {keytype} {key.get_base64()}\n')
 
     def _build_pct_command(self, cmd: str) -> str:
         cmd = ['/usr/sbin/pct', 'exec', str(self.get_option('vmid')), '--', cmd]
         if self.get_option('remote_user') != 'root':
             cmd = [self.get_option('proxmox_become_method')] + cmd
-            display.vvv("Running as non root user: %s, trying to run pct with become method: %s" %
-                        (self.get_option('remote_user'), self.get_option('proxmox_become_method')),
+            display.vvv(f'INFO Running as non root user: {self.get_option("remote_user")}, trying to run pct with become method: ' +
+                        f'{self.get_option("proxmox_become_method")}',
                         host=self.get_option('remote_addr'))
         return ' '.join(cmd)
 
@@ -585,9 +659,9 @@ class Connection(ConnectionBase):
             chan = self.ssh.get_transport().open_session()
         except Exception as e:
             text_e = to_text(e)
-            msg = u"Failed to open session"
+            msg = 'Failed to open session'
             if text_e:
-                msg += u": %s" % text_e
+                msg += f': {text_e}'
             raise AnsibleConnectionFailure(to_native(msg))
 
         # sudo usually requires a PTY (cf. requiretty option), therefore
@@ -596,7 +670,7 @@ class Connection(ConnectionBase):
         if self.get_option('pty') and sudoable:
             chan.get_pty(term=os.getenv('TERM', 'vt100'), width=int(os.getenv('COLUMNS', 0)), height=int(os.getenv('LINES', 0)))
 
-        display.vvv("EXEC %s" % cmd, host=self.get_option('remote_addr'))
+        display.vvv(f'EXEC {cmd}', host=self.get_option('remote_addr'))
 
         cmd = to_bytes(cmd, errors='surrogate_or_strict')
 
@@ -613,11 +687,11 @@ class Connection(ConnectionBase):
                     display.debug('Waiting for Privilege Escalation input')
 
                     chunk = chan.recv(bufsize)
-                    display.debug("chunk is: %r" % chunk)
+                    display.debug(f'chunk is: {to_text(chunk)}')
                     if not chunk:
                         if b'unknown user' in become_output:
                             n_become_user = to_native(self.become.get_option('become_user'))
-                            raise AnsibleError('user %s does not exist' % n_become_user)
+                            raise AnsibleError(f'user {n_become_user} does not exist')
                         else:
                             break
                             # raise AnsibleError('ssh connection closed waiting for password prompt')
@@ -638,7 +712,7 @@ class Connection(ConnectionBase):
                         become_pass = self.become.get_option('become_pass')
                         chan.sendall(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
                     else:
-                        raise AnsibleError("A password is required but none was supplied")
+                        raise AnsibleError('A password is required but none was supplied')
                 else:
                     no_prompt_out += become_output
                     no_prompt_err += become_output
@@ -657,7 +731,7 @@ class Connection(ConnectionBase):
 
         if 'pct: not found' in stderr.decode('utf-8'):
             raise AnsibleError(
-                'pct not found in path of host: %s' % (str(self.get_option('remote_addr'))))
+                f'pct not found in path of host: {to_text(self.get_option("remote_addr"))}')
 
         return (returncode, no_prompt_out + stdout, no_prompt_out + stderr)
 
@@ -665,7 +739,7 @@ class Connection(ConnectionBase):
         """ transfer a file from local to remote """
 
         try:
-            with open(in_path, "rb") as f:
+            with open(in_path, 'rb') as f:
                 data = f.read()
                 returncode, stdout, stderr = self.exec_command(
                     ' '.join([
@@ -676,12 +750,12 @@ class Connection(ConnectionBase):
             if returncode != 0:
                 if 'cat: not found' in stderr.decode('utf-8'):
                     raise AnsibleError(
-                        'cat not found in path of container: %s' % (str(self.get_option('vmid'))))
+                        f'cat not found in path of container: {to_text(self.get_option("vmid"))}')
                 raise AnsibleError(
-                    '%s\n%s' % (stdout.decode('utf-8'), stderr.decode('utf-8')))
+                    f'{to_text(stdout)}\n{to_text(stderr)}')
         except Exception as e:
             raise AnsibleError(
-                'error occurred while putting file from %s to %s!\n%s' % (in_path, out_path, str(e)))
+                f'error occurred while putting file from {in_path} to {out_path}!\n{to_text(e)}')
 
     def fetch_file(self, in_path: str, out_path: str) -> None:
         """ save a remote file to the specified path """
@@ -695,14 +769,14 @@ class Connection(ConnectionBase):
             if returncode != 0:
                 if 'cat: not found' in stderr.decode('utf-8'):
                     raise AnsibleError(
-                        'cat not found in path of container: %s' % (str(self.get_option('vmid'))))
+                        f'cat not found in path of container: {to_text(self.get_option("vmid"))}')
                 raise AnsibleError(
-                    '%s\n%s' % (stdout.decode('utf-8'), stderr.decode('utf-8')))
-            with open(out_path, "wb") as f:
+                    f'{to_text(stdout)}\n{to_text(stderr)}')
+            with open(out_path, 'wb') as f:
                 f.write(stdout)
         except Exception as e:
             raise AnsibleError(
-                'error occurred while fetching file from %s to %s!\n%s' % (in_path, out_path, str(e)))
+                f'error occurred while fetching file from {in_path} to {out_path}!\n{to_text(e)}')
 
     def reset(self) -> None:
         """ reset the connection """
@@ -723,7 +797,7 @@ class Connection(ConnectionBase):
             # (This doesn't acquire the connection lock because it needs
             # to exclude only other known_hosts writers, not connections
             # that are starting up.)
-            lockfile = self.keyfile.replace("known_hosts", ".known_hosts.lock")
+            lockfile = self.keyfile.replace('known_hosts', '.known_hosts.lock')
             dirname = os.path.dirname(self.keyfile)
             makedirs_safe(dirname)
 

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -228,8 +228,20 @@ EXAMPLES = r"""
 # --------------------------------------------------------------
 # Setup sudo with passwordless access to pct for user 'ansible':
 # --------------------------------------------------------------
+#
+# Open a Proxmox root shell and execute:
+# $ useradd -d /opt/ansible-pct -r -m -s /bin/sh ansible
+# $ mkdir -p /opt/ansible-pct/.ssh
+# $ ssh-keygen -t ed25519 -C 'ansible' -N "" -f /opt/ansible-pct/.ssh/ansible <<< y > /dev/null
+# $ cat /opt/ansible-pct/.ssh/ansible
+# $ mv /opt/ansible-pct/.ssh/ansible.pub /opt/ansible-pct/.ssh/authorized-keys
+# $ rm /opt/ansible-pct/.ssh/ansible*
+# $ chown -R ansible:ansible /opt/ansible-pct/.ssh
+# $ chmod 700 /opt/ansible-pct/.ssh
+# $ chmod 600 /opt/ansible-pct/.ssh/authorized-keys
 # $ echo 'ansible ALL = (root) NOPASSWD: /usr/sbin/pct' > /etc/sudoers.d/ansible_pct
 #
+# Save the displayed private key and add it to your ssh-agent
 #
 # --------------------------------
 # Static inventory file: hosts.yml

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -214,8 +214,7 @@ DOCUMENTATION = r"""
       vmid:
         description:
           - LXC Container ID
-        type: str
-        default: proxmox_vmid
+        type: int
         vars:
           - name: proxmox_vmid
     notes:

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -217,6 +217,13 @@ DOCUMENTATION = r"""
         type: int
         vars:
           - name: proxmox_vmid
+      proxmox_become_method:
+        description:
+          - Become command used in proxmox
+        type: str
+        default: sudo
+        vars:
+          - name: proxmox_become_method
     notes:
       - >
         When NOT using this plugin as root, you need to have a become mechanism,
@@ -558,7 +565,10 @@ class Connection(ConnectionBase):
     def _build_pct_command(self, cmd: str) -> str:
         cmd = ['/usr/sbin/pct', 'exec', str(self.get_option('vmid')), '--', cmd]
         if self.get_option('remote_user') != 'root':
-            cmd = [self.become.name] + cmd
+            cmd = [self.get_option('proxmox_become_method')] + cmd
+            display.vvv("Running as non root user: %s, trying to run pct with become method: %s" %
+                        (self.get_option('remote_user'), self.get_option('proxmox_become_method')),
+                        host=self.get_option('remote_addr'))
         return ' '.join(cmd)
 
     def exec_command(self, cmd: str, in_data: bytes | None = None, sudoable: bool = True) -> tuple[int, bytes, bytes]:

--- a/plugins/connection/pct_remote.py
+++ b/plugins/connection/pct_remote.py
@@ -805,7 +805,7 @@ class Connection(ConnectionBase):
                     uid = key_stat.st_uid
                     gid = key_stat.st_gid
                 else:
-                    mode = 33188
+                    mode = 0o644
                     uid = os.getuid()
                     gid = os.getgid()
 

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -727,6 +727,8 @@ class Connection(ConnectionBase):
                 for i in range(0, len(in_data), bufsize):
                     chan.send(in_data[i:i + bufsize])
                 chan.shutdown_write()
+            elif in_data == b'':
+                chan.shutdown_write()
 
         except socket.timeout:
             raise AnsibleError('ssh timed out waiting for privilege escalation.\n' + to_text(become_output))
@@ -744,6 +746,7 @@ class Connection(ConnectionBase):
     def put_file(self, in_path: str, out_path: str) -> None:
         """ transfer a file from local to remote """
 
+        display.vvv(f'PUT {in_path} TO {out_path}', host=self.get_option('remote_addr'))
         try:
             with open(in_path, 'rb') as f:
                 data = f.read()
@@ -766,6 +769,7 @@ class Connection(ConnectionBase):
     def fetch_file(self, in_path: str, out_path: str) -> None:
         """ save a remote file to the specified path """
 
+        display.vvv(f'FETCH {in_path} TO {out_path}', host=self.get_option('remote_addr'))
         try:
             returncode, stdout, stderr = self.exec_command(
                 ' '.join([

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -17,7 +17,7 @@ requirements:
 description:
   - Run commands or put/fetch files to an existing Proxmox LXC container using pct CLI via SSH.
   - Uses the Python SSH implementation (Paramiko) to connect to the Proxmox host.
-version_added: "10.2.0"
+version_added: "10.3.0"
 options:
   remote_addr:
     description:

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 author: Nils Stein (@mietzen) <github.nstein@mailbox.org>
-name: pct_remote
+name: proxmox_pct_remote
 short_description: Run tasks in Proxmox LXC container instances using pct CLI via SSH
 requirements:
   - paramiko
@@ -341,12 +341,12 @@ EXAMPLES = r"""
 #         container-1:
 #           ansible_host: 10.0.0.10
 #           proxmox_vmid: 100
-#           ansible_connection: community.general.pct_remote
+#           ansible_connection: community.general.proxmox_pct_remote
 #           ansible_user: ansible
 #         container-2:
 #           ansible_host: 10.0.0.10
 #           proxmox_vmid: 200
-#           ansible_connection: community.general.pct_remote
+#           ansible_connection: community.general.proxmox_pct_remote
 #           ansible_user: ansible
 #     proxmox:
 #       hosts:
@@ -373,7 +373,7 @@ EXAMPLES = r"""
 # want_proxmox_nodes_ansible_host: false
 # compose:
 #   ansible_host: "'10.0.0.10'"
-#   ansible_connection: "'community.general.pct_remote'"
+#   ansible_connection: "'community.general.proxmox_pct_remote'"
 #   ansible_user: "'ansible'"
 #
 #
@@ -472,7 +472,7 @@ class MyAddPolicy(MissingHostKeyPolicy):
 class Connection(ConnectionBase):
     """ SSH based connections (paramiko) to Proxmox pct """
 
-    transport = 'community.general.pct_remote'
+    transport = 'community.general.proxmox_pct_remote'
     _log_channel: str | None = None
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -383,8 +383,8 @@ EXAMPLES = r"""
 ---
 - hosts: lxc
   tasks:
-    - debug:
-        msg: "This is coming from pct environment"
+    - name: Ping LXC container
+      ansible.builtin.ping:
 """
 
 import os

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -382,6 +382,14 @@ EXAMPLES = r"""
 # ----------------------
 ---
 - hosts: lxc
+  # On nodes with many containers you might want to deactivate the devices facts
+  # or set `gather_facts: false` if you don't need them.
+  # More info on gathering fact subsets:
+  # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html
+  #
+  # gather_facts: true
+  #   gather_subset:
+  #     - "!devices"
   tasks:
     - name: Ping LXC container
       ansible.builtin.ping:

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -237,7 +237,7 @@ notes:
   - >
     When NOT using this plugin as root, you need to have a become mechanism,
     e.g. C(sudo), installed on Proxmox and setup so we can run it without prompting for the password.
-    Inside the container we need a shell e.g. C(sh) and C(cat), for this plugin to work.
+    Inside the container, we need a shell, for example C(sh) and the C(cat) command to be available in the C(PATH) for this plugin to work.
 """
 
 EXAMPLES = r"""

--- a/tests/integration/targets/connection_proxmox_pct_remote/aliases
+++ b/tests/integration/targets/connection_proxmox_pct_remote/aliases
@@ -1,5 +1,5 @@
-# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
-# Copyright (c) 2024 Ansible Project
+# Copyright (c) 2025 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/integration/targets/connection_proxmox_pct_remote/aliases
+++ b/tests/integration/targets/connection_proxmox_pct_remote/aliases
@@ -9,7 +9,3 @@ needs/root
 needs/target/connection
 skip/docker
 skip/alpine
-skip/aix
-skip/osx
-skip/macos
-skip/freebsd

--- a/tests/integration/targets/connection_proxmox_pct_remote/aliases
+++ b/tests/integration/targets/connection_proxmox_pct_remote/aliases
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+azp/posix/3
+destructive
+needs/root
+needs/target/connection
+skip/docker
+skip/alpine
+skip/aix
+skip/osx
+skip/macos
+skip/freebsd

--- a/tests/integration/targets/connection_proxmox_pct_remote/aliases
+++ b/tests/integration/targets/connection_proxmox_pct_remote/aliases
@@ -9,3 +9,4 @@ needs/root
 needs/target/connection
 skip/docker
 skip/alpine
+skip/macos

--- a/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
+++ b/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
@@ -1,6 +1,6 @@
 ---
-# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
-# Copyright (c) Ansible Project
+# Copyright (c) 2025 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
+++ b/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
@@ -5,15 +5,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: localhost
-  gather_facts: false
+  gather_facts: true
   serial: 1
   tasks:
     - name: Copy pct mock
       copy:
         src: files/pct
         dest: /usr/sbin/pct
-        owner: root
-        group: root
         mode: '0755'
     - name: Install paramiko
       pip:

--- a/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
+++ b/tests/integration/targets/connection_proxmox_pct_remote/dependencies.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: localhost
+  gather_facts: false
+  serial: 1
+  tasks:
+    - name: Copy pct mock
+      copy:
+        src: files/pct
+        dest: /usr/sbin/pct
+        owner: root
+        group: root
+        mode: '0755'
+    - name: Install paramiko
+      pip:
+        name: "paramiko>=3.0.0"

--- a/tests/integration/targets/connection_proxmox_pct_remote/files/pct
+++ b/tests/integration/targets/connection_proxmox_pct_remote/files/pct
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
-# Copyright (c) 2024 Ansible Project
+# Copyright (c) 2025 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,7 +8,7 @@
 
 >&2 echo "[DEBUG] INPUT: $@"
 
-pwd=$(pwd)
+pwd="$(pwd)"
 
 # Get quoted parts and restore quotes
 declare -a cmd=()
@@ -23,11 +23,11 @@ cmd="${cmd[@]:3}"
 vmid="${@:2:1}"
 >&2 echo "[INFO] MOCKING: pct ${@:1:3} ${cmd}"
 tmp_dir="/tmp/ansible-remote/proxmox_pct_remote/integration_test/ct_${vmid}"
-mkdir -p $tmp_dir
+mkdir -p "$tmp_dir"
 >&2 echo "[INFO] PWD: $tmp_dir"
 >&2 echo "[INFO] CMD: ${cmd}"
-cd $tmp_dir
+cd "$tmp_dir"
 
 eval "${cmd}"
 
-cd $pwd
+cd "$pwd"

--- a/tests/integration/targets/connection_proxmox_pct_remote/files/pct
+++ b/tests/integration/targets/connection_proxmox_pct_remote/files/pct
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Shell script to mock proxmox pct behaviour
+
+>&2 echo "[DEBUG] INPUT: $@"
+
+pwd=$(pwd)
+
+# Get quoted parts and restore quotes
+declare -a cmd=()
+for arg in "$@"; do
+    if [[ $arg =~ [[:space:]] ]]; then
+        arg="'$arg'"
+    fi
+    cmd+=("$arg")
+done
+
+cmd="${cmd[@]:3}"
+vmid="${@:2:1}"
+>&2 echo "[INFO] MOCKING: pct ${@:1:3} ${cmd}"
+tmp_dir="/tmp/ansible-remote/proxmox_pct_remote/integration_test/ct_${vmid}"
+mkdir -p $tmp_dir
+>&2 echo "[INFO] PWD: $tmp_dir"
+>&2 echo "[INFO] CMD: ${cmd}"
+cd $tmp_dir
+
+eval "${cmd}"
+
+cd $pwd

--- a/tests/integration/targets/connection_proxmox_pct_remote/plugin-specific-tests.yml
+++ b/tests/integration/targets/connection_proxmox_pct_remote/plugin-specific-tests.yml
@@ -1,0 +1,32 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  serial: 1
+  tasks:
+    - name: create file without content
+      copy:
+        content: ""
+        dest: "{{ remote_tmp }}/test_empty.txt"
+        force: no
+        mode: '0644'
+
+    - name: assert file without content exists
+      stat:
+        path: "{{ remote_tmp }}/test_empty.txt"
+      register: empty_file_stat
+
+    - name: verify file without content exists
+      assert:
+        that:
+          - empty_file_stat.stat.exists
+        fail_msg: "The file {{ remote_tmp }}/test_empty.txt does not exist."
+
+    - name: verify file without content is empty
+      assert:
+        that:
+          - empty_file_stat.stat.size == 0
+        fail_msg: "The file {{ remote_tmp }}/test_empty.txt is not empty."

--- a/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
@@ -15,14 +15,4 @@ chmod 755 /usr/sbin/pct
 
 "pip$ANSIBLE_TEST_PYTHON_VERSION" install paramiko
 
-group=$(python -c \
-    "from os import path; print(path.basename(path.abspath(path.dirname('$0'))).replace('connection_', ''))")
-
-cd ../connection
-
-INVENTORY="../connection_${group}/test_connection.inventory" ./test.sh \
-    -e target_hosts="${group}" \
-    -e action_prefix= \
-    -e local_tmp=/tmp/ansible-local \
-    -e remote_tmp=/tmp/ansible-remote \
-    "$@"
+./test.sh "$@"

--- a/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
-# Copyright (c) Ansible Project
+# Copyright (c) 2025 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eux
+
+# Connection tests for POSIX platforms use this script by linking to it from the appropriate 'connection_' target dir.
+# The name of the inventory group to test is extracted from the directory name following the 'connection_' prefix.
+
+cp files/pct /usr/sbin/pct
+chown root:root /usr/sbin/pct
+chmod 755 /usr/sbin/pct
+
+"pip$ANSIBLE_TEST_PYTHON_VERSION" install paramiko
+
+group=$(python -c \
+    "from os import path; print(path.basename(path.abspath(path.dirname('$0'))).replace('connection_', ''))")
+
+cd ../connection
+
+INVENTORY="../connection_${group}/test_connection.inventory" ./test.sh \
+    -e target_hosts="${group}" \
+    -e action_prefix= \
+    -e local_tmp=/tmp/ansible-local \
+    -e remote_tmp=/tmp/ansible-remote \
+    "$@"

--- a/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
@@ -6,13 +6,7 @@
 
 set -eux
 
-# Connection tests for POSIX platforms use this script by linking to it from the appropriate 'connection_' target dir.
-# The name of the inventory group to test is extracted from the directory name following the 'connection_' prefix.
-
-cp files/pct /usr/sbin/pct
-chown root:root /usr/sbin/pct
-chmod 755 /usr/sbin/pct
-
-"pip$ANSIBLE_TEST_PYTHON_VERSION" install paramiko
+ANSIBLE_ROLES_PATH=../ \
+    ansible-playbook dependencies.yml -v "$@"
 
 ./test.sh "$@"

--- a/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/runme.sh
@@ -10,3 +10,10 @@ ANSIBLE_ROLES_PATH=../ \
     ansible-playbook dependencies.yml -v "$@"
 
 ./test.sh "$@"
+
+ansible-playbook plugin-specific-tests.yml -i "./test_connection.inventory" \
+    -e target_hosts="proxmox_pct_remote" \
+    -e action_prefix= \
+    -e local_tmp=/tmp/ansible-local \
+    -e remote_tmp=/tmp/ansible-remote \
+    "$@"

--- a/tests/integration/targets/connection_proxmox_pct_remote/test.sh
+++ b/tests/integration/targets/connection_proxmox_pct_remote/test.sh
@@ -1,0 +1,1 @@
+../connection_posix/test.sh

--- a/tests/integration/targets/connection_proxmox_pct_remote/test_connection.inventory
+++ b/tests/integration/targets/connection_proxmox_pct_remote/test_connection.inventory
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[proxmox_pct_remote]
+proxmox_pct_remote-pipelining    ansible_ssh_pipelining=true
+proxmox_pct_remote-no-pipelining ansible_ssh_pipelining=false
+[proxmox_pct_remote:vars]
+ansible_host=localhost
+ansible_user=root
+ansible_python_interpreter="{{ ansible_playbook_python }}"
+ansible_connection=community.general.proxmox_pct_remote
+proxmox_vmid=123

--- a/tests/integration/targets/connection_proxmox_pct_remote/test_connection.inventory
+++ b/tests/integration/targets/connection_proxmox_pct_remote/test_connection.inventory
@@ -1,5 +1,5 @@
-# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
-# Copyright (c) Ansible Project
+# Copyright (c) 2025 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -1,0 +1,547 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Nils Stein (@mietzen) <github.nstein@mailbox.org>
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (annotations, absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pytest
+
+from ansible_collections.community.general.plugins.connection.proxmox_pct_remote import authenticity_msg, MyAddPolicy
+from ansible_collections.community.general.plugins.module_utils._filelock import FileLock, LockTimeout
+from ansible.errors import AnsibleError, AnsibleAuthenticationFailure, AnsibleConnectionFailure
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.compat.paramiko import paramiko
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import connection_loader
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock, mock_open
+
+
+@pytest.fixture
+def connection():
+    play_context = PlayContext()
+    in_stream = StringIO()
+    conn = connection_loader.get('community.general.proxmox_pct_remote', play_context, in_stream)
+    conn.set_option('remote_addr', '192.168.1.100')
+    conn.set_option('remote_user', 'root')
+    conn.set_option('password', 'password')
+    return conn
+
+
+def test_connection_options(connection):
+    """ Test that connection options are properly set """
+    assert connection.get_option('remote_addr') == '192.168.1.100'
+    assert connection.get_option('remote_user') == 'root'
+    assert connection.get_option('password') == 'password'
+
+
+def test_authenticity_msg():
+    """ Test authenticity message formatting """
+    msg = authenticity_msg('test.host', 'ssh-rsa', 'AA:BB:CC:DD')
+    assert 'test.host' in msg
+    assert 'ssh-rsa' in msg
+    assert 'AA:BB:CC:DD' in msg
+
+
+def test_missing_host_key(connection):
+    """ Test MyAddPolicy missing_host_key method """
+
+    client = MagicMock()
+    key = MagicMock()
+    key.get_fingerprint.return_value = b'fingerprint'
+    key.get_name.return_value = 'ssh-rsa'
+
+    policy = MyAddPolicy(connection)
+
+    connection.set_option('host_key_auto_add', True)
+    policy.missing_host_key(client, 'test.host', key)
+    assert hasattr(key, '_added_by_ansible_this_time')
+
+    connection.set_option('host_key_auto_add', False)
+    connection.set_option('host_key_checking', False)
+    policy.missing_host_key(client, 'test.host', key)
+
+    connection.set_option('host_key_checking', True)
+    connection.set_option('host_key_auto_add', False)
+    connection.set_option('use_persistent_connections', False)
+
+    with patch('ansible.utils.display.Display.prompt_until', return_value='yes'):
+        policy.missing_host_key(client, 'test.host', key)
+
+    with patch('ansible.utils.display.Display.prompt_until', return_value='no'):
+        with pytest.raises(AnsibleError, match='host connection rejected by user'):
+            policy.missing_host_key(client, 'test.host', key)
+
+
+def test_set_log_channel(connection):
+    """ Test setting log channel """
+    connection._set_log_channel('test_channel')
+    assert connection._log_channel == 'test_channel'
+
+
+def test_parse_proxy_command(connection):
+    """ Test proxy command parsing """
+    connection.set_option('proxy_command', 'ssh -W %h:%p proxy.example.com')
+    connection.set_option('remote_addr', 'target.example.com')
+    connection.set_option('remote_user', 'testuser')
+
+    result = connection._parse_proxy_command(port=2222)
+    assert 'sock' in result
+    assert isinstance(result['sock'], paramiko.ProxyCommand)
+
+
+@patch('paramiko.SSHClient')
+def test_connect_with_rsa_sha2_disabled(mock_ssh, connection):
+    """ Test connection with RSA SHA2 algorithms disabled """
+    connection.set_option('use_rsa_sha2_algorithms', False)
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+
+    connection._connect()
+
+    call_kwargs = mock_client.connect.call_args[1]
+    assert 'disabled_algorithms' in call_kwargs
+    assert 'pubkeys' in call_kwargs['disabled_algorithms']
+
+
+@patch('paramiko.SSHClient')
+def test_connect_with_bad_host_key(mock_ssh, connection):
+    """ Test connection with bad host key """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_client.connect.side_effect = paramiko.ssh_exception.BadHostKeyException(
+        'hostname', MagicMock(), MagicMock())
+
+    with pytest.raises(AnsibleConnectionFailure, match='host key mismatch'):
+        connection._connect()
+
+
+@patch('paramiko.SSHClient')
+def test_connect_success(mock_ssh, connection):
+    """ Test successful SSH connection establishment """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+
+    connection._connect()
+
+    assert mock_client.connect.called
+    assert connection._connected
+
+
+@patch('paramiko.SSHClient')
+def test_connect_authentication_failure(mock_ssh, connection):
+    """ Test SSH connection with authentication failure """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_client.connect.side_effect = paramiko.ssh_exception.AuthenticationException('Auth failed')
+
+    with pytest.raises(AnsibleAuthenticationFailure):
+        connection._connect()
+
+
+def test_any_keys_added(connection):
+    """ Test checking for added host keys """
+    connection.ssh = MagicMock()
+    connection.ssh._host_keys = {
+        'host1': {
+            'ssh-rsa': MagicMock(_added_by_ansible_this_time=True),
+            'ssh-ed25519': MagicMock(_added_by_ansible_this_time=False)
+        }
+    }
+
+    assert connection._any_keys_added() is True
+
+    connection.ssh._host_keys = {
+        'host1': {
+            'ssh-rsa': MagicMock(_added_by_ansible_this_time=False)
+        }
+    }
+    assert connection._any_keys_added() is False
+
+
+@patch('os.path.exists')
+@patch('os.stat')
+@patch('tempfile.NamedTemporaryFile')
+def test_save_ssh_host_keys(mock_tempfile, mock_stat, mock_exists, connection):
+    """ Test saving SSH host keys """
+    mock_exists.return_value = True
+    mock_stat.return_value = MagicMock(st_mode=0o644, st_uid=1000, st_gid=1000)
+    mock_tempfile.return_value.__enter__.return_value.name = '/tmp/test_keys'
+
+    connection.ssh = MagicMock()
+    connection.ssh._host_keys = {
+        'host1': {
+            'ssh-rsa': MagicMock(
+                get_base64=lambda: 'KEY1',
+                _added_by_ansible_this_time=True
+            )
+        }
+    }
+
+    mock_open_obj = mock_open()
+    with patch('builtins.open', mock_open_obj):
+        connection._save_ssh_host_keys('/tmp/test_keys')
+
+    mock_open_obj().write.assert_called_with('host1 ssh-rsa KEY1\n')
+
+
+def test_build_pct_command(connection):
+    """ Test PCT command building with different users """
+    connection.set_option('vmid', '100')
+
+    cmd = connection._build_pct_command('/bin/sh -c "ls -la"')
+    assert cmd == '/usr/sbin/pct exec 100 -- /bin/sh -c "ls -la"'
+
+    connection.set_option('remote_user', 'user')
+    connection.set_option('proxmox_become_method', 'sudo')
+    cmd = connection._build_pct_command('/bin/sh -c "ls -la"')
+    assert cmd == 'sudo /usr/sbin/pct exec 100 -- /bin/sh -c "ls -la"'
+
+
+@patch('paramiko.SSHClient')
+def test_exec_command_success(mock_ssh, connection):
+    """ Test successful command execution """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 0
+    mock_channel.makefile.return_value = [to_bytes('stdout')]
+    mock_channel.makefile_stderr.return_value = [to_bytes("")]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    returncode, stdout, stderr = connection.exec_command('ls -la')
+
+    mock_transport.open_session.assert_called_once()
+    mock_channel.get_pty.assert_called_once()
+    mock_transport.set_keepalive.assert_called_once_with(5)
+
+
+@patch('paramiko.SSHClient')
+def test_exec_command_pct_not_found(mock_ssh, connection):
+    """ Test command execution when PCT is not found """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 1
+    mock_channel.makefile.return_value = [to_bytes("")]
+    mock_channel.makefile_stderr.return_value = [to_bytes('pct: not found')]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleError, match='pct not found in path of host'):
+        connection.exec_command('ls -la')
+
+
+@patch('paramiko.SSHClient')
+def test_exec_command_session_open_failure(mock_ssh, connection):
+    """ Test exec_command when session opening fails """
+    mock_client = MagicMock()
+    mock_transport = MagicMock()
+    mock_transport.open_session.side_effect = Exception('Failed to open session')
+    mock_client.get_transport.return_value = mock_transport
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleConnectionFailure, match='Failed to open session'):
+        connection.exec_command('test command')
+
+
+@patch('paramiko.SSHClient')
+def test_exec_command_with_privilege_escalation(mock_ssh, connection):
+    """ Test exec_command with privilege escalation """
+    mock_client = MagicMock()
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    connection._connected = True
+    connection.ssh = mock_client
+
+    connection.become = MagicMock()
+    connection.become.expect_prompt.return_value = True
+    connection.become.check_success.return_value = False
+    connection.become.check_password_prompt.return_value = True
+    connection.become.get_option.return_value = 'sudo_password'
+
+    mock_channel.recv.return_value = b'[sudo] password:'
+    mock_channel.recv_exit_status.return_value = 0
+    mock_channel.makefile.return_value = [b""]
+    mock_channel.makefile_stderr.return_value = [b""]
+
+    returncode, stdout, stderr = connection.exec_command('sudo test command')
+
+    mock_channel.sendall.assert_called_once_with(b'sudo_password\n')
+
+
+def test_put_file(connection):
+    """ Test putting a file to the remote system """
+    connection.exec_command = MagicMock()
+    connection.exec_command.return_value = (0, b"", b"")
+
+    with patch('builtins.open', create=True) as mock_open:
+        mock_open.return_value.__enter__.return_value.read.return_value = b'test content'
+        connection.put_file('/local/path', '/remote/path')
+
+    connection.exec_command.assert_called_once_with("/bin/sh -c 'cat > /remote/path'", in_data=b'test content', sudoable=False)
+
+
+@patch('paramiko.SSHClient')
+def test_put_file_general_error(mock_ssh, connection):
+    """ Test put_file with general error """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 1
+    mock_channel.makefile.return_value = [to_bytes("")]
+    mock_channel.makefile_stderr.return_value = [to_bytes('Some error')]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleError, match='error occurred while putting file from /remote/path to /local/path'):
+        connection.put_file('/remote/path', '/local/path')
+
+
+@patch('paramiko.SSHClient')
+def test_put_file_cat_not_found(mock_ssh, connection):
+    """ Test command execution when cat is not found """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 1
+    mock_channel.makefile.return_value = [to_bytes("")]
+    mock_channel.makefile_stderr.return_value = [to_bytes('cat: not found')]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleError, match='cat not found in path of container:'):
+        connection.fetch_file('/remote/path', '/local/path')
+
+
+def test_fetch_file(connection):
+    """ Test fetching a file from the remote system """
+    connection.exec_command = MagicMock()
+    connection.exec_command.return_value = (0, b'test content', b"")
+
+    with patch('builtins.open', create=True) as mock_open:
+        connection.fetch_file('/remote/path', '/local/path')
+
+    connection.exec_command.assert_called_once_with("/bin/sh -c 'cat /remote/path'", sudoable=False)
+    mock_open.assert_called_with('/local/path', 'wb')
+
+
+@patch('paramiko.SSHClient')
+def test_fetch_file_general_error(mock_ssh, connection):
+    """ Test fetch_file with general error """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 1
+    mock_channel.makefile.return_value = [to_bytes("")]
+    mock_channel.makefile_stderr.return_value = [to_bytes('Some error')]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleError, match='error occurred while fetching file from /remote/path to /local/path'):
+        connection.fetch_file('/remote/path', '/local/path')
+
+
+@patch('paramiko.SSHClient')
+def test_fetch_file_cat_not_found(mock_ssh, connection):
+    """ Test command execution when cat is not found """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    mock_channel.recv_exit_status.return_value = 1
+    mock_channel.makefile.return_value = [to_bytes("")]
+    mock_channel.makefile_stderr.return_value = [to_bytes('cat: not found')]
+
+    connection._connected = True
+    connection.ssh = mock_client
+
+    with pytest.raises(AnsibleError, match='cat not found in path of container:'):
+        connection.fetch_file('/remote/path', '/local/path')
+
+
+def test_close(connection):
+    """ Test connection close """
+    mock_ssh = MagicMock()
+    connection.ssh = mock_ssh
+    connection._connected = True
+
+    connection.close()
+
+    assert mock_ssh.close.called, 'ssh.close was not called'
+    assert not connection._connected, 'self._connected is still True'
+
+
+def test_close_with_lock_file(connection):
+    """ Test close method with lock file creation """
+    connection._any_keys_added = MagicMock(return_value=True)
+    connection._connected = True
+    connection.keyfile = '/tmp/pct-remote-known_hosts-test'
+    connection.set_option('host_key_checking', True)
+    connection.set_option('lock_file_timeout', 5)
+    connection.set_option('record_host_keys', True)
+    connection.ssh = MagicMock()
+
+    lock_file_path = os.path.join(os.path.dirname(connection.keyfile),
+                                  f'ansible-{os.path.basename(connection.keyfile)}.lock')
+
+    try:
+        connection.close()
+        assert os.path.exists(lock_file_path), 'Lock file was not created'
+
+        lock_stat = os.stat(lock_file_path)
+        assert lock_stat.st_mode & 0o777 == 0o600, 'Incorrect lock file permissions'
+    finally:
+        Path(lock_file_path).unlink(missing_ok=True)
+
+
+@patch('pathlib.Path.unlink')
+@patch('os.path.exists')
+def test_close_lock_file_time_out_error_handling(mock_exists, mock_unlink, connection):
+    """ Test close method with lock file timeout error """
+    connection._any_keys_added = MagicMock(return_value=True)
+    connection._connected = True
+    connection._save_ssh_host_keys = MagicMock()
+    connection.keyfile = '/tmp/pct-remote-known_hosts-test'
+    connection.set_option('host_key_checking', True)
+    connection.set_option('lock_file_timeout', 5)
+    connection.set_option('record_host_keys', True)
+    connection.ssh = MagicMock()
+
+    mock_exists.return_value = False
+    matcher = f'writing lock file for {connection.keyfile} ran in to the timeout of {connection.get_option("lock_file_timeout")}s'
+    with pytest.raises(AnsibleError, match=matcher):
+        with patch('os.getuid', return_value=1000), \
+             patch('os.getgid', return_value=1000), \
+             patch('os.chmod'), patch('os.chown'), \
+             patch('os.rename'), \
+             patch.object(FileLock, 'lock_file', side_effect=LockTimeout()):
+            connection.close()
+
+
+@patch('ansible_collections.community.general.plugins.module_utils._filelock.FileLock.lock_file')
+@patch('tempfile.NamedTemporaryFile')
+@patch('os.chmod')
+@patch('os.chown')
+@patch('os.rename')
+@patch('os.path.exists')
+def test_tempfile_creation_and_move(mock_exists, mock_rename, mock_chown, mock_chmod, mock_tempfile, mock_lock_file, connection):
+    """ Test tempfile creation and move during close """
+    connection._any_keys_added = MagicMock(return_value=True)
+    connection._connected = True
+    connection._save_ssh_host_keys = MagicMock()
+    connection.keyfile = '/tmp/pct-remote-known_hosts-test'
+    connection.set_option('host_key_checking', True)
+    connection.set_option('lock_file_timeout', 5)
+    connection.set_option('record_host_keys', True)
+    connection.ssh = MagicMock()
+
+    mock_exists.return_value = False
+
+    mock_lock_file_instance = MagicMock()
+    mock_lock_file.return_value = mock_lock_file_instance
+    mock_lock_file_instance.__enter__.return_value = None
+
+    mock_tempfile_instance = MagicMock()
+    mock_tempfile_instance.name = '/tmp/mock_tempfile'
+    mock_tempfile.return_value.__enter__.return_value = mock_tempfile_instance
+
+    mode = 0o644
+    uid = 1000
+    gid = 1000
+    key_dir = os.path.dirname(connection.keyfile)
+
+    with patch('os.getuid', return_value=uid), patch('os.getgid', return_value=gid):
+        connection.close()
+
+    connection._save_ssh_host_keys.assert_called_once_with('/tmp/mock_tempfile')
+    mock_chmod.assert_called_once_with('/tmp/mock_tempfile', mode)
+    mock_chown.assert_called_once_with('/tmp/mock_tempfile', uid, gid)
+    mock_rename.assert_called_once_with('/tmp/mock_tempfile', connection.keyfile)
+    mock_tempfile.assert_called_once_with(dir=key_dir, delete=False)
+
+
+@patch('pathlib.Path.unlink')
+@patch('tempfile.NamedTemporaryFile')
+@patch('ansible_collections.community.general.plugins.module_utils._filelock.FileLock.lock_file')
+@patch('os.path.exists')
+def test_close_tempfile_error_handling(mock_exists, mock_lock_file, mock_tempfile, mock_unlink, connection):
+    """ Test tempfile creation error """
+    connection._any_keys_added = MagicMock(return_value=True)
+    connection._connected = True
+    connection._save_ssh_host_keys = MagicMock()
+    connection.keyfile = '/tmp/pct-remote-known_hosts-test'
+    connection.set_option('host_key_checking', True)
+    connection.set_option('lock_file_timeout', 5)
+    connection.set_option('record_host_keys', True)
+    connection.ssh = MagicMock()
+
+    mock_exists.return_value = False
+
+    mock_lock_file_instance = MagicMock()
+    mock_lock_file.return_value = mock_lock_file_instance
+    mock_lock_file_instance.__enter__.return_value = None
+
+    mock_tempfile_instance = MagicMock()
+    mock_tempfile_instance.name = '/tmp/mock_tempfile'
+    mock_tempfile.return_value.__enter__.return_value = mock_tempfile_instance
+
+    with pytest.raises(AnsibleError, match='error occurred while writing SSH host keys!'):
+        with patch.object(os, 'chmod', side_effect=Exception()):
+            connection.close()
+    mock_unlink.assert_called_with(missing_ok=True)
+
+
+def test_reset(connection):
+    """ Test connection reset """
+    connection._connected = True
+    connection.close = MagicMock()
+    connection._connect = MagicMock()
+
+    connection.reset()
+
+    connection.close.assert_called_once()
+    connection._connect.assert_called_once()
+
+    connection._connected = False
+    connection.reset()
+    assert connection.close.call_count == 1

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -51,6 +51,9 @@ passlib[argon2]
 proxmoxer < 2.0.0 ; python_version >= '2.7' and python_version <= '3.6'
 proxmoxer ; python_version > '3.6'
 
+# requirements for the proxmox_pct_remote connection plugin
+paramiko >= 3.0.0 ; python_version >= '3.6'
+
 #requirements for nomad_token modules
 python-nomad < 2.0.0 ; python_version <= '3.6'
 python-nomad >= 2.0.0 ; python_version >= '3.7'


### PR DESCRIPTION
##### SUMMARY
This connection plugin uses ssh (`paramiko`) to connect to a proxmox host and then calls `pct` to connect into the LXC Proxmox container. 

I mainly inherited from `ssh_paramiko` and overwrote the main methods. 

##### Why is this useful? 
With the new SDN functionality in proxmox we might want to  create container that are not reachable via ssh. With this plugin we can use ansible within the container without any network access to the container.

##### ISSUE TYPE
- New Module/Plugin Pull Request

##### COMPONENT NAME
pct_remote

##### ADDITIONAL INFORMATION
`pct` can only be executed as `root` this is why I put `/usr/bin/sudo` in front of it, I think this is not very clean. Is there a way to obtain the binary path from `become_method`?  Or is it possible to set `become: true` as default? 

