### PR TITLE
proxmox_kvm: document that force requires archive

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -174,6 +174,7 @@ options:
       - Allow to force stop VM.
       - Can be used with states V(stopped), V(restarted), and V(absent).
       - This option has no default unless O(proxmox_default_behavior) is set to V(compatibility); then the default is V(false).
+      - Requires parameter V(archive).
     type: bool
   format:
     description:

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -174,7 +174,7 @@ options:
       - Allow to force stop VM.
       - Can be used with states V(stopped), V(restarted), and V(absent).
       - This option has no default unless O(proxmox_default_behavior) is set to V(compatibility); then the default is V(false).
-      - Requires parameter V(archive).
+      - Requires parameter O(archive).
     type: bool
   format:
     description:


### PR DESCRIPTION
##### SUMMARY

As per `qm(1)`, the force option requires `archive`. Add this information in the `proxmox_kvm` module so one will know they have to define `archive` when using `force`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
proxmox_kvm