### PR TITLE
feat(redis_info): add option to fetch cluster info

### DIFF
--- a/changelogs/fragments/8464-redis-add-cluster-info.yml
+++ b/changelogs/fragments/8464-redis-add-cluster-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redis_info - adds support for getting cluster info (https://github.com/ansible-collections/community.general/pull/8464).

--- a/plugins/modules/redis_info.py
+++ b/plugins/modules/redis_info.py
@@ -30,6 +30,11 @@ options:
     version_added: 7.5.0
   ca_certs:
     version_added: 7.5.0
+  cluster:
+    default: false
+    description: Get informations about cluster status
+    type: bool
+    version_added: 9.1.0
 seealso:
 - module: community.general.redis
 author: "Pavlo Bashynskyi (@levonet)"
@@ -43,6 +48,15 @@ EXAMPLES = r'''
 - name: Print server information
   ansible.builtin.debug:
     var: result.info
+
+- name: Get server cluster information
+  community.general.redis_info:
+    cluster: true
+  register: result
+
+- name: Print server cluster information
+  ansible.builtin.debug:
+    var: result.cluster_info
 '''
 
 RETURN = r'''
@@ -178,6 +192,24 @@ info:
       "used_memory_scripts_human": "0B",
       "used_memory_startup": 791264
     }
+cluster:
+  description: The default set of cluster information sections U(https://redis.io/commands/cluster-info).
+  returned: success
+  type: dict
+  sample: {
+     "cluster_state": ok,
+     "cluster_slots_assigned": 16384,
+     "cluster_slots_ok": 16384,
+     "cluster_slots_pfail": 0,
+     "cluster_slots_fail": 0,
+     "cluster_known_nodes": 6,
+     "cluster_size": 3,
+     "cluster_current_epoch": 6,
+     "cluster_my_epoch": 2,
+     "cluster_stats_messages_sent": 1483972,
+     "cluster_stats_messages_received": 1483968,
+     "total_cluster_links_buffer_limit_exceeded": 0
+  }
 '''
 
 import traceback
@@ -202,14 +234,19 @@ def redis_client(**client_params):
 
 # Module execution.
 def main():
+    module_args = dict(
+        cluster=dict(type='bool', default=False)
+    )
+    module_args.update(redis_auth_argument_spec(tls_default=False))
     module = AnsibleModule(
-        argument_spec=redis_auth_argument_spec(tls_default=False),
+        argument_spec=module_args,
         supports_check_mode=True,
     )
 
     fail_imports(module, module.params['tls'])
 
     redis_params = redis_auth_params(module)
+    cluster = module.params['cluster']
 
     # Connect and check
     client = redis_client(**redis_params)
@@ -219,7 +256,12 @@ def main():
         module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
 
     info = client.info()
-    module.exit_json(changed=False, info=info)
+
+    cluster_info = dict()
+    if cluster:
+        cluster_info = client.execute_command('CLUSTER INFO')
+
+    module.exit_json(changed=False, info=info, cluster_info=cluster_info)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/redis_info.py
+++ b/plugins/modules/redis_info.py
@@ -194,7 +194,8 @@ info:
     }
 cluster:
   description: The default set of cluster information sections U(https://redis.io/commands/cluster-info).
-  returned: success
+  returned: success if O(cluster=true)
+  version_added: 9.1.0
   type: dict
   sample: {
      "cluster_state": ok,
@@ -235,7 +236,7 @@ def redis_client(**client_params):
 # Module execution.
 def main():
     module_args = dict(
-        cluster=dict(type='bool', default=False)
+        cluster=dict(type='bool', default=False),
     )
     module_args.update(redis_auth_argument_spec(tls_default=False))
     module = AnsibleModule(
@@ -257,11 +258,12 @@ def main():
 
     info = client.info()
 
-    cluster_info = dict()
-    if cluster:
-        cluster_info = client.execute_command('CLUSTER INFO')
+    result = dict(changed=False, info=info)
 
-    module.exit_json(changed=False, info=info, cluster_info=cluster_info)
+    if cluster:
+        result['cluster_info'] = client.execute_command('CLUSTER INFO')
+
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/redis_info.py
+++ b/plugins/modules/redis_info.py
@@ -32,7 +32,7 @@ options:
     version_added: 7.5.0
   cluster:
     default: false
-    description: Get informations about cluster status
+    description: Get informations about cluster status as RV(cluster).
     type: bool
     version_added: 9.1.0
 seealso:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds support for getting cluster information. It does not use, redis-py's [cluster_info()](https://redis-py.readthedocs.io/en/stable/commands.html#redis.commands.cluster.RedisClusterCommands.cluster_info) because I couldn't get it to work when the cluster is yet to be configured. Hence the `execute_command` which works in that case.

It's optional and can be invoked with adding `cluster: true` to the task:

```yaml
- name: Get server cluster information
  community.general.redis_info:
    cluster: true
  register: result
```

And returns the additionnal data in the `cluster_info` variable alongside `info`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
- redis_info