### PR TITLE
git_config: deprecate reading values

### DIFF
--- a/changelogs/fragments/8453-git_config-deprecate-read.yml
+++ b/changelogs/fragments/8453-git_config-deprecate-read.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - "git_config - the ``list_all`` option has been deprecated and will be removed in community.general 11.0.0. Use the ``community.general.git_config_info`` module instead (https://github.com/ansible-collections/community.general/pull/8453)."
+  - "git_config - using ``state=present`` without providing ``value`` is deprecated and will be disallowed in community.general 11.0.0. Use the ``community.general.git_config_info`` module instead to read a value (https://github.com/ansible-collections/community.general/pull/8453)."


### PR DESCRIPTION
##### SUMMARY
git_config_info has been added in community.general 8.1.0. It's time to disallow reading operations from git_config.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
git_config
