### PR TITLE
Fix OpenNebula inventory crash when NIC does not have IP

### DIFF
--- a/changelogs/fragments/8489-fix-opennebula-inventory-crash-when-nic-has-no-ip.yml
+++ b/changelogs/fragments/8489-fix-opennebula-inventory-crash-when-nic-has-no-ip.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - opennebula.py - fix invalid reference to IP when inventory runs against NICs with no IPv4 address (https://github.com/ansible-collections/community.general/pull/8489).
+  - opennebula inventory plugin - fix invalid reference to IP when inventory runs against NICs with no IPv4 address (https://github.com/ansible-collections/community.general/pull/8489).

--- a/changelogs/fragments/8489-fix-opennebula-inventory-crash-when-nic-has-no-ip.yml
+++ b/changelogs/fragments/8489-fix-opennebula-inventory-crash-when-nic-has-no-ip.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - opennebula.py - fix invalid reference to IP when inventory runs against NICs with no IPv4 address (https://github.com/ansible-collections/community.general/pull/8489).

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -143,7 +143,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             nic = [nic]
 
         for net in nic:
-            return net['IP']
+            ip = net.get('IP')
+            return ip
 
         return False
 

--- a/plugins/inventory/opennebula.py
+++ b/plugins/inventory/opennebula.py
@@ -143,8 +143,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             nic = [nic]
 
         for net in nic:
-            ip = net.get('IP')
-            return ip
+            if net.get('IP'):
+                return net['IP']
 
         return False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix OpenNebula inventory crash when NIC does not have IP.

Now matches IPv6 behaviour.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
community.general.opennebula

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
When a NIC does not have an IP:
```shell
  File "ansible/inventory/manager.py", line 292, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "ansible-cm/plugins/inventory/opennebula.py", line 263, in parse
    self._populate()
  File "ansible-cm/plugins/inventory/opennebula.py", line 226, in _populate
    servers = self._retrieve_servers(filter_by_label)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ansible-cm/plugins/inventory/opennebula.py", line 210, in _retrieve_servers
    server['v4_first_ip'] = self._get_vm_ipv4(vm)
                            ^^^^^^^^^^^^^^^^^^^^^
  File "ansible-cm/plugins/inventory/opennebula.py", line 154, in _get_vm_ipv4
    return net['IP']
```

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
