### PR TITLE
add special word '+value' to add_children/set_children in xml module

### DIFF
--- a/changelogs/fragments/8437-xml-children-value.yml
+++ b/changelogs/fragments/8437-xml-children-value.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - minor changes to xml module to support adding value of children when creating with subnodes.
+  - xml - support adding value of children when creating with subnodes (https://github.com/ansible-collections/community.general/pull/8437).

--- a/changelogs/fragments/8437-xml-children-value.yml
+++ b/changelogs/fragments/8437-xml-children-value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - minor changes to xml module to support adding value of children when creating with subnodes.

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -301,7 +301,9 @@ EXAMPLES = r"""
 # Attributes
           name: Scumm bar
           location: Monkey island
-# Subnodes
+          # Value
+          +value: unreal
+          # Subnodes
           _:
             - floor: Pirate hall
             - floor: Grog storage
@@ -756,7 +758,7 @@ def child_to_element(module, child, in_type):
             (key, value) = next(iteritems(child))
             if isinstance(value, MutableMapping):
                 children = value.pop('_', None)
-                child_value = value.pop('_value', None)
+                child_value = value.pop('+value', None)
 
                 node = etree.Element(key, value)
 

--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -756,6 +756,7 @@ def child_to_element(module, child, in_type):
             (key, value) = next(iteritems(child))
             if isinstance(value, MutableMapping):
                 children = value.pop('_', None)
+                child_value = value.pop('_value', None)
 
                 node = etree.Element(key, value)
 
@@ -765,6 +766,9 @@ def child_to_element(module, child, in_type):
 
                     subnodes = children_to_nodes(module, children)
                     node.extend(subnodes)
+
+                if child_value is not None:
+                    node.text = child_value
             else:
                 node = etree.Element(key)
                 node.text = value

--- a/tests/integration/targets/xml/results/test-set-children-elements-value.xml
+++ b/tests/integration/targets/xml/results/test-set-children-elements-value.xml
@@ -2,9 +2,7 @@
 <business type="bar">
   <name>Tasty Beverage Co.</name>
   <beers>
-    <beer alcohol="0.5" name="90 Minute IPA">2</beer>
-    <beer alcohol="0.3" name="Harvest Pumpkin Ale">5</beer>
-  </beers>
+    <beer alcohol="0.5" name="90 Minute IPA">2</beer><beer alcohol="0.3" name="Harvest Pumpkin Ale">5</beer></beers>
   <rating subjective="true">10</rating>
   <website>
     <mobilefriendly/>

--- a/tests/integration/targets/xml/results/test-set-children-elements-value.xml
+++ b/tests/integration/targets/xml/results/test-set-children-elements-value.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer alcohol="0.5" name="90 Minute IPA">2</beer>
+    <beer alcohol="0.3" name="Harvest Pumpkin Ale">5</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/integration/targets/xml/results/test-set-children-elements-value.xml.license
+++ b/tests/integration/targets/xml/results/test-set-children-elements-value.xml.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/xml/tasks/main.yml
+++ b/tests/integration/targets/xml/tasks/main.yml
@@ -62,6 +62,7 @@
   - include_tasks: test-set-attribute-value.yml
   - include_tasks: test-set-children-elements.yml
   - include_tasks: test-set-children-elements-level.yml
+  - include_tasks: test-set-children-elements-value.yml
   - include_tasks: test-set-element-value.yml
   - include_tasks: test-set-element-value-empty.yml
   - include_tasks: test-pretty-print.yml

--- a/tests/integration/targets/xml/tasks/test-set-children-elements-value.yml
+++ b/tests/integration/targets/xml/tasks/test-set-children-elements-value.yml
@@ -1,0 +1,64 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+  - name: Setup test fixture
+    copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: /tmp/ansible-xml-beers.xml
+
+
+  - name: Set child elements
+    xml:
+      path: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: &children
+        - beer:
+            alcohol: "0.5"
+            name: 90 Minute IPA
+            +value: "2"
+        - beer:
+            alcohol: "0.3"
+            name: Harvest Pumpkin Ale
+            +value: "5"
+    register: set_children_elements_value
+
+  - name: Add trailing newline
+    shell: echo "" >> /tmp/ansible-xml-beers.xml
+
+  - name: Compare to expected result
+    copy:
+      src: results/test-set-children-elements-value.xml
+      dest: /tmp/ansible-xml-beers.xml
+    check_mode: true
+    diff: true
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_elements_value is changed
+      - comparison is not changed  # identical
+
+
+  - name: Set child elements (again)
+    xml:
+      path: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: *children
+    register: set_children_again
+
+  - name: Compare to expected result
+    copy:
+      src: results/test-set-children-elements-value.xml
+      dest: /tmp/ansible-xml-beers.xml
+    check_mode: true
+    diff: true
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_again is not changed
+      - comparison is not changed   # identical


### PR DESCRIPTION
##### SUMMARY
This change adds support for creating value to node when using add_children/set_children with subnodes in xml module.

[Closes #2372](https://github.com/ansible-collections/community.general/issues/2372).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/xml.py
