### PR TITLE
homectl, udm_user: guard crypt imports

### DIFF
--- a/changelogs/fragments/8497-crypt.yml
+++ b/changelogs/fragments/8497-crypt.yml
@@ -1,0 +1,3 @@
+known_issues:
+  - "homectl - the module does not work under Python 3.13 or newer, since it relies on the removed ``crypt`` standard library module (https://github.com/ansible-collections/community.general/issues/4691, https://github.com/ansible-collections/community.general/pull/8497)."
+  - "udm_user - the module does not work under Python 3.13 or newer, since it relies on the removed ``crypt`` standard library module (https://github.com/ansible-collections/community.general/issues/4690, https://github.com/ansible-collections/community.general/pull/8497)."


### PR DESCRIPTION
##### SUMMARY
Now that ansible-core devel's ansible-test also tests with Python 3.13, in which the crypt standard library module has been removed, we have to do something about these two modules using that part of the standard library.

This PR makes the crypt import guarded and lets the module fail with an expressive error message. It would be better to get rid of the crypt usages, but that's for someone else...

Ref: https://github.com/ansible-collections/community.general/issues/4691
Ref: https://github.com/ansible-collections/community.general/issues/4690

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
homectl
udm_user
