### PR TITLE
feat: proxmox_vm_info - add network information for guests

### DIFF
--- a/changelogs/fragments/8471-proxmox-vm-info-network.yml
+++ b/changelogs/fragments/8471-proxmox-vm-info-network.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_vm_info - add ``network`` option to retrieve current network information (https://github.com/ansible-collections/community.general/pull/8471).

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -57,6 +57,10 @@ options:
       - pending
     default: none
     version_added: 8.1.0
+  network:
+    description:
+      - Whether to retrieve the current network status
+      - Requires enabled/running qemu-guest-agent
 extends_documentation_fragment:
   - community.general.proxmox.actiongroup_proxmox
   - community.general.proxmox.documentation
@@ -172,7 +176,7 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                 msg="Failed to retrieve VMs information from cluster resources: %s" % e
             )
 
-    def get_vms_from_nodes(self, cluster_machines, type, vmid=None, name=None, node=None, config=None):
+    def get_vms_from_nodes(self, cluster_machines, type, vmid=None, name=None, node=None, config=None, network=False):
         # Leave in dict only machines that user wants to know about
         filtered_vms = {
             vm: info for vm, info in cluster_machines.items() if not (
@@ -201,17 +205,23 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                         config_type = 0 if config == "pending" else 1
                         # GET /nodes/{node}/qemu/{vmid}/config current=[0/1]
                         desired_vm["config"] = call_vm_getter(this_vm_id).config().get(current=config_type)
+                    if network:
+                        if type == "qemu":
+                          desired_vm["network"] = call_vm_getter(this_vm_id).agent("network-get-interfaces").get()['result']
+                        elif type == "lxc":
+                          desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
+
         return filtered_vms
 
-    def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None):
+    def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):
         try:
-            return self.get_vms_from_nodes(cluster_machines, "qemu", vmid, name, node, config)
+            return self.get_vms_from_nodes(cluster_machines, "qemu", vmid, name, node, config, network)
         except Exception as e:
             self.module.fail_json(msg="Failed to retrieve QEMU VMs information: %s" % e)
 
-    def get_lxc_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None):
+    def get_lxc_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):
         try:
-            return self.get_vms_from_nodes(cluster_machines, "lxc", vmid, name, node, config)
+            return self.get_vms_from_nodes(cluster_machines, "lxc", vmid, name, node, config, network)
         except Exception as e:
             self.module.fail_json(msg="Failed to retrieve LXC VMs information: %s" % e)
 
@@ -229,6 +239,7 @@ def main():
             type="str", choices=["none", "current", "pending"],
             default="none", required=False
         ),
+        network=dict(type="bool", default=True, required=False)
     )
     module_args.update(vm_info_args)
 
@@ -245,6 +256,7 @@ def main():
     vmid = module.params["vmid"]
     name = module.params["name"]
     config = module.params["config"]
+    network = module.params["network"]
 
     result = dict(changed=False)
 
@@ -256,12 +268,12 @@ def main():
     vms = {}
 
     if type == "lxc":
-        vms = proxmox.get_lxc_vms(cluster_machines, vmid, name, node, config)
+        vms = proxmox.get_lxc_vms(cluster_machines, vmid, name, node, config, network)
     elif type == "qemu":
-        vms = proxmox.get_qemu_vms(cluster_machines, vmid, name, node, config)
+        vms = proxmox.get_qemu_vms(cluster_machines, vmid, name, node, config, network)
     else:
-        vms = proxmox.get_qemu_vms(cluster_machines, vmid, name, node, config)
-        vms.update(proxmox.get_lxc_vms(cluster_machines, vmid, name, node, config))
+        vms = proxmox.get_qemu_vms(cluster_machines, vmid, name, node, config, network)
+        vms.update(proxmox.get_lxc_vms(cluster_machines, vmid, name, node, config, network))
 
     result["proxmox_vms"] = [info for vm, info in sorted(vms.items())]
     module.exit_json(**result)

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -60,7 +60,7 @@ options:
   network:
     description:
       - Whether to retrieve the current network status
-      - Requires enabled/running qemu-guest-agent
+      - Requires enabled/running qemu-guest-agent on qemu vms
     type: bool
     default: false
 extends_documentation_fragment:

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -241,7 +241,7 @@ def main():
             type="str", choices=["none", "current", "pending"],
             default="none", required=False
         ),
-        network=dict(type="bool", default=False, required=False)
+        network=dict(type="bool", default=False, required=False),
     )
     module_args.update(vm_info_args)
 

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -63,6 +63,7 @@ options:
       - Requires enabled/running qemu-guest-agent on qemu vms
     type: bool
     default: false
+    version_added: 9.1.0
 extends_documentation_fragment:
   - community.general.proxmox.actiongroup_proxmox
   - community.general.proxmox.documentation

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -209,9 +209,9 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                         desired_vm["config"] = call_vm_getter(this_vm_id).config().get(current=config_type)
                     if network:
                         if type == "qemu":
-                          desired_vm["network"] = call_vm_getter(this_vm_id).agent("network-get-interfaces").get()['result']
+                            desired_vm["network"] = call_vm_getter(this_vm_id).agent("network-get-interfaces").get()['result']
                         elif type == "lxc":
-                          desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
+                            desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
 
         return filtered_vms
 

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -59,8 +59,8 @@ options:
     version_added: 8.1.0
   network:
     description:
-      - Whether to retrieve the current network status
-      - Requires enabled/running qemu-guest-agent on qemu vms
+      - Whether to retrieve the current network status.
+      - Requires enabled/running qemu-guest-agent on qemu VMs.
     type: bool
     default: false
     version_added: 9.1.0

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -61,6 +61,8 @@ options:
     description:
       - Whether to retrieve the current network status
       - Requires enabled/running qemu-guest-agent
+    type: bool
+    default: false
 extends_documentation_fragment:
   - community.general.proxmox.actiongroup_proxmox
   - community.general.proxmox.documentation
@@ -239,7 +241,7 @@ def main():
             type="str", choices=["none", "current", "pending"],
             default="none", required=False
         ),
-        network=dict(type="bool", default=True, required=False)
+        network=dict(type="bool", default=False, required=False)
     )
     module_args.update(vm_info_args)
 


### PR DESCRIPTION
##### SUMMARY
Information of guests should include current network settings to support waiting on network settings when provisioning new machines. The methods for accessing the information are already present in the API and only need to be called.

The retrieval of network information can be enabled/disabled via new bool param network (default=false)

For qemu vms, agent must be enabled and running. Otherwise, a clear error message from the API is shown: 
`"msg": "Failed to retrieve QEMU VMs information: 500 Internal Server Error: QEMU guest agent is not running"`

For lxc containers, the information is always there.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_vm_info

##### ADDITIONAL INFORMATION
Information of guests should include current network settings to support waiting on network settings when provisioning new machines. The methods for accessing the information are already present in the API and only need to be called.

New list of network interfaces in the result:
```
(QEMU)
[...]
"network": [
                    {
                        "hardware-address": "00:00:00:00:00:00",
                        "ip-addresses": [
                            {
                                "ip-address": "127.0.0.1",
                                "ip-address-type": "ipv4",
                                "prefix": 8
                            },
                            {
                                "ip-address": "::1",
                                "ip-address-type": "ipv6",
                                "prefix": 128
                            }
                        ],
                        "name": "lo",
                        "statistics": {
                            "rx-bytes": 5920,
                            "rx-dropped": 0,
                            "rx-errs": 0,
                            "rx-packets": 80,
                            "tx-bytes": 5920,
                            "tx-dropped": 0,
                            "tx-errs": 0,
                            "tx-packets": 80
                        }
                    },
                    {
                        "hardware-address": "bc:24:XX:XX:73:6d",
                        "ip-addresses": [
                            {
                                "ip-address": "192.168.XXX.XXX",
                                "ip-address-type": "ipv4",
                                "prefix": 24
                            },
                            {
                                "ip-address": "fe80::be24:XXXX:XXXX:736d",
                                "ip-address-type": "ipv6",
                                "prefix": 64
                            }
                        ],
                        "name": "ens18",
                        "statistics": {
                            "rx-bytes": 6134,
                            "rx-dropped": 30,
                            "rx-errs": 0,
                            "rx-packets": 51,
                            "tx-bytes": 1016,
                            "tx-dropped": 0,
                            "tx-errs": 0,
                            "tx-packets": 6
                        }
                    }
                ],
[...]

(LXC)
[...]
                "network": [
                    {
                        "hwaddr": "00:00:00:00:00:00",
                        "inet": "127.0.0.1/8",
                        "inet6": "::1/128",
                        "name": "lo"
                    },
                    {
                        "hwaddr": "82:00:XX:XX:84:f8",
                        "inet": "192.168.XXX.XXX/24",
                        "inet6": "fe80::8000:XXXX:XXXX:84f8/64",
                        "name": "eth0"
                    }
                ],
[...]
```
