### PR TITLE
Update docsite chapter "Merging lists of dictionaries"

### DIFF
--- a/docs/docsite/helper/lists_mergeby/default-common.yml
+++ b/docs/docsite/helper/lists_mergeby/default-common.yml
@@ -2,17 +2,11 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 list1:
-  - name: foo
-    extra: true
-  - name: bar
-    extra: false
-  - name: meh
-    extra: true
+  - {name: foo, extra: true}
+  - {name: bar, extra: false}
+  - {name: meh, extra: true}
 
 list2:
-  - name: foo
-    path: /foo
-  - name: baz
-    path: /baz
+  - {name: foo, path: /foo}
+  - {name: baz, path: /baz}

--- a/docs/docsite/helper/lists_mergeby/default-recursive-true.yml
+++ b/docs/docsite/helper/lists_mergeby/default-recursive-true.yml
@@ -2,14 +2,12 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 list1:
   - name: myname01
     param01:
       x: default_value
       y: default_value
-      list:
-        - default_value
+      list: [default_value]
   - name: myname02
     param01: [1, 1, 2, 3]
 
@@ -18,7 +16,6 @@ list2:
     param01:
       y: patch_value
       z: patch_value
-      list:
-        - patch_value
+      list: [patch_value]
   - name: myname02
-    param01: [3, 4, 4, {key: value}]
+    param01: [3, 4, 4]

--- a/docs/docsite/helper/lists_mergeby/example-001.yml
+++ b/docs/docsite/helper/lists_mergeby/example-001.yml
@@ -8,7 +8,7 @@
     dir: example-001_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-001.out

--- a/docs/docsite/helper/lists_mergeby/example-001_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-001_vars/list3.yml
@@ -2,6 +2,5 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ list1|
+list3: "{{ list1 |
            community.general.lists_mergeby(list2, 'name') }}"

--- a/docs/docsite/helper/lists_mergeby/example-002.yml
+++ b/docs/docsite/helper/lists_mergeby/example-002.yml
@@ -8,7 +8,7 @@
     dir: example-002_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-002.out

--- a/docs/docsite/helper/lists_mergeby/example-002_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-002_vars/list3.yml
@@ -2,6 +2,5 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name') }}"

--- a/docs/docsite/helper/lists_mergeby/example-003.yml
+++ b/docs/docsite/helper/lists_mergeby/example-003.yml
@@ -8,7 +8,7 @@
     dir: example-003_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-003.out

--- a/docs/docsite/helper/lists_mergeby/example-004.yml
+++ b/docs/docsite/helper/lists_mergeby/example-004.yml
@@ -8,7 +8,7 @@
     dir: example-004_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-004.out

--- a/docs/docsite/helper/lists_mergeby/example-004_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-004_vars/list3.yml
@@ -2,8 +2,7 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name',
                                            recursive=true,
                                            list_merge='keep') }}"

--- a/docs/docsite/helper/lists_mergeby/example-005.yml
+++ b/docs/docsite/helper/lists_mergeby/example-005.yml
@@ -8,7 +8,7 @@
     dir: example-005_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-005.out

--- a/docs/docsite/helper/lists_mergeby/example-005_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-005_vars/list3.yml
@@ -2,8 +2,7 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name',
                                            recursive=true,
                                            list_merge='append') }}"

--- a/docs/docsite/helper/lists_mergeby/example-006_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-006_vars/list3.yml
@@ -2,8 +2,7 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name',
                                            recursive=true,
                                            list_merge='prepend') }}"

--- a/docs/docsite/helper/lists_mergeby/example-007.yml
+++ b/docs/docsite/helper/lists_mergeby/example-007.yml
@@ -8,7 +8,7 @@
     dir: example-007_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug|d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-007.out

--- a/docs/docsite/helper/lists_mergeby/example-007_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-007_vars/list3.yml
@@ -2,8 +2,7 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name',
                                            recursive=true,
                                            list_merge='append_rp') }}"

--- a/docs/docsite/helper/lists_mergeby/example-008.yml
+++ b/docs/docsite/helper/lists_mergeby/example-008.yml
@@ -8,7 +8,7 @@
     dir: example-008_vars
 - debug:
     var: list3
-  when: debug|d(false)|bool
+  when: debug | d(false) | bool
 - template:
     src: list3.out.j2
     dest: example-008.out

--- a/docs/docsite/helper/lists_mergeby/example-008_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-008_vars/list3.yml
@@ -2,8 +2,7 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-list3: "{{ [list1, list2]|
+list3: "{{ [list1, list2] |
            community.general.lists_mergeby('name',
                                            recursive=true,
                                            list_merge='prepend_rp') }}"

--- a/docs/docsite/helper/lists_mergeby/example-009.yml
+++ b/docs/docsite/helper/lists_mergeby/example-009.yml
@@ -3,12 +3,12 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: 6. Merge recursive by 'name', prepend lists
+- name: 9. Merge single list by common attribute 'name'
   include_vars:
-    dir: example-006_vars
+    dir: example-009_vars
 - debug:
     var: list3
   when: debug | d(false) | bool
 - template:
     src: list3.out.j2
-    dest: example-006.out
+    dest: example-009.out

--- a/docs/docsite/helper/lists_mergeby/example-009_vars/default-common.yml
+++ b/docs/docsite/helper/lists_mergeby/example-009_vars/default-common.yml
@@ -1,0 +1,1 @@
+../default-common.yml

--- a/docs/docsite/helper/lists_mergeby/example-009_vars/default-recursive-true.yml
+++ b/docs/docsite/helper/lists_mergeby/example-009_vars/default-recursive-true.yml
@@ -1,0 +1,1 @@
+../default-recursive-true.yml

--- a/docs/docsite/helper/lists_mergeby/example-009_vars/default-recursive-true.yml
+++ b/docs/docsite/helper/lists_mergeby/example-009_vars/default-recursive-true.yml
@@ -1,1 +1,0 @@
-../default-recursive-true.yml

--- a/docs/docsite/helper/lists_mergeby/example-009_vars/list3.yml
+++ b/docs/docsite/helper/lists_mergeby/example-009_vars/list3.yml
@@ -2,6 +2,5 @@
 # Copyright (c) Ansible Project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-list3: "{{ [list1, list2] |
-           community.general.lists_mergeby('name',
-                                           recursive=true) }}"
+list3: "{{ [list1 + list2, []] |
+           community.general.lists_mergeby('name') }}"

--- a/docs/docsite/helper/lists_mergeby/examples.yml
+++ b/docs/docsite/helper/lists_mergeby/examples.yml
@@ -4,51 +4,75 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 examples:
-  - label: 'In the example below the lists are merged by the attribute ``name``:'
+  - title: Two lists
+    description: 'In the example below the lists are merged by the attribute ``name``:'
     file: example-001_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-001.out
     lang: 'yaml'
-  - label: 'It is possible to use a list of lists as an input of the filter:'
+  - title: List of two lists
+    description: 'It is possible to use a list of lists as an input of the filter:'
     file: example-002_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces the same result as in the previous example:'
+  - title:
+    description: 'This produces the same result as in the previous example:'
     file: example-002.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=replace`` (default):'
+  - title: Single list
+    description: 'It is possible to merge single list:'
+    file: example-009_vars/list3.yml
+    lang: 'yaml+jinja'
+  - title:
+    description: 'This produces the same result as in the previous example:'
+    file: example-009.out
+    lang: 'yaml'
+  - title: list_merge=replace (default)
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=replace` (default):'
     file: example-003_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-003.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=keep``:'
+  - title: list_merge=keep
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=keep`:'
     file: example-004_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-004.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=append``:'
+  - title: list_merge=append
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=append`:'
     file: example-005_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-005.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=prepend``:'
+  - title: list_merge=prepend
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend`:'
     file: example-006_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title: list_merge=append_rp
+    description: 'This produces:'
     file: example-006.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=append_rp``:'
+  - title: list_merge=append_rp
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=append_rp`:'
     file: example-007_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-007.out
     lang: 'yaml'
-  - label: 'Example ``list_merge=prepend_rp``:'
+  - title: list_merge=prepend_rp
+    description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend_rp`:'
     file: example-008_vars/list3.yml
     lang: 'yaml+jinja'
-  - label: 'This produces:'
+  - title:
+    description: 'This produces:'
     file: example-008.out
     lang: 'yaml'

--- a/docs/docsite/helper/lists_mergeby/examples.yml
+++ b/docs/docsite/helper/lists_mergeby/examples.yml
@@ -56,7 +56,7 @@ examples:
     description: 'Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend`:'
     file: example-006_vars/list3.yml
     lang: 'yaml+jinja'
-  - title: list_merge=append_rp
+  - title:
     description: 'This produces:'
     file: example-006.out
     lang: 'yaml'

--- a/docs/docsite/helper/lists_mergeby/examples_all.rst.j2
+++ b/docs/docsite/helper/lists_mergeby/examples_all.rst.j2
@@ -4,10 +4,10 @@
   SPDX-License-Identifier: GPL-3.0-or-later
 
 {% for i in examples %}
-{{ i.label }}
+{{ i.description }}
 
 .. code-block:: {{ i.lang }}
 
-  {{ lookup('file', i.file)|indent(2) }}
+  {{ lookup('file', i.file) | split('\n') | reject('match', '^(#|---)') | join ('\n') | indent(2) }}
 
 {% endfor %}

--- a/docs/docsite/helper/lists_mergeby/extra-vars.yml
+++ b/docs/docsite/helper/lists_mergeby/extra-vars.yml
@@ -1,3 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 examples_one: true
 examples_all: true
 merging_lists_of_dictionaries: true

--- a/docs/docsite/helper/lists_mergeby/extra-vars.yml
+++ b/docs/docsite/helper/lists_mergeby/extra-vars.yml
@@ -1,0 +1,3 @@
+examples_one: true
+examples_all: true
+merging_lists_of_dictionaries: true

--- a/docs/docsite/helper/lists_mergeby/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst.j2
+++ b/docs/docsite/helper/lists_mergeby/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst.j2
@@ -6,57 +6,69 @@
 Merging lists of dictionaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the ``lists_mergeby`` filter.
+If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the :ansplugin:`community.general.lists_mergeby <community.general.lists_mergeby#filter>` filter.
 
-.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See :ref:`the documentation for the community.general.yaml callback plugin <ansible_collections.community.general.yaml_callback>`.
+.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ref:`community.general.yaml <ansible_collections.community.general.yaml_callback>` callback plugin.
 
 Let us use the lists below in the following examples:
 
 .. code-block:: yaml
 
-  {{ lookup('file', 'default-common.yml')|indent(2) }}
+  {{ lookup('file', 'default-common.yml') | split('\n') | reject('match', '^(#|---)') | join ('\n')  | indent(2) }}
 
 {% for i in examples[0:2] %}
-{{ i.label }}
+{% if i.title | d('', true) | length > 0 %}
+{{ i.title }}
+{{ "%s" % ('"' * i.title|length) }}
+{% endif %}
+{{ i.description }}
 
 .. code-block:: {{ i.lang }}
 
-  {{ lookup('file', i.file)|indent(2) }}
+  {{ lookup('file', i.file) | split('\n') | reject('match', '^(#|---)') | join ('\n') | indent(2) }}
 
 {% endfor %}
 
 .. versionadded:: 2.0.0
 
-{% for i in examples[2:4] %}
-{{ i.label }}
+{% for i in examples[2:6] %}
+{% if i.title | d('', true) | length > 0 %}
+{{ i.title }}
+{{ "%s" % ('"' * i.title|length) }}
+{% endif %}
+{{ i.description }}
 
 .. code-block:: {{ i.lang }}
 
-  {{ lookup('file', i.file)|indent(2) }}
+  {{ lookup('file', i.file) | split('\n') | reject('match', '^(#|---)') | join ('\n') | indent(2) }}
 
 {% endfor %}
 
-The filter also accepts two optional parameters: ``recursive`` and ``list_merge``. These parameters are only supported when used with ansible-base 2.10 or ansible-core, but not with Ansible 2.9. This is available since community.general 4.4.0.
+The filter also accepts two optional parameters: :ansopt:`community.general.lists_mergeby#filter:recursive` and :ansopt:`community.general.lists_mergeby#filter:list_merge`. This is available since community.general 4.4.0.
 
 **recursive**
-    Is a boolean, default to ``False``. Should the ``community.general.lists_mergeby`` recursively merge nested hashes. Note: It does not depend on the value of the ``hash_behaviour`` setting in ``ansible.cfg``.
+    Is a boolean, default to ``false``. Should the :ansplugin:`community.general.lists_mergeby#filter` filter recursively merge nested hashes. Note: It does not depend on the value of the ``hash_behaviour`` setting in ``ansible.cfg``.
 
 **list_merge**
-    Is a string, its possible values are ``replace`` (default), ``keep``, ``append``, ``prepend``, ``append_rp`` or ``prepend_rp``. It modifies the behaviour of ``community.general.lists_mergeby`` when the hashes to merge contain arrays/lists.
+    Is a string, its possible values are :ansval:`replace` (default), :ansval:`keep`, :ansval:`append`, :ansval:`prepend`, :ansval:`append_rp` or :ansval:`prepend_rp`. It modifies the behaviour of :ansplugin:`community.general.lists_mergeby#filter` when the hashes to merge contain arrays/lists.
 
-The examples below set ``recursive=true`` and display the differences among all six options of ``list_merge``. Functionality of the parameters is exactly the same as in the filter ``combine``. See :ref:`Combining hashes/dictionaries <combine_filter>` to learn details about these options.
+The examples below set :ansopt:`community.general.lists_mergeby#filter:recursive=true` and display the differences among all six options of :ansopt:`community.general.lists_mergeby#filter:list_merge`. Functionality of the parameters is exactly the same as in the filter :ansplugin:`ansible.builtin.combine#filter`. See :ref:`Combining hashes/dictionaries <combine_filter>` to learn details about these options.
 
 Let us use the lists below in the following examples
 
 .. code-block:: yaml
 
-  {{ lookup('file', 'default-recursive-true.yml')|indent(2) }}
+  {{ lookup('file', 'default-recursive-true.yml') | split('\n') | reject('match', '^(#|---)') | join ('\n') |indent(2) }}
 
-{% for i in examples[4:16] %}
-{{ i.label }}
+{% for i in examples[6:] %}
+{% if i.title | d('', true) | length > 0 %}
+{{ i.title }}
+{{ "%s" % ('"' * i.title|length) }}
+{% endif %}
+{{ i.description }}
 
 .. code-block:: {{ i.lang }}
 
-  {{ lookup('file', i.file)|indent(2) }}
+  {{ lookup('file', i.file) | split('\n') | reject('match', '^(#|---)') | join ('\n') |indent(2) }}
 
 {% endfor %}

--- a/docs/docsite/helper/lists_mergeby/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst.j2
+++ b/docs/docsite/helper/lists_mergeby/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst.j2
@@ -8,7 +8,7 @@ Merging lists of dictionaries
 
 If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the :ansplugin:`community.general.lists_mergeby <community.general.lists_mergeby#filter>` filter.
 
-.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ref:`community.general.yaml <ansible_collections.community.general.yaml_callback>` callback plugin.
+.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ansplugin:`community.general.yaml callback plugin <community.general.yaml#callback>`.
 
 Let us use the lists below in the following examples:
 

--- a/docs/docsite/helper/lists_mergeby/list3.out.j2
+++ b/docs/docsite/helper/lists_mergeby/list3.out.j2
@@ -4,4 +4,4 @@ GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://w
 SPDX-License-Identifier: GPL-3.0-or-later
 #}
 list3:
-{{ list3|to_nice_yaml(indent=0) }}
+  {{ list3 | to_yaml(indent=2, sort_keys=false) | indent(2) }}

--- a/docs/docsite/helper/lists_mergeby/playbook.yml
+++ b/docs/docsite/helper/lists_mergeby/playbook.yml
@@ -5,7 +5,7 @@
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # 1) Run all examples and create example-XXX.out
-# shell> ansible-playbook playbook.yml -e examples=true
+# shell> ansible-playbook playbook.yml -e examples_one=true
 #
 # 2) Optionally, for testing, create examples_all.rst
 # shell> ansible-playbook playbook.yml -e examples_all=true
@@ -45,18 +45,20 @@
           tags: t007
         - import_tasks: example-008.yml
           tags: t008
-      when: examples|d(false)|bool
+        - import_tasks: example-009.yml
+          tags: t009
+      when: examples_one | d(false) | bool
 
     - block:
         - include_vars: examples.yml
         - template:
             src: examples_all.rst.j2
             dest: examples_all.rst
-      when: examples_all|d(false)|bool
+      when: examples_all | d(false) | bool
 
     - block:
         - include_vars: examples.yml
         - template:
             src: filter_guide_abstract_informations_merging_lists_of_dictionaries.rst.j2
             dest: filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
-      when: merging_lists_of_dictionaries|d(false)|bool
+      when: merging_lists_of_dictionaries | d(false) | bool

--- a/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
+++ b/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
@@ -78,13 +78,10 @@ This produces the same result as in the previous example:
 .. code-block:: yaml
 
   list3:
-    - name: myname01
-      param01:
-        y: patch_value
-        z: patch_value
-        list: [patch_value]
-    - name: myname02
-      param01: [3, 4, 4]
+    - {name: bar, extra: false}
+    - {name: baz, path: /baz}
+    - {name: foo, extra: true, path: /foo}
+    - {name: meh, extra: true}
 
 
 The filter also accepts two optional parameters: :ansopt:`community.general.lists_mergeby#filter:recursive` and :ansopt:`community.general.lists_mergeby#filter:list_merge`. This is available since community.general 4.4.0.
@@ -204,8 +201,6 @@ Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend`:
                                              recursive=true,
                                              list_merge='prepend') }}"
 
-list_merge=append_rp
-""""""""""""""""""""
 This produces:
 
 .. code-block:: yaml

--- a/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
+++ b/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
@@ -6,33 +6,30 @@
 Merging lists of dictionaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the :ansplugin:`community.general.lists_mergeby filter <community.general.lists_mergeby#filter>`.
+If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the :ansplugin:`community.general.lists_mergeby <community.general.lists_mergeby#filter>` filter.
 
-.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See :ref:`the documentation for the community.general.yaml callback plugin <ansible_collections.community.general.yaml_callback>`.
+.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ref:`community.general.yaml <ansible_collections.community.general.yaml_callback>` callback plugin.
 
 Let us use the lists below in the following examples:
 
 .. code-block:: yaml
 
   list1:
-    - name: foo
-      extra: true
-    - name: bar
-      extra: false
-    - name: meh
-      extra: true
+    - {name: foo, extra: true}
+    - {name: bar, extra: false}
+    - {name: meh, extra: true}
 
   list2:
-    - name: foo
-      path: /foo
-    - name: baz
-      path: /baz
+    - {name: foo, path: /foo}
+    - {name: baz, path: /baz}
 
+Two lists
+"""""""""
 In the example below the lists are merged by the attribute ``name``:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ list1|
+  list3: "{{ list1 |
              community.general.lists_mergeby(list2, 'name') }}"
 
 This produces:
@@ -40,24 +37,21 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - extra: false
-    name: bar
-  - name: baz
-    path: /baz
-  - extra: true
-    name: foo
-    path: /foo
-  - extra: true
-    name: meh
+    - {name: bar, extra: false}
+    - {name: baz, path: /baz}
+    - {name: foo, extra: true, path: /foo}
+    - {name: meh, extra: true}
 
 
 .. versionadded:: 2.0.0
 
+List of two lists
+"""""""""""""""""
 It is possible to use a list of lists as an input of the filter:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name') }}"
 
 This produces the same result as in the previous example:
@@ -65,15 +59,32 @@ This produces the same result as in the previous example:
 .. code-block:: yaml
 
   list3:
-  - extra: false
-    name: bar
-  - name: baz
-    path: /baz
-  - extra: true
-    name: foo
-    path: /foo
-  - extra: true
-    name: meh
+    - {name: bar, extra: false}
+    - {name: baz, path: /baz}
+    - {name: foo, extra: true, path: /foo}
+    - {name: meh, extra: true}
+
+Single list
+"""""""""""
+It is possible to merge single list:
+
+.. code-block:: yaml+jinja
+
+  list3: "{{ [list1 + list2, []] |
+             community.general.lists_mergeby('name') }}"
+
+This produces the same result as in the previous example:
+
+.. code-block:: yaml
+
+  list3:
+    - name: myname01
+      param01:
+        y: patch_value
+        z: patch_value
+        list: [patch_value]
+    - name: myname02
+      param01: [3, 4, 4]
 
 
 The filter also accepts two optional parameters: :ansopt:`community.general.lists_mergeby#filter:recursive` and :ansopt:`community.general.lists_mergeby#filter:list_merge`. This is available since community.general 4.4.0.
@@ -95,8 +106,7 @@ Let us use the lists below in the following examples
       param01:
         x: default_value
         y: default_value
-        list:
-          - default_value
+        list: [default_value]
     - name: myname02
       param01: [1, 1, 2, 3]
 
@@ -105,16 +115,17 @@ Let us use the lists below in the following examples
       param01:
         y: patch_value
         z: patch_value
-        list:
-          - patch_value
+        list: [patch_value]
     - name: myname02
-      param01: [3, 4, 4, {key: value}]
+      param01: [3, 4, 4]
 
+list_merge=replace (default)
+""""""""""""""""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=replace` (default):
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true) }}"
 
@@ -123,25 +134,22 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - patch_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 3
-    - 4
-    - 4
-    - key: value
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [patch_value]
+        z: patch_value
+    - name: myname02
+      param01: [3, 4, 4]
 
+list_merge=keep
+"""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=keep`:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true,
                                              list_merge='keep') }}"
@@ -151,25 +159,22 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - default_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 1
-    - 1
-    - 2
-    - 3
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [default_value]
+        z: patch_value
+    - name: myname02
+      param01: [1, 1, 2, 3]
 
+list_merge=append
+"""""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=append`:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true,
                                              list_merge='append') }}"
@@ -179,63 +184,49 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - default_value
-      - patch_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 1
-    - 1
-    - 2
-    - 3
-    - 3
-    - 4
-    - 4
-    - key: value
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [default_value, patch_value]
+        z: patch_value
+    - name: myname02
+      param01: [1, 1, 2, 3, 3, 4, 4]
 
+list_merge=prepend
+""""""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend`:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true,
                                              list_merge='prepend') }}"
 
+list_merge=append_rp
+""""""""""""""""""""
 This produces:
 
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - patch_value
-      - default_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 3
-    - 4
-    - 4
-    - key: value
-    - 1
-    - 1
-    - 2
-    - 3
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [patch_value, default_value]
+        z: patch_value
+    - name: myname02
+      param01: [3, 4, 4, 1, 1, 2, 3]
 
+list_merge=append_rp
+""""""""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=append_rp`:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true,
                                              list_merge='append_rp') }}"
@@ -245,29 +236,22 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - default_value
-      - patch_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 1
-    - 1
-    - 2
-    - 3
-    - 4
-    - 4
-    - key: value
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [default_value, patch_value]
+        z: patch_value
+    - name: myname02
+      param01: [1, 1, 2, 3, 4, 4]
 
+list_merge=prepend_rp
+"""""""""""""""""""""
 Example :ansopt:`community.general.lists_mergeby#filter:list_merge=prepend_rp`:
 
 .. code-block:: yaml+jinja
 
-  list3: "{{ [list1, list2]|
+  list3: "{{ [list1, list2] |
              community.general.lists_mergeby('name',
                                              recursive=true,
                                              list_merge='prepend_rp') }}"
@@ -277,21 +261,12 @@ This produces:
 .. code-block:: yaml
 
   list3:
-  - name: myname01
-    param01:
-      list:
-      - patch_value
-      - default_value
-      x: default_value
-      y: patch_value
-      z: patch_value
-  - name: myname02
-    param01:
-    - 3
-    - 4
-    - 4
-    - key: value
-    - 1
-    - 1
-    - 2
+    - name: myname01
+      param01:
+        x: default_value
+        y: patch_value
+        list: [patch_value, default_value]
+        z: patch_value
+    - name: myname02
+      param01: [3, 4, 4, 1, 1, 2]
 

--- a/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
+++ b/docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst
@@ -8,7 +8,7 @@ Merging lists of dictionaries
 
 If you have two or more lists of dictionaries and want to combine them into a list of merged dictionaries, where the dictionaries are merged by an attribute, you can use the :ansplugin:`community.general.lists_mergeby <community.general.lists_mergeby#filter>` filter.
 
-.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ref:`community.general.yaml <ansible_collections.community.general.yaml_callback>` callback plugin.
+.. note:: The output of the examples in this section use the YAML callback plugin. Quoting: "Ansible output that can be quite a bit easier to read than the default JSON formatting." See the documentation for the :ansplugin:`community.general.yaml callback plugin <community.general.yaml#callback>`.
 
 Let us use the lists below in the following examples:
 


### PR DESCRIPTION
##### SUMMARY

* Add subsections and improve formatting.
* Add example-009 'Merge single list'
* Adding links to module and plugin options in docs/docsite/helper/lists_mergeby

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/filter_guide_abstract_informations_merging_lists_of_dictionaries.rst

##### ADDITIONAL INFORMATION

The commands created the RST file:

```bash
(env) > cd docs/docsite/helper/lists_mergeby
(env) > ansible-playbook playbook.yml -e @extra-vars.yml
```
