### PR TITLE
Fix to handle Redfish Gen2 Firmware upgrade

### DIFF
--- a/changelogs/fragments/8444-fix-redfish-gen2-upgrade.yaml
+++ b/changelogs/fragments/8444-fix-redfish-gen2-upgrade.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - wdc_redfish_command - minor change to handle upgrade file for redfish gen 2 platform (https://github.com/ansible-collections/community.general/pull/8444).

--- a/changelogs/fragments/8444-fix-redfish-gen2-upgrade.yaml
+++ b/changelogs/fragments/8444-fix-redfish-gen2-upgrade.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - wdc_redfish_command - minor change to handle upgrade file for redfish gen 2 platform (https://github.com/ansible-collections/community.general/pull/8444).
+  - wdc_redfish_command - minor change to handle upgrade file for Redfish WD platforms (https://github.com/ansible-collections/community.general/pull/8444).

--- a/plugins/module_utils/wdc_redfish_utils.py
+++ b/plugins/module_utils/wdc_redfish_utils.py
@@ -210,7 +210,7 @@ class WdcRedfishUtils(RedfishUtils):
             # It is anticipated that DP firmware bundle will be having the value "DPG2"
             # for cookie1 in the header
             if cookie1.decode("utf8") == "MMG2" or cookie1.decode("utf8") == "DPG2":
-                file_name, _ = os.path.splitext(str(bundle_uri.rsplit('/', 1)[1]))
+                file_name, ext = os.path.splitext(str(bundle_uri.rsplit('/', 1)[1]))
                 # G2 bundle file name: Ultrastar-Data102_3000_SEP_1010-032_2.1.12.fwdl
                 parsedFileName = file_name.split('_')
                 if len(parsedFileName) == 5:

--- a/tests/unit/plugins/modules/test_wdc_redfish_command.py
+++ b/tests/unit/plugins/modules/test_wdc_redfish_command.py
@@ -289,7 +289,7 @@ def mock_get_firmware_inventory_version_1_2_3(*args, **kwargs):
     }
 
 
-ERROR_MESSAGE_UNABLE_TO_EXTRACT_BUNDLE_VERSION = "Unable to extract bundle version or multi-tenant status from update image tarfile"
+ERROR_MESSAGE_UNABLE_TO_EXTRACT_BUNDLE_VERSION = "Unable to extract bundle version or multi-tenant status or generation from update image file"
 ACTION_WAS_SUCCESSFUL_MESSAGE = "Action was successful"
 
 


### PR DESCRIPTION
##### SUMMARY
Fix to enable firmware upgrade on our Gen2 redfish based UltraStar Data102 platform.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
wdc_redfish_command module

##### ADDITIONAL INFORMATION
Firmware upgrade in case of Gen2 UltraStar Data102 platform is handled with the new firmware bundle format.
