### PR TITLE
Redfish: Add options to check the availability of the service

### DIFF
--- a/changelogs/fragments/8051-Redfish-Wait-For-Service.yml
+++ b/changelogs/fragments/8051-Redfish-Wait-For-Service.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - redfish_info - add command ``CheckAvailability`` to check if a service is accessible (https://github.com/ansible-collections/community.general/issues/8051).
-  - redfish_command - add ``wait`` and ``wait_timeout`` options to allow a user to block a command until a service is accessible after performing the requested command (https://github.com/ansible-collections/community.general/issues/8051).
+  - redfish_info - add command ``CheckAvailability`` to check if a service is accessible (https://github.com/ansible-collections/community.general/issues/8051, https://github.com/ansible-collections/community.general/pull/8434).
+  - redfish_command - add ``wait`` and ``wait_timeout`` options to allow a user to block a command until a service is accessible after performing the requested command (https://github.com/ansible-collections/community.general/issues/8051, https://github.com/ansible-collections/community.general/pull/8434).

--- a/changelogs/fragments/8051-Redfish-Wait-For-Service.yml
+++ b/changelogs/fragments/8051-Redfish-Wait-For-Service.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - redfish_info - add command ``CheckAvailability`` to check if a service is accessible (https://github.com/ansible-collections/community.general/issues/8051).
+  - redfish_command - add ``wait`` and ``wait_timeout`` options to allow a user to block a command until a service is accessible after performing the requested command (https://github.com/ansible-collections/community.general/issues/8051).

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -133,11 +133,13 @@ class RedfishUtils(object):
         return resp
 
     # The following functions are to send GET/POST/PATCH/DELETE requests
-    def get_request(self, uri, override_headers=None, allow_no_resp=False):
+    def get_request(self, uri, override_headers=None, allow_no_resp=False, timeout=None):
         req_headers = dict(GET_HEADERS)
         if override_headers:
             req_headers.update(override_headers)
         username, password, basic_auth = self._auth_params(req_headers)
+        if timeout is None:
+            timeout = self.timeout
         try:
             # Service root is an unauthenticated resource; remove credentials
             # in case the caller will be using sessions later.
@@ -147,7 +149,7 @@ class RedfishUtils(object):
                             url_username=username, url_password=password,
                             force_basic_auth=basic_auth, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=True, timeout=self.timeout)
+                            use_proxy=True, timeout=timeout)
             headers = dict((k.lower(), v) for (k, v) in resp.info().items())
             try:
                 if headers.get('content-encoding') == 'gzip' and LooseVersion(ansible_version) < LooseVersion('2.14'):
@@ -635,10 +637,7 @@ class RedfishUtils(object):
         # Get the service root
         # Override the timeout since the service root is expected to be readily
         # available.
-        original_timeout = self.timeout
-        self.timeout = 10
-        service_root = self.get_request(self.root_uri + self.service_root)
-        self.timeout = original_timeout
+        service_root = self.get_request(self.root_uri + self.service_root, timeout=10)
         if service_root['ret'] is False:
             # Failed, either due to a timeout or HTTP error; not available
             return {'ret': True, 'available': False}
@@ -1174,6 +1173,7 @@ class RedfishUtils(object):
         # If requested to wait for the service to be available again, block
         # until it's ready
         if wait:
+            elapsed_time = 0
             start_time = time.time()
             # Start with a large enough sleep.  Some services will process new
             # requests while in the middle of shutting down, thus breaking out
@@ -1183,13 +1183,18 @@ class RedfishUtils(object):
             # Periodically check for the service's availability.
             # Even if the timeout is exhausted, we still want to return success
             # since the power/reset operation was successful.
-            while wait_timeout > 0:
+            while elapsed_time <= wait_timeout:
                 status = self.check_service_availability()
                 if status['available']:
                     # It's available; we're done
                     break
                 time.sleep(5)
-                wait_timeout = wait_timeout - (time.time() - start_time)
+                elapsed_time = time.time() - start_time
+
+            if elapsed_time > wait_timeout:
+                # Exhausted the wait timer; error
+                return {'ret': False, 'changed': True,
+                        'msg': 'The service did not become available after %d seconds' % wait_timeout}
         return {'ret': True, 'changed': True}
 
     def manager_reset_to_defaults(self, command):

--- a/plugins/module_utils/redfish_utils.py
+++ b/plugins/module_utils/redfish_utils.py
@@ -1181,8 +1181,6 @@ class RedfishUtils(object):
             time.sleep(30)
 
             # Periodically check for the service's availability.
-            # Even if the timeout is exhausted, we still want to return success
-            # since the power/reset operation was successful.
             while elapsed_time <= wait_timeout:
                 status = self.check_service_availability()
                 if status['available']:

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -298,7 +298,7 @@ options:
   wait_timeout:
     required: false
     description:
-      - How long to block until the service is ready again before giving up
+      - How long to block until the service is ready again before giving up.
     type: int
     default: 120
     version_added: 9.2.0

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -294,7 +294,7 @@ options:
       - Block until the service is ready again.
     type: bool
     default: false
-    version_added: 9.2.0
+    version_added: 9.1.0
   wait_timeout:
     required: false
     description:

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -301,7 +301,7 @@ options:
       - How long to block until the service is ready again before giving up.
     type: int
     default: 120
-    version_added: 9.2.0
+    version_added: 9.1.0
 
 author:
   - "Jose Delarosa (@jose-delarosa)"

--- a/plugins/modules/redfish_command.py
+++ b/plugins/modules/redfish_command.py
@@ -291,7 +291,7 @@ options:
   wait:
     required: false
     description:
-      - Block until the service is ready again
+      - Block until the service is ready again.
     type: bool
     default: false
     version_added: 9.2.0

--- a/plugins/modules/redfish_info.py
+++ b/plugins/modules/redfish_info.py
@@ -359,6 +359,16 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+
+  - name: Check the availability of the service with a timeout of 5 seconds
+    community.general.redfish_info:
+      category: Service
+      command: CheckAvailability
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      timeout: 5
+    register: result
 '''
 
 RETURN = '''
@@ -385,6 +395,7 @@ CATEGORY_COMMANDS_ALL = {
                "GetUpdateStatus"],
     "Manager": ["GetManagerNicInventory", "GetVirtualMedia", "GetLogs", "GetNetworkProtocols",
                 "GetHealthReport", "GetHostInterfaces", "GetManagerInventory", "GetServiceIdentification"],
+    "Service": ["CheckAvailability"],
 }
 
 CATEGORY_COMMANDS_DEFAULT = {
@@ -393,7 +404,8 @@ CATEGORY_COMMANDS_DEFAULT = {
     "Accounts": "ListUsers",
     "Update": "GetFirmwareInventory",
     "Sessions": "GetSessions",
-    "Manager": "GetManagerNicInventory"
+    "Manager": "GetManagerNicInventory",
+    "Service": "CheckAvailability",
 }
 
 
@@ -473,7 +485,13 @@ def main():
             module.fail_json(msg="Invalid Category: %s" % category)
 
         # Organize by Categories / Commands
-        if category == "Systems":
+        if category == "Service":
+            # service-level commands are always available
+            for command in command_list:
+                if command == "CheckAvailability":
+                    result["service"] = rf_utils.check_service_availability()
+
+        elif category == "Systems":
             # execute only if we find a Systems resource
             resource = rf_utils._find_systems_resource()
             if resource['ret'] is False:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Adds new command to check if a Redfish service is available
* Adds new option to manager reset operations to wait for the service to become available again after the reset

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #8051

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->
~~I did not add a changelog fragment yet; will do that once I get some eyes on the design.~~

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
redfish_info, redfish_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
New "service available" command
```paste below
---
- hosts: all
  gather_facts: false
  vars:
    baseuri: REDACTED
    username: REDACTED
    password: REDACTED
  tasks:
  - name: Check service availability
    community.general.redfish_info:
      category: Service
      command: CheckAvailability
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
    register: redfish_results
  - debug:
      var: redfish_results
```

```
TASK [debug] *******************************************************************************************************************************************************
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": false,
        "failed": false,
        "redfish_facts": {
            "service": {
                "available": false,
                "ret": true
            }
        }
    }
}
```

Usage of new "wait for manager" option in manager power/reset requests:
```
---
- hosts: all
  gather_facts: false
  vars:
    username: REDACTED
    password: REDACTED
    baseuri: REDACTED
  tasks:
  - name: Reboot manager
    community.general.redfish_command:
      category: Manager
      command: GracefulRestart
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
      wait: True
    retries: "{{ default_uri_retries }}"
    register: redfish_results
  - debug:
      var: redfish_results
```

```
TASK [debug] *******************************************************************************************************************************************************
ok: [localhost] => {
    "redfish_results": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "failed": false,
        "msg": "Action was successful",
        "return_values": {},
        "session": {}
    }
}
```