### PR TITLE
Update VirtualBox Group parsing to align with documentation.

### DIFF
--- a/changelogs/fragments/8508-virtualbox-inventory.yml
+++ b/changelogs/fragments/8508-virtualbox-inventory.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - >- 
-    virtualbox inventory plugin - expose a new parameter ``enable_advanced_group_parsing`` to change how the VirtualBox dynamic inventory parses VM groups (https://github.com/ansible-collections/community.general/issues/8508).
+    virtualbox inventory plugin - expose a new parameter ``enable_advanced_group_parsing`` to change how the VirtualBox dynamic inventory parses VM groups (https://github.com/ansible-collections/community.general/issues/8508, https://github.com/ansible-collections/community.general/pull/8510).

--- a/changelogs/fragments/8508-virtualbox-inventory.yml
+++ b/changelogs/fragments/8508-virtualbox-inventory.yml
@@ -1,0 +1,7 @@
+breaking_changes:
+  - >- 
+    virtualbox inventory plugin - the VirtualBox dynamic inventory automatically infers Ansible Groups based on VirtualBox groups. 
+    This change converges the dynamic inventory's group parsing logic to align more closely to VirtualBox groups. 
+    Previously, the `/` character would delineate the different groups, and place them at the top level. 
+    Now, the `/` character allows creation of nested groups, akin to filesystem directory hierarchy. The `,` character is introduced to delineate other top-level groups.
+    See https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups for details on how to assign VirtualBox groups. (https://github.com/ansible-collections/community.general/issues/8508)

--- a/changelogs/fragments/8508-virtualbox-inventory.yml
+++ b/changelogs/fragments/8508-virtualbox-inventory.yml
@@ -1,7 +1,3 @@
 minor_changes:
   - >- 
-    virtualbox inventory plugin - expose a new parameter `enable_advanced_group_parsing` to change how the VirtualBox dynamic inventory parses VM groups.
-    The dynamic inventory automatically assigns VMs to Ansible Groups based on VirtualBox groups configured using VBoxManage.
-    When set to `false` (default, existing behaviour), the `/` character would delineate the different groups.
-    When set to `true`, the `/` character allows creation of nested groups, and the `,` character is used to delineate the groups.
-    See https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups for details on how to assign VirtualBox groups. (https://github.com/ansible-collections/community.general/issues/8508)
+    virtualbox inventory plugin - expose a new parameter ``enable_advanced_group_parsing`` to change how the VirtualBox dynamic inventory parses VM groups (https://github.com/ansible-collections/community.general/issues/8508).

--- a/changelogs/fragments/8508-virtualbox-inventory.yml
+++ b/changelogs/fragments/8508-virtualbox-inventory.yml
@@ -1,7 +1,7 @@
-breaking_changes:
+minor_changes:
   - >- 
-    virtualbox inventory plugin - the VirtualBox dynamic inventory automatically infers Ansible Groups based on VirtualBox groups. 
-    This change converges the dynamic inventory's group parsing logic to align more closely to VirtualBox groups. 
-    Previously, the `/` character would delineate the different groups, and place them at the top level. 
-    Now, the `/` character allows creation of nested groups, akin to filesystem directory hierarchy. The `,` character is introduced to delineate other top-level groups.
+    virtualbox inventory plugin - expose a new parameter `enable_advanced_group_parsing` to change how the VirtualBox dynamic inventory parses VM groups.
+    The dynamic inventory automatically assigns VMs to Ansible Groups based on VirtualBox groups configured using VBoxManage.
+    When set to `false` (default, existing behaviour), the `/` character would delineate the different groups.
+    When set to `true`, the `/` character allows creation of nested groups, and the `,` character is used to delineate the groups.
     See https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups for details on how to assign VirtualBox groups. (https://github.com/ansible-collections/community.general/issues/8508)

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -44,9 +44,9 @@ DOCUMENTATION = '''
               - Setting O(enable_advanced_group_parsing=true) changes this behaviour to match VirtualBox's interpretation of groups according to
                 U(https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups).
                 Groups are now split using the V(,) character, and the V(/) character indicates nested groups.
-              - So, for a VM that's been configured using V(VBoxManage modifyvm "vm01" --groups "/TestGroup/TestGroup2,/TestGroup3"):
-                C(TestGroup2) is a child group of C(TestGroup);
-                the VM will be part of C(TestGroup2) and C(TestGroup3).
+              - When enabled, a VM that's been configured using V(VBoxManage modifyvm "vm01" --groups "/TestGroup/TestGroup2,/TestGroup3") will result in
+                the group C(TestGroup2) being a child group of C(TestGroup); and
+                the VM being a part of C(TestGroup2) and C(TestGroup3).
             default: false
             type: bool
             version_added: 9.2.0

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -14,8 +14,8 @@ DOCUMENTATION = '''
         - Get inventory hosts from the local virtualbox installation.
         - Uses a YAML configuration file that ends with virtualbox.(yml|yaml) or vbox.(yml|yaml).
         - The inventory_hostname is always the 'Name' of the virtualbox instance.
-        - Groups can be assigned to the VMs using `VBoxManage`. Multiple groups can be assigned by using `/` as a delimeter.
-        - A separate parameter, `enable_advanced_group_parsing` is exposed to change grouping behaviour. See the parameter documentation for details.
+        - Groups can be assigned to the VMs using C(VBoxManage). Multiple groups can be assigned by using V(/) as a delimeter.
+        - A separate parameter, O(enable_advanced_group_parsing) is exposed to change grouping behaviour. See the parameter documentation for details.
     extends_documentation_fragment:
       - constructed
       - inventory_cache

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -38,16 +38,18 @@ DOCUMENTATION = '''
             type: dictionary
             default: {}
         enable_advanced_group_parsing:
-            description: >
-                The default group parsing rule (when this setting is set to `false`) is to split the VirtualBox VM's group based on the `/` character and
+            description:
+              - The default group parsing rule (when this setting is set to V(false)) is to split the VirtualBox VM's group based on the V(/) character and
                 assign the resulting list elements as an Ansible Group.
-                Setting `enable_advanced_group_parsing` to `true` changes this behaviour to match VirtualBox's interpretation of groups according to:
-                https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups
-                Groups are now split using the `,` character, and the `/` character indicates nested groups.
-                So, for a VM that's been configured using `VBoxManage modifyvm "vm01" --groups "/TestGroup/TestGroup2,/TestGroup3"`:
-                - TestGroup2 is a child group of TestGroup
-                - The VM will be part of TestGroup2 and TestGroup3.
+              - Setting O(enable_advanced_group_parsing=true) changes this behaviour to match VirtualBox's interpretation of groups according to
+                U(https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups).
+                Groups are now split using the V(,) character, and the V(/) character indicates nested groups.
+              - So, for a VM that's been configured using V(VBoxManage modifyvm "vm01" --groups "/TestGroup/TestGroup2,/TestGroup3"):
+                C(TestGroup2) is a child group of C(TestGroup);
+                the VM will be part of C(TestGroup2) and C(TestGroup3).
             default: false
+            type: bool
+            version_added: 9.2.0
 '''
 
 EXAMPLES = '''
@@ -271,7 +273,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 # unassigned to a group.
                 continue
 
-            parent_group = "all"
+            parent_group = None
             for subgroup in group.split('/'):
                 if not subgroup:
                     # Similarly to above, we could get an empty element.
@@ -285,7 +287,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
                 subgroup = make_unsafe(subgroup)
                 subgroup = self.inventory.add_group(subgroup)
-                self.inventory.add_child(parent_group, subgroup)
+                if parent_group is not None:
+                    self.inventory.add_child(parent_group, subgroup)
                 self.inventory.add_child(subgroup, current_host)
                 if subgroup not in cacheable_results:
                     cacheable_results[subgroup] = {'hosts': []}

--- a/plugins/inventory/virtualbox.py
+++ b/plugins/inventory/virtualbox.py
@@ -14,7 +14,8 @@ DOCUMENTATION = '''
         - Get inventory hosts from the local virtualbox installation.
         - Uses a YAML configuration file that ends with virtualbox.(yml|yaml) or vbox.(yml|yaml).
         - The inventory_hostname is always the 'Name' of the virtualbox instance.
-        - Groups can be assigned to the VMs using `VBoxManage modifyvm "vmid" -- groups "/TestGroup"`. Multiple groups can be assigned by using `/` as a delimeter. A separate parameter, `enable_advanced_group_parsing` is exposed to change this behaviour. See the parameter documentation for details.
+        - Groups can be assigned to the VMs using `VBoxManage`. Multiple groups can be assigned by using `/` as a delimeter.
+        - A separate parameter, `enable_advanced_group_parsing` is exposed to change grouping behaviour. See the parameter documentation for details.
     extends_documentation_fragment:
       - constructed
       - inventory_cache
@@ -38,8 +39,10 @@ DOCUMENTATION = '''
             default: {}
         enable_advanced_group_parsing:
             description: >
-                The default group parsing rule (when this setting is set to `false`) is to split the VirtualBox VM's group based on the `/` character and assign the resulting list elements as an Ansible Group.
-                Setting `enable_advanced_group_parsing` to `true` changes this behaviour to match VirtualBox's interpretation of groups according to: https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups
+                The default group parsing rule (when this setting is set to `false`) is to split the VirtualBox VM's group based on the `/` character and
+                assign the resulting list elements as an Ansible Group.
+                Setting `enable_advanced_group_parsing` to `true` changes this behaviour to match VirtualBox's interpretation of groups according to:
+                https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups
                 Groups are now split using the `,` character, and the `/` character indicates nested groups.
                 So, for a VM that's been configured using `VBoxManage modifyvm "vm01" --groups "/TestGroup/TestGroup2,/TestGroup3"`:
                 - TestGroup2 is a child group of TestGroup


### PR DESCRIPTION
Previously, we could separate the group string on the `/` char and consider each element to be distinct, top-level groups. This change implements the notion of nested groups and the use of the `,` char to split multiple groups.

##### SUMMARY
Fixes #8508 
Update the parsing algorithm in the VirtualBox dynamic inventory. The update changes how groups are formed when considering VirtualBox VMs.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
virtualbox inventory plugin

##### ADDITIONAL INFORMATION
Before, we would split groups based only on the `/` characters to form top-level groups. This was problematic for users (like me) who want to use nested groups for better variable management.

This change introduces the ability to use nested groups using `/`, and different groups using `,`. This approach more closely aligns with the official VirtualBox documentation.

https://www.virtualbox.org/manual/UserManual.html#gui-vmgroups

In the linked issue, it shows that previously, the `my_custom_variable` would resolve to `"This is in \"zgroup1\" group"` because the groups for vm-1 are on "the same level", and so variable resolution depends on lexicographical ordering.
Also, groups for vm-2 had a trailing `,` character.

Here are the results of the Ansible debug commands with this updated inventory file.

```console
ansible -i virtualbox.yml -m debug -a "var=my_custom_variable" all
vm-1 | SUCCESS => {
    "my_custom_variable": "This is in \"xgroup3\" group"
}
vm-2 | SUCCESS => {
    "my_custom_variable": "This is in \"all\" group"
}

ansible -i virtualbox.yml -m debug -a "var=group_names" all
vm-1 | SUCCESS => {
    "group_names": [
        "xgroup3",
        "ygroup2",
        "zgroup1"
    ]
}
vm-2 | SUCCESS => {
    "group_names": [
        "othergroup1",
        "othergroup2",
        "othergroup3"
    ]
}
```

