### PR TITLE
cmd_runner - handle special value "auto" in param force_lang

### DIFF
--- a/changelogs/fragments/8517-cmd-runner-lang-auto.yml
+++ b/changelogs/fragments/8517-cmd-runner-lang-auto.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - CmdRunner module utils - the parameter ``force_lang`` now supports the special value ``auto`` which will automatically try and determine the best parsable locale in the system (https://github.com/ansible-collections/community.general/pull/8517).

--- a/plugins/module_utils/cmd_runner.py
+++ b/plugins/module_utils/cmd_runner.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import iteritems
+from ansible.module_utils.common.locale import get_best_parsable_locale
 
 
 def _ensure_list(value):
@@ -236,7 +237,13 @@ class CmdRunner(object):
                 fmt = _Format.as_func(func=fmt, ignore_none=True)
             self.arg_formats[fmt_name] = fmt
         self.check_rc = check_rc
-        self.force_lang = force_lang
+        if force_lang == "auto":
+            try:
+                self.force_lang = get_best_parsable_locale()
+            except RuntimeWarning:
+                self.force_lang = "C"
+        else:
+            self.force_lang = force_lang
         self.path_prefix = path_prefix
         if environ_update is None:
             environ_update = {}

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -128,6 +128,8 @@ options:
       - The default value, V(C), is supported on every system, but can lead to encoding errors if UTF-8 is used in the output
       - Use V(C.UTF-8) or V(en_US.UTF-8) or similar UTF-8 supporting locales in case of problems. You need to make sure
         the selected locale is supported on the system the puppet agent runs on.
+      - Starting with community.general 9.1.0, you can use the value `auto` and the module will
+        try and determine the best parseable locale to use.
     type: str
     default: C
     version_added: 8.6.0

--- a/plugins/modules/puppet.py
+++ b/plugins/modules/puppet.py
@@ -128,7 +128,7 @@ options:
       - The default value, V(C), is supported on every system, but can lead to encoding errors if UTF-8 is used in the output
       - Use V(C.UTF-8) or V(en_US.UTF-8) or similar UTF-8 supporting locales in case of problems. You need to make sure
         the selected locale is supported on the system the puppet agent runs on.
-      - Starting with community.general 9.1.0, you can use the value `auto` and the module will
+      - Starting with community.general 9.1.0, you can use the value V(auto) and the module will
         try and determine the best parseable locale to use.
     type: str
     default: C


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Supplying the special value `auto` to the `force_lang` parameter now has the effect of determining the locale to be used in the command execution by calling `ansible.module_utils.common.locale.get_best_parsable_locale()`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
plugins/module_utils/cmd_runner.py
