### PR TITLE
keycloak_clientscope: add normalizations for attributes and protocol_mappers

### DIFF
--- a/changelogs/fragments/8496-keycloak_clientscope-add-normalizations.yaml
+++ b/changelogs/fragments/8496-keycloak_clientscope-add-normalizations.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - keycloak_realm - add normalizations for ``attributes`` and ``protocol_mappers`` (https://github.com/ansible-collections/community.general/pull/8496).

--- a/plugins/modules/keycloak_clientscope.py
+++ b/plugins/modules/keycloak_clientscope.py
@@ -301,8 +301,35 @@ end_state:
 '''
 
 from ansible_collections.community.general.plugins.module_utils.identity.keycloak.keycloak import KeycloakAPI, camel, \
-    keycloak_argument_spec, get_token, KeycloakError
+    keycloak_argument_spec, get_token, KeycloakError, is_struct_included
 from ansible.module_utils.basic import AnsibleModule
+
+
+def normalise_cr(clientscoperep, remove_ids=False):
+    """ Re-sorts any properties where the order so that diff's is minimised, and adds default values where appropriate so that the
+    the change detection is more effective.
+
+    :param clientscoperep: the clientscoperep dict to be sanitized
+    :param remove_ids: If set to true, then the unique ID's of objects is removed to make the diff and checks for changed
+                       not alert when the ID's of objects are not usually known, (e.g. for protocol_mappers)
+    :return: normalised clientscoperep dict
+    """
+    # Avoid the dict passed in to be modified
+    clientscoperep = clientscoperep.copy()
+
+    if 'attributes' in clientscoperep:
+        clientscoperep['attributes'] = list(sorted(clientscoperep['attributes']))
+
+    if 'protocolMappers' in clientscoperep:
+        clientscoperep['protocolMappers'] = sorted(clientscoperep['protocolMappers'], key=lambda x: (x.get('name'), x.get('protocol'), x.get('protocolMapper')))
+        for mapper in clientscoperep['protocolMappers']:
+            if remove_ids:
+                mapper.pop('id', None)
+
+            # Set to a default value.
+            mapper['consentRequired'] = mapper.get('consentRequired', False)
+
+    return clientscoperep
 
 
 def sanitize_cr(clientscoperep):
@@ -317,7 +344,7 @@ def sanitize_cr(clientscoperep):
     if 'attributes' in result:
         if 'saml.signing.private.key' in result['attributes']:
             result['attributes']['saml.signing.private.key'] = 'no_log'
-    return result
+    return normalise_cr(result)
 
 
 def main():
@@ -458,6 +485,13 @@ def main():
                 result['diff'] = dict(before=sanitize_cr(before_clientscope), after=sanitize_cr(desired_clientscope))
 
             if module.check_mode:
+                # We can only compare the current clientscope with the proposed updates we have
+                before_norm = normalise_cr(before_clientscope, remove_ids=True)
+                desired_norm = normalise_cr(desired_clientscope, remove_ids=True)
+                if module._diff:
+                    result['diff'] = dict(before=sanitize_cr(before_norm),
+                                          after=sanitize_cr(desired_norm))
+                result['changed'] = not is_struct_included(desired_norm, before_norm)
                 module.exit_json(**result)
 
             # do the update


### PR DESCRIPTION
##### SUMMARY
keycloak_clientscope: Add sorted `attributes` and `protocol_mappers` to normalizations.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
keycloak_clientscope

##### ADDITIONAL INFORMATION
Without this code, `ansible-playbook --check --diff`will show changes because a unsorted list is diffed.
It uses the same approach as for `keycloak_client` in https://github.com/ansible-collections/community.general/blob/6c8f949ba950309931d8931f4820b99707898850/plugins/modules/keycloak_client.py#L730